### PR TITLE
[agent-b][issue #809] Implement swarm version --server

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -66,7 +66,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newServeCommand(ctx, repo, opts.runServe),
 		newRunCommand(repo, opts),
 		newVerifyCommand(ctx, repo),
-		newVersionCommand(),
+		newVersionCommand(opts),
 		newCompletionCommand(),
 		newRunsCommand(opts),
 		newStatusCommand(opts),
@@ -134,18 +134,55 @@ func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 	}
 }
 
-func newVersionCommand() *cobra.Command {
-	return &cobra.Command{
+type versionCommandOptions struct {
+	apiOptions rootCommandOptions
+	server     bool
+}
+
+func newVersionCommand(opts rootCommandOptions) *cobra.Command {
+	versionOpts := versionCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print local Swarm binary version information.",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(cmd.OutOrStdout(), "Swarm %s\n", binaryVersion)
-			fmt.Fprintf(cmd.OutOrStdout(), "Commit: %s\n", binaryCommit)
-			fmt.Fprintf(cmd.OutOrStdout(), "Built: %s\n", binaryDate)
-			fmt.Fprintf(cmd.OutOrStdout(), "Go: %s %s/%s\n", goruntime.Version(), goruntime.GOOS, goruntime.GOARCH)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), versionOpts)
 		},
 	}
