### PR TITLE
[agent-b][issue #769] Add agent replay RPC

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -112,6 +112,404 @@
       }
     },
     {
+      "name": "agent.replay",
+      "description": "Agent-scoped projection of the canonical operator-facing event redelivery primitive.\n\nRedelivers one existing persisted event to exactly one requested original agent subscriber. This method MUST consume the same canonical event redelivery owner as event.replay by projecting the request to the singleton subscriber set [agent_id]. It MUST NOT implement independent replay target derivation, fresh replay event creation, audit emission, idempotency, or delivery/session interpretation.\n\nThe target authority remains the original event_deliveries agent rows for event_id. If agent_id was not an original agent subscriber for that event, the method fails closed with EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL. Current live subscriptions, route tables, bundle declarations, or agent backlog state must not add recipients.\n\nThe replay preserves the original event, delivery, receipt, and session inspection surface, creates a distinct replay event identity with source_event_id/parent lineage to the original event, creates a fresh delivery row for the selected agent, and returns the single original/new delivery projection. The synthetic audit event is the canonical event.replayed event; this method does not create agent.event_replayed or mutate/abort the original session.\n",
+      "params": [
+        {
+          "name": "event_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "agent_id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/AgentReplayResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32006,
+          "message": "Application error: EVENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32008,
+          "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_REPLAY_NO_DELIVERY_HISTORY",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32009,
+          "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "original_subscribers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "requested_subscribers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subscriber_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "event_id",
+                  "subscriber_id",
+                  "original_subscribers"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32010,
+          "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "deliverable": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "replay_event": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "requested": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subscribers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "event_id",
+                  "subscribers"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
+          "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_REPLAY_NOT_ELIGIBLE",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "delivery_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "subscriber_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "event_id",
+                  "delivery_id",
+                  "subscriber_id",
+                  "status",
+                  "reason"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32017,
+          "message": "Application error: PAYLOAD_VALIDATION_FAILED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "PAYLOAD_VALIDATION_FAILED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "violations": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "field_path": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "rule": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "field_path",
+                        "rule",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "violations"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32011,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "agent.replay_backlog",
       "description": "Replay the agent's pending event backlog. Used for recovery after restart or ingress pause.",
       "params": [
@@ -4707,6 +5105,44 @@
         },
         "required": [
           "agent"
+        ],
+        "type": "object"
+      },
+      "AgentReplayResult": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_id": {
+            "description": "Original agent subscriber selected for replay.",
+            "type": "string"
+          },
+          "audit_event_id": {
+            "$ref": "#/components/schemas/OpaqueId",
+            "description": "Persisted synthetic event.replayed audit event identity."
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId",
+            "description": "Original persisted event requested for agent-scoped replay."
+          },
+          "new_delivery": {
+            "$ref": "#/components/schemas/EventReplayDelivery",
+            "description": "Fresh delivery row created for replay_event_id with source_delivery_id lineage to original_delivery."
+          },
+          "original_delivery": {
+            "$ref": "#/components/schemas/EventReplayDelivery",
+            "description": "Original agent delivery row used as replay target authority."
+          },
+          "replay_event_id": {
+            "$ref": "#/components/schemas/OpaqueId",
+            "description": "Fresh replay event identity created by the canonical event redelivery owner."
+          }
+        },
+        "required": [
+          "event_id",
+          "agent_id",
+          "replay_event_id",
+          "audit_event_id",
+          "original_delivery",
+          "new_delivery"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5597,6 +5597,7 @@ api_specification:
       mutating_methods:
       - event.publish
       - event.replay
+      - agent.replay
       - run.start
       - run.stop
       - run.pause
@@ -6137,6 +6138,35 @@ api_specification:
             description: Fresh delivery rows created for replay_event_id. Each row carries source_delivery_id lineage to the original delivery.
             items:
               $ref: '#/components/schemas/EventReplayDelivery'
+      AgentReplayResult:
+        type: object
+        additionalProperties: false
+        required:
+        - event_id
+        - agent_id
+        - replay_event_id
+        - audit_event_id
+        - original_delivery
+        - new_delivery
+        properties:
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Original persisted event requested for agent-scoped replay.
+          agent_id:
+            type: string
+            description: Original agent subscriber selected for replay.
+          replay_event_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Fresh replay event identity created by the canonical event redelivery owner.
+          audit_event_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Persisted synthetic event.replayed audit event identity.
+          original_delivery:
+            $ref: '#/components/schemas/EventReplayDelivery'
+            description: Original agent delivery row used as replay target authority.
+          new_delivery:
+            $ref: '#/components/schemas/EventReplayDelivery'
+            description: Fresh delivery row created for replay_event_id with source_delivery_id lineage to original_delivery.
       DeadLetterRecord:
         type: object
         additionalProperties: false
@@ -8251,6 +8281,49 @@ api_specification:
           $ref: '#/components/schemas/OkResult'
       errors:
       - AGENT_NOT_FOUND
+      - IDEMPOTENCY_CONFLICT
+    agent.replay:
+      tier: should_have
+      description: "Agent-scoped projection of the canonical operator-facing event redelivery primitive.\n\nRedelivers one\
+        \ existing persisted event to exactly one requested original agent subscriber. This method MUST consume the same canonical\
+        \ event redelivery owner as event.replay by projecting the request to the singleton subscriber set [agent_id]. It\
+        \ MUST NOT implement independent replay target derivation, fresh replay event creation, audit emission, idempotency,\
+        \ or delivery/session interpretation.\n\nThe target authority remains the original event_deliveries agent rows for\
+        \ event_id. If agent_id was not an original agent subscriber for that event, the method fails closed with EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL.\
+        \ Current live subscriptions, route tables, bundle declarations, or agent backlog state must not add recipients.\n\
+        \nThe replay preserves the original event, delivery, receipt, and session inspection surface, creates a distinct replay\
+        \ event identity with source_event_id/parent lineage to the original event, creates a fresh delivery row for the selected\
+        \ agent, and returns the single original/new delivery projection. The synthetic audit event is the canonical event.replayed\
+        \ event; this method does not create agent.event_replayed or mutate/abort the original session.\n"
+      scope:
+        required:
+        - write:runs
+      idempotency: per the convention.
+      params:
+      - name: event_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: agent_id
+        required: true
+        schema:
+          type: string
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/AgentReplayResult'
+      errors:
+      - EVENT_NOT_FOUND
+      - EVENT_REPLAY_NO_DELIVERY_HISTORY
+      - EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL
+      - EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE
+      - EVENT_REPLAY_NOT_ELIGIBLE
+      - PAYLOAD_VALIDATION_FAILED
       - IDEMPOTENCY_CONFLICT
     agent.replay_backlog:
       tier: should_have

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,17 +16,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 40 {
-		t.Fatalf("method count = %d, want 40", report.MethodCount)
+	if report.MethodCount != 41 {
+		t.Fatalf("method count = %d, want 41", report.MethodCount)
 	}
-	if report.SchemaCount != 57 {
-		t.Fatalf("schema count = %d, want 57", report.SchemaCount)
+	if report.SchemaCount != 58 {
+		t.Fatalf("schema count = %d, want 58", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 27 {
 		t.Fatalf("error code count = %d, want 27", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 14 {
-		t.Fatalf("mutating method count = %d, want 14", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 15 {
+		t.Fatalf("mutating method count = %d, want 15", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
@@ -61,11 +61,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 40 {
-		t.Fatalf("generated OpenRPC methods = %d, want 40", len(doc.Methods))
+	if len(doc.Methods) != 41 {
+		t.Fatalf("generated OpenRPC methods = %d, want 41", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 57 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 57", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 58 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 58", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 27 {
 		t.Fatalf("generated OpenRPC errors = %d, want 27", len(doc.Components.Errors))
@@ -79,6 +79,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["event.replay"]; !ok {
 		t.Fatal("generated OpenRPC missing event.replay")
+	}
+	if _, ok := methods["agent.replay"]; !ok {
+		t.Fatal("generated OpenRPC missing agent.replay")
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 40 {
-		t.Fatalf("method count = %d, want 40", len(openRPCNames))
+	if len(openRPCNames) != 41 {
+		t.Fatalf("method count = %d, want 41", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/operator_event_replay.go
+++ b/internal/apiv1/operator_event_replay.go
@@ -51,11 +51,25 @@ type eventReplayDelivery struct {
 	SourceDeliveryID string `json:"source_delivery_id,omitempty"`
 }
 
+type agentReplayResult struct {
+	EventID          string              `json:"event_id"`
+	AgentID          string              `json:"agent_id"`
+	ReplayEventID    string              `json:"replay_event_id"`
+	AuditEventID     string              `json:"audit_event_id"`
+	OriginalDelivery eventReplayDelivery `json:"original_delivery"`
+	NewDelivery      eventReplayDelivery `json:"new_delivery"`
+}
+
 type eventReplayStoredResult struct {
 	EventID             string   `json:"event_id"`
 	ReplayEventID       string   `json:"replay_event_id"`
 	AuditEventID        string   `json:"audit_event_id"`
 	SubscribersReplayed []string `json:"subscribers_replayed"`
+}
+
+type operatorEventReplayRequest struct {
+	EventID              string
+	RequestedSubscribers []string
 }
 
 type eventReplayPerformed struct {
@@ -74,6 +88,9 @@ func OperatorEventReplayHandlers(opts OperatorReadOptions) map[string]MethodHand
 	return map[string]MethodHandler{
 		"event.replay": func(ctx context.Context, req Request) (any, error) {
 			return executeEventReplay(ctx, req, opts, now().UTC())
+		},
+		"agent.replay": func(ctx context.Context, req Request) (any, error) {
+			return executeAgentReplay(ctx, req, opts, now().UTC())
 		},
 	}
 }
@@ -95,13 +112,49 @@ func executeEventReplay(ctx context.Context, req Request, opts OperatorReadOptio
 	if err != nil {
 		return nil, err
 	}
-	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	return executeOperatorEventReplay(ctx, req, opts, now, operatorEventReplayRequest{
+		EventID:              eventID,
+		RequestedSubscribers: requestedSubscribers,
+	})
+}
+
+func executeAgentReplay(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	agentID, err := requiredStringParam(req.Params, "agent_id")
 	if err != nil {
 		return nil, err
 	}
+	eventID, err := requiredStringParam(req.Params, "event_id")
+	if err != nil {
+		return nil, err
+	}
+	result, err := executeOperatorEventReplay(ctx, req, opts, now, operatorEventReplayRequest{
+		EventID:              eventID,
+		RequestedSubscribers: []string{agentID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return agentReplayResultFromEventReplay(agentID, result)
+}
+
+func executeOperatorEventReplay(
+	ctx context.Context,
+	req Request,
+	opts OperatorReadOptions,
+	now time.Time,
+	replayReq operatorEventReplayRequest,
+) (eventReplayResult, error) {
 	publisher, ok := opts.Events.(eventReplayPublisher)
 	if !ok || publisher == nil {
-		return nil, errors.New("event replay publisher is required")
+		return eventReplayResult{}, errors.New("event replay publisher is required")
+	}
+	eventID := strings.TrimSpace(replayReq.EventID)
+	if eventID == "" {
+		return eventReplayResult{}, NewInvalidParamsError(map[string]any{"field": "event_id", "reason": "required parameter is missing"})
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return eventReplayResult{}, err
 	}
 	var replayPublishErr error
 	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
@@ -113,7 +166,7 @@ func executeEventReplay(ctx context.Context, req Request, opts OperatorReadOptio
 		TTL:            eventReplayIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		performed, err := performEventReplay(ctx, req, opts, publisher, eventID, requestedSubscribers, now)
+		performed, err := performEventReplay(ctx, req, opts, publisher, eventID, replayReq.RequestedSubscribers, now)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
@@ -128,24 +181,24 @@ func executeEventReplay(ctx context.Context, req Request, opts OperatorReadOptio
 		}, nil
 	})
 	if err != nil {
-		return nil, eventReplayError(err)
+		return eventReplayResult{}, eventReplayError(err)
 	}
 	var stored eventReplayStoredResult
 	if err := json.Unmarshal(completion.Response, &stored); err != nil {
 		if replay {
-			return nil, fmt.Errorf("decode event.replay idempotency response: %w", err)
+			return eventReplayResult{}, fmt.Errorf("decode %s idempotency response: %w", req.Method, err)
 		}
-		return nil, fmt.Errorf("decode event.replay response: %w", err)
+		return eventReplayResult{}, fmt.Errorf("decode %s response: %w", req.Method, err)
 	}
 	if err := ensureEventReplayAudit(ctx, req, opts, publisher, stored, now); err != nil {
-		return nil, err
+		return eventReplayResult{}, err
 	}
 	if replayPublishErr != nil {
-		return nil, replayPublishErr
+		return eventReplayResult{}, replayPublishErr
 	}
 	result, err := eventReplayResultFromStore(ctx, opts, stored)
 	if err != nil {
-		return nil, err
+		return eventReplayResult{}, err
 	}
 	return result, nil
 }
@@ -230,7 +283,7 @@ func ensureEventReplayAudit(
 	now time.Time,
 ) error {
 	if strings.TrimSpace(stored.AuditEventID) == "" {
-		return errors.New("event.replay idempotency response missing audit_event_id")
+		return fmt.Errorf("%s idempotency response missing audit_event_id", req.Method)
 	}
 	if _, err := opts.Observability.LoadOperatorEvent(ctx, stored.AuditEventID); err == nil {
 		return nil
@@ -443,6 +496,36 @@ func eventReplayNewDeliveries(deliveries []store.OperatorEventDelivery, original
 		})
 	}
 	return out
+}
+
+func agentReplayResultFromEventReplay(agentID string, replay eventReplayResult) (agentReplayResult, error) {
+	agentID = strings.TrimSpace(agentID)
+	original, ok := deliveryForSubscriber(replay.OriginalDeliveries, agentID)
+	if !ok {
+		return agentReplayResult{}, fmt.Errorf("agent.replay canonical replay result missing original delivery for agent %s", agentID)
+	}
+	newDelivery, ok := deliveryForSubscriber(replay.NewDeliveries, agentID)
+	if !ok {
+		return agentReplayResult{}, fmt.Errorf("agent.replay canonical replay result missing new delivery for agent %s", agentID)
+	}
+	return agentReplayResult{
+		EventID:          strings.TrimSpace(replay.EventID),
+		AgentID:          agentID,
+		ReplayEventID:    strings.TrimSpace(replay.ReplayEventID),
+		AuditEventID:     strings.TrimSpace(replay.AuditEventID),
+		OriginalDelivery: original,
+		NewDelivery:      newDelivery,
+	}, nil
+}
+
+func deliveryForSubscriber(deliveries []eventReplayDelivery, subscriberID string) (eventReplayDelivery, bool) {
+	subscriberID = strings.TrimSpace(subscriberID)
+	for _, delivery := range deliveries {
+		if strings.TrimSpace(delivery.SubscriberID) == subscriberID {
+			return delivery, true
+		}
+	}
+	return eventReplayDelivery{}, false
 }
 
 func eventReplayActorSource(req Request) string {

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -297,6 +297,136 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 	})
 }
 
+func TestOperatorAgentReplayProjectsSingletonEventReplayOwner(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	bus := eventReplayTestBus(t, pg)
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-b")
+	chA := bus.Subscribe("agent-a")
+	defer bus.Unsubscribe("agent-a")
+	chB := bus.Subscribe("agent-b")
+	defer bus.Unsubscribe("agent-b")
+	original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a", "agent-b"}, eventReplayStatusDelivered)
+	handler := eventReplayTestHandler(t, pg, bus)
+
+	body := agentReplayBody(original.EventID, "agent-a", "idem-agent-replay")
+	resp := rpcCall(t, handler, body)
+	if resp.Error != nil {
+		t.Fatalf("agent.replay error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["event_id"] != original.EventID || result["agent_id"] != "agent-a" {
+		t.Fatalf("agent.replay identity result = %#v, want event %s agent-a", result, original.EventID)
+	}
+	replayEventID := stringValue(t, result["replay_event_id"], "replay_event_id")
+	auditEventID := stringValue(t, result["audit_event_id"], "audit_event_id")
+	if replayEventID == original.EventID || auditEventID == original.EventID || auditEventID == replayEventID {
+		t.Fatalf("event IDs not distinct: original=%s replay=%s audit=%s", original.EventID, replayEventID, auditEventID)
+	}
+	originalDelivery := asMap(t, result["original_delivery"])
+	if originalDelivery["subscriber_id"] != "agent-a" || strings.TrimSpace(fmt.Sprint(originalDelivery["delivery_id"])) == "" {
+		t.Fatalf("original_delivery = %#v, want agent-a delivery", originalDelivery)
+	}
+	newDelivery := asMap(t, result["new_delivery"])
+	if newDelivery["subscriber_id"] != "agent-a" || newDelivery["source_delivery_id"] != originalDelivery["delivery_id"] {
+		t.Fatalf("new_delivery = %#v, want agent-a source delivery %s", newDelivery, originalDelivery["delivery_id"])
+	}
+	assertReplayEventDelivered(t, chA, replayEventID, original.EventID)
+	assertNoReplayEvent(t, chB)
+	assertAgentReplayPersistence(t, db, original.EventID, replayEventID, auditEventID, "agent-a", 2)
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows = %d, want 1", count)
+	}
+
+	replayed := rpcCall(t, handler, body)
+	if replayed.Error != nil {
+		t.Fatalf("agent.replay idempotent retry error = %#v", replayed.Error)
+	}
+	replayedResult := asMap(t, replayed.Result)
+	if replayedResult["replay_event_id"] != replayEventID || replayedResult["audit_event_id"] != auditEventID {
+		t.Fatalf("idempotent agent.replay result = %#v, want original replay/audit IDs", replayedResult)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
+		t.Fatalf("scan.requested events after idempotent retry = %d, want original+replay", count)
+	}
+
+	conflict := rpcCall(t, handler, agentReplayBody(original.EventID, "agent-b", "idem-agent-replay"))
+	if conflict.Error == nil {
+		t.Fatal("agent.replay idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("agent.replay conflict data = %#v, want %s", data, IdempotencyConflictCode)
+	}
+}
+
+func TestOperatorAgentReplayFailClosedCases(t *testing.T) {
+	t.Run("requested agent was not original subscriber", func(t *testing.T) {
+		ctx := context.Background()
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		bus := eventReplayTestBus(t, pg)
+		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
+		bus.Subscribe("agent-a")
+		defer bus.Unsubscribe("agent-a")
+		original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a"}, eventReplayStatusDelivered)
+		handler := eventReplayTestHandler(t, pg, bus)
+
+		resp := rpcCall(t, handler, agentReplayBody(original.EventID, "agent-b", "idem-agent-not-original"))
+		if resp.Error == nil {
+			t.Fatal("non-original agent.replay error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != EventReplaySubscriberNotOriginalCode {
+			t.Fatalf("non-original data = %#v, want %s", data, EventReplaySubscriberNotOriginalCode)
+		}
+		if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+			t.Fatalf("scan.requested events = %d, want original only", count)
+		}
+	})
+
+	t.Run("original agent no longer deliverable", func(t *testing.T) {
+		ctx := context.Background()
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		bus := eventReplayTestBus(t, pg)
+		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
+		original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a"}, eventReplayStatusDelivered)
+		handler := eventReplayTestHandler(t, pg, bus)
+
+		resp := rpcCall(t, handler, agentReplayBody(original.EventID, "agent-a", "idem-agent-unavailable"))
+		if resp.Error == nil {
+			t.Fatal("unavailable agent.replay error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != EventReplaySubscriberUnavailableCode {
+			t.Fatalf("unavailable data = %#v, want %s", data, EventReplaySubscriberUnavailableCode)
+		}
+		if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+			t.Fatalf("scan.requested events = %d, want original only", count)
+		}
+	})
+
+	t.Run("nonterminal original delivery is not eligible", func(t *testing.T) {
+		ctx := context.Background()
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		bus := eventReplayTestBus(t, pg)
+		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
+		bus.Subscribe("agent-a")
+		defer bus.Unsubscribe("agent-a")
+		original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a"}, eventReplayStatusPending)
+		handler := eventReplayTestHandler(t, pg, bus)
+
+		resp := rpcCall(t, handler, agentReplayBody(original.EventID, "agent-a", "idem-agent-not-eligible"))
+		if resp.Error == nil {
+			t.Fatal("not-eligible agent.replay error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != EventReplayNotEligibleCode {
+			t.Fatalf("not-eligible data = %#v, want %s", data, EventReplayNotEligibleCode)
+		}
+	})
+}
+
 func TestOperatorEventReplayQueuesWhenDispatchGated(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -449,6 +579,10 @@ func eventReplayBody(eventID string, subscribers []string, idempotencyKey string
 	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"replay","method":"event.replay","params":{%s}}`, strings.Join(parts, ","))
 }
 
+func agentReplayBody(eventID, agentID, idempotencyKey string) string {
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"agent-replay","method":"agent.replay","params":{"event_id":%q,"agent_id":%q,"idempotency_key":%q}}`, eventID, agentID, idempotencyKey)
+}
+
 func assertReplayEventDelivered(t *testing.T, ch <-chan events.Event, replayEventID, originalEventID string) {
 	t.Helper()
 	select {
@@ -530,6 +664,43 @@ func assertReplayPersistence(t *testing.T, db *sql.DB, originalEventID, replayEv
 	}
 	if !strings.Contains(payloadRaw, replayEventID) || !strings.Contains(payloadRaw, originalEventID) {
 		t.Fatalf("audit payload = %s, want original and replay IDs", payloadRaw)
+	}
+}
+
+func assertAgentReplayPersistence(t *testing.T, db *sql.DB, originalEventID, replayEventID, auditEventID, agentID string, wantOriginalDeliveries int) {
+	t.Helper()
+	if got := countEventDeliveries(t, db, replayEventID); got != 1 {
+		t.Fatalf("agent replay event deliveries = %d, want 1", got)
+	}
+	if got := countEventDeliveries(t, db, originalEventID); got != wantOriginalDeliveries {
+		t.Fatalf("original event deliveries = %d, want preserved %d", got, wantOriginalDeliveries)
+	}
+	if got := countEventsByName(t, db, "event.replayed"); got != 1 {
+		t.Fatalf("event.replayed count = %d, want 1", got)
+	}
+	var sourceEventID, payloadRaw string
+	if err := db.QueryRow(`
+		SELECT COALESCE(source_event_id::text, ''), payload::text
+		FROM events
+		WHERE event_id = $1::uuid
+	`, replayEventID).Scan(&sourceEventID, &payloadRaw); err != nil {
+		t.Fatalf("load agent replay event lineage: %v", err)
+	}
+	if sourceEventID != originalEventID {
+		t.Fatalf("agent replay source_event_id = %q, want original %q", sourceEventID, originalEventID)
+	}
+	if err := db.QueryRow(`
+		SELECT COALESCE(source_event_id::text, ''), payload::text
+		FROM events
+		WHERE event_id = $1::uuid
+	`, auditEventID).Scan(&sourceEventID, &payloadRaw); err != nil {
+		t.Fatalf("load agent replay audit event: %v", err)
+	}
+	if sourceEventID != originalEventID {
+		t.Fatalf("agent replay audit source_event_id = %q, want original %q", sourceEventID, originalEventID)
+	}
+	if !strings.Contains(payloadRaw, replayEventID) || !strings.Contains(payloadRaw, originalEventID) || !strings.Contains(payloadRaw, agentID) {
+		t.Fatalf("agent replay audit payload = %s, want original/replay IDs and %s", payloadRaw, agentID)
 	}
 }
 


### PR DESCRIPTION
Closes #769

## Summary

Adds `/v1/rpc agent.replay` as the event-targeted, agent-scoped replay API required by CLI v2. The method is a singleton projection over the canonical `event.replay` redelivery owner: it validates `event_id` + `agent_id`, reuses the shared event replay execution path with subscribers `[agent_id]`, returns a single original/new delivery projection, and preserves the canonical `event.replayed` audit event.

## Governing Refs / Context

- #769 Pre-Implementation Coverage Audit and independent gate outcome: `approved as first slice`.
- Parent #748 API extension/deprecation tracker.
- Adjacent closed owner: #763 / PR #764 canonical `event.replay` redelivery owner.
- Authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` method catalog, idempotency mutating method list, and `AgentReplayResult` schema.
- Generated artifact updated: `docs/specs/swarm-platform/platform/contracts/openrpc.json`.

## Semantic Migration

- New canonical owner after this PR: shared operator event-redelivery execution in `internal/apiv1/operator_event_replay.go`, consumed by both `event.replay` and `agent.replay`.
- Old/non-authoritative paths now invalid for this concept: any standalone `agent.replay` implementation, `agent.replay_backlog` as an event-targeted replay substitute, manual `event.publish` replay synthesis, direct `event_deliveries`/store mutation, or CLI/dashboard runtime bypass.
- Production paths checked for surviving old behavior: v1 API registry, Builder/dashboard backlog aliases, CLI/scripts, runtime bus direct publish primitives, recovery/sweeper/dead-letter/fork replay seams.
- Migration completeness: complete for the approved #769 API child. #748 remains open for other API tail items; #735 remains open for CLI consumer work.

## Proof

- `go test ./internal/apiv1 -run 'TestOperatorEventReplay|TestOperatorAgentReplay|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- Static sweeps for `agent.replay`, `agent.event_replayed`, `event.replay`, `replay_backlog`, and direct store/runtime replay paths.
