### PR TITLE
[agent-b][issue #837] Add agent replay-backlog CLI

### DIFF
--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentReplayBacklogMethod         = "agent.replay_backlog"
+	agentReplayBacklogExitValidation = 2
+	agentReplayBacklogExitRuntime    = 3
+	agentReplayBacklogExitAuth       = 4
+	agentReplayBacklogExitNotFound   = 5
+	agentReplayBacklogExitConflict   = 6
+)
+
+type agentReplayBacklogCommandOptions struct {
+	apiOptions     rootCommandOptions
+	idempotencyKey string
+}
+
+type agentReplayBacklogResult struct {
+	OK            bool `json:"ok"`
+	ReplayedCount *int `json:"replayed_count"`
+}
+
+func newAgentReplayBacklogCommand(opts rootCommandOptions) *cobra.Command {
+	replayOpts := agentReplayBacklogCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "replay-backlog <agent-id>",
+		Short: "Replay an agent backlog through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAgentReplayBacklogCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
+		},
+	}
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runAgentReplayBacklogCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentReplayBacklogCommandOptions) error {
+	agentID, err := validateAgentReplayBacklogArgs(args)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayBacklogExitValidation}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayBacklogErrorExitCode(err)}
+	}
+
+	var result agentReplayBacklogResult
+	if err := client.call(ctx, agentReplayBacklogMethod, opts.params(agentID), &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayBacklogErrorExitCode(err)}
+	}
+	if err := validateAgentReplayBacklogResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: agentReplayBacklogExitRuntime}
+	}
+	writeAgentReplayBacklogResult(out, agentID, result)
+	return nil
+}
+
+func validateAgentReplayBacklogArgs(args []string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("agent replay-backlog requires <agent-id>")
+	}
+	agentID := strings.TrimSpace(args[0])
+	if agentID == "" {
+		return "", fmt.Errorf("agent id is required")
+	}
+	return agentID, nil
+}
+
+func (opts agentReplayBacklogCommandOptions) params(agentID string) map[string]any {
+	params := map[string]any{"agent_id": agentID}
+	if key := strings.TrimSpace(opts.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	return params
+}
+
+func validateAgentReplayBacklogResult(result agentReplayBacklogResult) error {
+	if !result.OK {
+		return fmt.Errorf("malformed agent.replay_backlog result: ok must be true")
+	}
+	if result.ReplayedCount == nil {
+		return fmt.Errorf("malformed agent.replay_backlog result: replayed_count is required")
+	}
+	if *result.ReplayedCount < 0 {
+		return fmt.Errorf("malformed agent.replay_backlog result: replayed_count must be >= 0")
+	}
+	return nil
+}
+
+func writeAgentReplayBacklogResult(out io.Writer, agentID string, result agentReplayBacklogResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "agent replay-backlog ok: agent_id=%s replayed_count=%d\n", agentID, *result.ReplayedCount)
+}
+
+func agentReplayBacklogErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return agentReplayBacklogExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return agentReplayBacklogExitAuth
+		}
+		return agentReplayBacklogExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return agentReplayBacklogExitAuth
+		case "AGENT_NOT_FOUND":
+			return agentReplayBacklogExitNotFound
+		case "IDEMPOTENCY_CONFLICT":
+			return agentReplayBacklogExitConflict
+		default:
+			return agentReplayBacklogExitRuntime
+		}
+	}
+	return agentReplayBacklogExitRuntime
+}

