### PR TITLE
[agent-b][issue #826] Add agent restart CLI command

### DIFF
--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentRestartMethod         = "agent.restart"
+	agentRestartExitValidation = 2
+	agentRestartExitRuntime    = 3
+	agentRestartExitAuth       = 4
+	agentRestartExitNotFound   = 5
+	agentRestartExitConflict   = 6
+)
+
+type agentRestartCommandOptions struct {
+	apiOptions     rootCommandOptions
+	idempotencyKey string
+}
+
+type agentRestartResult struct {
+	OK bool `json:"ok"`
+}
+
+func newAgentRestartCommand(opts rootCommandOptions) *cobra.Command {
+	restartOpts := agentRestartCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "restart <agent-id>",
+		Short: "Restart an agent through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentRestartCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, restartOpts)
+		},
+	}
+	cmd.Flags().StringVar(&restartOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runAgentRestartCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentRestartCommandOptions) error {
+	agentID, err := validateAgentRestartArgs(args)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentRestartExitValidation}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentRestartErrorExitCode(err)}
+	}
+
+	var result agentRestartResult
+	if err := client.call(ctx, agentRestartMethod, opts.params(agentID), &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentRestartErrorExitCode(err)}
+	}
+	if err := validateAgentRestartResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentRestartExitRuntime}
+	}
+	writeAgentRestartResult(out, agentID)
+	return nil
+}
+
+func validateAgentRestartArgs(args []string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("agent restart requires <agent-id>")
+	}
+	agentID := strings.TrimSpace(args[0])
+	if agentID == "" {
+		return "", fmt.Errorf("agent id is required")
+	}
+	return agentID, nil
+}
+
+func (opts agentRestartCommandOptions) params(agentID string) map[string]any {
+	params := map[string]any{"agent_id": agentID}
+	if key := strings.TrimSpace(opts.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	return params
+}
+
+func validateAgentRestartResult(result agentRestartResult) error {
+	if !result.OK {
+		return fmt.Errorf("malformed agent.restart result: ok must be true")
+	}
+	return nil
+}
+
+func writeAgentRestartResult(out io.Writer, agentID string) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "agent restart ok: agent_id=%s\n", agentID)
+}
+
+func agentRestartErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return agentRestartExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return agentRestartExitAuth
+		}
+		return agentRestartExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return agentRestartExitAuth
+		case "AGENT_NOT_FOUND":
+			return agentRestartExitNotFound
+		case "IDEMPOTENCY_CONFLICT":
+			return agentRestartExitConflict
+		default:
+			return agentRestartExitRuntime
+		}
+	}
+	return agentRestartExitRuntime
+}

--- a/cmd/swarm/agent_restart_test.go
+++ b/cmd/swarm/agent_restart_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentRestartUsesV1RPCWithIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"agent", "restart", "agent-1",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != agentRestartMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, agentRestartMethod)
+	}
+	wantParams := map[string]any{"agent_id": "agent-1", "idempotency_key": "idem-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "agent restart ok: agent_id=agent-1" {
+		t.Fatalf("stdout = %q, want restart success", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentRestartOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "restart", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"agent_id": "agent-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+}
+
+func TestAgentRestartRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing id", args: []string{"agent", "restart"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank id", args: []string{"agent", "restart", "  "}, wantStderr: "agent id is required"},
+		{name: "extra arg", args: []string{"agent", "restart", "agent-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "unsupported flag", args: []string{"agent", "restart", "agent-1", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentRestartFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "restart", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentRestartMapsFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime failure exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "agent not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentRestartJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "AGENT_NOT_FOUND",
+		},
+		{
+			name: "idempotency conflict exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentRestartJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "unknown rpc error exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentRestartJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "malformed result exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": false})
+			},
+			wantCode:   3,
+			wantStderr: "ok must be true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "restart", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func writeAgentRestartJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"agent_id": "agent-1"},
+				"retryable":      false,
+				"correlation_id": "corr-agent-restart",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -92,6 +92,7 @@ func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newAgentViewCommand(opts),
+		newAgentRestartCommand(opts),
 		newAgentDirectiveCommand(opts),
 	)
 	return cmd

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5758,10 +5758,31 @@ cli_specification:
       - invalid args/flags make zero API calls
       - output remains refs-only; no conversation.current_for_agent, conversation.get, transcript, direct DB/store/runtime/EventBus/agentcontrol, or legacy endpoint usage
     agent_restart:
-      command: swarm agent restart <agent-id>
+      command: swarm agent restart <agent-id> [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.restart
+      behavior: Mutating agent-control CLI consumer. The CLI sends agent_id and optional idempotency_key to /v1/rpc agent.restart through the shared v1 API client. The CLI MUST NOT inspect runtime/session/agent state locally, call dashboard/Builder REST, call runtime/store/EventBus/agentcontrol directly, or use directive/replay/conversation owners to satisfy restart behavior.
+      output:
+        success_line: agent restart ok with agent_id
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - AGENT_NOT_FOUND
+        resource_state_or_conflict: 6
+        resource_state_or_conflict_errors:
+        - IDEMPOTENCY_CONFLICT
+      proof_expectations:
+      - exact /v1/rpc agent.restart call with agent_id param
+      - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
+      - output renders agent_id and validates OkResult.ok is true
+      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT, HTTP failures, unknown RPC errors, and malformed success responses fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/agentcontrol reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, dashboard/Builder REST, conversation owners, directive, or replay method usage
     agent_replay:
       command: swarm agent replay <agent-id>
       tier: should_have
@@ -5933,6 +5954,7 @@ cli_specification:
     - swarm control nuke
     - swarm agents list
     - swarm agent view
+    - swarm agent restart
     - swarm agent directive
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
@@ -5943,7 +5965,8 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm agent restart / agent replay
+    - swarm agent replay backlog shape over agent.replay_backlog, if exposed
+    - swarm agent replay event-targeted/catalog repair over agent.replay
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete


### PR DESCRIPTION
## Summary

- Adds `swarm agent restart <agent-id> [--idempotency-key <key>]` under the existing agent namespace.
- Consumes only `/v1/rpc agent.restart` through the shared CLI API client.
- Repairs `platform-spec.yaml` for command status, output, exit codes, proof expectations, and remaining agent-family tail.

Closes #826.
Part of #735 and #816.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.agent_restart`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.agent.restart`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` idempotency convention
- Generated OpenRPC `agent.restart`
- #826 approved gate: restart-only first slice over `/v1/rpc agent.restart`

## Semantic Migration

- New canonical CLI owner: `cmd/swarm` `swarm agent restart` consuming `/v1/rpc agent.restart`.
- Canonical API/runtime owner: `platform-spec.yaml` / OpenRPC `agent.restart`, `internal/apiv1/operator_agent_control.go`, and runtime `AgentControl.Restart` / `AgentManager.Restart`.
- Old invalid CLI paths: dashboard/Builder REST, direct runtime/store/EventBus/agentcontrol, conversation owners, directive, or replay methods.
- Production paths checked for surviving old behavior: `cmd/swarm` agent namespace, `scripts/run_clear.sh`, dashboard/Builder agent restart adapters, and runtime/API restart owners.
- Migration completeness: complete for the restart CLI consumer class; #735/#816 remain open for backlog replay shape and event-targeted replay/catalog repair.

## Proof

- `go test ./cmd/swarm -run 'Agent.*Restart|Restart.*Agent' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep over `cmd/swarm/agent_restart.go` returned no matches.
