### PR TITLE
[agent-b][issue #765] Add runtime log subscription

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -4477,6 +4477,69 @@
           }
         }
       ]
+    },
+    {
+      "name": "runtime.subscribe_logs",
+      "description": "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry` row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log filter fields as `runtime.logs`, but snapshot pagination and sort controls (`limit`, `cursor`, `order`) are not accepted on the subscription.\n",
+      "params": [
+        {
+          "name": "run_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "entity_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "component",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "level",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/LogLevel"
+          }
+        },
+        {
+          "name": "error_code",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "source",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "replay_since",
+          "required": false,
+          "description": "Optional catch-up window. If present, delivers runtime log entries from this time forward, then continues live. Subject to runtime log retention.",
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SubscriptionId"
+        }
+      }
     }
   ],
   "components": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8273,6 +8273,55 @@ api_specification:
             next_cursor:
               $ref: '#/components/schemas/Cursor'
       errors: []
+    runtime.subscribe_logs:
+      tier: should_have
+      description: "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry`\
+        \ row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log\
+        \ filter fields as `runtime.logs`, but snapshot pagination and sort controls (`limit`, `cursor`, `order`) are not\
+        \ accepted on the subscription.\n"
+      scope:
+        required:
+        - read:runtime
+      params:
+      - name: run_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: entity_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: component
+        required: false
+        schema:
+          type: string
+      - name: level
+        required: false
+        schema:
+          $ref: '#/components/schemas/LogLevel'
+      - name: error_code
+        required: false
+        schema:
+          type: string
+      - name: source
+        required: false
+        schema:
+          type: string
+      - name: replay_since
+        required: false
+        description: Optional catch-up window. If present, delivers runtime log entries from this time forward, then continues
+          live. Subject to runtime log retention.
+        schema:
+          $ref: '#/components/schemas/Timestamp'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/SubscriptionId'
+      notification_schema:
+        $ref: '#/components/schemas/LogEntry'
+      notification_cadence: Pushed per runtime log entry matching the filter.
+      errors: []
     runtime.incidents:
       tier: should_have
       description: Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage).

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,8 +16,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 38 {
-		t.Fatalf("method count = %d, want 38", report.MethodCount)
+	if report.MethodCount != 39 {
+		t.Fatalf("method count = %d, want 39", report.MethodCount)
 	}
 	if report.SchemaCount != 53 {
 		t.Fatalf("schema count = %d, want 53", report.SchemaCount)
@@ -28,8 +28,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MutatingMethodCount != 14 {
 		t.Fatalf("mutating method count = %d, want 14", report.MutatingMethodCount)
 	}
-	if report.SubscriptionMethodCnt != 3 {
-		t.Fatalf("subscription method count = %d, want 3", report.SubscriptionMethodCnt)
+	if report.SubscriptionMethodCnt != 4 {
+		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
 	}
 	if _, ok := api.MethodCatalog["rpc.unsubscribe"]; !ok {
 		t.Fatal("rpc.unsubscribe missing from method catalog")
@@ -61,8 +61,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 38 {
-		t.Fatalf("generated OpenRPC methods = %d, want 38", len(doc.Methods))
+	if len(doc.Methods) != 39 {
+		t.Fatalf("generated OpenRPC methods = %d, want 39", len(doc.Methods))
 	}
 	if len(doc.Components.Schemas) != 53 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 53", len(doc.Components.Schemas))
@@ -79,6 +79,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["event.replay"]; !ok {
 		t.Fatal("generated OpenRPC missing event.replay")
+	}
+	if _, ok := methods["runtime.subscribe_logs"]; !ok {
+		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")
 	}
 	if !methods["run.start"].Deprecated {
 		t.Fatal("generated OpenRPC run.start deprecated flag = false, want true")

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -314,7 +314,7 @@ func (s *webSocketSession) handleRaw(raw []byte) bool {
 		return s.enqueue(*failure)
 	}
 	switch req.Method {
-	case "health.subscribe", "event.subscribe", "run.subscribe_trace":
+	case "health.subscribe", "event.subscribe", "run.subscribe_trace", "runtime.subscribe_logs":
 		if s.handler.subs == nil {
 			return s.enqueue(s.handler.dispatchPrepared(s.ctx, req))
 		}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 38 {
-		t.Fatalf("method count = %d, want 38", len(openRPCNames))
+	if len(openRPCNames) != 39 {
+		t.Fatalf("method count = %d, want 39", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -158,8 +158,9 @@ type fakeObservabilityReadStore struct {
 	eventErr error
 	listErr  error
 
-	logs      []store.OperatorRuntimeLogEntry
-	incidents []store.OperatorRuntimeIncident
+	logs           []store.OperatorRuntimeLogEntry
+	runtimeLogsErr error
+	incidents      []store.OperatorRuntimeIncident
 
 	lastEventList   store.OperatorEventListOptions
 	lastTrace       store.RunDebugTraceQueryOptions
@@ -219,7 +220,35 @@ func (s *fakeObservabilityReadStore) LoadOperatorEvent(_ context.Context, eventI
 
 func (s *fakeObservabilityReadStore) ListOperatorRuntimeLogs(_ context.Context, opts store.OperatorRuntimeLogListOptions) (store.OperatorRuntimeLogListResult, error) {
 	s.lastRuntimeLogs = opts
-	return store.OperatorRuntimeLogListResult{Logs: s.logs}, nil
+	if s.runtimeLogsErr != nil {
+		return store.OperatorRuntimeLogListResult{}, s.runtimeLogsErr
+	}
+	out := make([]store.OperatorRuntimeLogEntry, 0, len(s.logs))
+	for _, log := range s.logs {
+		if opts.Since != nil && !log.TS.After(opts.Since.UTC()) {
+			continue
+		}
+		if opts.RunID != "" && log.RunID != opts.RunID {
+			continue
+		}
+		if opts.EntityID != "" && log.EntityID != opts.EntityID {
+			continue
+		}
+		if opts.Component != "" && log.Component != opts.Component {
+			continue
+		}
+		if opts.Level != "" && log.Level != opts.Level {
+			continue
+		}
+		if opts.ErrorCode != "" && log.ErrorCode != opts.ErrorCode {
+			continue
+		}
+		if opts.Source != "" && log.Source != opts.Source {
+			continue
+		}
+		out = append(out, log)
+	}
+	return store.OperatorRuntimeLogListResult{Logs: out}, nil
 }
 
 func (s *fakeObservabilityReadStore) ListOperatorRuntimeIncidents(_ context.Context, opts store.OperatorRuntimeIncidentListOptions) (store.OperatorRuntimeIncidentListResult, error) {

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -116,6 +116,8 @@ func (r *SubscriptionRuntime) prepare(session *webSocketSession, req Request) (s
 		return r.prepareEventSubscription(session, req)
 	case "run.subscribe_trace":
 		return r.prepareRunTraceSubscription(session, req)
+	case "runtime.subscribe_logs":
+		return r.prepareRuntimeLogSubscription(session, req)
 	default:
 		return subscriptionPlan{}, NewApplicationError(MethodUnavailableCode, false, map[string]any{"method": req.Method})
 	}
@@ -184,6 +186,70 @@ func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSess
 		},
 		Cancel: cancel,
 	}, nil
+}
+
+func (r *SubscriptionRuntime) prepareRuntimeLogSubscription(session *webSocketSession, req Request) (subscriptionPlan, error) {
+	reads, err := requireObservabilityReadStore(r.observability)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	opts, replaySince, err := runtimeLogSubscriptionOptionsFromParams(req.Params)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
+	opts.Since = subscriptionBaseSince(replaySince, r.now())
+	opts.Limit = subscriptionBatchLimit
+	opts.Order = "asc"
+	id, ctx, cancel := session.newSubscriptionContext("runtime-logs")
+	return subscriptionPlan{
+		Result: subscriptionIDResult{SubscriptionID: id},
+		Start: func() {
+			go r.runRuntimeLogSubscription(ctx, session, id, reads, opts)
+		},
+		Cancel: cancel,
+	}, nil
+}
+
+func runtimeLogSubscriptionOptionsFromParams(params map[string]any) (store.OperatorRuntimeLogListOptions, *time.Time, error) {
+	allowed := map[string]struct{}{
+		"run_id":       {},
+		"entity_id":    {},
+		"component":    {},
+		"level":        {},
+		"error_code":   {},
+		"source":       {},
+		"replay_since": {},
+	}
+	for name := range params {
+		if _, ok := allowed[name]; !ok {
+			return store.OperatorRuntimeLogListOptions{}, nil, NewInvalidParamsError(map[string]any{"field": name, "reason": "unknown parameter"})
+		}
+	}
+	out := store.OperatorRuntimeLogListOptions{}
+	var err error
+	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.Level, _, err = optionalStringParam(params, "level"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.ErrorCode, _, err = optionalStringParam(params, "error_code"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.Source, _, err = optionalStringParam(params, "source"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	replaySince, err := timestampParam(params, "replay_since")
+	if err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	return out, replaySince, nil
 }
 
 func (s *webSocketSession) newSubscriptionContext(prefix string) (string, context.Context, context.CancelFunc) {
@@ -310,6 +376,58 @@ func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, sessio
 			}
 		}
 		cursor = strings.TrimSpace(nextCursor)
+		if cursor == "" {
+			return true
+		}
+	}
+	session.close()
+	return false
+}
+
+func (r *SubscriptionRuntime) runRuntimeLogSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, opts store.OperatorRuntimeLogListOptions) {
+	seen := map[string]string{}
+	if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, seen) {
+		return
+	}
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, seen) {
+				return
+			}
+		}
+	}
+}
+
+func (r *SubscriptionRuntime) emitRuntimeLogNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, opts store.OperatorRuntimeLogListOptions, seen map[string]string) bool {
+	cursor := ""
+	for page := 0; page < subscriptionMaxPages; page++ {
+		query := opts
+		query.Cursor = cursor
+		result, err := reads.ListOperatorRuntimeLogs(ctx, query)
+		if err != nil {
+			session.close()
+			return false
+		}
+		for _, log := range result.Logs {
+			key := strings.TrimSpace(log.LogID)
+			if key == "" {
+				key = subscriptionPayloadFingerprint(log)
+			}
+			fingerprint := subscriptionPayloadFingerprint(log)
+			if seen[key] == fingerprint {
+				continue
+			}
+			seen[key] = fingerprint
+			if !session.notify(subscriptionID, log) {
+				return false
+			}
+		}
+		cursor = strings.TrimSpace(result.NextCursor)
 		if cursor == "" {
 			return true
 		}

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -59,6 +59,11 @@ type subscriptionPlan struct {
 	Cancel context.CancelFunc
 }
 
+type runtimeLogSubscriptionState struct {
+	since *time.Time
+	seen  map[string]string
+}
+
 func OperatorSubscriptions(opts OperatorReadOptions, overrides ...SubscriptionRuntimeOptions) *SubscriptionRuntime {
 	now := opts.Now
 	if now == nil {
@@ -385,8 +390,11 @@ func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, sessio
 }
 
 func (r *SubscriptionRuntime) runRuntimeLogSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, opts store.OperatorRuntimeLogListOptions) {
-	seen := map[string]string{}
-	if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, seen) {
+	state := &runtimeLogSubscriptionState{
+		since: opts.Since,
+		seen:  map[string]string{},
+	}
+	if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, state) {
 		return
 	}
 	ticker := time.NewTicker(r.pollInterval)
@@ -396,17 +404,25 @@ func (r *SubscriptionRuntime) runRuntimeLogSubscription(ctx context.Context, ses
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, seen) {
+			if !r.emitRuntimeLogNotifications(ctx, session, subscriptionID, reads, opts, state) {
 				return
 			}
 		}
 	}
 }
 
-func (r *SubscriptionRuntime) emitRuntimeLogNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, opts store.OperatorRuntimeLogListOptions, seen map[string]string) bool {
+func (r *SubscriptionRuntime) emitRuntimeLogNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, opts store.OperatorRuntimeLogListOptions, state *runtimeLogSubscriptionState) bool {
+	if state == nil {
+		state = &runtimeLogSubscriptionState{}
+	}
+	if state.seen == nil {
+		state.seen = map[string]string{}
+	}
 	cursor := ""
+	var latestDelivered time.Time
 	for page := 0; page < subscriptionMaxPages; page++ {
 		query := opts
+		query.Since = state.since
 		query.Cursor = cursor
 		result, err := reads.ListOperatorRuntimeLogs(ctx, query)
 		if err != nil {
@@ -419,21 +435,47 @@ func (r *SubscriptionRuntime) emitRuntimeLogNotifications(ctx context.Context, s
 				key = subscriptionPayloadFingerprint(log)
 			}
 			fingerprint := subscriptionPayloadFingerprint(log)
-			if seen[key] == fingerprint {
+			if state.seen[key] == fingerprint {
+				latestDelivered = laterRuntimeLogWatermark(latestDelivered, log.TS)
 				continue
 			}
-			seen[key] = fingerprint
+			state.seen[key] = fingerprint
 			if !session.notify(subscriptionID, log) {
 				return false
 			}
+			latestDelivered = laterRuntimeLogWatermark(latestDelivered, log.TS)
 		}
 		cursor = strings.TrimSpace(result.NextCursor)
 		if cursor == "" {
+			advanceRuntimeLogSubscriptionSince(state, latestDelivered)
 			return true
 		}
 	}
 	session.close()
 	return false
+}
+
+func laterRuntimeLogWatermark(current time.Time, candidate time.Time) time.Time {
+	if candidate.IsZero() {
+		return current
+	}
+	candidate = candidate.UTC()
+	if current.IsZero() || candidate.After(current) {
+		return candidate
+	}
+	return current
+}
+
+func advanceRuntimeLogSubscriptionSince(state *runtimeLogSubscriptionState, latest time.Time) {
+	if state == nil || latest.IsZero() {
+		return
+	}
+	next := latest.UTC().Add(-time.Nanosecond)
+	if state.since != nil && !next.After(state.since.UTC()) {
+		return
+	}
+	value := next
+	state.since = &value
 }
 
 func operatorHealthSnapshot(ctx context.Context, ready func() bool, database Pinger, bundle runtimecontracts.BundleIdentity) healthCheckResult {

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -253,6 +253,43 @@ func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
 	}
 }
 
+func TestHandlerWebSocketRuntimeSubscribeLogsOwnerErrorClosesConnection(t *testing.T) {
+	observability := &fakeObservabilityReadStore{runtimeLogsErr: errors.New("runtime logs unavailable")}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Observability: observability,
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-runtime-logs",
+		"method":  "runtime.subscribe_logs",
+		"params":  map[string]any{},
+	})
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer conn.SetReadDeadline(time.Time{})
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return
+	}
+	var subscribe rpcResponse
+	if err := json.Unmarshal(raw, &subscribe); err != nil {
+		t.Fatalf("decode runtime.subscribe_logs response before close: %v raw=%s", err, raw)
+	}
+	if subscribe.Error != nil {
+		t.Fatalf("runtime.subscribe_logs response error = %#v", subscribe.Error)
+	}
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("websocket stayed open after runtime log owner read error, want fail-closed disconnect")
+	}
+}
+
 func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testing.T) {
 	base := time.Unix(1700001200, 0).UTC()
 	missing := &fakeObservabilityReadStore{traceErr: store.ErrRunNotFound}
@@ -315,6 +352,132 @@ func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testi
 	}
 	if observability.lastTrace.Since == nil || !observability.lastTrace.Since.Equal(base) {
 		t.Fatalf("run.subscribe_trace since = %#v, want %s", observability.lastTrace.Since, base)
+	}
+}
+
+func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testing.T) {
+	base := time.Unix(1700001300, 0).UTC()
+	observability := &fakeObservabilityReadStore{
+		logs: []store.OperatorRuntimeLogEntry{
+			{
+				LogID:     "old-log",
+				TS:        base.Add(-time.Second),
+				Level:     "error",
+				Component: "scheduler",
+				Source:    "agent-1",
+				RunID:     "run-1",
+				EntityID:  "entity-1",
+				ErrorCode: "E_OLD",
+				Message:   "old log",
+			},
+			{
+				LogID:     "log-1",
+				TS:        base.Add(time.Second),
+				Level:     "error",
+				Component: "scheduler",
+				Source:    "agent-1",
+				RunID:     "run-1",
+				EntityID:  "entity-1",
+				ErrorCode: "E_RUNTIME",
+				Message:   "runtime failed",
+				Details:   map[string]any{"action": "dispatch"},
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Now:           func() time.Time { return base.Add(10 * time.Second) },
+			Observability: observability,
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-runtime-logs",
+		"method":  "runtime.subscribe_logs",
+		"params": map[string]any{
+			"run_id":       "run-1",
+			"entity_id":    "entity-1",
+			"component":    "scheduler",
+			"level":        "error",
+			"error_code":   "E_RUNTIME",
+			"source":       "agent-1",
+			"replay_since": base.Format(time.RFC3339Nano),
+		},
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("runtime.subscribe_logs error = %#v", subscribe.Error)
+	}
+	subscriptionID := asMap(t, subscribe.Result)["subscription_id"].(string)
+	notification := readWSNotification(t, conn)
+	if notification.Params.Subscription != subscriptionID {
+		t.Fatalf("runtime log notification subscription = %q, want %q", notification.Params.Subscription, subscriptionID)
+	}
+	got := asMap(t, notification.Params.Result)
+	if got["log_id"] != "log-1" || got["message"] != "runtime failed" {
+		t.Fatalf("runtime log notification result = %#v", got)
+	}
+	if observability.lastRuntimeLogs.RunID != "run-1" ||
+		observability.lastRuntimeLogs.EntityID != "entity-1" ||
+		observability.lastRuntimeLogs.Component != "scheduler" ||
+		observability.lastRuntimeLogs.Level != "error" ||
+		observability.lastRuntimeLogs.ErrorCode != "E_RUNTIME" ||
+		observability.lastRuntimeLogs.Source != "agent-1" {
+		t.Fatalf("runtime.subscribe_logs filters = %#v", observability.lastRuntimeLogs)
+	}
+	if observability.lastRuntimeLogs.Since == nil || !observability.lastRuntimeLogs.Since.Equal(base) {
+		t.Fatalf("runtime.subscribe_logs since = %#v, want %s", observability.lastRuntimeLogs.Since, base)
+	}
+	if observability.lastRuntimeLogs.Order != "asc" || observability.lastRuntimeLogs.Limit != subscriptionBatchLimit || observability.lastRuntimeLogs.Cursor != "" {
+		t.Fatalf("runtime.subscribe_logs paging = %#v, want asc limit %d without cursor", observability.lastRuntimeLogs, subscriptionBatchLimit)
+	}
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "unsub-runtime-logs",
+		"method":  "rpc.unsubscribe",
+		"params":  map[string]any{"subscription_id": subscriptionID},
+	})
+	unsubscribe := readWSResponse(t, conn)
+	if unsubscribe.Error != nil || asMap(t, unsubscribe.Result)["ok"] != true {
+		t.Fatalf("rpc.unsubscribe runtime logs response = %#v", unsubscribe)
+	}
+}
+
+func TestRuntimeSubscribeLogsRejectsSnapshotControls(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Observability: &fakeObservabilityReadStore{},
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	for _, field := range []string{"limit", "cursor", "order"} {
+		t.Run(field, func(t *testing.T) {
+			conn := dialTestWS(t, server.URL)
+			defer conn.Close()
+			writeWSRequest(t, conn, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "bad-runtime-logs",
+				"method":  "runtime.subscribe_logs",
+				"params":  map[string]any{field: "bad"},
+			})
+			resp := readWSResponse(t, conn)
+			if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+				t.Fatalf("runtime.subscribe_logs %s response = %#v, want invalid params", field, resp)
+			}
+			if details := asMap(t, asMap(t, resp.Error.Data)["details"]); details["field"] != field {
+				t.Fatalf("runtime.subscribe_logs %s details = %#v", field, details)
+			}
+		})
 	}
 }
 

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -450,6 +450,65 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 	}
 }
 
