### PR TITLE
[agent-b][issue #803] Implement swarm trace CLI

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -70,6 +70,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newCompletionCommand(),
 		newRunsCommand(opts),
 		newStatusCommand(opts),
+		newTraceCommand(opts),
 		newHealthCommand(opts),
 		newInvestigateCommand(opts),
 		newMailboxCommand(opts),

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -21,8 +21,7 @@ type diagnosticRunListOptions struct {
 
 type diagnosticTraceOptions struct {
 	apiOptions rootCommandOptions
-	limit      int
-	cursor     string
+	follow     bool
 }
 
 type diagnosticRunOptions struct {
@@ -157,6 +156,24 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
+func newTraceCommand(opts rootCommandOptions) *cobra.Command {
+	traceOpts := diagnosticTraceOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "trace [run-id]",
+		Short: "Print or follow a run trace through v1 API owners.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runID := ""
+			if len(args) == 1 {
+				runID = args[0]
+			}
+			return runDiagnosticTraceCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), traceOpts, runID)
+		},
+	}
+	cmd.Flags().BoolVar(&traceOpts.follow, "follow", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	return cmd
+}
+
 func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "investigate",
@@ -205,25 +222,15 @@ func newInvestigateRunCommand(opts rootCommandOptions) *cobra.Command {
 }
 
 func newInvestigateTraceCommand(opts rootCommandOptions) *cobra.Command {
-	traceOpts := diagnosticTraceOptions{apiOptions: opts}
-	cmd := &cobra.Command{
-		Use:   "trace [run-id]",
-		Short: "Print a snapshot run trace through v1 RPC.",
-		Args:  cobra.MaximumNArgs(1),
+	return &cobra.Command{
+		Use:                "trace [run-id]",
+		Short:              "Retired legacy command; use swarm trace.",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed("limit") && traceOpts.limit == 0 {
-				return fmt.Errorf("--limit must be between 1 and 2000")
-			}
-			runID := ""
-			if len(args) == 1 {
-				runID = args[0]
-			}
-			return runDiagnosticTraceCommand(cmd.Context(), cmd.OutOrStdout(), traceOpts, runID)
+			writeInvestigateTraceRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
 		},
 	}
-	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Optional page size, 1-2000")
-	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Optional pagination cursor")
-	return cmd
 }
 
 func newInvestigateHealthCommand() *cobra.Command {
@@ -253,6 +260,15 @@ func writeInvestigateRunRetiredMessage(w io.Writer) {
 	fmt.Fprintln(w, "ERROR: `swarm investigate run` was retired in CLI v2.")
 	fmt.Fprintln(w, "  Use `swarm status`.")
 	fmt.Fprintln(w, "  Use `swarm status --no-diagnose` for the header-only run read.")
+}
+
+func writeInvestigateTraceRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm investigate trace` was retired in CLI v2.")
+	fmt.Fprintln(w, "  Use `swarm trace`.")
+	fmt.Fprintln(w, "  Use `swarm trace --follow` for live trace streaming.")
 }
 
 func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptions) {
@@ -287,7 +303,7 @@ func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnostic
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		runID, err = activePreferredDiagnosticRunID(ctx, client)
+		runID, err = resolveActivePreferredRunID(ctx, client)
 		if err != nil {
 			return err
 		}
@@ -314,23 +330,22 @@ func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnostic
 	return nil
 }
 
-func runDiagnosticTraceCommand(ctx context.Context, out io.Writer, opts diagnosticTraceOptions, runID string) error {
-	params, err := opts.params()
-	if err != nil {
-		return err
-	}
+func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
 		return err
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		runID, err = activePreferredDiagnosticRunID(ctx, client)
+		runID, err = resolveActivePreferredRunID(ctx, client)
 		if err != nil {
 			return err
 		}
 	}
-	params["run_id"] = runID
+	if opts.follow {
+		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID)
+	}
+	params := map[string]any{"run_id": runID}
 	var result diagnosticRunTraceResult
 	if err := client.call(ctx, "run.trace", params, &result); err != nil {
 		return err
@@ -340,6 +355,55 @@ func runDiagnosticTraceCommand(ctx context.Context, out io.Writer, opts diagnost
 	}
 	writeDiagnosticRunTrace(out, runID, result)
 	return nil
+}
+
+func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string) error {
+	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintln(errOut, err)
+		}
+		return commandExitError{code: runCommandErrorExitCode(err)}
+	}
+	sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, nil)
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintln(errOut, err)
+		}
+		return commandExitError{code: runCommandErrorExitCode(err)}
+	}
+	defer sub.close()
+	for {
+		select {
+		case <-ctx.Done():
+			if errOut != nil {
+				fmt.Fprintln(errOut, "detached from run trace")
+			}
+			return commandExitError{code: 130}
+		case row, ok := <-sub.rows:
+			if !ok {
+				select {
+				case err := <-sub.errs:
+					if err != nil {
+						if errOut != nil {
+							fmt.Fprintln(errOut, err)
+						}
+						return commandExitError{code: runCommandErrorExitCode(err)}
+					}
+				default:
+				}
+				return nil
+			}
+			writeRunCommandTraceRow(out, row)
+		case err := <-sub.errs:
+			if err != nil {
+				if errOut != nil {
+					fmt.Fprintln(errOut, err)
+				}
+				return commandExitError{code: runCommandErrorExitCode(err)}
+			}
+		}
+	}
 }
 
 func runDiagnosticHealthCommand(ctx context.Context, out io.Writer, opts rootCommandOptions) error {
@@ -369,7 +433,7 @@ func fetchDiagnosticRunList(ctx context.Context, client *cliAPIClient, params ma
 	return result, nil
 }
 
-func activePreferredDiagnosticRunID(ctx context.Context, client *cliAPIClient) (string, error) {
+func resolveActivePreferredRunID(ctx context.Context, client *cliAPIClient) (string, error) {
 	for _, status := range []string{"running", "paused"} {
 		result, err := fetchDiagnosticRunList(ctx, client, map[string]any{"status": status, "limit": 1})
 		if err != nil {
@@ -414,20 +478,6 @@ func (o diagnosticRunListOptions) params() (map[string]any, error) {
 			return nil, err
 		}
 		params["until"] = until
-	}
-	return params, nil
-}
-
-func (o diagnosticTraceOptions) params() (map[string]any, error) {
-	params := map[string]any{}
-	if cursor := strings.TrimSpace(o.cursor); cursor != "" {
-		params["cursor"] = cursor
-	}
-	if o.limit != 0 {
-		if o.limit < 1 || o.limit > 2000 {
-			return nil, fmt.Errorf("--limit must be between 1 and 2000")
-		}
-		params["limit"] = o.limit
 	}
 	return params, nil
 }

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -138,7 +138,7 @@ func TestStatusUsesDiagnoseAndRunGet(t *testing.T) {
 	}
 }
 
-func TestStatusAndInvestigateTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
+func TestStatusAndTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -164,8 +164,8 @@ func TestStatusAndInvestigateTraceResolveOmittedRunThroughActivePreference(t *te
 			wantOutput: "Run: paused-run",
 		},
 		{
-			name:       "legacy trace uses terminal fallback",
-			args:       []string{"investigate", "trace"},
+			name:       "trace uses terminal fallback",
+			args:       []string{"trace"},
 			lists:      [][]any{{}, {}, {validDiagnosticRunHeaderWithStatus("terminal-run", "completed")}},
 			owner:      "run.trace",
 			selected:   "terminal-run",
@@ -268,13 +268,47 @@ func TestInvestigateRunIsRetiredWithoutRequest(t *testing.T) {
 	}
 }
 
-func TestInvestigateTraceUsesRunTraceSnapshot(t *testing.T) {
+func TestInvestigateTraceIsRetiredWithoutRequest(t *testing.T) {
+	for _, args := range [][]string{
+		{"investigate", "trace"},
+		{"investigate", "trace", "run-1"},
+		{"investigate", "trace", "run-1", "--limit", "5"},
+		{"investigate", "trace", "--cursor", "trace-cur"},
+		{"investigate", "trace", "run-1", "--follow"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, "ERROR: `swarm investigate trace` was retired in CLI v2.") || !strings.Contains(got, "Use `swarm trace`.") {
+				t.Fatalf("stderr = %q, want retired migration message", got)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "run.trace" {
 			t.Fatalf("method = %q, want run.trace", req.Method)
 		}
-		wantParams := map[string]any{"run_id": "run-1", "limit": float64(5), "cursor": "trace-cur"}
+		wantParams := map[string]any{"run_id": "run-1"}
 		if !reflect.DeepEqual(req.Params, wantParams) {
 			t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
 		}
@@ -295,7 +329,7 @@ func TestInvestigateTraceUsesRunTraceSnapshot(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"investigate", "trace", "run-1", "--limit", "5", "--cursor", "trace-cur"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -309,6 +343,131 @@ func TestInvestigateTraceUsesRunTraceSnapshot(t *testing.T) {
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+		wsRows:           []map[string]any{validRunCommandTraceRow("evt-follow")},
+		wsCloseAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-follow", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, nil)
+	assertRunCommandTraceSubscription(t, wsRequests, "run-follow", false)
+	if !strings.Contains(stdout.String(), "trace event_id=evt-follow") {
+		t.Fatalf("stdout = %q, want trace row", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, callIndex int) map[string]any {
+			if req.Method != "run.list" {
+				t.Fatalf("method[%d] = %q, want run.list", callIndex, req.Method)
+			}
+			if !reflect.DeepEqual(req.Params, map[string]any{"status": "running", "limit": float64(1)}) {
+				t.Fatalf("params = %#v, want running active preference", req.Params)
+			}
+			return map[string]any{"runs": []any{validDiagnosticRunHeaderWithStatus("active-run", "running")}}
+		},
+		wsRows:           []map[string]any{validRunCommandTraceRow("evt-active")},
+		wsCloseAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, []string{"run.list"})
+	assertRunCommandTraceSubscription(t, wsRequests, "active-run", false)
+	if !strings.Contains(stdout.String(), "trace event_id=evt-active") {
+		t.Fatalf("stdout = %q, want trace row", stdout.String())
+	}
+}
+
+func TestTraceFollowCtrlCDetachesWithoutRunStop(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	wsSubscribed := make(chan struct{})
+	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			if req.Method == "run.stop" {
+				t.Fatal("read-only trace Ctrl-C must not call run.stop")
+			}
+			t.Fatalf("unexpected RPC method = %q", req.Method)
+			return nil
+		},
+		wsSubscribed: wsSubscribed,
+	})
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-wsSubscribed
+		cancel()
+	}()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "run-active", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 130 {
+		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, nil)
+	assertRunCommandTraceSubscription(t, wsRequests, "run-active", false)
+	if !strings.Contains(stderr.String(), "detached from run trace") {
+		t.Fatalf("stderr = %q, want detach message", stderr.String())
+	}
+}
+
+func TestTraceFollowMalformedWebSocketFailuresExitThree(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, tc := range []struct {
+		name       string
+		serverOpts runCommandServerOptions
+		wantStderr string
+	}{
+		{
+			name: "subscription response missing id",
+			serverOpts: runCommandServerOptions{
+				wsSubscriptionResult: map[string]any{},
+			},
+			wantStderr: "subscription_id is required",
+		},
+		{
+			name: "notification missing event id",
+			serverOpts: runCommandServerOptions{
+				wsRows:           []map[string]any{{"event_name": "scan.requested", "event_created_at": "2026-05-13T10:00:01Z"}},
+				wsCloseAfterRows: true,
+			},
+			wantStderr: "event_id is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server, calls, wsRequests := newRunCommandServer(t, tc.serverOpts)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-bad-ws", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			assertRunCommandMethods(t, calls, nil)
+			assertRunCommandTraceSubscription(t, wsRequests, "run-bad-ws", false)
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
+			}
+		})
 	}
 }
 
@@ -390,8 +549,8 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 	}{
 		{name: "runs invalid limit", args: []string{"runs", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
 		{name: "runs invalid since", args: []string{"runs", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
-		{name: "trace invalid limit", args: []string{"investigate", "trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
-		{name: "trace follow unsupported", args: []string{"investigate", "trace", "run-1", "--follow"}, wantStderr: "unknown flag"},
+		{name: "trace extra arg", args: []string{"trace", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
+		{name: "trace unknown legacy flag", args: []string{"trace", "run-1", "--limit", "5"}, wantStderr: "unknown flag"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -415,24 +574,32 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 }
 
 func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "")
-	var calls atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls.Add(1)
-		writeJSONRPCResult(t, w, "unexpected", map[string]any{"runs": []any{}})
-	}))
-	defer server.Close()
+	for _, args := range [][]string{
+		{"runs"},
+		{"trace", "run-1"},
+		{"trace", "run-1", "--follow"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "")
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{"runs": []any{}})
+			}))
+			defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
-		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
-	}
-	if calls.Load() != 0 {
-		t.Fatalf("server calls = %d, want 0", calls.Load())
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0", calls.Load())
+			}
+		})
 	}
 }
 
@@ -440,7 +607,7 @@ func TestOmittedRunResolverFailsClosedWhenNoRunsExist(t *testing.T) {
 	for _, args := range [][]string{
 		{"status"},
 		{"status", "--no-diagnose"},
-		{"investigate", "trace"},
+		{"trace"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -621,7 +788,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 		{
 			name: "trace missing trace",
-			args: []string{"investigate", "trace", "run-1"},
+			args: []string{"trace", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -553,6 +553,7 @@ type runCommandServerOptions struct {
 	wsRows               []map[string]any
 	wsSubscribed         chan struct{}
 	wsSubscriptionResult map[string]any
+	wsCloseAfterRows     bool
 }
 
 func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.Server, *[]jsonRPCRequest, *[]jsonRPCRequest) {
@@ -626,6 +627,10 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 				}); err != nil {
 					return
 				}
+			}
+			if opts.wsCloseAfterRows {
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
 			}
 			<-r.Context().Done()
 		default:

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5436,7 +5436,7 @@ cli_specification:
     trace:
       command: swarm trace [<run-id>] [--follow]
       tier: must_have
-      implementation_status: absent_v2_top_level_snapshot_exists_under_legacy_investigate
+      implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run trace rendering over API-owned RunTraceRow facts only; no CLI reconstruction from tables.
@@ -5601,7 +5601,7 @@ cli_specification:
     investigate:
       command: swarm investigate *
       status: retired_legacy_v1_topology
-      current_code_state: partially_implemented_legacy_namespace; health and run fail closed after #797/#800; runs/trace remain implemented legacy until sibling repairs
+      current_code_state: partially_implemented_legacy_namespace; health, run, and trace fail closed after #797/#800/#803; the runs subcommand remains implemented legacy until sibling repair
       v2_replacements:
         swarm investigate runs: swarm runs
         swarm investigate run: swarm status


### PR DESCRIPTION
Closes #803
Part of #735

## Summary
- Add top-level `swarm trace [<run-id>] [--follow]`.
- Snapshot mode consumes `/v1/rpc run.trace`; follow mode consumes `/v1/ws run.subscribe_trace`.
- Reuse the shared API-only active-run resolver from #800/#801 for omitted run IDs.
- Retire/fail-close `swarm investigate trace` before any API or WS call.
- Update authoritative CLI catalog status in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.trace`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.retired_namespaces.investigate`.
- v1 API/OpenRPC owners: `run.list`, `run.trace`, `run.subscribe_trace`.
- #803 approved pre-audit gate: top-level trace first slice under #735.

## Semantic migration
- New canonical CLI owner: top-level `swarm trace` command in the Cobra tree.
- API owners: `/v1/rpc run.trace`, `/v1/ws run.subscribe_trace`, and `/v1/rpc run.list` for omitted-run resolution.
- Old path now invalid: successful `swarm investigate trace`; it now exits 2 with migration text and performs no API/WS call.
- Production paths checked for surviving old behavior: command routing, omitted-run resolver use, RPC/WS trace calls, legacy namespace retirement, legacy endpoint/token/static bypass grep.
- Migration completeness: complete for the chosen #803 trace CLI class. Broader #735 siblings remain tracked separately.

## Proof run
- `go test ./cmd/swarm -run 'TestTrace|TestInvestigateTrace|TestStatus|TestRunCommand|TestDiagnostics' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run 'TestRegistryMethodNamesMatchGeneratedOpenRPC|TestHandlerWebSocketRunSubscribeTrace|TestOperatorRunTrace' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `rg -n 'internal/(store|runtime)|database/sql|EventBus|LoadRunDebugTracePage|LoadRunDebugReport|ResolveLatestRunDebugRunID|ProjectRunOperationalStatus|SWARM_OPERATOR_AUTH_TOKEN|SWARM_BUILDER_AUTH_TOKEN|/api/rpc|/api/ws|"/rpc"|"/ws"|/api/' cmd/swarm/cli.go cmd/swarm/diagnostics.go cmd/swarm/run_command.go` returned no matches.
