### PR TITLE
[agent-b][issue #773] Add destructive reset planning owner

### DIFF
--- a/internal/runtime/destructivereset/contracts.go
+++ b/internal/runtime/destructivereset/contracts.go
@@ -1,0 +1,99 @@
+package destructivereset
+
+const (
+	ContractRunDeliveryQuiescence = "active_run_delivery_quiescence"
+	ContractRunScopedTruncation   = "run_scoped_truncation_preservation"
+	ContractManagedContainers     = "managed_entity_container_selection_preservation"
+	ContractPublicAPIWrapper      = "runtime_nuke_api_spec_wrapper"
+	ContractLegacyResetMigration  = "legacy_reset_seam_migration"
+)
+
+func DefaultDownstreamContracts() []DownstreamContract {
+	return []DownstreamContract{
+		{
+			ID:          ContractRunDeliveryQuiescence,
+			Status:      "split",
+			Owner:       "future runtime destructive reset run/delivery quiescence owner",
+			Description: "Stop active runs and cancel pending/in-progress deliveries with nuke-specific reasons before destructive reset can apply.",
+		},
+		{
+			ID:          ContractRunScopedTruncation,
+			Status:      "split",
+			Owner:       "future store destructive reset truncation owner",
+			Description: "Define the exact run-scoped table set and preservation rules for schema/auth/operator/system state before truncation can apply.",
+		},
+		{
+			ID:          ContractManagedContainers,
+			Status:      "split",
+			Owner:       "future workspace destructive reset container owner",
+			Description: "Select and stop only swarm-managed entity containers while proving system/operator-managed containers are preserved.",
+		},
+		{
+			ID:          ContractPublicAPIWrapper,
+			Status:      "split",
+			Owner:       "future v1 runtime.nuke API wrapper",
+			Description: "Expose /v1/rpc runtime.nuke and authoritative platform-spec/OpenRPC only after destructive reset owners exist.",
+		},
+		{
+			ID:          ContractLegacyResetMigration,
+			Status:      "split",
+			Owner:       "future legacy reset migration owner",
+			Description: "Retire, redirect, or explicitly split dashboard/Builder/run_clear reset seams after canonical reset ownership exists.",
+		},
+	}
+}
+
+func DefaultResetSeams() []ResetSeam {
+	return []ResetSeam{
+		{
+			ID:             "dashboard_runtime_actions_reset_state",
+			Classification: "legacy_deferred_sibling",
+			RequiredAction: "Do not treat dashboard reset_state as canonical reset ownership; migrate, retire, or split before runtime.nuke closure.",
+		},
+		{
+			ID:             "builder_runtime_reset_state",
+			Classification: "legacy_deferred_sibling",
+			RequiredAction: "Do not treat Builder reset_state/run hub reset as canonical reset ownership; migrate, retire, or split before runtime.nuke closure.",
+		},
+		{
+			ID:             "agent_manager_reset_runtime_state_with_source",
+			Classification: "partial_internal_primitive",
+			RequiredAction: "May become a downstream primitive only after explicit contract repair; not dry-run or destructive-reset ownership today.",
+		},
+		{
+			ID:             "startup_recovery_failed_reset",
+			Classification: "safety_trigger_sibling",
+			RequiredAction: "Keep as recovery-specific internal reset semantics unless a later gate explicitly absorbs it into the canonical reset owner.",
+		},
+		{
+			ID:             "sessions_reset_all",
+			Classification: "partial_session_primitive",
+			RequiredAction: "Session reset is downstream-only and must not imply run, delivery, table, or container reset ownership.",
+		},
+		{
+			ID:             "run_stop",
+			Classification: "different_narrower_concept",
+			RequiredAction: "Per-run stop can be a downstream primitive; it does not own all-run nuke planning or in-progress delivery cancellation.",
+		},
+		{
+			ID:             "workspace_docker_helpers",
+			Classification: "container_primitive",
+			RequiredAction: "Workspace helpers can be downstream primitives; they do not own global preservation or selection semantics.",
+		},
+		{
+			ID:             "scripts_run_clear_reset_dev",
+			Classification: "direct_dev_bypass",
+			RequiredAction: "Keep dev-only until migrated or split; raw truncate/docker stop must not become production reset ownership.",
+		},
+	}
+}
+
+func DefaultPreservedResources() PreservedResources {
+	return PreservedResources{
+		SystemContainers:        []string{"swarm-scaffold", "swarm-system"},
+		OperatorManagedBoundary: "operator-managed containers are outside Swarm ownership and are not enumerable by this planner",
+		SchemaMigrations:        true,
+		AuthTokens:              true,
+		BundleContracts:         true,
+	}
+}

--- a/internal/runtime/destructivereset/coordinator.go
+++ b/internal/runtime/destructivereset/coordinator.go
@@ -1,0 +1,119 @@
+package destructivereset
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type Coordinator struct {
+	Planner     Planner
+	Locks       LockManager
+	Idempotency IdempotencyStore
+	Now         func() time.Time
+	Operation   string
+	LockKey     string
+}
+
+func (c *Coordinator) BuildPlan(ctx context.Context, req Request) (Result, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := c.now()
+	req, err := req.normalize(now)
+	if err != nil {
+		return Result{}, false, err
+	}
+	if c == nil {
+		return Result{}, false, ErrPlannerNotConfigured
+	}
+	if c.Planner == nil {
+		return Result{}, false, ErrPlannerNotConfigured
+	}
+
+	operation := c.operationName()
+	idemKey := IdempotencyKey{
+		OperationName:  operation,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: req.IdempotencyKey,
+	}.normalized()
+	if idemKey.IdempotencyKey != "" {
+		if c.Idempotency == nil {
+			return Result{}, false, fmt.Errorf("destructive reset idempotency store is required")
+		}
+		stored, ok, err := c.Idempotency.LoadResetResult(ctx, idemKey)
+		if err != nil {
+			return Result{}, false, err
+		}
+		if ok {
+			if stored.RequestHash != req.RequestHash {
+				return Result{}, false, &IdempotencyConflictError{
+					Key:                    idemKey,
+					OriginalRequestHash:    stored.RequestHash,
+					ConflictingRequestHash: req.RequestHash,
+				}
+			}
+			return stored.Result, true, nil
+		}
+	}
+
+	if c.Locks == nil {
+		return Result{}, false, ErrLockNotConfigured
+	}
+	lease, acquired, err := c.Locks.TryAcquire(ctx, c.lockKey())
+	if err != nil {
+		return Result{}, false, err
+	}
+	if !acquired {
+		return Result{}, false, ErrOperationInProgress
+	}
+	if lease == nil {
+		return Result{}, false, ErrLockLeaseMissing
+	}
+	defer func() {
+		_ = lease.Release(context.Background())
+	}()
+
+	plan, err := c.Planner.BuildPlan(ctx, req)
+	if err != nil {
+		return Result{}, false, err
+	}
+	result := Result{
+		OperationName: operation,
+		DryRun:        req.DryRun,
+		PlannedAt:     req.RequestedAt,
+		Plan:          plan,
+	}
+	if idemKey.IdempotencyKey != "" {
+		if err := c.Idempotency.StoreResetResult(ctx, StoredResult{
+			Key:         idemKey,
+			RequestHash: req.RequestHash,
+			Result:      result,
+			StoredAt:    now,
+		}); err != nil {
+			return Result{}, false, err
+		}
+	}
+	return result, false, nil
+}
+
+func (c *Coordinator) now() time.Time {
+	if c != nil && c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (c *Coordinator) operationName() string {
+	if c == nil || c.Operation == "" {
+		return DefaultOperationName
+	}
+	return c.Operation
+}
+
+func (c *Coordinator) lockKey() string {
+	if c == nil || c.LockKey == "" {
+		return defaultLockKey
+	}
+	return c.LockKey
+}

--- a/internal/runtime/destructivereset/coordinator.go
+++ b/internal/runtime/destructivereset/coordinator.go
@@ -53,7 +53,7 @@ func (c *Coordinator) BuildPlan(ctx context.Context, req Request) (Result, bool,
 					ConflictingRequestHash: req.RequestHash,
 				}
 			}
-			return stored.Result, true, nil
+			return copyResult(stored.Result), true, nil
 		}
 	}
 
