### PR TITLE
[agent-a][issue #825] Add serve shutdown grace budget

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -27,7 +27,7 @@ type runtimeProjectSupervisor struct {
 	stores           storeBundle
 	ready            *atomic.Bool
 	startRuntime     func(context.Context, *runtime.Runtime) error
-	shutdownRuntime  func(context.Context, *runtime.Runtime) error
+	shutdownRuntime  func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
 	validateSource   func(context.Context, semanticview.Source) error
 	initStateStores  func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
@@ -61,8 +61,8 @@ func newRuntimeProjectSupervisor(
 		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
 			return rt.Start(ctx)
 		},
-		shutdownRuntime: func(_ context.Context, rt *runtime.Runtime) error {
-			return rt.Shutdown()
+		shutdownRuntime: func(_ context.Context, rt *runtime.Runtime, opts runtime.ShutdownOptions) error {
+			return rt.ShutdownWithOptions(opts)
 		},
 		loadWorkflow: func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 			return newSwarmWorkflowModule(repoRoot, contractsRoot, platformSpecPath)
@@ -119,11 +119,15 @@ func (s *runtimeProjectSupervisor) ReloadProject(ctx context.Context, projectDir
 	return s.loadProject(ctx, projectDir)
 }
 
-func (s *runtimeProjectSupervisor) CloseProject(context.Context) (builderpkg.ProjectStatus, error) {
+func (s *runtimeProjectSupervisor) CloseProject(ctx context.Context) (builderpkg.ProjectStatus, error) {
+	return s.CloseProjectWithShutdownOptions(ctx, runtime.DefaultShutdownOptions())
+}
+
+func (s *runtimeProjectSupervisor) CloseProjectWithShutdownOptions(ctx context.Context, opts runtime.ShutdownOptions) (builderpkg.ProjectStatus, error) {
 	oldRT := s.detachCurrentRuntime()
 
 	if oldRT != nil {
-		if err := s.shutdownCurrentRuntime(context.Background(), oldRT); err != nil {
+		if err := s.shutdownCurrentRuntimeWithOptions(ctx, oldRT, opts); err != nil {
 			return builderpkg.ProjectStatus{}, err
 		}
 	}
@@ -243,13 +247,17 @@ func (s *runtimeProjectSupervisor) startCurrentRuntime(ctx context.Context, rt *
 }
 
 func (s *runtimeProjectSupervisor) shutdownCurrentRuntime(ctx context.Context, rt *runtime.Runtime) error {
+	return s.shutdownCurrentRuntimeWithOptions(ctx, rt, runtime.DefaultShutdownOptions())
+}
+
+func (s *runtimeProjectSupervisor) shutdownCurrentRuntimeWithOptions(ctx context.Context, rt *runtime.Runtime, opts runtime.ShutdownOptions) error {
 	if s == nil || rt == nil {
 		return nil
 	}
 	if s.shutdownRuntime != nil {
-		return s.shutdownRuntime(ctx, rt)
+		return s.shutdownRuntime(ctx, rt, opts)
 	}
-	return rt.Shutdown()
+	return rt.ShutdownWithOptions(opts)
 }
 
 func (s *runtimeProjectSupervisor) projectStatusLocked() builderpkg.ProjectStatus {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"swarm/internal/config"
 	"swarm/internal/events"
@@ -38,10 +39,13 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShut
 
 	shutdownCalled := false
 	startCalled := false
-	supervisor.shutdownRuntime = func(_ context.Context, rt *runtimepkg.Runtime) error {
+	supervisor.shutdownRuntime = func(_ context.Context, rt *runtimepkg.Runtime, opts runtimepkg.ShutdownOptions) error {
 		shutdownCalled = true
 		if rt != oldRT {
 			t.Fatalf("shutdown runtime = %p, want old runtime %p", rt, oldRT)
+		}
+		if opts.Grace != runtimepkg.DefaultShutdownGrace {
+			t.Fatalf("shutdown grace = %s, want default %s", opts.Grace, runtimepkg.DefaultShutdownGrace)
 		}
 		if got := supervisor.CurrentRuntime(); got != nil {
 			t.Fatalf("CurrentRuntime during shutdown = %p, want nil", got)
@@ -95,6 +99,43 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShut
 	}
 	if status.ProjectDir != "/tmp/new-project" {
 		t.Fatalf("status.ProjectDir = %q, want /tmp/new-project", status.ProjectDir)
+	}
+}
+
+func TestRuntimeProjectSupervisorCloseProjectWithShutdownOptionsUsesConfiguredGrace(t *testing.T) {
+	oldRT := &runtimepkg.Runtime{}
+	var ready atomic.Bool
+	ready.Store(true)
+	wantGrace := 75 * time.Millisecond
+
+	supervisor := &runtimeProjectSupervisor{
+		ready:         &ready,
+		currentRoot:   "/tmp/old-project",
+		currentBundle: &runtimecontracts.WorkflowContractBundle{},
+		currentSource: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		currentRT:     oldRT,
+	}
+
+	var capturedGrace time.Duration
+	supervisor.shutdownRuntime = func(_ context.Context, rt *runtimepkg.Runtime, opts runtimepkg.ShutdownOptions) error {
+		if rt != oldRT {
+			t.Fatalf("shutdown runtime = %p, want old runtime %p", rt, oldRT)
+		}
+		capturedGrace = opts.Grace
+		return nil
+	}
+
+	if _, err := supervisor.CloseProjectWithShutdownOptions(context.Background(), runtimepkg.ShutdownOptions{Grace: wantGrace}); err != nil {
+		t.Fatalf("CloseProjectWithShutdownOptions: %v", err)
+	}
+	if capturedGrace != wantGrace {
+		t.Fatalf("shutdown grace = %s, want %s", capturedGrace, wantGrace)
+	}
+	if ready.Load() {
+		t.Fatal("ready flag remained true after close")
+	}
+	if got := supervisor.CurrentRuntime(); got != nil {
+		t.Fatalf("CurrentRuntime after close = %p, want nil", got)
 	}
 }
 
@@ -238,7 +279,7 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesRuntimeStartFailure(t *te
 	supervisor.currentSource = semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
 	supervisor.currentRT = oldRT
 	ready.Store(true)
-	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error {
 		return errors.New("runtime start denied by workspace dependency failure")
 	}
@@ -271,7 +312,7 @@ func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t 
 		return &runtimepkg.Runtime{}, nil
 	})
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
-	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
 
 	status, err := supervisor.OpenProject(context.Background(), projectRoot)
 	if err != nil {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -98,6 +98,9 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if opts.NoRequireBundleMatch {
 				opts.RequireBundleMatch = false
 			}
+			if opts.ShutdownGrace <= 0 {
+				return fmt.Errorf("--shutdown-grace must be a positive duration")
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -114,6 +117,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Store mode: postgres")
 	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", opts.HealthAddr, "HTTP bind address for health checks")
+	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs belong to a different non-NULL bundle fingerprint")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs belong to a different bundle fingerprint")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -100,6 +100,7 @@ type serveOptions struct {
 	PlatformSpecPath     string
 	StoreMode            string
 	HealthAddr           string
+	ShutdownGrace        time.Duration
 	SelfCheck            bool
 	RequireBundleMatch   bool
 	NoRequireBundleMatch bool
@@ -113,6 +114,7 @@ func defaultServeOptions() serveOptions {
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
 		HealthAddr:         defaultHealthAddr,
+		ShutdownGrace:      runtime.DefaultShutdownGrace,
 		SelfCheck:          true,
 		RequireBundleMatch: true,
 	}
@@ -239,7 +241,8 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt)
 	defer func() {
-		if _, err := supervisor.CloseProject(context.Background()); err != nil {
+		shutdownOpts := runtime.ShutdownOptions{Grace: opts.ShutdownGrace}
+		if _, err := supervisor.CloseProjectWithShutdownOptions(context.Background(), shutdownOpts); err != nil {
 			log.Printf("runtime shutdown failed: %v", err)
 		}
 	}()

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -158,7 +158,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -201,6 +201,58 @@ func TestCLI_ServeAbandonActiveRunsFlagConsumesServeOwner(t *testing.T) {
 	}
 	if !captured.AbandonActiveRuns {
 		t.Fatalf("serve abandon active runs = false, want true")
+	}
+}
+
+func TestCLI_ServeShutdownGraceFlagConsumesServeOwner(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	wantGrace := 42 * time.Second
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--shutdown-grace", wantGrace.String()}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.ShutdownGrace != wantGrace {
+		t.Fatalf("serve shutdown grace = %s, want %s", captured.ShutdownGrace, wantGrace)
+	}
+}
+
+func TestCLI_ServeShutdownGraceRejectsNonPositiveDurationBeforeOwner(t *testing.T) {
+	for _, args := range [][]string{
+		{"serve", "--shutdown-grace", "0s"},
+		{"serve", "--shutdown-grace", "-1s"},
+		{"serve", "--shutdown-grace", "not-a-duration"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var called atomic.Bool
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(context.Context, string, serveOptions) int {
+				called.Store(true)
+				return 0
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, opts)
+			if code != 2 {
+				t.Fatalf("serve code = %d stderr=%s stdout=%s, want 2", code, stderr.String(), stdout.String())
+			}
+			if args[2] == "not-a-duration" {
+				if !strings.Contains(stderr.String(), "invalid argument") {
+					t.Fatalf("stderr = %q, want invalid duration parse error", stderr.String())
+				}
+			} else if !strings.Contains(stderr.String(), "--shutdown-grace must be a positive duration") {
+				t.Fatalf("stderr = %q, want shutdown-grace validation error", stderr.String())
+			}
+			if called.Load() {
+				t.Fatal("serve owner was called despite invalid shutdown grace")
+			}
+		})
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5496,8 +5496,34 @@ cli_specification:
           Destructive reset/runtime.nuke consumes the same active-run quiescence owner with `runtime_nuke_cancelled` reasons and
           must retain its existing run-scoped cleanup and managed-container deletion semantics. `--abandon-active-runs` does not
           delete source rows, truncate tables, stop managed entity containers, or reuse nuke-specific reason codes.
-      remaining_tail: '#750 owns remaining serve/dev/shutdown lifecycle behavior: --shutdown-grace, --dev,
-        and dev entity-container shutdown cleanup are not implemented by #808.'
+      shutdown_grace_drain_budget:
+        implemented_by: '#825'
+        flag: --shutdown-grace <duration>
+        default: 30s
+        owner: cmd/swarm serve parses the operator duration; runtime.Runtime.ShutdownWithOptions and
+          internal/runtime/manager.AgentManager.ShutdownWithOptions own the runtime shutdown drain budget.
+        validation: >
+          The duration MUST be a positive Go duration string accepted by the CLI duration parser. Invalid, zero, or negative
+          values fail before runtime boot and MUST NOT start the runtime, mutate active runs, or begin shutdown.
+        ordering: >
+          The budget applies only after serve has already booted and the serve process begins shutdown from its signal/close
+          path. Runtime shutdown admission closes before the drain begins, so inbound, MCP/tool, manager replay/restart/chat,
+          and new agent work remain fail-closed while in-flight work drains.
+        drain_scope: >
+          The configured budget is consumed by the runtime/manager shutdown owner for agent in-flight quiescence and final
+          manager run goroutine shutdown. Serve MUST NOT keep a hidden manager timeout or a CLI-local timeout as an alternate
+          shutdown policy.
+        timeout_outcome: >
+          If in-flight work does not quiesce within the configured budget, the manager cancels active loop contexts and returns
+          an explicit timeout error that includes the configured budget. This slice does not persist `platform.shutdown` events
+          or terminalize event deliveries as `interrupted_by_shutdown`; those semantics remain split until promoted by a
+          merge-bearing spec contract.
+        sibling_boundaries: >
+          `--dev`, dev entity-container shutdown cleanup, `platform.shutdown` event persistence, and persisted delivery/receipt
+          interruption reasons remain outside this owner and under #750 unless a later child promotes them.
+      remaining_tail: '#750 owns remaining serve/dev lifecycle behavior after #825: --dev and dev entity-container shutdown cleanup.
+        `platform.shutdown` event persistence and persisted delivery/receipt interruption reasons remain unpromoted unless a later
+        child makes them authoritative.'
     run:
       command: swarm run [flags]
       tier: must_have

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -60,7 +60,6 @@ type AgentManager struct {
 }
 
 const (
-	managerShutdownTimeout        = 15 * time.Second
 	poisonPanicQuarantineAt       = 3
 	poisonEventEntityThreshold    = 3
 	deadLetterEscalationThreshold = 3

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -32,7 +32,28 @@ type bundleFingerprintContextOwner interface {
 	WithBundleFingerprint(context.Context) context.Context
 }
 
+const DefaultShutdownGrace = 30 * time.Second
+
 var errRuntimeShuttingDown = errors.New("runtime shutting down")
+
+type ShutdownOptions struct {
+	Grace time.Duration
+}
+
+func DefaultShutdownOptions() ShutdownOptions {
+	return ShutdownOptions{Grace: DefaultShutdownGrace}
+}
+
+func ResolveShutdownGrace(grace time.Duration) (time.Duration, error) {
+	switch {
+	case grace < 0:
+		return 0, fmt.Errorf("shutdown grace must be positive: %s", grace)
+	case grace == 0:
+		return DefaultShutdownGrace, nil
+	default:
+		return grace, nil
+	}
+}
 
 func (am *AgentManager) RestartAgent(agentID string) error {
 	_, err := am.Restart(context.Background(), runtimeagentcontrol.RestartRequest{AgentID: agentID})
@@ -70,13 +91,21 @@ func (am *AgentManager) Restart(_ context.Context, req runtimeagentcontrol.Resta
 }
 
 func (am *AgentManager) Shutdown() error {
-	drainCtx, cancelDrain := context.WithTimeout(context.Background(), managerShutdownTimeout)
+	return am.ShutdownWithOptions(DefaultShutdownOptions())
+}
+
+func (am *AgentManager) ShutdownWithOptions(opts ShutdownOptions) error {
+	grace, err := ResolveShutdownGrace(opts.Grace)
+	if err != nil {
+		return err
+	}
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), grace)
 	defer cancelDrain()
 
 	am.runMu.Lock()
 	if am.shuttingDown {
 		am.runMu.Unlock()
-		return am.waitForRunShutdown()
+		return am.waitForRunShutdown(grace)
 	}
 	am.shuttingDown = true
 	am.running = false
@@ -84,7 +113,7 @@ func (am *AgentManager) Shutdown() error {
 
 	var shutdownErr error
 	if err := am.WaitForQuiescence(drainCtx); err != nil {
-		shutdownErr = fmt.Errorf("agent manager shutdown drain timed out after %s", managerShutdownTimeout)
+		shutdownErr = fmt.Errorf("agent manager shutdown drain timed out after %s", grace)
 	}
 
 	am.runMu.Lock()
@@ -98,7 +127,7 @@ func (am *AgentManager) Shutdown() error {
 	}
 	am.runMu.Unlock()
 
-	if err := am.waitForRunShutdown(); err != nil {
+	if err := am.waitForRunShutdown(grace); err != nil {
 		if shutdownErr == nil {
 			shutdownErr = err
 		}
@@ -152,7 +181,7 @@ func (am *AgentManager) shutdownAdmissionClosedLocked() bool {
 	return false
 }
 
-func (am *AgentManager) waitForRunShutdown() error {
+func (am *AgentManager) waitForRunShutdown(grace time.Duration) error {
 	done := make(chan struct{})
 	go func() {
 		am.runWG.Wait()
@@ -161,8 +190,8 @@ func (am *AgentManager) waitForRunShutdown() error {
 	select {
 	case <-done:
 		return nil
-	case <-time.After(managerShutdownTimeout):
-		return fmt.Errorf("agent manager shutdown timed out after %s", managerShutdownTimeout)
+	case <-time.After(grace):
+		return fmt.Errorf("agent manager shutdown timed out after %s", grace)
 	}
 }
 

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -127,6 +128,82 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for shutdown to finish")
+	}
+}
+
+func TestShutdownWithOptions_TimesOutAfterConfiguredGraceAndCancelsLoopContext(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	started := make(chan struct{}, 1)
+	ctxErrCh := make(chan error, 1)
+
+	agent := shutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			ctxErrCh <- ctx.Err()
+			return nil, ctx.Err()
+		},
+	}
+
+	am := NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return agent, nil
+	})
+	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
+		Config: runtimeactors.AgentConfig{ID: agent.id},
+	}, false); err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight work to start")
+	}
+
+	grace := 25 * time.Millisecond
+	err = am.ShutdownWithOptions(ShutdownOptions{Grace: grace})
+	if err == nil || !strings.Contains(err.Error(), "agent manager shutdown drain timed out after 25ms") {
+		t.Fatalf("ShutdownWithOptions err = %v, want configured grace timeout", err)
+	}
+
+	select {
+	case err := <-ctxErrCh:
+		if err == nil {
+			t.Fatal("OnEvent context error = nil, want cancellation after timeout")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight context cancellation")
+	}
+}
+
+func TestShutdownWithOptions_RejectsNegativeGrace(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	am := NewAgentManager(bus, nil)
+
+	err = am.ShutdownWithOptions(ShutdownOptions{Grace: -time.Second})
+	if err == nil || !strings.Contains(err.Error(), "shutdown grace must be positive") {
+		t.Fatalf("ShutdownWithOptions err = %v, want positive grace validation", err)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -74,6 +74,15 @@ type RuntimeOptions struct {
 }
 
 const BootProgressTotalSteps = 22
+const DefaultShutdownGrace = runtimemanager.DefaultShutdownGrace
+
+type ShutdownOptions struct {
+	Grace time.Duration
+}
+
+func DefaultShutdownOptions() ShutdownOptions {
+	return ShutdownOptions{Grace: DefaultShutdownGrace}
+}
 
 type BootProgressEvent struct {
 	Step   int
@@ -848,13 +857,22 @@ func (rt *Runtime) Start(ctx context.Context) error {
 }
 
 func (rt *Runtime) Shutdown() error {
+	return rt.ShutdownWithOptions(DefaultShutdownOptions())
+}
+
+func (rt *Runtime) ShutdownWithOptions(opts ShutdownOptions) error {
 	if rt == nil {
 		return nil
+	}
+	grace, err := runtimemanager.ResolveShutdownGrace(opts.Grace)
+	if err != nil {
+		return err
 	}
 	rt.shutdownGate.Close()
 	var shutdownErr error
 	if rt.Manager != nil {
-		if err := rt.Manager.Shutdown(); err != nil && shutdownErr == nil {
+		managerOpts := runtimemanager.ShutdownOptions{Grace: grace}
+		if err := rt.Manager.ShutdownWithOptions(managerOpts); err != nil && shutdownErr == nil {
 			shutdownErr = err
 		}
 	}

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -184,3 +184,60 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 		t.Fatal("timed out waiting for shutdown to finish")
 	}
 }
+
+func TestRuntimeShutdownWithOptions_PropagatesConfiguredGraceToManagerDrain(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	started := make(chan struct{}, 1)
+
+	agent := runtimeShutdownTestAgent{
+		id:            "agent-1",
+		subscriptions: []events.EventType{"test.in"},
+		onEvent: func(ctx context.Context, evt events.Event) ([]events.Event, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	rt := &Runtime{}
+	am := runtimemanager.NewAgentManagerWithOptions(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return agent, nil
+	}, runtimemanager.AgentManagerOptions{
+		RuntimeShutdownAdmissionClosed: rt.shutdownAdmissionClosed,
+	})
+	rt.Manager = am
+
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	am.Run(context.Background())
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:          "evt-in-1",
+		Type:        events.EventType("test.in"),
+		SourceAgent: "tester",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight work to start")
+	}
+
+	grace := 25 * time.Millisecond
+	err = rt.ShutdownWithOptions(ShutdownOptions{Grace: grace})
+	if err == nil || !strings.Contains(err.Error(), "agent manager shutdown drain timed out after 25ms") {
+		t.Fatalf("ShutdownWithOptions err = %v, want configured grace manager timeout", err)
+	}
+	if !rt.shutdownAdmissionClosed() {
+		t.Fatal("runtime shutdown admission was not closed")
+	}
+}


### PR DESCRIPTION
## Summary
- Promotes `swarm serve --shutdown-grace <duration>` into authoritative `platform-spec.yaml` with validation, ordering, drain-budget ownership, timeout behavior, and sibling exclusions.
- Adds the serve CLI flag with fail-fast pre-boot validation and routes the configured duration through the supervisor into `runtime.Runtime.ShutdownWithOptions` and `AgentManager.ShutdownWithOptions`.
- Replaces the hidden manager shutdown timeout with an explicit defaulted runtime/manager shutdown budget owner while keeping non-serve supervisor consumers on explicit default behavior.

Closes #825
Part of #750

## Governing refs/context
- #825 implementer pre-audit and independent gate outcome: approved as first slice for `runtime.cli.serve.shutdown_grace_drain_budget_owner`.
- Authoritative spec updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` under `cli_specification.command_catalog.serve.shutdown_grace_drain_budget`.
- Parent context: #750 remains open for `--dev`, dev entity-container shutdown cleanup, and any future promoted `platform.shutdown` / persisted interruption semantics.

## Semantic migration
- New canonical owner: `cmd/swarm serve` parses/validates operator duration; `runtime.Runtime.ShutdownWithOptions` and `internal/runtime/manager.AgentManager.ShutdownWithOptions` own the shutdown drain budget and timeout behavior.
- Old non-authoritative path now invalid: hidden `managerShutdownTimeout = 15 * time.Second` inside the manager as the serve-path drain policy.
- Production paths checked: serve signal/defer close, runtime project supervisor close/replacement, runtime shutdown admission, manager quiescence, manager final run shutdown, and non-serve supervisor default consumers.
- Migration status: complete for the approved shutdown-grace drain-budget class. Siblings remain split under #750.

## Proof
- `go test ./cmd/swarm -run 'TestCLI_ServeShutdownGrace|TestRuntimeProjectSupervisor.*ShutdownOptions|TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShutdown|TestCLI_ServeOwnsRuntimeStartupFlags' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime/... -run 'Shutdown|Admission|Grace|Quiescence' -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`

## Explicit exclusions
- Does not implement `--dev`, dev entity-container shutdown cleanup, `platform.shutdown`, persisted `interrupted_by_shutdown`, `swarm run`/#743, B-lane #735 work, or #823 release/legal work.