### PR TITLE
[agent-b][issue #822] Add agent directive CLI command

### DIFF
--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentDirectiveMethod         = "agent.send_directive"
+	agentDirectiveEventType      = "platform.agent_directive"
+	agentDirectiveExitValidation = 2
+	agentDirectiveExitRuntime    = 3
+	agentDirectiveExitAuth       = 4
+	agentDirectiveExitNotFound   = 5
+	agentDirectiveExitConflict   = 6
+)
+
+type agentDirectiveCommandOptions struct {
+	apiOptions     rootCommandOptions
+	runID          string
+	idempotencyKey string
+}
+
+type agentDirectiveResult struct {
+	OK                 bool   `json:"ok"`
+	Response           string `json:"response,omitempty"`
+	RunID              string `json:"run_id"`
+	RunIDResolution    string `json:"run_id_resolution"`
+	DirectiveEventID   string `json:"directive_event_id"`
+	DirectiveEventType string `json:"directive_event_type"`
+}
+
+var agentDirectiveValidRunIDResolutions = map[string]struct{}{
+	"specified":                    {},
+	"inferred_from_active_session": {},
+	"new_run_allocated":            {},
+}
+
+func newAgentDirectiveCommand(opts rootCommandOptions) *cobra.Command {
+	directiveOpts := agentDirectiveCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "directive <agent-id> <message>",
+		Short: "Send a directive to an agent through v1 RPC.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentDirectiveCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, directiveOpts)
+		},
+	}
+	cmd.Flags().StringVar(&directiveOpts.runID, "run-id", "", "Optional explicit nonterminal run target")
+	cmd.Flags().StringVar(&directiveOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runAgentDirectiveCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentDirectiveCommandOptions) error {
+	agentID, directive, err := validateAgentDirectiveArgs(args)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentDirectiveExitValidation}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentDirectiveErrorExitCode(err)}
+	}
+
+	var result agentDirectiveResult
+	if err := client.call(ctx, agentDirectiveMethod, opts.params(agentID, directive), &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentDirectiveErrorExitCode(err)}
+	}
+	if err := validateAgentDirectiveResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentDirectiveExitRuntime}
+	}
+	writeAgentDirectiveResult(out, agentID, result)
+	return nil
+}
+
+func validateAgentDirectiveArgs(args []string) (string, string, error) {
+	if len(args) != 2 {
+		return "", "", fmt.Errorf("agent directive requires <agent-id> and <message>")
+	}
+	agentID := strings.TrimSpace(args[0])
+	if agentID == "" {
+		return "", "", fmt.Errorf("agent id is required")
+	}
+	directive := strings.TrimSpace(args[1])
+	if directive == "" {
+		return "", "", fmt.Errorf("directive is required")
+	}
+	return agentID, directive, nil
+}
+
+func (opts agentDirectiveCommandOptions) params(agentID, directive string) map[string]any {
+	params := map[string]any{
+		"agent_id":  agentID,
+		"directive": directive,
+	}
+	if runID := strings.TrimSpace(opts.runID); runID != "" {
+		params["run_id"] = runID
+	}
+	if key := strings.TrimSpace(opts.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	return params
+}
+
+func validateAgentDirectiveResult(result agentDirectiveResult) error {
+	if !result.OK {
+		return fmt.Errorf("malformed agent.send_directive result: ok must be true")
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "run_id", value: result.RunID},
+		{name: "run_id_resolution", value: result.RunIDResolution},
+		{name: "directive_event_id", value: result.DirectiveEventID},
+		{name: "directive_event_type", value: result.DirectiveEventType},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed agent.send_directive result: %s is required", field.name)
+		}
+	}
+	if _, ok := agentDirectiveValidRunIDResolutions[strings.TrimSpace(result.RunIDResolution)]; !ok {
+		return fmt.Errorf("malformed agent.send_directive result: run_id_resolution=%q is not valid", result.RunIDResolution)
+	}
+	if strings.TrimSpace(result.DirectiveEventType) != agentDirectiveEventType {
+		return fmt.Errorf("malformed agent.send_directive result: directive_event_type=%q, want %q", result.DirectiveEventType, agentDirectiveEventType)
+	}
+	return nil
+}
+
+func writeAgentDirectiveResult(out io.Writer, agentID string, result agentDirectiveResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "agent directive ok: agent_id=%s run_id=%s run_id_resolution=%s directive_event_id=%s directive_event_type=%s\n",
+		agentID,
+		result.RunID,
+		result.RunIDResolution,
+		result.DirectiveEventID,
+		result.DirectiveEventType,
+	)
+	if response := strings.TrimSpace(result.Response); response != "" {
+		fmt.Fprintf(out, "response=%s\n", response)
+	}
+}
+
+func agentDirectiveErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return agentDirectiveExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return agentDirectiveExitAuth
+		}
+		return agentDirectiveExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return agentDirectiveExitAuth
+		case "AGENT_NOT_FOUND", "RUN_NOT_FOUND":
+			return agentDirectiveExitNotFound
+		case "AGENT_NOT_RUNNING", "RUN_ALREADY_TERMINAL", "AMBIGUOUS_RUN_TARGET", "IDEMPOTENCY_CONFLICT":
+			return agentDirectiveExitConflict
+		default:
+			return agentDirectiveExitRuntime
+		}
+	}
+	return agentDirectiveExitRuntime
+}