@@ -88,7 +88,7 @@ func (c *Coordinator) BuildPlan(ctx context.Context, req Request) (Result, bool,
 		if err := c.Idempotency.StoreResetResult(ctx, StoredResult{
 			Key:         idemKey,
 			RequestHash: req.RequestHash,
-			Result:      result,
+			Result:      copyResult(result),
 			StoredAt:    now,
 		}); err != nil {
 			return Result{}, false, err

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -1,0 +1,277 @@
+package destructivereset
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorBuildPlanStoresAndReplaysIdempotentResult(t *testing.T) {
+	now := time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC)
+	reader := &recordingInventoryReader{inventory: Inventory{
+		ActiveRuns:       []RunRef{{RunID: "run-1", Status: "running"}},
+		ActiveDeliveries: []DeliveryRef{{DeliveryID: "delivery-1", RunID: "run-1", Status: "pending"}},
+		RunScopedTables:  []TableRef{{Name: "runs", Owner: ContractRunScopedTruncation, Action: "planned_by_downstream_owner"}},
+		EntityContainers: []ContainerRef{{Name: "swarm-entity-1", Kind: "entity", Action: "planned_by_downstream_owner"}},
+	}}
+	locks := &recordingLockManager{acquired: true}
+	idempotency := newRecordingIdempotencyStore()
+	coord := &Coordinator{
+		Planner:     InventoryPlanner{Reader: reader},
+		Locks:       locks,
+		Idempotency: idempotency,
+		Now:         func() time.Time { return now },
+	}
+	req := Request{
+		ActorTokenID:   "operator-token",
+		IdempotencyKey: "idem-1",
+		RequestHash:    "hash-1",
+		DryRun:         true,
+	}
+
+	result, replay, err := coord.BuildPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("BuildPlan first call error = %v", err)
+	}
+	if replay {
+		t.Fatal("first call replay = true, want false")
+	}
+	if result.OperationName != DefaultOperationName || !result.DryRun || !result.PlannedAt.Equal(now) {
+		t.Fatalf("result metadata = %#v, want operation/dry-run/time", result)
+	}
+	if len(result.Plan.ActiveRuns) != 1 || result.Plan.ActiveRuns[0].RunID != "run-1" {
+		t.Fatalf("active runs = %#v", result.Plan.ActiveRuns)
+	}
+	if reader.reads != 1 || locks.acquires != 1 || locks.lease.releases != 1 || idempotency.stores != 1 {
+		t.Fatalf("first call counts reader=%d acquires=%d releases=%d stores=%d", reader.reads, locks.acquires, locks.lease.releases, idempotency.stores)
+	}
+
+	replayed, replay, err := coord.BuildPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("BuildPlan replay error = %v", err)
+	}
+	if !replay {
+		t.Fatal("second call replay = false, want true")
+	}
+	if replayed.PlannedAt != result.PlannedAt || replayed.OperationName != result.OperationName {
+		t.Fatalf("replayed result = %#v, want stored result %#v", replayed, result)
+	}
+	if reader.reads != 1 || locks.acquires != 1 || idempotency.stores != 1 {
+		t.Fatalf("replay should not re-plan/lock/store: reader=%d acquires=%d stores=%d", reader.reads, locks.acquires, idempotency.stores)
+	}
+}
+
+func TestCoordinatorRejectsIdempotencyConflictBeforePlanning(t *testing.T) {
+	now := time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC)
+	reader := &recordingInventoryReader{}
+	locks := &recordingLockManager{acquired: true}
+	idempotency := newRecordingIdempotencyStore()
+	coord := &Coordinator{
+		Planner:     InventoryPlanner{Reader: reader},
+		Locks:       locks,
+		Idempotency: idempotency,
+		Now:         func() time.Time { return now },
+	}
+	req := Request{ActorTokenID: "operator-token", IdempotencyKey: "idem-1", RequestHash: "hash-1", DryRun: true}
+	if _, _, err := coord.BuildPlan(context.Background(), req); err != nil {
+		t.Fatalf("seed BuildPlan error = %v", err)
+	}
+
+	_, _, err := coord.BuildPlan(context.Background(), Request{
+		ActorTokenID:   "operator-token",
+		IdempotencyKey: "idem-1",
+		RequestHash:    "different-hash",
+		DryRun:         true,
+	})
+	if !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("conflict error = %v, want ErrIdempotencyConflict", err)
+	}
+	if reader.reads != 1 || locks.acquires != 1 || idempotency.stores != 1 {
+		t.Fatalf("conflict should not re-plan/lock/store: reader=%d acquires=%d stores=%d", reader.reads, locks.acquires, idempotency.stores)
+	}
+}
+
+func TestCoordinatorDoesNotStoreIdempotencyBeforeValidationOrPlanFailure(t *testing.T) {
+	idempotency := newRecordingIdempotencyStore()
+	coord := &Coordinator{
+		Planner:     InventoryPlanner{Reader: &recordingInventoryReader{}},
+		Locks:       &recordingLockManager{acquired: true},
+		Idempotency: idempotency,
+		Now:         func() time.Time { return time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC) },
+	}
+	_, _, err := coord.BuildPlan(context.Background(), Request{
+		ActorTokenID:   "operator-token",
+		IdempotencyKey: "idem-1",
+		DryRun:         true,
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("missing request hash error = %v, want ErrInvalidRequest", err)
+	}
+	if idempotency.loads != 0 || idempotency.stores != 0 {
+		t.Fatalf("validation failure idempotency counts loads=%d stores=%d, want 0/0", idempotency.loads, idempotency.stores)
+	}
+
+	planErr := errors.New("inventory unavailable")
+	locks := &recordingLockManager{acquired: true}
+	idempotency = newRecordingIdempotencyStore()
+	coord = &Coordinator{
+		Planner:     InventoryPlanner{Reader: &recordingInventoryReader{err: planErr}},
+		Locks:       locks,
+		Idempotency: idempotency,
+		Now:         func() time.Time { return time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC) },
+	}
+	_, _, err = coord.BuildPlan(context.Background(), Request{
+		ActorTokenID:   "operator-token",
+		IdempotencyKey: "idem-1",
+		RequestHash:    "hash-1",
+		DryRun:         true,
+	})
+	if !errors.Is(err, planErr) {
+		t.Fatalf("plan error = %v, want %v", err, planErr)
+	}
+	if idempotency.stores != 0 {
+		t.Fatalf("plan failure stored idempotency rows = %d, want 0", idempotency.stores)
+	}
+	if locks.lease.releases != 1 {
+		t.Fatalf("plan failure lock releases = %d, want 1", locks.lease.releases)
+	}
+}
+
+func TestCoordinatorLockConflictPreventsPlanning(t *testing.T) {
+	reader := &recordingInventoryReader{}
+	coord := &Coordinator{
+		Planner: InventoryPlanner{Reader: reader},
+		Locks:   &recordingLockManager{acquired: false},
+		Now:     func() time.Time { return time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC) },
+	}
+	_, _, err := coord.BuildPlan(context.Background(), Request{ActorTokenID: "operator-token", DryRun: true})
+	if !errors.Is(err, ErrOperationInProgress) {
+		t.Fatalf("lock conflict error = %v, want ErrOperationInProgress", err)
+	}
+	if reader.reads != 0 {
+		t.Fatalf("lock conflict reader reads = %d, want 0", reader.reads)
+	}
+}
+
+func TestCoordinatorFailsClosedWhenLockLeaseIsMissing(t *testing.T) {
+	reader := &recordingInventoryReader{}
+	coord := &Coordinator{
+		Planner: InventoryPlanner{Reader: reader},
+		Locks:   lockManagerFunc(func(context.Context, string) (LockLease, bool, error) { return nil, true, nil }),
+		Now:     func() time.Time { return time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC) },
+	}
+	_, _, err := coord.BuildPlan(context.Background(), Request{ActorTokenID: "operator-token", DryRun: true})
+	if !errors.Is(err, ErrLockLeaseMissing) {
+		t.Fatalf("missing lock lease error = %v, want ErrLockLeaseMissing", err)
+	}
+	if reader.reads != 0 {
+		t.Fatalf("missing lease reader reads = %d, want 0", reader.reads)
+	}
+}
+
+func TestInventoryPlannerCarriesSplitContractsAndResetSeams(t *testing.T) {
+	reader := &recordingInventoryReader{}
+	plan, err := (InventoryPlanner{Reader: reader}).BuildPlan(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("BuildPlan error = %v", err)
+	}
+	if !containsContract(plan.DownstreamContracts, ContractRunDeliveryQuiescence) ||
+		!containsContract(plan.DownstreamContracts, ContractRunScopedTruncation) ||
+		!containsContract(plan.DownstreamContracts, ContractManagedContainers) ||
+		!containsContract(plan.DownstreamContracts, ContractPublicAPIWrapper) ||
+		!containsContract(plan.DownstreamContracts, ContractLegacyResetMigration) {
+		t.Fatalf("downstream contracts = %#v, missing required split contract", plan.DownstreamContracts)
+	}
+	if !containsSeam(plan.ResetSeams, "startup_recovery_failed_reset") ||
+		!containsSeam(plan.ResetSeams, "scripts_run_clear_reset_dev") ||
+		!containsSeam(plan.ResetSeams, "agent_manager_reset_runtime_state_with_source") {
+		t.Fatalf("reset seams = %#v, missing required live seam classification", plan.ResetSeams)
+	}
+	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || !plan.Preserved.BundleContracts {
+		t.Fatalf("preserved resources = %#v, want schema/auth/bundle preserved", plan.Preserved)
+	}
+	if !slices.Contains(plan.Preserved.SystemContainers, "swarm-scaffold") || !slices.Contains(plan.Preserved.SystemContainers, "swarm-system") {
+		t.Fatalf("system containers = %#v, want scaffold/system preserved", plan.Preserved.SystemContainers)
+	}
+}
+
+type recordingInventoryReader struct {
+	inventory Inventory
+	err       error
+	reads     int
+}
+
+func (r *recordingInventoryReader) ReadResetInventory(context.Context) (Inventory, error) {
+	r.reads++
+	return r.inventory, r.err
+}
+
+type recordingLockManager struct {
+	acquired bool
+	err      error
+	acquires int
+	lease    *recordingLease
+}
+
+func (m *recordingLockManager) TryAcquire(context.Context, string) (LockLease, bool, error) {
+	m.acquires++
+	if m.err != nil {
+		return nil, false, m.err
+	}
+	if !m.acquired {
+		return nil, false, nil
+	}
+	m.lease = &recordingLease{}
+	return m.lease, true, nil
+}
+
+type lockManagerFunc func(context.Context, string) (LockLease, bool, error)
+
+func (f lockManagerFunc) TryAcquire(ctx context.Context, key string) (LockLease, bool, error) {
+	return f(ctx, key)
+}
+
+type recordingLease struct {
+	releases int
+}
+
+func (l *recordingLease) Release(context.Context) error {
+	l.releases++
+	return nil
+}
+
+type recordingIdempotencyStore struct {
+	records map[IdempotencyKey]StoredResult
+	loads   int
+	stores  int
+}
+
+func newRecordingIdempotencyStore() *recordingIdempotencyStore {
+	return &recordingIdempotencyStore{records: map[IdempotencyKey]StoredResult{}}
+}
+
+func (s *recordingIdempotencyStore) LoadResetResult(_ context.Context, key IdempotencyKey) (StoredResult, bool, error) {
+	s.loads++
+	record, ok := s.records[key.normalized()]
+	return record, ok, nil
+}
+
+func (s *recordingIdempotencyStore) StoreResetResult(_ context.Context, result StoredResult) error {
+	s.stores++
+	s.records[result.Key.normalized()] = result
+	return nil
+}
+
+func containsContract(contracts []DownstreamContract, id string) bool {
+	return slices.ContainsFunc(contracts, func(contract DownstreamContract) bool {
+		return contract.ID == id && contract.Status == "split"
+	})
+}
+
+func containsSeam(seams []ResetSeam, id string) bool {
+	return slices.ContainsFunc(seams, func(seam ResetSeam) bool {
+		return seam.ID == id
+	})
+}

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -47,6 +47,8 @@ func TestCoordinatorBuildPlanStoresAndReplaysIdempotentResult(t *testing.T) {
 	if reader.reads != 1 || locks.acquires != 1 || locks.lease.releases != 1 || idempotency.stores != 1 {
 		t.Fatalf("first call counts reader=%d acquires=%d releases=%d stores=%d", reader.reads, locks.acquires, locks.lease.releases, idempotency.stores)
 	}
+	result.Plan.ActiveRuns[0].RunID = "tampered-return"
+	result.Plan.Preserved.SystemContainers[0] = "tampered-container"
 
 	replayed, replay, err := coord.BuildPlan(context.Background(), req)
 	if err != nil {
@@ -58,8 +60,25 @@ func TestCoordinatorBuildPlanStoresAndReplaysIdempotentResult(t *testing.T) {
 	if replayed.PlannedAt != result.PlannedAt || replayed.OperationName != result.OperationName {
 		t.Fatalf("replayed result = %#v, want stored result %#v", replayed, result)
 	}
+	if replayed.Plan.ActiveRuns[0].RunID != "run-1" {
+		t.Fatalf("replayed active run = %q, want original stored value", replayed.Plan.ActiveRuns[0].RunID)
+	}
+	if replayed.Plan.Preserved.SystemContainers[0] != "swarm-scaffold" {
+		t.Fatalf("replayed preserved system container = %q, want original stored value", replayed.Plan.Preserved.SystemContainers[0])
+	}
 	if reader.reads != 1 || locks.acquires != 1 || idempotency.stores != 1 {
 		t.Fatalf("replay should not re-plan/lock/store: reader=%d acquires=%d stores=%d", reader.reads, locks.acquires, idempotency.stores)
+	}
+	replayed.Plan.ActiveRuns[0].RunID = "tampered-replay"
+	replayedAgain, replay, err := coord.BuildPlan(context.Background(), req)
+	if err != nil {
+		t.Fatalf("BuildPlan second replay error = %v", err)
+	}
+	if !replay {
+		t.Fatal("third call replay = false, want true")
+	}
+	if replayedAgain.Plan.ActiveRuns[0].RunID != "run-1" {
+		t.Fatalf("second replay active run = %q, want original stored value", replayedAgain.Plan.ActiveRuns[0].RunID)
 	}
 }
 
@@ -194,6 +213,27 @@ func TestInventoryPlannerCarriesSplitContractsAndResetSeams(t *testing.T) {
 	}
 	if !slices.Contains(plan.Preserved.SystemContainers, "swarm-scaffold") || !slices.Contains(plan.Preserved.SystemContainers, "swarm-system") {
 		t.Fatalf("system containers = %#v, want scaffold/system preserved", plan.Preserved.SystemContainers)
+	}
+}
+
+func TestInventoryPlannerMergesPreservedResourceDefaultsByField(t *testing.T) {
+	reader := &recordingInventoryReader{inventory: Inventory{
+		Preserved: PreservedResources{
+			SystemContainers: []string{"custom-system"},
+		},
+	}}
+	plan, err := (InventoryPlanner{Reader: reader}).BuildPlan(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("BuildPlan error = %v", err)
+	}
+	if !slices.Equal(plan.Preserved.SystemContainers, []string{"custom-system"}) {
+		t.Fatalf("system containers = %#v, want caller-provided value", plan.Preserved.SystemContainers)
+	}
+	if plan.Preserved.OperatorManagedBoundary == "" {
+		t.Fatalf("operator-managed boundary was not defaulted")
+	}
+	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || !plan.Preserved.BundleContracts {
+		t.Fatalf("preserved resources = %#v, want critical defaults merged", plan.Preserved)
 	}
 }
 

--- a/internal/runtime/destructivereset/planner.go
+++ b/internal/runtime/destructivereset/planner.go
@@ -18,10 +18,7 @@ func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error
 	if err != nil {
 		return Plan{}, err
 	}
-	preserved := inventory.Preserved
-	if !hasPreservedResources(preserved) {
-		preserved = DefaultPreservedResources()
-	}
+	preserved := mergePreservedResources(inventory.Preserved)
 	contracts := p.DownstreamContracts
 	if len(contracts) == 0 {
 		contracts = DefaultDownstreamContracts()
@@ -41,15 +38,37 @@ func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error
 	}, nil
 }
 
