### PR TITLE
[agent-b][issue #851] Fix conversation run_id projection

### DIFF
--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -2,9 +2,13 @@ package apiv1
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"swarm/internal/store"
 )
 
@@ -59,6 +63,26 @@ func (s *fakeAgentConversationReadStore) LoadOperatorConversationTurn(_ context.
 func (s *fakeAgentConversationReadStore) LoadCurrentOperatorConversationForAgent(_ context.Context, agentID string) (*store.OperatorConversationDetail, error) {
 	s.lastCurrentConversationFor = agentID
 	return s.currentConversationResult, s.currentConversationErr
+}
+
+type apiConversationCapabilitySource struct {
+	caps store.StoreSchemaCapabilities
+}
+
+func (s apiConversationCapabilitySource) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return s.caps, nil
+}
+
+func apiConversationReadCaps(sessionRunID, auditRunID bool) store.StoreSchemaCapabilities {
+	return store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:     store.SchemaFlavorCanonical,
+			Audits:       store.SchemaFlavorCanonical,
+			Turns:        store.SchemaFlavorCanonical,
+			SessionRunID: sessionRunID,
+			AuditRunID:   auditRunID,
+		},
+	}
 }
 
 func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
@@ -163,6 +187,97 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	}
 	if reads.lastCurrentConversationFor != "agent-1" {
 		t.Fatalf("current_for_agent id = %q", reads.lastCurrentConversationFor)
+	}
+}
+
+func TestOperatorAgentConversationHandlersSanitizeRunIDProjectionFailures(t *testing.T) {
+	rawRunIDColumnErr := errors.New(`pq: column "run_id" does not exist at position 46:14 (42703)`)
+	tests := []struct {
+		name   string
+		body   string
+		caps   store.StoreSchemaCapabilities
+		expect func(sqlmock.Sqlmock)
+	}{
+		{
+			name: "conversation list raw projection error",
+			body: `{"jsonrpc":"2.0","id":"convs","method":"conversation.list","params":{"limit":20}}`,
+			caps: apiConversationReadCaps(true, true),
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("(?s)SELECT\\s+conversations\\.session_id,\\s+conversations\\.agent_id,\\s+conversations\\.run_id,.*FROM \\(").
+					WithArgs(21).
+					WillReturnError(rawRunIDColumnErr)
+			},
+		},
+		{
+			name: "conversation get raw projection error",
+			body: `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"sess-1"}}`,
+			caps: apiConversationReadCaps(true, true),
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("(?s)SELECT\\s+session_id,\\s+agent_id,\\s+run_id,.*FROM \\(.*\\) conversations\\s+WHERE session_id = \\$1").
+					WithArgs("sess-1").
+					WillReturnError(rawRunIDColumnErr)
+			},
+		},
+		{
+			name: "conversation get_turn raw projection error",
+			body: `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"sess-1","turn_index":1,"include_logs":true}}`,
+			caps: apiConversationReadCaps(true, true),
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("(?s)SELECT\\s+session_id,\\s+agent_id,\\s+run_id,.*FROM \\(.*\\) conversations\\s+WHERE session_id = \\$1").
+					WithArgs("sess-1").
+					WillReturnError(rawRunIDColumnErr)
+			},
+		},
+		{
+			name: "conversation list run_id filter without any run_id capability",
+			body: `{"jsonrpc":"2.0","id":"convs","method":"conversation.list","params":{"run_id":"11111111-1111-1111-1111-111111111111"}}`,
+			caps: apiConversationReadCaps(false, false),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			if tc.expect != nil {
+				tc.expect(mock)
+			}
+
+			reader := store.NewOperatorConversationReadSurface(db, apiConversationCapabilitySource{caps: tc.caps})
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					AgentConversations: reader,
+				}),
+			})
+
+			resp := rpcCall(t, handler, tc.body)
+			assertConversationRunIDErrorSanitized(t, resp)
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("expectations: %v", err)
+			}
+		})
+	}
+}
+
+func assertConversationRunIDErrorSanitized(t *testing.T, resp rpcResponse) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatal("response error = nil, want sanitized run_id capability error")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	text := strings.ToLower(resp.Error.Message + " " + fmt.Sprint(resp.Error.Data))
+	if !strings.Contains(text, "operator conversation read surface run_id capability unavailable") {
+		t.Fatalf("error data = %s, want stable run_id capability error", text)
+	}
+	for _, forbidden := range []string{"pq:", `column "run_id"`, "42703", "position"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("error data leaked %q: %s", forbidden, text)
+		}
 	}
 }
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -26,6 +26,8 @@ var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")
 
 var ErrInvalidConversationCursor = errors.New("store: invalid conversation cursor")
 
