### PR TITLE
[agent-b][issue #782] Add public runtime.nuke wrapper

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -29,6 +29,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecredentials "swarm/internal/runtime/credentials"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
@@ -208,21 +209,34 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		apiEntities = stores.Postgres
 		apiAgentConversations = stores.Postgres
 	}
+	resetPlanner := runtimedestructivereset.InventoryPlanner{
+		Reader: runtimedestructivereset.CompositeInventoryReader{
+			Reader:     stores.Postgres,
+			Containers: workspaces,
+		},
+	}
 	apiReadOptions := apiv1.OperatorReadOptions{
 		Ready: func() bool {
 			return ready.Load()
 		},
-		Database:              stores.Postgres,
-		Runs:                  stores.Postgres,
-		Observability:         stores.Postgres,
-		Entities:              apiEntities,
-		AgentConversations:    apiAgentConversations,
-		AgentControl:          dashboardDynamicAgentControl{supervisor: supervisor},
-		Mailbox:               stores.Postgres,
-		Idempotency:           stores.Postgres,
-		Events:                rt.Bus,
-		RunControl:            rt.RunControl,
-		RuntimeIngress:        rt.RuntimeIngress,
+		Database:           stores.Postgres,
+		Runs:               stores.Postgres,
+		Observability:      stores.Postgres,
+		Entities:           apiEntities,
+		AgentConversations: apiAgentConversations,
+		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},
+		Mailbox:            stores.Postgres,
+		Idempotency:        stores.Postgres,
+		Events:             rt.Bus,
+		RunControl:         rt.RunControl,
+		RuntimeIngress:     rt.RuntimeIngress,
+		ResetCoordinator: &runtimedestructivereset.Coordinator{
+			Planner: resetPlanner,
+			Locks:   stores.Postgres,
+		},
+		ResetQuiescer:         runtimedestructivereset.Quiescer{Store: stores.Postgres},
+		ResetCleaner:          runtimedestructivereset.Cleaner{Store: stores.Postgres},
+		ResetContainers:       runtimedestructivereset.ManagedContainerStopper{Runtime: workspaces},
 		Source:                source,
 		MailboxApprovalRoutes: mailboxApprovalRoutes,
 		Bundle:                bootBundleIdentity,

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -936,7 +936,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -974,7 +974,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1226,7 +1226,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1303,7 +1303,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1341,7 +1341,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1849,7 +1849,7 @@
           }
         },
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -1986,7 +1986,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2024,7 +2024,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3439,7 +3439,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3477,7 +3477,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3600,7 +3600,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3669,7 +3669,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3802,7 +3802,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3840,7 +3840,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3882,7 +3882,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4087,7 +4087,7 @@
           }
         },
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -4312,7 +4312,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4350,7 +4350,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4481,7 +4481,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4558,7 +4558,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4792,6 +4792,133 @@
           "type": "object"
         }
       }