-func hasPreservedResources(p PreservedResources) bool {
-	return len(p.SystemContainers) > 0 ||
-		p.OperatorManagedBoundary != "" ||
-		p.SchemaMigrations ||
-		p.AuthTokens ||
-		p.BundleContracts
-}
-
 func copyPreservedResources(p PreservedResources) PreservedResources {
 	p.SystemContainers = append([]string(nil), p.SystemContainers...)
 	return p
+}
+
+func mergePreservedResources(p PreservedResources) PreservedResources {
+	defaults := DefaultPreservedResources()
+	if len(p.SystemContainers) == 0 {
+		p.SystemContainers = defaults.SystemContainers
+	}
+	if p.OperatorManagedBoundary == "" {
+		p.OperatorManagedBoundary = defaults.OperatorManagedBoundary
+	}
+	p.SchemaMigrations = p.SchemaMigrations || defaults.SchemaMigrations
+	p.AuthTokens = p.AuthTokens || defaults.AuthTokens
+	p.BundleContracts = p.BundleContracts || defaults.BundleContracts
+	return copyPreservedResources(p)
+}
+
+func copyResult(result Result) Result {
+	result.Plan = copyPlan(result.Plan)
+	return result
+}
+
+func copyPlan(plan Plan) Plan {
+	plan.ActiveRuns = append([]RunRef(nil), plan.ActiveRuns...)
+	plan.ActiveDeliveries = append([]DeliveryRef(nil), plan.ActiveDeliveries...)
+	plan.RunScopedTables = append([]TableRef(nil), plan.RunScopedTables...)
+	plan.EntityContainers = append([]ContainerRef(nil), plan.EntityContainers...)
+	plan.Preserved = copyPreservedResources(plan.Preserved)
+	plan.DownstreamContracts = append([]DownstreamContract(nil), plan.DownstreamContracts...)
+	plan.ResetSeams = append([]ResetSeam(nil), plan.ResetSeams...)
+	return plan
 }

