### PR TITLE
[agent-b][issue #868] Add event publish CLI

### DIFF
--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	eventPublishMethod         = "event.publish"
+	eventPublishExitValidation = 2
+	eventPublishExitRuntime    = 3
+	eventPublishExitAuth       = 4
+	eventPublishExitNotFound   = 5
+	eventPublishExitRejected   = 6
+)
+
+var eventPublishBundleFingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+
+type eventPublishCommandOptions struct {
+	apiOptions           rootCommandOptions
+	payloadJSON          string
+	runID                string
+	bundleFingerprint    string
+	emitter              string
+	idempotencyKey       string
+	payloadJSONSet       bool
+	runIDSet             bool
+	bundleFingerprintSet bool
+	emitterSet           bool
+	idempotencyKeySet    bool
+}
+
+type eventPublishResult struct {
+	EventID       string                 `json:"event_id"`
+	RunID         string                 `json:"run_id"`
+	NewRunCreated *bool                  `json:"new_run_created"`
+	Deliveries    []eventPublishDelivery `json:"deliveries"`
+}
+
+type eventPublishDelivery struct {
+	SubscriberID string `json:"subscriber_id"`
+	SessionID    string `json:"session_id,omitempty"`
+	Status       string `json:"status"`
+	Attempt      int    `json:"attempt"`
+}
+
+func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
+	publishOpts := eventPublishCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "publish <event-name>",
+		Short: "Publish one event through /v1/rpc event.publish.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			publishOpts.payloadJSONSet = cmd.Flags().Changed("payload-json")
+			publishOpts.runIDSet = cmd.Flags().Changed("run-id")
+			publishOpts.bundleFingerprintSet = cmd.Flags().Changed("bundle-fingerprint")
+			publishOpts.emitterSet = cmd.Flags().Changed("emitter")
+			publishOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			return runEventPublishCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, publishOpts)
+		},
+	}
+	cmd.Flags().StringVar(&publishOpts.payloadJSON, "payload-json", "", "Required JSON object payload")
+	cmd.Flags().StringVar(&publishOpts.runID, "run-id", "", "Optional existing nonterminal run id to inject into")
+	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
+	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
+	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	return cmd
+}
+
+func runEventPublishCommand(ctx context.Context, out, errOut io.Writer, args []string, opts eventPublishCommandOptions) error {
+	eventName, params, err := opts.params(args)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventPublishExitValidation}
+	}
+
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventPublishErrorExitCode(err)}
+	}
+
+	var result eventPublishResult
+	if err := client.call(ctx, eventPublishMethod, params, &result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventPublishErrorExitCode(err)}
+	}
+	if err := validateEventPublishResult(result); err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: eventPublishExitRuntime}
+	}
+	writeEventPublishResult(out, eventName, result)
+	return nil
+}
+
+func (opts eventPublishCommandOptions) params(args []string) (string, map[string]any, error) {
+	if len(args) != 1 {
+		return "", nil, fmt.Errorf("event publish requires <event-name>")
+	}
+	eventName := strings.TrimSpace(args[0])
+	if eventName == "" {
+		return "", nil, fmt.Errorf("event name is required")
+	}
+	payload, err := opts.payload()
+	if err != nil {
+		return "", nil, err
+	}
+	params := map[string]any{
+		"event_name": eventName,
+		"payload":    payload,
+	}
+	if runID, err := optionalNonEmptyFlag("--run-id", opts.runID, opts.runIDSet); err != nil {
+		return "", nil, err
+	} else if runID != "" {
+		params["run_id"] = runID
+	}
+	if fingerprint, err := optionalNonEmptyFlag("--bundle-fingerprint", opts.bundleFingerprint, opts.bundleFingerprintSet); err != nil {
+		return "", nil, err
+	} else if fingerprint != "" {
+		if !eventPublishBundleFingerprintPattern.MatchString(fingerprint) {
+			return "", nil, fmt.Errorf("--bundle-fingerprint must be sha256:<64 lowercase hex>")
+		}
+		params["bundle_ref"] = map[string]any{"fingerprint": fingerprint}
+	}
+	if emitter, err := optionalNonEmptyFlag("--emitter", opts.emitter, opts.emitterSet); err != nil {
+		return "", nil, err
+	} else if emitter != "" {
+		params["emitter"] = emitter
+	}
+	if key, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet); err != nil {
+		return "", nil, err
+	} else if key != "" {
+		params["idempotency_key"] = key
+	}
+	return eventName, params, nil
+}
+
+func (opts eventPublishCommandOptions) payload() (map[string]any, error) {
+	if !opts.payloadJSONSet || strings.TrimSpace(opts.payloadJSON) == "" {
+		return nil, fmt.Errorf("event publish requires --payload-json <json-object>")
+	}
+	var payload map[string]any
+	decoder := json.NewDecoder(strings.NewReader(opts.payloadJSON))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("--payload-json must be a valid JSON object: %w", err)
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("--payload-json must be a JSON object")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("--payload-json must contain exactly one JSON object")
+	}
+	return payload, nil
+}
+
+func optionalNonEmptyFlag(name, value string, changed bool) (string, error) {
+	value = strings.TrimSpace(value)
+	if changed && value == "" {
+		return "", fmt.Errorf("%s must be non-empty", name)
+	}
+	return value, nil
+}
+
+func validateEventPublishResult(result eventPublishResult) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "event_id", value: result.EventID},
+		{name: "run_id", value: result.RunID},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed event.publish result: %s is required", field.name)
+		}
+	}
+	if result.NewRunCreated == nil {
+		return fmt.Errorf("malformed event.publish result: new_run_created is required")
+	}
+	if result.Deliveries == nil {
+		return fmt.Errorf("malformed event.publish result: deliveries is required")
+	}
+	for i, delivery := range result.Deliveries {
+		if err := validateEventPublishDelivery(fmt.Sprintf("deliveries[%d]", i), delivery); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEventPublishDelivery(prefix string, delivery eventPublishDelivery) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "subscriber_id", value: delivery.SubscriberID},
+		{name: "status", value: delivery.Status},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed event.publish result: %s.%s is required", prefix, field.name)
+		}
+	}
+	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
+		return fmt.Errorf("malformed event.publish result: %s.status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
+	}
+	if delivery.Attempt < 1 {
+		return fmt.Errorf("malformed event.publish result: %s.attempt must be >= 1", prefix)
+	}
+	return nil
+}
+
+func writeEventPublishResult(out io.Writer, eventName string, result eventPublishResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "event publish ok: event_id=%s event_name=%s run_id=%s new_run_created=%t deliveries=%d\n",
+		result.EventID,
+		eventName,
+		result.RunID,
+		*result.NewRunCreated,
+		len(result.Deliveries),
+	)
+	for _, delivery := range result.Deliveries {
+		fmt.Fprintf(out, "delivery subscriber_id=%s status=%s session_id=%s attempt=%d\n",
+			delivery.SubscriberID,
+			delivery.Status,
+			eventObservationDash(delivery.SessionID),
+			delivery.Attempt,
+		)
+	}
+}
+
+func eventPublishErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
+		return eventPublishExitAuth
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return eventPublishExitAuth
+		}
+		return eventPublishExitRuntime
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch applicationErrorCode(rpcErr.Data) {
+		case "UNAUTHORIZED":
+			return eventPublishExitAuth
+		case "RUN_NOT_FOUND":
+			return eventPublishExitNotFound
+		case "BUNDLE_MISMATCH",
+			"UNSUPPORTED_BUNDLE_REF",
+			"EVENT_NOT_DECLARED",
+			"PAYLOAD_VALIDATION_FAILED",
+			"RUN_ALREADY_TERMINAL",
+			"IDEMPOTENCY_CONFLICT":
+			return eventPublishExitRejected
+		default:
+			return eventPublishExitRuntime
+		}
+	}
+	return eventPublishExitRuntime
+}

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, eventPublishTestResult(true))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "publish", "scan.requested",
+		"--payload-json", `{"topic":"sample","count":2}`,
+		"--run-id", "run-1",
+		"--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"--emitter", "cli:test",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != eventPublishMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, eventPublishMethod)
+	}
+	wantParams := map[string]any{
+		"event_name": "scan.requested",
+		"payload": map[string]any{
+			"topic": "sample",
+			"count": float64(2),
+		},
+		"run_id": "run-1",
+		"bundle_ref": map[string]any{
+			"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		"emitter":         "cli:test",
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"event publish ok:",
+		"event_id=event-1",
+		"event_name=scan.requested",
+		"run_id=run-1",
+		"new_run_created=true",
+		"deliveries=1",
+		"delivery subscriber_id=agent-1",
+		"session_id=session-1",
+		"attempt=2",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventPublishOmitsOptionalParamsWhenNotProvided(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, eventPublishTestResult(false))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "publish", "scan.requested",
+		"--payload-json", `{}`,
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{
+		"event_name": "scan.requested",
+		"payload":    map[string]any{},
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	if !strings.Contains(stdout.String(), "new_run_created=false") {
+		t.Fatalf("stdout = %q, want new_run_created=false", stdout.String())
+	}
+}
+
+func TestEventPublishRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", eventPublishTestResult(true))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing event name", args: []string{"event", "publish", "--payload-json", "{}"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank event name", args: []string{"event", "publish", "  ", "--payload-json", "{}"}, wantStderr: "event name is required"},
+		{name: "missing payload", args: []string{"event", "publish", "scan.requested"}, wantStderr: "requires --payload-json"},
+		{name: "blank payload", args: []string{"event", "publish", "scan.requested", "--payload-json", "  "}, wantStderr: "requires --payload-json"},
+		{name: "invalid payload json", args: []string{"event", "publish", "scan.requested", "--payload-json", "{"}, wantStderr: "valid JSON object"},
+		{name: "non object payload", args: []string{"event", "publish", "scan.requested", "--payload-json", "[]"}, wantStderr: "valid JSON object"},
+		{name: "null payload", args: []string{"event", "publish", "scan.requested", "--payload-json", "null"}, wantStderr: "JSON object"},
+		{name: "trailing json", args: []string{"event", "publish", "scan.requested", "--payload-json", `{} {}`}, wantStderr: "exactly one JSON object"},
+		{name: "blank run id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--run-id", "  "}, wantStderr: "--run-id must be non-empty"},
+		{name: "blank bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "  "}, wantStderr: "--bundle-fingerprint must be non-empty"},
+		{name: "invalid bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "sha256:BAD"}, wantStderr: "--bundle-fingerprint must be sha256:<64 lowercase hex>"},
+		{name: "blank emitter", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--emitter", "  "}, wantStderr: "--emitter must be non-empty"},
+		{name: "blank idempotency key", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestEventPublishFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", eventPublishTestResult(true))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "publish", "scan.requested",
+		"--payload-json", "{}",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestEventPublishMapsFailureExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "run not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "RUN_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "RUN_NOT_FOUND",
+		},
+		{
+			name: "bundle mismatch exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "BUNDLE_MISMATCH")
+			},
+			wantCode:   6,
+			wantStderr: "BUNDLE_MISMATCH",
+		},
+		{
+			name: "unsupported bundle exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "UNSUPPORTED_BUNDLE_REF")
+			},
+			wantCode:   6,
+			wantStderr: "UNSUPPORTED_BUNDLE_REF",
+		},
+		{
+			name: "undeclared event exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "EVENT_NOT_DECLARED")
+			},
+			wantCode:   6,
+			wantStderr: "EVENT_NOT_DECLARED",
+		},
+		{
+			name: "payload validation exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "PAYLOAD_VALIDATION_FAILED")
+			},
+			wantCode:   6,
+			wantStderr: "PAYLOAD_VALIDATION_FAILED",
+		},
+		{
+			name: "terminal run exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "RUN_ALREADY_TERMINAL")
+			},
+			wantCode:   6,
+			wantStderr: "RUN_ALREADY_TERMINAL",
+		},
+		{
+			name: "idempotency conflict exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "unauthorized rpc exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "unknown rpc exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "http auth exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+				"event", "publish", "scan.requested",
+				"--payload-json", "{}",
+			}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestEventPublishMalformedResultsFailClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mutate     func(map[string]any)
+		wantStderr string
+	}{
+		{
+			name:       "missing event id",
+			mutate:     func(result map[string]any) { delete(result, "event_id") },
+			wantStderr: "event_id is required",
+		},
+		{
+			name:       "missing run id",
+			mutate:     func(result map[string]any) { delete(result, "run_id") },
+			wantStderr: "run_id is required",
+		},
+		{
+			name:       "missing new run created",
+			mutate:     func(result map[string]any) { delete(result, "new_run_created") },
+			wantStderr: "new_run_created is required",
+		},
+		{
+			name:       "missing deliveries",
+			mutate:     func(result map[string]any) { delete(result, "deliveries") },
+			wantStderr: "deliveries is required",
+		},
+		{
+			name: "missing subscriber",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "subscriber_id")
+			},
+			wantStderr: "deliveries[0].subscriber_id is required",
+		},
+		{
+			name: "invalid delivery status",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delivery["status"] = "locally_published"
+			},
+			wantStderr: "deliveries[0].status",
+		},
+		{
+			name: "invalid delivery attempt",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delivery["attempt"] = 0
+			},
+			wantStderr: "deliveries[0].attempt must be >= 1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := eventPublishTestResult(true)
+				tc.mutate(result)
+				writeJSONRPCResult(t, w, req.ID, result)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+				"event", "publish", "scan.requested",
+				"--payload-json", "{}",
+			}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func eventPublishTestResult(newRunCreated bool) map[string]any {
+	return map[string]any{
+		"event_id":        "event-1",
+		"run_id":          "run-1",
+		"new_run_created": newRunCreated,
+		"deliveries": []any{
+			map[string]any{
+				"subscriber_id": "agent-1",
+				"session_id":    "session-1",
+				"status":        "delivered",
+				"attempt":       2,
+			},
+		},
+	}
+}
+
+func writeEventPublishJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32010,
+			"message": "Application error: " + code,
+			"data": map[string]any{
+				"code":           code,
+				"details":        map[string]any{"event_name": "scan.requested"},
+				"retryable":      false,
+				"correlation_id": "corr-event-publish",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -184,6 +184,7 @@ func newEventCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newEventViewCommand(opts),
+		newEventPublishCommand(opts),
 		newEventReplayCommand(opts),
 	)
 	return cmd

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5368,9 +5368,10 @@ cli_specification:
         tracker: '#863'
         action: '`swarm event replay` is implemented over `/v1/rpc event.replay` by PR #866 / commit 23ef7d9c; it must not be reopened or grouped with future event publish work.'
       event_publish:
