### PR TITLE
[agent-b][issue #863] Implement swarm event replay CLI

### DIFF
--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -21,6 +21,12 @@ const (
 	eventObservationExitRuntime     = 3
 	eventObservationExitAuth        = 4
 	eventObservationExitNotFound    = 5
+	eventReplayMethod               = "event.replay"
+	eventReplayExitValidation       = 2
+	eventReplayExitRuntime          = 3
+	eventReplayExitAuth             = 4
+	eventReplayExitNotFound         = 5
+	eventReplayExitConflict         = 6
 )
 
 type eventFilterOptions struct {
@@ -49,6 +55,12 @@ type eventFollowCommandOptions struct {
 	apiOptions  rootCommandOptions
 	filter      eventFilterOptions
 	replaySince string
+}
+
+type eventReplayCommandOptions struct {
+	apiOptions     rootCommandOptions
+	subscribers    []string
+	idempotencyKey string
 }
 
 type eventListResult struct {
@@ -90,6 +102,24 @@ type eventDeadLetter struct {
 
 type eventSubscriptionResult struct {
 	SubscriptionID string `json:"subscription_id"`
+}
+
+type eventReplayResult struct {
+	EventID             string                `json:"event_id"`
+	ReplayEventID       string                `json:"replay_event_id"`
+	AuditEventID        string                `json:"audit_event_id"`
+	SubscribersReplayed []string              `json:"subscribers_replayed"`
+	OriginalDeliveries  []eventReplayDelivery `json:"original_deliveries"`
+	NewDeliveries       []eventReplayDelivery `json:"new_deliveries"`
+}
+
+type eventReplayDelivery struct {
+	DeliveryID       string `json:"delivery_id"`
+	SubscriberID     string `json:"subscriber_id"`
+	SessionID        string `json:"session_id,omitempty"`
+	Status           string `json:"status"`
+	Attempt          int    `json:"attempt"`
+	SourceDeliveryID string `json:"source_delivery_id,omitempty"`
 }
 
 type eventSubscriptionNotification struct {
@@ -146,13 +176,16 @@ func newEventsCommand(opts rootCommandOptions) *cobra.Command {
 func newEventCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "event",
-		Short: "View one event through v1 API owners.",
+		Short: "View or replay one event through v1 API owners.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newEventViewCommand(opts))
+	cmd.AddCommand(
+		newEventViewCommand(opts),
+		newEventReplayCommand(opts),
+	)
 	return cmd
 }
 
@@ -201,6 +234,21 @@ func newEventViewCommand(opts rootCommandOptions) *cobra.Command {
 			return runEventViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
 		},
 	}
+}
+
+func newEventReplayCommand(opts rootCommandOptions) *cobra.Command {
+	replayOpts := eventReplayCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "replay <event-id>",
+		Short: "Replay one event through /v1/rpc event.replay.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEventReplayCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
+		},
+	}
+	cmd.Flags().StringArrayVar(&replayOpts.subscribers, "subscriber", nil, "Original agent subscriber to replay to; repeat to select a subset")
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
 }
 
 func bindEventFilterFlags(cmd *cobra.Command, opts *eventFilterOptions) {
@@ -259,6 +307,30 @@ func runEventViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCo
 		return commandExitError{code: eventObservationExitRuntime}
 	}
 	writeEventDetailResult(out, result)
+	return nil
+}
+
+func runEventReplayCommand(ctx context.Context, out, errOut io.Writer, args []string, opts eventReplayCommandOptions) error {
+	eventID, subscribers, err := validateEventReplayArgs(args, opts.subscribers)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventReplayExitValidation}
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventReplayErrorExitCode(err)}
+	}
+	var result eventReplayResult
+	if err := client.call(ctx, eventReplayMethod, opts.params(eventID, subscribers), &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventReplayErrorExitCode(err)}
+	}
+	if err := validateEventReplayResult(result, eventID); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventReplayExitRuntime}
+	}
+	writeEventReplayResult(out, result)
 	return nil
 }
 
@@ -360,6 +432,36 @@ func (opts eventFollowCommandOptions) params() (map[string]any, error) {
 		params["replay_since"] = replaySince
 	}
 	return params, nil
