### PR TITLE
[agent-b][issue #806] Retire investigate namespace

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -177,10 +177,11 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "investigate",
-		Short: "Inspect runtime state through v1 RPC read owners.",
+		Short: "Retired legacy namespace; use swarm runs/status/trace/health.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
+			writeInvestigateRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
 		},
 	}
 	cmd.AddCommand(
@@ -193,20 +194,15 @@ func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 }
 
 func newInvestigateRunsCommand(opts rootCommandOptions) *cobra.Command {
-	runOpts := diagnosticRunListOptions{apiOptions: opts}
-	cmd := &cobra.Command{
-		Use:   "runs",
-		Short: "List runs through the same v1 RPC path as swarm runs.",
-		Args:  cobra.NoArgs,
+	return &cobra.Command{
+		Use:                "runs",
+		Short:              "Retired legacy command; use swarm runs.",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
-				return fmt.Errorf("--limit must be between 1 and 500")
-			}
-			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), runOpts)
+			writeInvestigateRunsRetiredMessage(cmd.ErrOrStderr())
+			return commandExitError{code: 2}
 		},
 	}
-	bindDiagnosticRunListFlags(cmd, &runOpts)
-	return cmd
 }
 
 func newInvestigateRunCommand(opts rootCommandOptions) *cobra.Command {
@@ -243,6 +239,25 @@ func newInvestigateHealthCommand() *cobra.Command {
 			return commandExitError{code: 2}
 		},
 	}