--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -91,11 +91,10 @@ func validateAgentDirectiveArgs(args []string) (string, string, error) {
 	if agentID == "" {
 		return "", "", fmt.Errorf("agent id is required")
 	}
-	directive := strings.TrimSpace(args[1])
-	if directive == "" {
+	if strings.TrimSpace(args[1]) == "" {
 		return "", "", fmt.Errorf("directive is required")
 	}
-	return agentID, directive, nil
+	return agentID, args[1], nil
 }
 
 func (opts agentDirectiveCommandOptions) params(agentID, directive string) map[string]any {

--- a/cmd/swarm/agent_directive_test.go
+++ b/cmd/swarm/agent_directive_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentDirectiveUsesV1RPCWithRunIDAndIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, agentDirectiveTestResult("specified"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"agent", "directive", "agent-1", "rerun corpus",
+		"--run-id", "run-1",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != agentDirectiveMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, agentDirectiveMethod)
+	}
+	wantParams := map[string]any{
+		"agent_id":        "agent-1",
+		"directive":       "rerun corpus",
+		"run_id":          "run-1",
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"agent directive ok:",
+		"agent_id=agent-1",
+		"run_id=run-1",
+		"run_id_resolution=specified",
+		"directive_event_id=event-directive-1",
+		"directive_event_type=platform.agent_directive",
+		"response=accepted",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDirectiveOmitsOptionalParamsWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, agentDirectiveTestResult("new_run_allocated"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "directive", "agent-1", "start work"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"agent_id": "agent-1", "directive": "start work"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	if !strings.Contains(stdout.String(), "run_id_resolution=new_run_allocated") {
+		t.Fatalf("stdout = %q, want new run resolution", stdout.String())
+	}
+}
+
+func TestAgentDirectiveRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", agentDirectiveTestResult("specified"))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing args", args: []string{"agent", "directive"}, wantStderr: "accepts 2 arg(s)"},
+		{name: "blank agent", args: []string{"agent", "directive", "  ", "run it"}, wantStderr: "agent id is required"},
+		{name: "blank directive", args: []string{"agent", "directive", "agent-1", "  "}, wantStderr: "directive is required"},
+		{name: "extra arg", args: []string{"agent", "directive", "agent-1", "run it", "extra"}, wantStderr: "accepts 2 arg(s)"},
+		{name: "unsupported flag", args: []string{"agent", "directive", "agent-1", "run it", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentDirectiveFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", agentDirectiveTestResult("specified"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "directive", "agent-1", "run it"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentDirectiveMapsFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime failure exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "agent not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "AGENT_NOT_FOUND",
+		},
+		{
+			name: "run not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "RUN_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "RUN_NOT_FOUND",
+		},
+		{
+			name: "agent not running exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "AGENT_NOT_RUNNING")
+			},
+			wantCode:   6,
+			wantStderr: "AGENT_NOT_RUNNING",
+		},
+		{
+			name: "terminal run exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "RUN_ALREADY_TERMINAL")
+			},
+			wantCode:   6,
+			wantStderr: "RUN_ALREADY_TERMINAL",
+		},
+		{
+			name: "ambiguous target exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "AMBIGUOUS_RUN_TARGET")
+			},
+			wantCode:   6,
+			wantStderr: "AMBIGUOUS_RUN_TARGET",
+		},
+		{
+			name: "idempotency conflict exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentDirectiveJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "malformed result exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := agentDirectiveTestResult("specified")
+				delete(result, "directive_event_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "directive_event_id is required",
+		},
+		{
+			name: "invalid resolution exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, agentDirectiveTestResult("local_guess"))
+			},
+			wantCode:   3,
+			wantStderr: "run_id_resolution",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "directive", "agent-1", "run it"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func agentDirectiveTestResult(resolution string) map[string]any {
+	return map[string]any{
+		"ok":                   true,
+		"response":             "accepted",
+		"run_id":               "run-1",
+		"run_id_resolution":    resolution,
+		"directive_event_id":   "event-directive-1",
+		"directive_event_type": "platform.agent_directive",
+	}
+}
+
+func writeAgentDirectiveJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"agent_id": "agent-1"},
+				"retryable":      false,
+				"correlation_id": "corr-agent-directive",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/agent_directive_test.go
+++ b/cmd/swarm/agent_directive_test.go
@@ -93,6 +93,28 @@ func TestAgentDirectiveOmitsOptionalParamsWhenNotProvided(t *testing.T) {
 	}
 }
 
