### PR TITLE
[agent-b][issue #833] Add agent replay CLI

### DIFF
--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentReplayMethod         = "agent.replay"
+	agentReplayExitValidation = 2
+	agentReplayExitRuntime    = 3
+	agentReplayExitAuth       = 4
+	agentReplayExitNotFound   = 5
+	agentReplayExitConflict   = 6
+)
+
+type agentReplayCommandOptions struct {
+	apiOptions     rootCommandOptions
+	eventID        string
+	idempotencyKey string
+}
+
+type agentReplayResult struct {
+	EventID          string              `json:"event_id"`
+	AgentID          string              `json:"agent_id"`
+	ReplayEventID    string              `json:"replay_event_id"`
+	AuditEventID     string              `json:"audit_event_id"`
+	OriginalDelivery agentReplayDelivery `json:"original_delivery"`
+	NewDelivery      agentReplayDelivery `json:"new_delivery"`
+}
+
+type agentReplayDelivery struct {
+	DeliveryID       string `json:"delivery_id"`
+	SubscriberID     string `json:"subscriber_id"`
+	SessionID        string `json:"session_id,omitempty"`
+	Status           string `json:"status"`
+	Attempt          int    `json:"attempt"`
+	SourceDeliveryID string `json:"source_delivery_id,omitempty"`
+}
+
+var agentReplayValidDeliveryStatuses = map[string]struct{}{
+	"pending":     {},
+	"in_progress": {},
+	"delivered":   {},
+	"failed":      {},
+	"dead_letter": {},
+}
+
+func newAgentReplayCommand(opts rootCommandOptions) *cobra.Command {
+	replayOpts := agentReplayCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "replay <agent-id>",
+		Short: "Replay one event to an agent through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentReplayCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
+		},
+	}
+	cmd.Flags().StringVar(&replayOpts.eventID, "event-id", "", "Required event ID to replay")
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runAgentReplayCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentReplayCommandOptions) error {
+	agentID, eventID, err := validateAgentReplayArgs(args, opts.eventID)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayExitValidation}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayErrorExitCode(err)}
+	}
+
+	var result agentReplayResult
+	if err := client.call(ctx, agentReplayMethod, opts.params(agentID, eventID), &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayErrorExitCode(err)}
+	}
+	if err := validateAgentReplayResult(result, agentID, eventID); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayExitRuntime}
+	}
+	writeAgentReplayResult(out, result)
+	return nil
+}
+
+func validateAgentReplayArgs(args []string, eventIDFlag string) (string, string, error) {
+	if len(args) != 1 {
+		return "", "", fmt.Errorf("agent replay requires <agent-id>")
+	}
+	agentID := strings.TrimSpace(args[0])
+	if agentID == "" {
+		return "", "", fmt.Errorf("agent id is required")
+	}
+	eventID := strings.TrimSpace(eventIDFlag)
+	if eventID == "" {
+		return "", "", fmt.Errorf("--event-id is required")
+	}
+	return agentID, eventID, nil
+}
+
+func (opts agentReplayCommandOptions) params(agentID, eventID string) map[string]any {
+	params := map[string]any{
+		"agent_id": agentID,
+		"event_id": eventID,
+	}
+	if key := strings.TrimSpace(opts.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	return params
+}
+
+func validateAgentReplayResult(result agentReplayResult, expectedAgentID, expectedEventID string) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "agent_id", value: result.AgentID},
+		{name: "event_id", value: result.EventID},
+		{name: "replay_event_id", value: result.ReplayEventID},
+		{name: "audit_event_id", value: result.AuditEventID},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed agent.replay result: %s is required", field.name)
+		}
+	}
+	if strings.TrimSpace(result.AgentID) != expectedAgentID {
+		return fmt.Errorf("malformed agent.replay result: agent_id=%q, want %q", result.AgentID, expectedAgentID)
+	}
+	if strings.TrimSpace(result.EventID) != expectedEventID {
+		return fmt.Errorf("malformed agent.replay result: event_id=%q, want %q", result.EventID, expectedEventID)
+	}
+	if err := validateAgentReplayDelivery("original_delivery", result.OriginalDelivery); err != nil {
+		return err
+	}
+	if err := validateAgentReplayDelivery("new_delivery", result.NewDelivery); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAgentReplayDelivery(field string, delivery agentReplayDelivery) error {
+	for _, part := range []struct {
+		name  string
+		value string
+	}{
+		{name: "delivery_id", value: delivery.DeliveryID},
+		{name: "subscriber_id", value: delivery.SubscriberID},
+		{name: "status", value: delivery.Status},
+	} {
+		if strings.TrimSpace(part.value) == "" {
+			return fmt.Errorf("malformed agent.replay result: %s.%s is required", field, part.name)
+		}
+	}
+	if _, ok := agentReplayValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
+		return fmt.Errorf("malformed agent.replay result: %s.status=%q is not a valid DeliveryStatus", field, delivery.Status)
+	}
+	if delivery.Attempt < 1 {
+		return fmt.Errorf("malformed agent.replay result: %s.attempt must be >= 1", field)
+	}
+	return nil
+}
+
+func writeAgentReplayResult(out io.Writer, result agentReplayResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "agent replay ok: agent_id=%s event_id=%s replay_event_id=%s audit_event_id=%s original_delivery.delivery_id=%s new_delivery.delivery_id=%s\n",
+		result.AgentID,
+		result.EventID,
+		result.ReplayEventID,
+		result.AuditEventID,
+		result.OriginalDelivery.DeliveryID,
+		result.NewDelivery.DeliveryID,
+	)
+}
+
+func agentReplayErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return agentReplayExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return agentReplayExitAuth
+		}
+		return agentReplayExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return agentReplayExitAuth
+		case "EVENT_NOT_FOUND":
+			return agentReplayExitNotFound
+		case "EVENT_REPLAY_NO_DELIVERY_HISTORY",
+			"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+			"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+			"EVENT_REPLAY_NOT_ELIGIBLE",
+			"PAYLOAD_VALIDATION_FAILED",
+			"IDEMPOTENCY_CONFLICT":
+			return agentReplayExitConflict
+		default:
+			return agentReplayExitRuntime
+		}
+	}
+	return agentReplayExitRuntime
+}

