### PR TITLE
[agent-b][issue #788] Add swarm control nuke CLI

### DIFF
--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -15,15 +15,24 @@ import (
 const defaultCLIAPIEndpoint = "http://127.0.0.1:8081/v1/rpc"
 
 type rootCommandOptions struct {
-	apiEndpoint string
-	httpClient  *http.Client
+	apiEndpoint     string
+	httpClient      *http.Client
+	input           io.Reader
+	stdinIsTerminal func() bool
 }
 
 func defaultRootCommandOptions() rootCommandOptions {
 	return rootCommandOptions{
-		apiEndpoint: defaultCLIAPIEndpoint,
-		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		apiEndpoint:     defaultCLIAPIEndpoint,
+		httpClient:      &http.Client{Timeout: 30 * time.Second},
+		input:           os.Stdin,
+		stdinIsTerminal: processStdinIsTerminal,
 	}
+}
+
+func processStdinIsTerminal() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 type cliAPIClient struct {
@@ -91,6 +100,18 @@ func applicationErrorCode(raw json.RawMessage) string {
 	return strings.TrimSpace(data.Code)
 }
 
+type cliAPIHTTPError struct {
+	statusCode int
+	message    string
+}
+
+func (e *cliAPIHTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("v1 RPC HTTP %d: %s", e.statusCode, e.message)
+}
+
 func (c *cliAPIClient) call(ctx context.Context, method string, params map[string]any, result any) error {
 	requestID := "swarm-cli:" + method
 	body, err := json.Marshal(jsonRPCRequest{
@@ -124,7 +145,7 @@ func (c *cliAPIClient) call(ctx context.Context, method string, params map[strin
 		if message == "" {
 			message = http.StatusText(resp.StatusCode)
 		}
-		return fmt.Errorf("v1 RPC HTTP %d: %s", resp.StatusCode, message)
+		return &cliAPIHTTPError{statusCode: resp.StatusCode, message: message}
 	}
 
 	var envelope jsonRPCResponse

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -37,7 +37,10 @@ func newControlCommand(opts rootCommandOptions) *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newControlMailboxCommand(opts))
+	cmd.AddCommand(
+		newControlMailboxCommand(opts),
+		newControlNukeCommand(opts),
+	)
 	return cmd
 }
 

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	runtimeNukeMethod        = "runtime.nuke"
+	runtimeNukeStatusDryRun  = "dry_run"
+	runtimeNukeStatusDone    = "completed"
+	runtimeNukeStatusPartial = "partial_failure"
+)
+
+type runtimeNukeCommandOptions struct {
+	apiOptions rootCommandOptions
+	yes        bool
+	dryRun     bool
+}
+
+type runtimeNukeResult struct {
+	OK             bool                     `json:"ok"`
+	Status         string                   `json:"status"`
+	DryRun         bool                     `json:"dry_run"`
+	OperationName  string                   `json:"operation_name"`
+	Plan           runtimeNukePlanResult    `json:"plan"`
+	Quiescence     runtimeNukeQuiescence    `json:"quiescence"`
+	Cleanup        runtimeNukeCleanup       `json:"cleanup"`
+	Containers     runtimeNukeContainers    `json:"containers"`
+	PartialFailure bool                     `json:"partial_failure"`
+	Errors         []runtimeNukeResultError `json:"errors,omitempty"`
+}
+
+type runtimeNukePlanResult struct {
+	Plan runtimeNukePlan `json:"plan"`
+}
+
+type runtimeNukePlan struct {
+	ActiveRuns       []runtimeNukeRunRef       `json:"active_runs"`
+	ActiveDeliveries []runtimeNukeDeliveryRef  `json:"active_deliveries"`
+	RunScopedTables  []runtimeNukeTableRef     `json:"run_scoped_tables"`
+	EntityContainers []runtimeNukeContainerRef `json:"entity_containers"`
+}
+
+type runtimeNukeRunRef struct {
+	RunID  string `json:"run_id"`
+	Status string `json:"status"`
+}
+
+type runtimeNukeDeliveryRef struct {
+	DeliveryID string `json:"delivery_id"`
+	RunID      string `json:"run_id"`
+	Status     string `json:"status"`
+}
+
+type runtimeNukeTableRef struct {
+	Name   string `json:"name"`
+	Action string `json:"action"`
+}
+
+type runtimeNukeQuiescence struct {
+	Runs       []runtimeNukeQuiescedRun      `json:"runs"`
+	Deliveries []runtimeNukeQuiescedDelivery `json:"deliveries"`
+}
+
+type runtimeNukeQuiescedRun struct {
+	RunID   string `json:"run_id"`
+	Status  string `json:"status"`
+	Changed bool   `json:"changed"`
+}
+
+type runtimeNukeQuiescedDelivery struct {
+	DeliveryID string `json:"delivery_id"`
+	Status     string `json:"status"`
+	Changed    bool   `json:"changed"`
+}
+
+type runtimeNukeCleanup struct {
+	Tables []runtimeNukeCleanupTable `json:"tables"`
+}
+
+type runtimeNukeCleanupTable struct {
+	Table       string `json:"table"`
+	MatchedRows int64  `json:"matched_rows"`
+	DeletedRows int64  `json:"deleted_rows"`
+}
+
+type runtimeNukeContainers struct {
+	Selected       []runtimeNukeContainerRef     `json:"selected"`
+	Preserved      []runtimeNukeContainerRef     `json:"preserved"`
+	Missing        []runtimeNukeContainerRef     `json:"missing"`
+	AlreadyStopped []runtimeNukeContainerRef     `json:"already_stopped"`
+	Stopped        []runtimeNukeContainerRef     `json:"stopped"`
+	Failed         []runtimeNukeContainerFailure `json:"failed"`
+}
+
+type runtimeNukeContainerRef struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+type runtimeNukeContainerFailure struct {
+	Container runtimeNukeContainerRef `json:"container"`
+	Error     string                  `json:"error"`
+}
+
+type runtimeNukeResultError struct {
+	Scope   string `json:"scope"`
+	Message string `json:"message"`
+}
+
+func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
+	nukeOpts := runtimeNukeCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "nuke",
+		Short: "Destructively reset Swarm runtime state through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runControlNukeCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), nukeOpts)
+		},
+	}
+	cmd.Flags().BoolVarP(&nukeOpts.yes, "yes", "y", false, "Skip the destructive confirmation prompt")
+	cmd.Flags().BoolVar(&nukeOpts.dryRun, "dry-run", false, "Preview the destructive reset without applying it")
+	return cmd
+}
+
+func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runtimeNukeCommandOptions) error {
+	if !opts.dryRun && !opts.yes {
+		if !runtimeNukeStdinIsTerminal(opts.apiOptions) {
+			fmt.Fprintln(errOut, "ERROR: `swarm control nuke` is destructive; pass --yes for non-TTY invocations.")
+			return commandExitError{code: 2}
+		}
+		confirmed, err := confirmRuntimeNuke(opts.apiOptions.input, errOut)
+		if err != nil {
+			fmt.Fprintf(errOut, "read confirmation: %v\n", err)
+			return commandExitError{code: 2}
+		}
+		if !confirmed {
+			fmt.Fprintln(errOut, "Aborted; no destruction performed.")
+			return commandExitError{code: 2}
+		}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: runtimeNukeErrorExitCode(err)}
+	}
+	params := map[string]any{"dry_run": opts.dryRun}
+	var result runtimeNukeResult
+	if err := client.call(ctx, runtimeNukeMethod, params, &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: runtimeNukeErrorExitCode(err)}
+	}
+	if err := validateRuntimeNukeResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: 3}
+	}
+	writeRuntimeNukeResult(out, result)
+	if result.PartialFailure {
+		writeRuntimeNukeFailures(errOut, result)
+		return commandExitError{code: 3}
+	}
+	return nil
+}
+
+func runtimeNukeStdinIsTerminal(opts rootCommandOptions) bool {
+	if opts.stdinIsTerminal == nil {
+		return false
+	}
+	return opts.stdinIsTerminal()
+}
+
+func confirmRuntimeNuke(input io.Reader, errOut io.Writer) (bool, error) {
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	fmt.Fprintln(errOut, "WARNING: `swarm control nuke` will destroy all Swarm-owned runtime state.")
+	fmt.Fprint(errOut, "Continue? [y/N] ")
+	line, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func validateRuntimeNukeResult(result runtimeNukeResult) error {
+	if strings.TrimSpace(result.OperationName) == "" {
+		return fmt.Errorf("malformed runtime.nuke result: operation_name is required")
+	}
+	switch result.Status {
+	case runtimeNukeStatusDryRun:
+		if !result.OK || !result.DryRun || result.PartialFailure {
+			return fmt.Errorf("malformed runtime.nuke result: dry_run status must be ok=true dry_run=true partial_failure=false")
+		}
+	case runtimeNukeStatusDone:
+		if !result.OK || result.DryRun || result.PartialFailure {
+			return fmt.Errorf("malformed runtime.nuke result: completed status must be ok=true dry_run=false partial_failure=false")
+		}
+	case runtimeNukeStatusPartial:
+		if result.OK || result.DryRun || !result.PartialFailure {
+			return fmt.Errorf("malformed runtime.nuke result: partial_failure status must be ok=false dry_run=false partial_failure=true")
+		}
+	default:
+		return fmt.Errorf("malformed runtime.nuke result: unsupported status %q", result.Status)
+	}
+	return nil
+}
+
+func writeRuntimeNukeResult(out io.Writer, result runtimeNukeResult) {
+	if out == nil {
+		return
+	}
+	counts := runtimeNukeCounts(result)
+	switch result.Status {
+	case runtimeNukeStatusDryRun:
+		fmt.Fprintln(out, "runtime nuke dry-run: no destructive actions performed")
+	case runtimeNukeStatusDone:
+		if counts.empty() {
+			fmt.Fprintln(out, "runtime state is already empty; nuke complete (no-op)")
+		} else {
+			fmt.Fprintln(out, "runtime nuke complete")
+		}
+	case runtimeNukeStatusPartial:
+		fmt.Fprintln(out, "runtime nuke partial failure")
+	}
+	fmt.Fprintf(out, "operation=%s status=%s dry_run=%t partial_failure=%t\n", result.OperationName, result.Status, result.DryRun, result.PartialFailure)
+	fmt.Fprintf(out, "active_runs=%d active_deliveries=%d run_scoped_tables=%d selected_containers=%d preserved_containers=%d stopped_containers=%d failed_containers=%d\n",
+		counts.activeRuns, counts.activeDeliveries, counts.runScopedTables, counts.selectedContainers, counts.preservedContainers, counts.stoppedContainers, counts.failedContainers)
+	if len(result.Cleanup.Tables) > 0 {
+		fmt.Fprintf(out, "cleanup_matched_rows=%d cleanup_deleted_rows=%d\n", counts.cleanupMatchedRows, counts.cleanupDeletedRows)
+	}
+	writeContainerNames(out, "stopped", result.Containers.Stopped)
+	writeContainerNames(out, "already_stopped", result.Containers.AlreadyStopped)
+	writeContainerNames(out, "preserved", result.Containers.Preserved)
+}
+
+func writeRuntimeNukeFailures(errOut io.Writer, result runtimeNukeResult) {
+	if errOut == nil {
+		return
+	}
+	for _, failure := range result.Errors {
+		fmt.Fprintf(errOut, "runtime.nuke failure: scope=%s message=%s\n", failure.Scope, failure.Message)
+	}
+	for _, failure := range result.Containers.Failed {
+		fmt.Fprintf(errOut, "runtime.nuke container failure: container=%s error=%s\n", failure.Container.Name, failure.Error)
+	}
+}
+
+func writeContainerNames(out io.Writer, label string, containers []runtimeNukeContainerRef) {
+	if len(containers) == 0 {
+		return
+	}
+	names := make([]string, 0, len(containers))
+	for _, container := range containers {
+		if name := strings.TrimSpace(container.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "%s_containers=%s\n", label, strings.Join(names, ","))
+}
+
+type runtimeNukeResultCounts struct {
+	activeRuns          int
+	activeDeliveries    int
+	runScopedTables     int
+	selectedContainers  int
+	preservedContainers int
+	stoppedContainers   int
+	failedContainers    int
+	cleanupMatchedRows  int64
+	cleanupDeletedRows  int64
+}
+
+func (c runtimeNukeResultCounts) empty() bool {
+	return c.activeRuns == 0 &&
+		c.activeDeliveries == 0 &&
+		c.selectedContainers == 0 &&
+		c.stoppedContainers == 0 &&
+		c.failedContainers == 0 &&
+		c.cleanupMatchedRows == 0 &&
+		c.cleanupDeletedRows == 0
+}
+
+func runtimeNukeCounts(result runtimeNukeResult) runtimeNukeResultCounts {
+	counts := runtimeNukeResultCounts{
+		activeRuns:          len(result.Plan.Plan.ActiveRuns),
+		activeDeliveries:    len(result.Plan.Plan.ActiveDeliveries),
+		runScopedTables:     len(result.Plan.Plan.RunScopedTables),
+		selectedContainers:  len(result.Containers.Selected),
+		preservedContainers: len(result.Containers.Preserved),
+		stoppedContainers:   len(result.Containers.Stopped),
+		failedContainers:    len(result.Containers.Failed),
+	}
+	if counts.activeRuns == 0 {
+		counts.activeRuns = changedRunCount(result.Quiescence.Runs)
+	}
+	if counts.activeDeliveries == 0 {
+		counts.activeDeliveries = changedDeliveryCount(result.Quiescence.Deliveries)
+	}
+	for _, table := range result.Cleanup.Tables {
+		counts.cleanupMatchedRows += table.MatchedRows
+		counts.cleanupDeletedRows += table.DeletedRows
+	}
+	return counts
+}
+
+func changedRunCount(runs []runtimeNukeQuiescedRun) int {
+	count := 0
+	for _, run := range runs {
+		if run.Changed {
+			count++
+		}
+	}
+	return count
+}
+
+func changedDeliveryCount(deliveries []runtimeNukeQuiescedDelivery) int {
+	count := 0
+	for _, delivery := range deliveries {
+		if delivery.Changed {
+			count++
+		}
+	}
+	return count
+}
+
+func runtimeNukeErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return 4
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return 4
+		}
+		return 3
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return 4
+		case "RUNTIME_NUKE_IN_PROGRESS", "IDEMPOTENCY_CONFLICT":
+			return 6
+		default:
+			return 3
+		}
+	}
+	return 3
+}

