### PR TITLE
[agent-a][issue #802] Add serve boot observability

### DIFF
--- a/cmd/swarm/builtin_tool_parity_invariants_test.go
+++ b/cmd/swarm/builtin_tool_parity_invariants_test.go
@@ -91,7 +91,7 @@ func assertBootProgressUsesRuntimeToolInventory(t *testing.T, source semanticvie
 		t.Fatal("runtime tool inventory unexpectedly empty")
 	}
 
-	out := serveBootRegistryDetail(source)
+	out := serveBootBundleLoadDetail("sha256:test", source)
 	if !strings.Contains(out, fmt.Sprintf("tools=%d", wantTools)) {
 		t.Fatalf("boot progress detail missing runtime tool count %d:\n%s", wantTools, out)
 	}

--- a/cmd/swarm/builtin_tool_parity_invariants_test.go
+++ b/cmd/swarm/builtin_tool_parity_invariants_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"log/slog"
-	"strconv"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -63,7 +61,7 @@ func TestBuiltinToolParityInvariant_SupportedSurfacesShareRuntimeToolTruth_V2(t 
 				t.Fatalf("verifyBundle: %v", err)
 			}
 
-			assertBootSkeletonUsesRuntimeToolInventory(t, source, result.BootReport)
+			assertBootProgressUsesRuntimeToolInventory(t, source)
 		})
 	}
 }
@@ -85,7 +83,7 @@ func assertToolResolutionWarning(t *testing.T, warnings []runtimebootverify.Find
 	}
 }
 
-func assertBootSkeletonUsesRuntimeToolInventory(t *testing.T, source semanticview.Source, report runtimebootverify.Report) {
+func assertBootProgressUsesRuntimeToolInventory(t *testing.T, source semanticview.Source) {
 	t.Helper()
 
 	wantTools := len(runtimetools.RuntimeAvailableToolNamesForSource(source))
@@ -93,22 +91,11 @@ func assertBootSkeletonUsesRuntimeToolInventory(t *testing.T, source semanticvie
 		t.Fatal("runtime tool inventory unexpectedly empty")
 	}
 
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	previous := slog.Default()
-	slog.SetDefault(logger)
-	defer slog.SetDefault(previous)
-
-	logBootSkeleton(source, "/tmp/contracts", "/tmp/platform-spec.yaml", report, "state stores ready")
-
-	out := buf.String()
-	if !strings.Contains(out, "name=build_registries") {
-		t.Fatalf("log output missing build_registries step:\n%s", out)
-	}
-	if !strings.Contains(out, "tools="+strconv.Itoa(wantTools)) {
-		t.Fatalf("log output missing runtime tool count %d:\n%s", wantTools, out)
+	out := serveBootRegistryDetail(source)
+	if !strings.Contains(out, fmt.Sprintf("tools=%d", wantTools)) {
+		t.Fatalf("boot progress detail missing runtime tool count %d:\n%s", wantTools, out)
 	}
 	if strings.Contains(out, "tools=0") {
-		t.Fatalf("log output still reports zero tools:\n%s", out)
+		t.Fatalf("boot progress detail still reports zero tools:\n%s", out)
 	}
 }

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -63,7 +63,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
 	cmd.AddCommand(
-		newServeCommand(ctx, repo),
+		newServeCommand(ctx, repo, opts.runServe),
 		newRunCommand(repo, opts),
 		newVerifyCommand(ctx, repo),
 		newVersionCommand(),
@@ -79,8 +79,11 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	return cmd
 }
 
-func newServeCommand(ctx context.Context, repo string) *cobra.Command {
+func newServeCommand(ctx context.Context, repo string, runServe func(context.Context, string, serveOptions) int) *cobra.Command {
 	opts := defaultServeOptions()
+	if runServe == nil {
+		runServe = runServeRuntime
+	}
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the Swarm runtime, API, health, and MCP surfaces.",
@@ -95,7 +98,8 @@ func newServeCommand(ctx context.Context, repo string) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			code := runServeRuntime(ctx, repo, opts)
+			opts.Output = cmd.OutOrStdout()
+			code := runServe(ctx, repo, opts)
 			if code != 0 {
 				return commandExitError{code: code}
 			}
@@ -110,6 +114,7 @@ func newServeCommand(ctx context.Context, repo string) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs belong to a different non-NULL bundle fingerprint")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs belong to a different bundle fingerprint")
+	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Emit the serve boot sequence to stdout as each phase completes")
 	return cmd
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -150,7 +151,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	source := semanticview.Wrap(bundle)
-	reporter.emit(4, "bundle_load", "ok", fmt.Sprintf("%s, %d agents, %d events", bootBundleIdentity.Fingerprint, len(source.AgentEntries()), len(source.ResolvedEventCatalog())))
+	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(bootBundleIdentity.Fingerprint, source))
 	stateStoreSummary, err := initializeStateStores(ctx, stores, bundle)
 	if err != nil {
 		slog.Error("initialize state stores", "error", err)
@@ -270,7 +271,14 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	healthServer := newHealthServer(opts.HealthAddr, &ready, rt.ToolGateway, apiV1Handler)
-	go serveHealth(healthServer)
+	healthListener, err := listenHealthServer(healthServer)
+	if err != nil {
+		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
+		log.Printf("bind health server: %v", err)
+		return 1
+	}
+	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("health=%s routes=/healthz /readyz /v1/rpc /v1/ws", healthListener.Addr()))
+	go serveHealth(healthServer, healthListener)
 	defer shutdownHealthServer(healthServer)
 	logBootWarnings(bootReport)
 	if err := rt.Start(ctx); err != nil {
@@ -278,9 +286,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("start runtime: %v", err)
 		return 1
 	}
-	reporter.emit(20, "http_servers_start", "ok", fmt.Sprintf("health=%s v1_rpc=/v1/rpc v1_ws=/v1/ws listener active", opts.HealthAddr))
 	ready.Store(true)
-	reporter.emit(21, "health_endpoints_respond", "ok", "/healthz /readyz /v1/rpc /v1/ws")
+	if err := waitForServeHealthEndpoints(ctx, healthListener.Addr()); err != nil {
+		reporter.emit(21, "health_endpoints_respond", "FAILED", err.Error())
+		log.Printf("health endpoint verification failed: %v", err)
+		return 1
+	}
+	reporter.emit(21, "health_endpoints_respond", "ok", "/healthz /readyz")
 	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	logReadySummary(source, contractsRoot, opts.HealthAddr)
 
@@ -1547,6 +1559,14 @@ func serveBootRegistryDetail(source semanticview.Source) string {
 	return fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(availableToolNames))
 }
 
+func serveBootBundleLoadDetail(fingerprint string, source semanticview.Source) string {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return serveBootRegistryDetail(source)
+	}
+	return fmt.Sprintf("%s, %s", fingerprint, serveBootRegistryDetail(source))
+}
+
 func logBootWarnings(report runtimebootverify.Report) {
 	warningCounts := make(map[string]int, len(report.Findings))
 	for _, finding := range report.Warnings() {
@@ -1605,10 +1625,82 @@ func newHealthServer(addr string, ready *atomic.Bool, toolGateway *runtimemcp.Ga
 	}
 }
 
-func serveHealth(server *http.Server) {
-	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+func listenHealthServer(server *http.Server) (net.Listener, error) {
+	if server == nil {
+		return nil, errors.New("health server is not configured")
+	}
+	addr := strings.TrimSpace(server.Addr)
+	if addr == "" {
+		addr = defaultHealthAddr
+	}
+	return net.Listen("tcp", addr)
+}
+
+func serveHealth(server *http.Server, listener net.Listener) {
+	if server == nil || listener == nil {
+		return
+	}
+	if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Printf("health server stopped: %v", err)
 	}
+}
+
+func waitForServeHealthEndpoints(ctx context.Context, addr net.Addr) error {
+	baseURL, err := serveHealthProbeBaseURL(addr)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 200 * time.Millisecond}
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for {
+		lastErr = probeServeHealthEndpoint(ctx, client, baseURL+"/healthz")
+		if lastErr == nil {
+			lastErr = probeServeHealthEndpoint(ctx, client, baseURL+"/readyz")
+		}
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func serveHealthProbeBaseURL(addr net.Addr) (string, error) {
+	if addr == nil {
+		return "", errors.New("health listener address is unavailable")
+	}
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return "", fmt.Errorf("parse health listener address: %w", err)
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" || host == "::" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port), nil
+}
+
+func probeServeHealthEndpoint(ctx context.Context, client *http.Client, endpoint string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s returned HTTP %d", endpoint, resp.StatusCode)
+	}
+	return nil
 }
 
 func shutdownHealthServer(server *http.Server) {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -49,6 +49,19 @@ const (
 	defaultHealthAddr       = ":8081"
 )
 
+var (
+	buildStoresForServe                  = buildStores
+	configuredWorkspaceLifecycleForServe = func(db *sql.DB, repoRoot, contractsRoot string, source semanticview.Source) serveWorkspaceLifecycle {
+		return configuredWorkspaceLifecycle(db, repoRoot, contractsRoot, source)
+	}
+)
+
+type serveWorkspaceLifecycle interface {
+	workspace.Lifecycle
+	runtimedestructivereset.ManagedContainerInventoryReader
+	runtimedestructivereset.ManagedContainerRuntime
+}
+
 type storeBundle struct {
 	Postgres          *store.PostgresStore
 	SQLDB             *sql.DB
@@ -124,7 +137,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	reporter.emit(2, "config_load", "ok", fmt.Sprintf("config=%s contracts=%s", filepath.Clean(resolvedConfigPath), filepath.Clean(resolvedContractsPath)))
-	stores, err := buildStores(ctx, opts.StoreMode, cfg)
+	stores, err := buildStoresForServe(ctx, opts.StoreMode, cfg)
 	if err != nil {
 		reporter.emit(3, "db_connection", "FAILED", err.Error())
 		log.Printf("init stores: %v", err)
@@ -161,7 +174,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("bundle match admission failed", "error", err)
 		return 3
 	}
-	workspaces := configuredWorkspaceLifecycle(stores.SQLDB, repo, contractsRoot, source)
+	workspaces := configuredWorkspaceLifecycleForServe(stores.SQLDB, repo, contractsRoot, source)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
 		return 1
@@ -277,7 +290,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("bind health server: %v", err)
 		return 1
 	}
-	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("health=%s routes=/healthz /readyz /v1/rpc /v1/ws", healthListener.Addr()))
 	go serveHealth(healthServer, healthListener)
 	defer shutdownHealthServer(healthServer)
 	logBootWarnings(bootReport)
@@ -286,6 +298,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("start runtime: %v", err)
 		return 1
 	}
