### PR TITLE
[agent-b][issue #775] Add destructive reset quiescence owner

### DIFF
--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -237,10 +238,90 @@ func TestInventoryPlannerMergesPreservedResourceDefaultsByField(t *testing.T) {
 	}
 }
 
+func TestQuiescerAppliesPlanResultThroughStore(t *testing.T) {
+	now := time.Date(2026, 5, 15, 2, 30, 0, 0, time.UTC)
+	store := &recordingQuiescenceStore{
+		result: QuiescenceResult{
+			OperationName: DefaultOperationName,
+			DryRun:        false,
+			AppliedAt:     now,
+			ReasonCode:    QuiescenceReasonCode,
+			ControlledBy:  QuiescenceControlledBy,
+			Runs:          []QuiescedRun{{RunID: "run-1", PreviousStatus: "running", Status: "cancelled", Changed: true}},
+		},
+	}
+	q := Quiescer{Store: store, Now: func() time.Time { return now }}
+	plan := Result{
+		OperationName: DefaultOperationName,
+		PlannedAt:     now.Add(-time.Minute),
+		Plan:          Plan{ActiveRuns: []RunRef{{RunID: "run-1", Status: "running"}}},
+	}
+
+	got, err := q.Apply(context.Background(), QuiescenceRequest{Result: plan, ActorTokenID: "operator-token"})
+	if err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("store calls = %d, want 1", store.calls)
+	}
+	if store.last.ActorTokenID != "operator-token" || store.last.RequestedAt.IsZero() {
+		t.Fatalf("store request = %#v, want actor and requested_at", store.last)
+	}
+	if got.Runs[0].RunID != "run-1" {
+		t.Fatalf("quiescence runs = %#v", got.Runs)
+	}
+	got.Runs[0].RunID = "tampered"
+	if store.result.Runs[0].RunID != "run-1" {
+		t.Fatal("Apply leaked mutable result slices")
+	}
+}
+
+func TestQuiescerFailsClosedWithoutPlanResultOrStore(t *testing.T) {
+	_, err := (Quiescer{}).Apply(context.Background(), QuiescenceRequest{ActorTokenID: "operator-token"})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("missing plan error = %v, want ErrInvalidRequest", err)
+	}
+	_, err = (Quiescer{}).Apply(context.Background(), QuiescenceRequest{
+		ActorTokenID: "operator-token",
+		Result:       Result{PlannedAt: time.Date(2026, 5, 15, 2, 30, 0, 0, time.UTC)},
+	})
+	if err == nil || !strings.Contains(err.Error(), "quiescence store") {
+		t.Fatalf("missing store error = %v, want quiescence store failure", err)
+	}
+}
+
+func TestQuiescerPropagatesStoreFailure(t *testing.T) {
+	storeErr := errors.New("store failed")
+	_, err := (Quiescer{Store: &recordingQuiescenceStore{err: storeErr}}).Apply(context.Background(), QuiescenceRequest{
+		ActorTokenID: "operator-token",
+		Result: Result{
+			OperationName: DefaultOperationName,
+			PlannedAt:     time.Date(2026, 5, 15, 2, 30, 0, 0, time.UTC),
+			Plan:          Plan{ActiveRuns: []RunRef{{RunID: "run-1", Status: "running"}}},
+		},
+	})
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("Apply error = %v, want store failure", err)
+	}
+}
+
 type recordingInventoryReader struct {
 	inventory Inventory
 	err       error
 	reads     int
+}
+
+type recordingQuiescenceStore struct {
+	result QuiescenceResult
+	err    error
+	calls  int
+	last   QuiescenceRequest
+}
+
+func (s *recordingQuiescenceStore) ApplyDestructiveResetQuiescence(_ context.Context, req QuiescenceRequest) (QuiescenceResult, error) {
+	s.calls++
+	s.last = req
+	return copyQuiescenceResult(s.result), s.err
 }
 
 func (r *recordingInventoryReader) ReadResetInventory(context.Context) (Inventory, error) {

--- a/internal/runtime/destructivereset/quiescer.go
+++ b/internal/runtime/destructivereset/quiescer.go
@@ -1,0 +1,54 @@
+package destructivereset
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Quiescer struct {
+	Store QuiescenceStore
+	Now   func() time.Time
+}
+
+func (q Quiescer) Apply(ctx context.Context, req QuiescenceRequest) (QuiescenceResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	if req.ActorTokenID == "" {
+		return QuiescenceResult{}, fmt.Errorf("%w: actor token id is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(req.Result.OperationName) == "" {
+		req.Result.OperationName = DefaultOperationName
+	}
+	if req.Result.PlannedAt.IsZero() {
+		return QuiescenceResult{}, fmt.Errorf("%w: destructive reset plan result is required", ErrInvalidRequest)
+	}
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = q.now()
+	}
+	req.RequestedAt = req.RequestedAt.UTC()
+	if q.Store == nil {
+		return QuiescenceResult{}, fmt.Errorf("destructive reset quiescence store is not configured")
+	}
+	result, err := q.Store.ApplyDestructiveResetQuiescence(ctx, req)
+	if err != nil {
+		return QuiescenceResult{}, err
+	}
+	return copyQuiescenceResult(result), nil
+}
+
+func (q Quiescer) now() time.Time {
+	if q.Now != nil {
+		return q.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func copyQuiescenceResult(result QuiescenceResult) QuiescenceResult {
+	result.Runs = append([]QuiescedRun(nil), result.Runs...)
+	result.Deliveries = append([]QuiescedDelivery(nil), result.Deliveries...)
+	return result
+}

--- a/internal/runtime/destructivereset/types.go
+++ b/internal/runtime/destructivereset/types.go
@@ -11,6 +11,10 @@ import (
 const (
 	DefaultOperationName = "runtime.destructive_reset"
 	defaultLockKey       = "swarm:runtime:destructive-reset"
+
+	QuiescenceControlledBy = DefaultOperationName
+	QuiescenceReasonCode   = "runtime_nuke_cancelled"
+	QuiescenceDeliveryNote = "runtime destructive reset cancelled delivery"
 )
 
 var (
@@ -35,6 +39,45 @@ type Result struct {
 	DryRun        bool      `json:"dry_run"`
 	PlannedAt     time.Time `json:"planned_at"`
 	Plan          Plan      `json:"plan"`
+}
+
+type QuiescenceRequest struct {
+	Result       Result
+	ActorTokenID string
+	RequestedAt  time.Time
+}
+
+type QuiescenceResult struct {
+	OperationName        string             `json:"operation_name"`
+	DryRun               bool               `json:"dry_run"`
+	AppliedAt            time.Time          `json:"applied_at"`
+	ReasonCode           string             `json:"reason_code"`
+	ControlledBy         string             `json:"controlled_by"`
+	Runs                 []QuiescedRun      `json:"runs"`
+	Deliveries           []QuiescedDelivery `json:"deliveries"`
+	PipelineReceiptCount int                `json:"pipeline_receipt_count"`
+}
+
+type QuiescedRun struct {
+	RunID          string `json:"run_id"`
+	PreviousStatus string `json:"previous_status"`
+	Status         string `json:"status"`
+	ReasonCode     string `json:"reason_code"`
+	Changed        bool   `json:"changed"`
+}
+
+type QuiescedDelivery struct {
+	DeliveryID      string `json:"delivery_id"`
+	RunID           string `json:"run_id"`
+	EventID         string `json:"event_id"`
+	SubscriberType  string `json:"subscriber_type"`
+	SubscriberID    string `json:"subscriber_id"`
+	PreviousStatus  string `json:"previous_status"`
+	Status          string `json:"status"`
+	ReasonCode      string `json:"reason_code"`
+	PreviousReason  string `json:"previous_reason,omitempty"`
+	ActiveSessionID string `json:"active_session_id,omitempty"`
+	Changed         bool   `json:"changed"`
 }
 
 type Plan struct {
@@ -118,6 +161,10 @@ type LockLease interface {
 type IdempotencyStore interface {
 	LoadResetResult(context.Context, IdempotencyKey) (StoredResult, bool, error)
 	StoreResetResult(context.Context, StoredResult) error
+}
+
+type QuiescenceStore interface {
+	ApplyDestructiveResetQuiescence(context.Context, QuiescenceRequest) (QuiescenceResult, error)
 }
 
 type IdempotencyKey struct {

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -82,10 +82,10 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-# Branch on the actual tool-result payload, not the process invocation count.
-# Extra startup/probe/fallback invocations should not make the first real turn
-# skip the provider-native Read tool call.
-if grep -q '"name":"read_file"' "$captured"; then
+# Branch on the actual tool-result payload, not just the tool name or process
+# invocation count. Startup/probe prompts may include compact tool schema text
+# containing "read_file", but only the second turn includes an ok result.
+if grep -Eq '"name"[[:space:]]*:[[:space:]]*"read_file"' "$captured" && grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' "$captured"; then
   printf '%s\n' '{"type":"result","result":"done"}'
 else
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -27,6 +27,10 @@ type deliveryProgressWriter interface {
 	MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error
 }
 
+type destructiveResetDeliveryQuiescenceReader interface {
+	DestructiveResetDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error)
+}
+
 func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt events.Event) error {
 	result := am.processEventDetailed(ctx, agent, evt)
 	return result.err
@@ -101,7 +105,17 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 			})
 		}
 	}
+	if am.destructiveResetDeliveryQuiesced(ctx, evt.ID, agent.ID()) {
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = "runtime_nuke_cancelled"
+		return eventProcessResult{record: record}
+	}
 	out, err := agent.OnEvent(ctx, evt)
+	if am.destructiveResetDeliveryQuiesced(ctx, evt.ID, agent.ID()) {
+		record.Outcome = startupManagerReplayOutcomeSkipped
+		record.ReasonCode = "runtime_nuke_cancelled"
+		return eventProcessResult{record: record}
+	}
 	if err != nil {
 		if isTransientAgentError(err) {
 			// Transient lock/contention errors should be retried without poisoning receipts.
@@ -157,6 +171,31 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 	record.Outcome = startupManagerReplayOutcomeReplayed
 	record.ReasonCode = startupManagerReplayReasonReplayed
 	return eventProcessResult{record: record}
+}
+
+func (am *AgentManager) destructiveResetDeliveryQuiesced(ctx context.Context, eventID, agentID string) bool {
+	reader, ok := am.store.(destructiveResetDeliveryQuiescenceReader)
+	if !ok || reader == nil {
+		return false
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false
+	}
+	ok, err := reader.DestructiveResetDeliveryQuiesced(ctx, eventID, "agent", agentID)
+	if err != nil {
+		if am.bus != nil {
+			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
+				Level:     "error",
+				Component: "agent-manager",
+				Action:    "destructive_reset_quiescence_check_failed",
+				EventID:   strings.TrimSpace(eventID),
+				AgentID:   strings.TrimSpace(agentID),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+		return true
+	}
+	return ok
 }
 
 func (am *AgentManager) shouldInterceptDirective(agentID string, evt events.Event) bool {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -85,6 +86,18 @@ func (a *traceRecordingAgent) OnEvent(ctx context.Context, evt events.Event) ([]
 		a.parent = inbound.ID
 	}
 	return nil, nil
+}
+
+type outputRecordingAgent struct {
+	calls int
+}
+
+func (a *outputRecordingAgent) ID() string                        { return "agent-a" }
+func (a *outputRecordingAgent) Type() string                      { return "llm" }
+func (a *outputRecordingAgent) Subscriptions() []events.EventType { return nil }
+func (a *outputRecordingAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	a.calls++
+	return []events.Event{{ID: "out-1", Type: "task.done", SourceAgent: "agent-a", Payload: []byte(`{}`)}}, nil
 }
 
 type panicStubAgent struct{ id string }
@@ -356,12 +369,19 @@ func TestProcessEvent_PropagatesInboundParentWithoutTraceSeeding(t *testing.T) {
 
 type deliveryLifecycleStoreStub struct {
 	receiptReaderStub
-	markCalls []string
+	markCalls           []string
+	quiescenceChecks    int
+	quiescedAfterChecks int
 }
 
 func (s *deliveryLifecycleStoreStub) MarkEventDeliveryInProgress(_ context.Context, eventID, agentID, sessionID string) error {
 	s.markCalls = append(s.markCalls, strings.TrimSpace(eventID)+"|"+strings.TrimSpace(agentID)+"|"+strings.TrimSpace(sessionID))
 	return nil
+}
+
+func (s *deliveryLifecycleStoreStub) DestructiveResetDeliveryQuiesced(context.Context, string, string, string) (bool, error) {
+	s.quiescenceChecks++
+	return s.quiescedAfterChecks > 0 && s.quiescenceChecks >= s.quiescedAfterChecks, nil
 }
 
 func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {
@@ -387,6 +407,30 @@ func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {
 	detail := entry.Detail.(map[string]any)
 	if detail["delivery_state"] != "launching" || detail["delivery_previous_state"] != "queued" || detail["delivery_reason"] != "agent_processing" {
 		t.Fatalf("launching detail = %#v", detail)
+	}
+}
+
+func TestProcessEvent_SkipsLateOutputAndReceiptAfterDestructiveResetQuiescence(t *testing.T) {
+	bus := &recordingReceiptBus{}
+	store := &deliveryLifecycleStoreStub{quiescedAfterChecks: 2}
+	am := NewAgentManager(bus, nil, store)
+	agent := &outputRecordingAgent{}
+
+	result := am.processEventDetailed(context.Background(), agent, events.Event{ID: uuid.NewString(), Type: events.EventType("task.started")})
+	if result.err != nil {
+		t.Fatalf("processEventDetailed error = %v", result.err)
+	}
+	if agent.calls != 1 {
+		t.Fatalf("agent calls = %d, want 1 before late quiescence guard", agent.calls)
+	}
+	if len(bus.published) != 0 {
+		t.Fatalf("published events = %#v, want none after quiescence", bus.published)
+	}
+	if store.upsertCalls != 0 {
+		t.Fatalf("receipt upserts = %d, want none after quiescence", store.upsertCalls)
+	}
+	if result.record.ReasonCode != "runtime_nuke_cancelled" {
+		t.Fatalf("reason = %q, want runtime_nuke_cancelled", result.record.ReasonCode)
 	}
 }
 

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimerterr "swarm/internal/runtime/rterrors"
 	"swarm/internal/testutil"
 )
@@ -128,6 +129,52 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 	}
 	if failureType != "chain_depth_exceeded" || chainDepth != 6 || !strings.HasPrefix(handlerNode, "node-1") {
 		t.Fatalf("dead_letter row = type=%q chain_depth=%d handler=%q", failureType, chainDepth, handlerNode)
+	}
+}
+
+func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := testPipelineRunContext(t, db)
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'source.evt', 'global', '{}'::jsonb, 'src', 'agent', now()
+		)
+	`, eventID, testPipelineRunID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at, delivered_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', 'node-a', 'dead_letter', $3, now(), now()
+		)
+	`, testPipelineRunID, eventID, runtimedestructivereset.QuiescenceReasonCode); err != nil {
+		t.Fatalf("seed quiesced node delivery: %v", err)
+	}
+	bus := &capturingDeadLetterBus{}
+	handled := 0
+	runner := newSystemNodeRunner("node-a", bus, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+		handled++
+		return errors.New("should not run")
+	})
+
+	runner.ProcessEventForTest(ctx, events.Event{ID: eventID, RunID: testPipelineRunID, Type: "source.evt", Payload: []byte(`{}`), CreatedAt: time.Now().UTC()})
+
+	if handled != 0 {
+		t.Fatalf("handler calls = %d, want 0 for quiesced delivery", handled)
+	}
+	if got := len(bus.published()); got != 0 {
+		t.Fatalf("published events = %d, want 0 for quiesced delivery", got)
+	}
+	var deadLetters int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM dead_letters WHERE original_event_id = $1::uuid`, eventID).Scan(&deadLetters); err != nil {
+		t.Fatalf("count dead letters: %v", err)
+	}
+	if deadLetters != 0 {
+		t.Fatalf("dead letters = %d, want 0", deadLetters)
 	}
 }
 

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimerterr "swarm/internal/runtime/rterrors"
 )
 
@@ -104,6 +105,9 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	if eventID == "" {
 		return
 	}
+	if n.isDestructiveResetQuiesced(ctx, evt) {
+		return
+	}
 	if n.isProcessed(ctx, evt) {
 		return
 	}
@@ -120,7 +124,9 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	}
 	for attempt := 1; attempt <= retryLimit; attempt++ {
 		if err := n.handle(ctx, evt); err == nil {
-			n.markProcessed(ctx, evt)
+			if !n.isDestructiveResetQuiesced(ctx, evt) {
+				n.markProcessed(ctx, evt)
+			}
 			return
 		} else {
 			lastErr = err
@@ -139,6 +145,9 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 			return
 		case <-time.After(backoffFn(attempt)):
 		}
+	}
+	if n.isDestructiveResetQuiesced(ctx, evt) {
+		return
 	}
 	n.emitDeadLetter(ctx, evt, lastErr, failureType, retryCount)
 	n.markProcessed(ctx, evt)
@@ -297,7 +306,7 @@ func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bo
 			  AND subscriber_id = $1
 			  AND idempotency_key = $2
 		)
-	`, n.nodeID, systemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
+	`, n.nodeID, SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
 	return err == nil && ok
 }
 
@@ -306,11 +315,14 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	if n == nil || n.db == nil || eventID == "" {
 		return
 	}
+	if n.isDestructiveResetQuiesced(ctx, evt) {
+		return
+	}
 	if !n.eventReceiptsAvailable(ctx) {
 		return
 	}
 	sideEffects, _ := json.Marshal(map[string]any{
-		"idempotency_key": systemNodeReceiptIdempotencyKey(n.nodeID, eventID),
+		"idempotency_key": SystemNodeReceiptIdempotencyKey(n.nodeID, eventID),
 	})
 	if _, err := n.db.ExecContext(ctx, `
 		INSERT INTO event_receipts (
@@ -323,7 +335,7 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 		FROM events e
 		WHERE e.event_id = $1::uuid
 		ON CONFLICT (event_id, subscriber_id) DO NOTHING
-	`, eventID, n.nodeID, string(sideEffects), systemNodeReceiptIdempotencyKey(n.nodeID, eventID)); err != nil {
+	`, eventID, n.nodeID, string(sideEffects), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)); err != nil {
 		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -338,6 +350,33 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 			})
 		}
 	}
