### PR TITLE
[agent-a][issue #797] Implement swarm health

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -68,6 +68,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newVersionCommand(),
 		newCompletionCommand(),
 		newRunsCommand(opts),
+		newHealthCommand(opts),
 		newInvestigateCommand(opts),
 		newMailboxCommand(opts),
 		newControlCommand(opts),

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -128,6 +128,17 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
+func newHealthCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "health",
+		Short: "Print structured operator health through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+}
+
 func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "investigate",
@@ -141,7 +152,7 @@ func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 		newInvestigateRunsCommand(opts),
 		newInvestigateRunCommand(opts),
 		newInvestigateTraceCommand(opts),
-		newInvestigateHealthCommand(opts),
+		newInvestigateHealthCommand(),
 	)
 	return cmd
 }
@@ -203,15 +214,24 @@ func newInvestigateTraceCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func newInvestigateHealthCommand(opts rootCommandOptions) *cobra.Command {
+func newInvestigateHealthCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "health",
-		Short: "Print structured operator health through v1 RPC.",
-		Args:  cobra.NoArgs,
+		Use:                "health",
+		Short:              "Retired legacy command; use swarm health.",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), opts)
+			writeInvestigateHealthRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
 		},
 	}
+}
+
+func writeInvestigateHealthRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm investigate health` was retired in CLI v2.")
+	fmt.Fprintln(w, "  Use `swarm health`.")
 }
 
 func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptions) {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -249,7 +249,7 @@ func TestInvestigateTraceUsesRunTraceSnapshot(t *testing.T) {
 	}
 }
 
-func TestInvestigateHealthUsesHealthCheck(t *testing.T) {
+func TestHealthUsesHealthCheck(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "health.check" {
@@ -273,7 +273,7 @@ func TestInvestigateHealthUsesHealthCheck(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "health"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"health"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -284,6 +284,30 @@ func TestInvestigateHealthUsesHealthCheck(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestInvestigateHealthIsRetiredWithoutRequest(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "health"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "ERROR: `swarm investigate health` was retired in CLI v2.") || !strings.Contains(got, "Use `swarm health`.") {
+		t.Fatalf("stderr = %q, want retired migration message", got)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
 	}
 }
 
@@ -531,7 +555,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "health missing bundle fingerprint",
-			args: []string{"investigate", "health"},
+			args: []string{"health"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -547,7 +571,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "health missing workflow name",
-			args: []string{"investigate", "health"},
+			args: []string{"health"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -566,7 +590,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "health missing workflow version",
-			args: []string{"investigate", "health"},
+			args: []string{"health"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5474,7 +5474,7 @@ cli_specification:
     health:
       command: swarm health
       tier: must_have
-      implementation_status: absent_v2_top_level_exists_under_legacy_investigate
+      implementation_status: implemented
       owner: /v1/rpc health.check
       behavior: Structured authenticated operator health; separate from lightweight /healthz and /readyz process probes.
     control_pause:
@@ -5600,7 +5600,7 @@ cli_specification:
     investigate:
       command: swarm investigate *
       status: retired_legacy_v1_topology
-      current_code_state: implemented legacy namespace until a command repair child removes or fails it closed
+      current_code_state: partially_implemented_legacy_namespace; health fails closed after #797; runs/run/trace remain implemented legacy until sibling repairs
       v2_replacements:
         swarm investigate runs: swarm runs
         swarm investigate run: swarm status
@@ -5642,6 +5642,7 @@ cli_specification:
     - swarm serve (partial)
     - swarm verify
     - swarm runs
+    - swarm health
     - swarm mailbox list
     - swarm mailbox view
     - swarm mailbox approve
@@ -5652,12 +5653,12 @@ cli_specification:
     - swarm investigate runs
     - swarm investigate run
     - swarm investigate trace
+    retired_or_fail_closed:
     - swarm investigate health
     remaining_must_have_not_implemented:
     - swarm run
     - swarm status
     - swarm trace
-    - swarm health
     - swarm version --server
     remaining_should_have_not_implemented:
     - swarm control pause|continue|stop


### PR DESCRIPTION
## Summary

Implements the promoted CLI v2 `swarm health` command over canonical `/v1/rpc health.check` and retires the same-concept legacy `swarm investigate health` command with a fail-closed migration message.

This PR does not touch runtime health semantics, `/healthz`, `/readyz`, API methods, `swarm run`, `swarm status`, or `swarm trace`.

## Governing Context

- #797 pre-audit and gate outcome: `approved as first slice`.
- `platform-spec.yaml` `cli_specification.command_catalog.health`: `swarm health`, `tier: must_have`, owner `/v1/rpc health.check`, separate from `/healthz` and `/readyz`.
- `platform-spec.yaml` `cli_specification.retired_namespaces.investigate`: `swarm investigate *` is retired legacy v1 topology; `swarm investigate health` maps to `swarm health`.

## Semantic Migration

- New canonical CLI owner: top-level `swarm health`.
- Runtime health owner: `/v1/rpc health.check` only.
- Old path now invalid: `swarm investigate health` no longer calls the API and exits 2 with migration text pointing to `swarm health`.
- Production paths checked for surviving old behavior: CLI command tree and tests confirm no `investigate health` API request is made.
- Migration complete for the chosen class; `investigate runs/run/trace` remain split #735 siblings.

## Proof

- `go test ./cmd/swarm -run 'Health|InvestigateHealth' -count=1`
- `go test ./cmd/swarm -count=1`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`

Closes #797
Part of #735