--- a/internal/runtime/destructivereset/planner.go
+++ b/internal/runtime/destructivereset/planner.go
@@ -1,0 +1,55 @@
+package destructivereset
+
+import (
+	"context"
+)
+
+type InventoryPlanner struct {
+	Reader              InventoryReader
+	DownstreamContracts []DownstreamContract
+	ResetSeams          []ResetSeam
+}
+
+func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error) {
+	if p.Reader == nil {
+		return Plan{}, ErrPlannerNotConfigured
+	}
+	inventory, err := p.Reader.ReadResetInventory(ctx)
+	if err != nil {
+		return Plan{}, err
+	}
+	preserved := inventory.Preserved
+	if !hasPreservedResources(preserved) {
+		preserved = DefaultPreservedResources()
+	}
+	contracts := p.DownstreamContracts
+	if len(contracts) == 0 {
+		contracts = DefaultDownstreamContracts()
+	}
+	seams := p.ResetSeams
+	if len(seams) == 0 {
+		seams = DefaultResetSeams()
+	}
+	return Plan{
+		ActiveRuns:          append([]RunRef(nil), inventory.ActiveRuns...),
+		ActiveDeliveries:    append([]DeliveryRef(nil), inventory.ActiveDeliveries...),
+		RunScopedTables:     append([]TableRef(nil), inventory.RunScopedTables...),
+		EntityContainers:    append([]ContainerRef(nil), inventory.EntityContainers...),
+		Preserved:           copyPreservedResources(preserved),
+		DownstreamContracts: append([]DownstreamContract(nil), contracts...),
+		ResetSeams:          append([]ResetSeam(nil), seams...),
+	}, nil
+}
+
+func hasPreservedResources(p PreservedResources) bool {
+	return len(p.SystemContainers) > 0 ||
+		p.OperatorManagedBoundary != "" ||
+		p.SchemaMigrations ||
+		p.AuthTokens ||
+		p.BundleContracts
+}
+
+func copyPreservedResources(p PreservedResources) PreservedResources {
+	p.SystemContainers = append([]string(nil), p.SystemContainers...)
+	return p
+}