+	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("health=%s routes=/healthz /readyz /v1/rpc /v1/ws", healthListener.Addr()))
 	ready.Store(true)
 	if err := waitForServeHealthEndpoints(ctx, healthListener.Addr()); err != nil {
 		reporter.emit(21, "health_endpoints_respond", "FAILED", err.Error())

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -89,6 +89,8 @@ type serveOptions struct {
 	SelfCheck            bool
 	RequireBundleMatch   bool
 	NoRequireBundleMatch bool
+	Verbose              bool
+	Output               io.Writer
 }
 
 func defaultServeOptions() serveOptions {
@@ -102,41 +104,53 @@ func defaultServeOptions() serveOptions {
 }
 
 func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
+	bootStartedAt := time.Now().UTC()
+	reporter := newServeBootReporter(opts.Verbose, opts.Output)
+	reporter.emit(1, "process_start", "ok", "")
 	resolvedConfigPath := resolvePath(repo, opts.ConfigPath)
 	resolvedContractsPath := resolveContractsPath(repo, opts.ContractsPath)
 	resolvedPlatformSpecPath := resolvePath(repo, opts.PlatformSpecPath)
 	if err := loadRepoDotEnv(repo); err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("load .env: %v", err)
 		return 1
 	}
 
 	cfg, err := loadRuntimeConfig(resolvedConfigPath)
 	if err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("load config: %v", err)
 		return 1
 	}
+	reporter.emit(2, "config_load", "ok", fmt.Sprintf("config=%s contracts=%s", filepath.Clean(resolvedConfigPath), filepath.Clean(resolvedContractsPath)))
 	stores, err := buildStores(ctx, opts.StoreMode, cfg)
 	if err != nil {
+		reporter.emit(3, "db_connection", "FAILED", err.Error())
 		log.Printf("init stores: %v", err)
 		return 1
 	}
+	reporter.emit(3, "db_connection", "ok", opts.StoreMode)
 	defer closeDB(stores.SQLDB)
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
+		reporter.emit(4, "bundle_load", "FAILED", err.Error())
 		log.Printf("resolve contracts: %v", err)
 		return 1
 	}
 	module, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPlatformSpecPath)
 	if err != nil {
+		reporter.emit(4, "bundle_load", "FAILED", err.Error())
 		log.Printf("load Swarm contracts: %v", err)
 		return 1
 	}
 	bootBundleIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
 	if err != nil {
+		reporter.emit(4, "bundle_load", "FAILED", err.Error())
 		log.Printf("compute boot bundle identity: %v", err)
 		return 1
 	}
 	source := semanticview.Wrap(bundle)
+	reporter.emit(4, "bundle_load", "ok", fmt.Sprintf("%s, %d agents, %d events", bootBundleIdentity.Fingerprint, len(source.AgentEntries()), len(source.ResolvedEventCatalog())))
 	stateStoreSummary, err := initializeStateStores(ctx, stores, bundle)
 	if err != nil {
 		slog.Error("initialize state stores", "error", err)
@@ -159,6 +173,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("ensure system workspaces", "error", err)
 		return 1
 	}