--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestControlNukeDryRunSendsV1RPCRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, runtimeNukeTestResult(runtimeNukeStatusDryRun))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--dry-run"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "runtime.nuke" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/runtime.nuke", captured.JSONRPC, captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"dry_run": true}) {
+		t.Fatalf("params = %#v, want dry_run=true only", captured.Params)
+	}
+	for _, want := range []string{"runtime nuke dry-run", "status=dry_run", "active_runs=2", "selected_containers=1", "preserved_containers=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestControlNukeYesAppliesThroughV1RPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, runtimeNukeTestResult(runtimeNukeStatusDone))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "runtime.nuke" {
+		t.Fatalf("method = %q, want runtime.nuke", captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"dry_run": false}) {
+		t.Fatalf("params = %#v, want dry_run=false only", captured.Params)
+	}
+	for _, want := range []string{"runtime nuke complete", "status=completed", "cleanup_deleted_rows=17", "stopped_containers=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestControlNukeNoOpResultExitsZero(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		writeJSONRPCResult(t, w, req.ID, runtimeNukeEmptyResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "nuke complete (no-op)") {
+		t.Fatalf("stdout = %q, want no-op output", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		writeJSONRPCResult(t, w, req.ID, runtimeNukeTestResult(runtimeNukeStatusDone))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		input         string
+		stdinTerminal bool
+		wantCode      int
+		wantCalls     int32
+		wantStderr    string
+	}{
+		{name: "tty confirmation proceeds", args: []string{"control", "nuke"}, input: "y\n", stdinTerminal: true, wantCode: 0, wantCalls: 1, wantStderr: "Continue? [y/N]"},
+		{name: "tty abort makes no request", args: []string{"control", "nuke"}, input: "n\n", stdinTerminal: true, wantCode: 2, wantCalls: 0, wantStderr: "Aborted; no destruction performed."},
+		{name: "non tty apply without yes makes no request", args: []string{"control", "nuke"}, stdinTerminal: false, wantCode: 2, wantCalls: 0, wantStderr: "pass --yes for non-TTY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			opts := testRootCommandOptions(server)
+			opts.input = strings.NewReader(tc.input)
+			opts.stdinIsTerminal = func() bool { return tc.stdinTerminal }
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if calls.Load() != tc.wantCalls {
+				t.Fatalf("server calls = %d, want %d", calls.Load(), tc.wantCalls)
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestControlNukeMapsFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		token      string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name:     "partial failure exits three",
+			token:    "test-token",
+			wantCode: 3,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, runtimeNukeTestResult(runtimeNukeStatusPartial))
+			},
+			wantStderr: "runtime.nuke failure",
+		},
+		{
+			name:  "idempotency conflict exits six",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeRuntimeNukeJSONRPCError(t, w, r, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name:  "operation in progress exits six",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeRuntimeNukeJSONRPCError(t, w, r, "RUNTIME_NUKE_IN_PROGRESS")
+			},
+			wantCode:   6,
+			wantStderr: "RUNTIME_NUKE_IN_PROGRESS",
+		},
+		{
+			name:  "json rpc unauthorized exits four",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeRuntimeNukeJSONRPCError(t, w, r, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name:  "http unauthorized exits four",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name:     "missing token exits four before request",
+			token:    "",
+			wantCode: 4,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("unexpected request without SWARM_API_TOKEN")
+			},
+			wantStderr: "SWARM_API_TOKEN is required",
+		},
+		{
+			name:  "malformed response exits three",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{`))
+			},
+			wantCode:   3,
+			wantStderr: "decode JSON-RPC response",
+		},
+		{
+			name:  "malformed result exits three",
+			token: "test-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := runtimeNukeTestResult(runtimeNukeStatusDone)
+				result["operation_name"] = ""
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "operation_name is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", tc.token)
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestControlNukeTransportFailureExitsThree(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var stdout, stderr bytes.Buffer
+	opts := defaultRootCommandOptions()
+	opts.apiEndpoint = "http://127.0.0.1:1/v1/rpc"
+	opts.httpClient = &http.Client{Transport: errRoundTripper{}}
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--yes"}, &stdout, &stderr, opts)
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "v1 RPC request failed") {
+		t.Fatalf("stderr = %q, want transport failure", stderr.String())
+	}
+}
+
+type errRoundTripper struct{}
+
+func (errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("transport unavailable")
+}
+
+func runtimeNukeTestResult(status string) map[string]any {
+	result := map[string]any{
+		"ok":             true,
+		"status":         status,
+		"dry_run":        status == runtimeNukeStatusDryRun,
+		"operation_name": "runtime.destructive_reset",
+		"plan": map[string]any{
+			"plan": map[string]any{
+				"active_runs": []any{
+					map[string]any{"run_id": "run-1", "status": "running"},
+					map[string]any{"run_id": "run-2", "status": "paused"},
+				},
+				"active_deliveries": []any{
+					map[string]any{"delivery_id": "delivery-1", "run_id": "run-1", "status": "pending"},
+				},
+				"run_scoped_tables": []any{
+					map[string]any{"name": "events", "action": "delete"},
+					map[string]any{"name": "event_deliveries", "action": "delete"},
+				},
+				"entity_containers": []any{
+					map[string]any{"name": "swarm-agent-1", "kind": "entity"},
+				},
+			},
+		},
+		"quiescence": map[string]any{
+			"runs": []any{
+				map[string]any{"run_id": "run-1", "status": "stopped", "changed": true},
+			},
+			"deliveries": []any{
+				map[string]any{"delivery_id": "delivery-1", "status": "exhausted", "changed": true},
+			},
+		},
+		"cleanup": map[string]any{
+			"tables": []any{
+				map[string]any{"table": "events", "matched_rows": 10, "deleted_rows": 10},
+				map[string]any{"table": "event_deliveries", "matched_rows": 7, "deleted_rows": 7},
+			},
+		},
+		"containers": map[string]any{
+			"selected": []any{
+				map[string]any{"name": "swarm-agent-1", "kind": "entity"},
+			},
+			"preserved": []any{
+				map[string]any{"name": "swarm-system", "kind": "system"},
+			},
+			"stopped": []any{
+				map[string]any{"name": "swarm-agent-1", "kind": "entity"},
+			},
+		},
+		"partial_failure": false,
+	}
+	switch status {
+	case runtimeNukeStatusPartial:
+		result["ok"] = false
+		result["dry_run"] = false
+		result["partial_failure"] = true
+		result["errors"] = []any{
+			map[string]any{"scope": "managed_containers", "message": "docker stop denied"},
+		}
+		result["containers"].(map[string]any)["failed"] = []any{
+			map[string]any{
+				"container": map[string]any{"name": "swarm-agent-2", "kind": "entity"},
+				"error":     "docker stop denied",
+			},
+		}
+	case runtimeNukeStatusDone:
+		result["dry_run"] = false
+	}
+	return result
+}
+
+func runtimeNukeEmptyResult() map[string]any {
+	return map[string]any{
+		"ok":             true,
+		"status":         runtimeNukeStatusDone,
+		"dry_run":        false,
+		"operation_name": "runtime.destructive_reset",
+		"plan": map[string]any{
+			"plan": map[string]any{
+				"active_runs":       []any{},
+				"active_deliveries": []any{},
+				"run_scoped_tables": []any{},
+				"entity_containers": []any{},
+			},
+		},
+		"quiescence":      map[string]any{"runs": []any{}, "deliveries": []any{}},
+		"cleanup":         map[string]any{"tables": []any{}},
+		"containers":      map[string]any{"selected": []any{}, "preserved": []any{}, "stopped": []any{}},
+		"partial_failure": false,
+	}
+}
+
+func writeRuntimeNukeJSONRPCError(t *testing.T, w http.ResponseWriter, r *http.Request, code string) {
+	t.Helper()
+	var req jsonRPCRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{},
+				"retryable":      false,
+				"correlation_id": "corr-1",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5363,6 +5363,23 @@ cli_specification:
       status: must_have
       owner: /v1/rpc mailbox.defer
       behavior: Mailbox defer action through canonical v1 API owner; no direct DB/store/mailbox writes.
+    control_nuke:
+      command: swarm control nuke [--yes|-y] [--dry-run]
+      status: must_have
+      owner: /v1/rpc runtime.nuke
+      behavior: Destructive reset CLI consumer over the public runtime.nuke owner. The CLI MUST NOT call raw Docker, SQL,
+        store cleanup, runtime manager reset, or internal destructive-reset helpers directly.
+      flags:
+      - --yes
+      - -y
+      - --dry-run
+      exit_codes:
+        success_or_noop: 0
+        validation_or_abort: 2
+        transport_or_partial_failure: 3
+        auth_failure: 4
+        conflict_or_nuke_in_progress: 6
+      spec_status: implemented API consumer; supersedes older CLI v2 review-draft wording that marked runtime.nuke as proposed/pending.
     status:
       command: swarm status
       status: retired
@@ -5378,6 +5395,7 @@ cli_specification:
     - swarm control mailbox approve
     - swarm control mailbox reject
     - swarm control mailbox defer
+    - swarm control nuke
     - swarm runs
     - swarm investigate runs
     - swarm investigate run


### PR DESCRIPTION
## Summary

Adds the approved #788 CLI consumer for canonical destructive reset:

- `swarm control nuke [--yes|-y] [--dry-run]`
- Calls `/v1/rpc runtime.nuke` through the shared CLI JSON-RPC client with `SWARM_API_TOKEN`.
- Fails closed for non-TTY apply without `--yes`, operator abort, auth failures, conflicts/in-progress, malformed responses, transport errors, and partial failures.
- Adds a tracked `platform-spec.yaml` CLI entry for `control_nuke` so the nuke-specific stale CLI v2 pending/proposed wording is repaired in a merge artifact.

Closes #788
Part of #735
Related to #748
Related to #771

## Governing Refs / Context

- `platform-spec.yaml` `api_specification.method_catalog.runtime.nuke`: canonical public API owner and `RuntimeNukeResult` shape.
- Generated `openrpc.json` method `runtime.nuke`.
- #788 approved pre-audit and independent gate: implementation limited to CLI consumer only.
- #735 tracker comment superseding v1 CLI topology with CLI v2 context.
- #748/#771 tracker closeouts after #786 / PR #787: runtime.nuke owner chain and legacy reset-seam tail are closed for API/script surfaces.

## Semantic Migration Notes

- New canonical owner consumed by CLI: `/v1/rpc runtime.nuke`.
- Old invalid paths for this CLI command: direct DB/SQL truncation, raw Docker stop/list, store cleanup helpers, runtime manager reset, and `internal/runtime/destructivereset` internals.
- Production paths checked for surviving old behavior: `cmd/swarm/control_nuke.go`, `cmd/swarm/cli_api.go`, and `cmd/swarm/control_mailbox.go` have no direct reset bypass matches for `destructivereset`, `ResetRuntimeStateWithSource`, raw Docker/SQL, or store calls.
- Migration completeness: complete for the chosen #788 CLI destructive-reset consumer. #735 remains open for broader v2 CLI parity.

## Proof

- `go test ./cmd/swarm -run 'TestCLI|TestControlMailbox|TestControlNuke' -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `if rg -n "destructivereset|ResetRuntimeStateWithSource|docker|psql|TRUNCATE|sql\.Open|store\." cmd/swarm/control_nuke.go cmd/swarm/cli_api.go cmd/swarm/control_mailbox.go; then exit 1; else echo "no production CLI nuke reset bypass matches"; fi`
