### PR TITLE
[agent-b][issue #780] Managed container reset owner

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4859,6 +4859,30 @@ workspace_model:
       /opt/swarm/contracts: Read-only volume from deployment artifact.
     portability_rule: A product contract that works on local dev MUST work on Docker and production without contract changes.
       Mount paths are invariant. Only the backing storage implementation changes.
+  managed_container_identity:
+    status: internal_only
+    owner: internal/runtime/containeridentity plus internal/runtime/workspace creation paths
+    purpose: Durable, inspectable identity for platform-created workspace containers. Destructive reset and recovery code must
+      consume this identity rather than inferring ownership from container names, prefixes, or raw Docker listings.
+    labels:
+      owner: dev.swarm.owner = runtime
+      kind: dev.swarm.container.kind = scaffold | system | entity | agent | flow
+      reset_eligibility: dev.swarm.reset.eligible = true | false
+      creation_source: dev.swarm.creation_source names the workspace creation owner
+      container_name: dev.swarm.container.name records the exact container name stamped at creation
+      workspace_scope: dev.swarm.workspace.scope records scaffold, system, entity, per-agent, or per-flow-instance scope
+      lineage: dev.swarm.run_id, dev.swarm.entity_id, dev.swarm.agent_id, and dev.swarm.flow_instance are stamped when
+        that lineage is available to the creation owner
+    reset_policy:
+    - Destructive reset may stop only containers whose typed identity proves owner=runtime, reset_eligible=true, and kind
+      is entity, agent, or flow.
+    - scaffold and system containers are platform-created but reset_eligible=false and must be preserved by destructive reset.
+    - Unlabeled, unregistered, operator-managed, postgres/tool-gateway, name-only, and ambiguous containers are preserved
+      fail-closed. A Swarm-looking container name is not ownership proof.
+    - Destructive reset planning captures managed container refs before run-scoped DB cleanup can remove supporting runtime
+      rows. Cleanup tables are not the container selector.
+    - Broad Docker enumeration such as raw `docker ps | docker stop` is not a production reset owner. Label-filtered inventory
+      may be used only as a consumer of this typed identity model.
 agent_prompt_lint:
   description: Prompt/schema lint for authored agent prompts on the verify surface.
   authority_distribution:

--- a/internal/runtime/containeridentity/identity.go
+++ b/internal/runtime/containeridentity/identity.go
@@ -1,0 +1,203 @@
+package containeridentity
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	LabelOwner          = "dev.swarm.owner"
+	LabelKind           = "dev.swarm.container.kind"
+	LabelResetEligible  = "dev.swarm.reset.eligible"
+	LabelCreationSource = "dev.swarm.creation_source"
+	LabelContainerName  = "dev.swarm.container.name"
+	LabelWorkspaceScope = "dev.swarm.workspace.scope"
+	LabelRunID          = "dev.swarm.run_id"
+	LabelEntityID       = "dev.swarm.entity_id"
+	LabelAgentID        = "dev.swarm.agent_id"
+	LabelFlowInstance   = "dev.swarm.flow_instance"
+
+	OwnerRuntime = "runtime"
+
+	KindScaffold = "scaffold"
+	KindSystem   = "system"
+	KindEntity   = "entity"
+	KindAgent    = "agent"
+	KindFlow     = "flow"
+)
+
+type Identity struct {
+	Owner          string
+	Kind           string
+	ResetEligible  bool
+	CreationSource string
+	ContainerName  string
+	WorkspaceScope string
+	RunID          string
+	EntityID       string
+	AgentID        string
+	FlowInstance   string
+}
+
+func (i Identity) Normalized() Identity {
+	i.Owner = strings.TrimSpace(i.Owner)
+	i.Kind = strings.TrimSpace(i.Kind)
+	i.CreationSource = strings.TrimSpace(i.CreationSource)
+	i.ContainerName = strings.TrimSpace(i.ContainerName)
+	i.WorkspaceScope = strings.TrimSpace(i.WorkspaceScope)
+	i.RunID = strings.TrimSpace(i.RunID)
+	i.EntityID = strings.TrimSpace(i.EntityID)
+	i.AgentID = strings.TrimSpace(i.AgentID)
+	i.FlowInstance = strings.Trim(strings.TrimSpace(i.FlowInstance), "/")
+	return i
+}
+
+func (i Identity) Labels() map[string]string {
+	i = i.Normalized()
+	labels := map[string]string{
+		LabelOwner:          i.Owner,
+		LabelKind:           i.Kind,
+		LabelResetEligible:  boolLabel(i.ResetEligible),
+		LabelCreationSource: i.CreationSource,
+		LabelContainerName:  i.ContainerName,
+		LabelWorkspaceScope: i.WorkspaceScope,
+	}
+	addOptionalLabel(labels, LabelRunID, i.RunID)
+	addOptionalLabel(labels, LabelEntityID, i.EntityID)
+	addOptionalLabel(labels, LabelAgentID, i.AgentID)
+	addOptionalLabel(labels, LabelFlowInstance, i.FlowInstance)
+	for key, value := range labels {
+		if strings.TrimSpace(value) == "" {
+			delete(labels, key)
+		}
+	}
+	return labels
+}
+
+func (i Identity) Validate() error {
+	i = i.Normalized()
+	if i.Owner != OwnerRuntime {
+		return fmt.Errorf("container identity owner = %q, want %q", i.Owner, OwnerRuntime)
+	}
+	if !validKind(i.Kind) {
+		return fmt.Errorf("container identity kind = %q, want scaffold, system, entity, agent, or flow", i.Kind)
+	}
+	if i.ContainerName == "" {
+		return fmt.Errorf("container identity container name is required")
+	}
+	if i.ResetEligible && !ResetEligibleKind(i.Kind) {
+		return fmt.Errorf("container kind %q cannot be reset eligible", i.Kind)
+	}
+	switch i.Kind {
+	case KindEntity:
+		if i.EntityID == "" {
+			return fmt.Errorf("entity container identity requires entity_id")
+		}
+	case KindAgent:
+		if i.AgentID == "" {
+			return fmt.Errorf("agent container identity requires agent_id")
+		}
+	case KindFlow:
+		if i.FlowInstance == "" {
+			return fmt.Errorf("flow container identity requires flow_instance")
+		}
+	}
+	return nil
+}
+
+func (i Identity) ResetEligibleManaged() bool {
+	i = i.Normalized()
+	return i.Owner == OwnerRuntime && i.ResetEligible && ResetEligibleKind(i.Kind)
+}
+
+func ResetEligibleKind(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case KindEntity, KindAgent, KindFlow:
+		return true
+	default:
+		return false
+	}
+}
+
+func FromLabels(labels map[string]string) (Identity, bool, error) {
+	if len(labels) == 0 {
+		return Identity{}, false, nil
+	}
+	owner := strings.TrimSpace(labels[LabelOwner])
+	if owner == "" {
+		return Identity{}, false, nil
+	}
+	resetEligible, err := parseBoolLabel(labels[LabelResetEligible])
+	if err != nil {
+		return Identity{}, true, err
+	}
+	identity := Identity{
+		Owner:          owner,
+		Kind:           labels[LabelKind],
+		ResetEligible:  resetEligible,
+		CreationSource: labels[LabelCreationSource],
+		ContainerName:  labels[LabelContainerName],
+		WorkspaceScope: labels[LabelWorkspaceScope],
+		RunID:          labels[LabelRunID],
+		EntityID:       labels[LabelEntityID],
+		AgentID:        labels[LabelAgentID],
+		FlowInstance:   labels[LabelFlowInstance],
+	}.Normalized()
+	if err := identity.Validate(); err != nil {
+		return Identity{}, true, err
+	}
+	return identity, true, nil
+}
+
+func DockerCreateLabelArgs(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	args := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		args = append(args, "--label", key+"="+strings.TrimSpace(labels[key]))
+	}
+	return args
+}
+
+func boolLabel(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func parseBoolLabel(value string) (bool, error) {
+	switch strings.TrimSpace(value) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("container identity reset eligibility label must be true or false")
+	}
+}
+
+func validKind(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case KindScaffold, KindSystem, KindEntity, KindAgent, KindFlow:
+		return true
+	default:
+		return false
+	}
+}
+
+func addOptionalLabel(labels map[string]string, key, value string) {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		labels[key] = value
+	}
+}

