### PR TITLE
[agent-a][issue #800] Implement swarm status

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -68,11 +68,11 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newVersionCommand(),
 		newCompletionCommand(),
 		newRunsCommand(opts),
+		newStatusCommand(opts),
 		newHealthCommand(opts),
 		newInvestigateCommand(opts),
 		newMailboxCommand(opts),
 		newControlCommand(opts),
-		newRetiredStatusCommand(),
 		newRetiredForkCommand(),
 	)
 	return cmd
@@ -164,18 +164,6 @@ func newCompletionCommand() *cobra.Command {
 	}
 }
 
-func newRetiredStatusCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:                "status",
-		Short:              "Removed v1 command; use swarm investigate run.",
-		DisableFlagParsing: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			writeStatusRetiredMessage(cmd.ErrOrStderr())
-			return commandExitError{code: 2}
-		},
-	}
-}
-
 func newRetiredForkCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:                "fork",
@@ -186,16 +174,6 @@ func newRetiredForkCommand() *cobra.Command {
 			return commandExitError{code: 2}
 		},
 	}
-}
-
-func writeStatusRetiredMessage(w io.Writer) {
-	if w == nil {
-		return
-	}
-	fmt.Fprintln(w, "ERROR: `swarm status` was removed in v1.")
-	fmt.Fprintln(w, "  Replaced by `swarm investigate run` (interpreted) or")
-	fmt.Fprintln(w, "  `swarm investigate run --no-diagnose` (header only).")
-	fmt.Fprintln(w, "  See `swarm investigate run --help`.")
 }
 
 func writeForkRetiredMessage(w io.Writer) {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -139,6 +139,24 @@ func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 	}
 }
 
+func newStatusCommand(opts rootCommandOptions) *cobra.Command {
+	runOpts := diagnosticRunOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "status [run-id]",
+		Short: "Diagnose one run through the v1 RPC read owner.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runID := ""
+			if len(args) == 1 {
+				runID = args[0]
+			}
+			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), runOpts, runID)
+		},
+	}
+	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
+	return cmd
+}
+
 func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "investigate",
@@ -175,21 +193,15 @@ func newInvestigateRunsCommand(opts rootCommandOptions) *cobra.Command {
 }
 
 func newInvestigateRunCommand(opts rootCommandOptions) *cobra.Command {
-	runOpts := diagnosticRunOptions{apiOptions: opts}
-	cmd := &cobra.Command{
-		Use:   "run [run-id]",
-		Short: "Diagnose one run through v1 RPC.",
-		Args:  cobra.MaximumNArgs(1),
+	return &cobra.Command{
+		Use:                "run [run-id]",
+		Short:              "Retired legacy command; use swarm status.",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runID := ""
-			if len(args) == 1 {
-				runID = args[0]
-			}
-			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), runOpts, runID)
+			writeInvestigateRunRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
 		},
 	}
