### PR TITLE
[agent-b][issue #784] Retire dashboard Builder reset_state seams

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -292,17 +292,6 @@ func (c dashboardDynamicRuntimeControl) ResumeIngress() error {
 	return err
 }
 
-func (c dashboardDynamicRuntimeControl) ResetState() error {
-	rt := c.supervisor.CurrentRuntime()
-	if rt == nil || rt.Manager == nil {
-		return fmt.Errorf("runtime manager unavailable")
-	}
-	if resetter, ok := any(rt.Manager).(interface{ ResetRuntimeStateWithSource(string) error }); ok {
-		return resetter.ResetRuntimeStateWithSource("builder_api")
-	}
-	return rt.Manager.ResetRuntimeState()
-}
-
 type dashboardDynamicAgentControl struct {
 	supervisor *runtimeProjectSupervisor
 }

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4525,17 +4525,19 @@ platform_events:
       produced_by_type: platform
     platform.reset:
       description: Admin-initiated platform state reset. Emitted ONLY when a human administrator explicitly triggers a reset
-        via the admin CLI or builder API. NOT emitted on crash recovery or automatic recovery fallback — those use
-        platform.recovery_failed if they fail, or normal boot if they succeed.
+        via the internal admin reset source. Builder/dashboard reset_state is retired and MUST NOT emit this event. NOT
+        emitted on crash recovery or automatic recovery fallback — those use platform.recovery_failed if they fail, or normal
+        boot if they succeed.
       scope: global
-      trigger: Explicit admin action only. The runtime calls ResetRuntimeState() and emits this event after the reset completes.
+      trigger: Explicit internal admin action only. The runtime calls ResetRuntimeState() and emits this event after the reset
+        completes.
         Product nodes may subscribe to this event to clear their own state (e.g., accumulator state, cycle counters).
       payload:
-        source: string — who initiated the reset (admin_cli, builder_api, etc.)
+        source: string — who initiated the reset (admin_cli)
         timestamp: string (ISO 8601)
       produced_by_type: platform
       swarm:
-        source: external (platform admin CLI or builder API)
+        source: external (platform admin CLI)
     platform.auth_required:
       description: Agent or tool call blocked pending authorization.
       scope: flow
@@ -8936,8 +8938,8 @@ api_specification:
       methods:
       - runtime.reset_state
       rationale: Legacy reset_state naming remains deferred/retired. Public destructive reset is exposed as runtime.nuke,
-        backed by the destructive-reset owner chain; dashboard/Builder/reset_state migration is tracked separately from the
-        public wrapper.
+        backed by the destructive-reset owner chain. Dashboard/Builder reset_state plumbing is retired/fail-closed rather
+        than migrated as a legacy API; any future privileged admin reset namespace requires a separate spec-gated child.
     bundle_lifecycle:
       methods:
       - bundle.open
@@ -9008,8 +9010,8 @@ api_specification:
       - "GET /api/runtime/logs \u2192 runtime.logs"
       - "GET /api/runtime/incidents \u2192 runtime.incidents"
       - "POST /api/runtime/actions {pause/resume} \u2192 runtime.pause / runtime.resume"
-      - "POST /api/runtime/actions {reset_state} \u2192 runtime.nuke in a later dashboard/Builder migration; the legacy reset_state
-        name remains deferred/retired."
+      - "POST /api/runtime/actions {reset_state} \u2192 retired/fail-closed; future dashboard consumers must call runtime.nuke
+        directly and the legacy reset_state name remains deferred/retired."
       - "GET /api/runs/{runID}/trace \u2192 run.trace (also adds run.subscribe_trace as the live variant)"
     auth_token_disposition:
       v1_model: SWARM_API_TOKEN is the only user-facing API bearer-token source. SWARM_BUILDER_AUTH_TOKEN and SWARM_OPERATOR_AUTH_TOKEN

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -23,7 +23,6 @@ type EntityReader interface {
 type RuntimeController interface {
 	PauseIngress() error
 	ResumeIngress() error
-	ResetState() error
 }
 
 type SourceProvider func() semanticview.Source
@@ -169,12 +168,6 @@ func NewHandler(opts Options) http.Handler {
 	if h.currentRuntime != nil {
 		h.runHub = newRunHub(
 			h.currentRuntime,
-			func() error {
-				if h.runtime == nil {
-					return errUnavailable("runtime controller is not configured")
-				}
-				return h.runtime.ResetState()
-			},
 			func() error {
 				if h.runtime == nil {
 					return errUnavailable("runtime controller is not configured")

--- a/internal/builder/handler_auth_test.go
+++ b/internal/builder/handler_auth_test.go
@@ -7,7 +7,20 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
+
+	runtimepkg "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
 )
+
+type stubBuilderRuntimeControl struct{}
+
+func (stubBuilderRuntimeControl) PauseIngress() error {
+	return nil
+}
+
+func (stubBuilderRuntimeControl) ResumeIngress() error {
+	return nil
+}
 
 func TestHandler_LegacyRoutesFailClosed(t *testing.T) {
 	handler := NewHandler(Options{
@@ -51,5 +64,31 @@ func TestHandler_LegacyWebSocketRoutesDoNotUpgrade(t *testing.T) {
 				t.Fatalf("upgrade response = %#v, want 404", resp)
 			}
 		})
+	}
+}
+
+func TestHandler_RuntimeControllerHasNoResetCallback(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	h := NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Runtime:   stubBuilderRuntimeControl{},
+		CurrentRuntime: func() *runtimepkg.Runtime {
+			return &runtimepkg.Runtime{Bus: eb}
+		},
+	})
+	typed, ok := h.(*handler)
+	if !ok || typed.runHub == nil {
+		t.Fatalf("builder handler runHub = %#v, want configured runHub", typed)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"runtime.reset_state"}`))
+	req.Header.Set("Authorization", "Bearer "+testBuilderAuthToken)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("legacy reset RPC status = %d, want %d body=%s", rec.Code, http.StatusNotFound, rec.Body.String())
 	}
 }

--- a/internal/builder/runs.go
+++ b/internal/builder/runs.go
@@ -8,7 +8,6 @@ import (
 
 type runHub struct {
 	runtimeProvider func() *runtimepkg.Runtime
-	resetRuntime    func() error
 	pauseRuntime    func() error
 	resumeRuntime   func() error
 	runDebug        RunDebugReader

--- a/internal/builder/runs_control.go
+++ b/internal/builder/runs_control.go
@@ -17,13 +17,12 @@ import (
 
 var runCompletionTimeout = 30 * time.Second
 
-func newRunHub(runtimeProvider func() *runtimepkg.Runtime, resetRuntime func() error, pauseRuntime func() error, resumeRuntime func() error, runDebug RunDebugReader) *runHub {
+func newRunHub(runtimeProvider func() *runtimepkg.Runtime, pauseRuntime func() error, resumeRuntime func() error, runDebug RunDebugReader) *runHub {
 	if runtimeProvider == nil {
 		return nil
 	}
 	return &runHub{
 		runtimeProvider: runtimeProvider,
-		resetRuntime:    resetRuntime,
 		pauseRuntime:    pauseRuntime,
 		resumeRuntime:   resumeRuntime,
 		runDebug:        runDebug,

--- a/internal/builder/runs_test.go
+++ b/internal/builder/runs_test.go
@@ -86,7 +86,7 @@ func TestRunHubStartRunPublishesTypedEntityEnvelope(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	rt := &runtimepkg.Runtime{Bus: eb}
-	hub := newRunHub(func() *runtimepkg.Runtime { return rt }, nil, nil, nil, nil)
+	hub := newRunHub(func() *runtimepkg.Runtime { return rt }, nil, nil, nil)
 	ch := eb.Subscribe("observer", "review.requested")
 
 	if err := hub.startRun(context.Background(), "run-123", map[string]any{

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -196,7 +196,6 @@ type AgentController interface {
 type RuntimeController interface {
 	PauseIngress() error
 	ResumeIngress() error
-	ResetState() error
 }
 
 type Options struct {
@@ -913,12 +912,6 @@ func (h *Handler) handleRuntimeAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, http.StatusOK, controlResult{OK: true, Message: "runtime resumed"})
-	case "reset_state":
-		if err := h.runtime.ResetState(); err != nil {
-			writeJSONError(w, http.StatusInternalServerError, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, controlResult{OK: true, Message: "runtime state reset"})
 	default:
 		writeJSONError(w, http.StatusBadRequest, errors.New("unsupported runtime action"))
 	}

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -920,7 +920,6 @@ func testToolsContainName(tools []runtimellm.ToolDefinition, want string) bool {
 }
 
 type stubRuntimeControl struct {
-	resetCalls  int
 	pauseCalls  int
 	resumeCalls int
 }
@@ -931,10 +930,6 @@ func (s *stubRuntimeControl) PauseIngress() error {
 }
 func (s *stubRuntimeControl) ResumeIngress() error {
 	s.resumeCalls++
-	return nil
-}
-func (s *stubRuntimeControl) ResetState() error {
-	s.resetCalls++
 	return nil
 }
 
@@ -1393,6 +1388,12 @@ func TestHandler_LegacyDashboardRoutesFailClosedWithoutAuthBoundary(t *testing.T
 			body:   `{"action":"pause"}`,
 		},
 		{
+			name:   "runtime reset_state",
+			method: http.MethodPost,
+			path:   "/api/runtime/actions",
+			body:   `{"action":"reset_state"}`,
+		},
+		{
 			name:   "run trace",
 			method: http.MethodGet,
 			path:   "/api/runs/run-1/trace",
@@ -1430,6 +1431,24 @@ func TestHandler_LegacyDashboardRoutesFailClosedWithoutAuthBoundary(t *testing.T
 				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestHandler_RuntimeResetStateActionIsRetired(t *testing.T) {
+	runtimeCtl := &stubRuntimeControl{}
+	handler := NewHandler(Options{
+		Runtime: runtimeCtl,
+	}).(*Handler)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/actions", strings.NewReader(`{"action":"reset_state"}`))
+	handler.handleRuntimeAction(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("reset_state runtime action status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if runtimeCtl.pauseCalls != 0 || runtimeCtl.resumeCalls != 0 {
+		t.Fatalf("runtime control calls = pause:%d resume:%d, want no calls", runtimeCtl.pauseCalls, runtimeCtl.resumeCalls)
 	}
 }
 
@@ -3929,8 +3948,8 @@ func TestHandler_RunStopUsesRunControlOwnerAndStreamsStopped(t *testing.T) {
 		if eventType != "run.stopped" {
 			continue
 		}
-		if runtimeCtl.resetCalls != 0 {
-			t.Fatalf("expected run.stop not to reset runtime ingress, got %d reset calls", runtimeCtl.resetCalls)
+		if runtimeCtl.pauseCalls != 0 || runtimeCtl.resumeCalls != 0 {
+			t.Fatalf("expected run.stop not to change runtime ingress, got pause:%d resume:%d", runtimeCtl.pauseCalls, runtimeCtl.resumeCalls)
 		}
 		return
 	}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -1488,7 +1488,7 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 		RuntimeMode: runtimesessions.RuntimeModeSession.String(),
 		Sessions:    registry,
 	})
-	if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+	if err := am.ResetRuntimeStateWithSource("admin_cli"); err != nil {
 		t.Fatalf("ResetRuntimeStateWithSource: %v", err)
 	}
 
@@ -1514,8 +1514,8 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 		t.Fatalf("log action = %q, want reset_orphaned_sessions", log.Action)
 	}
 	detail, _ := log.Detail.(map[string]any)
-	if got := readString(detail["source"]); got != "builder_api" {
-		t.Fatalf("detail.source = %q, want builder_api", got)
+	if got := readString(detail["source"]); got != "admin_cli" {
+		t.Fatalf("detail.source = %q, want admin_cli", got)
 	}
 	if got, _ := detail["orphaned_session_count"].(float64); int(got) != 1 {
 		t.Fatalf("detail.orphaned_session_count = %v, want 1", detail["orphaned_session_count"])
@@ -1537,8 +1537,8 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	if got := readString(sessionRow["termination_reason"]); got != "orphaned" {
 		t.Fatalf("detail.orphaned_sessions[0].termination_reason = %q, want orphaned", got)
 	}
-	if got := readString(sessionRow["termination_detail"]); got != "builder_api" {
-		t.Fatalf("detail.orphaned_sessions[0].termination_detail = %q, want builder_api", got)
+	if got := readString(sessionRow["termination_detail"]); got != "admin_cli" {
+		t.Fatalf("detail.orphaned_sessions[0].termination_detail = %q, want admin_cli", got)
 	}
 
 	var (
@@ -1562,8 +1562,8 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	if terminationReason != "orphaned" {
 		t.Fatalf("termination_reason = %q, want orphaned", terminationReason)
 	}
-	if terminationDetail != "builder_api" {
-		t.Fatalf("termination_detail = %q, want builder_api", terminationDetail)
+	if terminationDetail != "admin_cli" {
+		t.Fatalf("termination_detail = %q, want admin_cli", terminationDetail)
 	}
 
 	var resetPayloadRaw []byte
@@ -1580,8 +1580,8 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	if err := json.Unmarshal(resetPayloadRaw, &resetPayload); err != nil {
 		t.Fatalf("unmarshal platform.reset payload: %v", err)
 	}
-	if got := readString(resetPayload["source"]); got != "builder_api" {
-		t.Fatalf("platform.reset payload.source = %q, want builder_api", got)
+	if got := readString(resetPayload["source"]); got != "admin_cli" {
+		t.Fatalf("platform.reset payload.source = %q, want admin_cli", got)
 	}
 }
 

--- a/internal/runtime/destructivereset/contracts.go
+++ b/internal/runtime/destructivereset/contracts.go
@@ -38,23 +38,13 @@ func DefaultDownstreamContracts() []DownstreamContract {
 			ID:          ContractLegacyResetMigration,
 			Status:      "split",
 			Owner:       "future legacy reset migration owner",
-			Description: "Retire, redirect, or explicitly split dashboard/Builder/run_clear reset seams after canonical reset ownership exists.",
+			Description: "Retire, redirect, or explicitly split remaining run_clear/CLI reset seams after canonical reset ownership exists; stale dashboard/Builder reset_state plumbing is retired/fail-closed.",
 		},
 	}
 }
 
 func DefaultResetSeams() []ResetSeam {
 	return []ResetSeam{
-		{
-			ID:             "dashboard_runtime_actions_reset_state",
-			Classification: "legacy_deferred_sibling",
-			RequiredAction: "Do not treat dashboard reset_state as canonical reset ownership; migrate, retire, or split before runtime.nuke closure.",
-		},
-		{
-			ID:             "builder_runtime_reset_state",
-			Classification: "legacy_deferred_sibling",
-			RequiredAction: "Do not treat Builder reset_state/run hub reset as canonical reset ownership; migrate, retire, or split before runtime.nuke closure.",
-		},
 		{
 			ID:             "agent_manager_reset_runtime_state_with_source",
 			Classification: "partial_internal_primitive",

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -270,6 +270,10 @@ func TestInventoryPlannerCarriesImplementedContractsAndSplitResetSeams(t *testin
 		!containsSeam(plan.ResetSeams, "agent_manager_reset_runtime_state_with_source") {
 		t.Fatalf("reset seams = %#v, missing required live seam classification", plan.ResetSeams)
 	}
+	if containsSeam(plan.ResetSeams, "dashboard_runtime_actions_reset_state") ||
+		containsSeam(plan.ResetSeams, "builder_runtime_reset_state") {
+		t.Fatalf("reset seams = %#v, want retired dashboard/Builder reset_state seams omitted", plan.ResetSeams)
+	}
 	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || !plan.Preserved.BundleContracts {
 		t.Fatalf("preserved resources = %#v, want schema/auth/bundle preserved", plan.Preserved)
 	}

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -942,7 +942,7 @@ func (am *AgentManager) ResetRuntimeStateWithSource(source string) error {
 
 func platformResetSourceAuthorized(source string) bool {
 	switch strings.TrimSpace(source) {
-	case "admin_cli", "builder_api":
+	case "admin_cli":
 		return true
 	default:
 		return false

--- a/internal/runtime/manager/runtime_reset_test.go
+++ b/internal/runtime/manager/runtime_reset_test.go
@@ -101,7 +101,7 @@ func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
 			ScopeKey:          "global",
 			PreviousStatus:    "active",
 			TerminationReason: sessions.TerminationReasonOrphaned.String(),
-			TerminationDetail: "builder_api",
+			TerminationDetail: "admin_cli",
 		}},
 	}}
 
@@ -109,7 +109,7 @@ func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
 		RuntimeMode: "session",
 		Sessions:    registry,
 	})
-	if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+	if err := am.ResetRuntimeStateWithSource("admin_cli"); err != nil {
 		t.Fatalf("ResetRuntimeStateWithSource: %v", err)
 	}
 
@@ -130,8 +130,8 @@ func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
 	if !ok {
 		t.Fatalf("runtime log detail = %#v, want map", entry.Detail)
 	}
-	if got := detail["source"]; got != "builder_api" {
-		t.Fatalf("detail.source = %#v, want builder_api", got)
+	if got := detail["source"]; got != "admin_cli" {
+		t.Fatalf("detail.source = %#v, want admin_cli", got)
 	}
 	if got := detail["orphaned_session_count"]; got != 1 {
 		t.Fatalf("detail.orphaned_session_count = %#v, want 1", got)
@@ -149,18 +149,30 @@ func TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath(t *testing.T) {
 }
 
 func TestResetRuntimeStateWithSource_PublishesPlatformResetOnlyForExplicitAdminSources(t *testing.T) {
-	t.Run("builder_api", func(t *testing.T) {
+	t.Run("admin_cli", func(t *testing.T) {
 		bus := &resetTestBus{}
 		am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{})
 
-		if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
-			t.Fatalf("ResetRuntimeStateWithSource(builder_api): %v", err)
+		if err := am.ResetRuntimeStateWithSource("admin_cli"); err != nil {
+			t.Fatalf("ResetRuntimeStateWithSource(admin_cli): %v", err)
 		}
 		if len(bus.publishes) != 1 {
 			t.Fatalf("published event count = %d, want 1", len(bus.publishes))
 		}
 		if got := string(bus.publishes[0].Type); got != "platform.reset" {
 			t.Fatalf("published event type = %q, want platform.reset", got)
+		}
+	})
+
+	t.Run("builder api retired", func(t *testing.T) {
+		bus := &resetTestBus{}
+		am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{})
+
+		if err := am.ResetRuntimeStateWithSource("builder_api"); err != nil {
+			t.Fatalf("ResetRuntimeStateWithSource(builder_api): %v", err)
+		}
+		if len(bus.publishes) != 0 {
+			t.Fatalf("published event count = %d, want 0", len(bus.publishes))
 		}
 	})
 


### PR DESCRIPTION
Closes #784.
Part of #771 and #748.

## Summary
- Retires dashboard/Builder `reset_state` as a live reset interpreter by removing `ResetState()` from dashboard and Builder runtime-control interfaces.
- Removes the unused Builder `runHub` reset callback and the `dashboardDynamicRuntimeControl.ResetState()` path that called `ResetRuntimeStateWithSource("builder_api")`.
- De-authorizes `builder_api` from `platform.reset` emission, keeping `admin_cli` and preserving startup recovery as a distinct internal safety-trigger reset.
- Updates `platform-spec.yaml` and destructive-reset seam inventory so dashboard/Builder reset_state is retired/fail-closed and remaining reset tail stays split to run_clear/CLI/future admin work.

## Governing refs/context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `runtime.nuke`: public destructive reset wrapper over the destructive-reset owner chain.
- `platform-spec.yaml` `deferred_namespaces.runtime_admin`: legacy `runtime.reset_state` remains deferred/retired.
- `platform-spec.yaml` migration map for `POST /api/runtime/actions {reset_state}`: now retired/fail-closed; future dashboard consumers must call `runtime.nuke` directly.
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` generated `runtime.nuke` method remains unchanged.
- Issue #784 pre-audit and independent gate approved this first slice: dashboard/Builder stale reset_state retirement, excluding run_clear, CLI #735, startup recovery, and future `runtime_admin.runtime.reset_state`.

## Semantic migration
- New canonical public owner: `/v1/rpc runtime.nuke` backed by the destructive-reset owners from #773/#774, #775/#776, #778/#779, #780/#781, and #782/#783.
- Old producer/reader/writer path now invalid: dashboard/Builder `reset_state`, Builder `resetRuntime`, `dashboardDynamicRuntimeControl.ResetState()`, and `builder_api` `platform.reset` emission.
- Production paths checked for surviving old behavior: dashboard handler registration, production health server mounts, Builder legacy HTTP/RPC handler, Builder runHub, runtime manager source authorization, `scripts/run_clear.sh reset-dev`, and startup recovery reset.
- Migration complete for the #784 dashboard/Builder reset_state child. Parent #771/#748 remain open for split run_clear/CLI/future admin reset tail.

## Proof
- `go test ./internal/dashboard/server -run 'TestHandler_LegacyDashboardRoutesFailClosedWithoutAuthBoundary|TestHandler_RuntimeResetStateActionIsRetired|TestHandler_DashboardRoutesFailClosedWhenAuthIsNotConfigured' -count=1`
- `go test ./internal/builder -run 'TestHandler_LegacyRoutesFailClosed|TestHandler_LegacyWebSocketRoutesDoNotUpgrade|TestHandler_RuntimeControllerHasNoResetCallback|TestRunHubStartRunPublishesTypedEntityEnvelope' -count=1`
- `go test ./internal/runtime/manager -run 'TestResetRuntimeState_LogsCanonicalOrphanedSessionAftermath|TestResetRuntimeStateWithSource_PublishesPlatformResetOnlyForExplicitAdminSources' -count=1`
- `go test ./internal/runtime/conformance -run TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader -count=1`
- `go test ./internal/runtime/destructivereset -count=1`
- `go test ./cmd/swarm -run TestNewHealthServerPreservesProcessProbesAndMountsV1API -count=1`
- `go test ./internal/apiv1 -run TestOperatorRuntimeNuke -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go test ./internal/apispec -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
