### PR TITLE
[agent-a][issue #830] Add serve dev lifecycle composition

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -95,6 +95,14 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if cmd.Flags().Changed("require-bundle-match") && cmd.Flags().Changed("no-require-bundle-match") && opts.RequireBundleMatch && opts.NoRequireBundleMatch {
 				return fmt.Errorf("--require-bundle-match and --no-require-bundle-match cannot both be set")
 			}
+			if opts.Dev && cmd.Flags().Changed("require-bundle-match") {
+				return fmt.Errorf("--dev cannot be combined with --require-bundle-match")
+			}
+			if opts.Dev {
+				opts.AbandonActiveRuns = true
+				opts.NoRequireBundleMatch = true
+				opts.Verbose = true
+			}
 			if opts.NoRequireBundleMatch {
 				opts.RequireBundleMatch = false
 			}
@@ -119,6 +127,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", opts.HealthAddr, "HTTP bind address for health checks")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
+	cmd.Flags().BoolVar(&opts.Dev, "dev", opts.Dev, "Enable local development mode: abandon active runs, skip bundle-match admission, emit verbose boot output, and clean up dev entity containers on shutdown")
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs belong to a different non-NULL bundle fingerprint")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs belong to a different bundle fingerprint")
 	cmd.Flags().BoolVar(&opts.AbandonActiveRuns, "abandon-active-runs", opts.AbandonActiveRuns, "Cancel active runs and quiesce recoverable work before startup recovery")

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -95,7 +95,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if cmd.Flags().Changed("require-bundle-match") && cmd.Flags().Changed("no-require-bundle-match") && opts.RequireBundleMatch && opts.NoRequireBundleMatch {
 				return fmt.Errorf("--require-bundle-match and --no-require-bundle-match cannot both be set")
 			}
-			if opts.Dev && cmd.Flags().Changed("require-bundle-match") {
+			if opts.Dev && cmd.Flags().Changed("require-bundle-match") && opts.RequireBundleMatch {
 				return fmt.Errorf("--dev cannot be combined with --require-bundle-match")
 			}
 			if opts.Dev {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -58,6 +58,7 @@ var (
 
 type serveWorkspaceLifecycle interface {
 	workspace.Lifecycle
+	workspace.DevEntityContainerCleaner
 	runtimedestructivereset.ManagedContainerInventoryReader
 	runtimedestructivereset.ManagedContainerRuntime
 }
@@ -101,6 +102,7 @@ type serveOptions struct {
 	StoreMode            string
 	HealthAddr           string
 	ShutdownGrace        time.Duration
+	Dev                  bool
 	SelfCheck            bool
 	RequireBundleMatch   bool
 	NoRequireBundleMatch bool
@@ -190,6 +192,10 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 3
 	}
 	workspaces := configuredWorkspaceLifecycleForServe(stores.SQLDB, repo, contractsRoot, source)
+	if opts.Dev && workspaces == nil {
+		slog.Error("dev entity cleanup owner unavailable", "error", "workspace lifecycle is not configured")
+		return 1
+	}
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
 		return 1
@@ -241,8 +247,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt)
 	defer func() {
-		shutdownOpts := runtime.ShutdownOptions{Grace: opts.ShutdownGrace}
-		if _, err := supervisor.CloseProjectWithShutdownOptions(context.Background(), shutdownOpts); err != nil {
+		if err := closeServeRuntime(context.Background(), supervisor, opts, workspaces); err != nil {
 			log.Printf("runtime shutdown failed: %v", err)
 		}
 	}()
@@ -328,6 +333,26 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	<-ctx.Done()
 	ready.Store(false)
 	return 0
+}
+
+func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor, opts serveOptions, workspaces serveWorkspaceLifecycle) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var shutdownErr error
+	if supervisor != nil {
+		shutdownOpts := runtime.ShutdownOptions{Grace: opts.ShutdownGrace}
+		_, shutdownErr = supervisor.CloseProjectWithShutdownOptions(ctx, shutdownOpts)
+	}
+	var cleanupErr error
+	if opts.Dev {
+		if workspaces == nil {
+			cleanupErr = fmt.Errorf("dev entity cleanup owner unavailable")
+		} else {
+			_, cleanupErr = workspaces.CleanupDevEntityContainers(ctx)
+		}
+	}
+	return errors.Join(shutdownErr, cleanupErr)
 }
 
 func runVerifyCommand(ctx context.Context, repo string, args []string, out io.Writer) int {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -217,6 +217,27 @@ func TestCLI_ServeDevRejectsRequireBundleMatchBeforeOwner(t *testing.T) {
 	}
 }
 