+}
+
+func (n *systemNodeRunner) isDestructiveResetQuiesced(ctx context.Context, evt events.Event) bool {
+	eventID := strings.TrimSpace(evt.ID)
+	if n == nil || n.db == nil || eventID == "" {
+		return false
+	}
+	if _, err := uuid.Parse(eventID); err != nil {
+		return false
+	}
+	var ok bool
+	err := n.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND status = 'dead_letter'
+			  AND reason_code = $3
+		)
+	`, eventID, n.nodeID, runtimedestructivereset.QuiescenceReasonCode).Scan(&ok)
+	if err != nil {
+		slog.Error("system node destructive reset quiescence check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+		return true
+	}
+	return ok
 }
 
 func (n *systemNodeRunner) eventReceiptsAvailable(ctx context.Context) bool {
@@ -388,6 +427,6 @@ func defaultSystemNodeBackoff(base time.Duration, attempt int) time.Duration {
 	return d
 }
 
-func systemNodeReceiptIdempotencyKey(nodeID, eventID string) string {
+func SystemNodeReceiptIdempotencyKey(nodeID, eventID string) string {
 	return strings.TrimSpace(nodeID) + ":" + strings.TrimSpace(eventID)
 }

--- a/internal/store/destructive_reset_quiescence.go
+++ b/internal/store/destructive_reset_quiescence.go
@@ -218,7 +218,7 @@ func (s *PostgresStore) lockDestructiveResetDeliveriesTx(ctx context.Context, tx
 		FROM event_deliveries d
 		WHERE d.run_id = ANY($1::uuid[])
 		  AND d.subscriber_type IN ('agent', 'node')
-		  AND d.status IN ('pending', 'in_progress')
+		  AND `+destructiveResetQuiescenceDeliveryPredicateSQL("d")+`
 		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
 		FOR UPDATE
 	`, pq.Array(runIDs))