--- a/cmd/swarm/agent_replay_backlog_test.go
+++ b/cmd/swarm/agent_replay_backlog_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentReplayBacklogUsesV1RPCWithIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true, "replayed_count": 3})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"agent", "replay-backlog", "agent-1",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != agentReplayBacklogMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, agentReplayBacklogMethod)
+	}
+	wantParams := map[string]any{"agent_id": "agent-1", "idempotency_key": "idem-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	if _, ok := captured.Params["event_id"]; ok {
+		t.Fatalf("params unexpectedly included event_id: %#v", captured.Params)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "agent replay-backlog ok: agent_id=agent-1 replayed_count=3" {
+		t.Fatalf("stdout = %q, want replay-backlog success", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentReplayBacklogOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true, "replayed_count": 0})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay-backlog", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"agent_id": "agent-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+}
+
+func TestAgentReplayBacklogRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true, "replayed_count": 1})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing id", args: []string{"agent", "replay-backlog"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank id", args: []string{"agent", "replay-backlog", "  "}, wantStderr: "agent id is required"},
+		{name: "extra arg", args: []string{"agent", "replay-backlog", "agent-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "unsupported event id flag", args: []string{"agent", "replay-backlog", "agent-1", "--event-id", "event-1"}, wantStderr: "unknown flag"},
+		{name: "unsupported flag", args: []string{"agent", "replay-backlog", "agent-1", "--unknown"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentReplayBacklogFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true, "replayed_count": 1})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay-backlog", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentReplayBacklogMapsFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime failure exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "agent not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayBacklogJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "AGENT_NOT_FOUND",
+		},
+		{
+			name: "idempotency conflict exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayBacklogJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "unauthorized rpc exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayBacklogJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "unknown rpc error exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentReplayBacklogJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "malformed ok exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": false, "replayed_count": 1})
+			},
+			wantCode:   3,
+			wantStderr: "ok must be true",
+		},
+		{
+			name: "missing replayed count exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true})
+			},
+			wantCode:   3,
+			wantStderr: "replayed_count is required",
+		},
+		{
+			name: "negative replayed count exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true, "replayed_count": -1})
+			},
+			wantCode:   3,
+			wantStderr: "replayed_count must be >= 0",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "replay-backlog", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func writeAgentReplayBacklogJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"agent_id": "agent-1"},
+				"retryable":      false,
+				"correlation_id": "corr-agent-replay-backlog",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -94,6 +94,7 @@ func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 		newAgentViewCommand(opts),
 		newAgentRestartCommand(opts),
 		newAgentReplayCommand(opts),
+		newAgentReplayBacklogCommand(opts),
 		newAgentDirectiveCommand(opts),
 	)
 	return cmd

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5873,7 +5873,7 @@ cli_specification:
     agent_replay_backlog:
       command: swarm agent replay-backlog <agent-id> [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc agent.replay_backlog
       behavior: Backlog recovery CLI consumer. The CLI sends agent_id and optional idempotency_key to /v1/rpc agent.replay_backlog through the shared v1 API client and renders only the server-owned replayed_count. This command is distinct from event-targeted redelivery and MUST NOT call agent.replay, event.replay, dashboard/Builder REST, runtime/store/EventBus/agentcontrol directly, or infer event/delivery/session replay evidence locally.
       output:
@@ -6070,6 +6070,7 @@ cli_specification:
     - swarm agent restart
     - swarm agent directive
     - swarm agent replay
+    - swarm agent replay-backlog
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6079,7 +6080,6 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm agent replay-backlog <agent-id>
     - swarm events list / events follow / event view / event replay / event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete


### PR DESCRIPTION
## Summary

Implements the backlog replay CLI consumer:

- Adds `swarm agent replay-backlog <agent-id> [--idempotency-key <key>]`.
- Calls exactly `/v1/rpc agent.replay_backlog` through the shared CLI API client.
- Sends `agent_id` and optional `idempotency_key`; never sends or accepts `event_id`.
- Renders `agent_id` plus server-owned `replayed_count`.
- Updates the authoritative CLI catalog state in `platform-spec.yaml`.

Closes #837
Part of #816
Part of #735

## Governing Refs / Context

- #837 issue body and pre-audit: backlog replay CLI consumer only.
- #837 independent gate: `approved as first slice` for `swarm agent replay-backlog` over `/v1/rpc agent.replay_backlog`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: `cli_specification.command_catalog.agent_replay_backlog`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`: API method `agent.replay_backlog`.
- `docs/specs/swarm-platform/platform/contracts/openrpc.json`: generated `agent.replay_backlog` method with `agent_id`, optional `idempotency_key`, result `{ ok, replayed_count }`.

## Semantic Migration

- New canonical owner consumed by CLI: `/v1/rpc agent.replay_backlog`.
- Old / invalid CLI paths: `agent.replay`, `event.replay`, dashboard/Builder REST, direct runtime/store/EventBus/agentcontrol, legacy `/api/*`, `/rpc`, `/api/rpc`, `/ws`, `/api/ws`.
- Production paths checked for surviving old behavior: `cmd/swarm`, scripts, dashboard/Builder adapters, `internal/apiv1`, runtime replay owners, OpenRPC, and `platform-spec.yaml`.
- Migration complete for this child: yes, the backlog replay CLI consumer gap is closed. Broader #735 should-have families remain outside this PR.

## Proof

- `go test ./cmd/swarm -run 'Agent.*Replay|Replay.*Backlog|ReplayBacklog' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep over `cmd/swarm/agent_replay_backlog.go` and `cmd/swarm/agent_replay_backlog_test.go` for forbidden legacy/runtime/event-replay paths.
