### PR TITLE
[agent-a][issue #808] Implement serve active-run abandon quiescence

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -115,6 +115,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs belong to a different non-NULL bundle fingerprint")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs belong to a different bundle fingerprint")
+	cmd.Flags().BoolVar(&opts.AbandonActiveRuns, "abandon-active-runs", opts.AbandonActiveRuns, "Cancel active runs and quiesce recoverable work before startup recovery")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Emit the serve boot sequence to stdout as each phase completes")
 	return cmd
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -103,6 +103,7 @@ type serveOptions struct {
 	SelfCheck            bool
 	RequireBundleMatch   bool
 	NoRequireBundleMatch bool
+	AbandonActiveRuns    bool
 	Verbose              bool
 	Output               io.Writer
 }
@@ -169,6 +170,18 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	if err != nil {
 		slog.Error("initialize state stores", "error", err)
 		return 1
+	}
+	if opts.AbandonActiveRuns {
+		if stores.Postgres == nil {
+			slog.Error("abandon active runs failed", "error", "postgres store is required")
+			return 3
+		}
+		result, err := stores.Postgres.ApplyServeAbandonActiveRunQuiescence(ctx, time.Now().UTC())
+		if err != nil {
+			slog.Error("abandon active runs failed", "error", err)
+			return 3
+		}
+		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
 	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, bootBundleIdentity.Fingerprint, opts.RequireBundleMatch); err != nil {
 		slog.Error("bundle match admission failed", "error", err)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -30,6 +30,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -157,7 +158,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -182,6 +183,24 @@ func TestCLI_ServeVerboseFlagConsumesServeOwner(t *testing.T) {
 	}
 	if captured.Output == nil {
 		t.Fatalf("serve output writer was not passed to serve owner")
+	}
+}
+
+func TestCLI_ServeAbandonActiveRunsFlagConsumesServeOwner(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--abandon-active-runs"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !captured.AbandonActiveRuns {
+		t.Fatalf("serve abandon active runs = false, want true")
 	}
 }
 
@@ -2685,21 +2704,25 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 
 	oldBuildStores := buildStoresForServe
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	_, db, _ := testutil.StartPostgres(t)
-	pg := &store.PostgresStore{DB: db}
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	runtimePG, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
 	buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
-		if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
 		return storeBundle{
-			Postgres:          pg,
-			SQLDB:             pg.DB,
-			EventStore:        pg,
-			SessionRegistry:   sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore: pg,
-			ManagerStore:      pg,
-			ScheduleStore:     pg,
-			TurnStore:         pg,
+			Postgres:          runtimePG,
+			SQLDB:             runtimePG.DB,
+			EventStore:        runtimePG,
+			SessionRegistry:   sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
+			ConversationStore: runtimePG,
+			ManagerStore:      runtimePG,
+			ScheduleStore:     runtimePG,
+			TurnStore:         runtimePG,
 		}, nil
 	}
 	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
@@ -2746,6 +2769,136 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "health_endpoints_respond       ok  (/healthz /readyz /v1/rpc /v1/ws)") {
 		t.Fatalf("serve verbose output still claims unproven v1 endpoint response:\n%s", out.String())
+	}
+}
+
+func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *testing.T) {
+	oldBuildStores := buildStoresForServe
+	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	runtimePG, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
+		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
+			return storeBundle{}, err
+		}
+		return storeBundle{
+			Postgres:          runtimePG,
+			SQLDB:             runtimePG.DB,
+			EventStore:        runtimePG,
+			SessionRegistry:   sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
+			ConversationStore: runtimePG,
+			ManagerStore:      runtimePG,
+			ScheduleStore:     runtimePG,
+			TurnStore:         runtimePG,
+		}, nil
+	}
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	}
+	t.Cleanup(func() {
+		buildStoresForServe = oldBuildStores
+		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
+	})
+
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	activeSessionID := uuid.NewString()
+	mismatchFingerprint := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', $2, now())
+	`, runID, mismatchFingerprint); err != nil {
+		t.Fatalf("seed active mismatched run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'serve.abandon.test', 'global', '{}'::jsonb, 'test', 'agent', now()
+		)
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed active delivery event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-a', 'in_progress', $3::uuid, 'agent_processing', now()
+		)
+	`, runID, eventID, activeSessionID); err != nil {
+		t.Fatalf("seed active delivery: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			HealthAddr:         "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			AbandonActiveRuns:  true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+
+	var runStatus, controlStatus, reason, controlledBy string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT r.status, rc.control_status, COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, '')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = $1::uuid
+	`, runID).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("load run/control state: %v", err)
+	}
+	if runStatus != "cancelled" || controlStatus != "stopped" || reason != runtimerunquiescence.ServeAbandonReasonCode || controlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("run/control = %s/%s/%s/%s, want cancelled/stopped/%s/%s", runStatus, controlStatus, reason, controlledBy, runtimerunquiescence.ServeAbandonReasonCode, runtimerunquiescence.ServeAbandonControlledBy)
+	}
+
+	var deliveryStatus, deliveryReason string
+	var deliveryActiveSession sql.NullString
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT status, COALESCE(reason_code, ''), active_session_id::text
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-a'
+	`, eventID).Scan(&deliveryStatus, &deliveryReason, &deliveryActiveSession); err != nil {
+		t.Fatalf("load delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != runtimerunquiescence.ServeAbandonReasonCode || deliveryActiveSession.Valid {
+		t.Fatalf("delivery = %s/%s active=%v, want serve abandon dead_letter", deliveryStatus, deliveryReason, deliveryActiveSession.Valid)
+	}
+	for _, subscriberID := range []string{"agent-a", "pipeline"} {
+		var outcome, receiptReason string
+		if err := db.QueryRowContext(context.Background(), `
+			SELECT outcome, COALESCE(reason_code, '')
+			FROM event_receipts
+			WHERE event_id = $1::uuid
+			  AND subscriber_id = $2
+		`, eventID, subscriberID).Scan(&outcome, &receiptReason); err != nil {
+			t.Fatalf("load receipt %s: %v", subscriberID, err)
+		}
+		if outcome != "dead_letter" || receiptReason != runtimerunquiescence.ServeAbandonReasonCode {
+			t.Fatalf("receipt %s = %s/%s, want serve abandon dead_letter", subscriberID, outcome, receiptReason)
+		}
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5468,8 +5468,36 @@ cli_specification:
           any active run has a non-NULL `runs.bundle_fingerprint` different from the boot bundle fingerprint. Legacy NULL fingerprints
           mean unknown bundle and do not block startup. `--no-require-bundle-match` disables this admission gate for operator-approved
           recovery/dev workflows.
-      remaining_tail: '#750 owns remaining serve/dev/shutdown lifecycle behavior: --abandon-active-runs, --shutdown-grace, --dev,
-        and dev entity-container shutdown cleanup are not implemented by #802.'
+      active_run_abandon_quiescence:
+        implemented_by: '#808'
+        flag: --abandon-active-runs
+        owner: internal/runtime/runquiescence plus PostgresStore active-run quiescence owner, consumed by cmd/swarm serve
+        ordering: >
+          `swarm serve --abandon-active-runs` applies after platform schema/state-store initialization and before bundle-match
+          admission, startup recovery, runtime start, API readiness, or late delivery recovery can reclaim work. Failure to apply
+          the quiescence owner is a serve startup failure; serve MUST NOT continue with partial abandon state.
+        active_run_scope: >
+          The owner selects all active source runs with `runs.status` in `running` or `paused`. Each selected run is terminalized
+          as `runs.status=cancelled`, with `run_control_state.control_status=stopped`, `reason=server_restart_abandon`, and
+          `controlled_by=swarm.serve.abandon_active_runs`.
+        delivery_scope: >
+          For those selected runs, same-run agent/node deliveries in `pending`, `in_progress`, or retryable `failed` state are
+          terminalized as `dead_letter` with `reason_code=server_restart_abandon`; `active_session_id` is cleared. Retryable failed
+          means the delivery is still eligible for normal runtime retry under the delivery retry policy. Delivered, exhausted,
+          unrelated, or terminal-run deliveries remain untouched.
+        receipt_scope: >
+          The owner writes matching agent/node event receipts and platform pipeline receipts with `outcome=dead_letter` and
+          `reason_code=server_restart_abandon` so missing-pipeline-receipt recovery cannot resurrect abandoned work.
+        late_writer_rule: >
+          EventBus, AgentManager, node pipeline, and pipeline-receipt writers MUST treat `server_restart_abandon` as a terminal
+          active-run quiescence reason. They MUST NOT overwrite the delivery/receipt reason, reclaim the delivery, or requeue
+          missing pipeline work after the owner has applied.
+        destructive_reset_separation: >
+          Destructive reset/runtime.nuke consumes the same active-run quiescence owner with `runtime_nuke_cancelled` reasons and
+          must retain its existing run-scoped cleanup and managed-container deletion semantics. `--abandon-active-runs` does not
+          delete source rows, truncate tables, stop managed entity containers, or reuse nuke-specific reason codes.
+      remaining_tail: '#750 owns remaining serve/dev/shutdown lifecycle behavior: --shutdown-grace, --dev,
+        and dev entity-container shutdown cleanup are not implemented by #808.'
     run:
       command: swarm run [flags]
       tier: must_have

--- a/internal/runtime/destructivereset/contracts.go
+++ b/internal/runtime/destructivereset/contracts.go
@@ -13,8 +13,8 @@ func DefaultDownstreamContracts() []DownstreamContract {
 		{
 			ID:          ContractRunDeliveryQuiescence,
 			Status:      "implemented_internal_owner",
-			Owner:       "internal/runtime/destructivereset Quiescer and PostgresStore.ApplyDestructiveResetQuiescence",
-			Description: "Stop active runs and cancel pending/in-progress deliveries with nuke-specific reasons before destructive reset cleanup can apply.",
+			Owner:       "internal/runtime/runquiescence and PostgresStore active-run quiescence owner, consumed by internal/runtime/destructivereset",
+			Description: "Stop active runs and cancel pending/in-progress deliveries with operation-specific reasons before destructive reset cleanup or serve restart recovery can apply.",
 		},
 		{
 			ID:          ContractRunScopedTruncation,

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -27,8 +27,8 @@ type deliveryProgressWriter interface {
 	MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error
 }
 
-type destructiveResetDeliveryQuiescenceReader interface {
-	DestructiveResetDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error)
+type activeRunDeliveryQuiescenceReader interface {
+	ActiveRunDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (string, bool, error)
 }
 
 func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt events.Event) error {
@@ -105,15 +105,15 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 			})
 		}
 	}
