### PR TITLE
[agent-b][issue #812] Add v1 CLI run control commands

### DIFF
--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -85,6 +85,9 @@ func newControlCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newRetiredControlMailboxCommand(),
+		newControlPauseCommand(opts),
+		newControlContinueCommand(opts),
+		newControlStopCommand(opts),
 		newControlNukeCommand(opts),
 	)
 	return cmd

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	controlCommandRunListMethod        = "run.list"
+	controlCommandRunPauseMethod       = "run.pause"
+	controlCommandRunContinueMethod    = "run.continue"
+	controlCommandRunStopMethod        = "run.stop"
+	controlCommandRuntimePauseMethod   = "runtime.pause"
+	controlCommandRuntimeResumeMethod  = "runtime.resume"
+	controlCommandStopAllPageLimit     = 500
+	controlCommandStatusRunning        = "running"
+	controlCommandStatusPaused         = "paused"
+	controlCommandExitCodeValidation   = 2
+	controlCommandExitCodeRuntimeError = 3
+	controlCommandExitCodeAuth         = 4
+	controlCommandExitCodeNotFound     = 5
+	controlCommandExitCodeConflict     = 6
+)
+
+type controlRunCommandOptions struct {
+	apiOptions rootCommandOptions
+	action     string
+	runMethod  string
+	allMethod  string
+	all        bool
+}
+
+type controlCommandOKResult struct {
+	OK bool `json:"ok"`
+}
+
+type controlStopAllFailure struct {
+	runID string
+	err   error
+}
+
+func newControlPauseCommand(opts rootCommandOptions) *cobra.Command {
+	return newControlRunCommand(controlRunCommandOptions{
+		apiOptions: opts,
+		action:     "pause",
+		runMethod:  controlCommandRunPauseMethod,
+		allMethod:  controlCommandRuntimePauseMethod,
+	})
+}
+
+func newControlContinueCommand(opts rootCommandOptions) *cobra.Command {
+	return newControlRunCommand(controlRunCommandOptions{
+		apiOptions: opts,
+		action:     "continue",
+		runMethod:  controlCommandRunContinueMethod,
+		allMethod:  controlCommandRuntimeResumeMethod,
+	})
+}
+
+func newControlStopCommand(opts rootCommandOptions) *cobra.Command {
+	return newControlRunCommand(controlRunCommandOptions{
+		apiOptions: opts,
+		action:     "stop",
+		runMethod:  controlCommandRunStopMethod,
+	})
+}
+
+func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
+	cmdOpts := opts
+	cmd := &cobra.Command{
+		Use:   opts.action + " [<run-id>] [--all]",
+		Short: fmt.Sprintf("%s a run or the supported all-runs scope through v1 RPC.", controlCommandTitle(opts.action)),
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runOpts := cmdOpts
+			return runControlRunCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, runOpts)
+		},
+	}
+	cmd.Flags().BoolVar(&cmdOpts.all, "all", false, "Apply the supported all-runs scope for this action")
+	return cmd
+}
+
+func controlCommandTitle(action string) string {
+	if action == "" {
+		return ""
+	}
+	return strings.ToUpper(action[:1]) + action[1:]
+}
+
+func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []string, opts controlRunCommandOptions) error {
+	runID, err := validateControlRunTarget(args, opts.all)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: controlCommandErrorExitCode(err)}
+	}
+
+	if opts.all {
+		if opts.action == "stop" {
+			return runControlStopAllCommand(ctx, out, errOut, client)
+		}
+		if opts.allMethod == "" {
+			fmt.Fprintf(errOut, "unsupported all-runs control action %q\n", opts.action)
+			return commandExitError{code: controlCommandExitCodeRuntimeError}
+		}
+		if err := callControlOK(ctx, client, opts.allMethod, map[string]any{}); err != nil {
+			fmt.Fprintln(errOut, err)
+			return commandExitError{code: controlCommandErrorExitCode(err)}
+		}
+		writeControlOK(out, opts.action, "runtime", "")
+		return nil
+	}
+
+	if err := callControlOK(ctx, client, opts.runMethod, map[string]any{"run_id": runID}); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: controlCommandErrorExitCode(err)}
+	}
+	writeControlOK(out, opts.action, "run", runID)
+	return nil
+}
+
+func validateControlRunTarget(args []string, all bool) (string, error) {
+	if all {
+		if len(args) > 0 {
+			return "", fmt.Errorf("--all cannot be combined with a run id")
+		}
+		return "", nil
+	}
+	if len(args) != 1 {
+		return "", fmt.Errorf("pass a run id or --all")
+	}
+	runID := strings.TrimSpace(args[0])
+	if runID == "" {
+		return "", fmt.Errorf("run id is required")
+	}
+	return runID, nil
+}
+
+func callControlOK(ctx context.Context, client *cliAPIClient, method string, params map[string]any) error {
+	var result controlCommandOKResult
+	if err := client.call(ctx, method, params, &result); err != nil {
+		return err
+	}
+	if !result.OK {
+		return fmt.Errorf("malformed %s result: ok must be true", method)
+	}
+	return nil
+}
+
+func runControlStopAllCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient) error {
+	runIDs, err := listControlStopAllRunIDs(ctx, client)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: controlCommandErrorExitCode(err)}
+	}
+	failures := []controlStopAllFailure{}
+	stopped := 0
+	for _, runID := range runIDs {
+		if err := callControlOK(ctx, client, controlCommandRunStopMethod, map[string]any{"run_id": runID}); err != nil {
+			failures = append(failures, controlStopAllFailure{runID: runID, err: err})
+			continue
+		}
+		stopped++
+	}
+
+	writeControlStopAllResult(out, len(runIDs), stopped, len(failures))
+	if len(failures) > 0 {
+		writeControlStopAllFailures(errOut, failures)
+		return commandExitError{code: controlStopAllExitCode(failures)}
+	}
+	return nil
+}
+
+func listControlStopAllRunIDs(ctx context.Context, client *cliAPIClient) ([]string, error) {
+	statuses := []string{controlCommandStatusRunning, controlCommandStatusPaused}
+	seenRuns := map[string]struct{}{}
+	runIDs := []string{}
+	for _, status := range statuses {
+		cursor := ""
+		seenCursors := map[string]struct{}{}
+		for {
+			params := map[string]any{
+				"status": status,
+				"limit":  controlCommandStopAllPageLimit,
+			}
+			if cursor != "" {
+				params["cursor"] = cursor
+			}
+			result, err := fetchDiagnosticRunList(ctx, client, params)
+			if err != nil {
+				return nil, err
+			}
+			for _, run := range result.Runs {
+				if run.Status != status {
+					return nil, fmt.Errorf("malformed run.list result: status filter %q returned run %s with status %q", status, run.RunID, run.Status)
+				}
+				runID := strings.TrimSpace(run.RunID)
+				if _, ok := seenRuns[runID]; ok {
+					continue
+				}
+				seenRuns[runID] = struct{}{}
+				runIDs = append(runIDs, runID)
+			}
+			nextCursor := strings.TrimSpace(result.NextCursor)
+			if nextCursor == "" {
+				break
+			}
+			if _, ok := seenCursors[nextCursor]; ok {
+				return nil, fmt.Errorf("malformed run.list result: repeated next_cursor %q for status %s", nextCursor, status)
+			}
+			seenCursors[nextCursor] = struct{}{}
+			cursor = nextCursor
+		}
+	}
+	return runIDs, nil
+}
+
+func writeControlOK(out io.Writer, action, scope, runID string) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "control %s ok: scope=%s", action, scope)
+	if runID != "" {
+		fmt.Fprintf(out, " run_id=%s", runID)
+	}
+	fmt.Fprintln(out)
+}
+
+func writeControlStopAllResult(out io.Writer, matched, stopped, failed int) {
+	if out == nil {
+		return
+	}
+	if failed == 0 {
+		fmt.Fprintf(out, "control stop ok: scope=all matched=%d stopped=%d failed=0\n", matched, stopped)
+		return
+	}
+	fmt.Fprintf(out, "control stop partial: scope=all matched=%d stopped=%d failed=%d\n", matched, stopped, failed)
+}
+
+func writeControlStopAllFailures(errOut io.Writer, failures []controlStopAllFailure) {
+	if errOut == nil {
+		return
+	}
+	for _, failure := range failures {
+		fmt.Fprintf(errOut, "control stop failed: run_id=%s error=%v\n", failure.runID, failure.err)
+	}
+}
+
+func controlStopAllExitCode(failures []controlStopAllFailure) int {
+	code := controlCommandExitCodeRuntimeError
+	for _, failure := range failures {
+		switch controlCommandErrorExitCode(failure.err) {
+		case controlCommandExitCodeAuth:
+			return controlCommandExitCodeAuth
+		case controlCommandExitCodeConflict:
+			code = controlCommandExitCodeConflict
+		}
+	}
+	return code
+}
+
+func controlCommandErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return controlCommandExitCodeAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return controlCommandExitCodeAuth
+		}
+		return controlCommandExitCodeRuntimeError
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return controlCommandExitCodeAuth
+		case "RUN_NOT_FOUND":
+			return controlCommandExitCodeNotFound
+		case "IDEMPOTENCY_CONFLICT":
+			return controlCommandExitCodeConflict
+		default:
+			return controlCommandExitCodeRuntimeError
+		}
+	}
+	return controlCommandExitCodeRuntimeError
+}