+	systemContainers := systemWorkspaceContainers(workspaces)
 	credentialStore, err := buildCredentialStore()
 	if err != nil {
 		slog.Error("configure credentials", "error", err)
@@ -185,6 +200,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
 		BundleFingerprint:  bootBundleIdentity.Fingerprint,
 		Credentials:        credentialStore,
+		BootStartedAt:      bootStartedAt,
+		BootProgress:       reporter.runtimeSink(),
+		SystemContainers:   systemContainers,
 	})
 	if err != nil {
 		log.Printf("init runtime: %v", err)
@@ -254,13 +272,16 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	healthServer := newHealthServer(opts.HealthAddr, &ready, rt.ToolGateway, apiV1Handler)
 	go serveHealth(healthServer)
 	defer shutdownHealthServer(healthServer)
-
-	logBootSkeleton(source, contractsRoot, resolvedPlatformSpecPath, bootReport, stateStoreSummary)
+	logBootWarnings(bootReport)
 	if err := rt.Start(ctx); err != nil {
+		reporter.emit(22, "ready", "FAILED", err.Error())
 		log.Printf("start runtime: %v", err)
 		return 1
 	}
+	reporter.emit(20, "http_servers_start", "ok", fmt.Sprintf("health=%s v1_rpc=/v1/rpc v1_ws=/v1/ws listener active", opts.HealthAddr))
 	ready.Store(true)
+	reporter.emit(21, "health_endpoints_respond", "ok", "/healthz /readyz /v1/rpc /v1/ws")
+	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	logReadySummary(source, contractsRoot, opts.HealthAddr)
 
 	<-ctx.Done()
@@ -1485,49 +1506,73 @@ func (m *swarmWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
 	return m.actionRegistry
 }
 
-func logBootSkeleton(source semanticview.Source, contractsRoot, platformSpecPath string, report runtimebootverify.Report, stateStoreSummary string) {
+type serveBootReporter struct {
+	enabled bool
+	out     io.Writer
+}
+
+func newServeBootReporter(enabled bool, out io.Writer) serveBootReporter {
+	if out == nil {
+		out = io.Discard
+	}
+	return serveBootReporter{enabled: enabled, out: out}
+}
+
+func (r serveBootReporter) runtimeSink() func(runtime.BootProgressEvent) {
+	if !r.enabled {
+		return nil
+	}
+	return func(evt runtime.BootProgressEvent) {
+		r.emit(evt.Step, evt.Name, evt.Status, evt.Detail)
+	}
+}
+
+func (r serveBootReporter) emit(step int, name, status, detail string) {
+	if !r.enabled || r.out == nil {
+		return
+	}
+	status = strings.TrimSpace(status)
+	if status == "" {
+		status = "ok"
+	}
+	detail = strings.TrimSpace(detail)
+	if detail != "" {
+		detail = "  (" + detail + ")"
+	}
+	fmt.Fprintf(r.out, "[%d/%d] %-34s %s%s\n", step, runtime.BootProgressTotalSteps, strings.TrimSpace(name), status, detail)
+}
+
+func serveBootRegistryDetail(source semanticview.Source) string {
+	availableToolNames := runtimetools.RuntimeAvailableToolNamesForSource(source)
+	return fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(availableToolNames))
+}
+
+func logBootWarnings(report runtimebootverify.Report) {
 	warningCounts := make(map[string]int, len(report.Findings))
 	for _, finding := range report.Warnings() {
 		warningCounts[strings.TrimSpace(finding.CheckID)]++
 	}
-	availableToolNames := runtimetools.RuntimeAvailableToolNamesForSource(source)
-	steps := []struct {
-		index int
-		name  string
-		note  string
-	}{
-		{1, "load_platform_spec", fmt.Sprintf("loaded %s", filepath.Clean(platformSpecPath))},
-		{2, "walk_flow_tree", fmt.Sprintf("discovered %d flow(s)", len(source.FlowSchemaEntries()))},
-		{3, "construct_paths", "constructed hierarchical contract paths from package tree"},
-		{4, "register_templates", fmt.Sprintf("registered %d template flow(s)", templateFlowCount(source))},
-		{5, "build_registries", fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(availableToolNames))},
-		{6, "resolve_subscriptions", "subscription resolution skeleton in place; full validation lands in CP4"},
-		{7, "validate_pins", fmt.Sprintf("validated flow pins and event wiring; warnings=%d", warningCounts["event_chain_integrity"]+warningCounts["event_consumer_exists"]+warningCounts["event_producer_exists"])},
-		{8, "validate_required_agents", "validated required_agents coverage and state-machine targets"},
-		{9, "validate_tools", fmt.Sprintf("validated tools and prompt coverage; warnings=%d", warningCounts["prompt_exists"]+warningCounts["tool_resolution"])},
-		{10, "validate_permissions", "validated platform permission requirements during boot verification"},
-		{11, "validate_platform_version", fmt.Sprintf("loaded platform spec version %s for workflow %s", strings.TrimSpace(source.PlatformSpec().Platform.Version), strings.TrimSpace(source.WorkflowVersion()))},
-		{12, "initialize_state_stores", fmt.Sprintf("%s (contracts=%s)", strings.TrimSpace(stateStoreSummary), contractsRoot)},
-		{13, "start_system_nodes", "delegated to runtime.Start()"},
-		{14, "start_agents", "delegated to runtime.Start()"},
-		{15, "ready", "health server transitions to ready after runtime start"},
-	}
-	for _, step := range steps {
-		slog.Info("swarm boot", "step", fmt.Sprintf("%02d", step.index), "name", step.name, "detail", step.note)
+	if len(warningCounts) > 0 {
+		slog.Info("swarm boot validation warning summary",
+			"event_wiring_warnings", warningCounts["event_chain_integrity"]+warningCounts["event_consumer_exists"]+warningCounts["event_producer_exists"],
+			"tool_warnings", warningCounts["prompt_exists"]+warningCounts["tool_resolution"],
+		)
 	}
 	for _, finding := range report.Warnings() {
 		slog.Warn("swarm boot validation warning", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
 	}
 }
 
-func templateFlowCount(source semanticview.Source) int {
-	count := 0
-	for _, flow := range source.FlowSchemaEntries() {
-		if strings.EqualFold(strings.TrimSpace(flow.Mode), "template") {
-			count++
-		}
+type systemWorkspaceContainerLister interface {
+	SystemWorkspaceContainers() []string
+}
+
+func systemWorkspaceContainers(lifecycle workspace.Lifecycle) []string {
+	lister, ok := lifecycle.(systemWorkspaceContainerLister)
+	if !ok || lister == nil {
+		return nil
 	}
-	return count
+	return lister.SystemWorkspaceContainers()
 }
 
 func newHealthServer(addr string, ready *atomic.Bool, toolGateway *runtimemcp.Gateway, apiV1Handler http.Handler) *http.Server {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2643,12 +2643,31 @@ func TestServeBootRegistryDetail_UsesRuntimeToolInventoryCount(t *testing.T) {
 		t.Fatal("runtime tool inventory unexpectedly empty")
 	}
 
-	out := serveBootRegistryDetail(source)
+	out := serveBootBundleLoadDetail("sha256:test", source)
+	if !strings.Contains(out, "sha256:test") {
+		t.Fatalf("boot progress detail missing fingerprint:\n%s", out)
+	}
 	if !strings.Contains(out, fmt.Sprintf("tools=%d", wantTools)) {
 		t.Fatalf("log output missing runtime tool count %d:\n%s", wantTools, out)
 	}
 	if strings.Contains(out, "tools=0") {
 		t.Fatalf("log output still reports zero tools:\n%s", out)
+	}
+}
+
+func TestWaitForServeHealthEndpointsProvesHealthAndReadyRoutes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz", "/readyz":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	if err := waitForServeHealthEndpoints(context.Background(), server.Listener.Addr()); err != nil {
+		t.Fatalf("waitForServeHealthEndpoints: %v", err)
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10,22 +10,28 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	"swarm/internal/runtime/semanticview"
+	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -2669,6 +2675,231 @@ func TestWaitForServeHealthEndpointsProvesHealthAndReadyRoutes(t *testing.T) {
 	if err := waitForServeHealthEndpoints(context.Background(), server.Listener.Addr()); err != nil {
 		t.Fatalf("waitForServeHealthEndpoints: %v", err)
 	}
+}
+
+func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
+	steps := loadServeBootProgressSequenceFromSpec(t)
+	if got, want := len(steps), runtimepkg.BootProgressTotalSteps; got != want {
+		t.Fatalf("serve boot progress spec step count = %d, want %d", got, want)
+	}
+
+	oldBuildStores := buildStoresForServe
+	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
+		if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+			return storeBundle{}, err
+		}
+		return storeBundle{
+			Postgres:          pg,
+			SQLDB:             pg.DB,
+			EventStore:        pg,
+			SessionRegistry:   sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
+			ConversationStore: pg,
+			ManagerStore:      pg,
+			ScheduleStore:     pg,
+			TurnStore:         pg,
+		}, nil
+	}
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	}
+	t.Cleanup(func() {
+		buildStoresForServe = oldBuildStores
+		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			HealthAddr:         "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+
+	rows := parseServeBootProgressRows(t, out.String())
+	if got, want := len(rows), len(steps); got != want {
+		t.Fatalf("serve boot progress rows = %d, want %d\noutput:\n%s", got, want, out.String())
+	}
+	for i, want := range steps {
+		got := rows[i]
+		if got.Step != want.Step || got.Total != runtimepkg.BootProgressTotalSteps || got.Name != want.Name {
+			t.Fatalf("row %d = step=%d total=%d name=%q, want step=%d total=%d name=%q\noutput:\n%s", i, got.Step, got.Total, got.Name, want.Step, runtimepkg.BootProgressTotalSteps, want.Name, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "health_endpoints_respond       ok  (/healthz /readyz /v1/rpc /v1/ws)") {
+		t.Fatalf("serve verbose output still claims unproven v1 endpoint response:\n%s", out.String())
+	}
+}
+
+type serveRuntimeWorkspaceStub struct {
+	stubWorkspaceLifecycle
+}
+
+func (serveRuntimeWorkspaceStub) ManagedResetContainerInventory(context.Context) ([]runtimedestructivereset.ContainerRef, error) {
+	return nil, nil
+}
+
+func (serveRuntimeWorkspaceStub) InspectManagedContainer(context.Context, string) (runtimedestructivereset.ManagedContainerInspection, error) {
+	return runtimedestructivereset.ManagedContainerInspection{}, nil
+}
+
+func (serveRuntimeWorkspaceStub) StopManagedContainer(context.Context, string) error {
+	return nil
+}
+
+type serveBootProgressSpecStep struct {
+	Step  int    `yaml:"step"`
+	Name  string `yaml:"name"`
+	Owner string `yaml:"owner"`
+}
+
+func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpecStep {
+	t.Helper()
+	var spec struct {
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					BootObservability struct {
+						BootProgressSequence struct {
+							TotalSteps int                         `yaml:"total_steps"`
+							Steps      []serveBootProgressSpecStep `yaml:"steps"`
+						} `yaml:"boot_progress_sequence"`
+					} `yaml:"boot_observability"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	sequence := spec.CLISpecification.CommandCatalog.Serve.BootObservability.BootProgressSequence
+	if sequence.TotalSteps != runtimepkg.BootProgressTotalSteps {
+		t.Fatalf("platform spec total_steps = %d, want %d", sequence.TotalSteps, runtimepkg.BootProgressTotalSteps)
+	}
+	for i, step := range sequence.Steps {
+		if step.Step != i+1 {
+			t.Fatalf("platform spec step index %d has step %d", i, step.Step)
+		}
+		if strings.TrimSpace(step.Name) == "" {
+			t.Fatalf("platform spec step %d missing name", step.Step)
+		}
+		if strings.TrimSpace(step.Owner) == "" {
+			t.Fatalf("platform spec step %d missing owner", step.Step)
+		}
+	}
+	return sequence.Steps
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func waitForServeReadyLine(t *testing.T, out *lockedBuffer, done <-chan int) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case code := <-done:
+			t.Fatalf("runServeRuntime exited before ready line with code %d\noutput:\n%s", code, out.String())
+		case <-deadline:
+			t.Fatalf("timed out waiting for serve ready line\noutput:\n%s", out.String())
+		case <-ticker.C:
+			if strings.Contains(out.String(), "[22/22]") {
+				return
+			}
+		}
+	}
+}
+
+type serveBootProgressRow struct {
+	Step  int
+	Total int
+	Name  string
+}
+
+func parseServeBootProgressRows(t *testing.T, output string) []serveBootProgressRow {
+	t.Helper()
+	rows := []serveBootProgressRow{}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "[") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			t.Fatalf("malformed serve boot progress line: %q", line)
+		}
+		parts := strings.Split(strings.Trim(fields[0], "[]"), "/")
+		if len(parts) != 2 {
+			t.Fatalf("malformed serve boot progress marker %q in line %q", fields[0], line)
+		}
+		step, err := strconv.Atoi(parts[0])
+		if err != nil {
+			t.Fatalf("parse step from %q: %v", fields[0], err)
+		}
+		total, err := strconv.Atoi(parts[1])
+		if err != nil {
+			t.Fatalf("parse total from %q: %v", fields[0], err)
+		}
+		rows = append(rows, serveBootProgressRow{Step: step, Total: total, Name: fields[1]})
+	}
+	return rows
+}
+
+func writeServeRuntimeTestConfig(t *testing.T) string {
+	t.Helper()
+	configText := strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"llm:",
+		"  runtime_mode: api",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(path, []byte(configText), 0o644); err != nil {
+		t.Fatalf("write serve runtime config: %v", err)
+	}
+	return path
 }
 
 func TestVerifyBundle_DoesNotWarnForFlowLocalEmittedEventsWithOwningFlowSchemas(t *testing.T) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6,12 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,7 +18,6 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
-	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -154,9 +151,47 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestCLI_ServeVerboseFlagConsumesServeOwner(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--verbose"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !captured.Verbose {
+		t.Fatalf("serve verbose = false, want true")
+	}
+	if captured.Output == nil {
+		t.Fatalf("serve output writer was not passed to serve owner")
+	}
+}
+
+func TestServeBootReporterEmitsNumberedProgressOnlyWhenVerbose(t *testing.T) {
+	var quiet bytes.Buffer
+	newServeBootReporter(false, &quiet).emit(1, "process_start", "ok", "")
+	if quiet.Len() != 0 {
+		t.Fatalf("quiet reporter output = %q, want empty", quiet.String())
+	}
+
+	var verbose bytes.Buffer
+	newServeBootReporter(true, &verbose).emit(1, "process_start", "ok", "contracts=contracts")
+	out := verbose.String()
+	for _, want := range []string{"[1/22]", "process_start", "ok", "contracts=contracts"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("verbose output missing %q:\n%s", want, out)
 		}
 	}
 }
@@ -2601,27 +2636,15 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 	}
 }
 
-func TestLogBootSkeleton_UsesRuntimeToolInventoryCount(t *testing.T) {
+func TestServeBootRegistryDetail_UsesRuntimeToolInventoryCount(t *testing.T) {
 	source := semanticview.Wrap(testWorkflowValidationBundle())
 	wantTools := len(runtimetools.RuntimeAvailableToolNamesForSource(source))
 	if wantTools == 0 {
 		t.Fatal("runtime tool inventory unexpectedly empty")
 	}
 
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	previous := slog.Default()
-	slog.SetDefault(logger)
-	defer slog.SetDefault(previous)
-
-	logBootSkeleton(source, "/tmp/contracts", "/tmp/platform-spec.yaml", runtimebootverify.Report{}, "state stores ready")
-
-	out := buf.String()
-	want := "name=build_registries"
-	if !strings.Contains(out, want) {
-		t.Fatalf("log output missing %q:\n%s", want, out)
-	}
-	if !strings.Contains(out, "tools="+strconv.Itoa(wantTools)) {
+	out := serveBootRegistryDetail(source)
+	if !strings.Contains(out, fmt.Sprintf("tools=%d", wantTools)) {
 		t.Fatalf("log output missing runtime tool count %d:\n%s", wantTools, out)
 	}
 	if strings.Contains(out, "tools=0") {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4643,7 +4643,10 @@ platform_events:
         static_agents_started: array<string>
         flow_required_agents_started: array<string>
         system_containers_started: array<string>
-        self_check_passed: boolean
+        self_check_required: boolean
+        self_check_passed: boolean (nullable)
+      notes:
+      - 'self_check_passed is nullable because platform.boot is the event verified by the post-publish self-check; the event MUST NOT claim a pass before that verification completes.'
       produced_by_type: platform
     platform.inbound_recorded:
       description: External event received and persisted. Emitted when an event enters the system from an external source
@@ -5365,7 +5368,7 @@ cli_specification:
         platform_boot_payload: >
           `platform.boot` carries the boot decision summary: boot timestamps/duration, bundle fingerprint,
           startup recovery decision, static and flow-required agent materialization lists, system container names,
-          and self-check status. CLI/dashboard/API readers consume this persisted event; they do not reconstruct boot
+          self-check-required state, and nullable self-check pass state. CLI/dashboard/API readers consume this persisted event; they do not reconstruct boot
           decisions from text logs.
       bundle_match_admission:
         default: require-bundle-match

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5365,6 +5365,75 @@ cli_specification:
           By default `swarm serve` remains quiet except for readiness and errors. With `--verbose` or `-v`, serve prints
           the numbered boot-progress sequence to stdout as the canonical serve/runtime boot phases complete. The CLI
           owns stdout rendering; runtime owns the boot-progress facts and the persisted `platform.boot` payload.
+        boot_progress_sequence:
+          total_steps: 22
+          steps:
+          - step: 1
+            name: process_start
+            owner: cmd/swarm
+          - step: 2
+            name: config_load
+            owner: cmd/swarm
+          - step: 3
+            name: db_connection
+            owner: cmd/swarm
+          - step: 4
+            name: bundle_load
+            owner: cmd/swarm
+          - step: 5
+            name: startup_ownership_lease
+            owner: internal/runtime
+          - step: 6
+            name: recovery_snapshot_inspection
+            owner: internal/runtime
+          - step: 7
+            name: recovery_decision
+            owner: internal/runtime
+          - step: 8
+            name: pipeline_maintenance
+            owner: internal/runtime
+          - step: 9
+            name: system_nodes_start
+            owner: internal/runtime
+          - step: 10
+            name: schedule_restoration
+            owner: internal/runtime
+          - step: 11
+            name: manager_recovery_if_enabled
+            owner: internal/runtime
+          - step: 12
+            name: outbox_sweeper
+            owner: internal/runtime
+          - step: 13
+            name: static_agents_bootstrap
+            owner: internal/runtime
+          - step: 14
+            name: flow_required_agents
+            owner: internal/runtime
+          - step: 15
+            name: workspace_validation_and_system_containers
+            owner: internal/runtime
+          - step: 16
+            name: mcp_tool_validation
+            owner: internal/runtime
+          - step: 17
+            name: manager_event_loop_start
+            owner: internal/runtime
+          - step: 18
+            name: boot_self_check_optional
+            owner: internal/runtime
+          - step: 19
+            name: platform_boot_event_published
+            owner: internal/runtime
+          - step: 20
+            name: http_listener_bind
+            owner: cmd/swarm
+          - step: 21
+            name: health_endpoints_respond
+            owner: cmd/swarm
+          - step: 22
+            name: ready
+            owner: cmd/swarm
         platform_boot_payload: >
           `platform.boot` carries the boot decision summary: boot timestamps/duration, bundle fingerprint,
           startup recovery decision, static and flow-required agent materialization lists, system container names,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4616,7 +4616,8 @@ platform_events:
         timestamp: string (ISO 8601)
       produced_by_type: platform
     platform.boot:
-      description: Platform boot completed successfully. Emitted after all validation passes and nodes/agents are started.
+      description: Platform boot completed successfully. Emitted after validation passes, runtime boot/recovery decisions are made,
+        nodes/agents are started, and the boot event is published before the runtime becomes ready.
       scope: global
       payload:
         flow_count: integer
@@ -4624,6 +4625,25 @@ platform_events:
         agent_count: integer
         event_count: integer
         timestamp: string (ISO 8601)
+        boot_started_at: string (ISO 8601)
+        boot_completed_at: string (ISO 8601)
+        duration_ms: integer
+        bundle_fingerprint: string
+        recovery_decision:
+          outcome: string (allowed | denied | degraded)
+          reason_code: string
+          recovery_on_startup: boolean
+          schedule_replay_count: integer
+          schedule_skip_count: integer
+          schedule_drop_count: integer
+          manager_replay_count: integer
+          manager_skip_count: integer
+          manager_drop_count: integer
+          error_text: string
+        static_agents_started: array<string>
+        flow_required_agents_started: array<string>
+        system_containers_started: array<string>
+        self_check_passed: boolean
       produced_by_type: platform
     platform.inbound_recorded:
       description: External event received and persisted. Emitted when an event enters the system from an external source
@@ -5333,6 +5353,20 @@ cli_specification:
       tier: must_have
       implementation_status: partial
       behavior: starts current runtime, process probes, /v1/rpc, /v1/ws, and MCP surfaces
+      boot_observability:
+        implemented_by: '#802'
+        flags:
+        - --verbose
+        - '-v'
+        rule: >
+          By default `swarm serve` remains quiet except for readiness and errors. With `--verbose` or `-v`, serve prints
+          the numbered boot-progress sequence to stdout as the canonical serve/runtime boot phases complete. The CLI
+          owns stdout rendering; runtime owns the boot-progress facts and the persisted `platform.boot` payload.
+        platform_boot_payload: >
+          `platform.boot` carries the boot decision summary: boot timestamps/duration, bundle fingerprint,
+          startup recovery decision, static and flow-required agent materialization lists, system container names,
+          and self-check status. CLI/dashboard/API readers consume this persisted event; they do not reconstruct boot
+          decisions from text logs.
       bundle_match_admission:
         default: require-bundle-match
         implemented_by: '#753/#754'
@@ -5344,7 +5378,8 @@ cli_specification:
           any active run has a non-NULL `runs.bundle_fingerprint` different from the boot bundle fingerprint. Legacy NULL fingerprints
           mean unknown bundle and do not block startup. `--no-require-bundle-match` disables this admission gate for operator-approved
           recovery/dev workflows.
-      remaining_tail: '#750 owns remaining serve/dev/boot/shutdown lifecycle behavior.'
+      remaining_tail: '#750 owns remaining serve/dev/shutdown lifecycle behavior: --abandon-active-runs, --shutdown-grace, --dev,
+        and dev entity-container shutdown cleanup are not implemented by #802.'
     run:
       command: swarm run [flags]
       tier: must_have

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -830,7 +830,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		StaticAgentsStarted:       staticAgentIDs,
 		FlowRequiredAgentsStarted: flowRequiredAgentIDs,
 		SystemContainersStarted:   rt.Options.SystemContainers,
-		SelfCheckPassed:           rt.Options.SelfCheck,
+		SelfCheckRequired:         rt.Options.SelfCheck,
 	})
 	if err != nil {
 		rt.emitBootProgress(19, "platform_boot_event_published", "FAILED", err.Error())
@@ -930,7 +930,7 @@ type bootCompletedReport struct {
 	StaticAgentsStarted       []string
 	FlowRequiredAgentsStarted []string
 	SystemContainersStarted   []string
-	SelfCheckPassed           bool
+	SelfCheckRequired         bool
 }
 
 func staticBootAgentIDs(source semanticview.Source) ([]string, error) {
@@ -1007,7 +1007,8 @@ func (rt *Runtime) publishBootCompleted(ctx context.Context, report bootComplete
 		"static_agents_started":        sortedNonEmptyStrings(report.StaticAgentsStarted),
 		"flow_required_agents_started": sortedNonEmptyStrings(report.FlowRequiredAgentsStarted),
 		"system_containers_started":    sortedNonEmptyStrings(report.SystemContainersStarted),
-		"self_check_passed":            report.SelfCheckPassed,
+		"self_check_required":          report.SelfCheckRequired,
+		"self_check_passed":            nil,
 	})
 	eventID := uuid.NewString()
 	evt := events.Event{

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -68,6 +68,20 @@ type RuntimeOptions struct {
 	WorkflowModule     runtimepipeline.WorkflowModule
 	LLMRuntime         llm.Runtime
 	Credentials        runtimecredentials.Store
+	BootStartedAt      time.Time
+	BootProgress       func(BootProgressEvent)
+	SystemContainers   []string
+}
+
+const BootProgressTotalSteps = 22
+
+type BootProgressEvent struct {
+	Step   int
+	Total  int
+	Name   string
+	Status string
+	Detail string
+	At     time.Time
 }
 
 type Runtime struct {
@@ -100,6 +114,20 @@ type Runtime struct {
 	Authority      runtimeauthority.Provider
 	EmitRegistry   *runtimetools.EmitRegistry
 	PromptResolver runtimecontracts.PromptResolver
+}
+
+func (rt *Runtime) emitBootProgress(step int, name, status, detail string) {
+	if rt == nil || rt.Options.BootProgress == nil {
+		return
+	}
+	rt.Options.BootProgress(BootProgressEvent{
+		Step:   step,
+		Total:  BootProgressTotalSteps,
+		Name:   strings.TrimSpace(name),
+		Status: strings.TrimSpace(status),
+		Detail: strings.TrimSpace(detail),
+		At:     time.Now().UTC(),
+	})
 }
 
 func (rt *Runtime) shutdownAdmissionClosed() bool {
@@ -549,6 +577,10 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	if rt == nil {
 		return fmt.Errorf("runtime is nil")
 	}
+	bootStartedAt := rt.Options.BootStartedAt
+	if bootStartedAt.IsZero() {
+		bootStartedAt = time.Now().UTC()
+	}
 	if rt.shutdownAdmissionClosed() {
 		return fmt.Errorf("runtime shutdown already started")
 	}
@@ -563,10 +595,14 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		var err error
 		lease, err = rt.Stores.StartupOwnership.AcquireRuntimeStartupOwnership(ctx, rt.ownerID)
 		if err != nil {
+			rt.emitBootProgress(5, "startup_ownership_lease", "FAILED", err.Error())
 			cancelStart()
 			rt.lifecycleMu.Unlock()
 			return err
 		}
+		rt.emitBootProgress(5, "startup_ownership_lease", "ok", "owner="+rt.ownerID)
+	} else {
+		rt.emitBootProgress(5, "startup_ownership_lease", "skipped", "startup ownership store unavailable")
 	}
 	rt.startCtx = startCtx
 	rt.cancelStart = cancelStart
@@ -583,6 +619,11 @@ func (rt *Runtime) Start(ctx context.Context) error {
 
 	startupRecoverySnapshot, err := rt.inspectStartupRecoverySnapshot(ctx)
 	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
+	if err != nil {
+		rt.emitBootProgress(6, "recovery_snapshot_inspection", "FAILED", err.Error())
+	} else {
+		rt.emitBootProgress(6, "recovery_snapshot_inspection", "ok", startupRecoverySnapshot.summary())
+	}
 	if err != nil && !startupRecoverySnapshot.RecoveryOnStartup {
 		return err
 	}
@@ -595,20 +636,29 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	if denyErr := startupRecoveryDecision.denialError(); denyErr != nil {
 		startupRecoveryDecision.ErrorText = denyErr.Error()
 		rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
+		rt.emitBootProgress(7, "recovery_decision", "FAILED", denyErr.Error())
 		return denyErr
 	}
+	rt.emitBootProgress(7, "recovery_decision", string(startupRecoveryDecision.Outcome), string(startupRecoveryDecision.ReasonCode))
 
 	if rt.Pipeline != nil {
 		go rt.Pipeline.RunMaintenance(startCtx)
+		rt.emitBootProgress(8, "pipeline_maintenance", "started", "")
+	} else {
+		rt.emitBootProgress(8, "pipeline_maintenance", "skipped", "pipeline unavailable")
 	}
+	systemNodeCount := 0
 	for _, node := range rt.SystemNodes {
 		if node != nil {
 			go node.Run(startCtx)
+			systemNodeCount++
 		}
 	}
+	rt.emitBootProgress(9, "system_nodes_start", "ok", fmt.Sprintf("%d nodes started", systemNodeCount))
 	if rt.Scheduler != nil && rt.Stores.ScheduleStore != nil {
 		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
 		if err != nil {
+			rt.emitBootProgress(10, "schedule_restoration", "FAILED", err.Error())
 			return fmt.Errorf("load schedules failed: %w", err)
 		}
 		startupRecoveryDecision.ScheduleRestoreAttempted = len(schedules) > 0
@@ -636,6 +686,9 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to restore %d active schedule(s)", startupRecoveryDecision.ScheduleDropCount)
 			}
 		}
+		rt.emitBootProgress(10, "schedule_restoration", "ok", fmt.Sprintf("%d schedules restored, %d skipped, %d dropped", startupRecoveryDecision.ScheduleReplayCount, startupRecoveryDecision.ScheduleSkipCount, startupRecoveryDecision.ScheduleDropCount))
+	} else {
+		rt.emitBootProgress(10, "schedule_restoration", "skipped", "scheduler or schedule store unavailable")
 	}
 	if rt.Config.Runtime.RecoveryOnStartup && rt.Manager != nil {
 		startupRecoveryDecision.ManagerRecoveryAttempted = true
@@ -700,42 +753,93 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				startupRecoveryDecision.ErrorText = fmt.Sprintf("failed to replay %d pending event(s) during startup recovery", startupRecoveryDecision.ManagerDropCount)
 			}
 		}
+		status := "ok"
+		if startupRecoveryDecision.Outcome == startupRecoveryOutcomeDegraded {
+			status = string(startupRecoveryDecision.Outcome)
+		}
+		rt.emitBootProgress(11, "manager_recovery_if_enabled", status, fmt.Sprintf("%d replayed, %d skipped, %d dropped", startupRecoveryDecision.ManagerReplayCount, startupRecoveryDecision.ManagerSkipCount, startupRecoveryDecision.ManagerDropCount))
+	} else {
+		rt.emitBootProgress(11, "manager_recovery_if_enabled", "skipped", "recovery_on_startup disabled or manager unavailable")
 	}
 	rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
 	if rt.Bus != nil {
 		rt.Bus.StartOutboxSweeper(startCtx, runtimebus.DefaultOutboxSweeperConfig())
+		rt.emitBootProgress(12, "outbox_sweeper", "started", "")
+	} else {
+		rt.emitBootProgress(12, "outbox_sweeper", "skipped", "event bus unavailable")
 	}
+	staticAgentIDs := []string{}
 	if rt.Manager != nil {
-		if err := rt.Manager.EnsureStaticAgents(ctx, rt.Options.WorkflowModule.SemanticSource()); err != nil {
+		staticAgentIDs, err = staticBootAgentIDs(rt.Options.WorkflowModule.SemanticSource())
+		if err != nil {
+			rt.emitBootProgress(13, "static_agents_bootstrap", "FAILED", err.Error())
 			return fmt.Errorf("bootstrap static agents: %w", err)
 		}
+		if err := rt.Manager.EnsureStaticAgents(ctx, rt.Options.WorkflowModule.SemanticSource()); err != nil {
+			rt.emitBootProgress(13, "static_agents_bootstrap", "FAILED", err.Error())
+			return fmt.Errorf("bootstrap static agents: %w", err)
+		}
+		rt.emitBootProgress(13, "static_agents_bootstrap", "ok", fmt.Sprintf("%d static agents", len(staticAgentIDs)))
+	} else {
+		rt.emitBootProgress(13, "static_agents_bootstrap", "skipped", "manager unavailable")
 	}
+	flowRequiredAgentIDs := []string{}
 	if rt.Manager != nil {
-		if err := rt.Manager.EnsureStaticFlowRequiredAgents(ctx, rt.Options.WorkflowModule.SemanticSource()); err != nil {
+		flowRequiredAgentIDs, err = staticFlowRequiredBootAgentIDs(rt.Options.WorkflowModule.SemanticSource())
+		if err != nil {
+			rt.emitBootProgress(14, "flow_required_agents", "FAILED", err.Error())
 			return fmt.Errorf("bootstrap static flow required agents: %w", err)
 		}
+		if err := rt.Manager.EnsureStaticFlowRequiredAgents(ctx, rt.Options.WorkflowModule.SemanticSource()); err != nil {
+			rt.emitBootProgress(14, "flow_required_agents", "FAILED", err.Error())
+			return fmt.Errorf("bootstrap static flow required agents: %w", err)
+		}
+		rt.emitBootProgress(14, "flow_required_agents", "ok", fmt.Sprintf("%d flow-required agents", len(flowRequiredAgentIDs)))
+	} else {
+		rt.emitBootProgress(14, "flow_required_agents", "skipped", "manager unavailable")
 	}
 	if err := validateClaudeManagedAgentWorkspaces(ctx, rt.Config, rt.Workspace, rt.Manager); err != nil {
+		rt.emitBootProgress(15, "workspace_validation_and_system_containers", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime workspace validation failed: %w", err)
 	}
+	rt.emitBootProgress(15, "workspace_validation_and_system_containers", "ok", fmt.Sprintf("%d system containers", len(rt.Options.SystemContainers)))
 	startupProbe, _ := rt.LLM.(llm.StartupVisibleToolSurfaceProber)
 	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
+		rt.emitBootProgress(16, "mcp_tool_validation", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)
 	}
+	rt.emitBootProgress(16, "mcp_tool_validation", "ok", "")
 	if rt.Manager != nil {
 		rt.Manager.Run(startCtx)
+		rt.emitBootProgress(17, "manager_event_loop_start", "ok", "")
+	} else {
+		rt.emitBootProgress(17, "manager_event_loop_start", "skipped", "manager unavailable")
 	}
 	if rt.Stores.SQLDB != nil && rt.Logger != nil {
 	}
 	var bootCheck <-chan events.Event
 	if rt.Options.SelfCheck && rt.Bus != nil {
 		bootCheck = rt.Bus.SubscribeInternal("bootstrap-self-check", events.EventType("platform.boot"))
+		rt.emitBootProgress(18, "boot_self_check_optional", "ok", "platform.boot self-check subscribed")
+	} else {
+		rt.emitBootProgress(18, "boot_self_check_optional", "skipped", "self-check disabled or event bus unavailable")
 	}
-	if err := rt.publishBootCompleted(context.Background()); err != nil {
+	bootEventID, err := rt.publishBootCompleted(context.Background(), bootCompletedReport{
+		StartedAt:                 bootStartedAt,
+		RecoveryDecision:          startupRecoveryDecision,
+		StaticAgentsStarted:       staticAgentIDs,
+		FlowRequiredAgentsStarted: flowRequiredAgentIDs,
+		SystemContainersStarted:   rt.Options.SystemContainers,
+		SelfCheckPassed:           rt.Options.SelfCheck,
+	})
+	if err != nil {
+		rt.emitBootProgress(19, "platform_boot_event_published", "FAILED", err.Error())
 		return fmt.Errorf("publish platform.boot: %w", err)
 	}
+	rt.emitBootProgress(19, "platform_boot_event_published", "ok", bootEventID)
 	if rt.Options.SelfCheck {
 		if err := rt.verifyBootPublished(bootCheck); err != nil {
+			rt.emitBootProgress(18, "boot_self_check_optional", "FAILED", err.Error())
 			return fmt.Errorf("self-check failed: %w", err)
 		}
 	}
@@ -820,9 +924,55 @@ func (rt *Runtime) Wait(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (rt *Runtime) publishBootCompleted(ctx context.Context) error {
+type bootCompletedReport struct {
+	StartedAt                 time.Time
+	RecoveryDecision          startupRecoveryDecisionReport
+	StaticAgentsStarted       []string
+	FlowRequiredAgentsStarted []string
+	SystemContainersStarted   []string
+	SelfCheckPassed           bool
+}
+
+func staticBootAgentIDs(source semanticview.Source) ([]string, error) {
+	records, err := runtimemanager.StaticAgentMaterializationRecords(source)
+	if err != nil {
+		return nil, err
+	}
+	return persistedBootAgentIDs(records), nil
+}
+
+func staticFlowRequiredBootAgentIDs(source semanticview.Source) ([]string, error) {
+	records, err := runtimemanager.StaticFlowRequiredAgentMaterializationRecords(source)
+	if err != nil {
+		return nil, err
+	}
+	return persistedBootAgentIDs(records), nil
+}
+
+func persistedBootAgentIDs(records []runtimemanager.PersistedAgent) []string {
+	out := make([]string, 0, len(records))
+	for _, rec := range records {
+		if id := strings.TrimSpace(rec.Config.ID); id != "" {
+			out = append(out, id)
+		}
+	}
+	return sortedNonEmptyStrings(out)
+}
+
+func sortedNonEmptyStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (rt *Runtime) publishBootCompleted(ctx context.Context, report bootCompletedReport) (string, error) {
 	if rt == nil || rt.Bus == nil {
-		return nil
+		return "", nil
 	}
 	t := events.EventType("platform.boot")
 	var flowCount, nodeCount, agentCount, eventCount int
@@ -834,21 +984,40 @@ func (rt *Runtime) publishBootCompleted(ctx context.Context) error {
 			eventCount = len(source.ResolvedEventCatalog())
 		}
 	}
+	completedAt := time.Now().UTC()
+	startedAt := report.StartedAt
+	if startedAt.IsZero() {
+		startedAt = completedAt
+	}
+	durationMS := completedAt.Sub(startedAt).Milliseconds()
+	if durationMS < 0 {
+		durationMS = 0
+	}
 	payload := mustJSON(map[string]any{
-		"flow_count":  flowCount,
-		"node_count":  nodeCount,
-		"agent_count": agentCount,
-		"event_count": eventCount,
-		"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+		"flow_count":                   flowCount,
+		"node_count":                   nodeCount,
+		"agent_count":                  agentCount,
+		"event_count":                  eventCount,
+		"timestamp":                    completedAt.Format(time.RFC3339Nano),
+		"boot_started_at":              startedAt.Format(time.RFC3339Nano),
+		"boot_completed_at":            completedAt.Format(time.RFC3339Nano),
+		"duration_ms":                  durationMS,
+		"bundle_fingerprint":           strings.TrimSpace(rt.Options.BundleFingerprint),
+		"recovery_decision":            report.RecoveryDecision.bootPayload(),
+		"static_agents_started":        sortedNonEmptyStrings(report.StaticAgentsStarted),
+		"flow_required_agents_started": sortedNonEmptyStrings(report.FlowRequiredAgentsStarted),
+		"system_containers_started":    sortedNonEmptyStrings(report.SystemContainersStarted),
+		"self_check_passed":            report.SelfCheckPassed,
 	})
+	eventID := uuid.NewString()
 	evt := events.Event{
-		ID:          uuid.NewString(),
+		ID:          eventID,
 		Type:        t,
 		SourceAgent: "runtime",
 		Payload:     payload,
 		CreatedAt:   time.Now(),
 	}
-	return rt.Bus.Publish(ctx, evt)
+	return eventID, rt.Bus.Publish(ctx, evt)
 }
 
 func (rt *Runtime) verifyBootPublished(ch <-chan events.Event) error {

--- a/internal/runtime/runtime_boot_selfcheck_test.go
+++ b/internal/runtime/runtime_boot_selfcheck_test.go
@@ -134,6 +134,7 @@ func TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary(t *testing.T
 		"static_agents_started",
 		"flow_required_agents_started",
 		"system_containers_started",
+		"self_check_required",
 		"self_check_passed",
 	} {
 		if _, ok := payload[key]; !ok {
@@ -150,7 +151,10 @@ func TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary(t *testing.T
 	if got := recovery["reason_code"]; got != "recovery_disabled_no_persisted_work" {
 		t.Fatalf("recovery reason = %#v", got)
 	}
-	if got := payload["self_check_passed"]; got != true {
+	if got := payload["self_check_required"]; got != true {
+		t.Fatalf("self_check_required = %#v", got)
+	}
+	if got := payload["self_check_passed"]; got != nil {
 		t.Fatalf("self_check_passed = %#v", got)
 	}
 	if !bootProgressContains(progress, 19, "platform_boot_event_published") {

--- a/internal/runtime/runtime_boot_selfcheck_test.go
+++ b/internal/runtime/runtime_boot_selfcheck_test.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
@@ -13,9 +15,15 @@ type bootSelfCheckDescriptorStore struct {
 	mu          sync.Mutex
 	descriptors []runtimebus.ActiveAgentDescriptor
 	deliveries  []string
+	events      []events.Event
 }
 
-func (*bootSelfCheckDescriptorStore) AppendEvent(context.Context, events.Event) error { return nil }
+func (s *bootSelfCheckDescriptorStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+	return nil
+}
 
 func (s *bootSelfCheckDescriptorStore) InsertEventDeliveries(_ context.Context, _ string, recipients []string) error {
 	s.mu.Lock()
@@ -38,6 +46,12 @@ func (s *bootSelfCheckDescriptorStore) persistedDeliveries() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.deliveries...)
+}
+
+func (s *bootSelfCheckDescriptorStore) appendedEvents() []events.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]events.Event(nil), s.events...)
 }
 
 func TestRuntimeStart_SelfCheckUsesInternalSubscriberVisibility(t *testing.T) {
@@ -66,4 +80,89 @@ func TestRuntimeStart_SelfCheckUsesInternalSubscriberVisibility(t *testing.T) {
 	if got := store.persistedDeliveries(); len(got) != 0 {
 		t.Fatalf("persisted deliveries = %#v, want none for bootstrap self-check", got)
 	}
+}
+
+func TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	store := &bootSelfCheckDescriptorStore{}
+	progress := []BootProgressEvent{}
+	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+		EventStore: store,
+	}, RuntimeOptions{
+		SelfCheck:         true,
+		WorkflowModule:    module,
+		LLMRuntime:        noopLLMRuntime{},
+		BundleFingerprint: "sha256:boot-test",
+		BootStartedAt:     time.Now().UTC().Add(-1500 * time.Millisecond),
+		SystemContainers:  []string{"swarm-system", "swarm-scaffold"},
+		BootProgress: func(evt BootProgressEvent) {
+			progress = append(progress, evt)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rt.Shutdown(); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	})
+
+	var boot events.Event
+	for _, evt := range store.appendedEvents() {
+		if evt.Type == events.EventType("platform.boot") {
+			boot = evt
+			break
+		}
+	}
+	if boot.ID == "" {
+		t.Fatalf("platform.boot event not appended: %#v", store.appendedEvents())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(boot.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal platform.boot payload: %v", err)
+	}
+	for _, key := range []string{
+		"boot_started_at",
+		"boot_completed_at",
+		"duration_ms",
+		"bundle_fingerprint",
+		"recovery_decision",
+		"static_agents_started",
+		"flow_required_agents_started",
+		"system_containers_started",
+		"self_check_passed",
+	} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("platform.boot payload missing %q: %#v", key, payload)
+		}
+	}
+	if got := payload["bundle_fingerprint"]; got != "sha256:boot-test" {
+		t.Fatalf("bundle_fingerprint = %#v", got)
+	}
+	recovery, ok := payload["recovery_decision"].(map[string]any)
+	if !ok {
+		t.Fatalf("recovery_decision = %#v", payload["recovery_decision"])
+	}
+	if got := recovery["reason_code"]; got != "recovery_disabled_no_persisted_work" {
+		t.Fatalf("recovery reason = %#v", got)
+	}
+	if got := payload["self_check_passed"]; got != true {
+		t.Fatalf("self_check_passed = %#v", got)
+	}
+	if !bootProgressContains(progress, 19, "platform_boot_event_published") {
+		t.Fatalf("boot progress missing platform boot publication: %#v", progress)
+	}
+}
+
+func bootProgressContains(events []BootProgressEvent, step int, name string) bool {
+	for _, evt := range events {
+		if evt.Step == step && evt.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/startup_recovery_diagnostics.go
+++ b/internal/runtime/startup_recovery_diagnostics.go
@@ -82,6 +82,17 @@ func (s startupRecoverySnapshot) Detail() map[string]any {
 	return detail
 }
 
+func (s startupRecoverySnapshot) summary() string {
+	if !s.InspectionComplete {
+		return "inspection incomplete"
+	}
+	classes := s.WorkClasses()
+	if len(classes) == 0 {
+		return "no recovery state"
+	}
+	return strings.Join(classes, ", ")
+}
+
 type startupRecoveryDecisionReport struct {
 	Snapshot startupRecoverySnapshot
 
@@ -182,6 +193,21 @@ func (r startupRecoveryDecisionReport) detail() map[string]any {
 		detail["manager_reset_error"] = resetErr
 	}
 	return detail
+}
+
+func (r startupRecoveryDecisionReport) bootPayload() map[string]any {
+	return map[string]any{
+		"outcome":               string(r.Outcome),
+		"reason_code":           string(r.ReasonCode),
+		"recovery_on_startup":   r.Snapshot.RecoveryOnStartup,
+		"schedule_replay_count": r.ScheduleReplayCount,
+		"schedule_skip_count":   r.ScheduleSkipCount,
+		"schedule_drop_count":   r.ScheduleDropCount,
+		"manager_replay_count":  r.ManagerReplayCount,
+		"manager_skip_count":    r.ManagerSkipCount,
+		"manager_drop_count":    r.ManagerDropCount,
+		"error_text":            strings.TrimSpace(r.ErrorText),
+	}
 }
 
 func (rt *Runtime) inspectStartupRecoverySnapshot(ctx context.Context) (startupRecoverySnapshot, error) {

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -171,6 +171,21 @@ func (m *DockerManager) EnsureSystemWorkspaces(ctx context.Context) error {
 	return nil
 }
 
+func (m *DockerManager) SystemWorkspaceContainers() []string {
+	if m == nil {
+		return nil
+	}
+	out := []string{}
+	if name := strings.TrimSpace(m.cfg.ScaffoldContainer); name != "" {
+		out = append(out, name)
+	}
+	if name := strings.TrimSpace(m.cfg.SystemContainer); name != "" {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (m *DockerManager) ValidateSource(ctx context.Context, source semanticview.Source) error {
 	if m == nil {
 		return fmt.Errorf("workspace manager is required")

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -370,6 +371,20 @@ func TestEnsureSystemWorkspaces_CreatesScaffoldAndSystemContainers(t *testing.T)
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("EnsureSystemWorkspaces calls missing %q: %s", expected, joined)
 		}
+	}
+}
+
+func TestSystemWorkspaceContainersUsesConfiguredNames(t *testing.T) {
+	manager := NewDockerManager(nil)
+	manager.SetConfigForTest(DockerConfig{
+		ScaffoldContainer: "custom-scaffold",
+		SystemContainer:   "custom-system",
+	})
+
+	got := manager.SystemWorkspaceContainers()
+	want := []string{"custom-scaffold", "custom-system"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SystemWorkspaceContainers = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #802
Part of #750
Related to #735

## Summary

Implements the approved first slice for `runtime.cli.serve.boot_observability_contract`:

- promotes `swarm serve --verbose/-v` and the extended `platform.boot` payload into authoritative `platform-spec.yaml`
- wires `swarm serve --verbose/-v` through the serve owner and prints numbered boot progress from the real startup path
- extends `platform.boot` with boot timestamps/duration, bundle fingerprint, startup recovery decision, agent materialization lists, system container names, and self-check status
- reconciles the old boot skeleton by removing it as an always-on proof surface and keeping default serve output quiet

## Governing refs/context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
  - `platform_events.catalog.platform.boot`
  - `cli_specification.command_catalog.serve`
- #802 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/802#issuecomment-4472674462
- #802 Independent Gate Review: https://github.com/yazzaoui/Swarm/issues/802#issuecomment-4472704295

## Semantic migration

New canonical owners:

- Serve CLI stdout boot progress: `cmd/swarm` serve owner via `serveOptions.Verbose` and `serveBootReporter`.
- Runtime boot facts and persisted boot decision payload: `internal/runtime.Runtime.Start` and `publishBootCompleted`.
- System workspace container names: `internal/runtime/workspace.DockerManager.SystemWorkspaceContainers` consumed by serve boot payload.

Old path now invalid/non-authoritative:

- `logBootSkeleton` as always-on `slog` boot progress proof. It no longer acts as a separate boot-progress interpreter.
- Minimal `platform.boot` payload as the final boot event contract.

Production paths checked for surviving old behavior:

- `cmd/swarm/run_command.go` and `cmd/swarm/run_command_test.go` unchanged.
- `swarm run` follow, exit-code, and local foreground behavior untouched.
- `--abandon-active-runs`, `--shutdown-grace`, `--dev`, and dev entity-container cleanup remain unimplemented split siblings under #750.

Migration completeness:

- Complete for the approved #802 first-slice boot-observability class.
- #750 remains open for serve dev/shutdown lifecycle tails.

## Proof

- `go test ./cmd/swarm ./internal/runtime ./internal/runtime/workspace -run 'TestCLI_ServeOwnsRuntimeStartupFlags|TestCLI_ServeVerboseFlagConsumesServeOwner|TestServeBootReporterEmitsNumberedProgressOnlyWhenVerbose|TestServeBootRegistryDetail_UsesRuntimeToolInventoryCount|TestBuiltinToolParityInvariant_SupportedSurfacesShareRuntimeToolTruth_V2|TestRuntimeStart_SelfCheckUsesInternalSubscriberVisibility|TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary|TestSystemWorkspaceContainersUsesConfiguredNames' -count=1`
- `go test ./cmd/swarm ./internal/runtime ./internal/runtime/workspace -count=1`
- `go test ./internal/runtime/... -count=1`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`

## Conflict boundary

No edits to `cmd/swarm/run_command.go` or `cmd/swarm/run_command_test.go`. This PR preserves the `runServeRuntime` startup owner consumed by #743/#799 and does not change run follow, exit-code, or local foreground behavior.