+func TestRuntimeLogSubscriptionPreservesWatermarkAcrossPolls(t *testing.T) {
+	base := time.Unix(1700001350, 0).UTC()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	session := &webSocketSession{
+		ctx:    ctx,
+		cancel: cancel,
+		out:    make(chan any, 4),
+		subs:   map[string]context.CancelFunc{},
+	}
+	observability := &fakeObservabilityReadStore{
+		logs: []store.OperatorRuntimeLogEntry{
+			{
+				LogID:   "log-1",
+				TS:      base.Add(time.Second),
+				Message: "first",
+			},
+		},
+	}
+	state := &runtimeLogSubscriptionState{since: &base}
+	runtime := &SubscriptionRuntime{}
+	opts := store.OperatorRuntimeLogListOptions{
+		Limit: subscriptionBatchLimit,
+		Order: "asc",
+	}
+
+	if !runtime.emitRuntimeLogNotifications(ctx, session, "sub-runtime-logs", observability, opts, state) {
+		t.Fatal("first runtime log emit returned false")
+	}
+	if observability.lastRuntimeLogs.Since == nil || !observability.lastRuntimeLogs.Since.Equal(base) {
+		t.Fatalf("first runtime log since = %#v, want %s", observability.lastRuntimeLogs.Since, base)
+	}
+	if state.since == nil || !state.since.After(base) {
+		t.Fatalf("runtime log watermark after first poll = %#v, want after %s", state.since, base)
+	}
+
+	observability.logs = append(observability.logs, store.OperatorRuntimeLogEntry{
+		LogID:   "log-2",
+		TS:      base.Add(2 * time.Second),
+		Message: "second",
+	})
+	if !runtime.emitRuntimeLogNotifications(ctx, session, "sub-runtime-logs", observability, opts, state) {
+		t.Fatal("second runtime log emit returned false")
+	}
+	if observability.lastRuntimeLogs.Since == nil || !observability.lastRuntimeLogs.Since.After(base) {
+		t.Fatalf("second runtime log since = %#v, want advanced watermark after %s", observability.lastRuntimeLogs.Since, base)
+	}
+	if got := len(session.out); got != 2 {
+		t.Fatalf("runtime log notifications = %d, want 2 without replaying old log", got)
+	}
+	first := (<-session.out).(rpcSubscriptionNotification)
+	second := (<-session.out).(rpcSubscriptionNotification)
+	firstLog := first.Params.Result.(store.OperatorRuntimeLogEntry)
+	secondLog := second.Params.Result.(store.OperatorRuntimeLogEntry)
+	if firstLog.LogID != "log-1" || secondLog.LogID != "log-2" {
+		t.Fatalf("runtime log notifications = %q then %q, want log-1 then log-2", firstLog.LogID, secondLog.LogID)
+	}
+}
+
 func TestRuntimeSubscribeLogsRejectsSnapshotControls(t *testing.T) {
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},