--- a/cmd/swarm/control_run_test.go
+++ b/cmd/swarm/control_run_test.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestControlRunSingleCommandsSendV1RPCRequests(t *testing.T) {
+	for _, tc := range []struct {
+		action     string
+		wantMethod string
+		wantOutput string
+	}{
+		{action: "pause", wantMethod: controlCommandRunPauseMethod, wantOutput: "control pause ok: scope=run run_id=run-1"},
+		{action: "continue", wantMethod: controlCommandRunContinueMethod, wantOutput: "control continue ok: scope=run run_id=run-1"},
+		{action: "stop", wantMethod: controlCommandRunStopMethod, wantOutput: "control stop ok: scope=run run_id=run-1"},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/rpc" {
+					t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+					t.Errorf("Authorization = %q, want bearer token", got)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", tc.action, "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.JSONRPC != "2.0" || captured.Method != tc.wantMethod {
+				t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, tc.wantMethod)
+			}
+			if !reflect.DeepEqual(captured.Params, map[string]any{"run_id": "run-1"}) {
+				t.Fatalf("params = %#v, want run_id", captured.Params)
+			}
+			if !strings.Contains(stdout.String(), tc.wantOutput) {
+				t.Fatalf("stdout = %q, want substring %q", stdout.String(), tc.wantOutput)
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestControlRunAllPauseContinueSendRuntimeRPCRequests(t *testing.T) {
+	for _, tc := range []struct {
+		action     string
+		wantMethod string
+		wantOutput string
+	}{
+		{action: "pause", wantMethod: controlCommandRuntimePauseMethod, wantOutput: "control pause ok: scope=runtime"},
+		{action: "continue", wantMethod: controlCommandRuntimeResumeMethod, wantOutput: "control continue ok: scope=runtime"},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", tc.action, "--all"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.JSONRPC != "2.0" || captured.Method != tc.wantMethod {
+				t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, tc.wantMethod)
+			}
+			if !reflect.DeepEqual(captured.Params, map[string]any{}) {
+				t.Fatalf("params = %#v, want empty map", captured.Params)
+			}
+			if !strings.Contains(stdout.String(), tc.wantOutput) {
+				t.Fatalf("stdout = %q, want substring %q", stdout.String(), tc.wantOutput)
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestControlStopAllListsActiveRunsAndStopsUniqueTargets(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		captured = append(captured, req)
+		switch len(captured) {
+		case 1:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"runs": []map[string]any{
+					controlRunHeaderResult("run-a", "running"),
+					controlRunHeaderResult("run-b", "running"),
+				},
+				"next_cursor": "running-2",
+			})
+		case 2:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"runs": []map[string]any{
+					controlRunHeaderResult("run-c", "running"),
+				},
+			})
+		case 3:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"runs": []map[string]any{
+					controlRunHeaderResult("run-b", "paused"),
+					controlRunHeaderResult("run-d", "paused"),
+				},
+			})
+		default:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true})
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(captured) != 7 {
+		t.Fatalf("captured %d requests, want 7: %#v", len(captured), captured)
+	}
+	assertControlRequest(t, captured[0], controlCommandRunListMethod, map[string]any{"status": "running", "limit": float64(controlCommandStopAllPageLimit)})
+	assertControlRequest(t, captured[1], controlCommandRunListMethod, map[string]any{"status": "running", "limit": float64(controlCommandStopAllPageLimit), "cursor": "running-2"})
+	assertControlRequest(t, captured[2], controlCommandRunListMethod, map[string]any{"status": "paused", "limit": float64(controlCommandStopAllPageLimit)})
+	assertControlRequest(t, captured[3], controlCommandRunStopMethod, map[string]any{"run_id": "run-a"})
+	assertControlRequest(t, captured[4], controlCommandRunStopMethod, map[string]any{"run_id": "run-b"})
+	assertControlRequest(t, captured[5], controlCommandRunStopMethod, map[string]any{"run_id": "run-c"})
+	assertControlRequest(t, captured[6], controlCommandRunStopMethod, map[string]any{"run_id": "run-d"})
+	if !strings.Contains(stdout.String(), "control stop ok: scope=all matched=4 stopped=4 failed=0") {
+		t.Fatalf("stdout = %q, want stop-all success summary", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestControlRunRejectsInvalidTargetsBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing target", args: []string{"control", "pause"}, wantStderr: "pass a run id or --all"},
+		{name: "all with run id", args: []string{"control", "pause", "run-1", "--all"}, wantStderr: "--all cannot be combined with a run id"},
+		{name: "extra target", args: []string{"control", "continue", "run-1", "run-2"}, wantStderr: "accepts at most 1 arg"},
+		{name: "blank run id", args: []string{"control", "stop", "  "}, wantStderr: "run id is required"},
+		{name: "unsupported flag", args: []string{"control", "stop", "run-1", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != before {
+				t.Fatalf("server calls changed from %d to %d, want no request", before, calls.Load())
+			}
+		})
+	}
+}
+
+func TestControlRunRequiresAPITokenBeforeRequest(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"control", "pause", "run-1"},
+		{"control", "continue", "--all"},
+		{"control", "stop", "--all"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "")
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 4 {
+				t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			args: []string{"control", "pause", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "run not found",
+			args: []string{"control", "stop", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeControlJSONRPCApplicationError(t, w, req.ID, "RUN_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "RUN_NOT_FOUND",
+		},
+		{
+			name: "malformed response",
+			args: []string{"control", "continue", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{`))
+			},
+			wantCode:   3,
+			wantStderr: "decode JSON-RPC response",
+		},
+		{
+			name: "malformed ok result",
+			args: []string{"control", "pause", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": false})
+			},
+			wantCode:   3,
+			wantStderr: "malformed run.pause result: ok must be true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestControlStopAllReportsPartialFailures(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		captured = append(captured, req)
+		switch len(captured) {
+		case 1:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []map[string]any{
+				controlRunHeaderResult("run-a", "running"),
+				controlRunHeaderResult("run-b", "running"),
+			}})
+		case 2:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+		case 3:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true})
+		case 4:
+			writeControlJSONRPCApplicationError(t, w, req.ID, "RUN_ALREADY_TERMINAL")
+		default:
+			t.Fatalf("unexpected request %d: %#v", len(captured), req)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(captured) != 4 {
+		t.Fatalf("captured %d requests, want 4: %#v", len(captured), captured)
+	}
+	if !strings.Contains(stdout.String(), "control stop partial: scope=all matched=2 stopped=1 failed=1") {
+		t.Fatalf("stdout = %q, want partial summary", stdout.String())
+	}
+	for _, want := range []string{"control stop failed: run_id=run-b", "RUN_ALREADY_TERMINAL"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func assertControlRequest(t *testing.T, req jsonRPCRequest, wantMethod string, wantParams map[string]any) {
+	t.Helper()
+	if req.JSONRPC != "2.0" || req.Method != wantMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", req.JSONRPC, req.Method, wantMethod)
+	}
+	if !reflect.DeepEqual(req.Params, wantParams) {
+		t.Fatalf("params for %s = %#v, want %#v", wantMethod, req.Params, wantParams)
+	}
+}
+
+func controlRunHeaderResult(runID, status string) map[string]any {
+	return map[string]any{
+		"run_id":             runID,
+		"status":             status,
+		"trigger_event_type": "manual.test",
+		"trigger_event_id":   "event-" + runID,
+		"entity_count":       1,
+		"event_count":        2,
+		"started_at":         "2026-05-18T01:00:00Z",
+	}
+}
+
+func writeControlJSONRPCApplicationError(t *testing.T, w http.ResponseWriter, id, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5606,18 +5606,87 @@ cli_specification:
     control_pause:
       command: swarm control pause <run-id> | --all
       tier: should_have
-      implementation_status: absent
-      owners: /v1/rpc run.pause for one run; /v1/rpc runtime.pause for --all
+      implementation_status: implemented
+      owners:
+        single_run: /v1/rpc run.pause
+        all_scope: /v1/rpc runtime.pause
+      targeting:
+        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
+        all_scope_semantics: '`--all` pauses runtime ingress through runtime.pause. It does not claim to pause every existing run-control state individually.'
+      output:
+        single_run_success: 'control pause ok: scope=run run_id=<run-id>'
+        all_success: 'control pause ok: scope=runtime'
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_api_or_state_error: 3
+        auth_failure: 4
+        run_not_found: 5
+        idempotency_conflict: 6
+      proof_expectations:
+      - exact /v1/rpc run.pause call with run_id for single-run mode
+      - exact /v1/rpc runtime.pause call with empty params for --all
+      - no direct DB/store/runtime/EventBus reads or writes
+      - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_continue:
       command: swarm control continue <run-id> | --all
       tier: should_have
-      implementation_status: absent
-      owners: /v1/rpc run.continue for one run; /v1/rpc runtime.resume for --all
+      implementation_status: implemented
+      owners:
+        single_run: /v1/rpc run.continue
+        all_scope: /v1/rpc runtime.resume
+      targeting:
+        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
+        all_scope_semantics: '`--all` resumes runtime ingress through runtime.resume. It does not claim to continue every existing run-control state individually.'
+      output:
+        single_run_success: 'control continue ok: scope=run run_id=<run-id>'
+        all_success: 'control continue ok: scope=runtime'
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_api_or_state_error: 3
+        auth_failure: 4
+        run_not_found: 5
+        idempotency_conflict: 6
+      proof_expectations:
+      - exact /v1/rpc run.continue call with run_id for single-run mode
+      - exact /v1/rpc runtime.resume call with empty params for --all
+      - no direct DB/store/runtime/EventBus reads or writes
+      - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_stop:
       command: swarm control stop <run-id> | --all
       tier: should_have
-      implementation_status: absent
-      owners: /v1/rpc run.stop for one run; run.list plus run.stop iteration for --all unless a future runtime stop-all owner is promoted
+      implementation_status: implemented
+      owners:
+        single_run: /v1/rpc run.stop
+        all_discovery: /v1/rpc run.list
+        all_stop: /v1/rpc run.stop
+      targeting:
+        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
+        all_scope_semantics: >
+          `--all` is an API-only CLI composite, not an atomic runtime-wide stop owner. The CLI lists active runs with status=running
+          and status=paused, follows next_cursor pagination to exhaustion with limit=500, deduplicates run IDs, and calls run.stop once
+          for each discovered target. It MUST NOT call runtime.nuke, introduce runtime.stop, inspect local DB/store/runtime state, or
+          infer targets from logs/EventBus.
+      output:
+        single_run_success: 'control stop ok: scope=run run_id=<run-id>'
+        all_success: 'control stop ok: scope=all matched=<n> stopped=<n> failed=0'
+        all_partial_stdout: 'control stop partial: scope=all matched=<n> stopped=<m> failed=<k>'
+        all_partial_stderr: 'control stop failed: run_id=<run-id> error=<error>'
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_api_or_state_error: 3
+        auth_failure: 4
+        run_not_found: 5
+        idempotency_conflict: 6
+        stop_all_partial_failure: 3
+      proof_expectations:
+      - exact /v1/rpc run.stop call with run_id for single-run mode
+      - exact /v1/rpc run.list status=running/status=paused paginated discovery for --all
+      - exact /v1/rpc run.stop calls for unique discovered run IDs and explicit partial-failure reporting
+      - no direct DB/store/runtime/EventBus reads or writes
+      - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_nuke:
       command: swarm control nuke [--yes|-y] [--dry-run]
       tier: should_have
@@ -5778,6 +5847,9 @@ cli_specification:
     - swarm mailbox approve
     - swarm mailbox reject
     - swarm mailbox defer
+    - swarm control pause
+    - swarm control continue
+    - swarm control stop
     - swarm control nuke
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
@@ -5788,7 +5860,6 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm control pause|continue|stop
     - swarm agents list / agent view / agent restart / agent replay / agent directive
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn


### PR DESCRIPTION
## Summary

Implements the approved #812 first-slice CLI consumer boundary for `swarm control pause|continue|stop`:

- `swarm control pause <run-id>` -> `/v1/rpc run.pause`
- `swarm control continue <run-id>` -> `/v1/rpc run.continue`
- `swarm control stop <run-id>` -> `/v1/rpc run.stop`
- `swarm control pause --all` -> `/v1/rpc runtime.pause`
- `swarm control continue --all` -> `/v1/rpc runtime.resume`
- `swarm control stop --all` -> `/v1/rpc run.list` over active statuses, then `/v1/rpc run.stop` once per unique discovered run ID

Closes #812.
Part of #735.

## Governing Refs / Context

- #812 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` CLI catalog entries: `control_pause`, `control_continue`, `control_stop`.
- v1 API owners: `run.pause`, `run.continue`, `run.stop`, `run.list`, `runtime.pause`, `runtime.resume`.
- OpenRPC remains generated/valid; no public API/OpenRPC method changes are introduced by this CLI consumer PR.

## Semantic Migration / Owner Boundary

- New canonical CLI owner consumption: `cmd/swarm` calls only the v1 JSON-RPC client for the approved methods.
- Old/non-authoritative paths now invalid for this CLI class: direct DB/store/runtime/EventBus reads/writes, legacy `/api/*`, `/rpc`, `/api/rpc`, `/ws`, `/api/ws`, Builder/operator token fallback, `runtime.nuke`, and any implicit `runtime.stop`.
- Production paths checked for surviving old behavior: new `cmd/swarm/control_run.go`, existing `cmd/swarm/control_mailbox.go` registration, and static grep over new CLI code.
- Migration completeness: complete for the #812 `swarm control pause|continue|stop` CLI command group. Parent #735 remains open for other should-have CLI families.

## Proof

- `go test ./cmd/swarm -run 'TestControlRun|TestControlStop|TestControlPause|TestControlContinue' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run TestRegistryMethodNamesMatchGeneratedOpenRPC -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static proof: `rg -n 'internal/store|internal/runtime|EventBus|runtime\.nuke|runtime\.stop|/api|/rpc|/ws|BUILDER|OPERATOR|runcontrol|ingress' cmd/swarm/control_run.go cmd/swarm/control_run_test.go` returns only test assertions for `/v1/rpc`.
- Negative split proof: no `abandon-active-runs`, `shutdown-grace`, `runtime.nuke`, `runtime.stop`, `run_clear`, `ResetRuntimeStateWithSource`, Docker, or SQL references in the touched CLI command files.