+}
+
+func writeInvestigateRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm investigate` was retired in CLI v2.")
+	fmt.Fprintln(w, "  Use `swarm runs` to list runs.")
+	fmt.Fprintln(w, "  Use `swarm status [run-id]` to diagnose a run.")
+	fmt.Fprintln(w, "  Use `swarm trace [run-id] [--follow]` for run traces.")
+	fmt.Fprintln(w, "  Use `swarm health` for runtime health.")
+}
+
+func writeInvestigateRunsRetiredMessage(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, "ERROR: `swarm investigate runs` was retired in CLI v2.")
+	fmt.Fprintln(w, "  Use `swarm runs`.")
 }
 
 func writeInvestigateHealthRetiredMessage(w io.Writer) {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -12,60 +12,104 @@ import (
 	"testing"
 )
 
-func TestRunsAndInvestigateRunsUseRunListV1RPC(t *testing.T) {
+func TestRunsUseRunListV1RPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+		if req.Method != "run.list" {
+			t.Fatalf("method = %q, want run.list", req.Method)
+		}
+		return map[string]any{
+			"runs":        []any{validDiagnosticRunHeader("run-1")},
+			"next_cursor": "next-1",
+		}
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", "--status", "RUNNING", "--limit", "2", "--cursor", "cur-1", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T11:00:00Z"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*requests))
+	}
+	wantParams := map[string]any{
+		"status": "running",
+		"limit":  float64(2),
+		"cursor": "cur-1",
+		"since":  "2026-05-13T10:00:00Z",
+		"until":  "2026-05-13T11:00:00Z",
+	}
+	if !reflect.DeepEqual((*requests)[0].Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", (*requests)[0].Params, wantParams)
+	}
+	for _, want := range []string{"RUN ID", "run-1", "running", "scan.requested", "next_cursor=next-1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestInvestigateNamespaceIsRetiredWithoutRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		args       []string
-		wantParams map[string]any
+		wantOutput []string
 	}{
 		{
-			name: "swarm runs",
-			args: []string{"runs", "--status", "RUNNING", "--limit", "2", "--cursor", "cur-1", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T11:00:00Z"},
-			wantParams: map[string]any{
-				"status": "running",
-				"limit":  float64(2),
-				"cursor": "cur-1",
-				"since":  "2026-05-13T10:00:00Z",
-				"until":  "2026-05-13T11:00:00Z",
+			name: "bare investigate",
+			args: []string{"investigate"},
+			wantOutput: []string{
+				"ERROR: `swarm investigate` was retired in CLI v2.",
+				"Use `swarm runs`",
+				"Use `swarm status [run-id]`",
+				"Use `swarm trace [run-id] [--follow]`",
+				"Use `swarm health`",
 			},
 		},
 		{
-			name:       "swarm investigate runs",
-			args:       []string{"investigate", "runs", "--limit", "1"},
-			wantParams: map[string]any{"limit": float64(1)},
+			name: "investigate runs",
+			args: []string{"investigate", "runs"},
+			wantOutput: []string{
+				"ERROR: `swarm investigate runs` was retired in CLI v2.",
+				"Use `swarm runs`.",
+			},
+		},
+		{
+			name: "investigate runs legacy flags",
+			args: []string{"investigate", "runs", "--status", "running", "--limit", "1", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T11:00:00Z"},
+			wantOutput: []string{
+				"ERROR: `swarm investigate runs` was retired in CLI v2.",
+				"Use `swarm runs`.",
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
-			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
-				if req.Method != "run.list" {
-					t.Fatalf("method = %q, want run.list", req.Method)
-				}
-				return map[string]any{
-					"runs":        []any{validDiagnosticRunHeader("run-1")},
-					"next_cursor": "next-1",
-				}
-			})
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+			}))
 			defer server.Close()
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 0 {
-				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
-			if len(*requests) != 1 {
-				t.Fatalf("requests = %d, want 1", len(*requests))
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
 			}
-			if !reflect.DeepEqual((*requests)[0].Params, tc.wantParams) {
-				t.Fatalf("params = %#v, want %#v", (*requests)[0].Params, tc.wantParams)
-			}
-			for _, want := range []string{"RUN ID", "run-1", "running", "scan.requested", "next_cursor=next-1"} {
-				if !strings.Contains(stdout.String(), want) {
-					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
 				}
 			}
-			if strings.TrimSpace(stderr.String()) != "" {
-				t.Fatalf("stderr = %q, want empty", stderr.String())
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
 			}
 		})
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5601,7 +5601,7 @@ cli_specification:
     investigate:
       command: swarm investigate *
       status: retired_legacy_v1_topology
-      current_code_state: partially_implemented_legacy_namespace; health, run, and trace fail closed after #797/#800/#803; the runs subcommand remains implemented legacy until sibling repair
+      current_code_state: fully_fail_closed_after_806; bare namespace and runs/run/trace/health subcommands exit 2 with migration guidance before API calls
       v2_replacements:
         swarm investigate runs: swarm runs
         swarm investigate run: swarm status
@@ -5645,6 +5645,7 @@ cli_specification:
     - swarm verify
     - swarm runs
     - swarm status
+    - swarm trace
     - swarm health
     - swarm mailbox list
     - swarm mailbox view
@@ -5652,14 +5653,14 @@ cli_specification:
     - swarm mailbox reject
     - swarm mailbox defer
     - swarm control nuke
-    implemented_legacy_or_wrong_namespace:
-    - swarm investigate runs
-    - swarm investigate trace
+    implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
+    - swarm investigate
+    - swarm investigate runs
     - swarm investigate health
     - swarm investigate run
+    - swarm investigate trace
     remaining_must_have_not_implemented:
-    - swarm trace
     - swarm version --server
     remaining_should_have_not_implemented:
     - swarm control pause|continue|stop


### PR DESCRIPTION
Closes #806
Part of #735

## Summary
- Fail-close bare `swarm investigate` with CLI v2 migration guidance.
- Fail-close `swarm investigate runs` before any API call, including legacy flags.
- Preserve no-call retirement for `swarm investigate run|trace|health`.
- Keep top-level `swarm runs|status|trace|health` behavior unchanged.
- Repair `platform-spec.yaml` conformance state so the only remaining must-have #735 tail is `swarm version --server`.

## Governing refs
- #806 approved pre-audit gate: remaining `swarm investigate` namespace retirement.
- #735 CLI v2 parent tracker.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.retired_namespaces.investigate`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` command catalog and parent-tail matrix.

## Semantic migration
- New canonical owner for run list discovery remains top-level `swarm runs` over `/v1/rpc run.list`.
- New canonical owners for diagnosis/trace/health remain top-level `swarm status`, `swarm trace`, and `swarm health`.
- Old producer/reader path now invalid: bare `swarm investigate` and `swarm investigate runs` as successful CLI surfaces.
- Checked surviving old behavior: all `swarm investigate` production command paths now fail closed before API/WS calls; top-level commands remain unchanged.
- Migration is complete for the retired `swarm investigate` namespace class.

## Proof run
- `go test ./cmd/swarm -run 'Investigate|Runs|Status|Trace|Health|Diagnostics' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `git diff --check`
- Retired namespace block static grep for API/client/internal/runtime/store/EventBus/legacy endpoint/token bypasses returned no matches.
