### PR TITLE
[agent-e][issue #847] Gate OpenRPC proof references

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,8 +65,8 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
-  - id: 847
-    title: Gate OpenRPC compliance proof-reference integrity
+  - id: 857
+    title: Track residual v1 OpenRPC runtime/schema/example gaps after proof-ref integrity
     maps_to:
       - v1_openrpc_api_conformance
 nodes:
@@ -172,6 +172,7 @@ nodes:
     representative_issues:
       - 835
       - 847
+      - 857
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,8 +65,8 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
-  - id: 835
-    title: Add OpenRPC-driven v1 API compliance harness and coverage matrix
+  - id: 847
+    title: Gate OpenRPC compliance proof-reference integrity
     maps_to:
       - v1_openrpc_api_conformance
 nodes:
@@ -166,10 +166,12 @@ nodes:
     known_manifestations:
       - no checked-in 42-method matrix keyed by generated OpenRPC method name
       - required params, unknown params, auth, declared errors, idempotency, result schema, and notification schema proof status can drift silently
+      - stale or free-form proof references in the checked-in compliance matrix can drift silently from their test/helper/artifact/tracker owners
       - OpenRPC method examples and rpc.discover publication status are not explicitly tracked
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
       - 835
+      - 847
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -52,9 +52,29 @@ type openRPCMethodMatrix struct {
 }
 
 type complianceEvidence struct {
-	Status      string               `yaml:"status"`
-	ProofRefs   []complianceProofRef `yaml:"proof_refs"`
-	LegacyProof []string             `yaml:"proof"`
+	Status             string               `yaml:"status"`
+	ProofRefs          []complianceProofRef `yaml:"proof_refs"`
+	LegacyProof        []string             `yaml:"proof"`
+	LegacyProofPresent bool                 `yaml:"-"`
+}
+
+func (e *complianceEvidence) UnmarshalYAML(value *yaml.Node) error {
+	type plain complianceEvidence
+	var decoded plain
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*e = complianceEvidence(decoded)
+	if value.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i].Value == "proof" {
+			e.LegacyProofPresent = true
+			return nil
+		}
+	}
+	return nil
 }
 
 type complianceProofRef struct {
@@ -281,6 +301,28 @@ func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 	}
 }
 