--- a/internal/runtime/destructivereset/types.go
+++ b/internal/runtime/destructivereset/types.go
@@ -1,0 +1,175 @@
+package destructivereset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultOperationName = "runtime.destructive_reset"
+	defaultLockKey       = "swarm:runtime:destructive-reset"
+)
+
+var (
+	ErrInvalidRequest       = errors.New("invalid destructive reset request")
+	ErrOperationInProgress  = errors.New("destructive reset operation already in progress")
+	ErrIdempotencyConflict  = errors.New("destructive reset idempotency conflict")
+	ErrPlannerNotConfigured = errors.New("destructive reset planner is not configured")
+	ErrLockNotConfigured    = errors.New("destructive reset lock manager is not configured")
+	ErrLockLeaseMissing     = errors.New("destructive reset lock lease is missing")
+)
+
+type Request struct {
+	ActorTokenID   string
+	IdempotencyKey string
+	RequestHash    string
+	DryRun         bool
+	RequestedAt    time.Time
+}
+
+type Result struct {
+	OperationName string    `json:"operation_name"`
+	DryRun        bool      `json:"dry_run"`
+	PlannedAt     time.Time `json:"planned_at"`
+	Plan          Plan      `json:"plan"`
+}
+
+type Plan struct {
+	ActiveRuns          []RunRef             `json:"active_runs"`
+	ActiveDeliveries    []DeliveryRef        `json:"active_deliveries"`
+	RunScopedTables     []TableRef           `json:"run_scoped_tables"`
+	EntityContainers    []ContainerRef       `json:"entity_containers"`
+	Preserved           PreservedResources   `json:"preserved"`
+	DownstreamContracts []DownstreamContract `json:"downstream_contracts"`
+	ResetSeams          []ResetSeam          `json:"reset_seams"`
+}
+
+type RunRef struct {
+	RunID  string `json:"run_id"`
+	Status string `json:"status"`
+}
+
+type DeliveryRef struct {
+	DeliveryID string `json:"delivery_id"`
+	RunID      string `json:"run_id"`
+	Status     string `json:"status"`
+}
+
+type TableRef struct {
+	Name   string `json:"name"`
+	Owner  string `json:"owner"`
+	Action string `json:"action"`
+}
+
+type ContainerRef struct {
+	Name   string `json:"name"`
+	Kind   string `json:"kind"`
+	Action string `json:"action"`
+}
+
+type PreservedResources struct {
+	SystemContainers        []string `json:"system_containers"`
+	OperatorManagedBoundary string   `json:"operator_managed_boundary"`
+	SchemaMigrations        bool     `json:"schema_migrations"`
+	AuthTokens              bool     `json:"auth_tokens"`
+	BundleContracts         bool     `json:"bundle_contracts"`
+}
+
+type DownstreamContract struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Owner       string `json:"owner"`
+	Description string `json:"description"`
+}
+
+type ResetSeam struct {
+	ID             string `json:"id"`
+	Classification string `json:"classification"`
+	RequiredAction string `json:"required_action"`
+}
+
+type Inventory struct {
+	ActiveRuns       []RunRef
+	ActiveDeliveries []DeliveryRef
+	RunScopedTables  []TableRef
+	EntityContainers []ContainerRef
+	Preserved        PreservedResources
+}
+
+type InventoryReader interface {
+	ReadResetInventory(context.Context) (Inventory, error)
+}
+
+type Planner interface {
+	BuildPlan(context.Context, Request) (Plan, error)
+}
+
+type LockManager interface {
+	TryAcquire(context.Context, string) (LockLease, bool, error)
+}
+
+type LockLease interface {
+	Release(context.Context) error
+}
+
+type IdempotencyStore interface {
+	LoadResetResult(context.Context, IdempotencyKey) (StoredResult, bool, error)
+	StoreResetResult(context.Context, StoredResult) error
+}
+
+type IdempotencyKey struct {
+	OperationName  string
+	ActorTokenID   string
+	IdempotencyKey string
+}
+
+type StoredResult struct {
+	Key         IdempotencyKey
+	RequestHash string
+	Result      Result
+	StoredAt    time.Time
+}
+
+type IdempotencyConflictError struct {
+	Key                    IdempotencyKey
+	OriginalRequestHash    string
+	ConflictingRequestHash string
+}
+
+func (e *IdempotencyConflictError) Error() string {
+	return ErrIdempotencyConflict.Error()
+}
+
+func (e *IdempotencyConflictError) Is(target error) bool {
+	return target == ErrIdempotencyConflict
+}
+
+func (r Request) normalize(now time.Time) (Request, error) {
+	r.ActorTokenID = strings.TrimSpace(r.ActorTokenID)
+	r.IdempotencyKey = strings.TrimSpace(r.IdempotencyKey)
+	r.RequestHash = strings.TrimSpace(r.RequestHash)
+	if r.ActorTokenID == "" {
+		return Request{}, fmt.Errorf("%w: actor token id is required", ErrInvalidRequest)
+	}
+	if r.IdempotencyKey != "" && r.RequestHash == "" {
+		return Request{}, fmt.Errorf("%w: request hash is required when idempotency key is present", ErrInvalidRequest)
+	}
+	if r.RequestedAt.IsZero() {
+		r.RequestedAt = now
+	}
+	r.RequestedAt = r.RequestedAt.UTC()
+	return r, nil
+}
+
+func (k IdempotencyKey) normalized() IdempotencyKey {
+	k.OperationName = strings.TrimSpace(k.OperationName)
+	if k.OperationName == "" {
+		k.OperationName = DefaultOperationName
+	}
+	k.ActorTokenID = strings.TrimSpace(k.ActorTokenID)
+	k.IdempotencyKey = strings.TrimSpace(k.IdempotencyKey)
+	return k
+}


