### PR TITLE
[agent-b][issue #767] Add conversation turn diagnosis RPC

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -868,6 +868,126 @@
       ]
     },
     {
+      "name": "conversation.get_turn",
+      "description": "Read one deep single-turn diagnosis record for an existing conversation session.\nThis method composes the canonical conversation/session/turn owner with the canonical persisted runtime log owner; clients MUST NOT reconstruct this shape by independently joining conversation.get, runtime.logs, run.trace, or dashboard audit tables.\n",
+      "params": [
+        {
+          "name": "session_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "turn_index",
+          "required": true,
+          "description": "1-based position in the session's canonical turn order, matching the `conversation.get` turns array order (`agent_turns.created_at ASC, turn_id ASC`).",
+          "schema": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "include_logs",
+          "required": false,
+          "schema": {
+            "default": true,
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ConversationTurnDetail"
+        }
+      },
+      "errors": [
+        {
+          "code": -32024,
+          "message": "Application error: SESSION_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "SESSION_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "session_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "session_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32025,
+          "message": "Application error: TURN_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "TURN_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "session_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "turn_index": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "session_id",
+                  "turn_index"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "conversation.list",
       "description": "List conversation summaries (one per session).",
       "params": [
@@ -1331,7 +1451,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -3569,7 +3689,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -4174,6 +4294,13 @@
           }
         },
         {
+          "name": "session_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
           "name": "component",
           "required": false,
           "schema": {
@@ -4199,6 +4326,20 @@
           "required": false,
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "since",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        {
+          "name": "until",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
           }
         },
         {
@@ -4480,7 +4621,7 @@
     },
     {
       "name": "runtime.subscribe_logs",
-      "description": "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry` row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log filter fields as `runtime.logs`, but snapshot pagination and sort controls (`limit`, `cursor`, `order`) are not accepted on the subscription.\n",
+      "description": "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry` row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log identity/content filter fields as `runtime.logs`, but snapshot pagination, sort, and fixed-window controls (`limit`, `cursor`, `order`, `since`, `until`) are not accepted on the subscription. Use `replay_since` for catch-up.\n",
       "params": [
         {
           "name": "run_id",
@@ -4491,6 +4632,13 @@
         },
         {
           "name": "entity_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "session_id",
           "required": false,
           "schema": {
             "$ref": "#/components/schemas/OpaqueId"
@@ -4646,6 +4794,164 @@
         ],
         "type": "object"
       },
+      "ConversationDeepTurn": {
+        "additionalProperties": false,
+        "properties": {
+          "advertised_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "assistant_visible_output": {
+            "type": "string"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "dispatch_metadata": {
+            "$ref": "#/components/schemas/ConversationTurnDispatchMetadata"
+          },
+          "duration_ms": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "emitted_events": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "error": {
+            "type": "string"
+          },
+          "full_prompt_context": {
+            "oneOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "full_prompt_context_v2_reserved": {
+            "const": true,
+            "type": "boolean"
+          },
+          "mcp_tools_listed": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mcp_tools_visible": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "parse_ok": {
+            "type": "boolean"
+          },
+          "progress_updates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "provider_metadata": {
+            "$ref": "#/components/schemas/ConversationTurnProviderMetadata"
+          },
+          "raw_llm_response": {
+            "oneOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "raw_llm_response_v2_reserved": {
+            "const": true,
+            "type": "boolean"
+          },
+          "reasoning_blocks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "request_payload": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "response_payload": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "runtime_log_entries": {
+            "items": {
+              "$ref": "#/components/schemas/LogEntry"
+            },
+            "type": "array"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "tool_calls": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "tool_results": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "turn_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "turn_index": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "turn_index",
+          "turn_id",
+          "started_at",
+          "completed_at",
+          "duration_ms",
+          "parse_ok",
+          "dispatch_metadata",
+          "advertised_tools",
+          "runtime_log_entries",
+          "provider_metadata",
+          "full_prompt_context",
+          "full_prompt_context_v2_reserved",
+          "raw_llm_response",
+          "raw_llm_response_v2_reserved"
+        ],
+        "type": "object"
+      },
       "ConversationDetail": {
         "additionalProperties": false,
         "properties": {
@@ -4714,6 +5020,64 @@
           "turn_count",
           "message_count",
           "status"
+        ],
+        "type": "object"
+      },
+      "ConversationTurnDetail": {
+        "additionalProperties": false,
+        "properties": {
+          "session": {
+            "$ref": "#/components/schemas/ConversationSummary"
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ConversationDeepTurn"
+          },
+          "turn_blocks_raw": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "session",
+          "turn",
+          "turn_blocks_raw"
+        ],
+        "type": "object"
+      },
+      "ConversationTurnDispatchMetadata": {
+        "additionalProperties": false,
+        "properties": {
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "trigger_event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "trigger_event_type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationTurnProviderMetadata": {
+        "additionalProperties": false,
+        "properties": {
+          "latency_ms": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "latency_ms"
         ],
         "type": "object"
       },
@@ -5240,6 +5604,9 @@
             "type": "string"
           },
           "run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "session_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
           "source": {
@@ -7033,8 +7400,51 @@
           "type": "object"
         }
       },
-      "UNSUPPORTED_BUNDLE_REF": {
+      "TURN_NOT_FOUND": {
         "code": -32025,
+        "message": "Application error: TURN_NOT_FOUND",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "TURN_NOT_FOUND",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "session_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                },
+                "turn_index": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "session_id",
+                "turn_index"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "UNSUPPORTED_BUNDLE_REF": {
+        "code": -32026,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6493,6 +6493,154 @@ api_specification:
             minimum: 0
           error:
             type: string
+      ConversationTurnDispatchMetadata:
+        type: object
+        additionalProperties: false
+        properties:
+          trigger_event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          trigger_event_type:
+            type: string
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          task_id:
+            type: string
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+      ConversationTurnProviderMetadata:
+        type: object
+        additionalProperties: false
+        required:
+        - latency_ms
+        properties:
+          latency_ms:
+            type: integer
+            minimum: 0
+      ConversationDeepTurn:
+        type: object
+        additionalProperties: false
+        required:
+        - turn_index
+        - turn_id
+        - started_at
+        - completed_at
+        - duration_ms
+        - parse_ok
+        - dispatch_metadata
+        - advertised_tools
+        - runtime_log_entries
+        - provider_metadata
+        - full_prompt_context
+        - full_prompt_context_v2_reserved
+        - raw_llm_response
+        - raw_llm_response_v2_reserved
+        properties:
+          turn_index:
+            type: integer
+            minimum: 1
+          turn_id:
+            $ref: '#/components/schemas/OpaqueId'
+          scope:
+            type: string
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          completed_at:
+            $ref: '#/components/schemas/Timestamp'
+          duration_ms:
+            type: integer
+            minimum: 0
+          outcome:
+            type: string
+          parse_ok:
+            type: boolean
+          error:
+            type: string
+          retry_count:
+            type: integer
+            minimum: 0
+          dispatch_metadata:
+            $ref: '#/components/schemas/ConversationTurnDispatchMetadata'
+          advertised_tools:
+            type: array
+            items:
+              type: string
+          mcp_tools_listed:
+            type: array
+            items:
+              type: string
+          mcp_tools_visible:
+            type: array
+            items:
+              type: string
+          reasoning_blocks:
+            type: array
+            items:
+              type: string
+          progress_updates:
+            type: array
+            items:
+              type: string
+          tool_calls:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
+          tool_results:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
+          emitted_events:
+            type: array
+            items:
+              type: string
+          runtime_log_entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/LogEntry'
+          provider_metadata:
+            $ref: '#/components/schemas/ConversationTurnProviderMetadata'
+          request_payload:
+            type: object
+            additionalProperties: true
+          response_payload:
+            type: object
+            additionalProperties: true
+          full_prompt_context:
+            oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          full_prompt_context_v2_reserved:
+            type: boolean
+            const: true
+          raw_llm_response:
+            oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+          raw_llm_response_v2_reserved:
+            type: boolean
+            const: true
+          assistant_visible_output:
+            type: string
+      ConversationTurnDetail:
+        type: object
+        additionalProperties: false
+        required:
+        - session
+        - turn
+        - turn_blocks_raw
+        properties:
+          session:
+            $ref: '#/components/schemas/ConversationSummary'
+          turn:
+            $ref: '#/components/schemas/ConversationDeepTurn'
+          turn_blocks_raw:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
       ConversationDetail:
         type: object
         additionalProperties: false
@@ -6537,6 +6685,8 @@ api_specification:
           run_id:
             $ref: '#/components/schemas/OpaqueId'
           entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          session_id:
             $ref: '#/components/schemas/OpaqueId'
           error_code:
             type: string
@@ -7075,6 +7225,18 @@ api_specification:
         properties:
           session_id:
             $ref: '#/components/schemas/OpaqueId'
+      TURN_NOT_FOUND:
+        type: object
+        additionalProperties: false
+        required:
+        - session_id
+        - turn_index
+        properties:
+          session_id:
+            $ref: '#/components/schemas/OpaqueId'
+          turn_index:
+            type: integer
+            minimum: 1
       RUNTIME_ALREADY_PAUSED:
         type: object
         additionalProperties: false
@@ -8185,6 +8347,40 @@ api_specification:
           $ref: '#/components/schemas/ConversationDetail'
       errors:
       - SESSION_NOT_FOUND
+    conversation.get_turn:
+      tier: should_have
+      description: "Read one deep single-turn diagnosis record for an existing conversation session.\nThis method composes\
+        \ the canonical conversation/session/turn owner with the canonical persisted runtime log owner; clients MUST NOT\
+        \ reconstruct this shape by independently joining conversation.get, runtime.logs, run.trace, or dashboard audit tables.\n"
+      scope:
+        required:
+        - read:conversations
+        - read:runtime
+      params:
+      - name: session_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: turn_index
+        required: true
+        description: "1-based position in the session's canonical turn order, matching the `conversation.get` turns array\
+          \ order (`agent_turns.created_at ASC, turn_id ASC`)."
+        schema:
+          type: integer
+          minimum: 1
+      - name: include_logs
+        required: false
+        schema:
+          type: boolean
+          default: true
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationTurnDetail'
+      errors:
+      - SESSION_NOT_FOUND
+      - TURN_NOT_FOUND
     conversation.current_for_agent:
       tier: should_have
       description: "Read the agent's current (most-recent active) session. Replaces the\nownership-violating agent.get_session\
@@ -8222,6 +8418,10 @@ api_specification:
         required: false
         schema:
           $ref: '#/components/schemas/OpaqueId'
+      - name: session_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
       - name: component
         required: false
         schema:
@@ -8238,6 +8438,14 @@ api_specification:
         required: false
         schema:
           type: string
+      - name: since
+        required: false
+        schema:
+          $ref: '#/components/schemas/Timestamp'
+      - name: until
+        required: false
+        schema:
+          $ref: '#/components/schemas/Timestamp'
       - name: limit
         required: false
         schema:
@@ -8277,8 +8485,8 @@ api_specification:
       tier: should_have
       description: "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry`\
         \ row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log\
-        \ filter fields as `runtime.logs`, but snapshot pagination and sort controls (`limit`, `cursor`, `order`) are not\
-        \ accepted on the subscription.\n"
+        \ identity/content filter fields as `runtime.logs`, but snapshot pagination, sort, and fixed-window controls (`limit`,\
+        \ `cursor`, `order`, `since`, `until`) are not accepted on the subscription. Use `replay_since` for catch-up.\n"
       scope:
         required:
         - read:runtime
@@ -8288,6 +8496,10 @@ api_specification:
         schema:
           $ref: '#/components/schemas/OpaqueId'
       - name: entity_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: session_id
         required: false
         schema:
           $ref: '#/components/schemas/OpaqueId'

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,14 +16,14 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 39 {
-		t.Fatalf("method count = %d, want 39", report.MethodCount)
+	if report.MethodCount != 40 {
+		t.Fatalf("method count = %d, want 40", report.MethodCount)
 	}
-	if report.SchemaCount != 53 {
-		t.Fatalf("schema count = %d, want 53", report.SchemaCount)
+	if report.SchemaCount != 57 {
+		t.Fatalf("schema count = %d, want 57", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 26 {
-		t.Fatalf("error code count = %d, want 26", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 27 {
+		t.Fatalf("error code count = %d, want 27", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 14 {
 		t.Fatalf("mutating method count = %d, want 14", report.MutatingMethodCount)
@@ -61,14 +61,14 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 39 {
-		t.Fatalf("generated OpenRPC methods = %d, want 39", len(doc.Methods))
+	if len(doc.Methods) != 40 {
+		t.Fatalf("generated OpenRPC methods = %d, want 40", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 53 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 53", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 57 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 57", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 26 {
-		t.Fatalf("generated OpenRPC errors = %d, want 26", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 27 {
+		t.Fatalf("generated OpenRPC errors = %d, want 27", len(doc.Components.Errors))
 	}
 	methods := map[string]OpenRPCMethod{}
 	for _, method := range doc.Methods {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 39 {
-		t.Fatalf("method count = %d, want 39", len(openRPCNames))
+	if len(openRPCNames) != 40 {
+		t.Fatalf("method count = %d, want 40", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -9,21 +9,25 @@ import (
 )
 
 type fakeAgentConversationReadStore struct {
-	listAgentsResult           store.OperatorAgentListResult
-	listAgentsErr              error
-	agentResult                store.OperatorAgentDetail
-	agentErr                   error
-	listConversationsResult    store.OperatorConversationListResult
-	listConversationsErr       error
-	conversationResult         store.OperatorConversationDetail
-	conversationErr            error
-	currentConversationResult  *store.OperatorConversationDetail
-	currentConversationErr     error
-	lastAgentList              store.OperatorAgentListOptions
-	lastConversationList       store.OperatorConversationListOptions
-	lastAgentID                string
-	lastConversationSessionID  string
-	lastCurrentConversationFor string
+	listAgentsResult              store.OperatorAgentListResult
+	listAgentsErr                 error
+	agentResult                   store.OperatorAgentDetail
+	agentErr                      error
+	listConversationsResult       store.OperatorConversationListResult
+	listConversationsErr          error
+	conversationResult            store.OperatorConversationDetail
+	conversationErr               error
+	conversationTurnResult        store.OperatorConversationTurnDetail
+	conversationTurnErr           error
+	currentConversationResult     *store.OperatorConversationDetail
+	currentConversationErr        error
+	lastAgentList                 store.OperatorAgentListOptions
+	lastConversationList          store.OperatorConversationListOptions
+	lastAgentID                   string
+	lastConversationSessionID     string
+	lastConversationTurnSessionID string
+	lastConversationTurnIndex     int
+	lastCurrentConversationFor    string
 }
 
 func (s *fakeAgentConversationReadStore) ListOperatorAgents(_ context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error) {
@@ -44,6 +48,12 @@ func (s *fakeAgentConversationReadStore) ListOperatorConversations(_ context.Con
 func (s *fakeAgentConversationReadStore) LoadOperatorConversation(_ context.Context, sessionID string) (store.OperatorConversationDetail, error) {
 	s.lastConversationSessionID = sessionID
 	return s.conversationResult, s.conversationErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorConversationTurn(_ context.Context, sessionID string, turnIndex int) (store.OperatorConversationTurnDetail, error) {
+	s.lastConversationTurnSessionID = sessionID
+	s.lastConversationTurnIndex = turnIndex
+	return s.conversationTurnResult, s.conversationTurnErr
 }
 
 func (s *fakeAgentConversationReadStore) LoadCurrentOperatorConversationForAgent(_ context.Context, agentID string) (*store.OperatorConversationDetail, error) {
@@ -79,6 +89,22 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		conversationResult: store.OperatorConversationDetail{
 			Conversation: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", StartedAt: now, Status: "active"},
 			Turns:        []store.OperatorConversationTurn{{TurnID: "turn-1", TriggerEventID: "evt-1", TriggerEventType: "task.started", ParseOK: true}},
+		},
+		conversationTurnResult: store.OperatorConversationTurnDetail{
+			Session: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", StartedAt: now, Status: "active"},
+			Turn: store.OperatorConversationDeepTurn{
+				TurnIndex:                   1,
+				TurnID:                      "turn-1",
+				StartedAt:                   now,
+				CompletedAt:                 now.Add(time.Second),
+				ParseOK:                     true,
+				AdvertisedTools:             []string{},
+				RuntimeLogEntries:           []store.OperatorRuntimeLogEntry{},
+				FullPromptContextV2Reserved: true,
+				RawLLMResponseV2Reserved:    true,
+			},
+			RuntimeLogWindowStart: now,
+			RuntimeLogWindowEnd:   ptrTime(now.Add(time.Second)),
 		},
 		currentConversationResult: &store.OperatorConversationDetail{
 			Conversation: store.OperatorConversationSummary{SessionID: "sess-current", AgentID: "agent-1", StartedAt: now, Status: "active"},
@@ -123,6 +149,14 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		t.Fatalf("conversation.get session = %q", reads.lastConversationSessionID)
 	}
 
+	getTurn := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"sess-1","turn_index":1,"include_logs":false}}`)
+	if getTurn.Error != nil {
+		t.Fatalf("conversation.get_turn error = %#v", getTurn.Error)
+	}
+	if reads.lastConversationTurnSessionID != "sess-1" || reads.lastConversationTurnIndex != 1 {
+		t.Fatalf("conversation.get_turn owner args = %q/%d", reads.lastConversationTurnSessionID, reads.lastConversationTurnIndex)
+	}
+
 	current := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"current","method":"conversation.current_for_agent","params":{"agent_id":"agent-1"}}`)
 	if current.Error != nil {
 		t.Fatalf("conversation.current_for_agent error = %#v", current.Error)
@@ -130,6 +164,72 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if reads.lastCurrentConversationFor != "agent-1" {
 		t.Fatalf("current_for_agent id = %q", reads.lastCurrentConversationFor)
 	}
+}
+
+func TestOperatorConversationGetTurnComposesRuntimeLogOwner(t *testing.T) {
+	start := time.Unix(1700000100, 0).UTC()
+	end := start.Add(2 * time.Second)
+	reads := &fakeAgentConversationReadStore{
+		conversationTurnResult: store.OperatorConversationTurnDetail{
+			Session: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", RunID: "run-1", StartedAt: start, Status: "terminated"},
+			Turn: store.OperatorConversationDeepTurn{
+				TurnIndex:                   2,
+				TurnID:                      "turn-2",
+				StartedAt:                   start,
+				CompletedAt:                 end,
+				ParseOK:                     true,
+				AdvertisedTools:             []string{"emit_done"},
+				RuntimeLogEntries:           []store.OperatorRuntimeLogEntry{},
+				FullPromptContextV2Reserved: true,
+				RawLLMResponseV2Reserved:    true,
+			},
+			RuntimeLogWindowStart: start,
+			RuntimeLogWindowEnd:   &end,
+		},
+	}
+	observability := &fakeObservabilityReadStore{logs: []store.OperatorRuntimeLogEntry{{
+		LogID:     "log-1",
+		TS:        start.Add(time.Second),
+		Level:     "error",
+		Component: "agent",
+		Source:    "agent-1",
+		SessionID: "sess-1",
+		Message:   "turn failed",
+	}}}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+			Observability:      observability,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"sess-1","turn_index":2}}`)
+	if resp.Error != nil {
+		t.Fatalf("conversation.get_turn error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	turn := asMap(t, result["turn"])
+	logs, _ := turn["runtime_log_entries"].([]any)
+	if len(logs) != 1 || asMap(t, logs[0])["log_id"] != "log-1" {
+		t.Fatalf("runtime_log_entries = %#v", turn["runtime_log_entries"])
+	}
+	if observability.lastRuntimeLogs.SessionID != "sess-1" {
+		t.Fatalf("runtime log session filter = %#v", observability.lastRuntimeLogs)
+	}
+	if observability.lastRuntimeLogs.Since == nil || !observability.lastRuntimeLogs.Since.Equal(start) {
+		t.Fatalf("runtime log since = %#v, want %s", observability.lastRuntimeLogs.Since, start)
+	}
+	if observability.lastRuntimeLogs.Until == nil || !observability.lastRuntimeLogs.Until.Equal(end) {
+		t.Fatalf("runtime log until = %#v, want %s", observability.lastRuntimeLogs.Until, end)
+	}
+	if observability.lastRuntimeLogs.Order != "asc" || observability.lastRuntimeLogs.Limit != 1000 {
+		t.Fatalf("runtime log options = %#v", observability.lastRuntimeLogs)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
 }
 
 func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
@@ -153,6 +253,20 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 			body:    `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"missing"}}`,
 			reads:   &fakeAgentConversationReadStore{conversationErr: store.ErrSessionNotFound},
 			wantApp: SessionNotFoundCode,
+		},
+		{
+			name:    "conversation turn missing session",
+			method:  "conversation.get_turn",
+			body:    `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"missing","turn_index":1,"include_logs":false}}`,
+			reads:   &fakeAgentConversationReadStore{conversationTurnErr: store.ErrSessionNotFound},
+			wantApp: SessionNotFoundCode,
+		},
+		{
+			name:    "conversation turn missing turn",
+			method:  "conversation.get_turn",
+			body:    `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"sess-1","turn_index":99,"include_logs":false}}`,
+			reads:   &fakeAgentConversationReadStore{conversationTurnErr: store.ErrTurnNotFound},
+			wantApp: TurnNotFoundCode,
 		},
 		{
 			name:    "current unknown agent",

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -43,6 +43,7 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 			Source:    "runtime",
 			RunID:     "run-1",
 			ErrorCode: "retry_exhausted",
+			SessionID: "sess-1",
 			Message:   "retry exhausted",
 			Details:   map[string]any{"action": "dispatch"},
 		}},
@@ -92,15 +93,22 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		t.Fatalf("event.get event_id = %#v", got)
 	}
 
-	logs := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":"run-1","component":"scheduler","level":"warn","limit":5}}`)
+	logs := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":"run-1","session_id":"sess-1","component":"scheduler","level":"warn","since":"2023-11-14T22:12:00Z","until":"2023-11-14T22:14:00Z","limit":5}}`)
 	if logs.Error != nil {
 		t.Fatalf("runtime.logs error = %#v", logs.Error)
 	}
 	if rows, _ := asMap(t, logs.Result)["logs"].([]any); len(rows) != 1 {
 		t.Fatalf("runtime.logs rows = %#v", asMap(t, logs.Result)["logs"])
 	}
-	if observability.lastRuntimeLogs.RunID != "run-1" || observability.lastRuntimeLogs.Component != "scheduler" {
+	if observability.lastRuntimeLogs.RunID != "run-1" || observability.lastRuntimeLogs.SessionID != "sess-1" || observability.lastRuntimeLogs.Component != "scheduler" {
 		t.Fatalf("runtime.logs options = %#v", observability.lastRuntimeLogs)
+	}
+	if observability.lastRuntimeLogs.Since == nil || observability.lastRuntimeLogs.Until == nil {
+		t.Fatalf("runtime.logs time window missing: %#v", observability.lastRuntimeLogs)
+	}
+	invalidWindow := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs-window","method":"runtime.logs","params":{"since":"2023-11-14T22:14:00Z","until":"2023-11-14T22:12:00Z"}}`)
+	if invalidWindow.Error == nil || invalidWindow.Error.Code != codeInvalidParams {
+		t.Fatalf("runtime.logs invalid window error = %#v, want invalid params", invalidWindow.Error)
 	}
 
 	incidents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"incidents","method":"runtime.incidents","params":{"since_hours":24,"component":"scheduler","limit":5}}`)
@@ -234,6 +242,9 @@ func (s *fakeObservabilityReadStore) ListOperatorRuntimeLogs(_ context.Context, 
 		if opts.EntityID != "" && log.EntityID != opts.EntityID {
 			continue
 		}
+		if opts.SessionID != "" && log.SessionID != opts.SessionID {
+			continue
+		}
 		if opts.Component != "" && log.Component != opts.Component {
 			continue
 		}
@@ -244,6 +255,9 @@ func (s *fakeObservabilityReadStore) ListOperatorRuntimeLogs(_ context.Context, 
 			continue
 		}
 		if opts.Source != "" && log.Source != opts.Source {
+			continue
+		}
+		if opts.Until != nil && log.TS.After(opts.Until.UTC()) {
 			continue
 		}
 		out = append(out, log)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -42,6 +42,7 @@ type AgentConversationReadStore interface {
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
+	LoadOperatorConversationTurn(context.Context, string, int) (store.OperatorConversationTurnDetail, error)
 	LoadCurrentOperatorConversationForAgent(context.Context, string) (*store.OperatorConversationDetail, error)
 }
 
@@ -325,6 +326,59 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			}
 			if err != nil {
 				return nil, err
+			}
+			return result, nil
+		},
+		"conversation.get_turn": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			sessionID, err := requiredStringParam(req.Params, "session_id")
+			if err != nil {
+				return nil, err
+			}
+			turnIndex, err := requiredBoundedIntegerParam(req.Params, "turn_index", 1, 1000000)
+			if err != nil {
+				return nil, err
+			}
+			includeLogs, err := optionalBoolParam(req.Params, "include_logs", true)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorConversationTurn(ctx, sessionID, turnIndex)
+			if errors.Is(err, store.ErrSessionNotFound) {
+				return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
+			}
+			if errors.Is(err, store.ErrTurnNotFound) {
+				return nil, NewApplicationError(TurnNotFoundCode, false, map[string]any{"session_id": sessionID, "turn_index": turnIndex})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if includeLogs {
+				observability, err := requireObservabilityReadStore(opts.Observability)
+				if err != nil {
+					return nil, err
+				}
+				logOpts := store.OperatorRuntimeLogListOptions{
+					SessionID: result.Session.SessionID,
+					Since:     &result.RuntimeLogWindowStart,
+					Until:     result.RuntimeLogWindowEnd,
+					Limit:     1000,
+					Order:     "asc",
+				}
+				logs, err := observability.ListOperatorRuntimeLogs(ctx, logOpts)
+				if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+					return nil, NewInvalidParamsError(map[string]any{"field": "runtime_log_entries", "reason": "invalid runtime log cursor"})
+				}
+				if err != nil {
+					return nil, err
+				}
+				if logs.Logs == nil {
+					logs.Logs = []store.OperatorRuntimeLogEntry{}
+				}
+				result.Turn.RuntimeLogEntries = logs.Logs
 			}
 			return result, nil
 		},
@@ -737,6 +791,9 @@ func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.Opera
 	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
 	}
+	if out.SessionID, _, err = optionalStringParam(params, "session_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
 	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
 	}
@@ -754,6 +811,15 @@ func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.Opera
 	}
 	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Since, err = timestampParam(params, "since"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Until, err = timestampParam(params, "until"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
+	if out.Since != nil && out.Until != nil && out.Since.After(*out.Until) {
+		return store.OperatorRuntimeLogListOptions{}, NewInvalidParamsError(map[string]any{"field": "until", "reason": "must be at or after since"})
 	}
 	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 1000); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
@@ -865,6 +931,21 @@ func requiredStringParam(params map[string]any, name string) (string, error) {
 	return value, nil
 }
 
+func optionalBoolParam(params map[string]any, name string, defaultValue bool) (bool, error) {
+	if params == nil {
+		return defaultValue, nil
+	}
+	value, ok := params[name]
+	if !ok || isEmptyParam(value) {
+		return defaultValue, nil
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false, NewInvalidParamsError(map[string]any{"field": name, "reason": "must be a boolean"})
+	}
+	return boolValue, nil
+}
+
 func stringParam(params map[string]any, name string) string {
 	if params == nil {
 		return ""
@@ -887,6 +968,24 @@ func integerParam(value any) (int, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func requiredBoundedIntegerParam(params map[string]any, name string, minValue, maxValue int) (int, error) {
+	if params == nil {
+		return 0, NewInvalidParamsError(map[string]any{"field": name, "reason": "is required"})
+	}
+	raw, ok := params[name]
+	if !ok || isEmptyParam(raw) {
+		return 0, NewInvalidParamsError(map[string]any{"field": name, "reason": "is required"})
+	}
+	value, ok := integerParam(raw)
+	if !ok || value < minValue || value > maxValue {
+		return 0, NewInvalidParamsError(map[string]any{
+			"field":  name,
+			"reason": fmt.Sprintf("must be an integer from %d to %d", minValue, maxValue),
+		})
+	}
+	return value, nil
 }
 
 func boundedIntegerParam(params map[string]any, name string, minValue, maxValue int) (int, error) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -24,6 +24,7 @@ const (
 	AgentNotFoundCode                    = "AGENT_NOT_FOUND"
 	AgentNotRunningCode                  = "AGENT_NOT_RUNNING"
 	SessionNotFoundCode                  = "SESSION_NOT_FOUND"
+	TurnNotFoundCode                     = "TURN_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -219,6 +219,7 @@ func runtimeLogSubscriptionOptionsFromParams(params map[string]any) (store.Opera
 	allowed := map[string]struct{}{
 		"run_id":       {},
 		"entity_id":    {},
+		"session_id":   {},
 		"component":    {},
 		"level":        {},
 		"error_code":   {},
@@ -236,6 +237,9 @@ func runtimeLogSubscriptionOptionsFromParams(params map[string]any) (store.Opera
 		return store.OperatorRuntimeLogListOptions{}, nil, err
 	}
 	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.SessionID, _, err = optionalStringParam(params, "session_id"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, nil, err
 	}
 	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -367,6 +367,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 				Source:    "agent-1",
 				RunID:     "run-1",
 				EntityID:  "entity-1",
+				SessionID: "sess-1",
 				ErrorCode: "E_OLD",
 				Message:   "old log",
 			},
@@ -378,6 +379,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 				Source:    "agent-1",
 				RunID:     "run-1",
 				EntityID:  "entity-1",
+				SessionID: "sess-1",
 				ErrorCode: "E_RUNTIME",
 				Message:   "runtime failed",
 				Details:   map[string]any{"action": "dispatch"},
@@ -403,6 +405,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 		"params": map[string]any{
 			"run_id":       "run-1",
 			"entity_id":    "entity-1",
+			"session_id":   "sess-1",
 			"component":    "scheduler",
 			"level":        "error",
 			"error_code":   "E_RUNTIME",
@@ -425,6 +428,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 	}
 	if observability.lastRuntimeLogs.RunID != "run-1" ||
 		observability.lastRuntimeLogs.EntityID != "entity-1" ||
+		observability.lastRuntimeLogs.SessionID != "sess-1" ||
 		observability.lastRuntimeLogs.Component != "scheduler" ||
 		observability.lastRuntimeLogs.Level != "error" ||
 		observability.lastRuntimeLogs.ErrorCode != "E_RUNTIME" ||
@@ -519,7 +523,7 @@ func TestRuntimeSubscribeLogsRejectsSnapshotControls(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	for _, field := range []string{"limit", "cursor", "order"} {
+	for _, field := range []string{"limit", "cursor", "order", "since", "until"} {
 		t.Run(field, func(t *testing.T) {
 			conn := dialTestWS(t, server.URL)
 			defer conn.Close()

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -312,7 +312,7 @@ func dashboardRuntimeLogRecord(log store.OperatorRuntimeLogEntry) runtimeLogReco
 		ErrorCode:     log.ErrorCode,
 		AgentID:       readString(details["agent_id"]),
 		EntityID:      log.EntityID,
-		SessionID:     readString(details["session_id"]),
+		SessionID:     firstString(log.SessionID, readString(details["session_id"])),
 		DurationUS:    readInt(details["duration_us"]),
 		Source:        log.Source,
 		Message:       log.Message,

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -18,6 +18,8 @@ var ErrAgentNotFound = errors.New("store: agent not found")
 
 var ErrSessionNotFound = errors.New("store: session not found")
 
+var ErrTurnNotFound = errors.New("store: turn not found")
+
 var ErrAmbiguousEntityRunID = errors.New("store: ambiguous entity run_id")
 
 var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -183,6 +183,113 @@ type OperatorConversationDetail struct {
 	RuntimeState OperatorConversationState     `json:"-"`
 }
 
+type OperatorConversationTurnDetail struct {
+	Session               OperatorConversationSummary     `json:"session"`
+	Turn                  OperatorConversationDeepTurn    `json:"turn"`
+	TurnBlocksRaw         []OperatorConversationTurnBlock `json:"turn_blocks_raw"`
+	RuntimeLogWindowStart time.Time                       `json:"-"`
+	RuntimeLogWindowEnd   *time.Time                      `json:"-"`
+}
+
+type OperatorConversationDeepTurn struct {
+	TurnIndex                   int                                  `json:"turn_index"`
+	TurnID                      string                               `json:"turn_id"`
+	Scope                       string                               `json:"scope,omitempty"`
+	StartedAt                   time.Time                            `json:"started_at"`
+	CompletedAt                 time.Time                            `json:"completed_at"`
+	DurationMS                  int                                  `json:"duration_ms"`
+	Outcome                     string                               `json:"outcome,omitempty"`
+	ParseOK                     bool                                 `json:"parse_ok"`
+	Error                       string                               `json:"error,omitempty"`
+	RetryCount                  int                                  `json:"retry_count,omitempty"`
+	DispatchMetadata            OperatorConversationDispatchMetadata `json:"dispatch_metadata"`
+	AdvertisedTools             []string                             `json:"advertised_tools"`
+	MCPToolsListed              []string                             `json:"mcp_tools_listed,omitempty"`
+	MCPToolsVisible             []string                             `json:"mcp_tools_visible,omitempty"`
+	ReasoningBlocks             []string                             `json:"reasoning_blocks,omitempty"`
+	ProgressUpdates             []string                             `json:"progress_updates,omitempty"`
+	ToolCalls                   []OperatorConversationToolCall       `json:"tool_calls,omitempty"`
+	ToolResults                 []OperatorConversationToolResult     `json:"tool_results,omitempty"`
+	EmittedEvents               []string                             `json:"emitted_events,omitempty"`
+	RuntimeLogEntries           []OperatorRuntimeLogEntry            `json:"runtime_log_entries"`
+	ProviderMetadata            OperatorConversationProviderMetadata `json:"provider_metadata"`
+	RequestPayload              json.RawMessage                      `json:"request_payload,omitempty"`
+	ResponsePayload             json.RawMessage                      `json:"response_payload,omitempty"`
+	FullPromptContext           any                                  `json:"full_prompt_context"`
+	FullPromptContextV2Reserved bool                                 `json:"full_prompt_context_v2_reserved"`
+	RawLLMResponse              any                                  `json:"raw_llm_response"`
+	RawLLMResponseV2Reserved    bool                                 `json:"raw_llm_response_v2_reserved"`
+	AssistantVisibleOutput      string                               `json:"assistant_visible_output,omitempty"`
+}
+
+type OperatorConversationDispatchMetadata struct {
+	TriggerEventID   string `json:"trigger_event_id,omitempty"`
+	TriggerEventType string `json:"trigger_event_type,omitempty"`
+	EntityID         string `json:"entity_id,omitempty"`
+	TaskID           string `json:"task_id,omitempty"`
+	RunID            string `json:"run_id,omitempty"`
+}
+
+type OperatorConversationProviderMetadata struct {
+	LatencyMS int `json:"latency_ms"`
+}
+
+func cloneStrings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneRawMessage(in json.RawMessage) json.RawMessage {
+	if in == nil {
+		return nil
+	}
+	out := make(json.RawMessage, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneConversationToolCalls(in []OperatorConversationToolCall) []OperatorConversationToolCall {
+	if in == nil {
+		return nil
+	}
+	out := make([]OperatorConversationToolCall, len(in))
+	for i, item := range in {
+		out[i] = item
+		out[i].Arguments = cloneRawMessage(item.Arguments)
+	}
+	return out
+}
+
+func cloneConversationToolResults(in []OperatorConversationToolResult) []OperatorConversationToolResult {
+	if in == nil {
+		return nil
+	}
+	out := make([]OperatorConversationToolResult, len(in))
+	for i, item := range in {
+		out[i] = item
+		out[i].Output = cloneRawMessage(item.Output)
+	}
+	return out
+}
+
+func cloneConversationTurnBlocks(in []OperatorConversationTurnBlock) []OperatorConversationTurnBlock {
+	if in == nil {
+		return nil
+	}
+	out := make([]OperatorConversationTurnBlock, len(in))
+	for i, item := range in {
+		out[i] = item
+		out[i].Input = cloneRawMessage(item.Input)
+		out[i].Output = cloneRawMessage(item.Output)
+		out[i].Data = cloneRawMessage(item.Data)
+	}
+	return out
+}
+
 type OperatorConversationMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
@@ -311,6 +418,10 @@ func (s *PostgresStore) ListOperatorConversations(ctx context.Context, opts Oper
 
 func (s *PostgresStore) LoadOperatorConversation(ctx context.Context, sessionID string) (OperatorConversationDetail, error) {
 	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorConversation(ctx, sessionID)
+}
+
+func (s *PostgresStore) LoadOperatorConversationTurn(ctx context.Context, sessionID string, turnIndex int) (OperatorConversationTurnDetail, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorConversationTurn(ctx, sessionID, turnIndex)
 }
 
 func (s *PostgresStore) LoadCurrentOperatorConversationForAgent(ctx context.Context, agentID string) (*OperatorConversationDetail, error) {
@@ -551,6 +662,73 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorConversation(ctx cont
 		item.Turns = []OperatorConversationTurn{}
 	}
 	return item, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorConversationTurn(ctx context.Context, sessionID string, turnIndex int) (OperatorConversationTurnDetail, error) {
+	if turnIndex < 1 {
+		return OperatorConversationTurnDetail{}, ErrTurnNotFound
+	}
+	detail, err := r.LoadOperatorConversation(ctx, sessionID)
+	if err != nil {
+		return OperatorConversationTurnDetail{}, err
+	}
+	if turnIndex > len(detail.Turns) {
+		return OperatorConversationTurnDetail{}, ErrTurnNotFound
+	}
+	selected := detail.Turns[turnIndex-1]
+	completedAt := selected.CreatedAt.UTC()
+	startedAt := completedAt
+	if selected.LatencyMS > 0 {
+		startedAt = completedAt.Add(-time.Duration(selected.LatencyMS) * time.Millisecond)
+	}
+	windowStart := startedAt.Add(-time.Nanosecond)
+	windowEnd := completedAt
+	out := OperatorConversationTurnDetail{
+		Session:               detail.Conversation,
+		TurnBlocksRaw:         cloneConversationTurnBlocks(selected.TurnBlocks),
+		RuntimeLogWindowStart: windowStart,
+		RuntimeLogWindowEnd:   &windowEnd,
+		Turn: OperatorConversationDeepTurn{
+			TurnIndex:   turnIndex,
+			TurnID:      selected.TurnID,
+			Scope:       selected.ScopeKey,
+			StartedAt:   startedAt,
+			CompletedAt: completedAt,
+			DurationMS:  selected.LatencyMS,
+			Outcome:     selected.Outcome,
+			ParseOK:     selected.ParseOK,
+			Error:       selected.Error,
+			RetryCount:  selected.RetryCount,
+			DispatchMetadata: OperatorConversationDispatchMetadata{
+				TriggerEventID:   selected.TriggerEventID,
+				TriggerEventType: selected.TriggerEventType,
+				EntityID:         selected.EntityID,
+				TaskID:           selected.TaskID,
+				RunID:            detail.Conversation.RunID,
+			},
+			AdvertisedTools:             cloneStrings(selected.AvailableTools),
+			MCPToolsListed:              cloneStrings(selected.MCPToolsListed),
+			MCPToolsVisible:             cloneStrings(selected.MCPToolsVisible),
+			ReasoningBlocks:             cloneStrings(selected.ReasoningBlocks),
+			ProgressUpdates:             cloneStrings(selected.ProgressUpdates),
+			ToolCalls:                   cloneConversationToolCalls(selected.ToolCalls),
+			ToolResults:                 cloneConversationToolResults(selected.ToolResults),
+			EmittedEvents:               cloneStrings(selected.EmittedEvents),
+			RuntimeLogEntries:           []OperatorRuntimeLogEntry{},
+			ProviderMetadata:            OperatorConversationProviderMetadata{LatencyMS: selected.LatencyMS},
+			RequestPayload:              cloneRawMessage(selected.RequestPayload),
+			ResponsePayload:             cloneRawMessage(selected.ResponsePayload),
+			FullPromptContext:           nil,
+			FullPromptContextV2Reserved: true,
+			RawLLMResponse:              nil,
+			RawLLMResponseV2Reserved:    true,
+			AssistantVisibleOutput:      selected.AssistantVisibleOutput,
+		},
+	}
+	if out.Turn.AdvertisedTools == nil {
+		out.Turn.AdvertisedTools = []string{}
+	}
+	return out, nil
 }
 
 func (r *OperatorAgentConversationReadSurface) ListDashboardOperatorConversations(ctx context.Context, limit int) ([]OperatorConversationSummary, error) {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -255,6 +256,94 @@ func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveL
 	}
 	if detail != nil {
 		t.Fatalf("expected nil current conversation without active live session, got %+v", detail)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorConversationReadSurfaceLoadTurnComposesConversationOwner(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	runID := "33333333-3333-3333-3333-333333333333"
+	firstTurnID := "44444444-4444-4444-4444-444444444444"
+	secondTurnID := "55555555-5555-5555-5555-555555555555"
+	startedAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	firstCompletedAt := startedAt.Add(time.Second)
+	secondCompletedAt := startedAt.Add(5 * time.Second)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+session_id,\\s+agent_id,.*FROM \\(.*\\) conversations\\s+WHERE session_id = \\$1").
+		WithArgs(sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
+			AddRow(sessionID, "agent-1", runID, "live_session", "global", "global", "session", "terminated", 2, 4, []byte(`{"summary":"active session"}`), []byte(`[{"role":"assistant","content":"ready"}]`), startedAt, secondCompletedAt, secondCompletedAt))
+	mock.ExpectQuery("(?s)SELECT\\s+turn_id::text,.*FROM agent_turns.*ORDER BY created_at ASC, turn_id ASC").
+		WithArgs("agent-1", sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationTurnColumns()).
+			AddRow(firstTurnID, "agent-1", sessionID, "session", "global", "", "", "", "task-1", []byte(`["emit_done"]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`), []byte(`{"first":true}`), []byte(`{"ok":true}`), []byte(`[]`), true, 1000, 0, "", firstCompletedAt).
+			AddRow(secondTurnID, "agent-1", sessionID, "session", "global", "", "66666666-6666-6666-6666-666666666666", "input.received", "task-2", []byte(`["emit_done","read_state"]`), []byte(`[{"name":"read_state","arguments":{"id":"entity-1"}}]`), []byte(`["task.completed"]`), []byte(`{}`), []byte(`["read_state"]`), []byte(`["read_state"]`), []byte(`{"turn":2}`), []byte(`{"ok":true}`), []byte(`[{"kind":"assistant","text":"done"}]`), true, 1500, 1, "", secondCompletedAt))
+
+	result, err := reader.LoadOperatorConversationTurn(context.Background(), sessionID, 2)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversationTurn: %v", err)
+	}
+	if result.Session.SessionID != sessionID || result.Session.RunID != runID {
+		t.Fatalf("session = %#v", result.Session)
+	}
+	wantStarted := secondCompletedAt.Add(-1500 * time.Millisecond)
+	if result.Turn.TurnIndex != 2 || result.Turn.TurnID != secondTurnID || !result.Turn.StartedAt.Equal(wantStarted) || !result.Turn.CompletedAt.Equal(secondCompletedAt) {
+		t.Fatalf("turn timing/id = %#v", result.Turn)
+	}
+	if !result.RuntimeLogWindowStart.Equal(wantStarted.Add(-time.Nanosecond)) || result.RuntimeLogWindowEnd == nil || !result.RuntimeLogWindowEnd.Equal(secondCompletedAt) {
+		t.Fatalf("runtime log window start=%s end=%v", result.RuntimeLogWindowStart, result.RuntimeLogWindowEnd)
+	}
+	if result.Turn.DispatchMetadata.TaskID != "task-2" || result.Turn.DispatchMetadata.RunID != runID || result.Turn.DispatchMetadata.TriggerEventType != "input.received" {
+		t.Fatalf("dispatch metadata = %#v", result.Turn.DispatchMetadata)
+	}
+	if len(result.Turn.AdvertisedTools) != 2 || result.Turn.AdvertisedTools[1] != "read_state" {
+		t.Fatalf("advertised tools = %#v", result.Turn.AdvertisedTools)
+	}
+	if len(result.TurnBlocksRaw) != 1 || result.TurnBlocksRaw[0].Text != "done" {
+		t.Fatalf("turn_blocks_raw = %#v", result.TurnBlocksRaw)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorConversationReadSurfaceLoadTurnOutOfRange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	now := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+session_id,\\s+agent_id,.*FROM \\(.*\\) conversations\\s+WHERE session_id = \\$1").
+		WithArgs(sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
+			AddRow(sessionID, "agent-1", "", "live_session", "global", "global", "session", "active", 0, 0, []byte(`{}`), []byte(`[]`), now, nil, now))
+	mock.ExpectQuery("(?s)SELECT\\s+turn_id::text,.*FROM agent_turns.*ORDER BY created_at ASC, turn_id ASC").
+		WithArgs("agent-1", sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationTurnColumns()))
+
+	_, err = reader.LoadOperatorConversationTurn(context.Background(), sessionID, 1)
+	if !errors.Is(err, ErrTurnNotFound) {
+		t.Fatalf("LoadOperatorConversationTurn missing turn err = %v, want ErrTurnNotFound", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -78,12 +78,14 @@ type OperatorDeadLetterRecord struct {
 type OperatorRuntimeLogListOptions struct {
 	RunID             string
 	EntityID          string
+	SessionID         string
 	Component         string
 	Level             string
 	ErrorCode         string
 	Source            string
 	ActionOrEventType string
 	Since             *time.Time
+	Until             *time.Time
 	Limit             int
 	Cursor            string
 	Order             string
@@ -102,6 +104,7 @@ type OperatorRuntimeLogEntry struct {
 	Source    string         `json:"source"`
 	RunID     string         `json:"run_id,omitempty"`
 	EntityID  string         `json:"entity_id,omitempty"`
+	SessionID string         `json:"session_id,omitempty"`
 	ErrorCode string         `json:"error_code,omitempty"`
 	Message   string         `json:"message"`
 	Details   map[string]any `json:"details,omitempty"`
@@ -457,10 +460,14 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 	}
 	opts = defaultOperatorRuntimeLogListOptions(opts)
 	cursorClause := ""
-	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType}
+	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType, opts.SessionID}
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
 		cursorClause += fmt.Sprintf(" AND e.created_at > $%d", len(args))
+	}
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		cursorClause += fmt.Sprintf(" AND e.created_at <= $%d", len(args))
 	}
 	if opts.Cursor != "" {
 		cursor, err := decodeObservabilityPositionCursor(opts.Cursor, "runtime.logs")
@@ -505,6 +512,7 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 		  AND ($5 = '' OR COALESCE(e.payload->'details'->>'error_code', '') = $5)
 		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'agent_id', e.produced_by, '') = $6)
 		  AND ($7 = '' OR COALESCE(e.payload->'details'->>'action', '') = $7 OR COALESCE(e.payload->'details'->>'event_name', e.payload->'details'->>'event_type', '') = $7)
+		  AND ($8 = '' OR COALESCE(e.payload->'details'->>'session_id', '') = $8)
 		  %s
 		ORDER BY e.created_at %s, e.event_id::text %s
 		LIMIT $%d
@@ -715,6 +723,7 @@ func operatorRuntimeLogEntry(eventID, runID, rowEntityID, producedBy string, cre
 		Source:    firstNonEmptyStore(payload.AgentID, producedBy, "runtime"),
 		RunID:     strings.TrimSpace(runID),
 		EntityID:  firstNonEmptyStore(payload.EntityID, rowEntityID),
+		SessionID: strings.TrimSpace(payload.SessionID),
 		ErrorCode: strings.TrimSpace(payload.ErrorCode),
 		Message:   strings.TrimSpace(payload.Message),
 		Details:   details,
@@ -750,6 +759,7 @@ func defaultOperatorEventListOptions(opts OperatorEventListOptions) OperatorEven
 func defaultOperatorRuntimeLogListOptions(opts OperatorRuntimeLogListOptions) OperatorRuntimeLogListOptions {
 	opts.RunID = strings.TrimSpace(opts.RunID)
 	opts.EntityID = strings.TrimSpace(opts.EntityID)
+	opts.SessionID = strings.TrimSpace(opts.SessionID)
 	opts.Component = strings.TrimSpace(opts.Component)
 	opts.Level = strings.TrimSpace(opts.Level)
 	opts.ErrorCode = strings.TrimSpace(opts.ErrorCode)

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -249,6 +249,62 @@ func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	}
 }
 
+func TestOperatorRuntimeLogsFilterBySessionAndTimeWindow(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	insertLog := func(sessionID string, createdAt time.Time) string {
+		t.Helper()
+		eventID := uuid.NewString()
+		payload := `{
+			"log_level":"warn",
+			"message":"runtime warning",
+			"details":{
+				"component":"agent-runtime",
+				"action":"turn_progress",
+				"session_id":"` + sessionID + `",
+				"error_code":"warn_code"
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'platform.runtime_log', 'global', $3::jsonb, 'runtime', 'platform', $4)
+		`, eventID, runID, payload, createdAt); err != nil {
+			t.Fatalf("seed runtime log: %v", err)
+		}
+		return eventID
+	}
+	inWindow := insertLog("sess-1", base.Add(1*time.Second))
+	_ = insertLog("sess-2", base.Add(2*time.Second))
+	_ = insertLog("sess-1", base.Add(3*time.Second))
+
+	since := base
+	until := base.Add(2500 * time.Millisecond)
+	result, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		SessionID: "sess-1",
+		Since:     &since,
+		Until:     &until,
+		Limit:     10,
+		Order:     "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs: %v", err)
+	}
+	if len(result.Logs) != 1 {
+		t.Fatalf("runtime logs len=%d logs=%#v, want one session/time-window row", len(result.Logs), result.Logs)
+	}
+	if got := result.Logs[0]; got.LogID != inWindow || got.SessionID != "sess-1" || got.Component != "agent-runtime" {
+		t.Fatalf("runtime log row = %#v", got)
+	}
+}
+
 func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)


### PR DESCRIPTION
## Summary

Closes #767.
Part of #748 and #735.

Implements the widened gate boundary from #767: canonical `conversation.get_turn` plus the minimal runtime-log owner/API extension needed for first-class `session_id` and turn-window log scoping.

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.get_turn`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.runtime.logs`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.runtime.subscribe_logs`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` schemas `ConversationTurnDetail`, `ConversationDeepTurn`, `LogEntry`
- Generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- #767 pre-audit and widened gate review

## Semantic Migration

New canonical owners after this PR:

- Deep single-turn diagnosis: `store.OperatorAgentConversationReadSurface.LoadOperatorConversationTurn`, consumed by `/v1/rpc conversation.get_turn`.
- Scoped runtime log evidence: `store.PostgresStore.ListOperatorRuntimeLogs` with typed `SessionID`, `Since`, and `Until`, consumed by `conversation.get_turn`, `runtime.logs`, and `runtime.subscribe_logs`.

Old/non-authoritative paths now invalid:

- Client-side composition of `conversation.get` plus ad hoc runtime-log filtering.
- Direct SQL/table reads of `agent_sessions`, `agent_turns`, `agent_conversation_audits`, or `events` as a deep-turn API owner.
- Dashboard conversation/runtime-log SQL as a semantic owner; dashboard remains adapter/projection only.

Production paths checked for surviving old behavior: `internal/apiv1`, `internal/store`, `internal/dashboard`, `internal/builder`, `cmd`, and `scripts` via grep/static sweeps. Migration is complete for the #767 chosen class; broader #748/#735/#363 tails remain tracked separately.

## Proof

- `go test ./internal/apiv1 -count=1`
- `go test ./internal/store -run 'TestOperator' -count=1`
- `go test ./internal/dashboard/server -run 'Test.*RuntimeLogs|TestDashboardRuntimeLogs|TestSQLConversationReader' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Grep sweeps for `conversation.get_turn`, `LoadOperatorConversationTurn`, `ConversationTurnDetail`, `TURN_NOT_FOUND`, `runtime.logs`, `runtime.subscribe_logs`, `ListOperatorRuntimeLogs`, `OperatorRuntimeLogListOptions`, `agent_turns`, `agent_sessions`, and `agent_conversation_audits` across API/store/dashboard/builder/CLI/scripts.