+func TestOpenRPCComplianceMatrixRejectsEmptyLegacyProofKey(t *testing.T) {
+	root := repoRoot(t)
+	matrix := loadComplianceMatrix(t, filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml"))
+	row := complianceMatrixRow(t, &matrix, "agent.get")
+	raw := []byte(`status: covered
+proof: []
+proof_refs:
+  - kind: go_test
+    name: TestOperatorAgentConversationHandlersExposeReadOwner
+`)
+	if err := yaml.Unmarshal(raw, &row.HappyPath); err != nil {
+		t.Fatalf("parse evidence fixture: %v", err)
+	}
+	if !row.HappyPath.LegacyProofPresent {
+		t.Fatal("legacy proof key presence was not recorded")
+	}
+	problems := validateProofReferenceIntegrity(root, matrix)
+	if !problemContains(problems, "agent.get happy_path uses legacy proof strings") {
+		t.Fatalf("validateProofReferenceIntegrity() problems = %v, want empty legacy proof key rejection", problems)
+	}
+}
+
 func loadComplianceAPISpec(t *testing.T, root string) *apispec.APISpecification {
 	t.Helper()
 	api, err := apispec.LoadPlatformSpec(filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
@@ -436,7 +478,7 @@ func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix o
 	var problems []string
 	label := methodName + " " + field
 	status := strings.TrimSpace(evidence.Status)
-	if len(evidence.LegacyProof) > 0 {
+	if evidence.LegacyProofPresent || len(evidence.LegacyProof) > 0 {
 		problems = append(problems, fmt.Sprintf("%s uses legacy proof strings; use proof_refs", label))
 	}
 	if status == "not_applicable" {
@@ -796,7 +838,7 @@ func assertEvidence(t *testing.T, methodName, field string, evidence complianceE
 	if _, ok := allowed[status]; !ok {
 		t.Fatalf("%s %s status = %q, want one of %v", methodName, field, status, sortedKeys(allowed))
 	}
-	if len(evidence.LegacyProof) > 0 {
+	if evidence.LegacyProofPresent || len(evidence.LegacyProof) > 0 {
 		t.Fatalf("%s %s proof uses legacy string refs; use proof_refs", methodName, field)
 	}
 	if len(evidence.ProofRefs) == 0 {
@@ -832,7 +874,7 @@ func assertNotApplicable(t *testing.T, methodName, field string, evidence compli
 	if evidence.Status != "not_applicable" {
 		t.Fatalf("%s %s status = %q, want not_applicable", methodName, field, evidence.Status)
 	}
-	if len(evidence.LegacyProof) > 0 || len(evidence.ProofRefs) > 0 {
+	if evidence.LegacyProofPresent || len(evidence.LegacyProof) > 0 || len(evidence.ProofRefs) > 0 {
 		t.Fatalf("%s %s not_applicable must not carry proof refs", methodName, field)
 	}
 }

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -210,7 +210,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 	root := repoRoot(t)
 	matrixPath := filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml")
-	trackerRef := complianceProofRef{Kind: "tracker", Issue: 847, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}
+	trackerRef := complianceProofRef{Kind: "tracker", Issue: 857, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}
 	tests := []struct {
 		name   string
 		mutate func(*openRPCComplianceMatrix)

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -2,6 +2,10 @@ package apiv1
 
 import (
 	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,10 +19,18 @@ import (
 )
 
 type openRPCComplianceMatrix struct {
-	Version int                   `yaml:"version"`
-	Kind    string                `yaml:"kind"`
-	Issue   int                   `yaml:"issue"`
-	Methods []openRPCMethodMatrix `yaml:"methods"`
+	Version        int                       `yaml:"version"`
+	Kind           string                    `yaml:"kind"`
+	Issue          int                       `yaml:"issue"`
+	IssueRole      string                    `yaml:"issue_role"`
+	ActiveTrackers []complianceActiveTracker `yaml:"active_trackers"`
+	Methods        []openRPCMethodMatrix     `yaml:"methods"`
+}
+
+type complianceActiveTracker struct {
+	Kind      string `yaml:"kind"`
+	Issue     int    `yaml:"issue"`
+	Watchlist string `yaml:"watchlist"`
 }
 
 type openRPCMethodMatrix struct {
@@ -40,8 +52,17 @@ type openRPCMethodMatrix struct {
 }
 
 type complianceEvidence struct {
-	Status string   `yaml:"status"`
-	Proof  []string `yaml:"proof"`
+	Status      string               `yaml:"status"`
+	ProofRefs   []complianceProofRef `yaml:"proof_refs"`
+	LegacyProof []string             `yaml:"proof"`
+}
+
+type complianceProofRef struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name,omitempty"`
+	Path      string `yaml:"path,omitempty"`
+	Issue     int    `yaml:"issue,omitempty"`
+	Watchlist string `yaml:"watchlist,omitempty"`
 }
 
 type rawOpenRPCDocument struct {
@@ -63,11 +84,17 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.Issue != 835 {
 		t.Fatalf("matrix issue = %d, want 835", matrix.Issue)
 	}
+	if matrix.IssueRole != "provenance" {
+		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
+	}
 	if len(doc.Methods) != 42 {
 		t.Fatalf("generated OpenRPC methods = %d, want 42", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))
+	}
+	if problems := validateProofReferenceIntegrity(root, matrix); len(problems) > 0 {
+		t.Fatalf("compliance matrix proof-reference integrity failed:\n- %s", strings.Join(problems, "\n- "))
 	}
 
 	openRPCByName := map[string]apispec.OpenRPCMethod{}
@@ -160,6 +187,100 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	}
 }
 
+func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
+	root := repoRoot(t)
+	matrixPath := filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml")
+	trackerRef := complianceProofRef{Kind: "tracker", Issue: 847, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}
+	tests := []struct {
+		name   string
+		mutate func(*openRPCComplianceMatrix)
+		want   string
+	}{
+		{
+			name: "stale go test",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "go_test", Name: "TestDoesNotExist"}}
+			},
+			want: "go_test proof_ref TestDoesNotExist does not resolve",
+		},
+		{
+			name: "stale go helper",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.UnknownTopLevelParamValidation.ProofRefs = []complianceProofRef{{Kind: "go_helper", Name: "missingHelper"}}
+			},
+			want: "go_helper proof_ref missingHelper does not resolve",
+		},
+		{
+			name: "stale tracker",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "mailbox.reject")
+				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "tracker", Issue: 835, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}}
+			},
+			want: "tracker proof_ref issue #835 is the provenance issue",
+		},
+		{
+			name: "unknown tracker",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "mailbox.reject")
+				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "tracker", Issue: 999999, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}}
+			},
+			want: "tracker proof_ref issue #999999 watchlist \"operator_surfaces.v1_openrpc_api_conformance\" is not in active_trackers",
+		},
+		{
+			name: "unknown gap class",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.GapClassification = append(row.GapClassification, "unknown_gap_class")
+			},
+			want: "unknown gap_classification",
+		},
+		{
+			name: "unsupported status proof kind",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "go_test", Name: "TestOperatorAgentConversationHandlersExposeReadOwner"}, trackerRef}
+			},
+			want: "status covered does not allow tracker proof_ref",
+		},
+		{
+			name: "unknown proof kind",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "spreadsheet", Name: "manual-audit"}}
+			},
+			want: "proof_ref kind \"spreadsheet\" is not allowed",
+		},
+		{
+			name: "invalid artifact path",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.ServiceDiscoveryPublication.ProofRefs = []complianceProofRef{{Kind: "artifact", Path: "docs/specs/missing-openrpc.json"}}
+			},
+			want: "artifact proof_ref path docs/specs/missing-openrpc.json does not exist",
+		},
+		{
+			name: "legacy proof strings",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.HappyPath.LegacyProof = []string{"TestOperatorAgentConversationHandlersExposeReadOwner"}
+			},
+			want: "uses legacy proof strings",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := loadComplianceMatrix(t, matrixPath)
+			tc.mutate(&matrix)
+			problems := validateProofReferenceIntegrity(root, matrix)
+			if !problemContains(problems, tc.want) {
+				t.Fatalf("validateProofReferenceIntegrity() problems = %v, want substring %q", problems, tc.want)
+			}
+		})
+	}
+}
+
 func loadComplianceAPISpec(t *testing.T, root string) *apispec.APISpecification {
 	t.Helper()
 	api, err := apispec.LoadPlatformSpec(filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
@@ -209,6 +330,397 @@ func loadComplianceMatrix(t *testing.T, path string) openRPCComplianceMatrix {
 		t.Fatalf("parse compliance matrix: %v", err)
 	}
 	return matrix
+}
+
+func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix) []string {
+	index, problems := newComplianceProofIndex(root, matrix)
+	if matrix.IssueRole != "provenance" {
+		problems = append(problems, fmt.Sprintf("matrix issue_role = %q, want provenance", matrix.IssueRole))
+	}
+	if len(matrix.ActiveTrackers) == 0 {
+		problems = append(problems, "matrix active_trackers must list at least one active tracker")
+	}
+	for _, tracker := range matrix.ActiveTrackers {
+		if strings.TrimSpace(tracker.Kind) != "github_issue" {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d kind = %q, want github_issue", tracker.Issue, tracker.Kind))
+		}
+		if tracker.Issue == 0 {
+			problems = append(problems, "active tracker missing issue")
+		}
+		if matrix.IssueRole == "provenance" && tracker.Issue == matrix.Issue {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d must not reuse provenance issue", tracker.Issue))
+		}
+		if strings.TrimSpace(tracker.Watchlist) == "" {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d missing watchlist", tracker.Issue))
+		}
+	}
+	for _, row := range matrix.Methods {
+		for _, gapClass := range row.GapClassification {
+			if _, ok := allowedComplianceGapClasses()[gapClass]; !ok {
+				problems = append(problems, fmt.Sprintf("%s unknown gap_classification %q", row.Method, gapClass))
+			}
+		}
+		for _, evidence := range complianceEvidenceFields(row) {
+			problems = append(problems, validateEvidenceProofRefs(root, index, matrix, row.Method, evidence.field, evidence.evidence)...)
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+type complianceProofIndex struct {
+	goTests             map[string]string
+	goHelpers           map[string]string
+	activeTrackers      map[string]struct{}
+	watchlistNodes      map[string]struct{}
+	watchlistIssueLinks map[string]struct{}
+}
+
+func newComplianceProofIndex(root string, matrix openRPCComplianceMatrix) (complianceProofIndex, []string) {
+	index := complianceProofIndex{
+		goTests:             map[string]string{},
+		goHelpers:           map[string]string{},
+		activeTrackers:      map[string]struct{}{},
+		watchlistNodes:      map[string]struct{}{},
+		watchlistIssueLinks: map[string]struct{}{},
+	}
+	var problems []string
+	symbols, err := loadGoFunctionSymbols(root)
+	if err != nil {
+		problems = append(problems, err.Error())
+	} else {
+		index.goTests = symbols.tests
+		index.goHelpers = symbols.helpers
+	}
+	watchlists, err := loadWatchlistProofIndex(root, complianceWatchlistIDs(matrix))
+	if err != nil {
+		problems = append(problems, err.Error())
+	} else {
+		index.watchlistNodes = watchlists.nodes
+		index.watchlistIssueLinks = watchlists.issueLinks
+	}
+	for _, tracker := range matrix.ActiveTrackers {
+		key := trackerKey(tracker.Issue, tracker.Watchlist)
+		index.activeTrackers[key] = struct{}{}
+		if _, ok := index.watchlistNodes[tracker.Watchlist]; !ok {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d watchlist %q does not resolve", tracker.Issue, tracker.Watchlist))
+		}
+		if _, ok := index.watchlistIssueLinks[key]; !ok {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d is not mapped to watchlist %q", tracker.Issue, tracker.Watchlist))
+		}
+	}
+	return index, problems
+}
+
+type namedComplianceEvidence struct {
+	field    string
+	evidence complianceEvidence
+}
+
+func complianceEvidenceFields(row openRPCMethodMatrix) []namedComplianceEvidence {
+	return []namedComplianceEvidence{
+		{field: "happy_path", evidence: row.HappyPath},
+		{field: "required_param_validation", evidence: row.RequiredParamValidation},
+		{field: "unknown_top_level_param_validation", evidence: row.UnknownTopLevelParamValidation},
+		{field: "auth", evidence: row.Auth},
+		{field: "declared_error_tests", evidence: row.DeclaredErrorTests},
+		{field: "idempotency", evidence: row.Idempotency},
+		{field: "result_schema", evidence: row.ResultSchema},
+		{field: "notification_schema", evidence: row.NotificationSchema},
+		{field: "examples", evidence: row.Examples},
+		{field: "service_discovery_publication", evidence: row.ServiceDiscoveryPublication},
+	}
+}
+
+func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix openRPCComplianceMatrix, methodName, field string, evidence complianceEvidence) []string {
+	var problems []string
+	label := methodName + " " + field
+	status := strings.TrimSpace(evidence.Status)
+	if len(evidence.LegacyProof) > 0 {
+		problems = append(problems, fmt.Sprintf("%s uses legacy proof strings; use proof_refs", label))
+	}
+	if status == "not_applicable" {
+		if len(evidence.ProofRefs) > 0 {
+			problems = append(problems, fmt.Sprintf("%s status not_applicable must not carry proof_refs", label))
+		}
+		return problems
+	}
+	if len(evidence.ProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s status %s requires proof_refs", label, status))
+		return problems
+	}
+	allowedKinds := allowedProofRefKinds(status, field)
+	kinds := map[string]struct{}{}
+	for _, ref := range evidence.ProofRefs {
+		kind := strings.TrimSpace(ref.Kind)
+		kinds[kind] = struct{}{}
+		if len(allowedKinds) > 0 {
+			if _, ok := allowedKinds[kind]; !ok {
+				problems = append(problems, fmt.Sprintf("%s status %s does not allow %s proof_ref", label, status, kind))
+			}
+		}
+		switch kind {
+		case "go_test":
+			if strings.TrimSpace(ref.Name) == "" {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", label))
+			} else if _, ok := index.goTests[ref.Name]; !ok {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref %s does not resolve", label, ref.Name))
+			}
+		case "go_helper":
+			if strings.TrimSpace(ref.Name) == "" {
+				problems = append(problems, fmt.Sprintf("%s go_helper proof_ref missing name", label))
+			} else if _, ok := index.goHelpers[ref.Name]; !ok {
+				problems = append(problems, fmt.Sprintf("%s go_helper proof_ref %s does not resolve", label, ref.Name))
+			}
+		case "artifact":
+			if strings.TrimSpace(ref.Path) == "" {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref missing path", label))
+				continue
+			}
+			if filepath.IsAbs(ref.Path) || strings.HasPrefix(filepath.Clean(ref.Path), "..") {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s must be repo-relative", label, ref.Path))
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.Clean(ref.Path))); err != nil {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s does not exist", label, ref.Path))
+			}
+		case "tracker":
+			if ref.Issue == 0 {
+				problems = append(problems, fmt.Sprintf("%s tracker proof_ref missing issue", label))
+			}
+			if matrix.IssueRole == "provenance" && ref.Issue == matrix.Issue {
+				problems = append(problems, fmt.Sprintf("%s tracker proof_ref issue #%d is the provenance issue, not an active tracker", label, ref.Issue))
+			}
+			key := trackerKey(ref.Issue, ref.Watchlist)
+			if _, ok := index.activeTrackers[key]; !ok {
+				problems = append(problems, fmt.Sprintf("%s tracker proof_ref issue #%d watchlist %q is not in active_trackers", label, ref.Issue, ref.Watchlist))
+			}
+		case "policy_gap":
+			if _, ok := allowedCompliancePolicyGaps()[ref.Name]; !ok {
+				problems = append(problems, fmt.Sprintf("%s policy_gap proof_ref %q is not allowed", label, ref.Name))
+			}
+		default:
+			problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", label, kind))
+		}
+	}
+	switch status {
+	case "covered", "spot_checked":
+		if _, ok := kinds["go_test"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status %s requires at least one go_test proof_ref", label, status))
+		}
+	case "shared":
+		if _, hasTest := kinds["go_test"]; !hasTest {
+			if _, hasHelper := kinds["go_helper"]; !hasHelper {
+				problems = append(problems, fmt.Sprintf("%s status shared requires at least one go_test or go_helper proof_ref", label))
+			}
+		}
+	case "tracked_gap":
+		if _, ok := kinds["tracker"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status tracked_gap requires a tracker proof_ref", label))
+		}
+	case "published_without_discovery":
+		if _, ok := kinds["artifact"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status published_without_discovery requires an artifact proof_ref", label))
+		}
+	}
+	return problems
+}
+
+func allowedComplianceGapClasses() map[string]struct{} {
+	return complianceStringSet([]string{
+		"missing_generated_declared_error_cases",
+		"missing_generated_result_schema_validation",
+		"missing_happy_path_test",
+		"missing_idempotency_test",
+		"missing_openrpc_examples",
+		"missing_result_schema_proof",
+		"notification_schema_not_emitted_in_openrpc_method",
+	})
+}
+
+func allowedCompliancePolicyGaps() map[string]struct{} {
+	return complianceStringSet([]string{
+		"openrpc_examples_absent",
+	})
+}
+
+func allowedProofRefKinds(status, field string) map[string]struct{} {
+	switch status {
+	case "covered", "spot_checked":
+		return complianceStringSet([]string{"go_test"})
+	case "shared":
+		return complianceStringSet([]string{"go_test", "go_helper"})
+	case "tracked_gap":
+		if field == "examples" {
+			return complianceStringSet([]string{"tracker", "policy_gap"})
+		}
+		return complianceStringSet([]string{"tracker"})
+	case "published_without_discovery":
+		return complianceStringSet([]string{"artifact", "go_test"})
+	default:
+		return map[string]struct{}{}
+	}
+}
+
+type goFunctionSymbols struct {
+	tests   map[string]string
+	helpers map[string]string
+}
+
+func loadGoFunctionSymbols(root string) (goFunctionSymbols, error) {
+	symbols := goFunctionSymbols{
+		tests:   map[string]string{},
+		helpers: map[string]string{},
+	}
+	for _, dir := range []string{"internal/apispec", "internal/apiv1"} {
+		base := filepath.Join(root, dir)
+		err := filepath.WalkDir(base, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			fileSet := token.NewFileSet()
+			parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+			if err != nil {
+				return err
+			}
+			rel, _ := filepath.Rel(root, path)
+			isTestFile := strings.HasSuffix(path, "_test.go")
+			for _, decl := range parsed.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil {
+					continue
+				}
+				name := fn.Name.Name
+				if isTestFile && strings.HasPrefix(name, "Test") {
+					symbols.tests[name] = rel
+					continue
+				}
+				symbols.helpers[name] = rel
+			}
+			return nil
+		})
+		if err != nil {
+			return symbols, fmt.Errorf("load go function symbols from %s: %w", dir, err)
+		}
+	}
+	return symbols, nil
+}
+
+type watchlistProofIndex struct {
+	nodes      map[string]struct{}
+	issueLinks map[string]struct{}
+}
+
+func complianceWatchlistIDs(matrix openRPCComplianceMatrix) map[string]struct{} {
+	ids := map[string]struct{}{}
+	add := func(watchlist string) {
+		id, _, ok := strings.Cut(strings.TrimSpace(watchlist), ".")
+		if ok && id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	for _, tracker := range matrix.ActiveTrackers {
+		add(tracker.Watchlist)
+	}
+	for _, row := range matrix.Methods {
+		for _, evidence := range complianceEvidenceFields(row) {
+			for _, ref := range evidence.evidence.ProofRefs {
+				if ref.Kind == "tracker" {
+					add(ref.Watchlist)
+				}
+			}
+		}
+	}
+	return ids
+}
+
+func loadWatchlistProofIndex(root string, ids map[string]struct{}) (watchlistProofIndex, error) {
+	index := watchlistProofIndex{
+		nodes:      map[string]struct{}{},
+		issueLinks: map[string]struct{}{},
+	}
+	paths := watchlistPaths(root, ids)
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return index, fmt.Errorf("read watchlist %s: %w", path, err)
+		}
+		var doc struct {
+			ID           string `yaml:"id"`
+			ActiveIssues []struct {
+				ID     int      `yaml:"id"`
+				MapsTo []string `yaml:"maps_to"`
+			} `yaml:"active_issues"`
+			Nodes []struct {
+				ID string `yaml:"id"`
+			} `yaml:"nodes"`
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return index, fmt.Errorf("parse watchlist %s: %w", path, err)
+		}
+		watchlistID := strings.TrimSpace(doc.ID)
+		for _, node := range doc.Nodes {
+			nodeID := strings.TrimSpace(node.ID)
+			if watchlistID != "" && nodeID != "" {
+				index.nodes[watchlistID+"."+nodeID] = struct{}{}
+			}
+		}
+		for _, issue := range doc.ActiveIssues {
+			for _, nodeID := range issue.MapsTo {
+				key := trackerKey(issue.ID, watchlistID+"."+strings.TrimSpace(nodeID))
+				index.issueLinks[key] = struct{}{}
+			}
+		}
+	}
+	return index, nil
+}
+
+func watchlistPaths(root string, ids map[string]struct{}) []string {
+	seen := map[string]struct{}{}
+	var paths []string
+	for id := range ids {
+		for _, candidate := range []string{
+			filepath.Join(root, "docs", "watchlists", id+".yaml"),
+			filepath.Join(root, "docs", "watchlists", strings.ReplaceAll(id, "_", "-")+".yaml"),
+		} {
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			if _, err := os.Stat(candidate); err == nil {
+				seen[candidate] = struct{}{}
+				paths = append(paths, candidate)
+			}
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func trackerKey(issue int, watchlist string) string {
+	return fmt.Sprintf("%d:%s", issue, strings.TrimSpace(watchlist))
+}
+
+func complianceMatrixRow(t *testing.T, matrix *openRPCComplianceMatrix, method string) *openRPCMethodMatrix {
+	t.Helper()
+	for i := range matrix.Methods {
+		if matrix.Methods[i].Method == method {
+			return &matrix.Methods[i]
+		}
+	}
+	t.Fatalf("matrix method %s not found", method)
+	return nil
+}
+
+func problemContains(problems []string, want string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func expectedComplianceTransport(methodName string, method apispec.Method) string {
@@ -284,8 +796,11 @@ func assertEvidence(t *testing.T, methodName, field string, evidence complianceE
 	if _, ok := allowed[status]; !ok {
 		t.Fatalf("%s %s status = %q, want one of %v", methodName, field, status, sortedKeys(allowed))
 	}
-	if len(evidence.Proof) == 0 {
-		t.Fatalf("%s %s proof must name the test, helper, issue, or artifact backing status %q", methodName, field, status)
+	if len(evidence.LegacyProof) > 0 {
+		t.Fatalf("%s %s proof uses legacy string refs; use proof_refs", methodName, field)
+	}
+	if len(evidence.ProofRefs) == 0 {
+		t.Fatalf("%s %s proof_refs must name the test, helper, issue, or artifact backing status %q", methodName, field, status)
 	}
 }
 
@@ -316,6 +831,9 @@ func assertNotApplicable(t *testing.T, methodName, field string, evidence compli
 	t.Helper()
 	if evidence.Status != "not_applicable" {
 		t.Fatalf("%s %s status = %q, want not_applicable", methodName, field, evidence.Status)
+	}
+	if len(evidence.LegacyProof) > 0 || len(evidence.ProofRefs) > 0 {
+		t.Fatalf("%s %s not_applicable must not carry proof refs", methodName, field)
 	}
 }
 

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -4,7 +4,7 @@ issue: 835
 issue_role: provenance
 active_trackers:
   - kind: github_issue
-    issue: 847
+    issue: 857
     watchlist: operator_surfaces.v1_openrpc_api_conformance
 source:
   platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -28,7 +28,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.list
@@ -43,7 +43,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.replay
@@ -58,7 +58,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.replay_backlog
@@ -73,7 +73,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.restart
@@ -88,7 +88,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.send_directive
@@ -103,7 +103,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.current_for_agent
@@ -118,7 +118,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.get
@@ -133,7 +133,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.get_turn
@@ -148,7 +148,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorConversationGetTurnComposesRuntimeLogOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.list
@@ -163,7 +163,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.aggregate
@@ -178,7 +178,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.get
@@ -193,7 +193,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.list
@@ -208,7 +208,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.get
@@ -223,7 +223,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.list
@@ -238,7 +238,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.publish
@@ -253,7 +253,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.replay
@@ -268,7 +268,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.subscribe
@@ -283,7 +283,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.check
@@ -298,7 +298,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.ping
@@ -313,7 +313,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.subscribe
@@ -328,7 +328,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.approve
@@ -343,7 +343,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.defer
@@ -358,7 +358,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.get
@@ -373,7 +373,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.list
@@ -388,22 +388,22 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.reject
     transport: http
     required_params: [mailbox_id, reason]
     declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
+    happy_path: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
-    idempotency: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
-    result_schema: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
+    idempotency: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
+    result_schema: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_happy_path_test, missing_idempotency_test, missing_result_schema_proof, missing_openrpc_examples]
   - method: rpc.unsubscribe
@@ -418,7 +418,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.continue
@@ -433,7 +433,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.diagnose
@@ -448,7 +448,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.get
@@ -463,7 +463,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.list
@@ -478,7 +478,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.pause
@@ -493,7 +493,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.start
@@ -508,7 +508,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.stop
@@ -523,7 +523,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.subscribe_trace
@@ -538,7 +538,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.trace
@@ -553,7 +553,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.incidents
@@ -568,7 +568,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.logs
@@ -583,7 +583,7 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.nuke
@@ -598,7 +598,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.pause
@@ -613,7 +613,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.resume
@@ -628,7 +628,7 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.subscribe_logs
@@ -643,6 +643,6 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -1,6 +1,11 @@
 version: 1
 kind: openrpc_compliance_matrix
 issue: 835
+issue_role: provenance
+active_trackers:
+  - kind: github_issue
+    issue: 847
+    watchlist: operator_surfaces.v1_openrpc_api_conformance
 source:
   platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -15,629 +20,629 @@ methods:
     transport: http
     required_params: [agent_id]
     declared_errors: [AGENT_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.replay
     transport: http
     required_params: [event_id, agent_id]
     declared_errors: [EVENT_NOT_FOUND, EVENT_REPLAY_NO_DELIVERY_HISTORY, EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL, EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE, EVENT_REPLAY_NOT_ELIGIBLE, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorAgentReplayFailClosedCases]}
-    idempotency: {status: covered, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentReplayProjectsSingletonEventReplayOwner]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayFailClosedCases}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.replay_backlog
     transport: http
     required_params: [agent_id]
     declared_errors: [AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentControlHandlersTypedResourceErrors]}
-    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersTypedResourceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.restart
     transport: http
     required_params: [agent_id]
     declared_errors: [AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentControlHandlersTypedResourceErrors]}
-    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersTypedResourceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: agent.send_directive
     transport: http
     required_params: [agent_id, directive]
     declared_errors: [AGENT_NOT_FOUND, AGENT_NOT_RUNNING, RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, AMBIGUOUS_RUN_TARGET, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorAgentControlHandlersTypedResourceErrors, TestOperatorAgentSendDirectiveRunTargetErrors]}
-    idempotency: {status: covered, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersTypedResourceErrors}, {kind: go_test, name: TestOperatorAgentSendDirectiveRunTargetErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.current_for_agent
     transport: http
     required_params: [agent_id]
     declared_errors: [AGENT_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.get
     transport: http
     required_params: [session_id]
     declared_errors: [SESSION_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.get_turn
     transport: http
     required_params: [session_id, turn_index]
     declared_errors: [SESSION_NOT_FOUND, TURN_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner, TestOperatorConversationGetTurnComposesRuntimeLogOwner]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorAgentConversationHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorConversationGetTurnComposesRuntimeLogOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner, TestOperatorConversationGetTurnComposesRuntimeLogOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorConversationGetTurnComposesRuntimeLogOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: conversation.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorAgentConversationHandlersExposeReadOwner]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.aggregate
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.get
     transport: http
     required_params: [entity_id]
     declared_errors: [ENTITY_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorEntityHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: entity.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorEntityHandlersExposeEntityNativeReads]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.get
     transport: http
     required_params: [event_id]
     declared_errors: [EVENT_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorObservabilityHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
     declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorEventPublishHandlersFailClosedBeforePersistence, TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun]}
-    idempotency: {status: covered, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersFailClosedBeforePersistence}, {kind: go_test, name: TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.replay
     transport: http
     required_params: [event_id]
     declared_errors: [EVENT_NOT_FOUND, EVENT_REPLAY_NO_DELIVERY_HISTORY, EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL, EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE, EVENT_REPLAY_NOT_ELIGIBLE, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorEventReplaySubsetAndFailClosedCases]}
-    idempotency: {status: covered, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventReplaySubsetAndFailClosedCases}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: event.subscribe
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
-    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay]}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.check
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.ping
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: health.subscribe
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
-    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.approve
     transport: http
     required_params: [mailbox_id]
     declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, MAILBOX_APPROVAL_EVENT_UNCONFIGURED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath, TestOperatorMailboxApprovePublishFailureLeavesItemRetryable]}