+	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
+	return cmd
+}
+
+func runVersionCommand(ctx context.Context, out io.Writer, opts versionCommandOptions) error {
+	if !opts.server {
+		writeLocalVersion(out)
+		return nil
+	}
+	result, err := fetchDiagnosticHealthCheck(ctx, opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	writeLocalVersion(out)
+	writeVersionServerIdentity(out, result)
+	return nil
+}
+
+func writeLocalVersion(out io.Writer) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Swarm %s\n", binaryVersion)
+	fmt.Fprintf(out, "Commit: %s\n", binaryCommit)
+	fmt.Fprintf(out, "Built: %s\n", binaryDate)
+	fmt.Fprintf(out, "Go: %s %s/%s\n", goruntime.Version(), goruntime.GOOS, goruntime.GOARCH)
+}
+
+func writeVersionServerIdentity(out io.Writer, result diagnosticHealthCheckResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintln(out, "Server:")
+	writeDiagnosticHealth(out, result)
 }
 
 func newCompletionCommand() *cobra.Command {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -422,19 +422,27 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 }
 
 func runDiagnosticHealthCommand(ctx context.Context, out io.Writer, opts rootCommandOptions) error {
-	client, err := newCLIAPIClient(opts)
+	result, err := fetchDiagnosticHealthCheck(ctx, opts)
 	if err != nil {
-		return err
-	}
-	var result diagnosticHealthCheckResult
-	if err := client.call(ctx, "health.check", map[string]any{}, &result); err != nil {
-		return err
-	}
-	if err := validateDiagnosticHealthCheck(result); err != nil {
 		return err
 	}
 	writeDiagnosticHealth(out, result)
 	return nil
+}
+
+func fetchDiagnosticHealthCheck(ctx context.Context, opts rootCommandOptions) (diagnosticHealthCheckResult, error) {
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return diagnosticHealthCheckResult{}, err
+	}
+	var result diagnosticHealthCheckResult
+	if err := client.call(ctx, "health.check", map[string]any{}, &result); err != nil {
+		return diagnosticHealthCheckResult{}, err
+	}
+	if err := validateDiagnosticHealthCheck(result); err != nil {
+		return diagnosticHealthCheckResult{}, err
+	}
+	return result, nil
 }
 
 func fetchDiagnosticRunList(ctx context.Context, client *cliAPIClient, params map[string]any) (diagnosticRunListResult, error) {

--- a/cmd/swarm/version_command_test.go
+++ b/cmd/swarm/version_command_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestVersionLocalDoesNotRequireTokenOrRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+	for _, want := range []string{"Swarm dev", "Commit: unknown", "Built: unknown", "Go:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "Server:") {
+		t.Fatalf("local version output unexpectedly included server section:\n%s", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestVersionServerUsesHealthCheck(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validVersionHealthResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "health.check" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/health.check", captured.JSONRPC, captured.Method)
+	}
+	if len(captured.Params) != 0 {
+		t.Fatalf("params = %#v, want empty", captured.Params)
+	}
+	for _, want := range []string{
+		"Swarm dev",
+		"Commit: unknown",
+		"Built: unknown",
+		"Go:",
+		"Server:",
+		"alive=true ready=false db_ok=true runtime_ok=false",
+		"bundle fingerprint=sha256:server workflow_name=workflow workflow_version=v1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestVersionServerRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validVersionHealthResult())
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "extra arg", args: []string{"version", "extra"}, wantStderr: "unknown command"},
+		{name: "server extra arg", args: []string{"version", "--server", "extra"}, wantStderr: "unknown command"},
+		{name: "unknown flag", args: []string{"version", "--bogus"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if calls.Load() != before {
+				t.Fatalf("server calls changed from %d to %d, want no request", before, calls.Load())
+			}
+		})
+	}
+}
+
+func TestVersionServerRequiresTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validVersionHealthResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "json rpc error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				w.Header().Set("content-type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      req.ID,
+					"error": map[string]any{
+						"code":    -32000,
+						"message": "unauthorized",
+						"data":    map[string]any{"code": "UNAUTHORIZED"},
+					},
+				})
+			},
+			wantStderr: "UNAUTHORIZED: unauthorized",
+		},
+		{
+			name: "malformed envelope",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				w.Header().Set("content-type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "1.0", "id": req.ID, "result": validVersionHealthResult()})
+			},
+			wantStderr: "malformed JSON-RPC response",
+		},
+		{
+			name: "malformed health result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validVersionHealthResult()
+				result["bundle"] = map[string]any{
+					"fingerprint":    "sha256:server",
+					"workflow_name":  "workflow",
+					"workflow_extra": "ignored",
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantStderr: "bundle.workflow_version is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestVersionServerFailsClosedOnTransportError(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to closed server")
+	}))
+	opts := testRootCommandOptions(server)
+	server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, opts)
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "v1 RPC request failed") {
+		t.Fatalf("stderr = %q, want transport failure", stderr.String())
+	}
+}
+
+func validVersionHealthResult() map[string]any {
+	return map[string]any{
+		"alive":      true,
+		"ready":      false,
+		"db_ok":      true,
+		"runtime_ok": false,
+		"bundle": map[string]any{
+			"fingerprint":      "sha256:server",
+			"workflow_name":    "workflow",
+			"workflow_version": "v1",
+		},
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5347,10 +5347,28 @@ cli_specification:
     version:
       command: swarm version [--server]
       tier: must_have
-      implementation_status: partial
+      implementation_status: implemented
       local_owner: local binary metadata
-      server_owner: /v1/rpc health.check or a future promoted server-identity owner
-      behavior: '`swarm version` prints local binary identity. `--server` remains an API-consuming tail until a child promotes exact server identity rendering.'
+      server_owner: /v1/rpc health.check
+      behavior: '`swarm version` prints local binary identity and performs no API call. `swarm version --server` first queries `/v1/rpc health.check`, then prints the same local binary identity followed by a `Server:` section containing v1 server bundle/runtime identity from health.check.'
+      output_contract:
+        local:
+        - Swarm <binary-version>
+        - 'Commit: <binary-commit>'
+        - 'Built: <binary-build-date>'
+        - 'Go: <go-version> <goos>/<goarch>'
+        server_flag:
+          source: /v1/rpc health.check
+          rendering:
+          - local output block first
+          - 'Server:'
+          - alive=<bool> ready=<bool> db_ok=<bool> runtime_ok=<bool>
+          - bundle fingerprint=<fingerprint> workflow_name=<workflow-name-or-dash> workflow_version=<workflow-version-or-dash>
+          forbidden_claims:
+          - remote server binary version
+          - remote server commit
+          - remote server build date
+          - server-local bundle path
     serve:
       command: swarm serve [flags]
       tier: must_have
@@ -5746,7 +5764,8 @@ cli_specification:
     - swarm
     - swarm help
     - swarm completion
-    - swarm version (local only)
+    - swarm version
+    - swarm version --server
     - swarm serve (partial)
     - swarm run
     - swarm verify
@@ -5767,8 +5786,7 @@ cli_specification:
     - swarm investigate health
     - swarm investigate run
     - swarm investigate trace
-    remaining_must_have_not_implemented:
-    - swarm version --server
+    remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
     - swarm control pause|continue|stop
     - swarm agents list / agent view / agent restart / agent replay / agent directive


### PR DESCRIPTION
## Summary

Closes #809.
Part of #735.

Implements the approved final #735 must-have child: `swarm version --server` as an API-consuming command over `/v1/rpc health.check`.

## Governing Refs / Gate

- #809 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/809#issuecomment-4473478826
- #809 independent gate: https://github.com/yazzaoui/Swarm/issues/809#issuecomment-4473524661
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.version`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.methods.health.check`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `deferred_namespaces.runtime_identity`
- generated OpenRPC `health.check`, `HealthCheckResult`, and `BundleIdentity`

## Semantic Migration

- New canonical consumer: `swarm version --server` consumes `/v1/rpc health.check` through the shared CLI API client.
- Canonical owner after change: local `swarm version` remains local binary metadata; server identity is v1 server bundle/runtime identity from `health.check` only.
- Old invalid paths: remote binary build metadata claims, direct runtime/store/DB reads, direct local bundle/contract inference for server identity, legacy `/api`, `/rpc`, `/ws`, and legacy Builder/operator token fallback.
- Production paths checked for surviving old behavior: `cmd/swarm` version command path, shared health.check client path, spec CLI catalog/tail, and grep proof over the new version command code.
- Migration complete for the #809 chosen class. If future work needs remote binary/deployment identity, it must promote the deferred `runtime.identity` owner first.

## Proof

- `go test ./cmd/swarm -run 'TestCLI|TestVersion|TestHealth' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- grep proof: `git grep -nE 'BootBundleIdentity|store\.|sql\.|EventBus|/api|/rpc|/ws|BUILDER|OPERATOR' -- cmd/swarm/cli.go cmd/swarm/version_command_test.go || true` only reports the allowed `/v1/rpc health.check` help text.
