### PR TITLE
[agent-b][issue #818] Add agent read CLI commands

### DIFF
--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type agentListCommandOptions struct {
+	apiOptions rootCommandOptions
+	flow       string
+	role       string
+}
+
+type agentListResult struct {
+	Agents []agentSummary `json:"agents"`
+}
+
+type agentDetailResult struct {
+	Agent             agentSummary     `json:"agent"`
+	CurrentSessionRef *agentSessionRef `json:"current_session_ref,omitempty"`
+	LastTurnRef       *agentTurnRef    `json:"last_turn_ref,omitempty"`
+}
+
+type agentSummary struct {
+	AgentID          string `json:"agent_id"`
+	Role             string `json:"role"`
+	Type             string `json:"type"`
+	ModelTier        string `json:"model_tier"`
+	ConversationMode string `json:"conversation_mode"`
+	SessionScope     string `json:"session_scope"`
+	Status           string `json:"status"`
+}
+
+type agentSessionRef struct {
+	SessionID string `json:"session_id"`
+	StartedAt string `json:"started_at"`
+}
+
+type agentTurnRef struct {
+	TurnID      string `json:"turn_id"`
+	CompletedAt string `json:"completed_at"`
+	ParseOK     *bool  `json:"parse_ok"`
+	Error       string `json:"error,omitempty"`
+}
+
+var agentValidStatuses = map[string]struct{}{
+	"idle":       {},
+	"running":    {},
+	"paused":     {},
+	"failed":     {},
+	"terminated": {},
+}
+
+var agentValidConversationModes = map[string]struct{}{
+	"task":               {},
+	"session":            {},
+	"session_per_entity": {},
+}
+
+var agentValidSessionScopes = map[string]struct{}{
+	"global": {},
+	"flow":   {},
+	"entity": {},
+}
+
+func newAgentsCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agents",
+		Short: "List agents through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newAgentsListCommand(opts))
+	return cmd
+}
+
+func newAgentCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "View one agent through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newAgentViewCommand(opts))
+	return cmd
+}
+
+func newAgentsListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := agentListCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List declared agents through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentListCommand(cmd.Context(), cmd.OutOrStdout(), listOpts)
+		},
+	}
+	cmd.Flags().StringVar(&listOpts.flow, "flow", "", "Filter by canonical flow path")
+	cmd.Flags().StringVar(&listOpts.role, "role", "", "Filter by agent role")
+	return cmd
+}
+
+func newAgentViewCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <agent-id>",
+		Short: "View one agent through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), opts, args[0])
+		},
+	}
+}
+
+func runAgentListCommand(ctx context.Context, out io.Writer, opts agentListCommandOptions) error {
+	params := opts.params()
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return err
+	}
+	var result agentListResult
+	if err := client.call(ctx, "agent.list", params, &result); err != nil {
+		return err
+	}
+	if err := validateAgentListResult(result); err != nil {
+		return err
+	}
+	writeAgentListResult(out, result)
+	return nil
+}
+
+func runAgentViewCommand(ctx context.Context, out io.Writer, opts rootCommandOptions, agentID string) error {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return err
+	}
+	var result agentDetailResult
+	if err := client.call(ctx, "agent.get", map[string]any{"agent_id": agentID}, &result); err != nil {
+		return err
+	}
+	if err := validateAgentDetailResult(result); err != nil {
+		return err
+	}
+	writeAgentDetailResult(out, result)
+	return nil
+}
+
+func (opts agentListCommandOptions) params() map[string]any {
+	params := map[string]any{}
+	if flow := strings.TrimSpace(opts.flow); flow != "" {
+		params["flow"] = flow
+	}
+	if role := strings.TrimSpace(opts.role); role != "" {
+		params["role"] = role
+	}
+	return params
+}
+
+func validateAgentListResult(result agentListResult) error {
+	if result.Agents == nil {
+		return fmt.Errorf("malformed agent.list result: agents is required")
+	}
+	for i, agent := range result.Agents {
+		if err := validateAgentSummary(agent); err != nil {
+			return fmt.Errorf("malformed agent.list result: agents[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateAgentDetailResult(result agentDetailResult) error {
+	if err := validateAgentSummary(result.Agent); err != nil {
+		return fmt.Errorf("malformed agent.get result: agent: %w", err)
+	}
+	if ref := result.CurrentSessionRef; ref != nil {
+		if strings.TrimSpace(ref.SessionID) == "" {
+			return fmt.Errorf("malformed agent.get result: current_session_ref.session_id is required")
+		}
+		if err := validateAgentTimestamp("current_session_ref.started_at", ref.StartedAt); err != nil {
+			return err
+		}
+	}
+	if ref := result.LastTurnRef; ref != nil {
+		if strings.TrimSpace(ref.TurnID) == "" {
+			return fmt.Errorf("malformed agent.get result: last_turn_ref.turn_id is required")
+		}
+		if err := validateAgentTimestamp("last_turn_ref.completed_at", ref.CompletedAt); err != nil {
+			return err
+		}
+		if ref.ParseOK == nil {
+			return fmt.Errorf("malformed agent.get result: last_turn_ref.parse_ok is required")
+		}
+	}
+	return nil
+}
+
+func validateAgentSummary(agent agentSummary) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "agent_id", value: agent.AgentID},
+		{name: "role", value: agent.Role},
+		{name: "type", value: agent.Type},
+		{name: "model_tier", value: agent.ModelTier},
+		{name: "conversation_mode", value: agent.ConversationMode},
+		{name: "session_scope", value: agent.SessionScope},
+		{name: "status", value: agent.Status},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+	if _, ok := agentValidStatuses[strings.TrimSpace(agent.Status)]; !ok {
+		return fmt.Errorf("status=%q is not a valid AgentStatus", agent.Status)
+	}
+	if _, ok := agentValidConversationModes[strings.TrimSpace(agent.ConversationMode)]; !ok {
+		return fmt.Errorf("conversation_mode=%q is not a valid ConversationMode", agent.ConversationMode)
+	}
+	if _, ok := agentValidSessionScopes[strings.TrimSpace(agent.SessionScope)]; !ok {
+		return fmt.Errorf("session_scope=%q is not a valid SessionScope", agent.SessionScope)
+	}
+	return nil
+}
+
+func validateAgentTimestamp(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("malformed agent.get result: %s is required", field)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("malformed agent.get result: %s must be an RFC3339 timestamp: %w", field, err)
+	}
+	return nil
+}
+
+func writeAgentListResult(out io.Writer, result agentListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Agents) == 0 {
+		fmt.Fprintln(out, "No agents match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "AGENT_ID\tROLE\tTYPE\tSTATUS\tMODEL_TIER\tMODE\tSCOPE")
+	for _, agent := range result.Agents {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			agent.AgentID,
+			agent.Role,
+			agent.Type,
+			agent.Status,
+			agent.ModelTier,
+			agent.ConversationMode,
+			agent.SessionScope,
+		)
+	}
+}
+
+func writeAgentDetailResult(out io.Writer, result agentDetailResult) {
+	if out == nil {
+		return
+	}
+	agent := result.Agent
+	fmt.Fprintf(out, "Agent %s\n", agent.AgentID)
+	fmt.Fprintf(out, "role=%s type=%s status=%s model_tier=%s conversation_mode=%s session_scope=%s\n",
+		agent.Role,
+		agent.Type,
+		agent.Status,
+		agent.ModelTier,
+		agent.ConversationMode,
+		agent.SessionScope,
+	)
+	if ref := result.CurrentSessionRef; ref != nil {
+		fmt.Fprintf(out, "current_session_ref: session_id=%s started_at=%s\n", ref.SessionID, ref.StartedAt)
+	}
+	if ref := result.LastTurnRef; ref != nil {
+		fmt.Fprintf(out, "last_turn_ref: turn_id=%s completed_at=%s parse_ok=%t error=%s\n",
+			ref.TurnID,
+			ref.CompletedAt,
+			*ref.ParseOK,
+			agentDash(ref.Error),
+		)
+	}
+}
+
+func agentDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}