-    idempotency: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}, {kind: go_test, name: TestOperatorMailboxApprovePublishFailureLeavesItemRetryable}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.defer
     transport: http
     required_params: [mailbox_id, until]
     declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, INVALID_DEFER_UNTIL, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    idempotency: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.get
     transport: http
     required_params: [mailbox_id]
     declared_errors: [MAILBOX_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: mailbox.reject
     transport: http
     required_params: [mailbox_id, reason]
     declared_errors: [MAILBOX_NOT_FOUND, MAILBOX_ALREADY_DECIDED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: tracked_gap, proof: ["issue #835"]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorMailboxHandlersSupportedRPCPath]}
-    idempotency: {status: tracked_gap, proof: ["issue #835"]}
-    result_schema: {status: tracked_gap, proof: ["issue #835"]}
+    happy_path: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
+    idempotency: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
+    result_schema: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_happy_path_test, missing_idempotency_test, missing_result_schema_proof, missing_openrpc_examples]
   - method: rpc.unsubscribe
     transport: ws
     required_params: [subscription_id]
     declared_errors: []
-    happy_path: {status: covered, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe, TestWebSocketSessionBackpressureAndUnsubscribeCancelState]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}, {kind: go_test, name: TestWebSocketSessionBackpressureAndUnsubscribeCancelState}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketHealthSubscribeAndUnsubscribe]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.continue
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND, RUN_NOT_PAUSED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersTypedResourceErrors]}
-    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersTypedResourceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.diagnose
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.get
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.list
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorReadHandlersExposeHealthAndRunReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.pause
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, RUN_ALREADY_PAUSED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency, TestOperatorRunControlHandlersTypedResourceErrors]}
-    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}, {kind: go_test, name: TestOperatorRunControlHandlersTypedResourceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.start
     transport: http
     required_params: [event_name, payload]
     declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: spot_checked, proof: [TestOperatorRunStartHandlersFailClosedBeforePersistence]}
