### PR TITLE
[agent-b][issue #849] Add event observation CLI

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -73,6 +73,8 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newTraceCommand(opts),
 		newHealthCommand(opts),
 		newInvestigateCommand(opts),
+		newEventsCommand(opts),
+		newEventCommand(opts),
 		newAgentsCommand(opts),
 		newAgentCommand(opts),
 		newMailboxCommand(opts),

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -109,6 +109,7 @@ func applicationErrorCode(raw json.RawMessage) string {
 }
 
 type cliAPIHTTPError struct {
+	surface    string
 	statusCode int
 	message    string
 }
@@ -117,7 +118,11 @@ func (e *cliAPIHTTPError) Error() string {
 	if e == nil {
 		return ""
 	}
-	return fmt.Sprintf("v1 RPC HTTP %d: %s", e.statusCode, e.message)
+	surface := strings.TrimSpace(e.surface)
+	if surface == "" {
+		surface = "v1 RPC"
+	}
+	return fmt.Sprintf("%s HTTP %d: %s", surface, e.statusCode, e.message)
 }
 
 func (c *cliAPIClient) call(ctx context.Context, method string, params map[string]any, result any) error {

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -1,0 +1,743 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/spf13/cobra"
+)
+
+const (
+	eventObservationMethodList      = "event.list"
+	eventObservationMethodGet       = "event.get"
+	eventObservationMethodSubscribe = "event.subscribe"
+	eventObservationExitValidation  = 2
+	eventObservationExitRuntime     = 3
+	eventObservationExitAuth        = 4
+	eventObservationExitNotFound    = 5
+)
+
+type eventFilterOptions struct {
+	runID            string
+	entityID         string
+	eventName        string
+	deliveryStatus   string
+	subscriberID     string
+	subscriberType   string
+	reasonCode       string
+	hasDeadLetter    bool
+	hasDeadLetterSet bool
+}
+
+type eventListCommandOptions struct {
+	apiOptions rootCommandOptions
+	filter     eventFilterOptions
+	since      string
+	until      string
+	limit      int
+	limitSet   bool
+	cursor     string
+}
+
+type eventFollowCommandOptions struct {
+	apiOptions  rootCommandOptions
+	filter      eventFilterOptions
+	replaySince string
+}
+
+type eventListResult struct {
+	Events     []eventFull `json:"events"`
+	NextCursor string      `json:"next_cursor,omitempty"`
+}
+
+type eventFull struct {
+	EventID     string            `json:"event_id"`
+	EventName   string            `json:"event_name"`
+	CreatedAt   string            `json:"created_at"`
+	RunID       string            `json:"run_id,omitempty"`
+	EntityID    string            `json:"entity_id,omitempty"`
+	Source      string            `json:"source"`
+	Payload     map[string]any    `json:"payload"`
+	Deliveries  []eventDelivery   `json:"deliveries"`
+	DeadLetters []eventDeadLetter `json:"dead_letters"`
+}
+
+type eventDelivery struct {
+	DeliveryID     string `json:"delivery_id"`
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	Status         string `json:"status"`
+	SessionID      string `json:"session_id,omitempty"`
+	ReasonCode     string `json:"reason_code,omitempty"`
+	LastError      string `json:"last_error,omitempty"`
+}
+
+type eventDeadLetter struct {
+	DeadLetterID string `json:"dead_letter_id"`
+	FailureType  string `json:"failure_type"`
+	RetryCount   *int   `json:"retry_count"`
+	ChainDepth   *int   `json:"chain_depth"`
+	CreatedAt    string `json:"created_at"`
+	HandlerNode  string `json:"handler_node,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type eventSubscriptionResult struct {
+	SubscriptionID string `json:"subscription_id"`
+}
+
+type eventSubscriptionNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  struct {
+		Subscription string    `json:"subscription"`
+		Result       eventFull `json:"result"`
+	} `json:"params"`
+}
+
+type eventSubscription struct {
+	conn           *websocket.Conn
+	subscriptionID string
+	events         chan eventFull
+	errs           chan error
+}
+
+var eventObservationValidDeliveryStatuses = map[string]struct{}{
+	"pending":     {},
+	"in_progress": {},
+	"delivered":   {},
+	"failed":      {},
+	"dead_letter": {},
+}
+
+var eventObservationValidSubscriberTypes = map[string]struct{}{
+	"node":  {},
+	"agent": {},
+}
+
+var eventObservationValidDeadLetterFailureTypes = map[string]struct{}{
+	"handler_error":        {},
+	"chain_depth_exceeded": {},
+	"retry_exhausted":      {},
+}
+
+func newEventsCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "List or follow events through v1 API owners.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newEventsListCommand(opts),
+		newEventsFollowCommand(opts),
+	)
+	return cmd
+}
+
+func newEventCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event",
+		Short: "View one event through v1 API owners.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newEventViewCommand(opts))
+	return cmd
+}
+
+func newEventsListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := eventListCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List events through /v1/rpc event.list.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listOpts.filter.hasDeadLetterSet = cmd.Flags().Changed("has-dead-letter")
+			listOpts.limitSet = cmd.Flags().Changed("limit")
+			return runEventListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
+		},
+	}
+	bindEventFilterFlags(cmd, &listOpts.filter)
+	cmd.Flags().StringVar(&listOpts.since, "since", "", "Optional RFC3339 lower created_at bound")
+	cmd.Flags().StringVar(&listOpts.until, "until", "", "Optional RFC3339 upper created_at bound")
+	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-1000")
+	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Optional pagination cursor")
+	return cmd
+}
+
+func newEventsFollowCommand(opts rootCommandOptions) *cobra.Command {
+	followOpts := eventFollowCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "follow",
+		Short: "Follow events through /v1/ws event.subscribe.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			followOpts.filter.hasDeadLetterSet = cmd.Flags().Changed("has-dead-letter")
+			return runEventFollowCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), followOpts)
+		},
+	}
+	bindEventFilterFlags(cmd, &followOpts.filter)
+	cmd.Flags().StringVar(&followOpts.replaySince, "replay-since", "", "Optional RFC3339 catch-up window start")
+	return cmd
+}
+
+func newEventViewCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <event-id>",
+		Short: "View one event through /v1/rpc event.get.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEventViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+		},
+	}
+}
+
+func bindEventFilterFlags(cmd *cobra.Command, opts *eventFilterOptions) {
+	cmd.Flags().StringVar(&opts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().StringVar(&opts.entityID, "entity-id", "", "Filter by entity id")
+	cmd.Flags().StringVar(&opts.eventName, "event-name", "", "Filter by event name")
+	cmd.Flags().StringVar(&opts.deliveryStatus, "delivery-status", "", "Filter by delivery status")
+	cmd.Flags().StringVar(&opts.subscriberID, "subscriber-id", "", "Filter by subscriber id")
+	cmd.Flags().StringVar(&opts.subscriberType, "subscriber-type", "", "Filter by subscriber type: node or agent")
+	cmd.Flags().StringVar(&opts.reasonCode, "reason-code", "", "Filter by delivery/dead-letter reason code")
+	cmd.Flags().BoolVar(&opts.hasDeadLetter, "has-dead-letter", false, "Filter by whether the event has dead letters")
+}
+
+func runEventListCommand(ctx context.Context, out, errOut io.Writer, opts eventListCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationExitValidation}
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	var result eventListResult
+	if err := client.call(ctx, eventObservationMethodList, params, &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	if err := validateEventListResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationExitRuntime}
+	}
+	writeEventListResult(out, result)
+	return nil
+}
+
+func runEventViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, eventID string) error {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		fmt.Fprintln(errOut, "event id is required")
+		return commandExitError{code: eventObservationExitValidation}
+	}
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	var result eventFull
+	if err := client.call(ctx, eventObservationMethodGet, map[string]any{"event_id": eventID}, &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	if err := validateEventFull("event.get result", result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationExitRuntime}
+	}
+	writeEventDetailResult(out, result)
+	return nil
+}
+
+func runEventFollowCommand(ctx context.Context, out, errOut io.Writer, opts eventFollowCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationExitValidation}
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	sub, err := subscribeEvents(ctx, wsEndpoint, client.token, params)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventObservationErrorExitCode(err)}
+	}
+	defer sub.close()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Fprintln(errOut, "detached from event stream")
+			return commandExitError{code: 130}
+		case event, ok := <-sub.events:
+			if !ok {
+				select {
+				case err := <-sub.errs:
+					if err != nil {
+						fmt.Fprintln(errOut, err)
+						return commandExitError{code: eventObservationErrorExitCode(err)}
+					}
+				default:
+				}
+				return nil
+			}
+			writeEventFollowEvent(out, event)
+		case err := <-sub.errs:
+			if err != nil {
+				fmt.Fprintln(errOut, err)
+				return commandExitError{code: eventObservationErrorExitCode(err)}
+			}
+		}
+	}
+}
+
+func (opts eventListCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	filter, err := opts.filter.params()
+	if err != nil {
+		return nil, err
+	}
+	if len(filter) > 0 {
+		params["filter"] = filter
+	}
+	if cursor := strings.TrimSpace(opts.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 1000 {
+			return nil, fmt.Errorf("--limit must be between 1 and 1000")
+		}
+		params["limit"] = opts.limit
+	}
+	if since := strings.TrimSpace(opts.since); since != "" {
+		if err := validateRFC3339Flag("--since", since); err != nil {
+			return nil, err
+		}
+		params["since"] = since
+	}
+	if until := strings.TrimSpace(opts.until); until != "" {
+		if err := validateRFC3339Flag("--until", until); err != nil {
+			return nil, err
+		}
+		params["until"] = until
+	}
+	return params, nil
+}
+
+func (opts eventFollowCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	filter, err := opts.filter.params()
+	if err != nil {
+		return nil, err
+	}
+	if len(filter) > 0 {
+		params["filter"] = filter
+	}
+	if replaySince := strings.TrimSpace(opts.replaySince); replaySince != "" {
+		if err := validateRFC3339Flag("--replay-since", replaySince); err != nil {
+			return nil, err
+		}
+		params["replay_since"] = replaySince
+	}
+	return params, nil
+}
+
+func (opts eventFilterOptions) params() (map[string]any, error) {
+	filter := map[string]any{}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "run_id", value: opts.runID},
+		{name: "entity_id", value: opts.entityID},
+		{name: "event_name", value: opts.eventName},
+		{name: "subscriber_id", value: opts.subscriberID},
+		{name: "reason_code", value: opts.reasonCode},
+	} {
+		if value := strings.TrimSpace(field.value); value != "" {
+			filter[field.name] = value
+		}
+	}
+	if status := strings.ToLower(strings.TrimSpace(opts.deliveryStatus)); status != "" {
+		if _, ok := eventObservationValidDeliveryStatuses[status]; !ok {
+			return nil, fmt.Errorf("--delivery-status must be one of pending, in_progress, delivered, failed, dead_letter")
+		}
+		filter["delivery_status"] = status
+	}
+	if subscriberType := strings.ToLower(strings.TrimSpace(opts.subscriberType)); subscriberType != "" {
+		if _, ok := eventObservationValidSubscriberTypes[subscriberType]; !ok {
+			return nil, fmt.Errorf("--subscriber-type must be one of node, agent")
+		}
+		filter["subscriber_type"] = subscriberType
+	}
+	if opts.hasDeadLetterSet {
+		filter["has_dead_letter"] = opts.hasDeadLetter
+	}
+	return filter, nil
+}
+
+func validateEventListResult(result eventListResult) error {
+	if result.Events == nil {
+		return fmt.Errorf("malformed event.list result: events is required")
+	}
+	for i, event := range result.Events {
+		if err := validateEventFull(fmt.Sprintf("event.list result: events[%d]", i), event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEventFull(prefix string, event eventFull) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "event_id", value: event.EventID},
+		{name: "event_name", value: event.EventName},
+		{name: "created_at", value: event.CreatedAt},
+		{name: "source", value: event.Source},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateRequiredTimestamp(prefix+".created_at", event.CreatedAt); err != nil {
+		return err
+	}
+	if event.Payload == nil {
+		return fmt.Errorf("malformed %s: payload is required", prefix)
+	}
+	if event.Deliveries == nil {
+		return fmt.Errorf("malformed %s: deliveries is required", prefix)
+	}
+	if event.DeadLetters == nil {
+		return fmt.Errorf("malformed %s: dead_letters is required", prefix)
+	}
+	for i, delivery := range event.Deliveries {
+		if err := validateEventDelivery(fmt.Sprintf("%s.deliveries[%d]", prefix, i), delivery); err != nil {
+			return err
+		}
+	}
+	for i, deadLetter := range event.DeadLetters {
+		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", prefix, i), deadLetter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEventDelivery(prefix string, delivery eventDelivery) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "delivery_id", value: delivery.DeliveryID},
+		{name: "subscriber_type", value: delivery.SubscriberType},
+		{name: "subscriber_id", value: delivery.SubscriberID},
+		{name: "status", value: delivery.Status},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if _, ok := eventObservationValidSubscriberTypes[strings.TrimSpace(delivery.SubscriberType)]; !ok {
+		return fmt.Errorf("malformed %s: subscriber_type=%q is not a valid SubscriberType", prefix, delivery.SubscriberType)
+	}
+	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
+		return fmt.Errorf("malformed %s: status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
+	}
+	return nil
+}
+
+func validateEventDeadLetter(prefix string, deadLetter eventDeadLetter) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "dead_letter_id", value: deadLetter.DeadLetterID},
+		{name: "failure_type", value: deadLetter.FailureType},
+		{name: "created_at", value: deadLetter.CreatedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if _, ok := eventObservationValidDeadLetterFailureTypes[strings.TrimSpace(deadLetter.FailureType)]; !ok {
+		return fmt.Errorf("malformed %s: failure_type=%q is not a valid DeadLetter failure_type", prefix, deadLetter.FailureType)
+	}
+	if deadLetter.RetryCount == nil {
+		return fmt.Errorf("malformed %s: retry_count is required", prefix)
+	}
+	if *deadLetter.RetryCount < 0 {
+		return fmt.Errorf("malformed %s: retry_count must be >= 0", prefix)
+	}
+	if deadLetter.ChainDepth == nil {
+		return fmt.Errorf("malformed %s: chain_depth is required", prefix)
+	}
+	if *deadLetter.ChainDepth < 0 {
+		return fmt.Errorf("malformed %s: chain_depth must be >= 0", prefix)
+	}
+	if err := validateRequiredTimestamp(prefix+".created_at", deadLetter.CreatedAt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[string]any) (*eventSubscription, error) {
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
+	if err != nil {
+		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
+	}
+	requestID := "swarm-cli:" + eventObservationMethodSubscribe
+	if err := conn.WriteJSON(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      requestID,
+		Method:  eventObservationMethodSubscribe,
+		Params:  params,
+	}); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("write event.subscribe request: %w", err)
+	}
+	var envelope jsonRPCResponse
+	if err := conn.ReadJSON(&envelope); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("read event.subscribe response: %w", err)
+	}
+	if envelope.JSONRPC != "2.0" {
+		conn.Close()
+		return nil, fmt.Errorf("malformed event.subscribe response: jsonrpc=%q", envelope.JSONRPC)
+	}
+	if id, ok := envelope.ID.(string); !ok || id != requestID {
+		conn.Close()
+		return nil, fmt.Errorf("malformed event.subscribe response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+	}
+	if envelope.Error != nil {
+		conn.Close()
+		return nil, envelope.Error
+	}
+	var result eventSubscriptionResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("decode event.subscribe result: %w", err)
+	}
+	if strings.TrimSpace(result.SubscriptionID) == "" {
+		conn.Close()
+		return nil, fmt.Errorf("malformed event.subscribe result: subscription_id is required")
+	}
+	sub := &eventSubscription{
+		conn:           conn,
+		subscriptionID: result.SubscriptionID,
+		events:         make(chan eventFull, 16),
+		errs:           make(chan error, 1),
+	}
+	go sub.readLoop()
+	return sub, nil
+}
+
+func (s *eventSubscription) readLoop() {
+	defer close(s.events)
+	for {
+		var notification eventSubscriptionNotification
+		if err := s.conn.ReadJSON(&notification); err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || strings.Contains(err.Error(), "use of closed network connection") {
+				return
+			}
+			s.reportError(fmt.Errorf("read event.subscribe notification: %w", err))
+			return
+		}
+		if notification.JSONRPC != "2.0" || notification.Method != "rpc.subscription" {
+			s.reportError(fmt.Errorf("malformed event.subscribe notification"))
+			return
+		}
+		if notification.Params.Subscription != s.subscriptionID {
+			s.reportError(fmt.Errorf("malformed event.subscribe notification: subscription mismatch"))
+			return
+		}
+		event := notification.Params.Result
+		if err := validateEventFull("event.subscribe notification", event); err != nil {
+			s.reportError(err)
+			return
+		}
+		select {
+		case s.events <- event:
+		default:
+			s.reportError(fmt.Errorf("event.subscribe notification queue overflow"))
+			return
+		}
+	}
+}
+
+func (s *eventSubscription) reportError(err error) {
+	select {
+	case s.errs <- err:
+	default:
+	}
+}
+
+func (s *eventSubscription) close() {
+	if s == nil || s.conn == nil {
+		return
+	}
+	_ = s.conn.Close()
+}
+
+func writeEventListResult(out io.Writer, result eventListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Events) == 0 {
+		fmt.Fprintln(out, "No events match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tRUN\tENTITY\tDELIVERIES\tDEAD_LETTERS")
+	for _, event := range result.Events {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+			event.CreatedAt,
+			event.EventName,
+			event.EventID,
+			eventObservationDash(event.RunID),
+			eventObservationDash(event.EntityID),
+			len(event.Deliveries),
+			len(event.DeadLetters),
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeEventDetailResult(out io.Writer, event eventFull) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Event %s\n", event.EventID)
+	fmt.Fprintf(out, "event_name=%s created_at=%s source=%s run_id=%s entity_id=%s\n",
+		event.EventName,
+		event.CreatedAt,
+		event.Source,
+		eventObservationDash(event.RunID),
+		eventObservationDash(event.EntityID),
+	)
+	fmt.Fprintf(out, "payload=%s\n", eventObservationCompactJSON(event.Payload))
+	if len(event.Deliveries) == 0 {
+		fmt.Fprintln(out, "deliveries: none")
+	} else {
+		fmt.Fprintln(out, "deliveries:")
+		for _, delivery := range event.Deliveries {
+			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s reason_code=%s last_error=%s\n",
+				delivery.DeliveryID,
+				delivery.SubscriberType,
+				delivery.SubscriberID,
+				delivery.Status,
+				eventObservationDash(delivery.SessionID),
+				eventObservationDash(delivery.ReasonCode),
+				eventObservationDash(delivery.LastError),
+			)
+		}
+	}
+	if len(event.DeadLetters) == 0 {
+		fmt.Fprintln(out, "dead_letters: none")
+	} else {
+		fmt.Fprintln(out, "dead_letters:")
+		for _, deadLetter := range event.DeadLetters {
+			fmt.Fprintf(out, "  dead_letter_id=%s failure_type=%s retry_count=%d chain_depth=%d created_at=%s handler_node=%s error=%s\n",
+				deadLetter.DeadLetterID,
+				deadLetter.FailureType,
+				*deadLetter.RetryCount,
+				*deadLetter.ChainDepth,
+				deadLetter.CreatedAt,
+				eventObservationDash(deadLetter.HandlerNode),
+				eventObservationDash(deadLetter.ErrorMessage),
+			)
+		}
+	}
+}
+
+func writeEventFollowEvent(out io.Writer, event eventFull) {
+	if out == nil {
+		return
+	}
+	fields := []string{
+		"event_id=" + event.EventID,
+		"event_name=" + event.EventName,
+		"at=" + event.CreatedAt,
+		"source=" + event.Source,
+	}
+	if event.RunID != "" {
+		fields = append(fields, "run_id="+event.RunID)
+	}
+	if event.EntityID != "" {
+		fields = append(fields, "entity_id="+event.EntityID)
+	}
+	fields = append(fields,
+		fmt.Sprintf("deliveries=%d", len(event.Deliveries)),
+		fmt.Sprintf("dead_letters=%d", len(event.DeadLetters)),
+	)
+	fmt.Fprintf(out, "event %s\n", strings.Join(fields, " "))
+}
+
+func eventObservationCompactJSON(value map[string]any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func eventObservationDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func eventObservationErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return eventObservationExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return eventObservationExitAuth
+		}
+		return eventObservationExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return eventObservationExitAuth
+		case "EVENT_NOT_FOUND":
+			return eventObservationExitNotFound
+		default:
+			return eventObservationExitRuntime
+		}
+	}
+	return eventObservationExitRuntime
+}

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -506,8 +506,11 @@ func validateEventDeadLetter(prefix string, deadLetter eventDeadLetter) error {
 
 func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[string]any) (*eventSubscription, error) {
 	header := http.Header{"Authorization": []string{"Bearer " + token}}
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
 	if err != nil {
+		if resp != nil {
+			return nil, eventObservationWSHTTPError(resp)
+		}
 		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
 	}
 	requestID := "swarm-cli:" + eventObservationMethodSubscribe
@@ -554,6 +557,21 @@ func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[s
 	}
 	go sub.readLoop()
 	return sub, nil
+}
+
+func eventObservationWSHTTPError(resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	message := http.StatusText(resp.StatusCode)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err == nil && strings.TrimSpace(string(raw)) != "" {
+			message = strings.TrimSpace(string(raw))
+		}
+	}
+	return &cliAPIHTTPError{surface: "v1 WS", statusCode: resp.StatusCode, message: message}
 }
 
 func (s *eventSubscription) readLoop() {

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -1,0 +1,491 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestEventsListUsesEventListV1RPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"events":      []any{validEventObservationEvent("event-1")},
+			"next_cursor": "event-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"events", "list",
+		"--run-id", "run-1",
+		"--entity-id", "entity-1",
+		"--event-name", "scan.requested",
+		"--delivery-status", "dead_letter",
+		"--subscriber-id", "agent-1",
+		"--subscriber-type", "agent",
+		"--reason-code", "handler_failed",
+		"--has-dead-letter=false",
+		"--limit", "2",
+		"--cursor", "cursor-1",
+		"--since", "2026-05-13T10:00:00Z",
+		"--until", "2026-05-13T11:00:00Z",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != eventObservationMethodList {
+		t.Fatalf("method = %q, want %s", captured.Method, eventObservationMethodList)
+	}
+	wantParams := map[string]any{
+		"filter": map[string]any{
+			"run_id":          "run-1",
+			"entity_id":       "entity-1",
+			"event_name":      "scan.requested",
+			"delivery_status": "dead_letter",
+			"subscriber_id":   "agent-1",
+			"subscriber_type": "agent",
+			"reason_code":     "handler_failed",
+			"has_dead_letter": false,
+		},
+		"limit":  float64(2),
+		"cursor": "cursor-1",
+		"since":  "2026-05-13T10:00:00Z",
+		"until":  "2026-05-13T11:00:00Z",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"EVENT AT", "scan.requested", "event-1", "run-1", "entity-1", "next_cursor=event-cursor-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventViewUsesEventGetV1RPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEventObservationEvent("event-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"event", "view", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != eventObservationMethodGet {
+		t.Fatalf("method = %q, want %s", captured.Method, eventObservationMethodGet)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"event_id": "event-1"}) {
+		t.Fatalf("params = %#v", captured.Params)
+	}
+	for _, want := range []string{
+		"Event event-1",
+		"event_name=scan.requested",
+		"payload={\"priority\":\"high\"}",
+		"delivery_id=delivery-1",
+		"dead_letter_id=dead-1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventsFollowUsesEventSubscribeV1WS(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, wsRequests := newEventObservationWSServer(t, eventObservationWSServerOptions{
+		events:         []map[string]any{validEventObservationEvent("event-live-1")},
+		closeAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"events", "follow",
+		"--run-id", "run-1",
+		"--event-name", "scan.requested",
+		"--delivery-status", "delivered",
+		"--subscriber-type", "agent",
+		"--has-dead-letter",
+		"--replay-since", "2026-05-13T10:00:00Z",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*wsRequests) != 1 {
+		t.Fatalf("ws requests = %d, want 1", len(*wsRequests))
+	}
+	req := (*wsRequests)[0]
+	if req.Method != eventObservationMethodSubscribe {
+		t.Fatalf("method = %q, want %s", req.Method, eventObservationMethodSubscribe)
+	}
+	wantParams := map[string]any{
+		"filter": map[string]any{
+			"run_id":          "run-1",
+			"event_name":      "scan.requested",
+			"delivery_status": "delivered",
+			"subscriber_type": "agent",
+			"has_dead_letter": true,
+		},
+		"replay_since": "2026-05-13T10:00:00Z",
+	}
+	if !reflect.DeepEqual(req.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
+	}
+	for _, want := range []string{"event event_id=event-live-1", "event_name=scan.requested", "run_id=run-1", "deliveries=1", "dead_letters=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"events": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "list invalid limit", args: []string{"events", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 1000"},
+		{name: "list invalid since", args: []string{"events", "list", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "list invalid delivery status", args: []string{"events", "list", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
+		{name: "view blank event id", args: []string{"event", "view", "  "}, wantStderr: "event id is required"},
+		{name: "follow rejects list limit", args: []string{"events", "follow", "--limit", "1"}, wantStderr: "unknown flag"},
+		{name: "follow invalid replay since", args: []string{"events", "follow", "--replay-since", "not-time"}, wantStderr: "--replay-since must be an RFC3339 timestamp"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestEventsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"events": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"events", "list"},
+		{"event", "view", "event-1"},
+		{"events", "follow"},
+	} {
+		calls.Store(0)
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 4 {
+			t.Fatalf("args=%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			t.Fatalf("stderr = %q, want token failure", stderr.String())
+		}
+		if calls.Load() != 0 {
+			t.Fatalf("args=%v calls = %d, want 0", args, calls.Load())
+		}
+	}
+}
+
+func TestEventsMapFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "event not found exits five",
+			args: []string{"event", "view", "missing-event"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventObservationJSONRPCError(t, w, req.ID, "EVENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "EVENT_NOT_FOUND",
+		},
+		{
+			name: "http auth exits four",
+			args: []string{"events", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "unknown rpc error exits three",
+			args: []string{"events", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventObservationJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "malformed list exits three",
+			args: []string{"events", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "events is required",
+		},
+		{
+			name: "malformed view exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delete(event, "event_id")
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "event_id is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestEventsFollowMalformedWSFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		subscriptionResult map[string]any
+		events             []map[string]any
+		wantStderr         string
+	}{
+		{
+			name:               "missing subscription id",
+			subscriptionResult: map[string]any{},
+			wantStderr:         "subscription_id is required",
+		},
+		{
+			name: "malformed notification",
+			events: []map[string]any{
+				func() map[string]any {
+					event := validEventObservationEvent("event-1")
+					delete(event, "event_id")
+					return event
+				}(),
+			},
+			wantStderr: "event_id is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, _ := newEventObservationWSServer(t, eventObservationWSServerOptions{
+				subscriptionResult: tc.subscriptionResult,
+				events:             tc.events,
+				closeAfterRows:     true,
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"events", "follow"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+type eventObservationWSServerOptions struct {
+	subscriptionResult map[string]any
+	events             []map[string]any
+	closeAfterRows     bool
+}
+
+func newEventObservationWSServer(t *testing.T, opts eventObservationWSServerOptions) (*httptest.Server, *[]jsonRPCRequest) {
+	t.Helper()
+	var mu sync.Mutex
+	wsRequests := []jsonRPCRequest{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/rpc":
+			t.Fatalf("unexpected RPC request for event follow")
+		case "/v1/ws":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Errorf("WS Authorization = %q, want bearer token", got)
+			}
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade websocket: %v", err)
+				return
+			}
+			defer conn.Close()
+			var req jsonRPCRequest
+			if err := conn.ReadJSON(&req); err != nil {
+				t.Errorf("read ws request: %v", err)
+				return
+			}
+			mu.Lock()
+			wsRequests = append(wsRequests, req)
+			mu.Unlock()
+			result := opts.subscriptionResult
+			if result == nil {
+				result = map[string]any{"subscription_id": "sub-events"}
+			}
+			if err := conn.WriteJSON(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  result,
+			}); err != nil {
+				t.Errorf("write ws subscription response: %v", err)
+				return
+			}
+			for _, event := range opts.events {
+				if err := conn.WriteJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"method":  "rpc.subscription",
+					"params": map[string]any{
+						"subscription": "sub-events",
+						"result":       event,
+					},
+				}); err != nil {
+					return
+				}
+			}
+			if opts.closeAfterRows {
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
+			}
+			<-r.Context().Done()
+		default:
+			t.Errorf("path = %q, want /v1/ws", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	return server, &wsRequests
+}
+
+func validEventObservationEvent(eventID string) map[string]any {
+	return map[string]any{
+		"event_id":   eventID,
+		"event_name": "scan.requested",
+		"created_at": "2026-05-13T10:00:01Z",
+		"run_id":     "run-1",
+		"entity_id":  "entity-1",
+		"source":     "external",
+		"payload": map[string]any{
+			"priority": "high",
+		},
+		"deliveries": []any{
+			map[string]any{
+				"delivery_id":     "delivery-1",
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-1",
+				"status":          "delivered",
+				"session_id":      "session-1",
+			},
+		},
+		"dead_letters": []any{
+			map[string]any{
+				"dead_letter_id": "dead-1",
+				"failure_type":   "handler_error",
+				"retry_count":    1,
+				"chain_depth":    2,
+				"created_at":     "2026-05-13T10:00:02Z",
+				"handler_node":   "agent-1",
+				"error_message":  "boom",
+			},
+		},
+	}
+}
+
+func writeEventObservationJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -368,6 +368,41 @@ func TestEventsFollowMalformedWSFailsClosed(t *testing.T) {
 	}
 }
 
+func TestEventsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var rpcCalls atomic.Int32
+	var wsCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/rpc":
+			rpcCalls.Add(1)
+			t.Errorf("unexpected RPC request for event follow")
+			http.Error(w, "unexpected rpc", http.StatusInternalServerError)
+		case "/v1/ws":
+			wsCalls.Add(1)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"events", "follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if rpcCalls.Load() != 0 {
+		t.Fatalf("rpc calls = %d, want 0", rpcCalls.Load())
+	}
+	if wsCalls.Load() != 1 {
+		t.Fatalf("ws calls = %d, want 1", wsCalls.Load())
+	}
+	if !strings.Contains(stderr.String(), "v1 WS HTTP 401") {
+		t.Fatalf("stderr = %q, want WS auth status", stderr.String())
+	}
+}
+
 type eventObservationWSServerOptions struct {
 	subscriptionResult map[string]any
 	events             []map[string]any

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5931,18 +5931,91 @@ cli_specification:
     events_list:
       command: swarm events list
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc event.list
+      behavior: Read-only event observation CLI consumer. The CLI sends only EventListFilter fields plus list-only limit/cursor/since/until params to /v1/rpc event.list through the shared v1 API client, renders server-owned EventFull summaries, and never reconstructs event, delivery, or dead-letter truth locally.
+      flags:
+      - --run-id <run-id>
+      - --entity-id <entity-id>
+      - --event-name <name>
+      - --delivery-status <pending|in_progress|delivered|failed|dead_letter>
+      - --subscriber-id <id>
+      - --subscriber-type <node|agent>
+      - --reason-code <code>
+      - --has-dead-letter[=true|false]
+      - --since <RFC3339>
+      - --until <RFC3339>
+      - --limit <1-1000>
+      - --cursor <cursor>
+      output:
+        success_table: EVENT AT / EVENT / EVENT ID / RUN / ENTITY / DELIVERIES / DEAD_LETTERS plus next_cursor when present
+        empty: No events match the filter.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+      proof_expectations:
+      - exact /v1/rpc event.list call with filter, since, until, limit, and cursor params only
+      - filter fields match EventListFilter and bool has_dead_letter is sent only when explicitly provided
+      - invalid flags and missing SWARM_API_TOKEN make zero API calls
+      - malformed event list results and HTTP/RPC failures fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     events_follow:
       command: swarm events follow
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/ws event.subscribe
+      behavior: Live read-only event observation CLI consumer. The CLI sends EventListFilter fields and optional replay_since to /v1/ws event.subscribe through the shared v1 WebSocket path, renders server-owned EventFull notifications, and rejects list-only pagination/time-window params.
+      flags:
+      - --run-id <run-id>
+      - --entity-id <entity-id>
+      - --event-name <name>
+      - --delivery-status <pending|in_progress|delivered|failed|dead_letter>
+      - --subscriber-id <id>
+      - --subscriber-type <node|agent>
+      - --reason-code <code>
+      - --has-dead-letter[=true|false]
+      - --replay-since <RFC3339>
+      rejected_list_only_flags:
+      - --limit
+      - --cursor
+      - --until
+      output:
+        notification_line: event event_id=<id> event_name=<name> at=<timestamp> source=<source> [run_id=<run>] [entity_id=<entity>] deliveries=<n> dead_letters=<n>
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        interrupted: 130
+      proof_expectations:
+      - exact /v1/ws event.subscribe call with filter and replay_since params only
+      - filter shape is identical to event.list EventListFilter; pagination and list-only until are not accepted
+      - invalid flags and missing SWARM_API_TOKEN make zero WS calls
+      - malformed subscription result/notification and HTTP/RPC/WS failures fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.subscribe_trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     event_view:
       command: swarm event view <event-id>
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc event.get
+      behavior: Read-only event detail CLI consumer. The CLI sends event_id to /v1/rpc event.get through the shared v1 API client and renders only the server-owned EventFull payload, delivery, and dead-letter detail.
+      output:
+        success_detail: Event header with event_id/event_name/created_at/source/run_id/entity_id, compact payload JSON, delivery rows, and dead-letter rows
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - EVENT_NOT_FOUND
+      proof_expectations:
+      - exact /v1/rpc event.get call with event_id param only
+      - missing or blank event id and missing SWARM_API_TOKEN make zero API calls
+      - EVENT_NOT_FOUND, HTTP/RPC failures, and malformed EventFull results fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     event_replay:
       command: swarm event replay <event-id>
       tier: should_have
@@ -6071,6 +6144,9 @@ cli_specification:
     - swarm agent directive
     - swarm agent replay
     - swarm agent replay-backlog
+    - swarm events list
+    - swarm events follow
+    - swarm event view
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6080,7 +6156,7 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm events list / events follow / event view / event replay / event publish
+    - swarm event replay / event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     - swarm entities list / entity view / entity aggregate


### PR DESCRIPTION
Closes #849
Part of #735 and #748

## Summary
- Add read-only event observation CLI commands: `swarm events list`, `swarm event view <event-id>`, and `swarm events follow`.
- Wire the commands only through the shared v1 client paths: `/v1/rpc event.list`, `/v1/rpc event.get`, and `/v1/ws event.subscribe`.
- Repair `platform-spec.yaml` for the gated event read slice: flags/filter params, pagination/time-window rules, `replay_since`, output, exit codes, proof expectations, and remaining #735 event tail.

## Governing Refs
- Issue/gate: #849, split from #845.
- Parent trackers/context: #735, #748.
- Adjacent event owner work: #761/#762 `event.publish`, #763/#764 `event.replay`.
- Exact spec references: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` CLI catalog rows for `events_list`, `events_follow`, and `event_view`; API convention rows for event subscription/filter parity; API method rows for `event.list`, `event.get`, and `event.subscribe`; legacy v1 disposition rows for retired REST event paths.

## Semantic Migration
- New canonical owners consumed by this PR: `/v1/rpc event.list`, `/v1/rpc event.get`, and `/v1/ws event.subscribe`.
- Old/non-authoritative paths now invalid for this CLI slice: direct DB/store/runtime/EventBus reads, dashboard/Builder REST, legacy `/api/*`, `/rpc`, `/api/rpc`, `/ws`, `/api/ws`, local token fallback, `run.trace`, `run.subscribe_trace`, `event.publish`, `event.replay`, `agent.replay`, and `agent.replay_backlog`.
- Production paths checked for surviving old behavior: `cmd/swarm`, `internal/apiv1`, generated OpenRPC, dashboard/Builder references, docs, scripts, and Makefile during the approved pre-audit.
- Migration completeness: complete for read-only event observation CLI only. Mutating `swarm event publish` and `swarm event replay` remain split children.

## Proof
- `go test ./cmd/swarm -run 'Event|Events' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep over `cmd/swarm/events.go` and `cmd/swarm/events_test.go` for DB/store/runtime/EventBus/dashboard/Builder, legacy transports, and split sibling method usage.