+func TestAgentDirectivePreservesDirectiveWhitespace(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, agentDirectiveTestResult("specified"))
+	}))
+	defer server.Close()
+
+	directive := "  keep this spacing\n  "
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "directive", "agent-1", directive}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got := captured.Params["directive"]; got != directive {
+		t.Fatalf("directive param = %#v, want exact original %#v", got, directive)
+	}
+}
+
 func TestAgentDirectiveRejectsInvalidInputBeforeRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var calls atomic.Int32

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -84,13 +84,16 @@ func newAgentsCommand(opts rootCommandOptions) *cobra.Command {
 func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
-		Short: "View one agent through v1 RPC.",
+		Short: "View or direct one agent through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newAgentViewCommand(opts))
+	cmd.AddCommand(
+		newAgentViewCommand(opts),
+		newAgentDirectiveCommand(opts),
+	)
 	return cmd
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5768,11 +5768,37 @@ cli_specification:
       implementation_status: absent
       owner: /v1/rpc agent.replay_backlog and /v1/rpc agent.replay
     agent_directive:
-      command: swarm agent directive <agent-id> "<message>"
+      command: swarm agent directive <agent-id> "<message>" [--run-id <run-id>] [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.send_directive
-      blocker_state: '#755 closed runtime directive run-targeting basics; CLI still needs its own gate.'
+      behavior: Mutating directive-delivery CLI consumer. The CLI sends agent_id, directive, optional run_id, and optional idempotency_key to /v1/rpc agent.send_directive. The CLI MUST NOT resolve runs, inspect sessions, read conversations, call dashboard/Builder REST, or call runtime/store/EventBus/agentcontrol directly; server-side agent.send_directive owns run target resolution, platform.agent_directive persistence, idempotency, and directive event identity.
+      output:
+        success_line: agent directive ok with agent_id, run_id, run_id_resolution, directive_event_id, and directive_event_type
+        optional_response_line: response=<server acknowledgement> when the API response includes a non-empty response
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - AGENT_NOT_FOUND
+        - RUN_NOT_FOUND
+        resource_state_or_conflict: 6
+        resource_state_or_conflict_errors:
+        - AGENT_NOT_RUNNING
+        - RUN_ALREADY_TERMINAL
+        - AMBIGUOUS_RUN_TARGET
+        - IDEMPOTENCY_CONFLICT
+      proof_expectations:
+      - exact /v1/rpc agent.send_directive call with agent_id and directive params
+      - --run-id passes run_id exactly and does not trigger local run/session lookup
+      - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
+      - output renders server-owned run_id, run_id_resolution, directive_event_id, and directive_event_type
+      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - AGENT_NOT_FOUND, RUN_NOT_FOUND, AGENT_NOT_RUNNING, RUN_ALREADY_TERMINAL, AMBIGUOUS_RUN_TARGET, IDEMPOTENCY_CONFLICT, HTTP failures, and malformed success responses fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/agentcontrol reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, dashboard/Builder REST, conversation owners, restart, or replay method usage
     events_list:
       command: swarm events list
       tier: should_have
@@ -5907,6 +5933,7 @@ cli_specification:
     - swarm control nuke
     - swarm agents list
     - swarm agent view
+    - swarm agent directive
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -5916,7 +5943,7 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm agent restart / agent replay / agent directive
+    - swarm agent restart / agent replay
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete


### PR DESCRIPTION
Closes #822
Part of #735

## Summary
- Adds `swarm agent directive <agent-id> <message> [--run-id <run-id>] [--idempotency-key <key>]`.
- Consumes only `/v1/rpc agent.send_directive` through the shared CLI API client.
- Renders server-owned directive result identities: `run_id`, `run_id_resolution`, `directive_event_id`, `directive_event_type`, and optional `response`.
- Updates `platform-spec.yaml` for the directive CLI row and remaining #735/#816 agent-family tail.

## Governing refs / context
- #822 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice for directive CLI consumer only.
- Parent/split context: #735 CLI v2 should-have tracker and #816 agent namespace split/classification record.
- Prior owner context: #755 / PR #756 closed server-side `agent.send_directive` run targeting, `AMBIGUOUS_RUN_TARGET`, idempotency, persisted `platform.agent_directive`, and directive event identity.
- Authoritative spec refs: `platform-spec.yaml` CLI row `agent_directive`; API method `agent.send_directive`; API idempotency convention.
- OpenRPC refs: `agent.send_directive` request/result/error contract.

## Semantic migration
- New CLI canonical owner consumed: `/v1/rpc agent.send_directive`.
- Old invalid CLI paths: dashboard/Builder REST, legacy `/api/*`, `/rpc`, `/api/rpc`, `/ws`, `/api/ws`, direct DB/store/runtime/EventBus/agentcontrol access, local run/session resolution, conversation/transcript expansion, and sibling agent restart/replay methods.
- Production paths checked for surviving old behavior: new directive CLI implementation, shared CLI API client, `scripts/run_clear.sh` as separate existing v1 RPC script consumer, dashboard/Builder as non-authoritative adapters, and static no-bypass grep over `cmd/swarm/agent_directive.go`.
- Migration completeness: complete for the directive CLI consumer class. Parent #735/#816 remains open for agent restart/control, backlog replay shape, and event-targeted replay/catalog repair.

## Proof
- `go test ./cmd/swarm -run 'Agent.*Directive|Directive.*Agent' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass: `rg -n '/api/agents|/api/rpc|/rpc|/ws|agentcontrol|SendDirective|ResolveAgentDirectiveRunTarget|conversation\.current_for_agent|conversation\.get|EventBus|store\.|agent\.restart|agent\.replay|agent\.replay_backlog|run\.list' cmd/swarm/agent_directive.go` returned no matches.