-    idempotency: {status: covered, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersFailClosedBeforePersistence}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_declared_error_cases, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.stop
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRunControlHandlersTypedResourceErrors]}
-    idempotency: {status: covered, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersTypedResourceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.subscribe_trace
     transport: ws
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
-    declared_error_tests: {status: covered, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
-    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound]}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: run.trace
     transport: http
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND]
-    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
-    required_param_validation: {status: shared, proof: [validateParams, TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics]}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorObservabilityHandlersTypedErrors]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.incidents
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.logs
     transport: http
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestOperatorObservabilityHandlersExposePersistedReadMethods]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.nuke
     transport: http
     required_params: []
     declared_errors: [RUNTIME_NUKE_IN_PROGRESS, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners, TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: covered, proof: [TestOperatorRuntimeNukeAuthFailureDoesNotTouchResetOwners]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency, TestOperatorRuntimeNukeOperationInProgressFailsClosed]}
-    idempotency: {status: covered, proof: [TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners, TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeAuthFailureDoesNotTouchResetOwners}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}, {kind: go_test, name: TestOperatorRuntimeNukeOperationInProgressFailsClosed}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.pause
     transport: http
     required_params: []
     declared_errors: [RUNTIME_ALREADY_PAUSED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
-    idempotency: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.resume
     transport: http
     required_params: []
     declared_errors: [RUNTIME_NOT_PAUSED, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerHTTPAuthBoundary]}