@@ -258,7 +258,7 @@ func (s *PostgresStore) terminalizeDestructiveResetDeliveryTx(ctx context.Contex
 			active_session_id = NULL,
 			delivered_at = COALESCE(delivered_at, $4)
 		WHERE delivery_id = $1::uuid
-		  AND status IN ('pending', 'in_progress')
+		  AND `+destructiveResetQuiescenceDeliveryPredicateSQL("")+`
 	`, item.DeliveryID, destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceDeliveryNote, at.UTC()); err != nil {
 		return fmt.Errorf("terminalize destructive reset delivery %s: %w", item.DeliveryID, err)
 	}
@@ -341,4 +341,19 @@ func (s *PostgresStore) upsertDestructiveResetRunControlTx(ctx context.Context, 
 
 func destructiveResetDeliveryTerminal(status, reasonCode string) bool {
 	return strings.TrimSpace(status) == "dead_letter" && strings.TrimSpace(reasonCode) == destructivereset.QuiescenceReasonCode
+}
+
+func destructiveResetQuiescenceDeliveryPredicateSQL(alias string) string {
+	prefix := ""
+	if strings.TrimSpace(alias) != "" {
+		prefix = strings.TrimSpace(alias) + "."
+	}
+	return `(
+			` + prefix + `status IN ('pending', 'in_progress')
+			OR (
+				` + prefix + `status = 'failed'
+				AND COALESCE(` + prefix + `retry_count, 0) < 2
+				AND COALESCE(` + prefix + `delivered_at, ` + prefix + `created_at) <= now() - interval '1 minute'
+			)
+		)`
 }

--- a/internal/store/destructive_reset_quiescence.go
+++ b/internal/store/destructive_reset_quiescence.go
@@ -1,0 +1,344 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"swarm/internal/runtime/destructivereset"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+const destructiveResetPipelineSubscriberID = "pipeline"
+
+type destructiveResetDeliveryTarget struct {
+	DeliveryID      string
+	RunID           string
+	EventID         string
+	SubscriberType  string
+	SubscriberID    string
+	Status          string
+	ReasonCode      string
+	ActiveSessionID string
+}
+
+func (s *PostgresStore) ApplyDestructiveResetQuiescence(ctx context.Context, req destructivereset.QuiescenceRequest) (destructivereset.QuiescenceResult, error) {
+	if s == nil || s.DB == nil {
+		return destructivereset.QuiescenceResult{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return destructivereset.QuiescenceResult{}, err
+	}
+	if !caps.Events.HasRuns {
+		return destructivereset.QuiescenceResult{}, fmt.Errorf("runs table is required")
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		if caps.Events.Deliveries != SchemaFlavorCanonical {
+			return destructivereset.QuiescenceResult{}, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+		}
+		return destructivereset.QuiescenceResult{}, fmt.Errorf("destructive reset quiescence requires canonical event_deliveries.run_id")
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical {
+		return destructivereset.QuiescenceResult{}, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	}
+	runIDs := activeRunIDsFromResetPlan(req.Result.Plan)
+	now := req.RequestedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	out := destructivereset.QuiescenceResult{
+		OperationName: strings.TrimSpace(req.Result.OperationName),
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     now,
+		ReasonCode:    destructivereset.QuiescenceReasonCode,
+		ControlledBy:  destructivereset.QuiescenceControlledBy,
+	}
+	if out.OperationName == "" {
+		out.OperationName = destructivereset.DefaultOperationName
+	}
+	if len(runIDs) == 0 {
+		return out, nil
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return destructivereset.QuiescenceResult{}, fmt.Errorf("begin destructive reset quiescence tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	runs, err := s.lockDestructiveResetRunsTx(ctx, tx, runIDs)
+	if err != nil {
+		return destructivereset.QuiescenceResult{}, err
+	}
+	deliveries, err := s.lockDestructiveResetDeliveriesTx(ctx, tx, runIDs)
+	if err != nil {
+		return destructivereset.QuiescenceResult{}, err
+	}
+	for _, delivery := range deliveries {
+		out.Deliveries = append(out.Deliveries, destructivereset.QuiescedDelivery{
+			DeliveryID:      delivery.DeliveryID,
+			RunID:           delivery.RunID,
+			EventID:         delivery.EventID,
+			SubscriberType:  delivery.SubscriberType,
+			SubscriberID:    delivery.SubscriberID,
+			PreviousStatus:  delivery.Status,
+			Status:          "dead_letter",
+			ReasonCode:      destructivereset.QuiescenceReasonCode,
+			PreviousReason:  delivery.ReasonCode,
+			ActiveSessionID: delivery.ActiveSessionID,
+			Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != destructivereset.QuiescenceReasonCode,
+		})
+	}
+	for _, run := range runs {
+		nextStatus := run.Status
+		changed := false
+		if destructiveResetRunStatusActive(run.Status) {
+			nextStatus = "cancelled"
+			changed = true
+		}
+		out.Runs = append(out.Runs, destructivereset.QuiescedRun{
+			RunID:          run.RunID,
+			PreviousStatus: run.Status,
+			Status:         nextStatus,
+			ReasonCode:     destructivereset.QuiescenceReasonCode,
+			Changed:        changed,
+		})
+	}
+	if req.Result.DryRun {
+		return out, nil
+	}
+
+	eventIDs := map[string]struct{}{}
+	for _, delivery := range deliveries {
+		if err := s.terminalizeDestructiveResetDeliveryTx(ctx, tx, delivery, now); err != nil {
+			return destructivereset.QuiescenceResult{}, err
+		}
+		if delivery.EventID != "" {
+			eventIDs[delivery.EventID] = struct{}{}
+		}
+	}
+	for eventID := range eventIDs {
+		if err := s.upsertDestructiveResetPipelineReceiptTx(ctx, tx, eventID, now); err != nil {
+			return destructivereset.QuiescenceResult{}, err
+		}
+		out.PipelineReceiptCount++
+	}
+	for _, run := range runs {
+		if !destructiveResetRunStatusActive(run.Status) {
+			continue
+		}
+		if _, err := storerunlifecycle.MarkTerminal(ctx, tx, run.RunID, "cancelled", "", now, runLifecycleOptions(caps)); err != nil {
+			return destructivereset.QuiescenceResult{}, fmt.Errorf("mark destructive reset run terminal: %w", err)
+		}
+		if err := s.upsertDestructiveResetRunControlTx(ctx, tx, run.RunID, now); err != nil {
+			return destructivereset.QuiescenceResult{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return destructivereset.QuiescenceResult{}, fmt.Errorf("commit destructive reset quiescence tx: %w", err)
+	}
+	return out, nil
+}
+
+func activeRunIDsFromResetPlan(plan destructivereset.Plan) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(plan.ActiveRuns))
+	for _, run := range plan.ActiveRuns {
+		if !destructiveResetRunStatusActive(run.Status) {
+			continue
+		}
+		id := nullUUIDString(run.RunID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func destructiveResetRunStatusActive(status string) bool {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "running", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *PostgresStore) lockDestructiveResetRunsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]destructivereset.QuiescedRun, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id::text, COALESCE(status, '')
+		FROM runs
+		WHERE run_id = ANY($1::uuid[])
+		ORDER BY run_id::text
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock destructive reset runs: %w", err)
+	}
+	defer rows.Close()
+	var out []destructivereset.QuiescedRun
+	for rows.Next() {
+		var run destructivereset.QuiescedRun
+		if err := rows.Scan(&run.RunID, &run.PreviousStatus); err != nil {
+			return nil, fmt.Errorf("scan destructive reset run: %w", err)
+		}
+		run.RunID = strings.TrimSpace(run.RunID)
+		run.PreviousStatus = strings.TrimSpace(run.PreviousStatus)
+		run.Status = run.PreviousStatus
+		out = append(out, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read destructive reset runs: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) lockDestructiveResetDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]destructiveResetDeliveryTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			d.delivery_id::text,
+			d.run_id::text,
+			d.event_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id::text, '')
+		FROM event_deliveries d
+		WHERE d.run_id = ANY($1::uuid[])
+		  AND d.subscriber_type IN ('agent', 'node')
+		  AND d.status IN ('pending', 'in_progress')
+		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock destructive reset deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []destructiveResetDeliveryTarget
+	for rows.Next() {
+		var item destructiveResetDeliveryTarget
+		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.ActiveSessionID); err != nil {
+			return nil, fmt.Errorf("scan destructive reset delivery: %w", err)
+		}
+		item.DeliveryID = strings.TrimSpace(item.DeliveryID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.EventID = strings.TrimSpace(item.EventID)
+		item.SubscriberType = strings.TrimSpace(item.SubscriberType)
+		item.SubscriberID = strings.TrimSpace(item.SubscriberID)
+		item.Status = strings.TrimSpace(item.Status)
+		item.ReasonCode = strings.TrimSpace(item.ReasonCode)
+		item.ActiveSessionID = strings.TrimSpace(item.ActiveSessionID)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read destructive reset deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) terminalizeDestructiveResetDeliveryTx(ctx context.Context, tx *sql.Tx, item destructiveResetDeliveryTarget, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'dead_letter',
+			reason_code = $2,
+			last_error = $3,
+			active_session_id = NULL,
+			delivered_at = COALESCE(delivered_at, $4)
+		WHERE delivery_id = $1::uuid
+		  AND status IN ('pending', 'in_progress')
+	`, item.DeliveryID, destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceDeliveryNote, at.UTC()); err != nil {
+		return fmt.Errorf("terminalize destructive reset delivery %s: %w", item.DeliveryID, err)
+	}
+	sideEffects, err := json.Marshal(map[string]any{
+		"manager_status": "dead_letter",
+		"reason_code":    destructivereset.QuiescenceReasonCode,
+		"error":          destructivereset.QuiescenceDeliveryNote,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal destructive reset receipt side effects: %w", err)
+	}
+	idempotencyKey := ""
+	if item.SubscriberType == "node" {
+		idempotencyKey = runtimepipeline.SystemNodeReceiptIdempotencyKey(item.SubscriberID, item.EventID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, $2, $3, e.entity_id, e.flow_instance,
+			'dead_letter', $4, $5::jsonb, NULLIF($6, ''), $7
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = $4,
+			side_effects = $5::jsonb,
+			idempotency_key = COALESCE(NULLIF($6, ''), event_receipts.idempotency_key),
+			processed_at = $7
+	`, item.EventID, item.SubscriberType, item.SubscriberID, destructivereset.QuiescenceReasonCode, string(sideEffects), idempotencyKey, at.UTC()); err != nil {
+		return fmt.Errorf("upsert destructive reset delivery receipt: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) upsertDestructiveResetPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID string, at time.Time) error {
+	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects("dead_letter", destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceDeliveryNote))
+	if err != nil {
+		return fmt.Errorf("marshal destructive reset pipeline receipt: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
+			'dead_letter', $3, $4::jsonb, $5
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = $3,
+			side_effects = $4::jsonb,
+			processed_at = $5
+	`, eventID, destructiveResetPipelineSubscriberID, destructivereset.QuiescenceReasonCode, string(sideEffects), at.UTC()); err != nil {
+		return fmt.Errorf("upsert destructive reset pipeline receipt: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) upsertDestructiveResetRunControlTx(ctx context.Context, tx *sql.Tx, runID string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES ($1::uuid, 'stopped', $2, $3, $4, NULL, $4)
+		ON CONFLICT (run_id) DO UPDATE SET
+			control_status = 'stopped',
+			reason = $2,
+			controlled_by = $3,
+			updated_at = $4,
+			paused_at = NULL,
+			stopped_at = COALESCE(run_control_state.stopped_at, $4)
+	`, runID, destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceControlledBy, at.UTC()); err != nil {
+		return fmt.Errorf("persist destructive reset run control state: %w", err)
+	}
+	return nil
+}
+
+func destructiveResetDeliveryTerminal(status, reasonCode string) bool {
+	return strings.TrimSpace(status) == "dead_letter" && strings.TrimSpace(reasonCode) == destructivereset.QuiescenceReasonCode
+}

--- a/internal/store/destructive_reset_quiescence.go
+++ b/internal/store/destructive_reset_quiescence.go
@@ -353,7 +353,6 @@ func destructiveResetQuiescenceDeliveryPredicateSQL(alias string) string {
 			OR (
 				` + prefix + `status = 'failed'
 				AND COALESCE(` + prefix + `retry_count, 0) < 2
-				AND COALESCE(` + prefix + `delivered_at, ` + prefix + `created_at) <= now() - interval '1 minute'
 			)
 		)`
 }

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -29,9 +29,11 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	agentPending := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.pending")
 	agentInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.in_progress")
 	agentRetryableFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.failed_retryable")
+	agentDelayedRetryableFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.failed_retryable_delayed")
 	agentExhaustedFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.failed_exhausted")
 	nodePending := seedDestructiveResetEvent(t, ctx, pg, runID, "node.pending")
 	nodeInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "node.in_progress")
+	nodeDelayedRetryableFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "node.failed_retryable_delayed")
 	delivered := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.delivered")
 	activeSessionID := uuid.NewString()
 	if _, err := pg.DB.ExecContext(ctx, `
@@ -39,13 +41,15 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, retry_count, reason_code, created_at, delivered_at
 		) VALUES
 			($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', now(), NULL),
-			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $8::uuid, 0, 'agent_processing', now(), NULL),
+			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $10::uuid, 0, 'agent_processing', now(), NULL),
 			($1::uuid, $4::uuid, 'agent', 'agent-a', 'failed', NULL, 1, 'agent_retryable_error', now() - interval '5 minutes', now() - interval '2 minutes'),
-			($1::uuid, $5::uuid, 'agent', 'agent-a', 'failed', NULL, 2, 'retry_exhausted', now() - interval '5 minutes', now() - interval '2 minutes'),
-			($1::uuid, $6::uuid, 'node', 'node-a', 'pending', NULL, 0, 'matched_node_subscription', now(), NULL),
-			($1::uuid, $7::uuid, 'node', 'node-a', 'in_progress', $8::uuid, 0, 'node_processing', now(), NULL),
-			($1::uuid, $9::uuid, 'agent', 'agent-a', 'delivered', NULL, 0, 'agent_processed', now(), now())
-	`, runID, agentPending, agentInProgress, agentRetryableFailed, agentExhaustedFailed, nodePending, nodeInProgress, activeSessionID, delivered); err != nil {
+			($1::uuid, $5::uuid, 'agent', 'agent-a', 'failed', NULL, 1, 'agent_retryable_error', now(), now()),
+			($1::uuid, $6::uuid, 'agent', 'agent-a', 'failed', NULL, 2, 'retry_exhausted', now() - interval '5 minutes', now() - interval '2 minutes'),
+			($1::uuid, $7::uuid, 'node', 'node-a', 'pending', NULL, 0, 'matched_node_subscription', now(), NULL),
+			($1::uuid, $8::uuid, 'node', 'node-a', 'in_progress', $10::uuid, 0, 'node_processing', now(), NULL),
+			($1::uuid, $9::uuid, 'node', 'node-a', 'failed', NULL, 1, 'node_retryable_error', now(), now()),
+			($1::uuid, $11::uuid, 'agent', 'agent-a', 'delivered', NULL, 0, 'agent_processed', now(), now())
+	`, runID, agentPending, agentInProgress, agentRetryableFailed, agentDelayedRetryableFailed, agentExhaustedFailed, nodePending, nodeInProgress, nodeDelayedRetryableFailed, activeSessionID, delivered); err != nil {
 		t.Fatalf("seed deliveries: %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, agentPending, "processed", ""); err != nil {
@@ -67,11 +71,11 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if len(result.Runs) != 1 || result.Runs[0].Status != "cancelled" || !result.Runs[0].Changed {
 		t.Fatalf("runs = %#v, want one cancelled run", result.Runs)
 	}
-	if len(result.Deliveries) != 5 {
-		t.Fatalf("deliveries = %#v, want five active/retryable deliveries", result.Deliveries)
+	if len(result.Deliveries) != 7 {
+		t.Fatalf("deliveries = %#v, want seven active/retryable deliveries", result.Deliveries)
 	}
-	if result.PipelineReceiptCount != 5 {
-		t.Fatalf("pipeline receipt count = %d, want 5", result.PipelineReceiptCount)
+	if result.PipelineReceiptCount != 7 {
+		t.Fatalf("pipeline receipt count = %d, want 7", result.PipelineReceiptCount)
 	}
 
 	var runStatus, controlStatus, reason, controlledBy string
@@ -90,8 +94,10 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	assertDestructiveResetDelivery(t, ctx, pg, agentPending, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, agentDelayedRetryableFailed, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, nodePending, "node", "node-a")
 	assertDestructiveResetDelivery(t, ctx, pg, nodeInProgress, "node", "node-a")
+	assertDestructiveResetDelivery(t, ctx, pg, nodeDelayedRetryableFailed, "node", "node-a")
 
 	var deliveredStatus, deliveredReason string
 	if err := pg.DB.QueryRowContext(ctx, `
@@ -122,6 +128,16 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if err := pg.MarkEventDeliveryInProgress(ctx, agentRetryableFailed, "agent-a", uuid.NewString()); err != nil {
 		t.Fatalf("late retryable failed MarkEventDeliveryInProgress: %v", err)
 	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET delivered_at = now() - interval '2 minutes'
+		WHERE event_id = $1::uuid
+	`, agentDelayedRetryableFailed); err != nil {
+		t.Fatalf("age delayed retryable failed delivery after quiescence: %v", err)
+	}
+	if err := pg.MarkEventDeliveryInProgress(ctx, agentDelayedRetryableFailed, "agent-a", uuid.NewString()); err != nil {
+		t.Fatalf("late delayed retryable failed MarkEventDeliveryInProgress: %v", err)
+	}
 	if err := pg.UpsertEventReceipt(ctx, agentInProgress, "agent-a", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
 		t.Fatalf("late UpsertEventReceipt: %v", err)
 	}
@@ -130,10 +146,13 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	}
 	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, agentDelayedRetryableFailed, "agent", "agent-a")
 	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, "agent-a")
 	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, destructiveResetPipelineSubscriberID)
 	assertDestructiveResetReceipt(t, ctx, pg, agentRetryableFailed, "agent-a")
 	assertDestructiveResetReceipt(t, ctx, pg, agentRetryableFailed, destructiveResetPipelineSubscriberID)
+	assertDestructiveResetReceipt(t, ctx, pg, agentDelayedRetryableFailed, "agent-a")
+	assertDestructiveResetReceipt(t, ctx, pg, agentDelayedRetryableFailed, destructiveResetPipelineSubscriberID)
 
 	pending, err := pg.ListPendingEventsForAgent(ctx, "agent-a", now.Add(-time.Hour), 50)
 	if err != nil {
@@ -149,8 +168,8 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if err != nil {
 		t.Fatalf("ListOperatorEvents: %v", err)
 	}
-	if len(events.Events) != 5 {
-		t.Fatalf("operator events = %d, want 5 nuke-quiesced events", len(events.Events))
+	if len(events.Events) != 7 {
+		t.Fatalf("operator events = %d, want 7 nuke-quiesced events", len(events.Events))
 	}
 }
 

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -1,0 +1,233 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/runtime/destructivereset"
+	runtimemanager "swarm/internal/runtime/manager"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDeliveries(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	now := time.Date(2026, 5, 15, 2, 40, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	agentPending := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.pending")
+	agentInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.in_progress")
+	nodePending := seedDestructiveResetEvent(t, ctx, pg, runID, "node.pending")
+	nodeInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "node.in_progress")
+	delivered := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.delivered")
+	activeSessionID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+		) VALUES
+			($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', NULL, 'matched_agent_subscription', now()),
+			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $6::uuid, 'agent_processing', now()),
+			($1::uuid, $4::uuid, 'node', 'node-a', 'pending', NULL, 'matched_node_subscription', now()),
+			($1::uuid, $5::uuid, 'node', 'node-a', 'in_progress', $6::uuid, 'node_processing', now()),
+			($1::uuid, $7::uuid, 'agent', 'agent-a', 'delivered', NULL, 'agent_processed', now())
+	`, runID, agentPending, agentInProgress, nodePending, nodeInProgress, activeSessionID, delivered); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, agentPending, "processed", ""); err != nil {
+		t.Fatalf("seed pipeline receipt: %v", err)
+	}
+
+	result, err := pg.ApplyDestructiveResetQuiescence(ctx, destructivereset.QuiescenceRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName: destructivereset.DefaultOperationName,
+			PlannedAt:     now.Add(-time.Minute),
+			Plan:          destructivereset.Plan{ActiveRuns: []destructivereset.RunRef{{RunID: runID, Status: "running"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDestructiveResetQuiescence: %v", err)
+	}
+	if len(result.Runs) != 1 || result.Runs[0].Status != "cancelled" || !result.Runs[0].Changed {
+		t.Fatalf("runs = %#v, want one cancelled run", result.Runs)
+	}
+	if len(result.Deliveries) != 4 {
+		t.Fatalf("deliveries = %#v, want four active deliveries", result.Deliveries)
+	}
+	if result.PipelineReceiptCount != 4 {
+		t.Fatalf("pipeline receipt count = %d, want 4", result.PipelineReceiptCount)
+	}
+
+	var runStatus, controlStatus, reason, controlledBy string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT r.status, rc.control_status, COALESCE(rc.reason,''), COALESCE(rc.controlled_by,'')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = $1::uuid
+	`, runID).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("load run/control state: %v", err)
+	}
+	if runStatus != "cancelled" || controlStatus != "stopped" || reason != destructivereset.QuiescenceReasonCode || controlledBy != destructivereset.QuiescenceControlledBy {
+		t.Fatalf("run/control = %s/%s/%s/%s", runStatus, controlStatus, reason, controlledBy)
+	}
+
+	assertDestructiveResetDelivery(t, ctx, pg, agentPending, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, nodePending, "node", "node-a")
+	assertDestructiveResetDelivery(t, ctx, pg, nodeInProgress, "node", "node-a")
+
+	var deliveredStatus, deliveredReason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, delivered).Scan(&deliveredStatus, &deliveredReason); err != nil {
+		t.Fatalf("load delivered row: %v", err)
+	}
+	if deliveredStatus != "delivered" || deliveredReason != "agent_processed" {
+		t.Fatalf("delivered row = %s/%s, want untouched", deliveredStatus, deliveredReason)
+	}
+
+	if err := pg.MarkEventDeliveryInProgress(ctx, agentInProgress, "agent-a", uuid.NewString()); err != nil {
+		t.Fatalf("late MarkEventDeliveryInProgress: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, agentInProgress, "agent-a", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("late UpsertEventReceipt: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, agentInProgress, "processed", ""); err != nil {
+		t.Fatalf("late UpsertPipelineReceipt: %v", err)
+	}
+	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
+	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, "agent-a")
+	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, destructiveResetPipelineSubscriberID)
+
+	pending, err := pg.ListPendingEventsForAgent(ctx, "agent-a", now.Add(-time.Hour), 50)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending events = %#v, want none after quiescence", pending)
+	}
+	events, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{
+		Filter: OperatorEventListFilter{RunID: runID, DeliveryStatus: "dead_letter", ReasonCode: destructivereset.QuiescenceReasonCode},
+		Limit:  20,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents: %v", err)
+	}
+	if len(events.Events) != 4 {
+		t.Fatalf("operator events = %d, want 4 nuke-quiesced events", len(events.Events))
+	}
+}
+
+func TestPostgresStore_ApplyDestructiveResetQuiescence_DryRunDoesNotMutate(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	now := time.Date(2026, 5, 15, 2, 45, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	eventID := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.pending")
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', now())
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	result, err := pg.ApplyDestructiveResetQuiescence(ctx, destructivereset.QuiescenceRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			DryRun:    true,
+			PlannedAt: now.Add(-time.Minute),
+			Plan:      destructivereset.Plan{ActiveRuns: []destructivereset.RunRef{{RunID: runID, Status: "running"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDestructiveResetQuiescence dry-run: %v", err)
+	}
+	if !result.DryRun || len(result.Deliveries) != 1 || !result.Deliveries[0].Changed {
+		t.Fatalf("dry-run result = %#v", result)
+	}
+	var status, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, eventID).Scan(&status, &reason); err != nil {
+		t.Fatalf("load delivery after dry-run: %v", err)
+	}
+	if status != "pending" || reason != "" {
+		t.Fatalf("dry-run mutated delivery = %s/%s", status, reason)
+	}
+}
+
+func seedDestructiveResetEvent(t *testing.T, ctx context.Context, pg *PostgresStore, runID, name string) string {
+	t.Helper()
+	eventID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, 'global', '{}'::jsonb, 'test', 'agent', now()
+		)
+	`, eventID, runID, name); err != nil {
+		t.Fatalf("seed event %s: %v", name, err)
+	}
+	return eventID
+}
+
+func assertDestructiveResetDelivery(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, subscriberType, subscriberID string) {
+	t.Helper()
+	var status, reason string
+	var activeSession sql.NullString
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), active_session_id::text
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+	`, eventID, subscriberType, subscriberID).Scan(&status, &reason, &activeSession); err != nil {
+		t.Fatalf("load delivery %s/%s/%s: %v", eventID, subscriberType, subscriberID, err)
+	}
+	if status != "dead_letter" || reason != destructivereset.QuiescenceReasonCode || activeSession.Valid {
+		t.Fatalf("delivery %s/%s/%s = %s/%s active=%v, want nuke dead_letter", eventID, subscriberType, subscriberID, status, reason, activeSession.Valid)
+	}
+	assertDestructiveResetReceipt(t, ctx, pg, eventID, subscriberID)
+}
+
+func assertDestructiveResetReceipt(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, subscriberID string) {
+	t.Helper()
+	var outcome, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = $2
+	`, eventID, subscriberID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load receipt %s/%s: %v", eventID, subscriberID, err)
+	}
+	if outcome != "dead_letter" || reason != destructivereset.QuiescenceReasonCode {
+		t.Fatalf("receipt %s/%s = %s/%s, want nuke dead_letter", eventID, subscriberID, outcome, reason)
+	}
+}

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -28,20 +28,24 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	}
 	agentPending := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.pending")
 	agentInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.in_progress")