+var ErrOperatorConversationRunIDCapability = errors.New("store: operator conversation read surface run_id capability unavailable")
+
 var ErrInvalidEntityReadParam = errors.New("store: invalid entity read parameter")
 
 type EntityReadParamError struct {

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -6,11 +6,13 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
@@ -497,7 +499,7 @@ func (r *OperatorAgentConversationReadSurface) ListOperatorConversations(ctx con
 		return OperatorConversationListResult{}, err
 	}
 	if opts.RunID != "" && !caps.Conversations.SessionRunID && !caps.Conversations.AuditRunID {
-		return OperatorConversationListResult{}, fmt.Errorf("operator conversation read surface requires conversation run_id columns for run_id filtering")
+		return OperatorConversationListResult{}, operatorConversationRunIDCapabilityError("run_id filtering requires agent_sessions.run_id or agent_conversation_audits.run_id")
 	}
 	sources := operatorConversationQuerySources(caps)
 	if len(sources) == 0 {
@@ -578,7 +580,7 @@ func (r *OperatorAgentConversationReadSurface) ListOperatorConversations(ctx con
 		LIMIT $%d
 	`, strings.Join(sources, "\nUNION ALL\n"), latestTurnBlocksExpr, strings.Join(where, " AND "), limitArg), args...)
 	if err != nil {
-		return OperatorConversationListResult{}, fmt.Errorf("list operator conversations: %w", err)
+		return OperatorConversationListResult{}, operatorConversationReadQueryError("list operator conversations", err)
 	}
 	defer rows.Close()
 	conversations := []OperatorConversationSummary{}
@@ -590,7 +592,7 @@ func (r *OperatorAgentConversationReadSurface) ListOperatorConversations(ctx con
 		conversations = append(conversations, item)
 	}
 	if err := rows.Err(); err != nil {
-		return OperatorConversationListResult{}, fmt.Errorf("read operator conversations: %w", err)
+		return OperatorConversationListResult{}, operatorConversationReadQueryError("read operator conversations", err)
 	}
 	nextCursor := ""
 	if len(conversations) > opts.Limit {
@@ -652,7 +654,7 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorConversation(ctx cont
 		return OperatorConversationDetail{}, ErrSessionNotFound
 	}
 	if err != nil {
-		return OperatorConversationDetail{}, fmt.Errorf("load operator conversation: %w", err)
+		return OperatorConversationDetail{}, operatorConversationReadQueryError("load operator conversation", err)
 	}
 	item.Turns, err = r.loadConversationTurns(ctx, item.Conversation.AgentID, item.Conversation.SessionID)
 	if err != nil {
@@ -1289,6 +1291,43 @@ func defaultOperatorConversationListOptions(opts OperatorConversationListOptions
 		opts.Limit = 500
 	}
 	return opts, nil
+}
+
+func operatorConversationRunIDCapabilityError(reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return ErrOperatorConversationRunIDCapability
+	}
+	return fmt.Errorf("%w: %s", ErrOperatorConversationRunIDCapability, reason)
+}
+
+func operatorConversationReadQueryError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	operation = strings.TrimSpace(operation)
+	if operation == "" {
+		operation = "operator conversation read"
+	}
+	if operatorConversationRunIDProjectionError(err) {
+		return fmt.Errorf("%s: %w", operation, operatorConversationRunIDCapabilityError("selected conversation source cannot project run_id"))
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}
+
+func operatorConversationRunIDProjectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr != nil {
+		if string(pqErr.Code) == "42703" && (strings.EqualFold(pqErr.Column, "run_id") || strings.Contains(strings.ToLower(pqErr.Message), "run_id")) {
+			return true
+		}
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "run_id") &&
+		(strings.Contains(message, `column "run_id" does not exist`) || strings.Contains(message, "42703"))
 }
 
 func operatorConversationQuerySources(caps StoreSchemaCapabilities) []string {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,6 +86,120 @@ func operatorConversationDetailColumns() []string {
 func operatorConversationTurnColumns() []string {
 	return []string{
 		"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id", "available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible", "request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+	}
+}
+
+func TestCanonicalTaskConversationVisibilitySourceProjectsRunIDByCapability(t *testing.T) {
+	withRunID := CanonicalTaskConversationVisibilitySourceSQL(ConversationSchemaCapabilities{
+		Audits:     SchemaFlavorCanonical,
+		AuditRunID: true,
+	})
+	if !strings.Contains(withRunID, "COALESCE(run_id::text, '') AS run_id") {
+		t.Fatalf("audit run_id projection missing from canonical source:\n%s", withRunID)
+	}
+
+	withoutRunID := CanonicalTaskConversationVisibilitySourceSQL(ConversationSchemaCapabilities{
+		Audits: SchemaFlavorCanonical,
+	})
+	if !strings.Contains(withoutRunID, "'' AS run_id") {
+		t.Fatalf("audit no-run_id projection missing stable blank run_id:\n%s", withoutRunID)
+	}
+	if strings.Contains(withoutRunID, "COALESCE(run_id::text") {
+		t.Fatalf("audit no-run_id projection referenced missing run_id column:\n%s", withoutRunID)
+	}
+}
+
+func TestOperatorConversationQuerySourcesRunIDCapabilityMatrix(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionRunID bool
+		auditRunID   bool
+	}{
+		{name: "both", sessionRunID: true, auditRunID: true},
+		{name: "session only", sessionRunID: true},
+		{name: "audit only", auditRunID: true},
+		{name: "neither"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sources := operatorConversationQuerySources(StoreSchemaCapabilities{
+				Conversations: ConversationSchemaCapabilities{
+					Sessions:     SchemaFlavorCanonical,
+					Audits:       SchemaFlavorCanonical,
+					Turns:        SchemaFlavorCanonical,
+					SessionRunID: tc.sessionRunID,
+					AuditRunID:   tc.auditRunID,
+				},
+			})
+			if len(sources) != 2 {
+				t.Fatalf("source count = %d, want 2", len(sources))
+			}
+			for _, source := range sources {
+				switch {
+				case strings.Contains(source, "'live_session' AS kind"):
+					assertRunIDSourceProjection(t, source, tc.sessionRunID)
+				case strings.Contains(source, "'turn_audit' AS kind"):
+					assertRunIDSourceProjection(t, source, tc.auditRunID)
+				default:
+					t.Fatalf("unknown conversation source:\n%s", source)
+				}
+			}
+		})
+	}
+}
+
+func assertRunIDSourceProjection(t *testing.T, source string, hasRunID bool) {
+	t.Helper()
+	if hasRunID {
+		if !strings.Contains(source, "COALESCE(run_id::text, '') AS run_id") {
+			t.Fatalf("run_id-capable source did not project run_id:\n%s", source)
+		}
+		return
+	}
+	if !strings.Contains(source, "'' AS run_id") {
+		t.Fatalf("non-run_id source did not project stable blank run_id:\n%s", source)
+	}
+}
+
+func TestOperatorConversationReadSurfaceListRejectsRunIDFilterWithoutRunIDCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorConversationReadSurface(db, fakeConversationCapabilitySource{caps: StoreSchemaCapabilities{
+		Conversations: ConversationSchemaCapabilities{
+			Sessions: SchemaFlavorCanonical,
+			Audits:   SchemaFlavorCanonical,
+			Turns:    SchemaFlavorCanonical,
+		},
+	}})
+
+	_, err = reader.ListOperatorConversations(context.Background(), OperatorConversationListOptions{
+		RunID: "11111111-1111-1111-1111-111111111111",
+	})
+	if !errors.Is(err, ErrOperatorConversationRunIDCapability) {
+		t.Fatalf("ListOperatorConversations err = %v, want ErrOperatorConversationRunIDCapability", err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "pq:") || strings.Contains(strings.ToLower(err.Error()), `column "run_id"`) {
+		t.Fatalf("capability error leaked driver detail: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorConversationReadSurfaceSanitizesRunIDProjectionDriverError(t *testing.T) {
+	err := operatorConversationReadQueryError("load operator conversation", errors.New(`pq: column "run_id" does not exist at position 46:14 (42703)`))
+	if !errors.Is(err, ErrOperatorConversationRunIDCapability) {
+		t.Fatalf("sanitized err = %v, want ErrOperatorConversationRunIDCapability", err)
+	}
+	lower := strings.ToLower(err.Error())
+	for _, forbidden := range []string{"pq:", `column "run_id"`, "42703", "position"} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("sanitized err leaked %q: %v", forbidden, err)
+		}
 	}
 }
 

--- a/internal/store/task_conversation_visibility.go
+++ b/internal/store/task_conversation_visibility.go
@@ -7,10 +7,17 @@ func CanonicalTaskConversationVisibilitySourceSQL(caps ConversationSchemaCapabil
 	if caps.Audits != SchemaFlavorCanonical {
 		return ""
 	}
+	runID := "''"
+	if caps.AuditRunID {
+		runID = "COALESCE(run_id::text, '')"
+	}
+	// Keep run_id in the projection even when the audit table lacks that
+	// column so shared conversation readers can always select it safely.
 	return `
 		SELECT
 			session_id::text AS session_id,
 			agent_id,
+			` + runID + ` AS run_id,
 			COALESCE(scope_key, '') AS scope_key,
 			COALESCE(scope, '') AS scope,
 			COALESCE(runtime_mode, '') AS runtime_mode,


### PR DESCRIPTION
## Summary
- Repair the canonical task-audit conversation projection so `run_id` is always selected safely according to schema capabilities.
- Convert conversation read `run_id` projection failures into a stable store capability error instead of leaking raw PostgreSQL driver text through `/v1/rpc`.
- Add store capability-matrix coverage and supported `/v1/rpc` coverage for `conversation.list`, `conversation.get`, and `conversation.get_turn`.

Closes #851

## Governing refs/context
- #851 issue body/thread
- #851 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/851#issuecomment-4491255537
- #851 independent gate: https://github.com/yazzaoui/Swarm/issues/851#issuecomment-4491311533
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.get_turn`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.conversation.current_for_agent`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` schema catalog for `agent_sessions`, `agent_conversation_audits`, and `ConversationSummary.run_id`

## Semantic migration accounting
- Canonical owner after change: `internal/store/operator_agent_conversation_read_surface.go` plus `internal/store/task_conversation_visibility.go` for the task-audit source projection.
- Old invalid path: treating `CanonicalTaskConversationVisibilitySourceSQL` as if it projected `run_id` when it did not.
- Production paths checked: `/v1/rpc conversation.list`, `/v1/rpc conversation.get`, `/v1/rpc conversation.get_turn`, `/v1/rpc conversation.current_for_agent`, dashboard `/api/conversations*` adapters, and repo greps for same-concept direct SQL readers.
- Migration complete for #851: yes, for the approved bug-fix class. Broader typed projection descriptor cleanup remains watchlist-only architecture debt.

## Tests
- `go test ./internal/store -run 'OperatorConversation.*(RunID|Capability|Projection|Source)|CanonicalTaskConversationVisibilitySource' -count=1`
- `go test ./internal/apiv1 -run 'OperatorAgentConversation.*(RunID|Capability|Raw|Supported|Sanitize)|OperatorAgentConversationHandlersSanitizeRunIDProjectionFailures' -count=1`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server -run 'OperatorConversation|OperatorAgentConversation|SQLConversationReader|handleConversations|Conversation' -count=1`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./... -count=1`