+func TestCLI_ServeDevAcceptsExplicitRequireBundleMatchFalse(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--dev", "--require-bundle-match=false"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s, want 0", code, stderr.String(), stdout.String())
+	}
+	if !captured.Dev {
+		t.Fatal("serve dev = false, want true")
+	}
+	if !captured.NoRequireBundleMatch || captured.RequireBundleMatch {
+		t.Fatalf("serve bundle match = require:%t no-require:%t, want dev no-require composition", captured.RequireBundleMatch, captured.NoRequireBundleMatch)
+	}
+}
+
 func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 	spec := loadServeDevModeSpec(t)
 	if strings.TrimSpace(spec.ImplementedBy) != "#830" {
@@ -241,6 +262,11 @@ func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 		}
 	}
 	for _, want := range []string{"--dev --require-bundle-match", "fails before runtime boot"} {
+		if !stringSliceContains(spec.ConflictRules, want) {
+			t.Fatalf("dev mode conflict rules missing %q: %#v", want, spec.ConflictRules)
+		}
+	}
+	for _, want := range []string{"--dev --require-bundle-match=false", "redundant but valid"} {
 		if !stringSliceContains(spec.ConflictRules, want) {
 			t.Fatalf("dev mode conflict rules missing %q: %#v", want, spec.ConflictRules)
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -158,9 +158,106 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestCLI_ServeDevFlagComposesClosedServeOwners(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	wantGrace := 42 * time.Second
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--dev", "--shutdown-grace", wantGrace.String()}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !captured.Dev {
+		t.Fatal("serve dev = false, want true")
+	}
+	if !captured.AbandonActiveRuns {
+		t.Fatal("serve abandon active runs = false, want dev composition")
+	}
+	if !captured.NoRequireBundleMatch || captured.RequireBundleMatch {
+		t.Fatalf("serve bundle match = require:%t no-require:%t, want dev no-require composition", captured.RequireBundleMatch, captured.NoRequireBundleMatch)
+	}
+	if !captured.Verbose {
+		t.Fatal("serve verbose = false, want dev composition")
+	}
+	if captured.ShutdownGrace != wantGrace {
+		t.Fatalf("serve shutdown grace = %s, want explicit %s", captured.ShutdownGrace, wantGrace)
+	}
+}
+
+func TestCLI_ServeDevRejectsRequireBundleMatchBeforeOwner(t *testing.T) {
+	var called atomic.Bool
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(context.Context, string, serveOptions) int {
+		called.Store(true)
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--dev", "--require-bundle-match"}, &stdout, &stderr, opts)
+	if code != 2 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s, want 2", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--dev cannot be combined with --require-bundle-match") {
+		t.Fatalf("stderr = %q, want dev conflict error", stderr.String())
+	}
+	if called.Load() {
+		t.Fatal("serve owner was called despite dev/require-bundle-match conflict")
+	}
+}
+
+func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
+	spec := loadServeDevModeSpec(t)
+	if strings.TrimSpace(spec.ImplementedBy) != "#830" {
+		t.Fatalf("dev mode implemented_by = %q, want #830", spec.ImplementedBy)
+	}
+	if strings.TrimSpace(spec.Flag) != "--dev" {
+		t.Fatalf("dev mode flag = %q, want --dev", spec.Flag)
+	}
+	for _, want := range []string{
+		"`--abandon-active-runs`",
+		"`--no-require-bundle-match`",
+		"`--verbose`",
+		"dev entity-container cleanup",
+	} {
+		if !stringSliceContains(spec.Composition, want) {
+			t.Fatalf("dev mode composition missing %q: %#v", want, spec.Composition)
+		}
+	}
+	for _, want := range []string{"workspace", "containeridentity"} {
+		if !strings.Contains(spec.Owner, want) {
+			t.Fatalf("dev mode owner missing %q:\n%s", want, spec.Owner)
+		}
+	}
+	for _, want := range []string{"--dev --require-bundle-match", "fails before runtime boot"} {
+		if !stringSliceContains(spec.ConflictRules, want) {
+			t.Fatalf("dev mode conflict rules missing %q: %#v", want, spec.ConflictRules)
+		}
+	}
+	for _, want := range []string{"runtime shutdown admission", "Cleanup still runs after a shutdown timeout/error", "joined shutdown and cleanup errors"} {
+		if !strings.Contains(spec.ShutdownOrdering, want) {
+			t.Fatalf("dev mode shutdown ordering missing %q:\n%s", want, spec.ShutdownOrdering)
+		}
+	}
+	for _, want := range []string{"identity-proven runtime-owned", "`kind=entity`", "MUST NOT infer ownership from names"} {
+		if !strings.Contains(spec.CleanupScope, want) {
+			t.Fatalf("dev mode cleanup scope missing %q:\n%s", want, spec.CleanupScope)
+		}
+	}
+	for _, want := range []string{"Scaffold/system", "operator-managed", "unlabeled", "`kind=agent`", "`kind=flow`"} {
+		if !strings.Contains(spec.PreservationBoundary, want) {
+			t.Fatalf("dev mode preservation boundary missing %q:\n%s", want, spec.PreservationBoundary)
 		}
 	}
 }