--- a/internal/runtime/containeridentity/identity_test.go
+++ b/internal/runtime/containeridentity/identity_test.go
@@ -1,0 +1,45 @@
+package containeridentity
+
+import "testing"
+
+func TestIdentityLabelsRoundTripResetEligibleAgent(t *testing.T) {
+	identity := Identity{
+		Owner:          OwnerRuntime,
+		Kind:           KindAgent,
+		ResetEligible:  true,
+		CreationSource: "workspace.ResolveWorkspace",
+		ContainerName:  "swarm-agent-agent-a",
+		WorkspaceScope: "per-agent",
+		RunID:          "11111111-1111-1111-1111-111111111111",
+		AgentID:        "agent-a",
+	}
+	labels := identity.Labels()
+	got, ok, err := FromLabels(labels)
+	if err != nil {
+		t.Fatalf("FromLabels: %v", err)
+	}
+	if !ok {
+		t.Fatal("FromLabels ok = false, want true")
+	}
+	if !got.ResetEligibleManaged() || got.AgentID != "agent-a" || got.RunID == "" {
+		t.Fatalf("identity = %#v, want reset-eligible agent with run lineage", got)
+	}
+}
+
+func TestIdentityRejectsResetEligibleSystemContainer(t *testing.T) {
+	_, _, err := FromLabels(map[string]string{
+		LabelOwner:         OwnerRuntime,
+		LabelKind:          KindSystem,
+		LabelResetEligible: "true",
+		LabelContainerName: "swarm-system",
+	})
+	if err == nil {
+		t.Fatal("FromLabels error = nil, want reset-eligible system rejection")
+	}
+}
+
+func TestIdentityReportsAbsentForUnlabeledContainer(t *testing.T) {
+	if _, ok, err := FromLabels(nil); ok || err != nil {
+		t.Fatalf("FromLabels(nil) = ok:%v err:%v, want absent nil", ok, err)
+	}
+}

--- a/internal/runtime/destructivereset/contracts.go
+++ b/internal/runtime/destructivereset/contracts.go
@@ -24,9 +24,9 @@ func DefaultDownstreamContracts() []DownstreamContract {
 		},
 		{
 			ID:          ContractManagedContainers,
-			Status:      "split",
-			Owner:       "future workspace destructive reset container owner",
-			Description: "Select and stop only swarm-managed entity containers while proving system/operator-managed containers are preserved.",
+			Status:      "implemented_internal_owner",
+			Owner:       "internal/runtime/containeridentity, internal/runtime/workspace managed identity stamping, and internal/runtime/destructivereset ManagedContainerStopper",
+			Description: "Select and stop only label-proven reset-eligible managed runtime containers while preserving system/operator/unowned containers.",
 		},
 		{
 			ID:          ContractPublicAPIWrapper,

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -212,7 +212,7 @@ func TestInventoryPlannerCarriesSplitContractsAndResetSeams(t *testing.T) {
 	}
 	if !containsContractStatus(plan.DownstreamContracts, ContractRunDeliveryQuiescence, "implemented_internal_owner") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractRunScopedTruncation, "implemented_internal_owner") ||