### PR DESCRIPTION
## Summary

Adds the canonical `/v1/ws` `runtime.subscribe_logs` subscription over the existing persisted `runtime.logs` read owner.

- Adds authoritative `platform-spec.yaml` method contract and regenerates `openrpc.json`.
- Routes `runtime.subscribe_logs` through the existing v1 WebSocket subscription transport.
- Streams `LogEntry` notifications by polling `ObservabilityReadStore.ListOperatorRuntimeLogs` with approved filters plus `replay_since`.
- Rejects snapshot-only controls (`limit`, `cursor`, `order`) for the subscription method.

Closes #765
Part of #748

## Governing Refs / Context

Exact governing spec/context used:

- `platform-spec.yaml` `api_specification.transport.json_rpc_over_websocket`: `/v1/ws`, `rpc.subscription`, and `rpc.unsubscribe`.
- `platform-spec.yaml` subscription conventions: best-effort connection lifetime, `replay_since`, filter parity, unsubscribe/backpressure semantics.
- `platform-spec.yaml` `event.subscribe` and `run.subscribe_trace` as adjacent subscription contracts.
- `platform-spec.yaml` `runtime.logs` and `LogEntry` as the existing persisted runtime-log read model.
- #765 pre-audit and independent gate outcome: approved as first slice.

## Semantic Migration / Ownership

- New canonical owner exposed: `/v1/ws runtime.subscribe_logs`, backed by `ObservabilityReadStore.ListOperatorRuntimeLogs` and the persisted `platform.runtime_log` projection.
- Old/non-authoritative paths invalid: raw process stdout or `/tmp/swarm-empire.log` tailing must not become the API live-log owner.
- Checked surviving production paths: Builder/dashboard log helpers still consume `ListOperatorRuntimeLogs` as adapters/readers; dashboard `/api/runtime/logs` was not reopened as a production route.
- Migration completeness: complete for the #765 API child. CLI `swarm logs --follow`, #363 log quality, and richer CLI-only filters remain split.

## Proof

- `go test ./internal/apiv1 -run 'TestHandlerWebSocketRuntimeSubscribeLogs|TestRuntimeSubscribeLogs|TestWebSocketSessionBackpressureAndUnsubscribeCancelState|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/store -run TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor -count=1`
- `go test ./internal/apispec -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- Grep proof: no `runtime.subscribe_logs` outside spec/OpenRPC/API subscription/tests; no `/tmp/swarm-empire.log` tail usage in `internal/apiv1`; dashboard only registers `GET /healthz` in `NewHandler`.
