### PR TITLE
[agent-b][issue #792] Implement mailbox read CLI

### DIFF
--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -334,7 +334,6 @@ func validateMailboxItem(item mailboxItem) error {
 		{name: "type", value: item.Type},
 		{name: "status", value: item.Status},
 		{name: "priority", value: item.Priority},
-		{name: "source_event_id", value: item.SourceEventID},
 		{name: "source_flow", value: item.SourceFlow},
 		{name: "created_at", value: item.CreatedAt},
 	} {
@@ -502,7 +501,7 @@ func writeMailboxListResult(out io.Writer, result mailboxListResult) {
 			item.Status,
 			item.Priority,
 			item.Type,
-			item.SourceEventID,
+			mailboxDash(item.SourceEventID),
 			mailboxDash(item.SourceEntityID),
 			item.CreatedAt,
 			mailboxDash(item.Decision),
@@ -521,7 +520,7 @@ func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
 	fmt.Fprintf(out, "Mailbox %s\n", item.MailboxID)
 	fmt.Fprintf(out, "status=%s priority=%s type=%s\n", item.Status, item.Priority, item.Type)
 	fmt.Fprintf(out, "source_event_id=%s source_flow=%s source_entity_id=%s created_at=%s\n",
-		item.SourceEventID,
+		mailboxDash(item.SourceEventID),
 		item.SourceFlow,
 		mailboxDash(item.SourceEntityID),
 		item.CreatedAt,

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -18,6 +18,52 @@ type mailboxDecisionResult struct {
 	Status            string `json:"status"`
 }
 
+type mailboxItem struct {
+	MailboxID      string         `json:"mailbox_id"`
+	Type           string         `json:"type"`
+	Status         string         `json:"status"`
+	Priority       string         `json:"priority"`
+	SourceEventID  string         `json:"source_event_id"`
+	SourceFlow     string         `json:"source_flow"`
+	SourceEntityID string         `json:"source_entity_id,omitempty"`
+	Payload        map[string]any `json:"payload"`
+	CreatedAt      string         `json:"created_at"`
+	DecidedAt      string         `json:"decided_at,omitempty"`
+	Decision       string         `json:"decision,omitempty"`
+}
+
+type mailboxHistoryEntry struct {
+	Action          string         `json:"action"`
+	ActorTokenID    string         `json:"actor_token_id"`
+	TS              string         `json:"ts"`
+	DecisionPayload map[string]any `json:"decision_payload,omitempty"`
+	Reason          string         `json:"reason,omitempty"`
+}
+
+type mailboxListResult struct {
+	Items      []mailboxItem `json:"items"`
+	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+type mailboxDetailResult struct {
+	Item    mailboxItem           `json:"item"`
+	Payload map[string]any        `json:"payload"`
+	History []mailboxHistoryEntry `json:"history"`
+}
+
+type mailboxListCommandOptions struct {
+	apiOptions rootCommandOptions
+	status     string
+	all        bool
+	runID      string
+	entityID   string
+	itemType   string
+	priority   string
+	limit      int
+	limitSet   bool
+	cursor     string
+}
+
 type mailboxDecisionCommandOptions struct {
 	apiOptions          rootCommandOptions
 	action              string
@@ -47,13 +93,15 @@ func newControlCommand(opts rootCommandOptions) *cobra.Command {
 func newMailboxCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mailbox",
-		Short: "Approve, reject, or defer mailbox items through v1 RPC.",
+		Short: "List, view, and decide mailbox items through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
 	cmd.AddCommand(
+		newMailboxListCommand(opts),
+		newMailboxViewCommand(opts),
 		newMailboxApproveCommand(opts),
 		newMailboxRejectCommand(opts),
 		newMailboxDeferCommand(opts),
@@ -82,6 +130,42 @@ func writeControlMailboxRetiredMessage(w io.Writer) {
 	fmt.Fprintln(w, "  `swarm mailbox approve <mailbox-item-id>`")
 	fmt.Fprintln(w, "  `swarm mailbox reject <mailbox-item-id> --reason <text>`")
 	fmt.Fprintln(w, "  `swarm mailbox defer <mailbox-item-id> --until <RFC3339>`")
+}
+
+func newMailboxListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := mailboxListCommandOptions{
+		apiOptions: opts,
+		status:     "pending",
+	}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List mailbox items through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listOpts.limitSet = cmd.Flags().Changed("limit")
+			return runMailboxListCommand(cmd.Context(), cmd.OutOrStdout(), listOpts)
+		},
+	}
+	cmd.Flags().StringVar(&listOpts.status, "status", listOpts.status, "Mailbox status: pending, decided, expired, or deferred")
+	cmd.Flags().BoolVar(&listOpts.all, "all", false, "List all mailbox statuses instead of only pending")
+	cmd.Flags().StringVar(&listOpts.runID, "run-id", "", "Filter to one run")
+	cmd.Flags().StringVar(&listOpts.entityID, "entity-id", "", "Filter to one entity")
+	cmd.Flags().StringVar(&listOpts.itemType, "type", "", "Filter by mailbox item type")
+	cmd.Flags().StringVar(&listOpts.priority, "priority", "", "Mailbox priority: normal, high, or critical")
+	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Page size from 1 to 200; omitted uses the API default")
+	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Continuation cursor")
+	return cmd
+}
+
+func newMailboxViewCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <mailbox-item-id>",
+		Short: "View one mailbox item through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), opts, args[0])
+		},
+	}
 }
 
 func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
@@ -141,6 +225,46 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
+func runMailboxListCommand(ctx context.Context, out io.Writer, opts mailboxListCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return err
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	var result mailboxListResult
+	if err := client.call(ctx, "mailbox.list", params, &result); err != nil {
+		return err
+	}
+	if err := validateMailboxListResult(result); err != nil {
+		return err
+	}
+	writeMailboxListResult(out, result)
+	return nil
+}
+
+func runMailboxViewCommand(ctx context.Context, out io.Writer, opts rootCommandOptions, mailboxID string) error {
+	mailboxID = strings.TrimSpace(mailboxID)
+	if mailboxID == "" {
+		return fmt.Errorf("mailbox item id is required")
+	}
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return err
+	}
+	var result mailboxDetailResult
+	if err := client.call(ctx, "mailbox.get", map[string]any{"mailbox_id": mailboxID}, &result); err != nil {
+		return err
+	}
+	if err := validateMailboxDetailResult(result); err != nil {
+		return err
+	}
+	writeMailboxDetailResult(out, result)
+	return nil
+}
+
 func runMailboxDecisionCommand(ctx context.Context, out io.Writer, opts mailboxDecisionCommandOptions, mailboxID string) error {
 	mailboxID = strings.TrimSpace(mailboxID)
 	if mailboxID == "" {
@@ -162,6 +286,65 @@ func runMailboxDecisionCommand(ctx context.Context, out io.Writer, opts mailboxD
 		return err
 	}
 	writeMailboxDecisionResult(out, opts.action, mailboxID, result)
+	return nil
+}
+
+func validateMailboxListResult(result mailboxListResult) error {
+	if result.Items == nil {
+		return fmt.Errorf("malformed mailbox.list result: items is required")
+	}
+	for i, item := range result.Items {
+		if err := validateMailboxItem(item); err != nil {
+			return fmt.Errorf("malformed mailbox.list result: items[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateMailboxDetailResult(result mailboxDetailResult) error {
+	if err := validateMailboxItem(result.Item); err != nil {
+		return fmt.Errorf("malformed mailbox.get result: item: %w", err)
+	}
+	if result.Payload == nil {
+		return fmt.Errorf("malformed mailbox.get result: payload is required")
+	}
+	if result.History == nil {
+		return fmt.Errorf("malformed mailbox.get result: history is required")
+	}
+	for i, entry := range result.History {
+		if strings.TrimSpace(entry.Action) == "" {
+			return fmt.Errorf("malformed mailbox.get result: history[%d].action is required", i)
+		}
+		if strings.TrimSpace(entry.ActorTokenID) == "" {
+			return fmt.Errorf("malformed mailbox.get result: history[%d].actor_token_id is required", i)
+		}
+		if strings.TrimSpace(entry.TS) == "" {
+			return fmt.Errorf("malformed mailbox.get result: history[%d].ts is required", i)
+		}
+	}
+	return nil
+}
+
+func validateMailboxItem(item mailboxItem) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "mailbox_id", value: item.MailboxID},
+		{name: "type", value: item.Type},
+		{name: "status", value: item.Status},
+		{name: "priority", value: item.Priority},
+		{name: "source_event_id", value: item.SourceEventID},
+		{name: "source_flow", value: item.SourceFlow},
+		{name: "created_at", value: item.CreatedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+	if item.Payload == nil {
+		return fmt.Errorf("payload is required")
+	}
 	return nil
 }
 
@@ -193,6 +376,63 @@ func expectedMailboxDecisionStatus(action string) (string, error) {
 		return "deferred", nil
 	default:
 		return "", fmt.Errorf("unsupported mailbox action %q", action)
+	}
+}
+
+func (o mailboxListCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if !o.all {
+		status := strings.TrimSpace(strings.ToLower(o.status))
+		if status == "" {
+			status = "pending"
+		}
+		if !validMailboxStatus(status) {
+			return nil, fmt.Errorf("--status must be one of pending, decided, expired, deferred")
+		}
+		params["status"] = status
+	}
+	if runID := strings.TrimSpace(o.runID); runID != "" {
+		params["run_id"] = runID
+	}
+	if entityID := strings.TrimSpace(o.entityID); entityID != "" {
+		params["entity_id"] = entityID
+	}
+	if itemType := strings.TrimSpace(o.itemType); itemType != "" {
+		params["type"] = itemType
+	}
+	if priority := strings.TrimSpace(strings.ToLower(o.priority)); priority != "" {
+		if !validMailboxPriority(priority) {
+			return nil, fmt.Errorf("--priority must be one of normal, high, critical")
+		}
+		params["priority"] = priority
+	}
+	if (o.limitSet && o.limit <= 0) || o.limit > 200 {
+		return nil, fmt.Errorf("--limit must be an integer from 1 to 200")
+	}
+	if o.limit > 0 {
+		params["limit"] = o.limit
+	}
+	if cursor := strings.TrimSpace(o.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	return params, nil
+}
+
+func validMailboxStatus(status string) bool {
+	switch status {
+	case "pending", "decided", "expired", "deferred":
+		return true
+	default:
+		return false
+	}
+}
+
+func validMailboxPriority(priority string) bool {
+	switch priority {
+	case "normal", "high", "critical":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -247,6 +487,65 @@ func parseOptionalDecisionPayload(raw string) (map[string]any, bool, error) {
 	return payload, true, nil
 }
 
+func writeMailboxListResult(out io.Writer, result mailboxListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Items) == 0 {
+		fmt.Fprintln(out, "No mailbox items match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "MAILBOX_ID\tSTATUS\tPRIORITY\tTYPE\tSOURCE_EVENT\tENTITY\tCREATED\tDECISION")
+	for _, item := range result.Items {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			item.MailboxID,
+			item.Status,
+			item.Priority,
+			item.Type,
+			item.SourceEventID,
+			mailboxDash(item.SourceEntityID),
+			item.CreatedAt,
+			mailboxDash(item.Decision),
+		)
+	}
+	if result.NextCursor != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
+	if out == nil {
+		return
+	}
+	item := result.Item
+	fmt.Fprintf(out, "Mailbox %s\n", item.MailboxID)
+	fmt.Fprintf(out, "status=%s priority=%s type=%s\n", item.Status, item.Priority, item.Type)
+	fmt.Fprintf(out, "source_event_id=%s source_flow=%s source_entity_id=%s created_at=%s\n",
+		item.SourceEventID,
+		item.SourceFlow,
+		mailboxDash(item.SourceEntityID),
+		item.CreatedAt,
+	)
+	if item.Decision != "" || item.DecidedAt != "" {
+		fmt.Fprintf(out, "decision=%s decided_at=%s\n", mailboxDash(item.Decision), mailboxDash(item.DecidedAt))
+	}
+	writeMailboxObject(out, "payload", result.Payload)
+	if len(result.History) > 0 {
+		fmt.Fprintln(out, "history:")
+		for _, entry := range result.History {
+			fmt.Fprintf(out, "- action=%s actor=%s ts=%s", entry.Action, entry.ActorTokenID, entry.TS)
+			if entry.Reason != "" {
+				fmt.Fprintf(out, " reason=%q", entry.Reason)
+			}
+			if len(entry.DecisionPayload) > 0 {
+				fmt.Fprint(out, " decision_payload=")
+				writeCompactJSON(out, entry.DecisionPayload)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+}
+
 func writeMailboxDecisionResult(out io.Writer, action, mailboxID string, result mailboxDecisionResult) {
 	if out == nil {
 		return
@@ -256,4 +555,30 @@ func writeMailboxDecisionResult(out io.Writer, action, mailboxID string, result 
 		fmt.Fprintf(out, " downstream_event_id=%s", result.DownstreamEventID)
 	}
 	fmt.Fprintln(out)
+}
+
+func writeMailboxObject(out io.Writer, label string, value map[string]any) {
+	if len(value) == 0 {
+		fmt.Fprintf(out, "%s={}\n", label)
+		return
+	}
+	fmt.Fprintf(out, "%s=", label)
+	writeCompactJSON(out, value)
+	fmt.Fprintln(out)
+}
+
+func writeCompactJSON(out io.Writer, value map[string]any) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		fmt.Fprint(out, "{}")
+		return
+	}
+	fmt.Fprint(out, string(raw))
+}
+
+func mailboxDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
 }

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -107,6 +107,147 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 	}
 }
 
+func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"items": []map[string]any{
+				mailboxItemResult("mailbox-1", "pending", "high"),
+				mailboxItemResult("mailbox-2", "decided", "normal"),
+			},
+			"next_cursor": "cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"mailbox", "list",
+		"--all",
+		"--run-id", "run-1",
+		"--entity-id", "entity-1",
+		"--type", "review_request",
+		"--priority", "high",
+		"--limit", "25",
+		"--cursor", "cursor-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "mailbox.list" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/mailbox.list", captured.JSONRPC, captured.Method)
+	}
+	wantParams := map[string]any{
+		"run_id":    "run-1",
+		"entity_id": "entity-1",
+		"type":      "review_request",
+		"priority":  "high",
+		"limit":     float64(25),
+		"cursor":    "cursor-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"MAILBOX_ID\tSTATUS\tPRIORITY\tTYPE",
+		"mailbox-1\tpending\thigh\treview_request",
+		"mailbox-2\tdecided\tnormal\treview_request",
+		"next_cursor=cursor-2",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestMailboxListDefaultsToPendingAndRendersEmptyResult(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"items": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "mailbox.list" {
+		t.Fatalf("method = %q, want mailbox.list", captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"status": "pending"}) {
+		t.Fatalf("params = %#v, want pending default", captured.Params)
+	}
+	if !strings.Contains(stdout.String(), "No mailbox items match the filter.") {
+		t.Fatalf("stdout = %q, want empty message", stdout.String())
+	}
+}
+
+func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"item":    mailboxItemResult("mailbox-1", "pending", "high"),
+			"payload": map[string]any{"summary": "needs review"},
+			"history": []map[string]any{
+				{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "view", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "mailbox.get" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/mailbox.get", captured.JSONRPC, captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"mailbox_id": "mailbox-1"}) {
+		t.Fatalf("params = %#v, want mailbox id", captured.Params)
+	}
+	for _, want := range []string{
+		"Mailbox mailbox-1",
+		"status=pending priority=high type=review_request",
+		"source_event_id=event-mailbox-1 source_flow=validation",
+		`payload={"summary":"needs review"}`,
+		"history:",
+		"- action=created actor=system ts=2026-05-13T12:00:00Z",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var calls atomic.Int32
@@ -122,6 +263,15 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 		wantStderr  string
 		wantNoCalls bool
 	}{
+		{name: "list extra arg", args: []string{"mailbox", "list", "extra"}, wantStderr: "unknown command", wantNoCalls: true},
+		{name: "list invalid status", args: []string{"mailbox", "list", "--status", "open"}, wantStderr: "--status must be one of", wantNoCalls: true},
+		{name: "list invalid priority", args: []string{"mailbox", "list", "--priority", "low"}, wantStderr: "--priority must be one of", wantNoCalls: true},
+		{name: "list invalid limit", args: []string{"mailbox", "list", "--limit", "201"}, wantStderr: "--limit must be an integer from 1 to 200", wantNoCalls: true},
+		{name: "list unsupported flag", args: []string{"mailbox", "list", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
+		{name: "view missing id", args: []string{"mailbox", "view"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "view extra arg", args: []string{"mailbox", "view", "mailbox-1", "extra"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
+		{name: "view blank id", args: []string{"mailbox", "view", "  "}, wantStderr: "mailbox item id is required", wantNoCalls: true},
+		{name: "view unsupported flag", args: []string{"mailbox", "view", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
 		{name: "approve missing id", args: []string{"mailbox", "approve"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
 		{name: "approve extra arg", args: []string{"mailbox", "approve", "mailbox-1", "extra"}, wantStderr: "accepts 1 arg(s)", wantNoCalls: true},
 		{name: "approve unsupported flag", args: []string{"mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
@@ -153,7 +303,6 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 }
 
 func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -161,16 +310,25 @@ func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
-		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
-	}
-	if calls.Load() != 0 {
-		t.Fatalf("server calls = %d, want 0", calls.Load())
+	for _, args := range [][]string{
+		{"mailbox", "list"},
+		{"mailbox", "view", "mailbox-1"},
+		{"mailbox", "approve", "mailbox-1"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "")
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0", calls.Load())
+			}
+		})
 	}
 }
 
@@ -184,6 +342,8 @@ func TestControlMailboxRetiredAliasesFailClosedBeforeRequest(t *testing.T) {
 	defer server.Close()
 
 	for _, args := range [][]string{
+		{"control", "mailbox", "list"},
+		{"control", "mailbox", "view", "mailbox-1"},
 		{"control", "mailbox", "approve", "mailbox-1"},
 		{"control", "mailbox", "reject", "mailbox-1", "--reason", "not enough evidence"},
 		{"control", "mailbox", "defer", "mailbox-1", "--until", "2026-05-13T12:30:00Z"},
@@ -314,6 +474,99 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 	}
 }
 
+func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantStderr string
+	}{
+		{
+			name: "list http auth failure",
+			args: []string{"mailbox", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "list malformed missing items",
+			args: []string{"mailbox", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"next_cursor": "cursor-1"})
+			},
+			wantStderr: "malformed mailbox.list result: items is required",
+		},
+		{
+			name: "list malformed item",
+			args: []string{"mailbox", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				item := mailboxItemResult("mailbox-1", "pending", "normal")
+				delete(item, "source_event_id")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"items": []map[string]any{item}})
+			},
+			wantStderr: "items[0]: source_event_id is required",
+		},
+		{
+			name: "view malformed missing payload",
+			args: []string{"mailbox", "view", "mailbox-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"item":    mailboxItemResult("mailbox-1", "pending", "normal"),
+					"history": []map[string]any{{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"}},
+				})
+			},
+			wantStderr: "malformed mailbox.get result: payload is required",
+		},
+		{
+			name: "view mailbox not found",
+			args: []string{"mailbox", "view", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      req.ID,
+					"error": map[string]any{
+						"code":    -32010,
+						"message": "Application error: MAILBOX_NOT_FOUND",
+						"data": map[string]any{
+							"code":    "MAILBOX_NOT_FOUND",
+							"details": map[string]any{"mailbox_id": "missing"},
+						},
+					},
+				})
+			},
+			wantStderr: "MAILBOX_NOT_FOUND",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
 func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -365,6 +618,34 @@ func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.want)
 			}
 		})
+	}
+}
+
+func mailboxItemResult(mailboxID, status, priority string) map[string]any {
+	return map[string]any{
+		"mailbox_id":       mailboxID,
+		"type":             "review_request",
+		"status":           status,
+		"priority":         priority,
+		"source_event_id":  "event-" + mailboxID,
+		"source_flow":      "validation",
+		"source_entity_id": "entity-1",
+		"payload":          map[string]any{"summary": "needs review"},
+		"created_at":       "2026-05-13T12:00:00Z",
+		"decision":         decisionForMailboxStatus(status),
+	}
+}
+
+func decisionForMailboxStatus(status string) string {
+	switch status {
+	case "decided":
+		return "approved"
+	case "deferred":
+		return "deferred"
+	case "expired":
+		return "expired"
+	default:
+		return ""
 	}
 }
 

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -120,9 +120,11 @@ func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Errorf("decode request: %v", err)
 		}
+		first := mailboxItemResult("mailbox-1", "pending", "high")
+		delete(first, "source_event_id")
 		writeJSONRPCResult(t, w, captured.ID, map[string]any{
 			"items": []map[string]any{
-				mailboxItemResult("mailbox-1", "pending", "high"),
+				first,
 				mailboxItemResult("mailbox-2", "decided", "normal"),
 			},
 			"next_cursor": "cursor-2",
@@ -160,7 +162,7 @@ func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
 	}
 	for _, want := range []string{
 		"MAILBOX_ID\tSTATUS\tPRIORITY\tTYPE",
-		"mailbox-1\tpending\thigh\treview_request",
+		"mailbox-1\tpending\thigh\treview_request\t-\tentity-1",
 		"mailbox-2\tdecided\tnormal\treview_request",
 		"next_cursor=cursor-2",
 	} {
@@ -210,8 +212,10 @@ func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Errorf("decode request: %v", err)
 		}
+		item := mailboxItemResult("mailbox-1", "pending", "high")
+		delete(item, "source_event_id")
 		writeJSONRPCResult(t, w, captured.ID, map[string]any{
-			"item":    mailboxItemResult("mailbox-1", "pending", "high"),
+			"item":    item,
 			"payload": map[string]any{"summary": "needs review"},
 			"history": []map[string]any{
 				{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"},
@@ -234,7 +238,7 @@ func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
 	for _, want := range []string{
 		"Mailbox mailbox-1",
 		"status=pending priority=high type=review_request",
-		"source_event_id=event-mailbox-1 source_flow=validation",
+		"source_event_id=- source_flow=validation",
 		`payload={"summary":"needs review"}`,
 		"history:",
 		"- action=created actor=system ts=2026-05-13T12:00:00Z",
@@ -507,10 +511,10 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				item := mailboxItemResult("mailbox-1", "pending", "normal")
-				delete(item, "source_event_id")
+				delete(item, "source_flow")
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"items": []map[string]any{item}})
 			},
-			wantStderr: "items[0]: source_event_id is required",
+			wantStderr: "items[0]: source_flow is required",
 		},
 		{
 			name: "view malformed missing payload",

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -6306,7 +6306,6 @@
           "type",
           "status",
           "priority",
-          "source_event_id",
           "source_flow",
           "payload",
           "created_at"

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5348,6 +5348,25 @@ cli_specification:
       status: must_have
       owner: /v1/rpc health.check
       behavior: Structured authenticated operator health; do not consume /healthz, /readyz, or retired dashboard aliases.
+    mailbox_list:
+      command: swarm mailbox list
+      status: must_have
+      owner: /v1/rpc mailbox.list
+      behavior: >
+        Primary mailbox read/discovery list through canonical v1 API owner; default status is pending, --all omits the status filter,
+        and supported filters/pagination map directly to mailbox.list params. No direct DB/store/dashboard REST/mailbox reads.
+      split_tail: >
+        Richer operator decision-sheet composition remains under #735; this implemented slice does not derive cross-resource
+        entity/downstream truth locally.
+    mailbox_view:
+      command: swarm mailbox view <mailbox-item-id>
+      status: must_have
+      owner: /v1/rpc mailbox.get
+      behavior: >
+        Primary mailbox item detail view through canonical v1 API owner. No direct DB/store/dashboard REST/mailbox reads and no
+        CLI-side entity/downstream composition in this first slice.
+      split_tail: >
+        The v2 review draft's richer composed view using entity context and downstream-subscriber preview remains split under #735.
     mailbox_approve:
       command: swarm mailbox approve <mailbox-item-id>
       status: must_have
@@ -5397,6 +5416,8 @@ cli_specification:
       message: "ERROR: `swarm fork` was removed in v1. Forking is a mutating control action; use `swarm control run fork <run-id>` once that command ships. For v1, manual run forking goes through the API owner and the API spec."
   parent_tail:
     implemented_after_first_slice:
+    - swarm mailbox list
+    - swarm mailbox view
     - swarm mailbox approve
     - swarm mailbox reject
     - swarm mailbox defer
@@ -5408,8 +5429,6 @@ cli_specification:
     - swarm investigate health
     remaining_not_implemented:
     - swarm run
-    - swarm mailbox list
-    - swarm mailbox view
     - swarm control run/runtime/agent
     rule: 'Remaining commands require separate gates and must consume v1 API owners; they MUST NOT resurrect local DB/store/runtime-state readers.'
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6399,7 +6399,6 @@ api_specification:
         - type
         - status
         - priority
-        - source_event_id
         - source_flow
         - payload
         - created_at


### PR DESCRIPTION
## Summary

Implements the approved #792 first-slice mailbox read/discovery CLI:

- Adds `swarm mailbox list` over `/v1/rpc mailbox.list`.
- Adds `swarm mailbox view <mailbox-item-id>` over `/v1/rpc mailbox.get`.
- Keeps `swarm control mailbox ...` retired/fail-closed; no compatibility aliases added.
- Updates authoritative `platform-spec.yaml` so list/view are concrete CLI catalog entries and no longer in `remaining_not_implemented`.

Closes #792
Part of #735

## Governing Refs / Context

- #792 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.command_catalog.mailbox_list`
  - `cli_specification.command_catalog.mailbox_view`
  - `api_specification.method_catalog.mailbox.list`
  - `api_specification.method_catalog.mailbox.get`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json`: generated catalog contains `mailbox.list` and `mailbox.get`.
- #790 / PR #791 closed mailbox decision verbs before this PR.

## Semantic Migration

- New CLI canonical consumers: `swarm mailbox list` and `swarm mailbox view <mailbox-item-id>` in `cmd/swarm`.
- Canonical API owners consumed: `/v1/rpc mailbox.list` and `/v1/rpc mailbox.get`.
- Old producer/reader paths invalid for this PR: direct CLI DB/store/mailbox package reads, dashboard REST, legacy `/api/mailbox`, and any `swarm control mailbox list/view` alias.
- Production paths checked for surviving old behavior: `cmd/swarm` grep for mailbox store/dashboard REST readers; old `control mailbox` remains retired/fail-closed.
- Migration completeness: complete for the primary mailbox read/discovery CLI slice. Richer entity/downstream composed `mailbox view` remains explicitly split under #735 per gate boundary.

## Proof

- `go test ./cmd/swarm -run 'TestCLI|TestMailbox' -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "ListV1MailboxItems|GetV1MailboxItem|ListMailboxItems|GetMailboxItem|/api/mailbox|api/mailbox" cmd/swarm || true` returned no matches.