-	if am.destructiveResetDeliveryQuiesced(ctx, evt.ID, agent.ID()) {
+	if reason, ok := am.activeRunDeliveryQuiesced(ctx, evt.ID, agent.ID()); ok {
 		record.Outcome = startupManagerReplayOutcomeSkipped
-		record.ReasonCode = "runtime_nuke_cancelled"
+		record.ReasonCode = reason
 		return eventProcessResult{record: record}
 	}
 	out, err := agent.OnEvent(ctx, evt)
-	if am.destructiveResetDeliveryQuiesced(ctx, evt.ID, agent.ID()) {
+	if reason, ok := am.activeRunDeliveryQuiesced(ctx, evt.ID, agent.ID()); ok {
 		record.Outcome = startupManagerReplayOutcomeSkipped
-		record.ReasonCode = "runtime_nuke_cancelled"
+		record.ReasonCode = reason
 		return eventProcessResult{record: record}
 	}
 	if err != nil {
@@ -173,29 +173,29 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 	return eventProcessResult{record: record}
 }
 
-func (am *AgentManager) destructiveResetDeliveryQuiesced(ctx context.Context, eventID, agentID string) bool {
-	reader, ok := am.store.(destructiveResetDeliveryQuiescenceReader)
+func (am *AgentManager) activeRunDeliveryQuiesced(ctx context.Context, eventID, agentID string) (startupManagerReplayReasonCode, bool) {
+	reader, ok := am.store.(activeRunDeliveryQuiescenceReader)
 	if !ok || reader == nil {
-		return false
+		return "", false
 	}
 	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
-		return false
+		return "", false
 	}
-	ok, err := reader.DestructiveResetDeliveryQuiesced(ctx, eventID, "agent", agentID)
+	reason, ok, err := reader.ActiveRunDeliveryQuiesced(ctx, eventID, "agent", agentID)
 	if err != nil {
 		if am.bus != nil {
 			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 				Level:     "error",
 				Component: "agent-manager",
-				Action:    "destructive_reset_quiescence_check_failed",
+				Action:    "active_run_quiescence_check_failed",
 				EventID:   strings.TrimSpace(eventID),
 				AgentID:   strings.TrimSpace(agentID),
 				Error:     strings.TrimSpace(err.Error()),
 			})
 		}
-		return true
+		return "active_run_quiescence_check_failed", true
 	}
-	return ok
+	return startupManagerReplayReasonCode(strings.TrimSpace(reason)), ok
 }
 
 func (am *AgentManager) shouldInterceptDirective(agentID string, evt events.Event) bool {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -379,9 +379,13 @@ func (s *deliveryLifecycleStoreStub) MarkEventDeliveryInProgress(_ context.Conte
 	return nil
 }
 
-func (s *deliveryLifecycleStoreStub) DestructiveResetDeliveryQuiesced(context.Context, string, string, string) (bool, error) {
+func (s *deliveryLifecycleStoreStub) ActiveRunDeliveryQuiesced(context.Context, string, string, string) (string, bool, error) {
 	s.quiescenceChecks++
-	return s.quiescedAfterChecks > 0 && s.quiescenceChecks >= s.quiescedAfterChecks, nil
+	ok := s.quiescedAfterChecks > 0 && s.quiescenceChecks >= s.quiescedAfterChecks
+	if !ok {
+		return "", false, nil
+	}
+	return "runtime_nuke_cancelled", true, nil
 }
 
 func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -14,6 +14,7 @@ import (
 	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimerterr "swarm/internal/runtime/rterrors"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 )
 
 type systemNodeBus interface {
@@ -105,7 +106,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	if eventID == "" {
 		return
 	}
-	if n.isDestructiveResetQuiesced(ctx, evt) {
+	if n.isActiveRunQuiesced(ctx, evt) {
 		return
 	}
 	if n.isProcessed(ctx, evt) {
@@ -124,7 +125,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	}
 	for attempt := 1; attempt <= retryLimit; attempt++ {
 		if err := n.handle(ctx, evt); err == nil {
-			if !n.isDestructiveResetQuiesced(ctx, evt) {
+			if !n.isActiveRunQuiesced(ctx, evt) {
 				n.markProcessed(ctx, evt)
 			}
 			return
@@ -146,7 +147,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 		case <-time.After(backoffFn(attempt)):
 		}
 	}
-	if n.isDestructiveResetQuiesced(ctx, evt) {
+	if n.isActiveRunQuiesced(ctx, evt) {
 		return
 	}
 	n.emitDeadLetter(ctx, evt, lastErr, failureType, retryCount)
@@ -315,7 +316,7 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	if n == nil || n.db == nil || eventID == "" {
 		return
 	}
-	if n.isDestructiveResetQuiesced(ctx, evt) {
+	if n.isActiveRunQuiesced(ctx, evt) {
 		return
 	}
 	if !n.eventReceiptsAvailable(ctx) {
@@ -352,7 +353,7 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	}
 }
 
-func (n *systemNodeRunner) isDestructiveResetQuiesced(ctx context.Context, evt events.Event) bool {
+func (n *systemNodeRunner) isActiveRunQuiesced(ctx context.Context, evt events.Event) bool {
 	eventID := strings.TrimSpace(evt.ID)
 	if n == nil || n.db == nil || eventID == "" {
 		return false
@@ -369,11 +370,11 @@ func (n *systemNodeRunner) isDestructiveResetQuiesced(ctx context.Context, evt e
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
 			  AND status = 'dead_letter'
-			  AND reason_code = $3
+			  AND reason_code IN ($3, $4)
 		)
-	`, eventID, n.nodeID, runtimedestructivereset.QuiescenceReasonCode).Scan(&ok)
+	`, eventID, n.nodeID, runtimedestructivereset.QuiescenceReasonCode, runtimerunquiescence.ServeAbandonReasonCode).Scan(&ok)
 	if err != nil {
-		slog.Error("system node destructive reset quiescence check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+		slog.Error("system node active run quiescence check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		return true
 	}
 	return ok

--- a/internal/runtime/runquiescence/types.go
+++ b/internal/runtime/runquiescence/types.go
@@ -1,0 +1,54 @@
+package runquiescence
+
+import "time"
+
+const (
+	ServeAbandonOperationName = "swarm.serve.abandon_active_runs"
+	ServeAbandonReasonCode    = "server_restart_abandon"
+	ServeAbandonControlledBy  = ServeAbandonOperationName
+	ServeAbandonDeliveryNote  = "server restart abandoned active delivery"
+)
+
+type Request struct {
+	OperationName string
+	DryRun        bool
+	RequestedAt   time.Time
+	RunIDs        []string
+	AllActiveRuns bool
+	ReasonCode    string
+	ControlledBy  string
+	DeliveryNote  string
+}
+
+type Result struct {
+	OperationName        string
+	DryRun               bool
+	AppliedAt            time.Time
+	ReasonCode           string
+	ControlledBy         string
+	Runs                 []QuiescedRun
+	Deliveries           []QuiescedDelivery
+	PipelineReceiptCount int
+}
+
+type QuiescedRun struct {
+	RunID          string
+	PreviousStatus string
+	Status         string
+	ReasonCode     string
+	Changed        bool
+}
+
+type QuiescedDelivery struct {
+	DeliveryID      string
+	RunID           string
+	EventID         string
+	SubscriberType  string
+	SubscriberID    string
+	PreviousStatus  string
+	Status          string
+	ReasonCode      string
+	PreviousReason  string
+	ActiveSessionID string
+	Changed         bool
+}

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -1,0 +1,438 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+const activeRunQuiescencePipelineSubscriberID = "pipeline"
+
+type activeRunQuiescenceDeliveryTarget struct {
+	DeliveryID      string
+	RunID           string
+	EventID         string
+	SubscriberType  string
+	SubscriberID    string
+	Status          string
+	ReasonCode      string
+	ActiveSessionID string
+}
+
+func (s *PostgresStore) ApplyServeAbandonActiveRunQuiescence(ctx context.Context, at time.Time) (runtimerunquiescence.Result, error) {
+	return s.ApplyActiveRunQuiescence(ctx, runtimerunquiescence.Request{
+		OperationName: runtimerunquiescence.ServeAbandonOperationName,
+		RequestedAt:   at,
+		AllActiveRuns: true,
+		ReasonCode:    runtimerunquiescence.ServeAbandonReasonCode,
+		ControlledBy:  runtimerunquiescence.ServeAbandonControlledBy,
+		DeliveryNote:  runtimerunquiescence.ServeAbandonDeliveryNote,
+	})
+}
+
+func (s *PostgresStore) ApplyActiveRunQuiescence(ctx context.Context, req runtimerunquiescence.Request) (runtimerunquiescence.Result, error) {
+	if s == nil || s.DB == nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	if !caps.Events.HasRuns {
+		return runtimerunquiescence.Result{}, fmt.Errorf("runs table is required")
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		if caps.Events.Deliveries != SchemaFlavorCanonical {
+			return runtimerunquiescence.Result{}, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+		}
+		return runtimerunquiescence.Result{}, fmt.Errorf("active run quiescence requires canonical event_deliveries.run_id")
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical {
+		return runtimerunquiescence.Result{}, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	}
+	now := req.RequestedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	out := runtimerunquiescence.Result{
+		OperationName: strings.TrimSpace(req.OperationName),
+		DryRun:        req.DryRun,
+		AppliedAt:     now,
+		ReasonCode:    strings.TrimSpace(req.ReasonCode),
+		ControlledBy:  strings.TrimSpace(req.ControlledBy),
+	}
+	if out.OperationName == "" {
+		return out, fmt.Errorf("active run quiescence operation_name is required")
+	}
+	if out.ReasonCode == "" {
+		return out, fmt.Errorf("active run quiescence reason_code is required")
+	}
+	if out.ControlledBy == "" {
+		return out, fmt.Errorf("active run quiescence controlled_by is required")
+	}
+	deliveryNote := strings.TrimSpace(req.DeliveryNote)
+	if deliveryNote == "" {
+		deliveryNote = out.ReasonCode
+	}
+
+	runIDs := normalizeQuiescenceRunIDs(req.RunIDs)
+	if len(runIDs) == 0 && !req.AllActiveRuns {
+		return out, nil
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("begin active run quiescence tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var runs []runtimerunquiescence.QuiescedRun
+	if req.AllActiveRuns {
+		runs, err = lockAllActiveQuiescenceRunsTx(ctx, tx)
+	} else {
+		runs, err = lockActiveRunQuiescenceRunsTx(ctx, tx, runIDs)
+	}
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	runIDs = quiescenceRunIDs(runs)
+	if len(runIDs) == 0 {
+		return out, nil
+	}
+	deliveries, err := lockActiveRunQuiescenceDeliveriesTx(ctx, tx, runIDs)
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	for _, delivery := range deliveries {
+		out.Deliveries = append(out.Deliveries, runtimerunquiescence.QuiescedDelivery{
+			DeliveryID:      delivery.DeliveryID,
+			RunID:           delivery.RunID,
+			EventID:         delivery.EventID,
+			SubscriberType:  delivery.SubscriberType,
+			SubscriberID:    delivery.SubscriberID,
+			PreviousStatus:  delivery.Status,
+			Status:          "dead_letter",
+			ReasonCode:      out.ReasonCode,
+			PreviousReason:  delivery.ReasonCode,
+			ActiveSessionID: delivery.ActiveSessionID,
+			Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != out.ReasonCode,
+		})
+	}
+	for _, run := range runs {
+		nextStatus := run.Status
+		changed := false
+		if activeRunQuiescenceRunStatusActive(run.Status) {
+			nextStatus = "cancelled"
+			changed = true
+		}
+		out.Runs = append(out.Runs, runtimerunquiescence.QuiescedRun{
+			RunID:          run.RunID,
+			PreviousStatus: run.Status,
+			Status:         nextStatus,
+			ReasonCode:     out.ReasonCode,
+			Changed:        changed,
+		})
+	}
+	if req.DryRun {
+		return out, nil
+	}
+
+	eventIDs := map[string]struct{}{}
+	for _, delivery := range deliveries {
+		if err := terminalizeActiveRunQuiescenceDeliveryTx(ctx, tx, delivery, out.ReasonCode, deliveryNote, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+		if delivery.EventID != "" {
+			eventIDs[delivery.EventID] = struct{}{}
+		}
+	}
+	for eventID := range eventIDs {
+		if err := upsertActiveRunQuiescencePipelineReceiptTx(ctx, tx, eventID, out.ReasonCode, deliveryNote, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+		out.PipelineReceiptCount++
+	}
+	for _, run := range runs {
+		if !activeRunQuiescenceRunStatusActive(run.Status) {
+			continue
+		}
+		if _, err := storerunlifecycle.MarkTerminal(ctx, tx, run.RunID, "cancelled", "", now, runLifecycleOptions(caps)); err != nil {
+			return runtimerunquiescence.Result{}, fmt.Errorf("mark active run quiescence run terminal: %w", err)
+		}
+		if err := upsertActiveRunQuiescenceRunControlTx(ctx, tx, run.RunID, out.ReasonCode, out.ControlledBy, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("commit active run quiescence tx: %w", err)
+	}
+	committed = true
+	return out, nil
+}
+
+func normalizeQuiescenceRunIDs(runIDs []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(runIDs))
+	for _, raw := range runIDs {
+		id := nullUUIDString(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func quiescenceRunIDs(runs []runtimerunquiescence.QuiescedRun) []string {
+	out := make([]string, 0, len(runs))
+	for _, run := range runs {
+		if id := nullUUIDString(run.RunID); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func activeRunQuiescenceRunStatusActive(status string) bool {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "running", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func lockAllActiveQuiescenceRunsTx(ctx context.Context, tx *sql.Tx) ([]runtimerunquiescence.QuiescedRun, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id::text, COALESCE(status, '')
+		FROM runs
+		WHERE lower(COALESCE(status, '')) IN ('running', 'paused')
+		ORDER BY run_id::text
+		FOR UPDATE
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("lock all active quiescence runs: %w", err)
+	}
+	return scanActiveRunQuiescenceRuns(rows)
+}
+
+func lockActiveRunQuiescenceRunsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]runtimerunquiescence.QuiescedRun, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id::text, COALESCE(status, '')
+		FROM runs
+		WHERE run_id = ANY($1::uuid[])
+		  AND lower(COALESCE(status, '')) IN ('running', 'paused')
+		ORDER BY run_id::text
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock active quiescence runs: %w", err)
+	}
+	return scanActiveRunQuiescenceRuns(rows)
+}
+
+func scanActiveRunQuiescenceRuns(rows *sql.Rows) ([]runtimerunquiescence.QuiescedRun, error) {
+	defer rows.Close()
+	var out []runtimerunquiescence.QuiescedRun
+	for rows.Next() {
+		var run runtimerunquiescence.QuiescedRun
+		if err := rows.Scan(&run.RunID, &run.PreviousStatus); err != nil {
+			return nil, fmt.Errorf("scan active quiescence run: %w", err)
+		}
+		run.RunID = strings.TrimSpace(run.RunID)
+		run.PreviousStatus = strings.TrimSpace(run.PreviousStatus)
+		run.Status = run.PreviousStatus
+		out = append(out, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active quiescence runs: %w", err)
+	}
+	return out, nil
+}
+
+func lockActiveRunQuiescenceDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]activeRunQuiescenceDeliveryTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			d.delivery_id::text,
+			d.run_id::text,
+			d.event_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id::text, '')
+		FROM event_deliveries d
+		WHERE d.run_id = ANY($1::uuid[])
+		  AND d.subscriber_type IN ('agent', 'node')
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("d")+`
+		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock active run quiescence deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []activeRunQuiescenceDeliveryTarget
+	for rows.Next() {
+		var item activeRunQuiescenceDeliveryTarget
+		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.ActiveSessionID); err != nil {
+			return nil, fmt.Errorf("scan active run quiescence delivery: %w", err)
+		}
+		item.DeliveryID = strings.TrimSpace(item.DeliveryID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.EventID = strings.TrimSpace(item.EventID)
+		item.SubscriberType = strings.TrimSpace(item.SubscriberType)
+		item.SubscriberID = strings.TrimSpace(item.SubscriberID)
+		item.Status = strings.TrimSpace(item.Status)
+		item.ReasonCode = strings.TrimSpace(item.ReasonCode)
+		item.ActiveSessionID = strings.TrimSpace(item.ActiveSessionID)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active run quiescence deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func terminalizeActiveRunQuiescenceDeliveryTx(ctx context.Context, tx *sql.Tx, item activeRunQuiescenceDeliveryTarget, reasonCode, note string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'dead_letter',
+			reason_code = $2,
+			last_error = $3,
+			active_session_id = NULL,
+			delivered_at = COALESCE(delivered_at, $4)
+		WHERE delivery_id = $1::uuid
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("")+`
+	`, item.DeliveryID, reasonCode, note, at.UTC()); err != nil {
+		return fmt.Errorf("terminalize active run quiescence delivery %s: %w", item.DeliveryID, err)
+	}
+	sideEffects, err := json.Marshal(map[string]any{
+		"manager_status": "dead_letter",
+		"reason_code":    reasonCode,
+		"error":          note,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal active run quiescence receipt side effects: %w", err)
+	}
+	idempotencyKey := ""
+	if item.SubscriberType == "node" {
+		idempotencyKey = runtimepipeline.SystemNodeReceiptIdempotencyKey(item.SubscriberID, item.EventID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, $2, $3, e.entity_id, e.flow_instance,
+			'dead_letter', $4, $5::jsonb, NULLIF($6, ''), $7
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = $4,
+			side_effects = $5::jsonb,
+			idempotency_key = COALESCE(NULLIF($6, ''), event_receipts.idempotency_key),
+			processed_at = $7
+	`, item.EventID, item.SubscriberType, item.SubscriberID, reasonCode, string(sideEffects), idempotencyKey, at.UTC()); err != nil {
+		return fmt.Errorf("upsert active run quiescence delivery receipt: %w", err)
+	}
+	return nil
+}
+
+func upsertActiveRunQuiescencePipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, reasonCode, note string, at time.Time) error {
+	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects("dead_letter", reasonCode, note))
+	if err != nil {
+		return fmt.Errorf("marshal active run quiescence pipeline receipt: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
+			'dead_letter', $3, $4::jsonb, $5
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = $3,
+			side_effects = $4::jsonb,
+			processed_at = $5
+	`, eventID, activeRunQuiescencePipelineSubscriberID, reasonCode, string(sideEffects), at.UTC()); err != nil {
+		return fmt.Errorf("upsert active run quiescence pipeline receipt: %w", err)
+	}
+	return nil
+}
+
+func upsertActiveRunQuiescenceRunControlTx(ctx context.Context, tx *sql.Tx, runID, reasonCode, controlledBy string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES ($1::uuid, 'stopped', $2, $3, $4, NULL, $4)
+		ON CONFLICT (run_id) DO UPDATE SET
+			control_status = 'stopped',
+			reason = $2,
+			controlled_by = $3,
+			updated_at = $4,
+			paused_at = NULL,
+			stopped_at = COALESCE(run_control_state.stopped_at, $4)
+	`, runID, reasonCode, controlledBy, at.UTC()); err != nil {
+		return fmt.Errorf("persist active run quiescence run control state: %w", err)
+	}
+	return nil
+}
+
+func activeRunQuiescenceDeliveryPredicateSQL(alias string) string {
+	prefix := ""
+	if strings.TrimSpace(alias) != "" {
+		prefix = strings.TrimSpace(alias) + "."
+	}
+	return `(
+			` + prefix + `status IN ('pending', 'in_progress')
+			OR (
+				` + prefix + `status = 'failed'
+				AND COALESCE(` + prefix + `retry_count, 0) < 2
+			)
+		)`
+}
+
+func activeRunQuiescenceDeliveryTerminal(status, reasonCode string) bool {
+	if strings.TrimSpace(status) != "dead_letter" {
+		return false
+	}
+	reasonCode = strings.TrimSpace(reasonCode)
+	for _, terminalReason := range activeRunQuiescenceTerminalReasonCodes() {
+		if reasonCode == terminalReason {
+			return true
+		}
+	}
+	return false
+}
+
+func activeRunQuiescenceTerminalReasonCodes() []string {
+	return []string{
+		runtimedestructivereset.QuiescenceReasonCode,
+		runtimerunquiescence.ServeAbandonReasonCode,
+	}
+}

--- a/internal/store/destructive_reset_inventory.go
+++ b/internal/store/destructive_reset_inventory.go
@@ -26,7 +26,7 @@ func (s *PostgresStore) ReadResetInventory(ctx context.Context) (destructiverese
 		Preserved:          destructivereset.DefaultPreservedResources(),
 	}
 	for _, run := range runs {
-		if destructiveResetRunStatusActive(run.Status) {
+		if activeRunQuiescenceRunStatusActive(run.Status) {
 			out.ActiveRuns = append(out.ActiveRuns, run)
 		}
 	}
@@ -74,7 +74,7 @@ func (s *PostgresStore) readDestructiveResetInventoryDeliveries(ctx context.Cont
 		SELECT delivery_id::text, run_id::text, COALESCE(status, '')
 		FROM event_deliveries
 		WHERE subscriber_type IN ('agent', 'node')
-		  AND `+destructiveResetQuiescenceDeliveryPredicateSQL("")+`
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("")+`
 		ORDER BY run_id::text, event_id::text, subscriber_type, subscriber_id
 	`)
 	if err != nil {

--- a/internal/store/destructive_reset_quiescence.go
+++ b/internal/store/destructive_reset_quiescence.go
@@ -2,155 +2,44 @@ package store
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
-	"github.com/lib/pq"
 	"swarm/internal/runtime/destructivereset"
-	runtimepipeline "swarm/internal/runtime/pipeline"
-	storerunlifecycle "swarm/internal/store/runlifecycle"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 )
 
-const destructiveResetPipelineSubscriberID = "pipeline"
-
-type destructiveResetDeliveryTarget struct {
-	DeliveryID      string
-	RunID           string
-	EventID         string
-	SubscriberType  string
-	SubscriberID    string
-	Status          string
-	ReasonCode      string
-	ActiveSessionID string
-}
+const destructiveResetPipelineSubscriberID = activeRunQuiescencePipelineSubscriberID
 
 func (s *PostgresStore) ApplyDestructiveResetQuiescence(ctx context.Context, req destructivereset.QuiescenceRequest) (destructivereset.QuiescenceResult, error) {
-	if s == nil || s.DB == nil {
-		return destructivereset.QuiescenceResult{}, fmt.Errorf("postgres store is required")
+	requestedAt := req.RequestedAt.UTC()
+	if requestedAt.IsZero() {
+		requestedAt = time.Now().UTC()
 	}
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return destructivereset.QuiescenceResult{}, err
+	operationName := strings.TrimSpace(req.Result.OperationName)
+	if operationName == "" {
+		operationName = destructivereset.DefaultOperationName
 	}
-	if !caps.Events.HasRuns {
-		return destructivereset.QuiescenceResult{}, fmt.Errorf("runs table is required")
-	}
-	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
-		if caps.Events.Deliveries != SchemaFlavorCanonical {
-			return destructivereset.QuiescenceResult{}, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
-		}
-		return destructivereset.QuiescenceResult{}, fmt.Errorf("destructive reset quiescence requires canonical event_deliveries.run_id")
-	}
-	if caps.Events.Receipts != SchemaFlavorCanonical {
-		return destructivereset.QuiescenceResult{}, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
-	}
-	runIDs := activeRunIDsFromResetPlan(req.Result.Plan)
-	now := req.RequestedAt.UTC()
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
-	out := destructivereset.QuiescenceResult{
-		OperationName: strings.TrimSpace(req.Result.OperationName),
+	result, err := s.ApplyActiveRunQuiescence(ctx, runtimerunquiescence.Request{
+		OperationName: operationName,
 		DryRun:        req.Result.DryRun,
-		AppliedAt:     now,
+		RequestedAt:   requestedAt,
+		RunIDs:        activeRunIDsFromResetPlan(req.Result.Plan),
 		ReasonCode:    destructivereset.QuiescenceReasonCode,
 		ControlledBy:  destructivereset.QuiescenceControlledBy,
-	}
-	if out.OperationName == "" {
-		out.OperationName = destructivereset.DefaultOperationName
-	}
-	if len(runIDs) == 0 {
-		return out, nil
-	}
-
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return destructivereset.QuiescenceResult{}, fmt.Errorf("begin destructive reset quiescence tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	runs, err := s.lockDestructiveResetRunsTx(ctx, tx, runIDs)
+		DeliveryNote:  destructivereset.QuiescenceDeliveryNote,
+	})
 	if err != nil {
 		return destructivereset.QuiescenceResult{}, err
 	}
-	deliveries, err := s.lockDestructiveResetDeliveriesTx(ctx, tx, runIDs)
-	if err != nil {
-		return destructivereset.QuiescenceResult{}, err
-	}
-	for _, delivery := range deliveries {
-		out.Deliveries = append(out.Deliveries, destructivereset.QuiescedDelivery{
-			DeliveryID:      delivery.DeliveryID,
-			RunID:           delivery.RunID,
-			EventID:         delivery.EventID,
-			SubscriberType:  delivery.SubscriberType,
-			SubscriberID:    delivery.SubscriberID,
-			PreviousStatus:  delivery.Status,
-			Status:          "dead_letter",
-			ReasonCode:      destructivereset.QuiescenceReasonCode,
-			PreviousReason:  delivery.ReasonCode,
-			ActiveSessionID: delivery.ActiveSessionID,
-			Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != destructivereset.QuiescenceReasonCode,
-		})
-	}
-	for _, run := range runs {
-		nextStatus := run.Status
-		changed := false
-		if destructiveResetRunStatusActive(run.Status) {
-			nextStatus = "cancelled"
-			changed = true
-		}
-		out.Runs = append(out.Runs, destructivereset.QuiescedRun{
-			RunID:          run.RunID,
-			PreviousStatus: run.Status,
-			Status:         nextStatus,
-			ReasonCode:     destructivereset.QuiescenceReasonCode,
-			Changed:        changed,
-		})
-	}
-	if req.Result.DryRun {
-		return out, nil
-	}
-
-	eventIDs := map[string]struct{}{}
-	for _, delivery := range deliveries {
-		if err := s.terminalizeDestructiveResetDeliveryTx(ctx, tx, delivery, now); err != nil {
-			return destructivereset.QuiescenceResult{}, err
-		}
-		if delivery.EventID != "" {
-			eventIDs[delivery.EventID] = struct{}{}
-		}
-	}
-	for eventID := range eventIDs {
-		if err := s.upsertDestructiveResetPipelineReceiptTx(ctx, tx, eventID, now); err != nil {
-			return destructivereset.QuiescenceResult{}, err
-		}
-		out.PipelineReceiptCount++
-	}
-	for _, run := range runs {
-		if !destructiveResetRunStatusActive(run.Status) {
-			continue
-		}
-		if _, err := storerunlifecycle.MarkTerminal(ctx, tx, run.RunID, "cancelled", "", now, runLifecycleOptions(caps)); err != nil {
-			return destructivereset.QuiescenceResult{}, fmt.Errorf("mark destructive reset run terminal: %w", err)
-		}
-		if err := s.upsertDestructiveResetRunControlTx(ctx, tx, run.RunID, now); err != nil {
-			return destructivereset.QuiescenceResult{}, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return destructivereset.QuiescenceResult{}, fmt.Errorf("commit destructive reset quiescence tx: %w", err)
-	}
-	return out, nil
+	return destructiveResetQuiescenceResult(result), nil
 }
 
 func activeRunIDsFromResetPlan(plan destructivereset.Plan) []string {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(plan.ActiveRuns))
 	for _, run := range plan.ActiveRuns {
-		if !destructiveResetRunStatusActive(run.Status) {
+		if !activeRunQuiescenceRunStatusActive(run.Status) {
 			continue
 		}
 		id := nullUUIDString(run.RunID)
@@ -166,193 +55,38 @@ func activeRunIDsFromResetPlan(plan destructivereset.Plan) []string {
 	return out
 }
 
-func destructiveResetRunStatusActive(status string) bool {
-	switch strings.TrimSpace(strings.ToLower(status)) {
-	case "running", "paused":
-		return true
-	default:
-		return false
+func destructiveResetQuiescenceResult(result runtimerunquiescence.Result) destructivereset.QuiescenceResult {
+	out := destructivereset.QuiescenceResult{
+		OperationName:        result.OperationName,
+		DryRun:               result.DryRun,
+		AppliedAt:            result.AppliedAt,
+		ReasonCode:           result.ReasonCode,
+		ControlledBy:         result.ControlledBy,
+		PipelineReceiptCount: result.PipelineReceiptCount,
 	}
-}
-
-func (s *PostgresStore) lockDestructiveResetRunsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]destructivereset.QuiescedRun, error) {
-	rows, err := tx.QueryContext(ctx, `
-		SELECT run_id::text, COALESCE(status, '')
-		FROM runs
-		WHERE run_id = ANY($1::uuid[])
-		ORDER BY run_id::text
-		FOR UPDATE
-	`, pq.Array(runIDs))
-	if err != nil {
-		return nil, fmt.Errorf("lock destructive reset runs: %w", err)
+	for _, run := range result.Runs {
+		out.Runs = append(out.Runs, destructivereset.QuiescedRun{
+			RunID:          run.RunID,
+			PreviousStatus: run.PreviousStatus,
+			Status:         run.Status,
+			ReasonCode:     run.ReasonCode,
+			Changed:        run.Changed,
+		})
 	}
-	defer rows.Close()
-	var out []destructivereset.QuiescedRun
-	for rows.Next() {
-		var run destructivereset.QuiescedRun
-		if err := rows.Scan(&run.RunID, &run.PreviousStatus); err != nil {
-			return nil, fmt.Errorf("scan destructive reset run: %w", err)
-		}
-		run.RunID = strings.TrimSpace(run.RunID)
-		run.PreviousStatus = strings.TrimSpace(run.PreviousStatus)
-		run.Status = run.PreviousStatus
-		out = append(out, run)
+	for _, delivery := range result.Deliveries {
+		out.Deliveries = append(out.Deliveries, destructivereset.QuiescedDelivery{
+			DeliveryID:      delivery.DeliveryID,
+			RunID:           delivery.RunID,
+			EventID:         delivery.EventID,
+			SubscriberType:  delivery.SubscriberType,
+			SubscriberID:    delivery.SubscriberID,
+			PreviousStatus:  delivery.PreviousStatus,
+			Status:          delivery.Status,
+			ReasonCode:      delivery.ReasonCode,
+			PreviousReason:  delivery.PreviousReason,
+			ActiveSessionID: delivery.ActiveSessionID,
+			Changed:         delivery.Changed,
+		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read destructive reset runs: %w", err)
-	}
-	return out, nil
-}
-
-func (s *PostgresStore) lockDestructiveResetDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]destructiveResetDeliveryTarget, error) {
-	rows, err := tx.QueryContext(ctx, `
-		SELECT
-			d.delivery_id::text,
-			d.run_id::text,
-			d.event_id::text,
-			COALESCE(d.subscriber_type, ''),
-			COALESCE(d.subscriber_id, ''),
-			COALESCE(d.status, ''),
-			COALESCE(d.reason_code, ''),
-			COALESCE(d.active_session_id::text, '')
-		FROM event_deliveries d
-		WHERE d.run_id = ANY($1::uuid[])
-		  AND d.subscriber_type IN ('agent', 'node')
-		  AND `+destructiveResetQuiescenceDeliveryPredicateSQL("d")+`
-		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
-		FOR UPDATE
-	`, pq.Array(runIDs))
-	if err != nil {
-		return nil, fmt.Errorf("lock destructive reset deliveries: %w", err)
-	}
-	defer rows.Close()
-	var out []destructiveResetDeliveryTarget
-	for rows.Next() {
-		var item destructiveResetDeliveryTarget
-		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.ActiveSessionID); err != nil {
-			return nil, fmt.Errorf("scan destructive reset delivery: %w", err)
-		}
-		item.DeliveryID = strings.TrimSpace(item.DeliveryID)
-		item.RunID = strings.TrimSpace(item.RunID)
-		item.EventID = strings.TrimSpace(item.EventID)
-		item.SubscriberType = strings.TrimSpace(item.SubscriberType)
-		item.SubscriberID = strings.TrimSpace(item.SubscriberID)
-		item.Status = strings.TrimSpace(item.Status)
-		item.ReasonCode = strings.TrimSpace(item.ReasonCode)
-		item.ActiveSessionID = strings.TrimSpace(item.ActiveSessionID)
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read destructive reset deliveries: %w", err)
-	}
-	return out, nil
-}
-
-func (s *PostgresStore) terminalizeDestructiveResetDeliveryTx(ctx context.Context, tx *sql.Tx, item destructiveResetDeliveryTarget, at time.Time) error {
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET
-			status = 'dead_letter',
-			reason_code = $2,
-			last_error = $3,
-			active_session_id = NULL,
-			delivered_at = COALESCE(delivered_at, $4)
-		WHERE delivery_id = $1::uuid
-		  AND `+destructiveResetQuiescenceDeliveryPredicateSQL("")+`
-	`, item.DeliveryID, destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceDeliveryNote, at.UTC()); err != nil {
-		return fmt.Errorf("terminalize destructive reset delivery %s: %w", item.DeliveryID, err)
-	}
-	sideEffects, err := json.Marshal(map[string]any{
-		"manager_status": "dead_letter",
-		"reason_code":    destructivereset.QuiescenceReasonCode,
-		"error":          destructivereset.QuiescenceDeliveryNote,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal destructive reset receipt side effects: %w", err)
-	}
-	idempotencyKey := ""
-	if item.SubscriberType == "node" {
-		idempotencyKey = runtimepipeline.SystemNodeReceiptIdempotencyKey(item.SubscriberID, item.EventID)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, reason_code, side_effects, idempotency_key, processed_at
-		)
-		SELECT
-			e.event_id, $2, $3, e.entity_id, e.flow_instance,
-			'dead_letter', $4, $5::jsonb, NULLIF($6, ''), $7
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			outcome = 'dead_letter',
-			reason_code = $4,
-			side_effects = $5::jsonb,
-			idempotency_key = COALESCE(NULLIF($6, ''), event_receipts.idempotency_key),
-			processed_at = $7
-	`, item.EventID, item.SubscriberType, item.SubscriberID, destructivereset.QuiescenceReasonCode, string(sideEffects), idempotencyKey, at.UTC()); err != nil {
-		return fmt.Errorf("upsert destructive reset delivery receipt: %w", err)
-	}
-	return nil
-}
-
-func (s *PostgresStore) upsertDestructiveResetPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID string, at time.Time) error {
-	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects("dead_letter", destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceDeliveryNote))
-	if err != nil {
-		return fmt.Errorf("marshal destructive reset pipeline receipt: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, reason_code, side_effects, processed_at
-		)
-		SELECT
-			e.event_id, 'platform', $2, e.entity_id, e.flow_instance,
-			'dead_letter', $3, $4::jsonb, $5
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
-			outcome = 'dead_letter',
-			reason_code = $3,
-			side_effects = $4::jsonb,
-			processed_at = $5
-	`, eventID, destructiveResetPipelineSubscriberID, destructivereset.QuiescenceReasonCode, string(sideEffects), at.UTC()); err != nil {
-		return fmt.Errorf("upsert destructive reset pipeline receipt: %w", err)
-	}
-	return nil
-}
-
-func (s *PostgresStore) upsertDestructiveResetRunControlTx(ctx context.Context, tx *sql.Tx, runID string, at time.Time) error {
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
-		VALUES ($1::uuid, 'stopped', $2, $3, $4, NULL, $4)
-		ON CONFLICT (run_id) DO UPDATE SET
-			control_status = 'stopped',
-			reason = $2,
-			controlled_by = $3,
-			updated_at = $4,
-			paused_at = NULL,
-			stopped_at = COALESCE(run_control_state.stopped_at, $4)
-	`, runID, destructivereset.QuiescenceReasonCode, destructivereset.QuiescenceControlledBy, at.UTC()); err != nil {
-		return fmt.Errorf("persist destructive reset run control state: %w", err)
-	}
-	return nil
-}
-
-func destructiveResetDeliveryTerminal(status, reasonCode string) bool {
-	return strings.TrimSpace(status) == "dead_letter" && strings.TrimSpace(reasonCode) == destructivereset.QuiescenceReasonCode
-}
-
-func destructiveResetQuiescenceDeliveryPredicateSQL(alias string) string {
-	prefix := ""
-	if strings.TrimSpace(alias) != "" {
-		prefix = strings.TrimSpace(alias) + "."
-	}
-	return `(
-			` + prefix + `status IN ('pending', 'in_progress')
-			OR (
-				` + prefix + `status = 'failed'
-				AND COALESCE(` + prefix + `retry_count, 0) < 2
-			)
-		)`
+	return out
 }

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/runtime/destructivereset"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 	"swarm/internal/testutil"
 )
 
@@ -173,6 +174,109 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 	}
 }
 
+func TestPostgresStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableWork(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	now := time.Date(2026, 5, 18, 2, 10, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	terminalRunID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES
+			($1::uuid, 'running'),
+			($2::uuid, 'completed')
+	`, runID, terminalRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	agentPending := seedDestructiveResetEvent(t, ctx, pg, runID, "serve.agent.pending")
+	agentInProgress := seedDestructiveResetEvent(t, ctx, pg, runID, "serve.agent.in_progress")
+	agentRetryableFailed := seedDestructiveResetEvent(t, ctx, pg, runID, "serve.agent.failed_retryable")
+	nodePending := seedDestructiveResetEvent(t, ctx, pg, runID, "serve.node.pending")
+	terminalRunPending := seedDestructiveResetEvent(t, ctx, pg, terminalRunID, "serve.terminal.pending")
+	activeSessionID := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, retry_count, reason_code, created_at, delivered_at
+		) VALUES
+			($1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', now(), NULL),
+			($1::uuid, $3::uuid, 'agent', 'agent-a', 'in_progress', $7::uuid, 0, 'agent_processing', now(), NULL),
+			($1::uuid, $4::uuid, 'agent', 'agent-a', 'failed', NULL, 1, 'agent_retryable_error', now() - interval '5 minutes', now() - interval '2 minutes'),
+			($1::uuid, $5::uuid, 'node', 'node-a', 'pending', NULL, 0, 'matched_node_subscription', now(), NULL),
+			($6::uuid, $8::uuid, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', now(), NULL)
+	`, runID, agentPending, agentInProgress, agentRetryableFailed, nodePending, terminalRunID, activeSessionID, terminalRunPending); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+
+	result, err := pg.ApplyServeAbandonActiveRunQuiescence(ctx, now)
+	if err != nil {
+		t.Fatalf("ApplyServeAbandonActiveRunQuiescence: %v", err)
+	}
+	if result.OperationName != runtimerunquiescence.ServeAbandonOperationName || result.ReasonCode != runtimerunquiescence.ServeAbandonReasonCode || result.ControlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("serve abandon result metadata = %#v", result)
+	}
+	if len(result.Runs) != 1 || result.Runs[0].RunID != runID || result.Runs[0].Status != "cancelled" || !result.Runs[0].Changed {
+		t.Fatalf("runs = %#v, want one cancelled active run", result.Runs)
+	}
+	if len(result.Deliveries) != 4 || result.PipelineReceiptCount != 4 {
+		t.Fatalf("deliveries=%d pipeline_receipts=%d, want 4/4", len(result.Deliveries), result.PipelineReceiptCount)
+	}
+
+	var runStatus, controlStatus, reason, controlledBy string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT r.status, rc.control_status, COALESCE(rc.reason,''), COALESCE(rc.controlled_by,'')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = $1::uuid
+	`, runID).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("load run/control state: %v", err)
+	}
+	if runStatus != "cancelled" || controlStatus != "stopped" || reason != runtimerunquiescence.ServeAbandonReasonCode || controlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("run/control = %s/%s/%s/%s", runStatus, controlStatus, reason, controlledBy)
+	}
+
+	assertServeAbandonDelivery(t, ctx, pg, agentPending, "agent", "agent-a")
+	assertServeAbandonDelivery(t, ctx, pg, agentInProgress, "agent", "agent-a")
+	assertServeAbandonDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
+	assertServeAbandonDelivery(t, ctx, pg, nodePending, "node", "node-a")
+
+	if err := pg.MarkEventDeliveryInProgress(ctx, agentRetryableFailed, "agent-a", uuid.NewString()); err != nil {
+		t.Fatalf("late retryable failed MarkEventDeliveryInProgress: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, agentInProgress, "agent-a", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("late UpsertEventReceipt: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, agentInProgress, "processed", ""); err != nil {
+		t.Fatalf("late UpsertPipelineReceipt: %v", err)
+	}
+	assertServeAbandonDelivery(t, ctx, pg, agentRetryableFailed, "agent", "agent-a")
+	assertServeAbandonReceipt(t, ctx, pg, agentInProgress, "agent-a")
+	assertServeAbandonReceipt(t, ctx, pg, agentInProgress, activeRunQuiescencePipelineSubscriberID)
+
+	replay, err := pg.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun: %v", err)
+	}
+	if len(replay) != 0 {
+		t.Fatalf("missing pipeline replay events = %#v, want none", replay)
+	}
+	var terminalDeliveryStatus, terminalDeliveryReason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, terminalRunPending).Scan(&terminalDeliveryStatus, &terminalDeliveryReason); err != nil {
+		t.Fatalf("load terminal run delivery: %v", err)
+	}
+	if terminalDeliveryStatus != "pending" || terminalDeliveryReason != "matched_agent_subscription" {
+		t.Fatalf("terminal run delivery = %s/%s, want untouched", terminalDeliveryStatus, terminalDeliveryReason)
+	}
+}
+
 func TestPostgresStore_ApplyDestructiveResetQuiescence_DryRunDoesNotMutate(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -220,6 +324,41 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_DryRunDoesNotMutate(t *te
 	}
 	if status != "pending" || reason != "" {
 		t.Fatalf("dry-run mutated delivery = %s/%s", status, reason)
+	}
+}
+
+func assertServeAbandonDelivery(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, subscriberType, subscriberID string) {
+	t.Helper()
+	var status, reason string
+	var activeSession sql.NullString
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), active_session_id::text
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+	`, eventID, subscriberType, subscriberID).Scan(&status, &reason, &activeSession); err != nil {
+		t.Fatalf("load delivery %s/%s/%s: %v", eventID, subscriberType, subscriberID, err)
+	}
+	if status != "dead_letter" || reason != runtimerunquiescence.ServeAbandonReasonCode || activeSession.Valid {
+		t.Fatalf("delivery %s/%s/%s = %s/%s active=%v, want serve abandon dead_letter", eventID, subscriberType, subscriberID, status, reason, activeSession.Valid)
+	}
+	assertServeAbandonReceipt(t, ctx, pg, eventID, subscriberID)
+}
+
+func assertServeAbandonReceipt(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, subscriberID string) {
+	t.Helper()
+	var outcome, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = $2
+	`, eventID, subscriberID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load receipt %s/%s: %v", eventID, subscriberID, err)
+	}
+	if outcome != "dead_letter" || reason != runtimerunquiescence.ServeAbandonReasonCode {
+		t.Fatalf("receipt %s/%s = %s/%s, want serve abandon dead_letter", eventID, subscriberID, outcome, reason)
 	}
 }
 

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
 	"swarm/internal/events"
 	"swarm/internal/runtime/core/eventidentity"
 	"swarm/internal/runtime/destructivereset"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 )
 
 func (s *PostgresStore) MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error {
@@ -159,7 +161,7 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSc
 		if !delivery.found {
 			return fmt.Errorf("upsert event receipt: delivery row required for event %s agent %s", strings.TrimSpace(eventID), strings.TrimSpace(agentID))
 		}
-		if destructiveResetDeliveryTerminal(delivery.status, delivery.reasonCode) {
+		if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
 			return nil
 		}
 		state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
@@ -366,12 +368,44 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 			status IN ('pending', 'in_progress')
 			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
 		  )
-		  AND COALESCE(reason_code, '') <> $4
+		  AND COALESCE(reason_code, '') <> ALL($4)
 	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, destructivereset.QuiescenceReasonCode); err != nil {
+	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes())); err != nil {
 		return fmt.Errorf("mark event delivery in progress: %w", err)
 	}
 	return nil
+}
+
+func (s *PostgresStore) ActiveRunDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (string, bool, error) {
+	if s == nil || s.DB == nil {
+		return "", false, fmt.Errorf("postgres store is required")
+	}
+	eventID = strings.TrimSpace(eventID)
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	if eventID == "" || subscriberType == "" || subscriberID == "" {
+		return "", false, nil
+	}
+	var reason string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = $2
+		  AND subscriber_id = $3
+		  AND status = 'dead_letter'
+		  AND reason_code = ANY($4)
+		ORDER BY reason_code
+		LIMIT 1
+	`, eventID, subscriberType, subscriberID, pq.Array(activeRunQuiescenceTerminalReasonCodes())).Scan(&reason)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", false, nil
+	case err != nil:
+		return "", false, fmt.Errorf("check active run delivery quiescence: %w", err)
+	default:
+		return strings.TrimSpace(reason), true, nil
+	}
 }
 
 func (s *PostgresStore) DestructiveResetDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error) {
@@ -397,6 +431,33 @@ func (s *PostgresStore) DestructiveResetDeliveryQuiesced(ctx context.Context, ev
 		)
 	`, eventID, subscriberType, subscriberID, destructivereset.QuiescenceReasonCode).Scan(&ok); err != nil {
 		return false, fmt.Errorf("check destructive reset delivery quiescence: %w", err)
+	}
+	return ok, nil
+}
+
+func (s *PostgresStore) ServeAbandonDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error) {
+	if s == nil || s.DB == nil {
+		return false, fmt.Errorf("postgres store is required")
+	}
+	eventID = strings.TrimSpace(eventID)
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	if eventID == "" || subscriberType == "" || subscriberID == "" {
+		return false, nil
+	}
+	var ok bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = $2
+			  AND subscriber_id = $3
+			  AND status = 'dead_letter'
+			  AND reason_code = $4
+		)
+	`, eventID, subscriberType, subscriberID, runtimerunquiescence.ServeAbandonReasonCode).Scan(&ok); err != nil {
+		return false, fmt.Errorf("check serve abandon delivery quiescence: %w", err)
 	}
 	return ok, nil
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -16,6 +16,7 @@ import (
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/destructivereset"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
@@ -731,20 +732,20 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 			FROM event_deliveries d
 			WHERE d.event_id = e.event_id
 			  AND d.status = 'dead_letter'
-			  AND d.reason_code = $5
+			  AND d.reason_code IN ($5, $6)
 		  )
 		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
 			outcome = EXCLUDED.outcome,
 			reason_code = EXCLUDED.reason_code,
 			side_effects = EXCLUDED.side_effects,
 			processed_at = now()
-		WHERE COALESCE(event_receipts.reason_code, '') <> $5
+		WHERE COALESCE(event_receipts.reason_code, '') NOT IN ($5, $6)
 	`
 	execFn := s.DB.ExecContext
 	if tx != nil {
 		execFn = tx.ExecContext
 	}
-	if _, err := execFn(ctx, q, eventID, outcome, reasonCode, string(sideEffects), destructivereset.QuiescenceReasonCode); err != nil {
+	if _, err := execFn(ctx, q, eventID, outcome, reasonCode, string(sideEffects), destructivereset.QuiescenceReasonCode, runtimerunquiescence.ServeAbandonReasonCode); err != nil {
 		return fmt.Errorf("upsert pipeline receipt: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Closes #808.

Implements the approved first-slice class `runtime.cli.serve.active_run_abandon_quiescence`:

- Adds `swarm serve --abandon-active-runs` and runs it before bundle-match admission, startup recovery, runtime start, and readiness.
- Factors a canonical active-run quiescence owner (`internal/runtime/runquiescence` + `PostgresStore.ApplyActiveRunQuiescence`) consumed by serve abandon and destructive reset with distinct operation/reason encodings.
- Terminalizes active `running|paused` runs as `cancelled`, writes `run_control_state.control_status=stopped`, and records `server_restart_abandon` / `swarm.serve.abandon_active_runs`.
- Terminalizes same-run agent/node `pending`, `in_progress`, and retryable `failed` deliveries as `dead_letter`, clears `active_session_id`, writes agent/node receipts, and writes platform pipeline receipts.
- Protects abandoned work from late AgentManager/EventBus/node/pipeline writers and missing-pipeline replay.

## Governing Refs / Context

- `platform-spec.yaml` `cli_specification.command_catalog.serve`: serve startup owner, #753/#754 bundle-match admission, #802/#804 boot observability, and #750 remaining tail.
- `platform-spec.yaml` `storage_schema.tables.runs`: durable run status uses `cancelled`; no literal `stopped` run status.
- `platform-spec.yaml` `storage_schema.tables.run_control_state`: `control_status=stopped` plus reason/actor.
- #808 Pre-Implementation Coverage Audit and Independent Gate Re-Review: approved as first slice for `runtime.cli.serve.active_run_abandon_quiescence`.

## Semantic Migration

- New canonical owner: `internal/runtime/runquiescence` request/result types plus `PostgresStore.ApplyActiveRunQuiescence`.
- Old non-authoritative path now invalid: destructive-reset-specific quiescence as the only broad active-run quiescence interpreter.
- Invalid implementation paths not introduced: no raw SQL in `cmd/swarm`, no loop over `/v1/rpc run.stop`, no `runtime_nuke_cancelled` reuse for serve abandon.
- Production paths checked: serve startup, destructive reset quiescence, AgentManager receipt/write path, node pipeline runner, platform pipeline receipt writer, missing-pipeline replay selection.
- Migration is complete for the chosen #808 class. `--shutdown-grace`, `interrupted_by_shutdown`, `--dev`, dev entity-container cleanup, #806, and #743 remain split under their own trackers.

## Proof

- `go test ./cmd/swarm -run 'TestCLI_Serve|TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission|TestServeBundleMatchAdmission' -count=1`
- `go test ./internal/store -run 'ServeAbandon|Quiescence|PipelineReplay|MarkEventDeliveryInProgress' -count=1`
- `go test ./internal/runtime/destructivereset ./internal/runtime/pipeline -count=1`
- `go test ./cmd/swarm ./internal/store ./internal/runtime/destructivereset ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime/runquiescence -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`