+}
+
+func validateEventReplayArgs(args []string, subscriberFlags []string) (string, []string, error) {
+	if len(args) != 1 {
+		return "", nil, fmt.Errorf("event replay requires <event-id>")
+	}
+	eventID := strings.TrimSpace(args[0])
+	if eventID == "" {
+		return "", nil, fmt.Errorf("event id is required")
+	}
+	subscribers := make([]string, 0, len(subscriberFlags))
+	for _, subscriber := range subscriberFlags {
+		subscriber = strings.TrimSpace(subscriber)
+		if subscriber == "" {
+			return "", nil, fmt.Errorf("--subscriber must be a non-empty agent id")
+		}
+		subscribers = append(subscribers, subscriber)
+	}
+	return eventID, subscribers, nil
+}
+
+func (opts eventReplayCommandOptions) params(eventID string, subscribers []string) map[string]any {
+	params := map[string]any{"event_id": eventID}
+	if len(subscribers) > 0 {
+		params["subscribers"] = subscribers
+	}
+	if key := strings.TrimSpace(opts.idempotencyKey); key != "" {
+		params["idempotency_key"] = key
+	}
+	return params
 }
 
 func (opts eventFilterOptions) params() (map[string]any, error) {
@@ -500,6 +602,74 @@ func validateEventDeadLetter(prefix string, deadLetter eventDeadLetter) error {
 	}
 	if err := validateRequiredTimestamp(prefix+".created_at", deadLetter.CreatedAt); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateEventReplayResult(result eventReplayResult, expectedEventID string) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "event_id", value: result.EventID},
+		{name: "replay_event_id", value: result.ReplayEventID},
+		{name: "audit_event_id", value: result.AuditEventID},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed event.replay result: %s is required", field.name)
+		}
+	}
+	if strings.TrimSpace(result.EventID) != expectedEventID {
+		return fmt.Errorf("malformed event.replay result: event_id=%q, want %q", result.EventID, expectedEventID)
+	}
+	if result.SubscribersReplayed == nil {
+		return fmt.Errorf("malformed event.replay result: subscribers_replayed is required")
+	}
+	if result.OriginalDeliveries == nil {
+		return fmt.Errorf("malformed event.replay result: original_deliveries is required")
+	}
+	if result.NewDeliveries == nil {
+		return fmt.Errorf("malformed event.replay result: new_deliveries is required")
+	}
+	for i, subscriber := range result.SubscribersReplayed {
+		if strings.TrimSpace(subscriber) == "" {
+			return fmt.Errorf("malformed event.replay result: subscribers_replayed[%d] is required", i)
+		}
+	}
+	for i, delivery := range result.OriginalDeliveries {
+		if err := validateEventReplayDelivery(fmt.Sprintf("original_deliveries[%d]", i), delivery, false); err != nil {
+			return err
+		}
+	}
+	for i, delivery := range result.NewDeliveries {
+		if err := validateEventReplayDelivery(fmt.Sprintf("new_deliveries[%d]", i), delivery, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEventReplayDelivery(field string, delivery eventReplayDelivery, requireSource bool) error {
+	for _, part := range []struct {
+		name  string
+		value string
+	}{
+		{name: "delivery_id", value: delivery.DeliveryID},
+		{name: "subscriber_id", value: delivery.SubscriberID},
+		{name: "status", value: delivery.Status},
+	} {
+		if strings.TrimSpace(part.value) == "" {
+			return fmt.Errorf("malformed event.replay result: %s.%s is required", field, part.name)
+		}
+	}
+	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
+		return fmt.Errorf("malformed event.replay result: %s.status=%q is not a valid DeliveryStatus", field, delivery.Status)
+	}
+	if delivery.Attempt < 1 {
+		return fmt.Errorf("malformed event.replay result: %s.attempt must be >= 1", field)
+	}
+	if requireSource && strings.TrimSpace(delivery.SourceDeliveryID) == "" {
+		return fmt.Errorf("malformed event.replay result: %s.source_delivery_id is required", field)
 	}
 	return nil
 }
@@ -716,6 +886,39 @@ func writeEventFollowEvent(out io.Writer, event eventFull) {
 	fmt.Fprintf(out, "event %s\n", strings.Join(fields, " "))
 }
 
+func writeEventReplayResult(out io.Writer, result eventReplayResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "event replay ok: event_id=%s replay_event_id=%s audit_event_id=%s subscribers_replayed=%s original_deliveries=%d new_deliveries=%d\n",
+		result.EventID,
+		result.ReplayEventID,
+		result.AuditEventID,
+		strings.Join(result.SubscribersReplayed, ","),
+		len(result.OriginalDeliveries),
+		len(result.NewDeliveries),
+	)
+	for _, delivery := range result.OriginalDeliveries {
+		fmt.Fprintf(out, "original_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d\n",
+			delivery.DeliveryID,
+			delivery.SubscriberID,
+			delivery.Status,
+			eventObservationDash(delivery.SessionID),
+			delivery.Attempt,
+		)
+	}
+	for _, delivery := range result.NewDeliveries {
+		fmt.Fprintf(out, "new_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d source_delivery_id=%s\n",
+			delivery.DeliveryID,
+			delivery.SubscriberID,
+			delivery.Status,
+			eventObservationDash(delivery.SessionID),
+			delivery.Attempt,
+			delivery.SourceDeliveryID,
+		)
+	}
+}
+
 func eventObservationCompactJSON(value map[string]any) string {
 	raw, err := json.Marshal(value)
 	if err != nil {
@@ -758,4 +961,39 @@ func eventObservationErrorExitCode(err error) int {
 		}
 	}
 	return eventObservationExitRuntime
+}
+
+func eventReplayErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return eventReplayExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return eventReplayExitAuth
+		}
+		return eventReplayExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return eventReplayExitAuth
+		case "EVENT_NOT_FOUND":
+			return eventReplayExitNotFound
+		case "EVENT_REPLAY_NO_DELIVERY_HISTORY",
+			"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+			"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+			"EVENT_REPLAY_NOT_ELIGIBLE",
+			"PAYLOAD_VALIDATION_FAILED",
+			"IDEMPOTENCY_CONFLICT":
+			return eventReplayExitConflict
+		default:
+			return eventReplayExitRuntime
+		}
+	}
+	return eventReplayExitRuntime
 }

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -124,6 +124,106 @@ func TestEventViewUsesEventGetV1RPC(t *testing.T) {
 	}
 }
 
