### PR TITLE
[agent-e][issue #835] Add v1 OpenRPC compliance matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build swarm binary
         run: go build ./cmd/swarm
 
+      - name: Check OpenRPC artifact
+        run: go run ./cmd/swarm-openrpc-gen --check
+
       - name: Vet
         run: go vet ./...
 

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,6 +65,10 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
+  - id: 835
+    title: Add OpenRPC-driven v1 API compliance harness and coverage matrix
+    maps_to:
+      - v1_openrpc_api_conformance
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -148,6 +152,31 @@ nodes:
         - run scoping is inconsistent
       too_narrow:
         - one dashboard filter or query is wrong
+    current_action_pressure: active
+  - id: v1_openrpc_api_conformance
+    title: V1 OpenRPC API Conformance
+    parent_class: operator-facing API/spec/runtime parity and conformance proof drift
+    canonical_owners:
+      - docs/specs/swarm-platform/platform/contracts/platform-spec.yaml api_specification
+      - docs/specs/swarm-platform/platform/contracts/openrpc.json
+      - internal/apispec
+      - internal/apiv1
+      - .github/workflows/ci.yml
+    why_this_node_exists: v1 API compliance drifts when method coverage, OpenRPC generation, CI checks, and runtime proof accounting are inferred from scattered tests instead of a method-keyed canonical matrix
+    known_manifestations:
+      - no checked-in 42-method matrix keyed by generated OpenRPC method name
+      - required params, unknown params, auth, declared errors, idempotency, result schema, and notification schema proof status can drift silently
+      - OpenRPC method examples and rpc.discover publication status are not explicitly tracked
+      - CI can pass without a direct swarm-openrpc-gen --check step
+    representative_issues:
+      - 835
+    common_framing_mistakes:
+      too_broad:
+        - full v1 runtime conformance can be closed by one matrix PR
+        - rpc.discover should be added without a promoted platform-spec requirement
+      too_narrow:
+        - one handler test is enough API compliance accounting
+        - generated OpenRPC drift is only an internal/apispec concern
     current_action_pressure: active
 reserve_backlog:
   - ordinal: 17

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -274,11 +274,9 @@ func assertEvidence(t *testing.T, methodName, field string, evidence complianceE
 	if status == "" {
 		t.Fatalf("%s %s status is empty", methodName, field)
 	}
-	allowed := map[string]struct{}{
-		"covered":                     {},
-		"shared":                      {},
-		"spot_checked":                {},
-		"published_without_discovery": {},
+	allowed := allowedEvidenceStatuses(field)
+	if len(allowed) == 0 {
+		t.Fatalf("%s uses unknown evidence field %q", methodName, field)
 	}
 	if allowTrackedGap {
 		allowed["tracked_gap"] = struct{}{}
@@ -288,6 +286,29 @@ func assertEvidence(t *testing.T, methodName, field string, evidence complianceE
 	}
 	if len(evidence.Proof) == 0 {
 		t.Fatalf("%s %s proof must name the test, helper, issue, or artifact backing status %q", methodName, field, status)
+	}
+}
+
+func allowedEvidenceStatuses(field string) map[string]struct{} {
+	switch field {
+	case "happy_path":
+		return complianceStringSet([]string{"covered"})
+	case "required_param_validation", "unknown_top_level_param_validation":
+		return complianceStringSet([]string{"shared", "covered"})
+	case "auth":
+		return complianceStringSet([]string{"shared", "covered"})
+	case "declared_error_tests":
+		return complianceStringSet([]string{"covered", "spot_checked"})
+	case "idempotency":
+		return complianceStringSet([]string{"covered"})
+	case "result_schema", "notification_schema":
+		return complianceStringSet([]string{"covered", "spot_checked"})
+	case "examples":
+		return complianceStringSet([]string{"covered"})
+	case "service_discovery_publication":
+		return complianceStringSet([]string{"published_without_discovery"})
+	default:
+		return map[string]struct{}{}
 	}
 }
 

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -1,0 +1,324 @@
+package apiv1
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"swarm/internal/apispec"
+)
+
+type openRPCComplianceMatrix struct {
+	Version int                   `yaml:"version"`
+	Kind    string                `yaml:"kind"`
+	Issue   int                   `yaml:"issue"`
+	Methods []openRPCMethodMatrix `yaml:"methods"`
+}
+
+type openRPCMethodMatrix struct {
+	Method                         string             `yaml:"method"`
+	Transport                      string             `yaml:"transport"`
+	RequiredParams                 []string           `yaml:"required_params"`
+	DeclaredErrors                 []string           `yaml:"declared_errors"`
+	HappyPath                      complianceEvidence `yaml:"happy_path"`
+	RequiredParamValidation        complianceEvidence `yaml:"required_param_validation"`
+	UnknownTopLevelParamValidation complianceEvidence `yaml:"unknown_top_level_param_validation"`
+	Auth                           complianceEvidence `yaml:"auth"`
+	DeclaredErrorTests             complianceEvidence `yaml:"declared_error_tests"`
+	Idempotency                    complianceEvidence `yaml:"idempotency"`
+	ResultSchema                   complianceEvidence `yaml:"result_schema"`
+	NotificationSchema             complianceEvidence `yaml:"notification_schema"`
+	Examples                       complianceEvidence `yaml:"examples"`
+	ServiceDiscoveryPublication    complianceEvidence `yaml:"service_discovery_publication"`
+	GapClassification              []string           `yaml:"gap_classification"`
+}
+
+type complianceEvidence struct {
+	Status string   `yaml:"status"`
+	Proof  []string `yaml:"proof"`
+}
+
+type rawOpenRPCDocument struct {
+	Methods []map[string]json.RawMessage `json:"methods"`
+}
+
+func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
+	root := repoRoot(t)
+	api := loadComplianceAPISpec(t, root)
+	doc, rawMethods := loadComplianceOpenRPC(t, filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json"))
+	matrix := loadComplianceMatrix(t, filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml"))
+
+	if matrix.Version != 1 {
+		t.Fatalf("matrix version = %d, want 1", matrix.Version)
+	}
+	if matrix.Kind != "openrpc_compliance_matrix" {
+		t.Fatalf("matrix kind = %q, want openrpc_compliance_matrix", matrix.Kind)
+	}
+	if matrix.Issue != 835 {
+		t.Fatalf("matrix issue = %d, want 835", matrix.Issue)
+	}
+	if len(doc.Methods) != 42 {
+		t.Fatalf("generated OpenRPC methods = %d, want 42", len(doc.Methods))
+	}
+	if len(matrix.Methods) != len(doc.Methods) {
+		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))
+	}
+
+	openRPCByName := map[string]apispec.OpenRPCMethod{}
+	for _, method := range doc.Methods {
+		name := strings.TrimSpace(method.Name)
+		if name == "" {
+			t.Fatal("generated OpenRPC method missing name")
+		}
+		if _, exists := openRPCByName[name]; exists {
+			t.Fatalf("generated OpenRPC method %s appears more than once", name)
+		}
+		openRPCByName[name] = method
+	}
+	if _, ok := openRPCByName["rpc.discover"]; ok {
+		t.Fatal("rpc.discover is not part of the approved #835 v1 publication boundary")
+	}
+
+	rowsByName := map[string]openRPCMethodMatrix{}
+	for _, row := range matrix.Methods {
+		name := strings.TrimSpace(row.Method)
+		if name == "" {
+			t.Fatal("matrix row missing method")
+		}
+		if _, exists := rowsByName[name]; exists {
+			t.Fatalf("matrix method %s appears more than once", name)
+		}
+		rowsByName[name] = row
+	}
+
+	mutatingMethods := complianceStringSet(api.Conventions.Idempotency.MutatingMethods)
+	for methodName, openRPCMethod := range openRPCByName {
+		row, ok := rowsByName[methodName]
+		if !ok {
+			t.Fatalf("matrix missing generated OpenRPC method %s", methodName)
+		}
+		specMethod, ok := api.MethodCatalog[methodName]
+		if !ok {
+			t.Fatalf("generated OpenRPC method %s missing from platform spec method_catalog", methodName)
+		}
+
+		if row.Transport != expectedComplianceTransport(methodName, specMethod) {
+			t.Fatalf("%s transport = %q, want %q", methodName, row.Transport, expectedComplianceTransport(methodName, specMethod))
+		}
+		assertStringList(t, methodName+" required_params", row.RequiredParams, requiredParamNames(specMethod))
+		assertStringList(t, methodName+" declared_errors", row.DeclaredErrors, specMethod.Errors)
+		assertStringList(t, methodName+" openrpc declared_errors", row.DeclaredErrors, openRPCErrorCodes(t, methodName, openRPCMethod))
+
+		assertEvidence(t, methodName, "happy_path", row.HappyPath, true)
+		assertEvidence(t, methodName, "unknown_top_level_param_validation", row.UnknownTopLevelParamValidation, false)
+		assertEvidence(t, methodName, "auth", row.Auth, false)
+		assertEvidence(t, methodName, "result_schema", row.ResultSchema, true)
+		assertEvidence(t, methodName, "examples", row.Examples, true)
+		assertEvidence(t, methodName, "service_discovery_publication", row.ServiceDiscoveryPublication, false)
+
+		if len(row.GapClassification) == 0 {
+			t.Fatalf("%s gap_classification must classify remaining proof gaps", methodName)
+		}
+		if len(row.RequiredParams) == 0 {
+			assertNotApplicable(t, methodName, "required_param_validation", row.RequiredParamValidation)
+		} else {
+			assertEvidence(t, methodName, "required_param_validation", row.RequiredParamValidation, false)
+		}
+		if len(row.DeclaredErrors) == 0 {
+			assertNotApplicable(t, methodName, "declared_error_tests", row.DeclaredErrorTests)
+		} else {
+			assertEvidence(t, methodName, "declared_error_tests", row.DeclaredErrorTests, true)
+		}
+		if _, mutating := mutatingMethods[methodName]; mutating {
+			assertEvidence(t, methodName, "idempotency", row.Idempotency, true)
+		} else {
+			assertNotApplicable(t, methodName, "idempotency", row.Idempotency)
+		}
+		if specMethod.NotificationSchema == nil {
+			assertNotApplicable(t, methodName, "notification_schema", row.NotificationSchema)
+		} else {
+			assertEvidence(t, methodName, "notification_schema", row.NotificationSchema, true)
+		}
+		if !rawMethods[methodName].hasExamples && row.Examples.Status != "tracked_gap" {
+			t.Fatalf("%s examples status = %q, want tracked_gap while openrpc.json has no method examples", methodName, row.Examples.Status)
+		}
+		if row.ServiceDiscoveryPublication.Status != "published_without_discovery" {
+			t.Fatalf("%s service_discovery_publication status = %q, want published_without_discovery", methodName, row.ServiceDiscoveryPublication.Status)
+		}
+	}
+
+	for methodName := range rowsByName {
+		if _, ok := openRPCByName[methodName]; !ok {
+			t.Fatalf("matrix has method %s absent from generated OpenRPC", methodName)
+		}
+	}
+}
+
+func loadComplianceAPISpec(t *testing.T, root string) *apispec.APISpecification {
+	t.Helper()
+	api, err := apispec.LoadPlatformSpec(filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+	if err != nil {
+		t.Fatalf("LoadPlatformSpec() error = %v", err)
+	}
+	return api
+}
+
+type rawOpenRPCMethodProof struct {
+	hasExamples bool
+}
+
+func loadComplianceOpenRPC(t *testing.T, path string) (apispec.OpenRPCDocument, map[string]rawOpenRPCMethodProof) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read openrpc artifact: %v", err)
+	}
+	var doc apispec.OpenRPCDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse openrpc artifact: %v", err)
+	}
+	var rawDoc rawOpenRPCDocument
+	if err := json.Unmarshal(raw, &rawDoc); err != nil {
+		t.Fatalf("parse raw openrpc artifact: %v", err)
+	}
+	rawMethods := map[string]rawOpenRPCMethodProof{}
+	for _, method := range rawDoc.Methods {
+		var name string
+		if err := json.Unmarshal(method["name"], &name); err != nil {
+			t.Fatalf("parse raw openrpc method name: %v", err)
+		}
+		rawMethods[name] = rawOpenRPCMethodProof{hasExamples: rawJSONHasContent(method["examples"])}
+	}
+	return doc, rawMethods
+}
+
+func loadComplianceMatrix(t *testing.T, path string) openRPCComplianceMatrix {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read compliance matrix: %v", err)
+	}
+	var matrix openRPCComplianceMatrix
+	if err := yaml.Unmarshal(raw, &matrix); err != nil {
+		t.Fatalf("parse compliance matrix: %v", err)
+	}
+	return matrix
+}
+
+func expectedComplianceTransport(methodName string, method apispec.Method) string {
+	if methodName == "rpc.unsubscribe" || method.NotificationSchema != nil {
+		return "ws"
+	}
+	return "http"
+}
+
+func requiredParamNames(method apispec.Method) []string {
+	var names []string
+	for _, param := range method.Params {
+		if param.Required {
+			names = append(names, param.Name)
+		}
+	}
+	return names
+}
+
+func openRPCErrorCodes(t *testing.T, methodName string, method apispec.OpenRPCMethod) []string {
+	t.Helper()
+	out := make([]string, 0, len(method.Errors))
+	for _, errDef := range method.Errors {
+		data, ok := errDef.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("%s OpenRPC error %d data = %#v, want object", methodName, errDef.Code, errDef.Data)
+		}
+		properties, ok := data["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s OpenRPC error %d data.properties = %#v, want object", methodName, errDef.Code, data["properties"])
+		}
+		code, ok := properties["code"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s OpenRPC error %d data.properties.code = %#v, want object", methodName, errDef.Code, properties["code"])
+		}
+		name, ok := code["const"].(string)
+		if !ok || strings.TrimSpace(name) == "" {
+			t.Fatalf("%s OpenRPC error %d data.properties.code.const = %#v, want error code", methodName, errDef.Code, code["const"])
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+func assertStringList(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	if got == nil {
+		got = []string{}
+	}
+	if want == nil {
+		want = []string{}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+}
+
+func assertEvidence(t *testing.T, methodName, field string, evidence complianceEvidence, allowTrackedGap bool) {
+	t.Helper()
+	status := strings.TrimSpace(evidence.Status)
+	if status == "" {
+		t.Fatalf("%s %s status is empty", methodName, field)
+	}
+	allowed := map[string]struct{}{
+		"covered":                     {},
+		"shared":                      {},
+		"spot_checked":                {},
+		"published_without_discovery": {},
+	}
+	if allowTrackedGap {
+		allowed["tracked_gap"] = struct{}{}
+	}
+	if _, ok := allowed[status]; !ok {
+		t.Fatalf("%s %s status = %q, want one of %v", methodName, field, status, sortedKeys(allowed))
+	}
+	if len(evidence.Proof) == 0 {
+		t.Fatalf("%s %s proof must name the test, helper, issue, or artifact backing status %q", methodName, field, status)
+	}
+}
+
+func assertNotApplicable(t *testing.T, methodName, field string, evidence complianceEvidence) {
+	t.Helper()
+	if evidence.Status != "not_applicable" {
+		t.Fatalf("%s %s status = %q, want not_applicable", methodName, field, evidence.Status)
+	}
+}
+
+func rawJSONHasContent(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null" && trimmed != "[]"
+}
+
+func sortedKeys(in map[string]struct{}) []string {
+	out := make([]string, 0, len(in))
+	for key := range in {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func complianceStringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		clean := strings.TrimSpace(value)
+		if clean != "" {
+			out[clean] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -1,0 +1,643 @@
+version: 1
+kind: openrpc_compliance_matrix
+issue: 835
+source:
+  platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+  openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
+  generated_from: api_specification.method_catalog
+policy:
+  closure_level: coverage_accounting_and_proof_ownership_only
+  runtime_behavior_changes: forbidden_by_gate
+  examples_policy: OpenRPC method examples are tracked gaps in this slice.
+  service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
+methods:
+  - method: agent.get
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: agent.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: agent.replay
+    transport: http
+    required_params: [event_id, agent_id]
+    declared_errors: [EVENT_NOT_FOUND, EVENT_REPLAY_NO_DELIVERY_HISTORY, EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL, EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE, EVENT_REPLAY_NOT_ELIGIBLE, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorAgentReplayFailClosedCases]}
+    idempotency: {status: covered, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: agent.replay_backlog
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentControlHandlersTypedResourceErrors]}
+    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: agent.restart
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentControlHandlersTypedResourceErrors]}
+    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: agent.send_directive
+    transport: http
+    required_params: [agent_id, directive]
+    declared_errors: [AGENT_NOT_FOUND, AGENT_NOT_RUNNING, RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, AMBIGUOUS_RUN_TARGET, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorAgentControlHandlersTypedResourceErrors, TestOperatorAgentSendDirectiveRunTargetErrors]}
+    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: conversation.current_for_agent
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: conversation.get
+    transport: http
+    required_params: [session_id]
+    declared_errors: [SESSION_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: conversation.get_turn
+    transport: http
+    required_params: [session_id, turn_index]
+    declared_errors: [SESSION_NOT_FOUND, TURN_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner, TestOperatorConversationGetTurnComposesRuntimeLogOwner]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner, TestOperatorConversationGetTurnComposesRuntimeLogOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: conversation.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: entity.aggregate
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: entity.get
+    transport: http
+    required_params: [entity_id]
+    declared_errors: [ENTITY_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorEntityHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: entity.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: event.get
+    transport: http
+    required_params: [event_id]
+    declared_errors: [EVENT_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorObservabilityHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: event.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: event.publish
+    transport: http
+    required_params: [event_name, payload]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorEventPublishHandlersFailClosedBeforePersistence, TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun]}
+    idempotency: {status: covered, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: event.replay
+    transport: http
+    required_params: [event_id]
+    declared_errors: [EVENT_NOT_FOUND, EVENT_REPLAY_NO_DELIVERY_HISTORY, EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL, EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE, EVENT_REPLAY_NOT_ELIGIBLE, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorEventReplaySubsetAndFailClosedCases]}
+    idempotency: {status: covered, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: event.subscribe
+    transport: ws
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
+    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: health.check
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: health.ping
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: health.subscribe
+    transport: ws
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: mailbox.approve
+    transport: http
+    required_params: [mailbox_id]
+    declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, MAILBOX_APPROVAL_EVENT_UNCONFIGURED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath, TestOperatorMailboxApprovePublishFailureLeavesItemRetryable]}
+    idempotency: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: mailbox.defer
+    transport: http
+    required_params: [mailbox_id, until]
+    declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, INVALID_DEFER_UNTIL, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    idempotency: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: mailbox.get
+    transport: http
+    required_params: [mailbox_id]
+    declared_errors: [MAILBOX_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: mailbox.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: mailbox.reject
+    transport: http
+    required_params: [mailbox_id, reason]
+    declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: tracked_gap, proof: ["issue #835"]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    idempotency: {status: tracked_gap, proof: ["issue #835"]}
+    result_schema: {status: tracked_gap, proof: ["issue #835"]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_happy_path_test, missing_idempotency_test, missing_result_schema_proof, missing_openrpc_examples]
+  - method: rpc.unsubscribe
+    transport: ws
+    required_params: [subscription_id]
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe, TestWebSocketSessionBackpressureAndUnsubscribeCancelState]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.continue
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND, RUN_NOT_PAUSED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersTypedResourceErrors]}
+    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.diagnose
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.get
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.pause
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, RUN_ALREADY_PAUSED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency, TestOperatorRunControlHandlersTypedResourceErrors]}
+    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.start
+    transport: http
+    required_params: [event_name, payload]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: spot_checked, proof: [TestOperatorRunStartHandlersFailClosedBeforePersistence]}
+    idempotency: {status: covered, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.stop
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersTypedResourceErrors]}
+    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.subscribe_trace
+    transport: ws
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    declared_error_tests: {status: covered, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
+    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: run.trace
+    transport: http
+    required_params: [run_id]
+    declared_errors: [RUN_NOT_FOUND]
+    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorObservabilityHandlersTypedErrors]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.incidents
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.logs
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.nuke
+    transport: http
+    required_params: []
+    declared_errors: [RUNTIME_NUKE_IN_PROGRESS, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners, TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: covered, proof: [TestOperatorRuntimeNukeAuthFailureDoesNotTouchResetOwners]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency, TestOperatorRuntimeNukeOperationInProgressFailsClosed]}
+    idempotency: {status: covered, proof: [TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners, TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.pause
+    transport: http
+    required_params: []
+    declared_errors: [RUNTIME_ALREADY_PAUSED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    idempotency: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.resume
+    transport: http
+    required_params: []
+    declared_errors: [RUNTIME_NOT_PAUSED, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    idempotency: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
+  - method: runtime.subscribe_logs
+    transport: ws
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
+    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
+    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
+    examples: {status: tracked_gap, proof: ["issue #835"]}
+    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]


### PR DESCRIPTION
## Summary

Closes #835.

This PR implements the approved first-slice boundary for v1 API/OpenRPC compliance accounting only:

- adds a checked-in 42-method compliance matrix keyed by generated OpenRPC method name
- adds an OpenRPC-driven harness that validates matrix rows against `platform-spec.yaml` and `openrpc.json`
- tracks required params, unknown top-level params, auth, declared errors, mutating-method idempotency, result schema policy, subscription notification schema policy, examples status, and service-discovery/publication status per method
- adds a direct CI check for `go run ./cmd/swarm-openrpc-gen --check`
- adds the required operator-surfaces watchlist node for `v1_openrpc_api_conformance`

No API runtime behavior is changed.

## Governing refs / context

Exact governing contract refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.transport`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog_metadata`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.idempotency.mutating_methods`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- Issue #835 pre-audit and approved first-slice gate comment

## Semantic ownership / migration

New canonical owner for coverage-accounting proof status:

- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`

Enforcement owner:

- `internal/apiv1/openrpc_compliance_test.go`

Existing canonical contract owners remain authoritative:

- `platform-spec.yaml` `api_specification`
- generated `openrpc.json`
- `internal/apispec`
- `internal/apiv1`
- `.github/workflows/ci.yml`

Old non-authoritative path now invalid for this slice: inferring API compliance coverage from scattered test names, generated artifact checks, and CI coverage without a method-keyed matrix. Production API paths were checked by diff review; no handler/runtime semantics were modified. The approved coverage-accounting migration is complete for this PR.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `go test ./internal/apispec ./internal/apiv1 -coverprofile=/tmp/swarm-api-cover.out -count=1`
- `go tool cover -func=/tmp/swarm-api-cover.out | tail -n 5` -> total 77.0%
- `go test ./internal/apiv1 -run TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod -count=1`
- `git diff --check`