-        disposition: future_child
-        tracker: '#735'
-        action: '`swarm event publish` remains a future #735 child; it must not be absorbed by the #863 event replay slice.'
+        disposition: closed_child
+        tracker: '#868'
+        pr: '#869'
+        action: '`swarm event publish` is implemented over `/v1/rpc event.publish` by #868 / PR #869; it must not be reopened as a future #735 event-family child or grouped with run.start migration work.'
       conversations:
         disposition: future_child
         tracker: '#735'

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6192,10 +6192,57 @@ cli_specification:
       - EVENT_NOT_FOUND, replay conflict errors, auth/HTTP/RPC failures, and malformed EventReplayResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.publish, agent.replay, or agent.replay_backlog usage
     event_publish:
-      command: swarm event publish <event-name>
+      command: swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc event.publish
+      behavior: >-
+        Mutating event publication CLI consumer. The CLI validates the event name, required JSON object payload, optional run
+        target, optional bundle fingerprint assertion, optional emitter, and optional idempotency key, then sends exactly those
+        params to /v1/rpc event.publish through the shared v1 API client. The server remains the event-publication owner:
+        it validates declared event/payload/run/bundle/idempotency semantics, publishes through the runtime EventBus/store
+        owner, derives delivery rows, and returns EventPublishResult.
+      flags:
+      - name: --payload-json <json-object>
+        required: true
+        maps_to: payload
+        behavior: Required inline JSON object payload. File/stdin payload input is not part of the v1 CLI event-publish slice.
+      - name: --run-id <run-id>
+        maps_to: run_id
+        behavior: Optional existing nonterminal run id to inject the event into. Omitted means the server allocates and starts a new run.
+      - name: --bundle-fingerprint <sha256:...>
+        maps_to: bundle_ref.fingerprint
+        behavior: Optional assertion that the server is running the expected boot bundle fingerprint. v1 BundleRef supports fingerprint only.
+      - name: --emitter <source>
+        maps_to: emitter
+        behavior: Optional producer identifier. Omitted means the server default emitter applies.
+      - name: --idempotency-key <key>
+        maps_to: idempotency_key
+        behavior: Optional v1 API idempotency key for this mutating publish request.
+      output:
+        success_detail: One publish summary line with event_id, event_name, run_id, new_run_created, and delivery count, followed by persisted delivery rows containing subscriber_id, status, session_id, and attempt.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        publish_rejected: 6
+        not_found_errors:
+        - RUN_NOT_FOUND
+        publish_rejected_errors:
+        - BUNDLE_MISMATCH
+        - UNSUPPORTED_BUNDLE_REF
+        - EVENT_NOT_DECLARED
+        - PAYLOAD_VALIDATION_FAILED
+        - RUN_ALREADY_TERMINAL
+        - IDEMPOTENCY_CONFLICT
+      proof_expectations:
+      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
+      - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle fingerprint, invalid args, and missing SWARM_API_TOKEN make zero API calls
+      - success output renders only server-owned EventPublishResult event_id, run_id, new_run_created, and delivery rows
+      - RUN_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
       relation_to_run_start: '`run.start` remains usable for #743 until a separate migration changes the CLI internals to event.publish.'
     conversations_list:
       command: swarm conversations list