+func TestEventReplayUsesEventReplayV1RPCWithSubscribersAndIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, eventReplayTestResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "replay", "event-1",
+		"--subscriber", "agent-1",
+		"--subscriber", "agent-2",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != eventReplayMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, eventReplayMethod)
+	}
+	wantParams := map[string]any{
+		"event_id":        "event-1",
+		"subscribers":     []any{"agent-1", "agent-2"},
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"event replay ok:",
+		"event_id=event-1",
+		"replay_event_id=event-replay-1",
+		"audit_event_id=event-audit-1",
+		"subscribers_replayed=agent-1,agent-2",
+		"original_delivery delivery_id=delivery-original-1",
+		"new_delivery delivery_id=delivery-new-1",
+		"source_delivery_id=delivery-original-1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventReplayOmitsOptionalParamsWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := eventReplayTestResult()
+		result["subscribers_replayed"] = []any{"agent-1"}
+		result["original_deliveries"] = []any{
+			map[string]any{
+				"delivery_id":   "delivery-original-1",
+				"subscriber_id": "agent-1",
+				"session_id":    "session-original-1",
+				"status":        "delivered",
+				"attempt":       1,
+			},
+		}
+		result["new_deliveries"] = []any{
+			map[string]any{
+				"delivery_id":        "delivery-new-1",
+				"subscriber_id":      "agent-1",
+				"session_id":         "session-new-1",
+				"status":             "pending",
+				"attempt":            1,
+				"source_delivery_id": "delivery-original-1",
+			},
+		}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"event", "replay", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"event_id": "event-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+}
+
 func TestEventsFollowUsesEventSubscribeV1WS(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	server, wsRequests := newEventObservationWSServer(t, eventObservationWSServerOptions{
@@ -193,6 +293,10 @@ func TestEventsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "list invalid since", args: []string{"events", "list", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp"},
 		{name: "list invalid delivery status", args: []string{"events", "list", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
 		{name: "view blank event id", args: []string{"event", "view", "  "}, wantStderr: "event id is required"},
+		{name: "replay missing event id", args: []string{"event", "replay"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "replay blank event id", args: []string{"event", "replay", "  "}, wantStderr: "event id is required"},
+		{name: "replay blank subscriber", args: []string{"event", "replay", "event-1", "--subscriber", "  "}, wantStderr: "--subscriber must be a non-empty agent id"},
+		{name: "replay extra arg", args: []string{"event", "replay", "event-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
 		{name: "follow rejects list limit", args: []string{"events", "follow", "--limit", "1"}, wantStderr: "unknown flag"},
 		{name: "follow invalid replay since", args: []string{"events", "follow", "--replay-since", "not-time"}, wantStderr: "--replay-since must be an RFC3339 timestamp"},
 	} {
@@ -225,6 +329,7 @@ func TestEventsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 	for _, args := range [][]string{
 		{"events", "list"},
 		{"event", "view", "event-1"},
+		{"event", "replay", "event-1"},
 		{"events", "follow"},
 	} {
 		calls.Store(0)
@@ -243,6 +348,36 @@ func TestEventsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 }
 
 func TestEventsMapFailureExitCodes(t *testing.T) {
+	replayConflictErrors := []string{
+		"EVENT_REPLAY_NO_DELIVERY_HISTORY",
+		"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
+		"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
+		"EVENT_REPLAY_NOT_ELIGIBLE",
+		"PAYLOAD_VALIDATION_FAILED",
+		"IDEMPOTENCY_CONFLICT",
+	}
+	for _, code := range replayConflictErrors {
+		code := code
+		t.Run("event replay "+code+" exits six", func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventReplayJSONRPCError(t, w, req.ID, code)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			exit := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"event", "replay", "event-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if exit != 6 {
+				t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", exit, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), code) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), code)
+			}
+		})
+	}
+
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -262,6 +397,17 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			wantStderr: "EVENT_NOT_FOUND",
 		},
 		{
+			name: "event replay not found exits five",
+			args: []string{"event", "replay", "missing-event"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventReplayJSONRPCError(t, w, req.ID, "EVENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "EVENT_NOT_FOUND",
+		},
+		{
 			name: "http auth exits four",
 			args: []string{"events", "list"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -269,6 +415,24 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			},
 			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "event replay http auth exits four",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "event replay http runtime exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
 		},
 		{
 			name: "unknown rpc error exits three",
@@ -280,6 +444,84 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "event replay unauthorized rpc exits four",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventReplayJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "event replay unknown rpc exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventReplayJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "malformed event replay exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := eventReplayTestResult()
+				delete(result, "replay_event_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "replay_event_id is required",
+		},
+		{
+			name: "malformed event replay subscribers exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := eventReplayTestResult()
+				delete(result, "subscribers_replayed")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "subscribers_replayed is required",
+		},
+		{
+			name: "malformed event replay source lineage exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := eventReplayTestResult()
+				newDeliveries := result["new_deliveries"].([]any)
+				newDelivery := newDeliveries[0].(map[string]any)
+				delete(newDelivery, "source_delivery_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "new_deliveries[0].source_delivery_id is required",
+		},
+		{
+			name: "malformed event replay status exits three",
+			args: []string{"event", "replay", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := eventReplayTestResult()
+				originalDeliveries := result["original_deliveries"].([]any)
+				originalDelivery := originalDeliveries[0].(map[string]any)
+				originalDelivery["status"] = "locally_replayed"
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "original_deliveries[0].status",
 		},
 		{
 			name: "malformed list exits three",
@@ -507,6 +749,31 @@ func validEventObservationEvent(eventID string) map[string]any {
 	}
 }
 
+func eventReplayTestResult() map[string]any {
+	return map[string]any{
+		"event_id":             "event-1",
+		"replay_event_id":      "event-replay-1",
+		"audit_event_id":       "event-audit-1",
+		"subscribers_replayed": []any{"agent-1", "agent-2"},
+		"original_deliveries":  []any{eventReplayTestDelivery("delivery-original-1", "agent-1", "session-original-1", "delivered", 1, ""), eventReplayTestDelivery("delivery-original-2", "agent-2", "session-original-2", "failed", 2, "")},
+		"new_deliveries":       []any{eventReplayTestDelivery("delivery-new-1", "agent-1", "session-new-1", "pending", 1, "delivery-original-1"), eventReplayTestDelivery("delivery-new-2", "agent-2", "session-new-2", "pending", 1, "delivery-original-2")},
+	}
+}
+
+func eventReplayTestDelivery(deliveryID, subscriberID, sessionID, status string, attempt int, sourceDeliveryID string) map[string]any {
+	delivery := map[string]any{
+		"delivery_id":   deliveryID,
+		"subscriber_id": subscriberID,
+		"session_id":    sessionID,
+		"status":        status,
+		"attempt":       attempt,
+	}
+	if sourceDeliveryID != "" {
+		delivery["source_delivery_id"] = sourceDeliveryID
+	}
+	return delivery
+}
+
 func writeEventObservationJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
 	t.Helper()
 	w.Header().Set("content-type", "application/json")
@@ -522,5 +789,26 @@ func writeEventObservationJSONRPCError(t *testing.T, w http.ResponseWriter, id s
 		},
 	}); err != nil {
 		t.Fatalf("encode error response: %v", err)
+	}
+}
+
+func writeEventReplayJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"event_id": "event-1"},
+				"retryable":      false,
+				"correlation_id": "corr-event-replay",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
 	}
 }

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6017,10 +6017,47 @@ cli_specification:
       - EVENT_NOT_FOUND, HTTP/RPC failures, and malformed EventFull results fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     event_replay:
-      command: swarm event replay <event-id>
+      command: swarm event replay <event-id> [--subscriber <agent-id> ...] [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc event.replay
+      behavior: >-
+        Mutating event redelivery CLI consumer. The CLI sends event_id, optional subscribers from repeated --subscriber flags,
+        and optional idempotency_key to /v1/rpc event.replay through the shared v1 API client. The server remains the replay
+        owner: it derives replay targets from original event_deliveries, creates fresh replay/audit evidence, and returns
+        EventReplayResult.
+      flags:
+      - name: --subscriber <agent-id>
+        repeatable: true
+        maps_to: subscribers
+        behavior: Optional subset of original agent subscriber IDs. Omitted means all original agent subscribers.
+      - name: --idempotency-key <key>
+        maps_to: idempotency_key
+        behavior: Optional v1 API idempotency key for this mutating replay request.
+      output:
+        success_detail: One replay summary line with event_id/replay_event_id/audit_event_id/subscribers_replayed/delivery counts, followed by original_delivery and new_delivery lineage rows from the server-owned EventReplayResult.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        replay_conflict: 6
+        not_found_errors:
+        - EVENT_NOT_FOUND
+        replay_conflict_errors:
+        - EVENT_REPLAY_NO_DELIVERY_HISTORY
+        - EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL
+        - EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE
+        - EVENT_REPLAY_NOT_ELIGIBLE
+        - PAYLOAD_VALIDATION_FAILED
+        - IDEMPOTENCY_CONFLICT
+      proof_expectations:
+      - exact /v1/rpc event.replay call with event_id, optional subscribers, and optional idempotency_key params only
+      - missing or blank event id, blank --subscriber, invalid args, and missing SWARM_API_TOKEN make zero API calls
+      - success output renders server-owned replay_event_id, audit_event_id, subscribers_replayed, and original/new delivery lineage
+      - EVENT_NOT_FOUND, replay conflict errors, auth/HTTP/RPC failures, and malformed EventReplayResult values fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.publish, agent.replay, or agent.replay_backlog usage
     event_publish:
       command: swarm event publish <event-name>
       tier: should_have
@@ -6156,7 +6193,7 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm event replay / event publish
+    - swarm event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     - swarm entities list / entity view / entity aggregate


### PR DESCRIPTION
## Summary

- Implements `swarm event replay <event-id> [--subscriber <agent-id> ...] [--idempotency-key <key>]` as the CLI consumer of `/v1/rpc event.replay`.
- Repairs `platform-spec.yaml` for the event replay CLI command shape, flags, idempotency, output, exit codes, proof expectations, and #735 remaining event tail.
- Adds focused fake-RPC tests for exact params, subscriber subset, idempotency, no-call validation/token failures, declared replay errors, malformed results, and no-bypass behavior.

Closes #863
Part of #735
Related to #748, #763, #764, #849, #858

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` CLI row `event_replay`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` API method `event.replay` and schema `EventReplayResult` / `EventReplayDelivery`.
- #863 Pre-Implementation Coverage Audit and independent gate review: approved as first slice with full subscriber/idempotency CLI shape.
- #763/#764 established the canonical server/API event replay owner.

## Semantic migration / owner notes

- New CLI consumer: `swarm event replay` now consumes `/v1/rpc event.replay` through the shared CLI v1 API client.
- Canonical owner remains server/API `/v1/rpc event.replay`; the CLI does not derive replay targets, delivery rows, or audit evidence.
- Old producer/reader/writer path invalid for this command: direct DB/store/runtime/EventBus/dashboard/Builder/legacy transports. No old top-level `swarm event replay` implementation existed.
- Production paths checked for surviving old behavior: `cmd/swarm`, event read/view/follow CLI, agent replay/backlog siblings, OpenRPC, and platform spec event rows. `event.publish` remains intentionally split.
- Migration completeness: complete for the #863 `swarm event replay` CLI consumer class; #735 event-family tail remains `swarm event publish`.

## Proof

- `go test ./cmd/swarm -run 'Event.*Replay|Replay.*Event' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `rg -n 'internal/(store|runtime)|EventBus|dashboard|Builder|/api/|/api/rpc|/api/ws|"/rpc"|"/ws"|event\.publish|agent\.replay|agent\.replay_backlog|run\.start' cmd/swarm/events.go cmd/swarm/events_test.go` returned no matches.
