### PR TITLE
[agent-a][issue #838] Define CLI catalog accounting model

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5323,6 +5323,51 @@ cli_specification:
     - docs/SWARM_INVESTIGATE_COMMAND_DRAFT.md
     - docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux.yaml
     - stale v1 `swarm investigate *` command catalog entries
+  catalog_accounting_model:
+    owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog
+    accounting_unit: explicit_command_catalog_row
+    rule: >
+      CLI v2 catalog accounting counts one explicit `command_catalog` map entry as one row.
+      Row keys, not Cobra nodes, literal subcommands, optional flags, examples, target modes,
+      or ignored review-artifact prose, define the implementation and tracker accounting unit.
+      Future #794/#735 children MUST bind to these explicit rows unless a later tracked spec
+      change deliberately splits or merges rows.
+    derived_count_rule: >
+      Numeric totals are not independently authoritative prose. Total, tier, and implementation
+      status counts MUST be derived from the structured `command_catalog` rows at review/proof
+      time by grouping row entries by `tier` and `implementation_status`.
+    stale_count_policy: >
+      Count claims in ignored review artifacts, issue prose, historical matrices, or non-promoted
+      design notes are reconciliation evidence only. If they disagree with the structured rows,
+      the structured rows win until a tracked spec PR changes the catalog.
+    family_normalization_examples:
+      forkchat:
+        row: forkchat
+        rule: >
+          `swarm forkchat new|resume|list|view|delete` is one blocked backlog family row for
+          #735/#749 accounting until a future tracked spec PR splits the family.
+      control:
+        rows:
+        - control_pause
+        - control_continue
+        - control_stop
+        rule: >
+          Each control verb is one row. Target forms such as `<run-id>` and `--all` are modes
+          of that row, not separate command rows.
+      agent_replay:
+        rows:
+        - agent_replay
+        - agent_replay_backlog
+        rule: >
+          Event-targeted replay and backlog replay are separate rows because they have different
+          runtime/API ownership and were intentionally split by the promoted catalog.
+      events:
+        rows:
+        - event_replay
+        - event_publish
+        rule: >
+          Event replay and event publish are separate rows. The implemented replay row MUST NOT
+          be reopened or counted as closing the absent publish row.
   review_artifact_reconciliation:
     source: docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux-v2.yaml
     source_status: ignored_untracked_reconciliation_input


### PR DESCRIPTION
## Summary

Closes #838.

This PR promotes the CLI v2 catalog accounting model into merge-bearing `platform-spec.yaml#cli_specification`: one explicit `command_catalog` map entry is one accounting row. Numeric totals, ignored review-artifact count claims, issue prose, and historical matrices are reconciliation evidence only unless promoted into the tracked spec.

No CLI/runtime/OpenRPC behavior changes are included.

## Governing Context

- #838 refreshed implementer pre-audit: https://github.com/yazzaoui/Swarm/issues/838#issuecomment-4489749464
- #838 independent gate: https://github.com/yazzaoui/Swarm/issues/838#issuecomment-4491018572
- Merge-bearing owner: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog`
- Source-of-truth rule: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.source_of_truth`

## Semantic Migration

- New canonical owner: `cli_specification.catalog_accounting_model` plus the existing structured `command_catalog` rows.
- Old non-authoritative producers/readers: ignored `platform-spec.cli-ux-v2.yaml` count claims, historical issue prose, and audit matrices that count by Cobra node, literal mode, or review-artifact prose.
- Production paths checked for surviving old behavior: tracked `platform-spec.yaml`, #794 tracker pointer, #735 tracker pointer, and ignored review-artifact disposition from #836/#867.
- Migration status: complete for #838's catalog accounting/family-normalization class; broader ignored-artifact hygiene remains tracked under #865.

## Proof

- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `ruby -ryaml -e 'spec=YAML.load_file("docs/specs/swarm-platform/platform/contracts/platform-spec.yaml"); cc=spec.fetch("cli_specification").fetch("command_catalog"); puts "total_rows=#{cc.size}"; cc.group_by{|_,v| v["tier"]}.sort.each{|tier,rows| puts "#{tier}=#{rows.size}"}; cc.group_by{|_,v| v["implementation_status"] || "(none)"}.sort.each{|st,rows| puts "#{st}=#{rows.size}"}'`
- `git ls-files | xargs rg -n "37 commands|36 commands|13 must_have|25 should_have|command catalog.*count|catalog accounting|catalog_accounting_model|explicit_command_catalog_row"`
- `rg -n "catalog_accounting_model|explicit_command_catalog_row|family_normalization_examples|forkchat|control_pause|agent_replay_backlog|event_publish|stale_count_policy" docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`