@@ -253,6 +350,39 @@ func TestCLI_ServeShutdownGraceRejectsNonPositiveDurationBeforeOwner(t *testing.
 				t.Fatal("serve owner was called despite invalid shutdown grace")
 			}
 		})
+	}
+}
+
+func TestCloseServeRuntimeDevCleanupRunsAfterShutdownAndJoinsErrors(t *testing.T) {
+	shutdownErr := fmt.Errorf("shutdown timed out")
+	cleanupErr := fmt.Errorf("cleanup failed")
+	var order []string
+	supervisor := &runtimeProjectSupervisor{
+		currentRT: &runtimepkg.Runtime{},
+	}
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error {
+		order = append(order, "shutdown")
+		return shutdownErr
+	}
+	workspaces := serveRuntimeWorkspaceStub{
+		cleanup: func(context.Context) (runtimedestructivereset.ContainerResetResult, error) {
+			order = append(order, "cleanup")
+			return runtimedestructivereset.ContainerResetResult{}, cleanupErr
+		},
+	}
+
+	err := closeServeRuntime(context.Background(), supervisor, serveOptions{
+		Dev:           true,
+		ShutdownGrace: runtimepkg.DefaultShutdownGrace,
+	}, workspaces)
+	if err == nil || !strings.Contains(err.Error(), shutdownErr.Error()) || !strings.Contains(err.Error(), cleanupErr.Error()) {
+		t.Fatalf("closeServeRuntime err = %v, want joined shutdown and cleanup errors", err)
+	}
+	if got := strings.Join(order, ","); got != "shutdown,cleanup" {
+		t.Fatalf("order = %s, want shutdown,cleanup", got)
+	}
+	if got := supervisor.CurrentRuntime(); got != nil {
+		t.Fatalf("CurrentRuntime after close = %p, want nil", got)
 	}
 }
 
@@ -2956,6 +3086,14 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 
 type serveRuntimeWorkspaceStub struct {
 	stubWorkspaceLifecycle
+	cleanup func(context.Context) (runtimedestructivereset.ContainerResetResult, error)
+}
+
+func (s serveRuntimeWorkspaceStub) CleanupDevEntityContainers(ctx context.Context) (runtimedestructivereset.ContainerResetResult, error) {
+	if s.cleanup != nil {
+		return s.cleanup(ctx)
+	}
+	return runtimedestructivereset.ContainerResetResult{}, nil
 }
 
 func (serveRuntimeWorkspaceStub) ManagedResetContainerInventory(context.Context) ([]runtimedestructivereset.ContainerRef, error) {
@@ -2974,6 +3112,18 @@ type serveBootProgressSpecStep struct {
 	Step  int    `yaml:"step"`
 	Name  string `yaml:"name"`
 	Owner string `yaml:"owner"`
+}
+
+type serveDevModeSpec struct {
+	ImplementedBy        string   `yaml:"implemented_by"`
+	Flag                 string   `yaml:"flag"`
+	Owner                string   `yaml:"owner"`
+	Composition          []string `yaml:"composition"`
+	ConflictRules        []string `yaml:"conflict_rules"`
+	ShutdownOrdering     string   `yaml:"shutdown_ordering"`
+	CleanupScope         string   `yaml:"cleanup_scope"`
+	PreservationBoundary string   `yaml:"preservation_boundary"`
+	SiblingBoundaries    string   `yaml:"sibling_boundaries"`
 }
 
 func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpecStep {
@@ -3015,6 +3165,39 @@ func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpec
 		}
 	}
 	return sequence.Steps