### PR DESCRIPTION
Closes #773
Part of #771
Part of #748

## Summary
- Adds `internal/runtime/destructivereset` as the canonical internal owner for destructive reset plan/result contracts, dry-run planning, global lock coordination, and idempotency replay/conflict behavior.
- Enumerates downstream split contracts for active run/delivery quiescence, run-scoped truncation, managed container selection, future public `runtime.nuke`, and legacy reset migration.
- Keeps this PR inside the approved first-slice boundary: no public `/v1/rpc runtime.nuke`, no OpenRPC/platform-spec method addition, no destructive apply path, and no dashboard/Builder/run_clear migration.

## Governing Context
- Binding gate: #773 Pre-Implementation Coverage Audit and independent gate outcome `approved as first slice`.
- Parent context: #771 destructive runtime reset ownership and #748 CLI v2 API extension/deprecation tail.
- Authoritative adjacent spec refs: `platform-spec.yaml` `api_idempotency`, `runtime_ingress_state`, API idempotency convention, and deferred `runtime_admin.runtime.reset_state` / `/api/runtime/actions {reset_state}` migration text.
- Draft consumer context: root CLI v2 proposed `swarm control nuke`, treated only as downstream context, not authority to expose public API in this PR.

## Semantic Boundary
- New canonical owner: `internal/runtime/destructivereset.Coordinator` and `InventoryPlanner` for plan/result/lock/dry-run/idempotency envelope.
- Old paths are explicitly non-authoritative for this class: dashboard/Builder reset_state, `AgentManager.ResetRuntimeStateWithSource`, startup recovery reset, `sessions.ResetAll`, `run.stop`, workspace Docker helpers, and `scripts/run_clear.sh reset-dev`.
- Migration is not complete for the parent class; downstream destructive apply and public API exposure remain split under #771/#748.

## Proof
- `go test ./internal/runtime/destructivereset -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `rg -n 'runtime\.nuke' internal/apiv1 docs/specs/swarm-platform/platform/contracts/platform-spec.yaml docs/specs/swarm-platform/platform/contracts/openrpc.json` returned no matches.
- `rg -n 'ResetRuntimeStateWithSource|StopRunControl\(|StopEntityWorkspace\(|TRUNCATE|CancelActiveRunWorkByProducer' internal/runtime/destructivereset` returned no matches.