-	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
-	return cmd
 }
 
 func newInvestigateTraceCommand(opts rootCommandOptions) *cobra.Command {
@@ -234,6 +246,15 @@ func writeInvestigateHealthRetiredMessage(w io.Writer) {
 	fmt.Fprintln(w, "  Use `swarm health`.")
 }
 
+func writeInvestigateRunRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm investigate run` was retired in CLI v2.")
+	fmt.Fprintln(w, "  Use `swarm status`.")
+	fmt.Fprintln(w, "  Use `swarm status --no-diagnose` for the header-only run read.")
+}
+
 func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptions) {
 	cmd.Flags().StringVar(&opts.status, "status", "", "Optional run status filter")
 	cmd.Flags().StringVar(&opts.since, "since", "", "Optional RFC3339 lower started_at bound")
@@ -266,7 +287,7 @@ func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnostic
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		runID, err = latestDiagnosticRunID(ctx, client)
+		runID, err = activePreferredDiagnosticRunID(ctx, client)
 		if err != nil {
 			return err
 		}
@@ -304,7 +325,7 @@ func runDiagnosticTraceCommand(ctx context.Context, out io.Writer, opts diagnost
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		runID, err = latestDiagnosticRunID(ctx, client)
+		runID, err = activePreferredDiagnosticRunID(ctx, client)
 		if err != nil {
 			return err
 		}
@@ -348,7 +369,16 @@ func fetchDiagnosticRunList(ctx context.Context, client *cliAPIClient, params ma
 	return result, nil
 }
 
-func latestDiagnosticRunID(ctx context.Context, client *cliAPIClient) (string, error) {
+func activePreferredDiagnosticRunID(ctx context.Context, client *cliAPIClient) (string, error) {
+	for _, status := range []string{"running", "paused"} {
+		result, err := fetchDiagnosticRunList(ctx, client, map[string]any{"status": status, "limit": 1})
+		if err != nil {
+			return "", err
+		}
+		if len(result.Runs) > 0 {
+			return result.Runs[0].RunID, nil
+		}
+	}
 	result, err := fetchDiagnosticRunList(ctx, client, map[string]any{"limit": 1})
 	if err != nil {
 		return "", err

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -71,7 +71,7 @@ func TestRunsAndInvestigateRunsUseRunListV1RPC(t *testing.T) {
 	}
 }
 
-func TestInvestigateRunUsesDiagnoseAndRunGet(t *testing.T) {
+func TestStatusUsesDiagnoseAndRunGet(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -81,13 +81,13 @@ func TestInvestigateRunUsesDiagnoseAndRunGet(t *testing.T) {
 	}{
 		{
 			name:       "diagnose default",
-			args:       []string{"investigate", "run", "run-1"},
+			args:       []string{"status", "run-1"},
 			wantMethod: "run.diagnose",
 			wantOutput: []string{"Run: run-1", "operational_state=stalled", "blocking_layer=delivery_lifecycle", "dead letters exist"},
 		},
 		{
 			name:       "header only",
-			args:       []string{"investigate", "run", "run-1", "--no-diagnose"},
+			args:       []string{"status", "run-1", "--no-diagnose"},
 			wantMethod: "run.get",
 			wantOutput: []string{"Run: run-1", "status=running", "trigger=scan.requested"},
 			notOutput:  "operational_state=",
@@ -138,55 +138,85 @@ func TestInvestigateRunUsesDiagnoseAndRunGet(t *testing.T) {
 	}
 }
 
-func TestInvestigateRunAndTraceResolveLatestRunThroughRunList(t *testing.T) {
+func TestStatusAndInvestigateTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
 	for _, tc := range []struct {
-		name         string
-		args         []string
-		secondMethod string
-		wantOutput   string
+		name       string
+		args       []string
+		lists      [][]any
+		owner      string
+		selected   string
+		wantOutput string
 	}{
-		{name: "run", args: []string{"investigate", "run"}, secondMethod: "run.diagnose", wantOutput: "Run: latest-run"},
-		{name: "trace", args: []string{"investigate", "trace"}, secondMethod: "run.trace", wantOutput: "run trace: run_id=latest-run"},
+		{
+			name:       "status prefers running",
+			args:       []string{"status"},
+			lists:      [][]any{{validDiagnosticRunHeaderWithStatus("running-run", "running")}},
+			owner:      "run.diagnose",
+			selected:   "running-run",
+			wantOutput: "Run: running-run",
+		},
+		{
+			name:       "status falls back to paused",
+			args:       []string{"status", "--no-diagnose"},
+			lists:      [][]any{{}, {validDiagnosticRunHeaderWithStatus("paused-run", "paused")}},
+			owner:      "run.get",
+			selected:   "paused-run",
+			wantOutput: "Run: paused-run",
+		},
+		{
+			name:       "legacy trace uses terminal fallback",
+			args:       []string{"investigate", "trace"},
+			lists:      [][]any{{}, {}, {validDiagnosticRunHeaderWithStatus("terminal-run", "completed")}},
+			owner:      "run.trace",
+			selected:   "terminal-run",
+			wantOutput: "run trace: run_id=terminal-run",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
 			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
-				switch callIndex {
-				case 0:
+				if callIndex < len(tc.lists) {
 					if req.Method != "run.list" {
-						t.Fatalf("first method = %q, want run.list", req.Method)
+						t.Fatalf("method[%d] = %q, want run.list", callIndex, req.Method)
 					}
-					if got := req.Params["limit"]; got != float64(1) {
-						t.Fatalf("latest run limit = %#v, want 1", got)
+					wantParams := map[string]any{"limit": float64(1)}
+					switch callIndex {
+					case 0:
+						wantParams["status"] = "running"
+					case 1:
+						wantParams["status"] = "paused"
 					}
-					return map[string]any{"runs": []any{validDiagnosticRunHeader("latest-run")}}
-				case 1:
-					if req.Method != tc.secondMethod {
-						t.Fatalf("second method = %q, want %s", req.Method, tc.secondMethod)
+					if !reflect.DeepEqual(req.Params, wantParams) {
+						t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, wantParams)
 					}
-					if got := req.Params["run_id"]; got != "latest-run" {
-						t.Fatalf("second run_id = %#v, want latest-run", got)
-					}
-					if tc.secondMethod == "run.trace" {
-						return map[string]any{
-							"trace": []any{map[string]any{
-								"event_id":         "event-1",
-								"event_name":       "scan.requested",
-								"event_created_at": "2026-05-13T10:00:01Z",
-							}},
-						}
-					}
+					return map[string]any{"runs": tc.lists[callIndex]}
+				}
+				if req.Method != tc.owner {
+					t.Fatalf("owner method = %q, want %s", req.Method, tc.owner)
+				}
+				if got := req.Params["run_id"]; got != tc.selected {
+					t.Fatalf("owner run_id = %#v, want %s", got, tc.selected)
+				}
+				switch tc.owner {
+				case "run.trace":
 					return map[string]any{
-						"run":               validDiagnosticRunHeader("latest-run"),
+						"trace": []any{map[string]any{
+							"event_id":         "event-1",
+							"event_name":       "scan.requested",
+							"event_created_at": "2026-05-13T10:00:01Z",
+						}},
+					}
+				case "run.get":
+					return map[string]any{"run": validDiagnosticRunHeaderWithStatus(tc.selected, "paused")}
+				default:
+					return map[string]any{
+						"run":               validDiagnosticRunHeader(tc.selected),
 						"operational_state": "running",
 						"blocking_layer":    "",
 						"blocking_reason":   "",
 						"heuristics":        []any{},
 					}
-				default:
-					t.Fatalf("unexpected request %d: %s", callIndex+1, req.Method)
 				}
-				return nil
 			})
 			defer server.Close()
 
@@ -195,11 +225,44 @@ func TestInvestigateRunAndTraceResolveLatestRunThroughRunList(t *testing.T) {
 			if code != 0 {
 				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 			}
-			if len(*requests) != 2 {
-				t.Fatalf("requests = %d, want 2", len(*requests))
+			if len(*requests) != len(tc.lists)+1 {
+				t.Fatalf("requests = %d, want %d", len(*requests), len(tc.lists)+1)
 			}
 			if !strings.Contains(stdout.String(), tc.wantOutput) {
 				t.Fatalf("stdout missing %q:\n%s", tc.wantOutput, stdout.String())
+			}
+		})
+	}
+}
+
+func TestInvestigateRunIsRetiredWithoutRequest(t *testing.T) {
+	for _, args := range [][]string{
+		{"investigate", "run"},
+		{"investigate", "run", "run-1"},
+		{"investigate", "run", "run-1", "--no-diagnose"},
+		{"investigate", "run", "--no-diagnose"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, "ERROR: `swarm investigate run` was retired in CLI v2.") || !strings.Contains(got, "Use `swarm status`.") {
+				t.Fatalf("stderr = %q, want retired migration message", got)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
 			}
 		})
 	}
@@ -329,7 +392,7 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "runs invalid since", args: []string{"runs", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
 		{name: "trace invalid limit", args: []string{"investigate", "trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
 		{name: "trace follow unsupported", args: []string{"investigate", "trace", "run-1", "--follow"}, wantStderr: "unknown flag"},
-		{name: "run extra arg", args: []string{"investigate", "run", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
+		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			before := calls.Load()
@@ -373,26 +436,39 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 	}
 }
 
-func TestInvestigateOmittedRunFailsClosedWhenNoRunsExist(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
-	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
-		if req.Method != "run.list" {
-			t.Fatalf("method = %q, want run.list", req.Method)
-		}
-		return map[string]any{"runs": []any{}}
-	})
-	defer server.Close()
+func TestOmittedRunResolverFailsClosedWhenNoRunsExist(t *testing.T) {
+	for _, args := range [][]string{
+		{"status"},
+		{"status", "--no-diagnose"},
+		{"investigate", "trace"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != "run.list" {
+					t.Fatalf("method = %q, want run.list", req.Method)
+				}
+				return map[string]any{"runs": []any{}}
+			})
+			defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "run"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	if len(*requests) != 1 {
-		t.Fatalf("requests = %d, want 1", len(*requests))
-	}
-	if !strings.Contains(stderr.String(), "no runs found") {
-		t.Fatalf("stderr = %q, want no-runs error", stderr.String())
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if len(*requests) != 3 {
+				t.Fatalf("requests = %d, want 3 active-preference run.list probes", len(*requests))
+			}
+			for _, req := range *requests {
+				if req.Method != "run.list" {
+					t.Fatalf("method = %q, want only run.list before no-runs failure", req.Method)
+				}
+			}
+			if !strings.Contains(stderr.String(), "no runs found") {
+				t.Fatalf("stderr = %q, want no-runs error", stderr.String())
+			}
+		})
 	}
 }
 
@@ -414,7 +490,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "json rpc run not found",
-			args: []string{"investigate", "run", "missing"},
+			args: []string{"status", "missing"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -448,7 +524,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run get missing required run id",
-			args: []string{"investigate", "run", "run-1", "--no-diagnose"},
+			args: []string{"status", "run-1", "--no-diagnose"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -472,7 +548,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run get invalid run status",
-			args: []string{"investigate", "run", "run-1", "--no-diagnose"},
+			args: []string{"status", "run-1", "--no-diagnose"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -484,7 +560,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run diagnose missing blocking layer",
-			args: []string{"investigate", "run", "run-1"},
+			args: []string{"status", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -499,7 +575,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run diagnose invalid operational state",
-			args: []string{"investigate", "run", "run-1"},
+			args: []string{"status", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -515,7 +591,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run diagnose missing blocking reason",
-			args: []string{"investigate", "run", "run-1"},
+			args: []string{"status", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -530,7 +606,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "run diagnose missing heuristics",
-			args: []string{"investigate", "run", "run-1"},
+			args: []string{"status", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -660,4 +736,10 @@ func validDiagnosticRunHeader(runID string) map[string]any {
 		"event_count":        3,
 		"started_at":         "2026-05-13T10:00:00Z",
 	}
+}
+
+func validDiagnosticRunHeaderWithStatus(runID, status string) map[string]any {
+	run := validDiagnosticRunHeader(runID)
+	run["status"] = status
+	return run
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -259,14 +259,12 @@ func TestCLI_VerifyPreservesLocalContractCarveOut(t *testing.T) {
 	}
 }
 
-func TestCLI_StatusAndForkAreHardRetired(t *testing.T) {
+func TestCLI_ForkIsHardRetired(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		args []string
 		want string
 	}{
-		{name: "status", args: []string{"status"}, want: "ERROR: `swarm status` was removed in v1."},
-		{name: "status-help", args: []string{"status", "--help"}, want: "ERROR: `swarm status` was removed in v1."},
 		{name: "fork", args: []string{"fork"}, want: "ERROR: `swarm fork` was removed in v1."},
 		{name: "fork-help", args: []string{"fork", "--help"}, want: "ERROR: `swarm fork` was removed in v1."},
 	} {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5428,7 +5428,7 @@ cli_specification:
     status:
       command: swarm status [<run-id>]
       tier: must_have
-      implementation_status: absent_v2_top_level_currently_retired
+      implementation_status: implemented
       owner: /v1/rpc run.diagnose by default; /v1/rpc run.get for header-only mode if exposed
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
@@ -5600,7 +5600,7 @@ cli_specification:
     investigate:
       command: swarm investigate *
       status: retired_legacy_v1_topology
-      current_code_state: partially_implemented_legacy_namespace; health fails closed after #797; runs/run/trace remain implemented legacy until sibling repairs
+      current_code_state: partially_implemented_legacy_namespace; health and run fail closed after #797/#800; runs/trace remain implemented legacy until sibling repairs
       v2_replacements:
         swarm investigate runs: swarm runs
         swarm investigate run: swarm status
@@ -5651,13 +5651,12 @@ cli_specification:
     - swarm control nuke
     implemented_legacy_or_wrong_namespace:
     - swarm investigate runs
-    - swarm investigate run
     - swarm investigate trace
     retired_or_fail_closed:
     - swarm investigate health
+    - swarm investigate run
     remaining_must_have_not_implemented:
     - swarm run
-    - swarm status
     - swarm trace
     - swarm version --server
     remaining_should_have_not_implemented:


### PR DESCRIPTION
## Summary

Closes #800
Part of #735

Implements the approved first slice for the CLI v2 status surface:

- adds top-level `swarm status [<run-id>]` over `/v1/rpc run.diagnose`
- preserves header-only `swarm status --no-diagnose` over `/v1/rpc run.get`
- replaces the omitted-run latest-row shortcut with a shared API-only active-preference resolver backed by `/v1/rpc run.list`
- fail-closes `swarm investigate run` with migration text before any RPC call
- keeps top-level `swarm trace`, #743 `swarm run`, `version --server`, and `investigate runs/trace` retirement out of scope

## Governing Refs

- `platform-spec.yaml` `cli_specification.command_catalog.status`: `swarm status [<run-id>]`, owner `/v1/rpc run.diagnose` by default and `/v1/rpc run.get` for header-only mode if exposed.
- `platform-spec.yaml` status/trace defaulting: omitted run ID resolves through `/v1/rpc run.list` with active-run preference.
- `platform-spec.yaml` `cli_specification.retired_namespaces.investigate`: `swarm investigate run` maps to `swarm status` and the `investigate` namespace is retired legacy v1 topology.
- #800 approved repaired gate: https://github.com/yazzaoui/Swarm/issues/800#issuecomment-4472588946

## Semantic Migration

- New canonical CLI surface: `swarm status [<run-id>]`.
- Canonical API owners: `run.diagnose`, optional `run.get`, and `run.list` for omitted target selection.
- Old path now invalid: successful `swarm investigate run` over `run.diagnose` / `run.get`.
- Surviving old behavior checked: the old `latestDiagnosticRunID` helper is removed; omitted `swarm status` and omitted still-live `swarm investigate trace` both consume the repaired shared resolver.
- Migration complete for the chosen class: status command, same-concept investigate-run retirement, and live omitted-run resolver consumers.

## Proof

- `go test ./cmd/swarm -run 'Status|InvestigateRun|InvestigateTrace|Diagnostics' -count=1`
- `go test ./cmd/swarm -count=1`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "latestDiagnosticRunID|newRetiredStatusCommand|writeStatusRetiredMessage" cmd/swarm` returned no matches.
