### PR TITLE
[agent-b][issue #790] Retarget mailbox CLI namespace

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -69,6 +69,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newCompletionCommand(),
 		newRunsCommand(opts),
 		newInvestigateCommand(opts),
+		newMailboxCommand(opts),
 		newControlCommand(opts),
 		newRetiredStatusCommand(),
 		newRetiredForkCommand(),

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -38,13 +38,13 @@ func newControlCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(
-		newControlMailboxCommand(opts),
+		newRetiredControlMailboxCommand(),
 		newControlNukeCommand(opts),
 	)
 	return cmd
 }
 
-func newControlMailboxCommand(opts rootCommandOptions) *cobra.Command {
+func newMailboxCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mailbox",
 		Short: "Approve, reject, or defer mailbox items through v1 RPC.",
@@ -54,14 +54,37 @@ func newControlMailboxCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(
-		newControlMailboxApproveCommand(opts),
-		newControlMailboxRejectCommand(opts),
-		newControlMailboxDeferCommand(opts),
+		newMailboxApproveCommand(opts),
+		newMailboxRejectCommand(opts),
+		newMailboxDeferCommand(opts),
 	)
 	return cmd
 }
 
-func newControlMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
+func newRetiredControlMailboxCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:                "mailbox",
+		Short:              "Removed v2 command; use swarm mailbox.",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			writeControlMailboxRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
+		},
+	}
+}
+
+func writeControlMailboxRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm control mailbox` was removed in CLI v2.")
+	fmt.Fprintln(w, "  Mailbox decisions are resource-noun-first commands now:")
+	fmt.Fprintln(w, "  `swarm mailbox approve <mailbox-item-id>`")
+	fmt.Fprintln(w, "  `swarm mailbox reject <mailbox-item-id> --reason <text>`")
+	fmt.Fprintln(w, "  `swarm mailbox defer <mailbox-item-id> --until <RFC3339>`")
+}
+
+func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 	actionOpts := mailboxDecisionCommandOptions{
 		apiOptions: opts,
 		action:     "approve",
@@ -80,7 +103,7 @@ func newControlMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func newControlMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
+func newMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 	actionOpts := mailboxDecisionCommandOptions{
 		apiOptions: opts,
 		action:     "reject",
@@ -99,7 +122,7 @@ func newControlMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func newControlMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
+func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	actionOpts := mailboxDecisionCommandOptions{
 		apiOptions: opts,
 		action:     "defer",

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
+func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -22,7 +22,7 @@ func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
 	}{
 		{
 			name:       "approve",
-			args:       []string{"control", "mailbox", "approve", "mailbox-1", "--idempotency-key", "idem-approve", "--decision-payload-json", `{"approved":true}`},
+			args:       []string{"mailbox", "approve", "mailbox-1", "--idempotency-key", "idem-approve", "--decision-payload-json", `{"approved":true}`},
 			wantMethod: "mailbox.approve",
 			wantParams: map[string]any{
 				"mailbox_id":       "mailbox-1",
@@ -33,7 +33,7 @@ func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
 		},
 		{
 			name:       "reject",
-			args:       []string{"control", "mailbox", "reject", "mailbox-2", "--reason", "not enough evidence", "--idempotency-key", "idem-reject"},
+			args:       []string{"mailbox", "reject", "mailbox-2", "--reason", "not enough evidence", "--idempotency-key", "idem-reject"},
 			wantMethod: "mailbox.reject",
 			wantParams: map[string]any{
 				"mailbox_id":      "mailbox-2",
@@ -44,7 +44,7 @@ func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
 		},
 		{
 			name:       "defer",
-			args:       []string{"control", "mailbox", "defer", "mailbox-3", "--until", "2026-05-13T12:30:00Z", "--idempotency-key", "idem-defer"},
+			args:       []string{"mailbox", "defer", "mailbox-3", "--until", "2026-05-13T12:30:00Z", "--idempotency-key", "idem-defer"},
 			wantMethod: "mailbox.defer",
 			wantParams: map[string]any{
 				"mailbox_id":      "mailbox-3",
@@ -107,7 +107,7 @@ func TestControlMailboxCommandsSendV1RPCRequests(t *testing.T) {
 	}
 }
 
-func TestControlMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
+func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -122,15 +122,15 @@ func TestControlMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 		wantStderr  string
 		wantNoCalls bool
 	}{
-		{name: "approve missing id", args: []string{"control", "mailbox", "approve"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
-		{name: "approve extra arg", args: []string{"control", "mailbox", "approve", "mailbox-1", "extra"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
-		{name: "approve unsupported flag", args: []string{"control", "mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
-		{name: "approve malformed payload", args: []string{"control", "mailbox", "approve", "mailbox-1", "--decision-payload-json", "{"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
-		{name: "approve non-object payload", args: []string{"control", "mailbox", "approve", "mailbox-1", "--decision-payload-json", "[]"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
-		{name: "reject missing reason", args: []string{"control", "mailbox", "reject", "mailbox-1"}, wantStderr: "--reason is required", wantNoCalls: true},
-		{name: "reject blank reason", args: []string{"control", "mailbox", "reject", "mailbox-1", "--reason", "  "}, wantStderr: "--reason is required", wantNoCalls: true},
-		{name: "defer missing until", args: []string{"control", "mailbox", "defer", "mailbox-1"}, wantStderr: "--until is required", wantNoCalls: true},
-		{name: "defer invalid until", args: []string{"control", "mailbox", "defer", "mailbox-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp", wantNoCalls: true},
+		{name: "approve missing id", args: []string{"mailbox", "approve"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "approve extra arg", args: []string{"mailbox", "approve", "mailbox-1", "extra"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "approve unsupported flag", args: []string{"mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
+		{name: "approve malformed payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "{"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "approve non-object payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "[]"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "reject missing reason", args: []string{"mailbox", "reject", "mailbox-1"}, wantStderr: "--reason is required", wantNoCalls: true},
+		{name: "reject blank reason", args: []string{"mailbox", "reject", "mailbox-1", "--reason", "  "}, wantStderr: "--reason is required", wantNoCalls: true},
+		{name: "defer missing until", args: []string{"mailbox", "defer", "mailbox-1"}, wantStderr: "--until is required", wantNoCalls: true},
+		{name: "defer invalid until", args: []string{"mailbox", "defer", "mailbox-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp", wantNoCalls: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			before := calls.Load()
@@ -152,7 +152,7 @@ func TestControlMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 	}
 }
 
-func TestControlMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
+func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +162,7 @@ func TestControlMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 2 {
 		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -174,7 +174,48 @@ func TestControlMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 	}
 }
 
-func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
+func TestControlMailboxRetiredAliasesFailClosedBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"control", "mailbox", "approve", "mailbox-1"},
+		{"control", "mailbox", "reject", "mailbox-1", "--reason", "not enough evidence"},
+		{"control", "mailbox", "defer", "mailbox-1", "--until", "2026-05-13T12:30:00Z"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			for _, want := range []string{
+				"`swarm control mailbox` was removed in CLI v2",
+				"`swarm mailbox approve <mailbox-item-id>`",
+				"`swarm mailbox reject <mailbox-item-id> --reason <text>`",
+				"`swarm mailbox defer <mailbox-item-id> --until <RFC3339>`",
+			} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+			if calls.Load() != before {
+				t.Fatalf("server calls changed from %d to %d, want no request", before, calls.Load())
+			}
+		})
+	}
+}
+
+func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		handler    http.HandlerFunc
@@ -259,7 +300,7 @@ func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 			defer server.Close()
 
 			var stdout, stderr bytes.Buffer
-			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
 			if code != 2 {
 				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
@@ -273,7 +314,7 @@ func TestControlMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 	}
 }
 
-func TestControlMailboxRejectsMalformedStatusByAction(t *testing.T) {
+func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		args   []string
@@ -282,19 +323,19 @@ func TestControlMailboxRejectsMalformedStatusByAction(t *testing.T) {
 	}{
 		{
 			name:   "approve invalid enum status",
-			args:   []string{"control", "mailbox", "approve", "mailbox-1"},
+			args:   []string{"mailbox", "approve", "mailbox-1"},
 			status: "garbage",
 			want:   `status="garbage", want "decided" for mailbox approve`,
 		},
 		{
 			name:   "reject wrong action status",
-			args:   []string{"control", "mailbox", "reject", "mailbox-1", "--reason", "not enough evidence"},
+			args:   []string{"mailbox", "reject", "mailbox-1", "--reason", "not enough evidence"},
 			status: "deferred",
 			want:   `status="deferred", want "decided" for mailbox reject`,
 		},
 		{
 			name:   "defer wrong action status",
-			args:   []string{"control", "mailbox", "defer", "mailbox-1", "--until", "2026-05-13T12:30:00Z"},
+			args:   []string{"mailbox", "defer", "mailbox-1", "--until", "2026-05-13T12:30:00Z"},
 			status: "decided",
 			want:   `status="decided", want "deferred" for mailbox defer`,
 		},

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5348,21 +5348,26 @@ cli_specification:
       status: must_have
       owner: /v1/rpc health.check
       behavior: Structured authenticated operator health; do not consume /healthz, /readyz, or retired dashboard aliases.
-    control_mailbox_approve:
-      command: swarm control mailbox approve <mailbox-item-id>
+    mailbox_approve:
+      command: swarm mailbox approve <mailbox-item-id>
       status: must_have
       owner: /v1/rpc mailbox.approve
       behavior: Mailbox approval action through canonical v1 API owner; no direct DB/store/mailbox writes.
-    control_mailbox_reject:
-      command: swarm control mailbox reject <mailbox-item-id>
+    mailbox_reject:
+      command: swarm mailbox reject <mailbox-item-id>
       status: must_have
       owner: /v1/rpc mailbox.reject
       behavior: Mailbox rejection action through canonical v1 API owner; no direct DB/store/mailbox writes.
-    control_mailbox_defer:
-      command: swarm control mailbox defer <mailbox-item-id>
+    mailbox_defer:
+      command: swarm mailbox defer <mailbox-item-id>
       status: must_have
       owner: /v1/rpc mailbox.defer
       behavior: Mailbox defer action through canonical v1 API owner; no direct DB/store/mailbox writes.
+    control_mailbox:
+      command: swarm control mailbox approve|reject|defer
+      status: retired
+      exit_code: 2
+      message: "ERROR: `swarm control mailbox` was removed in CLI v2. Use resource-noun-first `swarm mailbox approve|reject|defer`."
     control_nuke:
       command: swarm control nuke [--yes|-y] [--dry-run]
       status: must_have
@@ -5392,9 +5397,9 @@ cli_specification:
       message: "ERROR: `swarm fork` was removed in v1. Forking is a mutating control action; use `swarm control run fork <run-id>` once that command ships. For v1, manual run forking goes through the API owner and the API spec."
   parent_tail:
     implemented_after_first_slice:
-    - swarm control mailbox approve
-    - swarm control mailbox reject
-    - swarm control mailbox defer
+    - swarm mailbox approve
+    - swarm mailbox reject
+    - swarm mailbox defer
     - swarm control nuke
     - swarm runs
     - swarm investigate runs
@@ -5403,6 +5408,8 @@ cli_specification:
     - swarm investigate health
     remaining_not_implemented:
     - swarm run
+    - swarm mailbox list
+    - swarm mailbox view
     - swarm control run/runtime/agent
     rule: 'Remaining commands require separate gates and must consume v1 API owners; they MUST NOT resurrect local DB/store/runtime-state readers.'
 


### PR DESCRIPTION
## Summary

Retargets the mailbox decision CLI from the stale v1 control namespace to the CLI v2 resource-noun-first namespace:

- Adds supported `swarm mailbox approve|reject|defer` commands over `/v1/rpc mailbox.approve|reject|defer`.
- Retires/fail-closes `swarm control mailbox ...` with a CLI v2 migration message and no API request.
- Repairs tracked `platform-spec.yaml` CLI catalog entries from `control_mailbox_*` to noun-first `mailbox_*`, and records `mailbox list/view` as remaining #735 parent tail.

Closes #790
Part of #735

## Governing Refs / Context

- #790 pre-audit and independent gate: https://github.com/yazzaoui/Swarm/issues/790#issuecomment-4468973669 and https://github.com/yazzaoui/Swarm/issues/790#issuecomment-4468981122
- #735 v2 tracker update: https://github.com/yazzaoui/Swarm/issues/735#issuecomment-4446362677
- Authoritative tracked contract: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification` and `api_specification.method_catalog.mailbox.*`
- Generated API contract: `docs/specs/swarm-platform/platform/contracts/openrpc.json` mailbox methods

## Semantic Migration

- New canonical CLI owner: `swarm mailbox approve|reject|defer` in the Cobra command tree and tracked `platform-spec.yaml` CLI catalog.
- Old path now invalid: `swarm control mailbox approve|reject|defer` is retired/fail-closed with exit 2 and migration guidance.
- Production paths checked for surviving old behavior: `cmd/swarm` command routing, tests, tracked platform spec, docs/scripts/Makefile grep, and direct mailbox store/DB bypass grep.
- Migration complete for the chosen class: all three mailbox decision verbs moved together; `mailbox list/view` remain explicitly split under #735.

## Proof

- `go test ./cmd/swarm -run 'TestCLI|TestMailbox|TestControlMailbox' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Grep proof: no direct `cmd/swarm` mailbox command store/DB/runtime bypass; no old live `control_mailbox_*` command functions remain.