--- a/cmd/swarm/agents_test.go
+++ b/cmd/swarm/agents_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentsListUsesV1RPCWithFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"agents": []map[string]any{
+				agentSummaryResult("agent-1", "researcher", "running"),
+				agentSummaryResult("agent-2", "researcher", "idle"),
+			},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agents", "list", "--flow", "flows/research", "--role", "researcher"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "agent.list" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/agent.list", captured.JSONRPC, captured.Method)
+	}
+	wantParams := map[string]any{"flow": "flows/research", "role": "researcher"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"AGENT_ID", "agent-1", "researcher", "worker", "running", "default", "task", "global", "agent-2", "idle"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentsListEmptyResult(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"agents": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agents", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "agent.list" {
+		t.Fatalf("method = %q, want agent.list", captured.Method)
+	}
+	if len(captured.Params) != 0 {
+		t.Fatalf("params = %#v, want empty", captured.Params)
+	}
+	if !strings.Contains(stdout.String(), "No agents match the filter.") {
+		t.Fatalf("stdout = %q, want empty message", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentViewUsesAgentGetAndRendersRefsOnly(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		parseOK := true
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"agent":               agentSummaryResult("agent-1", "reviewer", "running"),
+			"current_session_ref": map[string]any{"session_id": "session-1", "started_at": "2026-05-18T03:00:00Z"},
+			"last_turn_ref":       map[string]any{"turn_id": "turn-1", "completed_at": "2026-05-18T03:05:00Z", "parse_ok": parseOK},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "view", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "agent.get" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/agent.get", captured.JSONRPC, captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"agent_id": "agent-1"}) {
+		t.Fatalf("params = %#v, want agent id", captured.Params)
+	}
+	for _, want := range []string{
+		"Agent agent-1",
+		"role=reviewer type=worker status=running model_tier=default conversation_mode=task session_scope=global",
+		"current_session_ref: session_id=session-1 started_at=2026-05-18T03:00:00Z",
+		"last_turn_ref: turn_id=turn-1 completed_at=2026-05-18T03:05:00Z parse_ok=true error=-",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"transcript", "conversation.current_for_agent", "conversation.get"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("stdout contains split concept %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentReadCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "agents list extra arg", args: []string{"agents", "list", "extra"}, wantStderr: "unknown command"},
+		{name: "agents list unsupported flag", args: []string{"agents", "list", "--unknown"}, wantStderr: "unknown flag"},
+		{name: "agent view missing id", args: []string{"agent", "view"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "agent view blank id", args: []string{"agent", "view", "  "}, wantStderr: "agent id is required"},
+		{name: "agent view extra arg", args: []string{"agent", "view", "agent-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "agent view unsupported flag", args: []string{"agent", "view", "agent-1", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentReadCommandsFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agents", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantStderr string
+	}{
+		{
+			name: "list http auth failure",
+			args: []string{"agents", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "list missing agents",
+			args: []string{"agents", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantStderr: "malformed agent.list result: agents is required",
+		},
+		{
+			name: "list malformed agent",
+			args: []string{"agents", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				agent := agentSummaryResult("agent-1", "researcher", "running")
+				delete(agent, "status")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"agents": []map[string]any{agent}})
+			},
+			wantStderr: "malformed agent.list result: agents[0]: status is required",
+		},
+		{
+			name: "view missing agent",
+			args: []string{"agent", "view", "agent-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantStderr: "malformed agent.get result: agent: agent_id is required",
+		},
+		{
+			name: "view agent not found",
+			args: []string{"agent", "view", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantStderr: "AGENT_NOT_FOUND: Application error: AGENT_NOT_FOUND",
+		},
+		{
+			name: "view malformed ref",
+			args: []string{"agent", "view", "agent-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"agent":               agentSummaryResult("agent-1", "researcher", "running"),
+					"current_session_ref": map[string]any{"session_id": "session-1"},
+				})
+			},
+			wantStderr: "malformed agent.get result: current_session_ref.started_at is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func agentSummaryResult(agentID, role, status string) map[string]any {
+	return map[string]any{
+		"agent_id":          agentID,
+		"role":              role,
+		"type":              "worker",
+		"model_tier":        "default",
+		"conversation_mode": "task",
+		"session_scope":     "global",
+		"status":            status,
+	}
+}
+
+func writeAgentJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"agent_id": "missing"},
+				"retryable":      false,
+				"correlation_id": "corr-agent",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -73,6 +73,8 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newTraceCommand(opts),
 		newHealthCommand(opts),
 		newInvestigateCommand(opts),
+		newAgentsCommand(opts),
+		newAgentCommand(opts),
 		newMailboxCommand(opts),
 		newControlCommand(opts),
 		newRetiredForkCommand(),

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5724,13 +5724,39 @@ cli_specification:
     agents_list:
       command: swarm agents list
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.list
+      behavior: Read-only agent discovery CLI consumer. The CLI sends only non-empty --flow and --role filters to /v1/rpc agent.list, renders AgentSummary rows returned by the API, and MUST NOT filter locally or read dashboard/Builder REST, DB/store, runtime, EventBus, agentcontrol, or conversation owners.
+      output:
+        empty: No agents match the filter.
+        columns: AGENT_ID, ROLE, TYPE, STATUS, MODEL_TIER, MODE, SCOPE
+      exit_codes:
+        success: 0
+        cli_validation_or_transport_or_rpc_or_malformed_response: 2
+      proof_expectations:
+      - exact /v1/rpc agent.list call with flow/role params only when provided
+      - fail-closed SWARM_API_TOKEN behavior before any request
+      - invalid args/flags make zero API calls
+      - malformed agent.list responses fail closed
+      - no direct DB/store/runtime/EventBus/agentcontrol reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or token fallback
     agent_view:
       command: swarm agent view <agent-id>
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.get
+      behavior: Read-only single-agent detail CLI consumer. The CLI renders only AgentDetail and refs returned by /v1/rpc agent.get; it MUST NOT expand transcripts, call conversation.current_for_agent, call conversation.get, or reconstruct agent/session/turn state locally.
+      output:
+        header: Agent <agent-id>
+        summary_line: role=<role> type=<type> status=<status> model_tier=<model_tier> conversation_mode=<mode> session_scope=<scope>
+        refs_only: optional current_session_ref and last_turn_ref lines when present
+      exit_codes:
+        success: 0
+        cli_validation_or_transport_or_rpc_or_malformed_response: 2
+      proof_expectations:
+      - exact /v1/rpc agent.get call with agent_id
+      - AGENT_NOT_FOUND and malformed AgentDetail responses fail closed
+      - invalid args/flags make zero API calls
+      - output remains refs-only; no conversation.current_for_agent, conversation.get, transcript, direct DB/store/runtime/EventBus/agentcontrol, or legacy endpoint usage
     agent_restart:
       command: swarm agent restart <agent-id>
       tier: should_have
@@ -5879,6 +5905,8 @@ cli_specification:
     - swarm control continue
     - swarm control stop
     - swarm control nuke
+    - swarm agents list
+    - swarm agent view
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -5888,7 +5916,7 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm agents list / agent view / agent restart / agent replay / agent directive
+    - swarm agent restart / agent replay / agent directive
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete


### PR DESCRIPTION
Closes #818

## Summary
- Adds `swarm agents list [--flow <flow>] [--role <role>]` over `/v1/rpc agent.list`.
- Adds `swarm agent view <agent-id>` over `/v1/rpc agent.get` with refs-only output for session/turn state.
- Updates `platform-spec.yaml` so `swarm agents list` and `swarm agent view` are concrete implemented CLI catalog rows and removes them from the #735 remaining agent tail.

## Governing refs / context
- Issue/gate: #818 Pre-Implementation Coverage Audit and approved first-slice gate.
- Parent context: #735 CLI v2 parity and #816 agent namespace/read-vs-control split.
- Authoritative spec refs: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` CLI rows `agents_list` and `agent_view`.
- API owners: `/v1/rpc agent.list`, `/v1/rpc agent.get`; OpenRPC `agent.list`, `agent.get`, `AgentSummary`, `AgentDetail`.

## Semantic migration
- New canonical owner consumed by CLI: `/v1/rpc agent.list` and `/v1/rpc agent.get` through the shared CLI API client.
- Old invalid reader paths for this CLI slice: dashboard/Builder REST, legacy `/api/*`, legacy `/rpc`, direct DB/store/runtime/EventBus/agentcontrol reads, and conversation/transcript expansion.
- Production paths checked for surviving old behavior: `cmd/swarm/agents.go` static no-bypass grep plus fake-server CLI tests asserting exact `/v1/rpc` method names/params and no-call invalid paths.
- Migration completeness: complete for read-only agent discovery CLI; parent #735/#816 remains open for directive, restart/control, backlog replay shape, and event-targeted replay/catalog repair.

## Proof
- `go test ./cmd/swarm -run 'Agent|Agents' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass: `rg -n '/api/agents|agentcontrol|ListOperatorAgents|LoadOperatorAgent|conversation\.current_for_agent|conversation\.get|EventBus|store\.|agent\.send_directive|agent\.restart|agent\.replay|agent\.replay_backlog' cmd/swarm/agents.go` returned no matches.