+    },
+    {
+      "name": "runtime.nuke",
+      "description": "Public destructive runtime reset wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the destructive-reset owner chain for execution: plan/result/lock, active-run and delivery quiescence, run-scoped cleanup/preservation, and managed entity-container selection/stop. It MUST NOT directly truncate tables, call raw Docker stop/list helpers, call AgentManager.ResetRuntimeStateWithSource, or migrate dashboard/Builder/run_clear/CLI reset seams in this method implementation.\n\n`dry_run=true` returns the same top-level shape with side-effect-free previews from each owner. Apply mode sequences plan -\u003e quiescence -\u003e cleanup -\u003e managed-container stop. Managed-container stop failures are represented as `status=partial_failure`, `ok=false`, and explicit `errors`; they must not masquerade as complete success. Public final-response idempotency follows the v1 API idempotency convention.\n",
+      "params": [
+        {
+          "name": "dry_run",
+          "required": false,
+          "schema": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/RuntimeNukeResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32020,
+          "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "RUNTIME_NUKE_IN_PROGRESS",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "operation_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_name"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32011,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
     },
     {
       "name": "runtime.pause",
@@ -6517,6 +6644,83 @@
         ],
         "type": "object"
       },
+      "RuntimeNukeResult": {
+        "additionalProperties": false,
+        "properties": {
+          "cleanup": {
+            "additionalProperties": true,
+            "description": "Exact result from the run-scoped cleanup/preservation owner.",
+            "type": "object"
+          },
+          "containers": {
+            "additionalProperties": true,
+            "description": "Exact result from the managed entity-container selection/stop owner.",
+            "type": "object"
+          },
+          "dry_run": {
+            "type": "boolean"
+          },
+          "errors": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "scope",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "ok": {
+            "description": "True for dry-run or fully completed apply; false when the operation completed with explicit partial failures.",
+            "type": "boolean"
+          },
+          "operation_name": {
+            "type": "string"
+          },
+          "partial_failure": {
+            "type": "boolean"
+          },
+          "plan": {
+            "additionalProperties": true,
+            "description": "Exact result from the destructive-reset plan/result owner.",
+            "type": "object"
+          },
+          "quiescence": {
+            "additionalProperties": true,
+            "description": "Exact result from the active-run/delivery quiescence owner.",
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "dry_run",
+              "completed",
+              "partial_failure"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "status",
+          "dry_run",
+          "operation_name",
+          "plan",
+          "quiescence",
+          "cleanup",
+          "containers",
+          "partial_failure"
+        ],
+        "type": "object"
+      },
       "ScopeName": {
         "description": "Action-resource scopes used for v1 authorization. v1 enforcement\ntreats every valid token as granting every scope; the enum exists\nfor forward-compat with Phase 2/3 per-token scope restrictions.\nNew scopes added by deferred namespaces (e.g., verify:contracts\nwhen verify.* lands, debug:* when debug.* lands) are additive.\n",
         "enum": [
@@ -7638,8 +7842,46 @@
           "type": "object"
         }
       },
-      "RUN_ALREADY_PAUSED": {
+      "RUNTIME_NUKE_IN_PROGRESS": {
         "code": -32020,
+        "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "RUNTIME_NUKE_IN_PROGRESS",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "operation_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "operation_name"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "RUN_ALREADY_PAUSED": {
+        "code": -32021,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -7677,7 +7919,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -7719,7 +7961,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -7757,7 +7999,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -7799,7 +8041,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -7837,7 +8079,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -7880,7 +8122,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5688,6 +5688,7 @@ api_specification:
       - agent.replay_backlog
       - runtime.pause
       - runtime.resume
+      - runtime.nuke
     mailbox:
       status_storage_model: 'The storage table keeps terminal defer decisions as status = decided and decision = deferred.
         v1 read projections expose that row as MailboxStatus deferred. Approval/reject terminal rows remain status = decided
@@ -6980,6 +6981,65 @@ api_specification:
           ok:
             type: boolean
             const: true
+      RuntimeNukeResult:
+        type: object
+        additionalProperties: false
+        required:
+        - ok
+        - status
+        - dry_run
+        - operation_name
+        - plan
+        - quiescence
+        - cleanup
+        - containers
+        - partial_failure
+        properties:
+          ok:
+            type: boolean
+            description: True for dry-run or fully completed apply; false when the operation completed with explicit partial
+              failures.
+          status:
+            type: string
+            enum:
+            - dry_run
+            - completed
+            - partial_failure
+          dry_run:
+            type: boolean
+          operation_name:
+            type: string
+          plan:
+            type: object
+            additionalProperties: true
+            description: Exact result from the destructive-reset plan/result owner.
+          quiescence:
+            type: object
+            additionalProperties: true
+            description: Exact result from the active-run/delivery quiescence owner.
+          cleanup:
+            type: object
+            additionalProperties: true
+            description: Exact result from the run-scoped cleanup/preservation owner.
+          containers:
+            type: object
+            additionalProperties: true
+            description: Exact result from the managed entity-container selection/stop owner.
+          partial_failure:
+            type: boolean
+          errors:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              required:
+              - scope
+              - message
+              properties:
+                scope:
+                  type: string
+                message:
+                  type: string
       SubscriptionId:
         type: object
         additionalProperties: false
@@ -7353,6 +7413,14 @@ api_specification:
         type: object
         additionalProperties: false
         properties: {}
+      RUNTIME_NUKE_IN_PROGRESS:
+        type: object
+        additionalProperties: false
+        required:
+        - operation_name
+        properties:
+          operation_name:
+            type: string
   method_catalog_metadata:
     description: "All v1 methods. Each method declares: tier, description, scope.required,\nparams (array of contentDescriptors),\
       \ result (contentDescriptor), errors\n(array of error codes from components.errors). Mutating methods include\nidempotency.\
@@ -8780,6 +8848,38 @@ api_specification:
       errors:
       - RUNTIME_NOT_PAUSED
       - IDEMPOTENCY_CONFLICT
+    runtime.nuke:
+      tier: should_have
+      description: "Public destructive runtime reset wrapper. The API layer owns only the v1 request/response/auth/idempotency\
+        \ contract and MUST consume the destructive-reset owner chain for execution: plan/result/lock, active-run and delivery\
+        \ quiescence, run-scoped cleanup/preservation, and managed entity-container selection/stop. It MUST NOT directly\
+        \ truncate tables, call raw Docker stop/list helpers, call AgentManager.ResetRuntimeStateWithSource, or migrate dashboard/Builder/run_clear/CLI\
+        \ reset seams in this method implementation.\n\n`dry_run=true` returns the same top-level shape with side-effect-free\
+        \ previews from each owner. Apply mode sequences plan -> quiescence -> cleanup -> managed-container stop. Managed-container\
+        \ stop failures are represented as `status=partial_failure`, `ok=false`, and explicit `errors`; they must not masquerade\
+        \ as complete success. Public final-response idempotency follows the v1 API idempotency convention.\n"
+      scope:
+        required:
+        - control:runtime
+      idempotency: per the convention.
+      params:
+      - name: dry_run
+        required: false
+        schema:
+          type: boolean
+          default: false
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/RuntimeNukeResult'
+      errors:
+      - RUNTIME_NUKE_IN_PROGRESS
+      - IDEMPOTENCY_CONFLICT
   deferred_namespaces:
     description: 'Explicitly out of v1 scope. Listed here so consumers know to expect them
 
@@ -8835,7 +8935,9 @@ api_specification:
     runtime_admin:
       methods:
       - runtime.reset_state
-      rationale: Dangerous operation. Defer until operator-permission scoping is more concrete than the v1 single-token model.
+      rationale: Legacy reset_state naming remains deferred/retired. Public destructive reset is exposed as runtime.nuke,
+        backed by the destructive-reset owner chain; dashboard/Builder/reset_state migration is tracked separately from the
+        public wrapper.
     bundle_lifecycle:
       methods:
       - bundle.open
@@ -8906,7 +9008,8 @@ api_specification:
       - "GET /api/runtime/logs \u2192 runtime.logs"
       - "GET /api/runtime/incidents \u2192 runtime.incidents"
       - "POST /api/runtime/actions {pause/resume} \u2192 runtime.pause / runtime.resume"
-      - "POST /api/runtime/actions {reset_state} \u2192 deferred to runtime_admin.runtime.reset_state"
+      - "POST /api/runtime/actions {reset_state} \u2192 runtime.nuke in a later dashboard/Builder migration; the legacy reset_state
+        name remains deferred/retired."
       - "GET /api/runs/{runID}/trace \u2192 run.trace (also adds run.subscribe_trace as the live variant)"
     auth_token_disposition:
       v1_model: SWARM_API_TOKEN is the only user-facing API bearer-token source. SWARM_BUILDER_AUTH_TOKEN and SWARM_OPERATOR_AUTH_TOKEN

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,23 +16,26 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 41 {
-		t.Fatalf("method count = %d, want 41", report.MethodCount)
+	if report.MethodCount != 42 {
+		t.Fatalf("method count = %d, want 42", report.MethodCount)
 	}
-	if report.SchemaCount != 58 {
-		t.Fatalf("schema count = %d, want 58", report.SchemaCount)
+	if report.SchemaCount != 59 {
+		t.Fatalf("schema count = %d, want 59", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 27 {
-		t.Fatalf("error code count = %d, want 27", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 28 {
+		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 15 {
-		t.Fatalf("mutating method count = %d, want 15", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 16 {
+		t.Fatalf("mutating method count = %d, want 16", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
 	}
 	if _, ok := api.MethodCatalog["rpc.unsubscribe"]; !ok {
 		t.Fatal("rpc.unsubscribe missing from method catalog")
+	}
+	if _, ok := api.MethodCatalog["runtime.nuke"]; !ok {
+		t.Fatal("runtime.nuke missing from method catalog")
 	}
 	if _, ok := api.MethodCatalog["description"]; ok {
 		t.Fatal("method_catalog.description must not be a generated method")
@@ -61,14 +64,14 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 41 {
-		t.Fatalf("generated OpenRPC methods = %d, want 41", len(doc.Methods))
+	if len(doc.Methods) != 42 {
+		t.Fatalf("generated OpenRPC methods = %d, want 42", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 58 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 58", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 59 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 59", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 27 {
-		t.Fatalf("generated OpenRPC errors = %d, want 27", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 28 {
+		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
 	}
 	methods := map[string]OpenRPCMethod{}
 	for _, method := range doc.Methods {
@@ -85,6 +88,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")
+	}
+	if _, ok := methods["runtime.nuke"]; !ok {
+		t.Fatal("generated OpenRPC missing runtime.nuke")
 	}
 	if !methods["run.start"].Deprecated {
 		t.Fatal("generated OpenRPC run.start deprecated flag = false, want true")

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,11 +29,14 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 41 {
-		t.Fatalf("method count = %d, want 41", len(openRPCNames))
+	if len(openRPCNames) != 42 {
+		t.Fatalf("method count = %d, want 42", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")
+	}
+	if _, ok := registry.Method("runtime.nuke"); !ok {
+		t.Fatal("runtime.nuke missing from generated registry")
 	}
 }
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -60,6 +60,10 @@ type OperatorReadOptions struct {
 	Events                EventPublisher
 	RunControl            RunControlController
 	RuntimeIngress        RuntimeIngressController
+	ResetCoordinator      DestructiveResetCoordinator
+	ResetQuiescer         DestructiveResetQuiescer
+	ResetCleaner          DestructiveResetCleaner
+	ResetContainers       DestructiveResetContainerStopper
 	Source                semanticview.Source
 	MailboxApprovalRoutes map[string]string
 	Bundle                runtimecontracts.BundleIdentity
@@ -207,6 +211,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorRuntimeControlHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorRuntimeNukeHandlers(opts) {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorObservabilityHandlers(opts) {

--- a/internal/apiv1/operator_runtime_nuke.go
+++ b/internal/apiv1/operator_runtime_nuke.go
@@ -1,0 +1,208 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/store"
+)
+
+const runtimeNukeIdempotencyTTL = 24 * time.Hour
+
+type DestructiveResetCoordinator interface {
+	BuildPlanWithLock(context.Context, destructivereset.Request, func(context.Context, destructivereset.Result) error) (destructivereset.Result, bool, error)
+}
+
+type DestructiveResetQuiescer interface {
+	Apply(context.Context, destructivereset.QuiescenceRequest) (destructivereset.QuiescenceResult, error)
+}
+
+type DestructiveResetCleaner interface {
+	Apply(context.Context, destructivereset.CleanupRequest) (destructivereset.CleanupResult, error)
+}
+
+type DestructiveResetContainerStopper interface {
+	Apply(context.Context, destructivereset.ContainerResetRequest) (destructivereset.ContainerResetResult, error)
+}
+
+type runtimeNukeResult struct {
+	OK             bool                                  `json:"ok"`
+	Status         string                                `json:"status"`
+	DryRun         bool                                  `json:"dry_run"`
+	OperationName  string                                `json:"operation_name"`
+	Plan           destructivereset.Result               `json:"plan"`
+	Quiescence     destructivereset.QuiescenceResult     `json:"quiescence"`
+	Cleanup        destructivereset.CleanupResult        `json:"cleanup"`
+	Containers     destructivereset.ContainerResetResult `json:"containers"`
+	PartialFailure bool                                  `json:"partial_failure"`
+	Errors         []runtimeNukePartialError             `json:"errors,omitempty"`
+}
+
+type runtimeNukePartialError struct {
+	Scope   string `json:"scope"`
+	Message string `json:"message"`
+}
+
+func OperatorRuntimeNukeHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.ResetCoordinator == nil || opts.ResetQuiescer == nil || opts.ResetCleaner == nil || opts.ResetContainers == nil || opts.Idempotency == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"runtime.nuke": func(ctx context.Context, req Request) (any, error) {
+			return executeRuntimeNuke(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func executeRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	dryRun, err := optionalBoolParam(req.Params, "dry_run", false)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     destructivereset.DefaultOperationName,
+		TTL:            runtimeNukeIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := performRuntimeNuke(ctx, req, opts, dryRun, now)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		response, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: result.OperationName,
+			Response:   response,
+		}, nil
+	})
+	if err != nil {
+		return nil, runtimeNukeError(err)
+	}
+	var stored runtimeNukeResult
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode runtime.nuke idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode runtime.nuke response: %w", err)
+	}
+	return stored, nil
+}
+
+func performRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptions, dryRun bool, now time.Time) (runtimeNukeResult, error) {
+	var quiescence destructivereset.QuiescenceResult
+	var cleanup destructivereset.CleanupResult
+	var containers destructivereset.ContainerResetResult
+	planResult, _, err := opts.ResetCoordinator.BuildPlanWithLock(ctx, destructivereset.Request{
+		ActorTokenID: req.ActorTokenID,
+		RequestHash:  req.RequestHash,
+		DryRun:       dryRun,
+		RequestedAt:  now,
+	}, func(ctx context.Context, planResult destructivereset.Result) error {
+		var err error
+		quiescence, err = opts.ResetQuiescer.Apply(ctx, destructivereset.QuiescenceRequest{
+			Result:       planResult,
+			ActorTokenID: req.ActorTokenID,
+			RequestedAt:  now,
+		})
+		if err != nil {
+			return err
+		}
+		cleanup, err = opts.ResetCleaner.Apply(ctx, destructivereset.CleanupRequest{
+			Result:       planResult,
+			Quiescence:   quiescence,
+			ActorTokenID: req.ActorTokenID,
+			RequestedAt:  now,
+		})
+		if err != nil {
+			return err
+		}
+		containers, err = opts.ResetContainers.Apply(ctx, destructivereset.ContainerResetRequest{
+			Result:       planResult,
+			Cleanup:      cleanup,
+			ActorTokenID: req.ActorTokenID,
+			RequestedAt:  now,
+		})
+		return err
+	})
+	if err != nil {
+		return runtimeNukeResult{}, err
+	}
+	result := runtimeNukeResult{
+		OK:            true,
+		Status:        "completed",
+		DryRun:        dryRun,
+		OperationName: strings.TrimSpace(planResult.OperationName),
+		Plan:          planResult,
+		Quiescence:    quiescence,
+		Cleanup:       cleanup,
+		Containers:    containers,
+	}
+	if result.OperationName == "" {
+		result.OperationName = destructivereset.DefaultOperationName
+	}
+	if dryRun {
+		result.Status = "dry_run"
+	}
+	if len(containers.Failed) > 0 {
+		result.OK = false
+		result.Status = "partial_failure"
+		result.PartialFailure = true
+		for _, failure := range containers.Failed {
+			result.Errors = append(result.Errors, runtimeNukePartialError{
+				Scope:   "managed_containers",
+				Message: strings.TrimSpace(failure.Error),
+			})
+		}
+	}
+	return result, nil
+}
+
+func runtimeNukeError(err error) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	var resetConflict *destructivereset.IdempotencyConflictError
+	if errors.As(err, &resetConflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    resetConflict.OriginalRequestHash,
+			"conflicting_request_hash": resetConflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      "runtime.nuke",
+				"resource_id": resetConflict.Key.OperationName,
+			},
+		})
+	}
+	if errors.Is(err, destructivereset.ErrOperationInProgress) {
+		return NewApplicationError(RuntimeNukeInProgressCode, true, map[string]any{
+			"operation_name": destructivereset.DefaultOperationName,
+		})
+	}
+	return err
+}

--- a/internal/apiv1/operator_runtime_nuke_test.go
+++ b/internal/apiv1/operator_runtime_nuke_test.go
@@ -41,6 +41,8 @@ func TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners(t *testing.T) {
 	if got, want := strings.Join(owners.calls, ","), "plan,quiescence,cleanup,containers"; got != want {
 		t.Fatalf("owner calls = %s, want %s", got, want)
 	}
+	assertRuntimeNukeContractStatus(t, result, destructivereset.ContractPublicAPIWrapper, "implemented_public_owner")
+	assertRuntimeNukeContractStatus(t, result, destructivereset.ContractLegacyResetMigration, "split")
 	if owners.lastPlan.DryRun != true || owners.lastQuiescence.Result.DryRun != true || owners.lastCleanup.Result.DryRun != true || owners.lastContainers.Result.DryRun != true {
 		t.Fatalf("dry-run flag not propagated through owners: plan=%v quiescence=%v cleanup=%v containers=%v", owners.lastPlan.DryRun, owners.lastQuiescence.Result.DryRun, owners.lastCleanup.Result.DryRun, owners.lastContainers.Result.DryRun)
 	}
@@ -187,6 +189,8 @@ func (o *recordingRuntimeNukeOwners) BuildPlan(_ context.Context, req destructiv
 				ResetEligible: true,
 				RunID:         "00000000-0000-0000-0000-000000000001",
 			}},
+			DownstreamContracts: destructivereset.DefaultDownstreamContracts(),
+			ResetSeams:          destructivereset.DefaultResetSeams(),
 		},
 	}, false, nil
 }
@@ -319,4 +323,24 @@ func (s *recordingAPIIdempotencyStore) WithAPIIdempotency(
 	s.records[key] = copied
 	s.hashes[key] = req.RequestHash
 	return completion, false, nil
+}
+
+func assertRuntimeNukeContractStatus(t *testing.T, result map[string]any, contractID, status string) {
+	t.Helper()
+	planResult := asMap(t, result["plan"])
+	plan := asMap(t, planResult["plan"])
+	contracts, ok := plan["downstream_contracts"].([]any)
+	if !ok {
+		t.Fatalf("downstream_contracts = %#v, want array", plan["downstream_contracts"])
+	}
+	for _, raw := range contracts {
+		contract := asMap(t, raw)
+		if contract["id"] == contractID {
+			if contract["status"] != status {
+				t.Fatalf("contract %s status = %#v, want %s", contractID, contract["status"], status)
+			}
+			return
+		}
+	}
+	t.Fatalf("contract %s missing from downstream_contracts: %#v", contractID, contracts)
 }

--- a/internal/apiv1/operator_runtime_nuke_test.go
+++ b/internal/apiv1/operator_runtime_nuke_test.go
@@ -1,0 +1,322 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/store"
+)
+
+func TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	owners := newRecordingRuntimeNukeOwners()
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:              func() time.Time { return now },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Idempotency:      newRecordingAPIIdempotencyStore(),
+			ResetCoordinator: owners,
+			ResetQuiescer:    recordingRuntimeNukeQuiescer{owners},
+			ResetCleaner:     recordingRuntimeNukeCleaner{owners},
+			ResetContainers:  recordingRuntimeNukeContainerStopper{owners},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"dry_run":true,"idempotency_key":"dry-run"}}`)
+	if resp.Error != nil {
+		t.Fatalf("runtime.nuke dry-run error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["ok"] != true || result["status"] != "dry_run" || result["dry_run"] != true || result["partial_failure"] != false {
+		t.Fatalf("runtime.nuke dry-run result = %#v", result)
+	}
+	if got, want := strings.Join(owners.calls, ","), "plan,quiescence,cleanup,containers"; got != want {
+		t.Fatalf("owner calls = %s, want %s", got, want)
+	}
+	if owners.lastPlan.DryRun != true || owners.lastQuiescence.Result.DryRun != true || owners.lastCleanup.Result.DryRun != true || owners.lastContainers.Result.DryRun != true {
+		t.Fatalf("dry-run flag not propagated through owners: plan=%v quiescence=%v cleanup=%v containers=%v", owners.lastPlan.DryRun, owners.lastQuiescence.Result.DryRun, owners.lastCleanup.Result.DryRun, owners.lastContainers.Result.DryRun)
+	}
+}
+
+func TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	owners := newRecordingRuntimeNukeOwners()
+	owners.containerFailure = "docker stop denied"
+	idempotency := newRecordingAPIIdempotencyStore()
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:              func() time.Time { return now },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Idempotency:      idempotency,
+			ResetCoordinator: owners,
+			ResetQuiescer:    recordingRuntimeNukeQuiescer{owners},
+			ResetCleaner:     recordingRuntimeNukeCleaner{owners},
+			ResetContainers:  recordingRuntimeNukeContainerStopper{owners},
+		}),
+	})
+	body := `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"idempotency_key":"apply"}}`
+
+	resp := rpcCall(t, handler, body)
+	if resp.Error != nil {
+		t.Fatalf("runtime.nuke apply error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["ok"] != false || result["status"] != "partial_failure" || result["partial_failure"] != true {
+		t.Fatalf("runtime.nuke partial result = %#v", result)
+	}
+	if len(owners.calls) != 4 {
+		t.Fatalf("owner call count = %d, want 4", len(owners.calls))
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("runtime.nuke replay error = %#v", replay.Error)
+	}
+	if len(owners.calls) != 4 {
+		t.Fatalf("owner calls after replay = %d, want unchanged 4", len(owners.calls))
+	}
+
+	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"dry_run":true,"idempotency_key":"apply"}}`)
+	if conflict.Error == nil {
+		t.Fatal("runtime.nuke idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("runtime.nuke conflict data = %#v, want %s", data, IdempotencyConflictCode)
+	}
+}
+
+func TestOperatorRuntimeNukeAuthFailureDoesNotTouchResetOwners(t *testing.T) {
+	owners := newRecordingRuntimeNukeOwners()
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Idempotency:      newRecordingAPIIdempotencyStore(),
+			ResetCoordinator: owners,
+			ResetQuiescer:    recordingRuntimeNukeQuiescer{owners},
+			ResetCleaner:     recordingRuntimeNukeCleaner{owners},
+			ResetContainers:  recordingRuntimeNukeContainerStopper{owners},
+		}),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{}}`))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing auth status = %d, want 401", rec.Code)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{}}`))
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad auth status = %d, want 401", rec.Code)
+	}
+	if len(owners.calls) != 0 {
+		t.Fatalf("owner calls after auth failures = %v, want none", owners.calls)
+	}
+}
+
+func TestOperatorRuntimeNukeOperationInProgressFailsClosed(t *testing.T) {
+	owners := newRecordingRuntimeNukeOwners()
+	owners.planErr = destructivereset.ErrOperationInProgress
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Idempotency:      newRecordingAPIIdempotencyStore(),
+			ResetCoordinator: owners,
+			ResetQuiescer:    recordingRuntimeNukeQuiescer{owners},
+			ResetCleaner:     recordingRuntimeNukeCleaner{owners},
+			ResetContainers:  recordingRuntimeNukeContainerStopper{owners},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"idempotency_key":"busy"}}`)
+	if resp.Error == nil {
+		t.Fatal("runtime.nuke busy error = nil")
+	}
+	data := asMap(t, resp.Error.Data)
+	if data["code"] != RuntimeNukeInProgressCode || data["retryable"] != true {
+		t.Fatalf("runtime.nuke busy data = %#v, want retryable %s", data, RuntimeNukeInProgressCode)
+	}
+}
+
+type recordingRuntimeNukeOwners struct {
+	calls            []string
+	planErr          error
+	containerFailure string
+	lastPlan         destructivereset.Request
+	lastQuiescence   destructivereset.QuiescenceRequest
+	lastCleanup      destructivereset.CleanupRequest
+	lastContainers   destructivereset.ContainerResetRequest
+}
+
+func newRecordingRuntimeNukeOwners() *recordingRuntimeNukeOwners {
+	return &recordingRuntimeNukeOwners{}
+}
+
+func (o *recordingRuntimeNukeOwners) BuildPlan(_ context.Context, req destructivereset.Request) (destructivereset.Result, bool, error) {
+	o.calls = append(o.calls, "plan")
+	o.lastPlan = req
+	if o.planErr != nil {
+		return destructivereset.Result{}, false, o.planErr
+	}
+	return destructivereset.Result{
+		OperationName: destructivereset.DefaultOperationName,
+		DryRun:        req.DryRun,
+		PlannedAt:     req.RequestedAt,
+		Plan: destructivereset.Plan{
+			ActiveRuns: []destructivereset.RunRef{{RunID: "00000000-0000-0000-0000-000000000001", Status: "running"}},
+			EntityContainers: []destructivereset.ContainerRef{{
+				Name:          "swarm-agent-1",
+				Kind:          "agent",
+				Action:        destructivereset.ContainerActionStop,
+				ResetEligible: true,
+				RunID:         "00000000-0000-0000-0000-000000000001",
+			}},
+		},
+	}, false, nil
+}
+
+func (o *recordingRuntimeNukeOwners) BuildPlanWithLock(ctx context.Context, req destructivereset.Request, apply func(context.Context, destructivereset.Result) error) (destructivereset.Result, bool, error) {
+	result, replay, err := o.BuildPlan(ctx, req)
+	if err != nil || replay || apply == nil {
+		return result, replay, err
+	}
+	if err := apply(ctx, result); err != nil {
+		return destructivereset.Result{}, false, err
+	}
+	return result, false, nil
+}
+
+func (o *recordingRuntimeNukeOwners) ApplyQuiescence(req destructivereset.QuiescenceRequest) destructivereset.QuiescenceResult {
+	return destructivereset.QuiescenceResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+		ReasonCode:    destructivereset.QuiescenceReasonCode,
+		ControlledBy:  destructivereset.QuiescenceControlledBy,
+	}
+}
+
+type recordingRuntimeNukeQuiescer struct {
+	owners *recordingRuntimeNukeOwners
+}
+
+func (q recordingRuntimeNukeQuiescer) Apply(ctx context.Context, req destructivereset.QuiescenceRequest) (destructivereset.QuiescenceResult, error) {
+	o := q.owners
+	o.calls = append(o.calls, "quiescence")
+	o.lastQuiescence = req
+	return o.ApplyQuiescence(req), nil
+}
+
+func (o *recordingRuntimeNukeOwners) ApplyCleanup(req destructivereset.CleanupRequest) destructivereset.CleanupResult {
+	return destructivereset.CleanupResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+		RunIDs:        []string{"00000000-0000-0000-0000-000000000001"},
+	}
+}
+
+type recordingRuntimeNukeCleaner struct {
+	owners *recordingRuntimeNukeOwners
+}
+
+func (c recordingRuntimeNukeCleaner) Apply(ctx context.Context, req destructivereset.CleanupRequest) (destructivereset.CleanupResult, error) {
+	o := c.owners
+	o.calls = append(o.calls, "cleanup")
+	o.lastCleanup = req
+	return o.ApplyCleanup(req), nil
+}
+
+func (o *recordingRuntimeNukeOwners) ApplyContainerReset(req destructivereset.ContainerResetRequest) destructivereset.ContainerResetResult {
+	result := destructivereset.ContainerResetResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+		Selected:      req.Result.Plan.EntityContainers,
+	}
+	if req.Result.DryRun {
+		return result
+	}
+	if o.containerFailure != "" {
+		result.Failed = []destructivereset.ContainerStopFailure{{
+			Container: req.Result.Plan.EntityContainers[0],
+			Error:     o.containerFailure,
+		}}
+		return result
+	}
+	result.Stopped = req.Result.Plan.EntityContainers
+	return result
+}
+
+type recordingRuntimeNukeContainerStopper struct {
+	owners *recordingRuntimeNukeOwners
+}
+
+func (s recordingRuntimeNukeContainerStopper) Apply(ctx context.Context, req destructivereset.ContainerResetRequest) (destructivereset.ContainerResetResult, error) {
+	o := s.owners
+	o.calls = append(o.calls, "containers")
+	o.lastContainers = req
+	return o.ApplyContainerReset(req), nil
+}
+
+type recordingAPIIdempotencyStore struct {
+	records map[string]store.APIIdempotencyCompletion
+	hashes  map[string]string
+}
+
+func newRecordingAPIIdempotencyStore() *recordingAPIIdempotencyStore {
+	return &recordingAPIIdempotencyStore{
+		records: map[string]store.APIIdempotencyCompletion{},
+		hashes:  map[string]string{},
+	}
+}
+
+func (s *recordingAPIIdempotencyStore) WithAPIIdempotency(
+	ctx context.Context,
+	req store.APIIdempotencyRequest,
+	execute func(context.Context) (store.APIIdempotencyCompletion, error),
+) (store.APIIdempotencyCompletion, bool, error) {
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		completion, err := execute(ctx)
+		return completion, false, err
+	}
+	key := strings.Join([]string{req.Method, req.ActorTokenID, req.IdempotencyKey}, "|")
+	if completion, ok := s.records[key]; ok {
+		if s.hashes[key] != req.RequestHash {
+			return store.APIIdempotencyCompletion{}, false, &store.APIIdempotencyConflictError{
+				OriginalRequestHash:    s.hashes[key],
+				ConflictingRequestHash: req.RequestHash,
+				Method:                 req.Method,
+				ResourceID:             completion.ResourceID,
+			}
+		}
+		copied := completion
+		copied.Response = append(json.RawMessage(nil), completion.Response...)
+		return copied, true, nil
+	}
+	completion, err := execute(ctx)
+	if err != nil {
+		return store.APIIdempotencyCompletion{}, false, err
+	}
+	copied := completion
+	copied.Response = append(json.RawMessage(nil), completion.Response...)
+	s.records[key] = copied
+	s.hashes[key] = req.RequestHash
+	return completion, false, nil
+}

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -38,6 +38,7 @@ const (
 	IdempotencyConflictCode              = "IDEMPOTENCY_CONFLICT"
 	RuntimeAlreadyPausedCode             = "RUNTIME_ALREADY_PAUSED"
 	RuntimeNotPausedCode                 = "RUNTIME_NOT_PAUSED"
+	RuntimeNukeInProgressCode            = "RUNTIME_NUKE_IN_PROGRESS"
 )
 
 type Registry struct {

--- a/internal/runtime/destructivereset/contracts.go
+++ b/internal/runtime/destructivereset/contracts.go
@@ -30,9 +30,9 @@ func DefaultDownstreamContracts() []DownstreamContract {
 		},
 		{
 			ID:          ContractPublicAPIWrapper,
-			Status:      "split",
-			Owner:       "future v1 runtime.nuke API wrapper",
-			Description: "Expose /v1/rpc runtime.nuke and authoritative platform-spec/OpenRPC only after destructive reset owners exist.",
+			Status:      "implemented_public_owner",
+			Owner:       "platform-spec.yaml, generated openrpc.json, and internal/apiv1 runtime.nuke handler over destructive reset owners",
+			Description: "Expose /v1/rpc runtime.nuke as the authoritative public wrapper over the destructive reset plan, quiescence, cleanup, and managed-container owners.",
 		},
 		{
 			ID:          ContractLegacyResetMigration,

--- a/internal/runtime/destructivereset/coordinator.go
+++ b/internal/runtime/destructivereset/coordinator.go
@@ -16,6 +16,10 @@ type Coordinator struct {
 }
 
 func (c *Coordinator) BuildPlan(ctx context.Context, req Request) (Result, bool, error) {
+	return c.BuildPlanWithLock(ctx, req, nil)
+}
+
+func (c *Coordinator) BuildPlanWithLock(ctx context.Context, req Request, apply func(context.Context, Result) error) (Result, bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -83,6 +87,11 @@ func (c *Coordinator) BuildPlan(ctx context.Context, req Request) (Result, bool,
 		DryRun:        req.DryRun,
 		PlannedAt:     req.RequestedAt,
 		Plan:          plan,
+	}
+	if apply != nil {
+		if err := apply(ctx, copyResult(result)); err != nil {
+			return Result{}, false, err
+		}
 	}
 	if idemKey.IdempotencyKey != "" {
 		if err := c.Idempotency.StoreResetResult(ctx, StoredResult{

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -188,6 +188,54 @@ func TestCoordinatorLockConflictPreventsPlanning(t *testing.T) {
 	}
 }
 
+func TestCoordinatorBuildPlanWithLockHoldsLeaseThroughApply(t *testing.T) {
+	now := time.Date(2026, 5, 15, 1, 2, 3, 0, time.UTC)
+	reader := &recordingInventoryReader{inventory: Inventory{
+		ActiveRuns: []RunRef{{RunID: "run-1", Status: "running"}},
+	}}
+	locks := &recordingLockManager{acquired: true}
+	idempotency := newRecordingIdempotencyStore()
+	coord := &Coordinator{
+		Planner:     InventoryPlanner{Reader: reader},
+		Locks:       locks,
+		Idempotency: idempotency,
+		Now:         func() time.Time { return now },
+	}
+	called := false
+	_, replay, err := coord.BuildPlanWithLock(context.Background(), Request{
+		ActorTokenID:   "operator-token",
+		IdempotencyKey: "idem-locked-apply",
+		RequestHash:    "hash-locked-apply",
+	}, func(_ context.Context, result Result) error {
+		called = true
+		if result.OperationName != DefaultOperationName || result.PlannedAt != now {
+			t.Fatalf("callback result = %#v, want normalized plan result", result)
+		}
+		if locks.lease == nil || locks.lease.releases != 0 {
+			t.Fatalf("lock release before callback completed = %#v", locks.lease)
+		}
+		if idempotency.stores != 0 {
+			t.Fatalf("idempotency stored before callback completed = %d, want 0", idempotency.stores)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BuildPlanWithLock error = %v", err)
+	}
+	if replay {
+		t.Fatal("BuildPlanWithLock replay = true, want false")
+	}
+	if !called {
+		t.Fatal("BuildPlanWithLock callback not called")
+	}
+	if locks.lease.releases != 1 {
+		t.Fatalf("lock releases after callback = %d, want 1", locks.lease.releases)
+	}
+	if idempotency.stores != 1 {
+		t.Fatalf("idempotency stores after callback = %d, want 1", idempotency.stores)
+	}
+}
+
 func TestCoordinatorFailsClosedWhenLockLeaseIsMissing(t *testing.T) {
 	reader := &recordingInventoryReader{}
 	coord := &Coordinator{

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -252,7 +252,7 @@ func TestCoordinatorFailsClosedWhenLockLeaseIsMissing(t *testing.T) {
 	}
 }
 
-func TestInventoryPlannerCarriesSplitContractsAndResetSeams(t *testing.T) {
+func TestInventoryPlannerCarriesImplementedContractsAndSplitResetSeams(t *testing.T) {
 	reader := &recordingInventoryReader{}
 	plan, err := (InventoryPlanner{Reader: reader}).BuildPlan(context.Background(), Request{})
 	if err != nil {
@@ -261,7 +261,7 @@ func TestInventoryPlannerCarriesSplitContractsAndResetSeams(t *testing.T) {
 	if !containsContractStatus(plan.DownstreamContracts, ContractRunDeliveryQuiescence, "implemented_internal_owner") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractRunScopedTruncation, "implemented_internal_owner") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractManagedContainers, "implemented_internal_owner") ||
-		!containsContractStatus(plan.DownstreamContracts, ContractPublicAPIWrapper, "split") ||
+		!containsContractStatus(plan.DownstreamContracts, ContractPublicAPIWrapper, "implemented_public_owner") ||
 		!containsContractStatus(plan.DownstreamContracts, ContractLegacyResetMigration, "split") {
 		t.Fatalf("downstream contracts = %#v, missing required contract state", plan.DownstreamContracts)
 	}

--- a/internal/store/destructive_reset_lock.go
+++ b/internal/store/destructive_reset_lock.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/runtime/destructivereset"
+)
+
+func (s *PostgresStore) TryAcquire(ctx context.Context, lockKey string) (destructivereset.LockLease, bool, error) {
+	if s == nil || s.DB == nil {
+		return nil, false, fmt.Errorf("postgres store is required")
+	}
+	lockKey = strings.TrimSpace(lockKey)
+	if lockKey == "" {
+		return nil, false, fmt.Errorf("destructive reset lock key is required")
+	}
+	lease, acquired, err := acquireAdvisoryLockLease(ctx, s.DB, lockKey)
+	if lease == nil {
+		return nil, acquired, err
+	}
+	return lease, acquired, err
+}

--- a/internal/store/destructive_reset_lock_test.go
+++ b/internal/store/destructive_reset_lock_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_TryAcquireSerializesDestructiveResetLock(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	first, acquired, err := pg.TryAcquire(ctx, "test:destructive-reset")
+	if err != nil {
+		t.Fatalf("first TryAcquire: %v", err)
+	}
+	if !acquired || first == nil {
+		t.Fatalf("first TryAcquire acquired=%v lease=%#v, want acquired lease", acquired, first)
+	}
+	second, acquired, err := pg.TryAcquire(ctx, "test:destructive-reset")
+	if err != nil {
+		t.Fatalf("second TryAcquire: %v", err)
+	}
+	if acquired || second != nil {
+		t.Fatalf("second TryAcquire acquired=%v lease=%#v, want contention", acquired, second)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("release first lease: %v", err)
+	}
+	third, acquired, err := pg.TryAcquire(ctx, "test:destructive-reset")
+	if err != nil {
+		t.Fatalf("third TryAcquire: %v", err)
+	}
+	if !acquired || third == nil {
+		t.Fatalf("third TryAcquire acquired=%v lease=%#v, want acquired after release", acquired, third)
+	}
+	if err := third.Release(ctx); err != nil {
+		t.Fatalf("release third lease: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #782
Part of #771
Related to #748

## Summary

Adds the public `/v1/rpc` `runtime.nuke` method over the destructive reset owners merged in #774, #776, #779, and #781.

This PR keeps the approved first-slice boundary: public API/spec/OpenRPC/handler wrapper only. It does not migrate dashboard/Builder reset, `scripts/run_clear.sh reset-dev`, or CLI #735 consumers.

## Governing Refs / Context

Exact public `runtime.nuke` governing spec did not exist before this PR. This PR promotes the contract into authoritative `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` and regenerates `openrpc.json`.

Binding context used:
- #782 pre-audit and independent gate outcome: `approved as first slice`.
- #771 runtime.nuke decomposition tracker.
- #748 API extension/deprecation tracker.
- Adjacent spec sections: destructive reset cleanup policy, managed container identity, v1 idempotency convention, runtime pause/resume, deferred `runtime_admin.runtime.reset_state`, and API migration text.

## Semantic Migration

New canonical public owner:
- `/v1/rpc runtime.nuke` in `platform-spec.yaml`, generated OpenRPC, and `internal/apiv1`.

Consumed internal owners:
- `internal/runtime/destructivereset.Coordinator` for plan/result and operation lock.
- `destructivereset.Quiescer` for active-run/delivery quiescence.
- `destructivereset.Cleaner` for run-scoped cleanup/preservation.
- `destructivereset.ManagedContainerStopper` for managed entity-container selection/stop.
- v1 API idempotency for final public response replay/conflict.

Old paths now invalid/non-authoritative for public destructive reset:
- `AgentManager.ResetRuntimeStateWithSource`.
- dashboard `reset_state`.
- Builder reset.
- startup recovery reset.
- `scripts/run_clear.sh reset-dev` raw reset.

Production paths checked for surviving old behavior:
- `cmd/swarm/builder_project_supervisor.go` still has Builder reset split.
- `internal/dashboard/server/server.go` still has dashboard reset split.
- `internal/runtime/runtime.go` startup recovery reset remains split/different safety trigger.
- `scripts/run_clear.sh reset-dev` remains split dev bypass.

Migration completeness:
- Complete for the chosen #782 public wrapper class.
- Not complete for the broader #771 reset migration parent; legacy consumers remain tracked separately.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'TestRegistryMethodNamesMatchGeneratedOpenRPC|TestOperatorRuntimeNuke' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/store -run 'TestPostgresStore_TryAcquireSerializesDestructiveResetLock|TestPostgresStore_ApplyDestructiveResetQuiescence|TestPostgresStore_ApplyDestructiveResetCleanup' -count=1`
- `go test ./internal/runtime/destructivereset -count=1`
- Static grep proof for no raw DB/Docker/reset bypass in new `internal/apiv1` code.