--- a/cmd/swarm/agent_replay_test.go
+++ b/cmd/swarm/agent_replay_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentReplayUsesV1RPCWithEventIDAndIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, agentReplayTestResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"agent", "replay", "agent-1",
+		"--event-id", "event-1",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != agentReplayMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, agentReplayMethod)
+	}
+	wantParams := map[string]any{
+		"agent_id":        "agent-1",
+		"event_id":        "event-1",
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"agent replay ok:",
+		"agent_id=agent-1",
+		"event_id=event-1",
+		"replay_event_id=event-replay-1",
+		"audit_event_id=event-audit-1",
+		"original_delivery.delivery_id=delivery-original-1",
+		"new_delivery.delivery_id=delivery-new-1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentReplayOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, agentReplayTestResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay", "agent-1", "--event-id", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"agent_id": "agent-1", "event_id": "event-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+}
+
+func TestAgentReplayRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", agentReplayTestResult())
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing id", args: []string{"agent", "replay", "--event-id", "event-1"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank id", args: []string{"agent", "replay", "  ", "--event-id", "event-1"}, wantStderr: "agent id is required"},
+		{name: "missing event id", args: []string{"agent", "replay", "agent-1"}, wantStderr: "--event-id is required"},
+		{name: "blank event id", args: []string{"agent", "replay", "agent-1", "--event-id", "  "}, wantStderr: "--event-id is required"},
+		{name: "extra arg", args: []string{"agent", "replay", "agent-1", "extra", "--event-id", "event-1"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "unsupported flag", args: []string{"agent", "replay", "agent-1", "--event-id", "event-1", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentReplayFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", agentReplayTestResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay", "agent-1", "--event-id", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentReplayMapsFailureExitCodes(t *testing.T) {
+	resourceErrors := []string{
+		"EVENT_REPLAY_NO_DELIVERY_HISTORY",
+		"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+		"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+		"EVENT_REPLAY_NOT_ELIGIBLE",
+		"PAYLOAD_VALIDATION_FAILED",
+		"IDEMPOTENCY_CONFLICT",
+	}
+	for _, code := range resourceErrors {
+		code := code
+		t.Run(code+" exits six", func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayJSONRPCError(t, w, req.ID, code)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			exit := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay", "agent-1", "--event-id", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if exit != 6 {
+				t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", exit, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), code) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), code)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime failure exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "event not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayJSONRPCError(t, w, req.ID, "EVENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "EVENT_NOT_FOUND",
+		},
+		{
+			name: "unauthorized rpc exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "unknown rpc error exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "malformed result exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := agentReplayTestResult()
+				delete(result, "replay_event_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "replay_event_id is required",
+		},
+		{
+			name: "missing delivery id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := agentReplayTestResult()
+				original := result["original_delivery"].(map[string]any)
+				delete(original, "delivery_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "original_delivery.delivery_id is required",
+		},
+		{
+			name: "invalid delivery status exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := agentReplayTestResult()
+				newDelivery := result["new_delivery"].(map[string]any)
+				newDelivery["status"] = "locally_replayed"
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "new_delivery.status",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay", "agent-1", "--event-id", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func agentReplayTestResult() map[string]any {
+	return map[string]any{
+		"event_id":        "event-1",
+		"agent_id":        "agent-1",
+		"replay_event_id": "event-replay-1",
+		"audit_event_id":  "event-audit-1",
+		"original_delivery": map[string]any{
+			"delivery_id":   "delivery-original-1",
+			"subscriber_id": "agent-1",
+			"session_id":    "session-original-1",
+			"status":        "delivered",
+			"attempt":       1,
+		},
+		"new_delivery": map[string]any{
+			"delivery_id":        "delivery-new-1",
+			"subscriber_id":      "agent-1",
+			"session_id":         "session-new-1",
+			"status":             "pending",
+			"attempt":            1,
+			"source_delivery_id": "delivery-original-1",
+		},
+	}
+}
+
+func writeAgentReplayJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"agent_id": "agent-1", "event_id": "event-1"},
+				"retryable":      false,
+				"correlation_id": "corr-agent-replay",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -93,6 +93,7 @@ func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.AddCommand(
 		newAgentViewCommand(opts),
 		newAgentRestartCommand(opts),
+		newAgentReplayCommand(opts),
 		newAgentDirectiveCommand(opts),
 	)
 	return cmd

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5841,7 +5841,7 @@ cli_specification:
     agent_replay:
       command: swarm agent replay <agent-id> --event-id <event-id> [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.replay
       behavior: Event-targeted redelivery CLI consumer. The CLI sends agent_id, event_id, and optional idempotency_key to /v1/rpc agent.replay through the shared v1 API client. This command MUST NOT replay backlog state, call agent.replay_backlog, derive recipients locally, synthesize replay events, or call dashboard/Builder REST, runtime/store/EventBus/agentcontrol, directive, restart, list, or view owners.
       output:
@@ -6069,6 +6069,7 @@ cli_specification:
     - swarm agent view
     - swarm agent restart
     - swarm agent directive
+    - swarm agent replay
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6078,7 +6079,6 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm agent replay <agent-id> --event-id <event-id>
     - swarm agent replay-backlog <agent-id>
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn


### PR DESCRIPTION
Closes #833

## Summary

Implements the event-targeted agent replay CLI consumer:

- `swarm agent replay <agent-id> --event-id <event-id> [--idempotency-key <key>]`
- calls exactly `/v1/rpc agent.replay` through the shared CLI API client
- validates and renders server-owned `agent_id`, `event_id`, `replay_event_id`, `audit_event_id`, `original_delivery.delivery_id`, and `new_delivery.delivery_id`
- updates `platform-spec.yaml` to mark only `agent_replay` implemented and leaves `agent_replay_backlog` absent

## Governing Refs / Context

- #833 Pre-Implementation Coverage Audit and independent gate outcome: `approved as first slice` for event-targeted `agent.replay` CLI only.
- Parent trackers: #735 and #816.
- Closed prerequisite: #829 / PR #831 catalog split.
- API owner: #769 / PR #770.
- Exact authoritative spec refs:
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.foundations.cli_consumes_api_rule`
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.foundations.auth_boundary`
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.agent_replay`
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.AgentReplayResult`
  - `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.agent.replay`

## Semantic Migration

- New canonical CLI owner: `swarm agent replay <agent-id> --event-id <event-id> [--idempotency-key <key>]` consumes `/v1/rpc agent.replay` via the shared CLI API client.
- Old invalid path: event-targeted replay cannot be satisfied by no-`--event-id` `swarm agent replay`, `agent.replay_backlog`, direct `event.replay`, dashboard/Builder replay, runtime/store/EventBus/agentcontrol calls, or legacy transports.
- Production paths checked for surviving old behavior: `cmd/swarm`, scripts, dashboard/Builder backlog seams, `internal/apiv1` replay owners, runtime backlog owner, generated OpenRPC, and `platform-spec.yaml` migration rows.
- Migration completeness: complete for #833 event-targeted CLI replay. Backlog replay remains a separate #735/#816 child.

## Proof

- `go test ./cmd/swarm -run 'Agent.*Replay|Replay.*Agent|Agent|Agents|Directive|Restart' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventReplay|TestOperatorAgentReplay|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check --cached`
- Static no-bypass grep over the new replay CLI implementation and scripts.