@@ -6317,6 +6364,8 @@ cli_specification:
     - swarm events list
     - swarm events follow
     - swarm event view
+    - swarm event replay
+    - swarm event publish
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6326,7 +6375,6 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm event publish
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     - swarm entities list / entity view / entity aggregate


### PR DESCRIPTION
Closes #868
Part of #735
Related to #748, #761, #762, #845, #849, #858, #863, #866

## Summary
- Implements `swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]`.
- Consumes only `/v1/rpc event.publish` through the shared CLI v1 API client and `SWARM_API_TOKEN`.
- Repairs `platform-spec.yaml` for the event publish CLI command shape, flags, idempotency, output, exit codes, proof expectations, implemented list, and remaining event-family tail.

## Governing Refs / Context
- #868 Pre-Implementation Coverage Audit and independent gate: approved as first slice.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` CLI row `event_publish`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` API method `event.publish`, schema `EventPublishResult`, schema `EventPublishDelivery`, schema `BundleRef`, mutating idempotency convention, and queueable event-producing ingress convention.
- #761/#762 established the canonical server/API `event.publish` owner and deprecated `run.start` wrapper.
- #845 classified the broad event-family CLI class; #849/#858 closed read/follow/view; #863/#866 closed replay.

## Semantic Migration / Owner Notes
- New CLI consumer: `swarm event publish` now consumes `/v1/rpc event.publish` through the shared v1 API client.
- Canonical owner remains server/API `/v1/rpc event.publish`; the CLI does not publish directly, derive deliveries, plan subscribers, allocate run truth, or implement idempotency locally.
- Old/non-authoritative paths invalid for this command: direct DB/store/runtime/EventBus/dashboard/Builder/legacy transports, deprecated `run.start`, `event.replay`, `agent.replay`, and `agent.replay_backlog`.
- Production paths checked for surviving old behavior: `cmd/swarm`, event read/follow/view CLI, event replay CLI, `swarm run`, `scripts/run_clear.sh`, dashboard/Builder references, OpenRPC, and platform spec event rows.
- Migration completeness: complete for the #868 `swarm event publish` CLI consumer class. `swarm run` / deprecated `run.start` migration remains explicitly split.

## Proof
- `go test ./cmd/swarm -run 'Event.*Publish|Publish.*Event' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `rg -n 'internal/(store|runtime)|EventBus|dashboard|Builder|/api/|/api/rpc|/api/ws|"/rpc"|"/ws"|run\.start|event\.replay|agent\.replay|agent\.replay_backlog' cmd/swarm/event_publish.go cmd/swarm/event_publish_test.go` returned no matches.
