### PR TITLE
[agent-a][issue #819] Enforce CI build proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches:
+      - master
       - main
   pull_request:
   workflow_dispatch:
@@ -53,6 +54,12 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+
+      - name: Build packages
+        run: go build ./...
+
+      - name: Build swarm binary
+        run: go build ./cmd/swarm
 
       - name: Vet
         run: go vet ./...


### PR DESCRIPTION
## Summary

Closes #819.

This PR closes the approved class `maintenance.release_readiness.ci_build_proof_and_default_branch_trigger` by updating the single CI workflow to:

- run on pushes to `master` while preserving the existing `main` trigger
- add a named package-wide build proof: `go build ./...`
- add a named supported binary compile proof: `go build ./cmd/swarm`
- keep existing formatting, `go vet ./...`, and `go test ./... -count=1` checks intact

No runtime behavior, CLI behavior, platform spec semantics, cataloge2e harness behavior, #735 work, #750 work, or broader #814 docs/legal/security/release artifacts are changed.

## Governing Context

No exact platform runtime/spec section governs this CI/readiness issue. Binding context is #819 issue body/thread, #814 parent tracker, #813 / PR #817 closeout, `.github/workflows/ci.yml` as the CI owner, GitHub repository metadata identifying `master` as the default branch, and Go command semantics for package/binary compile proofs.

## Ownership / Migration

Canonical owners after the change:

- `.github/workflows/ci.yml` owns enforced CI proof for PR, push, and manual workflow runs.
- `go build ./...` owns package-wide compile proof.
- `go build ./cmd/swarm` owns explicit `swarm` binary compile proof.
- GitHub repository metadata owns default-branch truth; CI push triggers now include `master`.

Old invalid path: CI treated `go vet ./...` and `go test ./...` as sufficient release proof and only triggered pushes on `main`. That is now invalid after #813/#817 proved a build-only failure could survive without an explicit build gate.

Migration completeness: complete for #819. Broader #814 release-readiness items remain split.

## Proof

- `go build ./...` passed
- `go build ./cmd/swarm` passed
- `go vet ./...` passed
- `go test ./... -count=1` passed
- `git diff --check` passed
- Workflow inspection confirms `master` and `main` push triggers are present
- Workflow inspection confirms named `Build packages` / `go build ./...` and `Build swarm binary` / `go build ./cmd/swarm` steps are present
- Workflow inspection confirms existing formatting, vet, and test checks remain present