-		!containsContractStatus(plan.DownstreamContracts, ContractManagedContainers, "split") ||
+		!containsContractStatus(plan.DownstreamContracts, ContractManagedContainers, "implemented_internal_owner") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractPublicAPIWrapper, "split") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractLegacyResetMigration, "split") {
 		t.Fatalf("downstream contracts = %#v, missing required contract state", plan.DownstreamContracts)

--- a/internal/runtime/destructivereset/managed_containers.go
+++ b/internal/runtime/destructivereset/managed_containers.go
@@ -1,0 +1,162 @@
+package destructivereset
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ManagedContainerStopper struct {
+	Runtime ManagedContainerRuntime
+	Now     func() time.Time
+}
+
+func (s ManagedContainerStopper) Apply(ctx context.Context, req ContainerResetRequest) (ContainerResetResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	if req.ActorTokenID == "" {
+		return ContainerResetResult{}, fmt.Errorf("%w: actor token id is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(req.Result.OperationName) == "" {
+		req.Result.OperationName = DefaultOperationName
+	}
+	if req.Result.PlannedAt.IsZero() {
+		return ContainerResetResult{}, fmt.Errorf("%w: destructive reset plan result is required", ErrInvalidRequest)
+	}
+	if !req.Result.DryRun {
+		if req.Cleanup.AppliedAt.IsZero() {
+			return ContainerResetResult{}, fmt.Errorf("%w: destructive reset cleanup result is required", ErrInvalidRequest)
+		}
+		if req.Cleanup.DryRun {
+			return ContainerResetResult{}, fmt.Errorf("%w: destructive reset managed containers require applied cleanup", ErrInvalidRequest)
+		}
+		if strings.TrimSpace(req.Cleanup.OperationName) != strings.TrimSpace(req.Result.OperationName) {
+			return ContainerResetResult{}, fmt.Errorf("%w: destructive reset cleanup operation does not match plan result", ErrInvalidRequest)
+		}
+		if req.Cleanup.AppliedAt.Before(req.Result.PlannedAt) {
+			return ContainerResetResult{}, fmt.Errorf("%w: destructive reset cleanup predates plan result", ErrInvalidRequest)
+		}
+	}
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = s.now()
+	}
+	req.RequestedAt = req.RequestedAt.UTC()
+	if s.Runtime == nil {
+		return ContainerResetResult{}, fmt.Errorf("destructive reset managed container runtime is not configured")
+	}
+
+	result := ContainerResetResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+	}
+	for _, planned := range req.Result.Plan.EntityContainers {
+		if strings.TrimSpace(planned.Name) == "" {
+			return ContainerResetResult{}, fmt.Errorf("%w: destructive reset container name is required", ErrInvalidRequest)
+		}
+		inspection, err := s.Runtime.InspectManagedContainer(ctx, planned.Name)
+		if err != nil {
+			result.Failed = append(result.Failed, ContainerStopFailure{
+				Container: withContainerAction(planned, ContainerActionFailed),
+				Error:     err.Error(),
+			})
+			continue
+		}
+		if !inspection.Exists {
+			result.Missing = append(result.Missing, withContainerAction(planned, ContainerActionMissing))
+			continue
+		}
+		if !inspection.HasIdentity || !resetEligibleManagedIdentity(inspection.Identity) || strings.TrimSpace(inspection.Identity.ContainerName) != strings.TrimSpace(planned.Name) {
+			result.Preserved = append(result.Preserved, preservedContainerRef(planned, inspection.Identity))
+			continue
+		}
+		ref := containerRefFromIdentity(inspection.Identity, ContainerActionStop)
+		if !inspection.Running {
+			result.AlreadyStopped = append(result.AlreadyStopped, withContainerAction(ref, ContainerActionAlreadyStopped))
+			continue
+		}
+		result.Selected = append(result.Selected, ref)
+		if req.Result.DryRun {
+			continue
+		}
+		if err := s.Runtime.StopManagedContainer(ctx, ref.Name); err != nil {
+			result.Failed = append(result.Failed, ContainerStopFailure{
+				Container: withContainerAction(ref, ContainerActionFailed),
+				Error:     err.Error(),
+			})
+			continue
+		}
+		result.Stopped = append(result.Stopped, withContainerAction(ref, ContainerActionStop))
+	}
+	return copyContainerResetResult(result), nil
+}
+
+func (s ManagedContainerStopper) now() time.Time {
+	if s.Now != nil {
+		return s.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func resetEligibleManagedIdentity(identity ContainerIdentity) bool {
+	return strings.TrimSpace(identity.Owner) == "runtime" &&
+		identity.ResetEligible &&
+		resetEligibleContainerKind(identity.Kind)
+}
+
+func resetEligibleContainerKind(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case "entity", "agent", "flow":
+		return true
+	default:
+		return false
+	}
+}
+
+func containerRefFromIdentity(identity ContainerIdentity, action string) ContainerRef {
+	return ContainerRef{
+		Name:           strings.TrimSpace(identity.ContainerName),
+		Kind:           strings.TrimSpace(identity.Kind),
+		Action:         strings.TrimSpace(action),
+		ResetEligible:  identity.ResetEligible,
+		CreationSource: strings.TrimSpace(identity.CreationSource),
+		WorkspaceScope: strings.TrimSpace(identity.WorkspaceScope),
+		RunID:          strings.TrimSpace(identity.RunID),
+		EntityID:       strings.TrimSpace(identity.EntityID),
+		AgentID:        strings.TrimSpace(identity.AgentID),
+		FlowInstance:   strings.Trim(strings.TrimSpace(identity.FlowInstance), "/"),
+	}
+}
+
+func preservedContainerRef(planned ContainerRef, identity ContainerIdentity) ContainerRef {
+	if strings.TrimSpace(identity.ContainerName) == "" {
+		return withContainerAction(planned, ContainerActionUnowned)
+	}
+	return withContainerAction(containerRefFromIdentity(identity, ContainerActionUnowned), ContainerActionUnowned)
+}
+
+func withContainerAction(ref ContainerRef, action string) ContainerRef {
+	ref.Name = strings.TrimSpace(ref.Name)
+	ref.Kind = strings.TrimSpace(ref.Kind)
+	ref.Action = strings.TrimSpace(action)
+	ref.CreationSource = strings.TrimSpace(ref.CreationSource)
+	ref.WorkspaceScope = strings.TrimSpace(ref.WorkspaceScope)
+	ref.RunID = strings.TrimSpace(ref.RunID)
+	ref.EntityID = strings.TrimSpace(ref.EntityID)
+	ref.AgentID = strings.TrimSpace(ref.AgentID)
+	ref.FlowInstance = strings.Trim(strings.TrimSpace(ref.FlowInstance), "/")
+	return ref
+}
+
+func copyContainerResetResult(result ContainerResetResult) ContainerResetResult {
+	result.Selected = append([]ContainerRef(nil), result.Selected...)
+	result.Preserved = append([]ContainerRef(nil), result.Preserved...)
+	result.Missing = append([]ContainerRef(nil), result.Missing...)
+	result.AlreadyStopped = append([]ContainerRef(nil), result.AlreadyStopped...)
+	result.Stopped = append([]ContainerRef(nil), result.Stopped...)
+	result.Failed = append([]ContainerStopFailure(nil), result.Failed...)
+	return result
+}

--- a/internal/runtime/destructivereset/managed_containers_test.go
+++ b/internal/runtime/destructivereset/managed_containers_test.go
@@ -1,0 +1,191 @@
+package destructivereset
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCompositeInventoryReaderCapturesManagedContainersAtPlanTime(t *testing.T) {
+	base := &recordingInventoryReader{inventory: Inventory{
+		CleanupRuns:        []RunRef{{RunID: "run-1", Status: "running"}},
+		CleanupRunSetKnown: true,
+	}}
+	containers := managedContainerInventoryFunc(func(context.Context) ([]ContainerRef, error) {
+		return []ContainerRef{{
+			Name:          "swarm-agent-agent-a",
+			Kind:          "agent",
+			Action:        ContainerActionStop,
+			ResetEligible: true,
+			RunID:         "run-1",
+			AgentID:       "agent-a",
+		}}, nil
+	})
+
+	inventory, err := (CompositeInventoryReader{Reader: base, Containers: containers}).ReadResetInventory(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResetInventory: %v", err)
+	}
+	if len(inventory.EntityContainers) != 1 || inventory.EntityContainers[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("entity containers = %#v, want plan-time managed container refs", inventory.EntityContainers)
+	}
+	inventory.EntityContainers[0].Name = "tampered"
+	again, err := (CompositeInventoryReader{Reader: base, Containers: containers}).ReadResetInventory(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResetInventory again: %v", err)
+	}
+	if again.EntityContainers[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("inventory leaked mutable container refs: %#v", again.EntityContainers)
+	}
+}
+
+func TestManagedContainerStopperDryRunSelectsOnlyResetEligibleLabeledContainers(t *testing.T) {
+	now := time.Date(2026, 5, 16, 20, 10, 0, 0, time.UTC)
+	runtime := &recordingManagedContainerRuntime{
+		inspections: map[string]ManagedContainerInspection{
+			"swarm-agent-agent-a": managedInspection("swarm-agent-agent-a", "agent", true, true),
+			"swarm-system":        managedInspection("swarm-system", "system", false, true),
+			"swarm-unlabeled":     {Exists: true, Running: true},
+			"swarm-missing":       {Exists: false},
+		},
+	}
+	result, err := (ManagedContainerStopper{
+		Runtime: runtime,
+		Now:     func() time.Time { return now },
+	}).Apply(context.Background(), ContainerResetRequest{
+		ActorTokenID: "operator-token",
+		Result: Result{
+			OperationName: DefaultOperationName,
+			DryRun:        true,
+			PlannedAt:     now.Add(-time.Minute),
+			Plan: Plan{EntityContainers: []ContainerRef{
+				{Name: "swarm-agent-agent-a", Action: ContainerActionStop},
+				{Name: "swarm-system", Action: ContainerActionStop},
+				{Name: "swarm-unlabeled", Action: ContainerActionStop},
+				{Name: "swarm-missing", Action: ContainerActionStop},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(runtime.stops) != 0 {
+		t.Fatalf("dry-run stops = %#v, want none", runtime.stops)
+	}
+	if len(result.Selected) != 1 || result.Selected[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("selected = %#v, want only reset-eligible agent", result.Selected)
+	}
+	if len(result.Preserved) != 2 {
+		t.Fatalf("preserved = %#v, want system and unlabeled", result.Preserved)
+	}
+	if len(result.Missing) != 1 || result.Missing[0].Name != "swarm-missing" {
+		t.Fatalf("missing = %#v, want missing no-op", result.Missing)
+	}
+}
+
+func TestManagedContainerStopperApplyReportsStoppedNoopAndPartialFailure(t *testing.T) {
+	now := time.Date(2026, 5, 16, 20, 15, 0, 0, time.UTC)
+	stopErr := errors.New("docker stop failed")
+	runtime := &recordingManagedContainerRuntime{
+		inspections: map[string]ManagedContainerInspection{
+			"swarm-agent-agent-a": managedInspection("swarm-agent-agent-a", "agent", true, true),
+			"swarm-flow-flow-a":   managedInspection("swarm-flow-flow-a", "flow", true, false),
+			"swarm-entity-a":      managedInspection("swarm-entity-a", "entity", true, true),
+		},
+		stopErrors: map[string]error{"swarm-entity-a": stopErr},
+	}
+	result, err := (ManagedContainerStopper{
+		Runtime: runtime,
+		Now:     func() time.Time { return now },
+	}).Apply(context.Background(), ContainerResetRequest{
+		ActorTokenID: "operator-token",
+		Result: Result{
+			OperationName: DefaultOperationName,
+			DryRun:        false,
+			PlannedAt:     now.Add(-2 * time.Minute),
+			Plan: Plan{EntityContainers: []ContainerRef{
+				{Name: "swarm-agent-agent-a", Action: ContainerActionStop},
+				{Name: "swarm-flow-flow-a", Action: ContainerActionStop},
+				{Name: "swarm-entity-a", Action: ContainerActionStop},
+			}},
+		},
+		Cleanup: CleanupResult{
+			OperationName: DefaultOperationName,
+			DryRun:        false,
+			AppliedAt:     now.Add(-time.Minute),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(runtime.stops) != 2 || runtime.stops[0] != "swarm-agent-agent-a" || runtime.stops[1] != "swarm-entity-a" {
+		t.Fatalf("stops = %#v, want running reset-eligible containers only", runtime.stops)
+	}
+	if len(result.Stopped) != 1 || result.Stopped[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("stopped = %#v, want agent stopped", result.Stopped)
+	}
+	if len(result.AlreadyStopped) != 1 || result.AlreadyStopped[0].Name != "swarm-flow-flow-a" {
+		t.Fatalf("already stopped = %#v, want flow no-op", result.AlreadyStopped)
+	}
+	if len(result.Failed) != 1 || result.Failed[0].Container.Name != "swarm-entity-a" || !strings.Contains(result.Failed[0].Error, stopErr.Error()) {
+		t.Fatalf("failed = %#v, want entity stop failure", result.Failed)
+	}
+}
+
+func TestManagedContainerStopperRequiresAppliedCleanupForMutation(t *testing.T) {
+	now := time.Date(2026, 5, 16, 20, 20, 0, 0, time.UTC)
+	_, err := (ManagedContainerStopper{Runtime: &recordingManagedContainerRuntime{}, Now: func() time.Time { return now }}).Apply(context.Background(), ContainerResetRequest{
+		ActorTokenID: "operator-token",
+		Result: Result{
+			OperationName: DefaultOperationName,
+			PlannedAt:     now.Add(-time.Minute),
+		},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Apply error = %v, want invalid request for missing applied cleanup", err)
+	}
+}
+
+type managedContainerInventoryFunc func(context.Context) ([]ContainerRef, error)
+
+func (f managedContainerInventoryFunc) ManagedResetContainerInventory(ctx context.Context) ([]ContainerRef, error) {
+	return f(ctx)
+}
+
+type recordingManagedContainerRuntime struct {
+	inspections map[string]ManagedContainerInspection
+	stopErrors  map[string]error
+	stops       []string
+}
+
+func (r *recordingManagedContainerRuntime) InspectManagedContainer(_ context.Context, name string) (ManagedContainerInspection, error) {
+	return r.inspections[strings.TrimSpace(name)], nil
+}
+
+func (r *recordingManagedContainerRuntime) StopManagedContainer(_ context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	r.stops = append(r.stops, name)
+	return r.stopErrors[name]
+}
+
+func managedInspection(name, kind string, resetEligible, running bool) ManagedContainerInspection {
+	return ManagedContainerInspection{
+		Exists:      true,
+		Running:     running,
+		HasIdentity: true,
+		Identity: ContainerIdentity{
+			Owner:          "runtime",
+			Kind:           kind,
+			ResetEligible:  resetEligible,
+			CreationSource: "test",
+			ContainerName:  name,
+			WorkspaceScope: kind,
+			RunID:          "11111111-1111-1111-1111-111111111111",
+			EntityID:       "entity-a",
+			AgentID:        "agent-a",
+			FlowInstance:   "flow/a",
+		},
+	}
+}

--- a/internal/runtime/destructivereset/planner.go
+++ b/internal/runtime/destructivereset/planner.go
@@ -10,6 +10,30 @@ type InventoryPlanner struct {
 	ResetSeams          []ResetSeam
 }
 
+type CompositeInventoryReader struct {
+	Reader     InventoryReader
+	Containers ManagedContainerInventoryReader
+}
+
+func (r CompositeInventoryReader) ReadResetInventory(ctx context.Context) (Inventory, error) {
+	if r.Reader == nil {
+		return Inventory{}, ErrPlannerNotConfigured
+	}
+	inventory, err := r.Reader.ReadResetInventory(ctx)
+	if err != nil {
+		return Inventory{}, err
+	}
+	if r.Containers == nil {
+		return inventory, nil
+	}
+	containers, err := r.Containers.ManagedResetContainerInventory(ctx)
+	if err != nil {
+		return Inventory{}, err
+	}
+	inventory.EntityContainers = append([]ContainerRef(nil), containers...)
+	return inventory, nil
+}
+
 func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error) {
 	if p.Reader == nil {
 		return Plan{}, ErrPlannerNotConfigured

--- a/internal/runtime/destructivereset/types.go
+++ b/internal/runtime/destructivereset/types.go
@@ -15,6 +15,13 @@ const (
 	QuiescenceControlledBy = DefaultOperationName
 	QuiescenceReasonCode   = "runtime_nuke_cancelled"
 	QuiescenceDeliveryNote = "runtime destructive reset cancelled delivery"
+
+	ContainerActionStop           = "stop"
+	ContainerActionPreserve       = "preserve"
+	ContainerActionMissing        = "missing"
+	ContainerActionAlreadyStopped = "already_stopped"
+	ContainerActionFailed         = "failed"
+	ContainerActionUnowned        = "preserve_unowned"
 )
 
 var (
@@ -84,6 +91,30 @@ type CleanupTableResult struct {
 	PreservedRows    int64  `json:"preserved_rows"`
 }
 
+type ContainerResetRequest struct {
+	Result       Result
+	Cleanup      CleanupResult
+	ActorTokenID string
+	RequestedAt  time.Time
+}
+
+type ContainerResetResult struct {
+	OperationName  string                 `json:"operation_name"`
+	DryRun         bool                   `json:"dry_run"`
+	AppliedAt      time.Time              `json:"applied_at"`
+	Selected       []ContainerRef         `json:"selected"`
+	Preserved      []ContainerRef         `json:"preserved"`
+	Missing        []ContainerRef         `json:"missing"`
+	AlreadyStopped []ContainerRef         `json:"already_stopped"`
+	Stopped        []ContainerRef         `json:"stopped"`
+	Failed         []ContainerStopFailure `json:"failed"`
+}
+
+type ContainerStopFailure struct {
+	Container ContainerRef `json:"container"`
+	Error     string       `json:"error"`
+}
+
 type CleanupCatalogEntry struct {
 	Table             string
 	TableKind         string
@@ -145,9 +176,16 @@ type TableRef struct {
 }
 
 type ContainerRef struct {
-	Name   string `json:"name"`
-	Kind   string `json:"kind"`
-	Action string `json:"action"`
+	Name           string `json:"name"`
+	Kind           string `json:"kind"`
+	Action         string `json:"action"`
+	ResetEligible  bool   `json:"reset_eligible,omitempty"`
+	CreationSource string `json:"creation_source,omitempty"`
+	WorkspaceScope string `json:"workspace_scope,omitempty"`
+	RunID          string `json:"run_id,omitempty"`
+	EntityID       string `json:"entity_id,omitempty"`
+	AgentID        string `json:"agent_id,omitempty"`
+	FlowInstance   string `json:"flow_instance,omitempty"`
 }
 
 type PreservedResources struct {
@@ -185,6 +223,10 @@ type InventoryReader interface {
 	ReadResetInventory(context.Context) (Inventory, error)
 }
 
+type ManagedContainerInventoryReader interface {
+	ManagedResetContainerInventory(context.Context) ([]ContainerRef, error)
+}
+
 type Planner interface {
 	BuildPlan(context.Context, Request) (Plan, error)
 }
@@ -208,6 +250,31 @@ type QuiescenceStore interface {
 
 type CleanupStore interface {
 	ApplyDestructiveResetCleanup(context.Context, CleanupRequest) (CleanupResult, error)
+}
+
+type ManagedContainerRuntime interface {
+	InspectManagedContainer(context.Context, string) (ManagedContainerInspection, error)
+	StopManagedContainer(context.Context, string) error
+}
+
+type ManagedContainerInspection struct {
+	Exists      bool
+	Running     bool
+	HasIdentity bool
+	Identity    ContainerIdentity
+}
+
+type ContainerIdentity struct {
+	Owner          string
+	Kind           string
+	ResetEligible  bool
+	CreationSource string
+	ContainerName  string
+	WorkspaceScope string
+	RunID          string
+	EntityID       string
+	AgentID        string
+	FlowInstance   string
 }
 
 type IdempotencyKey struct {

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -69,6 +69,9 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 		t.Fatalf("mkdir capture dir: %v", err)
 	}
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
+	// Keep the fake provider turn progression tied to invocation count. CI has
+	// produced first-turn prompts containing read_file result markers, so the
+	// semantic proof stays in capturedToolResultInput rather than branching here.
 	script := `#!/bin/sh
 set -eu
 capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
@@ -82,11 +85,12 @@ count=$((count + 1))
 printf '%s' "$count" > "$count_file"
 captured="$capture_dir/$count.stdin"
 cat > "$captured"
-# Branch on the actual tool-result payload, not just the tool name or process
-# invocation count. Startup/probe prompts may include compact tool schema text
-# containing "read_file" and success examples, but only the actual second-turn
-# tool-result payload includes the read result's size_bytes field.
-if grep -Eq '"name"[[:space:]]*:[[:space:]]*"read_file"' "$captured" && grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' "$captured" && grep -Eq '"size_bytes"[[:space:]]*:' "$captured"; then
+# Keep the fake provider's control flow tied to process invocation order, not
+# stdin marker matching. CI has exposed prompts that can contain read_file
+# examples with ok/size_bytes before the tool is actually executed; the
+# capturedToolResultInput assertion below remains the proof that invocation 2
+# carried the real read_file result payload.
+if [ "$count" -ge 2 ]; then
   printf '%s\n' '{"type":"result","result":"done"}'
 else
   printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -12,9 +12,11 @@ import (
 	"sort"
 	"strings"
 
+	runtimecontaineridentity "swarm/internal/runtime/containeridentity"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
@@ -144,7 +146,7 @@ func (m *DockerManager) SetRunDockerFnForTest(runDockerFn func(ctx context.Conte
 }
 
 func (m *DockerManager) EnsureSystemWorkspaces(ctx context.Context) error {
-	if err := m.EnsureContainerRunning(ctx, m.cfg.ScaffoldContainer, append(m.standardMountArgs(),
+	if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.ScaffoldContainer, m.systemContainerIdentity("workspace.EnsureSystemWorkspaces", runtimecontaineridentity.KindScaffold), append(m.standardMountArgs(),
 		[]string{
 			"-v", fmt.Sprintf("%s:%s", m.cfg.ScaffoldVolume, m.cfg.ScaffoldWorkdir),
 			"-w", m.cfg.ScaffoldWorkdir,
@@ -154,7 +156,7 @@ func (m *DockerManager) EnsureSystemWorkspaces(ctx context.Context) error {
 		return fmt.Errorf("ensure scaffold workspace: %w", err)
 	}
 
-	if err := m.EnsureContainerRunning(ctx, m.cfg.SystemContainer, append(m.standardMountArgs(),
+	if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.SystemContainer, m.systemContainerIdentity("workspace.EnsureSystemWorkspaces", runtimecontaineridentity.KindSystem), append(m.standardMountArgs(),
 		[]string{
 			"--privileged",
 			"-v", fmt.Sprintf("%s:/opt/swarm/entities", m.cfg.SystemEntitiesVolume),
@@ -230,8 +232,21 @@ func (m *DockerManager) EnsureEntityWorkspace(ctx context.Context, entityID stri
 	}
 	container := m.EntityContainerName(slug)
 	volume := fmt.Sprintf("entities_%s", slug)
+	runID, err := workspaceRunID(ctx)
+	if err != nil {
+		return err
+	}
 
-	return m.EnsureContainerRunning(ctx, container, append(m.standardMountArgs(),
+	return m.EnsureContainerRunningWithIdentity(ctx, container, runtimecontaineridentity.Identity{
+		Owner:          runtimecontaineridentity.OwnerRuntime,
+		Kind:           runtimecontaineridentity.KindEntity,
+		ResetEligible:  true,
+		CreationSource: "workspace.EnsureEntityWorkspace",
+		ContainerName:  container,
+		WorkspaceScope: "entity",
+		RunID:          runID,
+		EntityID:       strings.TrimSpace(entityID),
+	}, append(m.standardMountArgs(),
 		[]string{
 			"-v", fmt.Sprintf("%s:%s", volume, m.cfg.EntityWorkdir),
 			"-w", m.cfg.EntityWorkdir,
@@ -343,7 +358,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 	}
 	switch workspaceRouteClass(class) {
 	case "scaffold":
-		if err := m.EnsureContainerRunning(ctx, m.cfg.ScaffoldContainer, []string{
+		if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.ScaffoldContainer, m.systemContainerIdentity("workspace.ResolveWorkspace", runtimecontaineridentity.KindScaffold), []string{
 			"-v", fmt.Sprintf("%s:%s", m.cfg.ScaffoldVolume, m.cfg.ScaffoldWorkdir),
 			"-w", m.cfg.ScaffoldWorkdir,
 			m.cfg.WorkspaceImage,
@@ -356,7 +371,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 			Workdir:   m.cfg.ScaffoldWorkdir,
 		}, nil
 	case "system":
-		if err := m.EnsureContainerRunning(ctx, m.cfg.SystemContainer, []string{
+		if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.SystemContainer, m.systemContainerIdentity("workspace.ResolveWorkspace", runtimecontaineridentity.KindSystem), []string{
 			"--privileged",
 			"-v", fmt.Sprintf("%s:/opt/swarm/entities", m.cfg.SystemEntitiesVolume),
 			"-v", fmt.Sprintf("%s:/opt/swarm/nginx", m.cfg.SystemNginxVolume),
@@ -377,7 +392,11 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 		return nil, err
 	}
 	container, volume := m.workspaceContainerAndVolume(scope, scopeKey)
-	if err := m.EnsureContainerRunning(ctx, container, append(m.standardMountArgs(),
+	identity, err := m.workspaceContainerIdentity(ctx, container, scope, scopeKey, actor)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.EnsureContainerRunningWithIdentity(ctx, container, identity, append(m.standardMountArgs(),
 		[]string{
 			"-v", fmt.Sprintf("%s:%s", volume, m.cfg.EntityWorkdir),
 			"-w", m.cfg.EntityWorkdir,
@@ -471,6 +490,58 @@ func (m *DockerManager) workspaceContainerAndVolume(scope, scopeKey string) (str
 	default:
 		return "swarm-agent-" + scopeKey, "workspaces_agent_" + scopeKey
 	}
+}
+
+func (m *DockerManager) systemContainerIdentity(source, kind string) runtimecontaineridentity.Identity {
+	name := strings.TrimSpace(m.cfg.ScaffoldContainer)
+	scope := runtimecontaineridentity.KindScaffold
+	if strings.TrimSpace(kind) == runtimecontaineridentity.KindSystem {
+		name = strings.TrimSpace(m.cfg.SystemContainer)
+		scope = runtimecontaineridentity.KindSystem
+	}
+	return runtimecontaineridentity.Identity{
+		Owner:          runtimecontaineridentity.OwnerRuntime,
+		Kind:           strings.TrimSpace(kind),
+		ResetEligible:  false,
+		CreationSource: strings.TrimSpace(source),
+		ContainerName:  name,
+		WorkspaceScope: scope,
+	}
+}
+
+func (m *DockerManager) workspaceContainerIdentity(ctx context.Context, container, scope, scopeKey string, actor models.AgentConfig) (runtimecontaineridentity.Identity, error) {
+	runID, err := workspaceRunID(ctx)
+	if err != nil {
+		return runtimecontaineridentity.Identity{}, err
+	}
+	identity := runtimecontaineridentity.Identity{
+		Owner:          runtimecontaineridentity.OwnerRuntime,
+		ResetEligible:  true,
+		CreationSource: "workspace.ResolveWorkspace",
+		ContainerName:  strings.TrimSpace(container),
+		WorkspaceScope: strings.TrimSpace(scope),
+		RunID:          runID,
+	}
+	switch strings.TrimSpace(scope) {
+	case "per-flow-instance":
+		identity.Kind = runtimecontaineridentity.KindFlow
+		identity.FlowInstance = strings.Trim(strings.TrimSpace(scopeKey), "/")
+	default:
+		identity.Kind = runtimecontaineridentity.KindAgent
+		identity.AgentID = strings.TrimSpace(actor.ID)
+	}
+	return identity, nil
+}
+
+func workspaceRunID(ctx context.Context) (string, error) {
+	runID, ok, err := runtimecurrentstate.RunIDFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", nil
+	}
+	return runID, nil
 }
 
 func (m *DockerManager) standardMountArgs() []string {
@@ -672,6 +743,10 @@ func asString(v any) string {
 }
 
 func (m *DockerManager) EnsureContainerRunning(ctx context.Context, name string, createArgs []string) error {
+	return m.EnsureContainerRunningWithIdentity(ctx, name, runtimecontaineridentity.Identity{}, createArgs)
+}
+
+func (m *DockerManager) EnsureContainerRunningWithIdentity(ctx context.Context, name string, identity runtimecontaineridentity.Identity, createArgs []string) error {
 	exists, running, err := m.InspectContainer(ctx, name)
 	if err != nil {
 		return err
@@ -680,6 +755,13 @@ func (m *DockerManager) EnsureContainerRunning(ctx context.Context, name string,
 		args := []string{"create", "--name", name}
 		if network := strings.TrimSpace(m.cfg.WorkspaceNetwork); network != "" {
 			args = append(args, "--network", network)
+		}
+		labels, err := identityLabelsForContainer(name, identity)
+		if err != nil {
+			return err
+		}
+		if len(labels) > 0 {
+			args = append(args, runtimecontaineridentity.DockerCreateLabelArgs(labels)...)
 		}
 		args = append(args, createArgs...)
 		if _, err := m.RunDocker(ctx, args...); err != nil {
@@ -703,6 +785,17 @@ func (m *DockerManager) EnsureContainerRunning(ctx context.Context, name string,
 		return err
 	}
 	return nil
+}
+
+func identityLabelsForContainer(name string, identity runtimecontaineridentity.Identity) (map[string]string, error) {
+	if strings.TrimSpace(identity.Owner) == "" {
+		return nil, nil
+	}
+	identity.ContainerName = strings.TrimSpace(name)
+	if err := identity.Validate(); err != nil {
+		return nil, err
+	}
+	return identity.Labels(), nil
 }
 
 func (m *DockerManager) EnsureContainerNetwork(ctx context.Context, name string) error {
@@ -734,6 +827,128 @@ func (m *DockerManager) StopContainer(ctx context.Context, name string) error {
 		return err
 	}
 	return nil
+}
+
+func (m *DockerManager) StopManagedContainer(ctx context.Context, name string) error {
+	return m.StopContainer(ctx, name)
+}
+
+func (m *DockerManager) ManagedResetContainerInventory(ctx context.Context) ([]runtimedestructivereset.ContainerRef, error) {
+	out, err := m.RunDocker(ctx,
+		"container", "ls", "--all",
+		"--filter", "label="+runtimecontaineridentity.LabelOwner+"="+runtimecontaineridentity.OwnerRuntime,
+		"--filter", "label="+runtimecontaineridentity.LabelResetEligible+"=true",
+		"--format", "{{.Names}}",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list managed reset containers: %w", err)
+	}
+	var refs []runtimedestructivereset.ContainerRef
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		inspection, err := m.InspectManagedContainer(ctx, name)
+		if err != nil {
+			return nil, fmt.Errorf("inspect managed reset container %s: %w", name, err)
+		}
+		identity := containerIdentityFromResetInspection(inspection)
+		if !inspection.Exists || !inspection.HasIdentity || !identity.ResetEligibleManaged() {
+			continue
+		}
+		if strings.TrimSpace(identity.ContainerName) != name {
+			return nil, fmt.Errorf("managed reset container %s identity names %s", name, identity.ContainerName)
+		}
+		refs = append(refs, managedContainerRef(identity, runtimedestructivereset.ContainerActionStop))
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Kind != refs[j].Kind {
+			return refs[i].Kind < refs[j].Kind
+		}
+		return refs[i].Name < refs[j].Name
+	})
+	return refs, nil
+}
+
+func (m *DockerManager) InspectManagedContainer(ctx context.Context, name string) (runtimedestructivereset.ManagedContainerInspection, error) {
+	out, err := m.RunDocker(ctx, "inspect", "--format", "{{json .}}", strings.TrimSpace(name))
+	if err != nil {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "no such object") {
+			return runtimedestructivereset.ManagedContainerInspection{}, nil
+		}
+		return runtimedestructivereset.ManagedContainerInspection{}, err
+	}
+	var doc struct {
+		State struct {
+			Running bool `json:"Running"`
+		} `json:"State"`
+		Config struct {
+			Labels map[string]string `json:"Labels"`
+		} `json:"Config"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &doc); err != nil {
+		return runtimedestructivereset.ManagedContainerInspection{}, err
+	}
+	identity, ok, err := runtimecontaineridentity.FromLabels(doc.Config.Labels)
+	if err != nil {
+		return runtimedestructivereset.ManagedContainerInspection{}, err
+	}
+	return runtimedestructivereset.ManagedContainerInspection{
+		Exists:      true,
+		Running:     doc.State.Running,
+		HasIdentity: ok,
+		Identity:    resetContainerIdentity(identity),
+	}, nil
+}
+
+func resetContainerIdentity(identity runtimecontaineridentity.Identity) runtimedestructivereset.ContainerIdentity {
+	identity = identity.Normalized()
+	return runtimedestructivereset.ContainerIdentity{
+		Owner:          identity.Owner,
+		Kind:           identity.Kind,
+		ResetEligible:  identity.ResetEligible,
+		CreationSource: identity.CreationSource,
+		ContainerName:  identity.ContainerName,
+		WorkspaceScope: identity.WorkspaceScope,
+		RunID:          identity.RunID,
+		EntityID:       identity.EntityID,
+		AgentID:        identity.AgentID,
+		FlowInstance:   identity.FlowInstance,
+	}
+}
+
+func containerIdentityFromResetInspection(inspection runtimedestructivereset.ManagedContainerInspection) runtimecontaineridentity.Identity {
+	identity := inspection.Identity
+	return runtimecontaineridentity.Identity{
+		Owner:          identity.Owner,
+		Kind:           identity.Kind,
+		ResetEligible:  identity.ResetEligible,
+		CreationSource: identity.CreationSource,
+		ContainerName:  identity.ContainerName,
+		WorkspaceScope: identity.WorkspaceScope,
+		RunID:          identity.RunID,
+		EntityID:       identity.EntityID,
+		AgentID:        identity.AgentID,
+		FlowInstance:   identity.FlowInstance,
+	}.Normalized()
+}
+
+func managedContainerRef(identity runtimecontaineridentity.Identity, action string) runtimedestructivereset.ContainerRef {
+	identity = identity.Normalized()
+	return runtimedestructivereset.ContainerRef{
+		Name:           identity.ContainerName,
+		Kind:           identity.Kind,
+		Action:         strings.TrimSpace(action),
+		ResetEligible:  identity.ResetEligible,
+		CreationSource: identity.CreationSource,
+		WorkspaceScope: identity.WorkspaceScope,
+		RunID:          identity.RunID,
+		EntityID:       identity.EntityID,
+		AgentID:        identity.AgentID,
+		FlowInstance:   identity.FlowInstance,
+	}
 }
 
 func (m *DockerManager) InspectContainer(ctx context.Context, name string) (bool, bool, error) {

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -858,7 +858,7 @@ func (m *DockerManager) ManagedResetContainerInventory(ctx context.Context) ([]r
 			continue
 		}
 		if strings.TrimSpace(identity.ContainerName) != name {
-			return nil, fmt.Errorf("managed reset container %s identity names %s", name, identity.ContainerName)
+			continue
 		}
 		refs = append(refs, managedContainerRef(identity, runtimedestructivereset.ContainerActionStop))
 	}

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -893,7 +893,12 @@ func (m *DockerManager) InspectManagedContainer(ctx context.Context, name string
 	}
 	identity, ok, err := runtimecontaineridentity.FromLabels(doc.Config.Labels)
 	if err != nil {
-		return runtimedestructivereset.ManagedContainerInspection{}, err
+		// Malformed runtime labels are not ownership proof. Preserve fail-closed
+		// instead of letting one stale candidate abort the whole reset inventory.
+		return runtimedestructivereset.ManagedContainerInspection{
+			Exists:  true,
+			Running: doc.State.Running,
+		}, nil
 	}
 	return runtimedestructivereset.ManagedContainerInspection{
 		Exists:      true,

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -383,7 +383,7 @@ func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
 		joined := strings.Join(args, " ")
 		switch {
 		case joined == "container ls --all --filter label=dev.swarm.owner=runtime --filter label=dev.swarm.reset.eligible=true --format {{.Names}}":
-			return "swarm-agent-agent-a\nswarm-system\nswarm-malformed\n", nil
+			return "swarm-agent-agent-a\nswarm-system\nswarm-malformed\nswarm-stale-name\n", nil
 		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-agent-agent-a":
 			return managedContainerInspectJSON(map[string]string{
 				"dev.swarm.owner":           "runtime",
@@ -410,6 +410,17 @@ func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
 				"dev.swarm.container.kind": "agent",
 				"dev.swarm.reset.eligible": "true",
 				"dev.swarm.container.name": "different-container-name",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-stale-name":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "agent",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.ResolveWorkspace",
+				"dev.swarm.container.name":  "old-valid-container-name",
+				"dev.swarm.workspace.scope": "per-agent",
+				"dev.swarm.run_id":          "44444444-4444-4444-4444-444444444444",
+				"dev.swarm.agent_id":        "agent-stale",
 			}, true), nil
 		default:
 			return "", nil

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
 )
@@ -106,7 +107,8 @@ func TestResolveWorkspace_PerAgentMountsStandardPaths(t *testing.T) {
 			return "", nil
 		}
 	})
-	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+	ctx := runtimecorrelation.WithRunID(context.Background(), "11111111-1111-1111-1111-111111111111")
+	target, err := manager.ResolveWorkspace(ctx, models.AgentConfig{
 		ID:             "dedicated-agent",
 		WorkspaceClass: "dedicated",
 	})
@@ -121,6 +123,10 @@ func TestResolveWorkspace_PerAgentMountsStandardPaths(t *testing.T) {
 		dataDir + ":/data:ro",
 		contractsDir + ":/opt/swarm/contracts:ro",
 		"workspaces_agent_dedicated-agent:/workspace",
+		"--label dev.swarm.container.kind=agent",
+		"--label dev.swarm.reset.eligible=true",
+		"--label dev.swarm.agent_id=dedicated-agent",
+		"--label dev.swarm.run_id=11111111-1111-1111-1111-111111111111",
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("create args missing %q: %v", expected, created)
@@ -165,7 +171,8 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 			return "", nil
 		}
 	})
-	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+	ctx := runtimecorrelation.WithRunID(context.Background(), "22222222-2222-2222-2222-222222222222")
+	target, err := manager.ResolveWorkspace(ctx, models.AgentConfig{
 		ID:             "shared-work-lead",
 		WorkspaceClass: "shared_flow",
 		FlowPath:       "shared/work-001",
@@ -179,6 +186,16 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 	joined := strings.Join(created, " ")
 	if !strings.Contains(joined, "workspaces_flow_shared-work-001:/workspace") {
 		t.Fatalf("expected shared flow workspace volume, got %v", created)
+	}
+	for _, expected := range []string{
+		"--label dev.swarm.container.kind=flow",
+		"--label dev.swarm.reset.eligible=true",
+		"--label dev.swarm.flow_instance=shared/work-001",
+		"--label dev.swarm.run_id=22222222-2222-2222-2222-222222222222",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("create args missing %q: %v", expected, created)
+		}
 	}
 }
 
@@ -345,11 +362,63 @@ func TestEnsureSystemWorkspaces_CreatesScaffoldAndSystemContainers(t *testing.T)
 	for _, expected := range []string{
 		"create --name swarm-scaffold",
 		"create --name swarm-system",
+		"--label dev.swarm.container.kind=scaffold",
+		"--label dev.swarm.container.kind=system",
+		"--label dev.swarm.reset.eligible=false",
 		"test-image sleep infinity",
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("EnsureSystemWorkspaces calls missing %q: %s", expected, joined)
 		}
+	}
+}
+
+func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.WorkspaceNetwork = ""
+	manager.SetConfig(cfg)
+
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case joined == "container ls --all --filter label=dev.swarm.owner=runtime --filter label=dev.swarm.reset.eligible=true --format {{.Names}}":
+			return "swarm-agent-agent-a\nswarm-system\n", nil
+		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-agent-agent-a":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "agent",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.ResolveWorkspace",
+				"dev.swarm.container.name":  "swarm-agent-agent-a",
+				"dev.swarm.workspace.scope": "per-agent",
+				"dev.swarm.run_id":          "33333333-3333-3333-3333-333333333333",
+				"dev.swarm.agent_id":        "agent-a",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-system":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "system",
+				"dev.swarm.reset.eligible":  "false",
+				"dev.swarm.creation_source": "workspace.EnsureSystemWorkspaces",
+				"dev.swarm.container.name":  "swarm-system",
+				"dev.swarm.workspace.scope": "system",
+			}, true), nil
+		default:
+			return "", nil
+		}
+	})
+
+	refs, err := manager.ManagedResetContainerInventory(context.Background())
+	if err != nil {
+		t.Fatalf("ManagedResetContainerInventory: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("refs = %#v, want one reset-eligible managed container", refs)
+	}
+	ref := refs[0]
+	if ref.Name != "swarm-agent-agent-a" || ref.Kind != "agent" || !ref.ResetEligible || ref.AgentID != "agent-a" || ref.RunID == "" {
+		t.Fatalf("ref = %#v, want agent identity with run lineage", ref)
 	}
 }
 
@@ -359,4 +428,12 @@ func flattenDockerCalls(calls [][]string) string {
 		lines = append(lines, strings.Join(call, " "))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func managedContainerInspectJSON(labels map[string]string, running bool) string {
+	labelParts := make([]string, 0, len(labels))
+	for key, value := range labels {
+		labelParts = append(labelParts, fmt.Sprintf("%q:%q", key, value))
+	}
+	return fmt.Sprintf(`{"State":{"Running":%t},"Config":{"Labels":{%s}}}`, running, strings.Join(labelParts, ","))
 }

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -383,7 +383,7 @@ func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
 		joined := strings.Join(args, " ")
 		switch {
 		case joined == "container ls --all --filter label=dev.swarm.owner=runtime --filter label=dev.swarm.reset.eligible=true --format {{.Names}}":
-			return "swarm-agent-agent-a\nswarm-system\n", nil
+			return "swarm-agent-agent-a\nswarm-system\nswarm-malformed\n", nil
 		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-agent-agent-a":
 			return managedContainerInspectJSON(map[string]string{
 				"dev.swarm.owner":           "runtime",
@@ -403,6 +403,13 @@ func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
 				"dev.swarm.creation_source": "workspace.EnsureSystemWorkspaces",
 				"dev.swarm.container.name":  "swarm-system",
 				"dev.swarm.workspace.scope": "system",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[len(args)-1] == "swarm-malformed":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":          "runtime",
+				"dev.swarm.container.kind": "agent",
+				"dev.swarm.reset.eligible": "true",
+				"dev.swarm.container.name": "different-container-name",
 			}, true), nil
 		default:
 			return "", nil

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -194,6 +194,58 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DoesNotDeleteRunsCreatedAfte
 	}
 }
 
+func TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanup(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	seedDestructiveResetCleanupRows(t, ctx, pg)
+	containerRefs := []destructivereset.ContainerRef{{
+		Name:          "swarm-agent-agent-a",
+		Kind:          "agent",
+		Action:        destructivereset.ContainerActionStop,
+		ResetEligible: true,
+		RunID:         "11111111-1111-1111-1111-111111111111",
+		AgentID:       "agent-a",
+	}}
+	plan, err := (destructivereset.InventoryPlanner{Reader: destructivereset.CompositeInventoryReader{
+		Reader:     pg,
+		Containers: managedContainerInventoryFunc(func(context.Context) ([]destructivereset.ContainerRef, error) { return containerRefs, nil }),
+	}}).BuildPlan(ctx, destructivereset.Request{ActorTokenID: "operator-token"})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.EntityContainers) != 1 || plan.EntityContainers[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("planned entity containers = %#v, want managed container snapshot", plan.EntityContainers)
+	}
+	now := time.Date(2026, 5, 16, 18, 45, 0, 0, time.UTC)
+	if _, err := pg.ApplyDestructiveResetCleanup(ctx, destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName: destructivereset.DefaultOperationName,
+			PlannedAt:     now.Add(-time.Minute),
+			Plan:          plan,
+		},
+		Quiescence: destructivereset.QuiescenceResult{
+			OperationName: destructivereset.DefaultOperationName,
+			AppliedAt:     now.Add(-30 * time.Second),
+		},
+	}); err != nil {
+		t.Fatalf("ApplyDestructiveResetCleanup: %v", err)
+	}
+	if len(plan.EntityContainers) != 1 || plan.EntityContainers[0].Name != "swarm-agent-agent-a" {
+		t.Fatalf("plan entity containers after cleanup = %#v, want immutable pre-cleanup snapshot", plan.EntityContainers)
+	}
+	if got := countRows(t, ctx, pg, "entity_state"); got != 0 {
+		t.Fatalf("entity_state after cleanup = %d, want deleted while plan still carries container refs", got)
+	}
+}
+
 func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesIntoCleanupSet(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -629,6 +681,12 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RequiresPlannedCleanupRunSet
 type destructiveResetCleanupSeed struct {
 	RunA string
 	RunB string
+}
+
+type managedContainerInventoryFunc func(context.Context) ([]destructivereset.ContainerRef, error)
+
+func (f managedContainerInventoryFunc) ManagedResetContainerInventory(ctx context.Context) ([]destructivereset.ContainerRef, error) {
+	return f(ctx)
 }
 
 func cleanupPlanForRunIDs(runIDs ...string) destructivereset.Plan {


### PR DESCRIPTION
Closes #780
Part of #771
Related to #748

## Governing refs/context
- #780 Pre-Implementation Coverage Audit and independent gate re-review: approved as first slice for typed managed runtime-container identity + plan-time capture + stop/preservation/result ownership.
- Authoritative spec refs: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `workspace_model.managed_container_identity`, `platform_tables.destructive_reset_cleanup_policy`, and `deferred_namespaces.runtime_admin` / migration text deferring public `runtime.reset_state`.
- Prerequisites consumed: #773/#774 reset plan/result/lock/dry-run/idempotency, #775/#776 quiescence, #778/#779 DB cleanup.
- Process refs: `docs/IMPLEMENTER_GUIDELINES.md`, `docs/SEMANTIC_DRIFT.md`.

## Summary
- Adds `internal/runtime/containeridentity` as the typed Docker-label identity owner for platform-created workspace containers.
- Stamps scaffold/system/entity/agent/flow workspace containers at creation time with owner kind, reset eligibility, source, name, scope, and available run/entity/agent/flow lineage.
- Adds plan-time managed-container inventory composition and `ManagedContainerStopper`, which stops only label-proven reset-eligible runtime containers and preserves unlabeled/system/operator/name-only containers fail-closed.
- Updates authoritative `platform-spec.yaml` for the internal managed container identity/reset policy. No public `/v1/rpc runtime.nuke`, OpenRPC method, dashboard/Builder migration, or `scripts/run_clear.sh` migration is included.

## Semantic migration
- New canonical owner: `internal/runtime/containeridentity` + workspace creation stamping + `internal/runtime/destructivereset.ManagedContainerStopper`.
- Old invalid/non-authoritative paths: name-prefix-only ownership, `RuntimeWorkspaceContainers` as a stop list, direct `StopEntityWorkspace`/`StopContainer` use as reset ownership, dashboard/Builder reset helpers, and `scripts/run_clear.sh reset-dev` raw Docker/database reset.
- Production paths checked for surviving old behavior: workspace creation/stop helpers, destructive reset contracts/planner, API/OpenRPC/spec public surfaces, dashboard/Builder/script reset seams, and raw Docker stop/list commands.
- Migration completeness: complete for new managed runtime containers created after this PR. Existing unlabeled/name-only containers are intentionally preserved as unowned legacy residuals; final public `runtime.nuke` wrapper and legacy reset seam migrations remain split under #771/#748.

## Proof
- `go test ./internal/runtime/containeridentity -count=1`
- `go test ./internal/runtime/destructivereset -count=1`
- `go test ./internal/runtime/workspace -count=1`
- `go test ./internal/store -run 'TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanup|TestPostgresStore_ApplyDestructiveResetCleanup' -count=1`
- `go test ./internal/runtime/containeridentity ./internal/runtime/destructivereset ./internal/runtime/workspace -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static grep proof: no public `runtime.nuke` API/OpenRPC exposure; remaining `docker ps/docker stop` is the already-split `scripts/run_clear.sh reset-dev`; new Docker inventory is label-filtered and consumes typed identity.