+}
+
+func loadServeDevModeSpec(t *testing.T) serveDevModeSpec {
+	t.Helper()
+	var spec struct {
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					DevMode serveDevModeSpec `yaml:"dev_mode_lifecycle_composition"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	if strings.TrimSpace(spec.CLISpecification.CommandCatalog.Serve.DevMode.Flag) == "" {
+		t.Fatal("platform spec missing serve dev_mode_lifecycle_composition")
+	}
+	return spec.CLISpecification.CommandCatalog.Serve.DevMode
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
 }
 
 type lockedBuffer struct {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5521,9 +5521,38 @@ cli_specification:
         sibling_boundaries: >
           `--dev`, dev entity-container shutdown cleanup, `platform.shutdown` event persistence, and persisted delivery/receipt
           interruption reasons remain outside this owner and under #750 unless a later child promotes them.
-      remaining_tail: '#750 owns remaining serve/dev lifecycle behavior after #825: --dev and dev entity-container shutdown cleanup.
-        `platform.shutdown` event persistence and persisted delivery/receipt interruption reasons remain unpromoted unless a later
-        child makes them authoritative.'
+      dev_mode_lifecycle_composition:
+        implemented_by: '#830'
+        flag: --dev
+        owner: >
+          `cmd/swarm serve` owns command-line composition; existing serve startup owners perform active-run abandon,
+          bundle-match admission, and verbose boot output; `internal/runtime/workspace` plus
+          `internal/runtime/containeridentity` own dev entity-container cleanup and preservation.
+        composition:
+        - sets `--abandon-active-runs`
+        - sets `--no-require-bundle-match`
+        - sets `--verbose`
+        - enables dev entity-container cleanup after runtime shutdown/drain
+        conflict_rules:
+        - '`--dev --require-bundle-match` fails before runtime boot because dev mode disables bundle-match admission.'
+        - '`--dev --no-require-bundle-match`, `--dev --abandon-active-runs`, and `--dev --verbose` are redundant but valid.'
+        shutdown_ordering: >
+          On serve shutdown, runtime shutdown admission and the runtime/manager shutdown-grace drain run first. Dev cleanup runs
+          only after that shutdown attempt reaches its completion point. Cleanup still runs after a shutdown timeout/error and
+          the serve path reports joined shutdown and cleanup errors.
+        cleanup_scope: >
+          Dev cleanup stops only identity-proven runtime-owned, reset-eligible, `kind=entity` containers. The cleanup owner
+          consumes typed managed-container identity and MUST NOT infer ownership from names, raw Docker listings, or
+          `RuntimeWorkspaceContainers` alone.
+        preservation_boundary: >
+          Scaffold/system containers, operator-managed containers, unlabeled containers, malformed identity rows, name-mismatched
+          containers, unrelated containers, and runtime-owned `kind=agent` or `kind=flow` containers are preserved fail-closed.
+        sibling_boundaries: >
+          `platform.shutdown` event persistence, persisted `interrupted_by_shutdown` delivery/receipt terminalization,
+          destructive reset/runtime.nuke behavior, and `swarm run` foreground behavior remain outside this owner unless a later
+          child promotes them.
+      remaining_tail: '#750 has no remaining promoted serve/dev lifecycle tail after #830. `platform.shutdown` event persistence
+        and persisted delivery/receipt interruption reasons remain unpromoted unless a later child makes them authoritative.'
     run:
       command: swarm run [flags]
       tier: must_have
@@ -5954,7 +5983,12 @@ cli_specification:
       closed_slices:
       - '#753/#754 run bundle fingerprint and serve bundle-match admission'
       - '#755 directive run targeting and persisted platform.agent_directive'
-      remaining_tail: 'serve dev/shutdown/boot observability/runtime lifecycle behavior; not a direct blocker for #743 API owners.'
+      - '#802/#804 serve verbose boot output and platform.boot payload'
+      - '#808/#811 serve active-run abandon quiescence'
+      - '#825/#827 serve shutdown-grace drain budget'
+      - '#830 serve dev-mode lifecycle composition and dev entity-container cleanup'
+      remaining_tail: 'No promoted serve lifecycle tail remains after #830. `platform.shutdown` and persisted `interrupted_by_shutdown`
+        remain unpromoted unless a later runtime lifecycle child makes them authoritative; not a direct blocker for #743 API owners.'
   parent_tail:
     implemented_v2_compliant:
     - swarm

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5534,8 +5534,8 @@ cli_specification:
         - sets `--verbose`
         - enables dev entity-container cleanup after runtime shutdown/drain
         conflict_rules:
-        - '`--dev --require-bundle-match` fails before runtime boot because dev mode disables bundle-match admission.'
-        - '`--dev --no-require-bundle-match`, `--dev --abandon-active-runs`, and `--dev --verbose` are redundant but valid.'
+        - '`--dev --require-bundle-match` or `--dev --require-bundle-match=true` fails before runtime boot because dev mode disables bundle-match admission.'
+        - '`--dev --require-bundle-match=false`, `--dev --no-require-bundle-match`, `--dev --abandon-active-runs`, and `--dev --verbose` are redundant but valid.'
         shutdown_ordering: >
           On serve shutdown, runtime shutdown admission and the runtime/manager shutdown-grace drain run first. Dev cleanup runs
           only after that shutdown attempt reaches its completion point. Cleanup still runs after a shutdown timeout/error and

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	runtimecontaineridentity "swarm/internal/runtime/containeridentity"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -46,6 +47,12 @@ type Lifecycle interface {
 type OrphanKiller interface {
 	KillOrphanProcesses(ctx context.Context) error
 }
+
+type DevEntityContainerCleaner interface {
+	CleanupDevEntityContainers(ctx context.Context) (runtimedestructivereset.ContainerResetResult, error)
+}
+
+const DevEntityCleanupOperationName = "swarm.serve.dev.entity_container_cleanup"
 
 type DockerConfig struct {
 	DockerBin             string
@@ -283,6 +290,68 @@ func (m *DockerManager) StopEntityWorkspace(ctx context.Context, entityID string
 		return fmt.Errorf("stop entity workspace %s: %w", container, err)
 	}
 	return nil
+}
+
+func (m *DockerManager) CleanupDevEntityContainers(ctx context.Context) (runtimedestructivereset.ContainerResetResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := runtimedestructivereset.ContainerResetResult{
+		OperationName: DevEntityCleanupOperationName,
+		AppliedAt:     time.Now().UTC(),
+	}
+	if m == nil {
+		return result, fmt.Errorf("dev entity container cleanup workspace manager is not configured")
+	}
+	inventory, err := m.ManagedResetContainerInventory(ctx)
+	if err != nil {
+		return result, fmt.Errorf("dev entity container cleanup inventory: %w", err)
+	}
+	for _, candidate := range inventory {
+		name := strings.TrimSpace(candidate.Name)
+		if name == "" {
+			continue
+		}
+		if strings.TrimSpace(candidate.Kind) != runtimecontaineridentity.KindEntity {
+			result.Preserved = append(result.Preserved, containerRefWithAction(candidate, runtimedestructivereset.ContainerActionPreserve))
+			continue
+		}
+		inspection, err := m.InspectManagedContainer(ctx, name)
+		if err != nil {
+			result.Failed = append(result.Failed, runtimedestructivereset.ContainerStopFailure{
+				Container: containerRefWithAction(candidate, runtimedestructivereset.ContainerActionFailed),
+				Error:     err.Error(),
+			})
+			continue
+		}
+		if !inspection.Exists {
+			result.Missing = append(result.Missing, containerRefWithAction(candidate, runtimedestructivereset.ContainerActionMissing))
+			continue
+		}
+		identity := containerIdentityFromResetInspection(inspection)
+		if !inspection.HasIdentity || !identity.ResetEligibleManaged() || strings.TrimSpace(identity.Kind) != runtimecontaineridentity.KindEntity || strings.TrimSpace(identity.ContainerName) != name {
+			result.Preserved = append(result.Preserved, preservedManagedContainerRef(candidate, identity))
+			continue
+		}
+		ref := managedContainerRef(identity, runtimedestructivereset.ContainerActionStop)
+		if !inspection.Running {
+			result.AlreadyStopped = append(result.AlreadyStopped, containerRefWithAction(ref, runtimedestructivereset.ContainerActionAlreadyStopped))
+			continue
+		}
+		result.Selected = append(result.Selected, ref)
+		if err := m.StopManagedContainer(ctx, ref.Name); err != nil {
+			result.Failed = append(result.Failed, runtimedestructivereset.ContainerStopFailure{
+				Container: containerRefWithAction(ref, runtimedestructivereset.ContainerActionFailed),
+				Error:     err.Error(),
+			})
+			continue
+		}
+		result.Stopped = append(result.Stopped, ref)
+	}
+	if len(result.Failed) > 0 {
+		return result, fmt.Errorf("dev entity container cleanup failed: %d container(s)", len(result.Failed))
+	}
+	return result, nil
 }
 
 func (m *DockerManager) KillOrphanProcesses(ctx context.Context) error {
@@ -969,6 +1038,19 @@ func managedContainerRef(identity runtimecontaineridentity.Identity, action stri
 		AgentID:        identity.AgentID,
 		FlowInstance:   identity.FlowInstance,
 	}
+}
+
+func containerRefWithAction(ref runtimedestructivereset.ContainerRef, action string) runtimedestructivereset.ContainerRef {
+	ref.Action = strings.TrimSpace(action)
+	return ref
+}
+
+func preservedManagedContainerRef(fallback runtimedestructivereset.ContainerRef, identity runtimecontaineridentity.Identity) runtimedestructivereset.ContainerRef {
+	identity = identity.Normalized()
+	if strings.TrimSpace(identity.ContainerName) == "" {
+		return containerRefWithAction(fallback, runtimedestructivereset.ContainerActionPreserve)
+	}
+	return managedContainerRef(identity, runtimedestructivereset.ContainerActionPreserve)
 }
 
 func (m *DockerManager) InspectContainer(ctx context.Context, name string) (bool, bool, error) {

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -455,6 +455,160 @@ func TestManagedResetContainerInventoryConsumesTypedLabels(t *testing.T) {
 	}
 }
 
+func TestCleanupDevEntityContainersStopsOnlyIdentityProvenEntityContainers(t *testing.T) {
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.WorkspaceNetwork = ""
+	manager.SetConfig(cfg)
+
+	var calls [][]string
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		calls = append(calls, append([]string{}, args...))
+		joined := strings.Join(args, " ")
+		switch {
+		case joined == "container ls --all --filter label=dev.swarm.owner=runtime --filter label=dev.swarm.reset.eligible=true --format {{.Names}}":
+			return strings.Join([]string{
+				"swarm-entity-acme",
+				"swarm-agent-agent-a",
+				"swarm-flow-flow-a",
+				"swarm-system",
+				"swarm-unlabeled",
+				"swarm-operator",
+				"swarm-stale-name",
+			}, "\n"), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-entity-acme":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "entity",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.EnsureEntityWorkspace",
+				"dev.swarm.container.name":  "swarm-entity-acme",
+				"dev.swarm.workspace.scope": "entity",
+				"dev.swarm.entity_id":       "entity-1",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-agent-agent-a":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "agent",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.ResolveWorkspace",
+				"dev.swarm.container.name":  "swarm-agent-agent-a",
+				"dev.swarm.workspace.scope": "per-agent",
+				"dev.swarm.agent_id":        "agent-a",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-flow-flow-a":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "flow",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.ResolveWorkspace",
+				"dev.swarm.container.name":  "swarm-flow-flow-a",
+				"dev.swarm.workspace.scope": "per-flow-instance",
+				"dev.swarm.flow_instance":   "flow-a",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-system":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "system",
+				"dev.swarm.reset.eligible":  "false",
+				"dev.swarm.creation_source": "workspace.EnsureSystemWorkspaces",
+				"dev.swarm.container.name":  "swarm-system",
+				"dev.swarm.workspace.scope": "system",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-unlabeled":
+			return managedContainerInspectJSON(nil, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-operator":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "operator",
+				"dev.swarm.container.kind":  "entity",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.container.name":  "swarm-operator",
+				"dev.swarm.workspace.scope": "entity",
+				"dev.swarm.entity_id":       "operator-entity",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-stale-name":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":          "runtime",
+				"dev.swarm.container.kind": "entity",
+				"dev.swarm.reset.eligible": "true",
+				"dev.swarm.container.name": "different-container-name",
+				"dev.swarm.entity_id":      "stale-entity",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{.State.Running}}" && args[len(args)-1] == "swarm-entity-acme":
+			return "true", nil
+		case joined == "stop swarm-entity-acme":
+			return "", nil
+		default:
+			return "", nil
+		}
+	})
+
+	result, err := manager.CleanupDevEntityContainers(context.Background())
+	if err != nil {
+		t.Fatalf("CleanupDevEntityContainers: %v", err)
+	}
+	if result.OperationName != DevEntityCleanupOperationName {
+		t.Fatalf("operation = %q, want %q", result.OperationName, DevEntityCleanupOperationName)
+	}
+	if len(result.Stopped) != 1 || result.Stopped[0].Name != "swarm-entity-acme" || result.Stopped[0].Kind != "entity" {
+		t.Fatalf("stopped = %#v, want only entity container", result.Stopped)
+	}
+	if len(result.Preserved) != 2 {
+		t.Fatalf("preserved = %#v, want agent and flow reset-eligible containers preserved", result.Preserved)
+	}
+	joined := flattenDockerCalls(calls)
+	for _, forbidden := range []string{"stop swarm-agent-agent-a", "stop swarm-flow-flow-a", "stop swarm-system", "stop swarm-unlabeled", "stop swarm-operator", "stop swarm-stale-name"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("dev cleanup stopped forbidden container %q:\n%s", forbidden, joined)
+		}
+	}
+}
+
+func TestCleanupDevEntityContainersReportsStopFailures(t *testing.T) {
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.WorkspaceNetwork = ""
+	manager.SetConfig(cfg)
+
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case joined == "container ls --all --filter label=dev.swarm.owner=runtime --filter label=dev.swarm.reset.eligible=true --format {{.Names}}":
+			return "swarm-entity-acme", nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{json .}}" && args[len(args)-1] == "swarm-entity-acme":
+			return managedContainerInspectJSON(map[string]string{
+				"dev.swarm.owner":           "runtime",
+				"dev.swarm.container.kind":  "entity",
+				"dev.swarm.reset.eligible":  "true",
+				"dev.swarm.creation_source": "workspace.EnsureEntityWorkspace",
+				"dev.swarm.container.name":  "swarm-entity-acme",
+				"dev.swarm.workspace.scope": "entity",
+				"dev.swarm.entity_id":       "entity-1",
+			}, true), nil
+		case len(args) >= 4 && args[0] == "inspect" && args[2] == "{{.State.Running}}" && args[len(args)-1] == "swarm-entity-acme":
+			return "true", nil
+		case joined == "stop swarm-entity-acme":
+			return "", fmt.Errorf("docker stop failed")
+		default:
+			return "", nil
+		}
+	})
+
+	result, err := manager.CleanupDevEntityContainers(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "dev entity container cleanup failed: 1 container(s)") {
+		t.Fatalf("CleanupDevEntityContainers err = %v, want stop failure", err)
+	}
+	if len(result.Selected) != 1 || result.Selected[0].Name != "swarm-entity-acme" {
+		t.Fatalf("selected = %#v, want failed entity selected", result.Selected)
+	}
+	if len(result.Stopped) != 0 {
+		t.Fatalf("stopped = %#v, want none after failure", result.Stopped)
+	}
+	if len(result.Failed) != 1 || result.Failed[0].Container.Name != "swarm-entity-acme" || !strings.Contains(result.Failed[0].Error, "docker stop failed") {
+		t.Fatalf("failed = %#v, want entity stop failure", result.Failed)
+	}
+}
+
 func flattenDockerCalls(calls [][]string) string {
 	lines := make([]string, 0, len(calls))
 	for _, call := range calls {


### PR DESCRIPTION
## Summary

Closes #830
Part of #750

Implements the approved first-slice boundary `runtime.cli.serve.dev_mode_lifecycle_composition`:

- promotes the authoritative `swarm serve --dev` contract into `platform-spec.yaml`
- adds `serveOptions.Dev` / `swarm serve --dev`
- composes existing closed owners: `--abandon-active-runs`, `--no-require-bundle-match`, and `--verbose`
- rejects `--dev --require-bundle-match` before runtime boot
- runs runtime shutdown/drain first, then dev entity-container cleanup, joining shutdown and cleanup errors
- adds a typed workspace/container lifecycle cleanup owner that stops only identity-proven runtime-owned reset-eligible `kind=entity` containers and preserves non-entity/unowned/malformed/name-mismatched candidates fail-closed

## Governing refs/context

- #830 implementer pre-audit and independent gate outcome: approved as first slice for full `runtime.cli.serve.dev_mode_lifecycle_composition`
- Authoritative spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`, `cli_specification.command_catalog.serve.dev_mode_lifecycle_composition`
- Adjacent authoritative owners consumed, not reimplemented: #753/#754 bundle-match/no-bundle-match, #802/#804 verbose boot output, #808/#811 active-run abandon, #825/#827 shutdown-grace drain budget
- Explicitly out of scope: `platform.shutdown`, persisted `interrupted_by_shutdown`, destructive reset/runtime.nuke behavior, `swarm run`/#743, B-lane #735 work, and #823 release/legal work

## Semantic migration

New canonical owners:

- `platform-spec.yaml` owns the merge-bearing `--dev` contract and remaining #750 serve-tail disposition.
- `cmd/swarm serve` owns operator flag composition and conflict validation.
- `internal/runtime/workspace` plus `internal/runtime/containeridentity` own dev entity-container cleanup and preservation.

Old/non-authoritative paths now invalid for this class:

- raw Docker cleanup from `cmd/swarm`
- `RuntimeWorkspaceContainers` as a stop list
- name-only `StopEntityWorkspace` as cleanup proof
- destructive-reset `ManagedContainerStopper` wholesale as the serve-dev owner

Production paths checked for surviving old behavior: changed code does not touch `run_command.go`, #823/release files, raw Docker enumeration from CLI, `runtime.nuke`, `platform.shutdown`, or persisted `interrupted_by_shutdown`. Migration is complete for the chosen class.

## Proof

- `go test ./cmd/swarm -run 'TestCLI_Serve(OwnsRuntimeStartupFlags|DevFlagComposesClosedServeOwners|DevRejectsRequireBundleMatchBeforeOwner)|TestCloseServeRuntimeDevCleanupRunsAfterShutdownAndJoinsErrors|TestPlatformSpecServeDevModeCompositionPromoted' -count=1`
- `go test ./internal/runtime/workspace -run 'TestCleanupDevEntityContainers|TestManagedResetContainerInventoryConsumesTypedLabels' -count=1`
- `go test ./internal/runtime/workspace ./internal/runtime/destructivereset ./internal/runtime/containeridentity -run 'Managed|Container|Workspace|Identity|ResetEligible|Dev|Cleanup' -count=1`
- `go test ./internal/runtime ./internal/runtime/manager -run 'Shutdown|Admission|Grace|Quiescence' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime/workspace ./internal/runtime/destructivereset ./internal/runtime/containeridentity -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`
- grep proof: no `run_command`, #823/release, raw Docker cleanup from CLI, `runtime.nuke`, `platform.shutdown`, or `interrupted_by_shutdown` code additions outside spec split/exclusion text