-    declared_error_tests: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
-    idempotency: {status: covered, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
-    result_schema: {status: spot_checked, proof: [TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [missing_generated_result_schema_validation, missing_openrpc_examples]
   - method: runtime.subscribe_logs
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof: [validateParams]}
-    auth: {status: shared, proof: [TestHandlerWebSocketAuthAndFrameValidation]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
-    notification_schema: {status: spot_checked, proof: [TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay]}
-    examples: {status: tracked_gap, proof: ["issue #835"]}
-    service_discovery_publication: {status: published_without_discovery, proof: [TestGeneratedOpenRPCArtifactMatchesPlatformSpec]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 847, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]


### PR DESCRIPTION
## Summary

Closes #847.

This PR closes the approved first-slice failure class: OpenRPC compliance matrix proof-reference integrity. It does not change API runtime behavior.

Changes:

- Converts `internal/apiv1/testdata/openrpc_compliance_matrix.yaml` from free-form `proof` strings to structured `proof_refs` with typed `go_test`, `go_helper`, `artifact`, `tracker`, and `policy_gap` references.
- Treats the matrix root `issue: 835` as provenance-only and moves active residual-gap tracking to #857 through `active_trackers` plus the operator-surfaces watchlist node.
- Extends `internal/apiv1/openrpc_compliance_test.go` to fail closed on stale test/helper refs, invalid artifact refs, unknown or provenance-only tracker refs, unknown gap classes, legacy proof strings, and unsupported status/proof-kind combinations.
- Refines `docs/watchlists/operator-surfaces.yaml` so `operator_surfaces.v1_openrpc_api_conformance` keeps #847 as the completed proof-reference child and maps active residual parent-tail gaps to #857.

## Governing Context

No exact `platform-spec.yaml` section defines proof-reference integrity for the compliance matrix itself. Binding context is issue #847, the approved Pre-Implementation Coverage Audit, the independent gate comment, #835 closeout, PR #841 merged as `4e013e1d86b51dead35b8c4f70eee9b497ce1f21`, and residual parent-tail tracker #857 opened during review.

Adjacent authoritative API contract references remain:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.transport`
- `api_specification.method_catalog_metadata`
- `api_specification.method_catalog`
- `api_specification.conventions.idempotency.mutating_methods`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json`

## Semantic Migration

New canonical owner: the structured proof-reference schema in `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`, interpreted by `validateProofReferenceIntegrity` in `internal/apiv1/openrpc_compliance_test.go`.

Old invalid producer/interpreter paths: bare `proof` strings, generic `issue #835` active residual-gap refs, unvalidated gap-class strings, child issue #847 used as an active residual tracker, and status checks that accepted non-resolving prose evidence.

Production/runtime paths checked for surviving old behavior: no `/v1/rpc` or `/v1/ws` runtime behavior changed; this PR only touches test/matrix/watchlist proof accounting. The old proof-string interpreter is retained only as a legacy YAML field detector so stale `proof` keys fail closed, including empty `proof: []` keys.

Migration completeness: complete for the approved proof-reference integrity slice. Full runtime conformance, OpenRPC examples, `rpc.discover`, generated result/notification schema validation, and method-level runtime probes remain out of scope and tracked as parent residual gaps under #857.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'TestOpenRPCComplianceMatrix(CoversEveryGeneratedMethod|RejectsInvalidProofReferences|RejectsEmptyLegacyProofKey)$' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `go test ./internal/apispec ./internal/apiv1 -coverprofile=/tmp/swarm-api-cover.out -count=1`
- `git diff --check`