+	agentRetryableFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.failed_retryable")
+	agentExhaustedFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.failed_exhausted")
 	nodePending := seedDestructiveResetEvent(t, ctx, pg, runID, "node.pending")
 	nodeInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "node.in_progress")
 	delivered := seedDestructiveResetEvent(t, ctx, pg, runID, "agent.delivered")
 	activeSessionID := uuid.NewString()
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, retry_count, reason_code, created_at, delivered_at
 		) VALUES
-			($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', NULL, 'matched_agent_subscription', now()),
-			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $6::uuid, 'agent_processing', now()),
-			($1::uuid, $4::uuid, 'node', 'node-a', 'pending', NULL, 'matched_node_subscription', now()),
-			($1::uuid, $5::uuid, 'node', 'node-a', 'in_progress', $6::uuid, 'node_processing', now()),
-			($1::uuid, $7::uuid, 'agent', 'agent-a', 'delivered', NULL, 'agent_processed', now())
-	`, runID, agentPending, agentInProgress, nodePending, nodeInProgress, activeSessionID, delivered); err != nil {
+			($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', now(), NULL),
+			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $8::uuid, 0, 'agent_processing', now(), NULL),
+			($1::uuid, $4::uuid, 'agent', 'agent-a', 'failed', NULL, 1, 'agent_retryable_error', now() - interval '5 minutes', now() - interval '2 minutes'),
+			($1::uuid, $5::uuid, 'agent', 'agent-a', 'failed', NULL, 2, 'retry_exhausted', now() - interval '5 minutes', now() - interval '2 minutes'),
+			($1::uuid, $6::uuid, 'node', 'node-a', 'pending', NULL, 0, 'matched_node_subscription', now(), NULL),
+			($1::uuid, $7::uuid, 'node', 'node-a', 'in_progress', $8::uuid, 0, 'node_processing', now(), NULL),
+			($1::uuid, $9::uuid, 'agent', 'agent-a', 'delivered', NULL, 0, 'agent_processed', now(), now())
+	`, runID, agentPending, agentInProgress, agentRetryableFailed, agentExhaustedFailed, nodePending, nodeInProgress, activeSessionID, delivered); err != nil {
 		t.Fatalf("seed deliveries: %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, agentPending, "processed", ""); err != nil {
@@ -63,11 +67,11 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if len(result.Runs) != 1 || result.Runs[0].Status != "cancelled" || !result.Runs[0].Changed {
 		t.Fatalf("runs = %#v, want one cancelled run", result.Runs)
 	}
-	if len(result.Deliveries) != 4 {
-		t.Fatalf("deliveries = %#v, want four active deliveries", result.Deliveries)
+	if len(result.Deliveries) != 5 {
+		t.Fatalf("deliveries = %#v, want five active/retryable deliveries", result.Deliveries)
 	}
-	if result.PipelineReceiptCount != 4 {
-		t.Fatalf("pipeline receipt count = %d, want 4", result.PipelineReceiptCount)
+	if result.PipelineReceiptCount != 5 {
+		t.Fatalf("pipeline receipt count = %d, want 5", result.PipelineReceiptCount)
 	}
 
 	var runStatus, controlStatus, reason, controlledBy string
@@ -85,6 +89,7 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 
 	assertDestructiveResetDelivery(t, ctx, pg, agentPending, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
 	assertDestructiveResetDelivery(t, ctx, pg, nodePending, "node", "node-a")
 	assertDestructiveResetDelivery(t, ctx, pg, nodeInProgress, "node", "node-a")
 
@@ -99,9 +104,23 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if deliveredStatus != "delivered" || deliveredReason != "agent_processed" {
 		t.Fatalf("delivered row = %s/%s, want untouched", deliveredStatus, deliveredReason)
 	}
+	var exhaustedStatus, exhaustedReason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, agentExhaustedFailed).Scan(&exhaustedStatus, &exhaustedReason); err != nil {
+		t.Fatalf("load exhausted failed row: %v", err)
+	}
+	if exhaustedStatus != "failed" || exhaustedReason != "retry_exhausted" {
+		t.Fatalf("exhausted failed row = %s/%s, want untouched", exhaustedStatus, exhaustedReason)
+	}
 
 	if err := pg.MarkEventDeliveryInProgress(ctx, agentInProgress, "agent-a", uuid.NewString()); err != nil {
 		t.Fatalf("late MarkEventDeliveryInProgress: %v", err)
+	}
+	if err := pg.MarkEventDeliveryInProgress(ctx, agentRetryableFailed, "agent-a", uuid.NewString()); err != nil {
+		t.Fatalf("late retryable failed MarkEventDeliveryInProgress: %v", err)
 	}
 	if err := pg.UpsertEventReceipt(ctx, agentInProgress, "agent-a", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
 		t.Fatalf("late UpsertEventReceipt: %v", err)
@@ -110,8 +129,11 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 		t.Fatalf("late UpsertPipelineReceipt: %v", err)
 	}
 	assertDestructiveResetDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
+	assertDestructiveResetDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
 	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, "agent-a")
 	assertDestructiveResetReceipt(t, ctx, pg, agentInProgress, destructiveResetPipelineSubscriberID)
+	assertDestructiveResetReceipt(t, ctx, pg, agentRetryableFailed, "agent-a")
+	assertDestructiveResetReceipt(t, ctx, pg, agentRetryableFailed, destructiveResetPipelineSubscriberID)
 
 	pending, err := pg.ListPendingEventsForAgent(ctx, "agent-a", now.Add(-time.Hour), 50)
 	if err != nil {
@@ -127,8 +149,8 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	if err != nil {
 		t.Fatalf("ListOperatorEvents: %v", err)
 	}
-	if len(events.Events) != 4 {
-		t.Fatalf("operator events = %d, want 4 nuke-quiesced events", len(events.Events))
+	if len(events.Events) != 5 {
+		t.Fatalf("operator events = %d, want 5 nuke-quiesced events", len(events.Events))
 	}
 }
 

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -10,6 +10,7 @@ import (
 
 	"swarm/internal/events"
 	"swarm/internal/runtime/core/eventidentity"
+	"swarm/internal/runtime/destructivereset"
 	runtimemanager "swarm/internal/runtime/manager"
 )
 
@@ -128,6 +129,7 @@ type agentReceiptWriteState struct {
 type lockedAgentDelivery struct {
 	retryCount      int
 	status          string
+	reasonCode      string
 	activeSessionID string
 	entityID        string
 	flowInstance    string
@@ -156,6 +158,9 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSc
 		}
 		if !delivery.found {
 			return fmt.Errorf("upsert event receipt: delivery row required for event %s agent %s", strings.TrimSpace(eventID), strings.TrimSpace(agentID))
+		}
+		if destructiveResetDeliveryTerminal(delivery.status, delivery.reasonCode) {
+			return nil
 		}
 		state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
 		if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
@@ -223,6 +228,7 @@ func (s *PostgresStore) lockAgentDeliveryTx(
 		SELECT
 			d.retry_count,
 			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
 			COALESCE(d.active_session_id::text, ''),
 			COALESCE(e.entity_id::text, ''),
 			COALESCE(e.flow_instance, '')
@@ -232,7 +238,7 @@ func (s *PostgresStore) lockAgentDeliveryTx(
 		  AND d.subscriber_type = 'agent'
 		  AND d.subscriber_id = $2
 		FOR UPDATE
-	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
+	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return lockedAgentDelivery{}, nil
@@ -356,11 +362,40 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
 		  AND subscriber_id = $2
+		  AND status IN ('pending', 'in_progress')
+		  AND COALESCE(reason_code, '') <> $4
 	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID); err != nil {
+	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, destructivereset.QuiescenceReasonCode); err != nil {
 		return fmt.Errorf("mark event delivery in progress: %w", err)
 	}
 	return nil
+}
+
+func (s *PostgresStore) DestructiveResetDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error) {
+	if s == nil || s.DB == nil {
+		return false, fmt.Errorf("postgres store is required")
+	}
+	eventID = strings.TrimSpace(eventID)
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	if eventID == "" || subscriberType == "" || subscriberID == "" {
+		return false, nil
+	}
+	var ok bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = $2
+			  AND subscriber_id = $3
+			  AND status = 'dead_letter'
+			  AND reason_code = $4
+		)
+	`, eventID, subscriberType, subscriberID, destructivereset.QuiescenceReasonCode).Scan(&ok); err != nil {
+		return false, fmt.Errorf("check destructive reset delivery quiescence: %w", err)
+	}
+	return ok, nil
 }
 
 func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -362,7 +362,10 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
 		  AND subscriber_id = $2
-		  AND status IN ('pending', 'in_progress')
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+		  )
 		  AND COALESCE(reason_code, '') <> $4
 	`
 	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, destructivereset.QuiescenceReasonCode); err != nil {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -14,6 +14,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimeownership "swarm/internal/runtime/core/ownership"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/destructivereset"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
@@ -725,17 +726,25 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 			$2, NULLIF($3,''), $4::jsonb, now()
 		FROM events e
 		WHERE e.event_id = $1::uuid
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM event_deliveries d
+			WHERE d.event_id = e.event_id
+			  AND d.status = 'dead_letter'
+			  AND d.reason_code = $5
+		  )
 		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
 			outcome = EXCLUDED.outcome,
 			reason_code = EXCLUDED.reason_code,
 			side_effects = EXCLUDED.side_effects,
 			processed_at = now()
+		WHERE COALESCE(event_receipts.reason_code, '') <> $5
 	`
 	execFn := s.DB.ExecContext
 	if tx != nil {
 		execFn = tx.ExecContext
 	}
-	if _, err := execFn(ctx, q, eventID, outcome, reasonCode, string(sideEffects)); err != nil {
+	if _, err := execFn(ctx, q, eventID, outcome, reasonCode, string(sideEffects), destructivereset.QuiescenceReasonCode); err != nil {
 		return fmt.Errorf("upsert pipeline receipt: %w", err)
 	}
 	return nil

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -811,6 +811,39 @@ func TestListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending(t *te
 	}
 }
 
+func TestMarkEventDeliveryInProgress_AllowsRetryableFailedDeliveryClaim_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+	evt := seedEvent(t, ctx, pg, entityID, "test.retry_claim.failed")
+	if err := pg.InsertEventDeliveries(ctx, evt.ID, []string{agentID}); err != nil {
+		t.Fatalf("insert deliveries: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, evt.ID, agentID, runtimemanager.ReceiptStatusError, "retryable"); err != nil {
+		t.Fatalf("upsert retryable receipt: %v", err)
+	}
+	rewindCanonicalDeliveryAttempt(t, ctx, pg, evt.ID, agentID, time.Now().Add(-2*time.Minute))
+
+	if err := pg.MarkEventDeliveryInProgress(ctx, evt.ID, agentID, ""); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress retryable failed delivery: %v", err)
+	}
+
+	var status, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = $2
+	`, evt.ID, agentID).Scan(&status, &reason); err != nil {
+		t.Fatalf("load delivery: %v", err)
+	}
+	if status != "in_progress" || reason != "agent_processing" {
+		t.Fatalf("delivery = %s/%s, want in_progress/agent_processing", status, reason)
+	}
+}
+
 func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
 	pg, cleanup := newTestPostgresStore(t)
 	defer cleanup()


### PR DESCRIPTION
Closes #775
Part of #771
Part of #748

## Summary
- Adds `internal/runtime/destructivereset.Quiescer` as the internal active-run/delivery quiescence owner consuming the #773/#774 destructive-reset plan/result owner.
- Terminalizes selected active runs and pending/in-progress agent/node deliveries with `dead_letter` plus `runtime_nuke_cancelled`, and records nuke-specific run-control and receipt/read-model state.
- Guards late AgentManager, system-node, and pipeline receipt/output writers so nuke terminalization is not overwritten or resurrected.

## Governing refs / context
- Binding issue/gate context: #775 approved as first slice under #771, with #748 as broader API parent and #564 as historical replay sibling.
- Adjacent authoritative spec context: `platform-spec.yaml` `runs.status`, `event_deliveries`, `event_receipts`, and `run_control_state` contracts.
- No public `runtime.nuke` method exists in the authoritative spec yet; this PR intentionally does not add `/v1/rpc runtime.nuke`, OpenRPC, dashboard/Builder/run_clear migration, table truncation, or container stop behavior.

## Semantic migration
- New canonical owner: `internal/runtime/destructivereset.Quiescer` plus `PostgresStore.ApplyDestructiveResetQuiescence`.
- Old non-authoritative paths now invalid for this class: direct `run.stop` composition, store-only row flips, AgentManager late output/receipt writes, system-node late receipt/dead-letter writes, and pipeline receipt overwrites as proof of destructive-reset quiescence.
- Production paths checked for surviving old behavior: AgentManager receipt/output path, `PostgresStore` delivery/receipt transitions, system node runner, EventBus/pipeline receipt upsert, persisted pending delivery reads, and operator event read model.
- Migration completeness: complete for the approved internal active-run/delivery quiescence child; broader runtime.nuke truncation, container stop, public API/spec wrapper, and legacy migrations remain split under #771/#748.

## Proof run
- `go test ./internal/runtime/destructivereset ./internal/runtime/manager ./internal/runtime/pipeline ./internal/store ./internal/runtime/bus ./internal/apiv1 -count=1`
- `git diff --check`
- Static diff/grep proof: no changed `docs`, `internal/apiv1`, `internal/dashboard`, `internal/builder`, or `scripts` surfaces; no OpenRPC/platform-spec generated/public method change.
