### PR TITLE
[agent-a][issue #846] Normalize CLI API error exits

### DIFF
--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -154,31 +152,17 @@ func writeAgentDirectiveResult(out io.Writer, agentID string, result agentDirect
 }
 
 func agentDirectiveErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return agentDirectiveExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return agentDirectiveExitAuth
-		}
-		return agentDirectiveExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return agentDirectiveExitAuth
-		case "AGENT_NOT_FOUND", "RUN_NOT_FOUND":
-			return agentDirectiveExitNotFound
-		case "AGENT_NOT_RUNNING", "RUN_ALREADY_TERMINAL", "AMBIGUOUS_RUN_TARGET", "IDEMPOTENCY_CONFLICT":
-			return agentDirectiveExitConflict
-		default:
-			return agentDirectiveExitRuntime
-		}
-	}
-	return agentDirectiveExitRuntime
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   agentDirectiveExitRuntime,
+		authExit:      agentDirectiveExitAuth,
+		notFoundExit:  agentDirectiveExitNotFound,
+		conflictExit:  agentDirectiveExitConflict,
+		notFoundCodes: []string{"AGENT_NOT_FOUND", "RUN_NOT_FOUND"},
+		conflictCodes: []string{
+			"AGENT_NOT_RUNNING",
+			"RUN_ALREADY_TERMINAL",
+			"AMBIGUOUS_RUN_TARGET",
+			"IDEMPOTENCY_CONFLICT",
+		},
+	})
 }

--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -185,36 +183,19 @@ func writeAgentReplayResult(out io.Writer, result agentReplayResult) {
 }
 
 func agentReplayErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return agentReplayExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return agentReplayExitAuth
-		}
-		return agentReplayExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return agentReplayExitAuth
-		case "EVENT_NOT_FOUND":
-			return agentReplayExitNotFound
-		case "EVENT_REPLAY_NO_DELIVERY_HISTORY",
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   agentReplayExitRuntime,
+		authExit:      agentReplayExitAuth,
+		notFoundExit:  agentReplayExitNotFound,
+		conflictExit:  agentReplayExitConflict,
+		notFoundCodes: []string{"EVENT_NOT_FOUND"},
+		conflictCodes: []string{
+			"EVENT_REPLAY_NO_DELIVERY_HISTORY",
 			"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
 			"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
 			"EVENT_REPLAY_NOT_ELIGIBLE",
 			"PAYLOAD_VALIDATION_FAILED",
-			"IDEMPOTENCY_CONFLICT":
-			return agentReplayExitConflict
-		default:
-			return agentReplayExitRuntime
-		}
-	}
-	return agentReplayExitRuntime
+			"IDEMPOTENCY_CONFLICT",
+		},
+	})
 }

--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -110,31 +108,12 @@ func writeAgentReplayBacklogResult(out io.Writer, agentID string, result agentRe
 }
 
 func agentReplayBacklogErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return agentReplayBacklogExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return agentReplayBacklogExitAuth
-		}
-		return agentReplayBacklogExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return agentReplayBacklogExitAuth
-		case "AGENT_NOT_FOUND":
-			return agentReplayBacklogExitNotFound
-		case "IDEMPOTENCY_CONFLICT":
-			return agentReplayBacklogExitConflict
-		default:
-			return agentReplayBacklogExitRuntime
-		}
-	}
-	return agentReplayBacklogExitRuntime
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   agentReplayBacklogExitRuntime,
+		authExit:      agentReplayBacklogExitAuth,
+		notFoundExit:  agentReplayBacklogExitNotFound,
+		conflictExit:  agentReplayBacklogExitConflict,
+		notFoundCodes: []string{"AGENT_NOT_FOUND"},
+		conflictCodes: []string{"IDEMPOTENCY_CONFLICT"},
+	})
 }

--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -103,31 +101,12 @@ func writeAgentRestartResult(out io.Writer, agentID string) {
 }
 
 func agentRestartErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return agentRestartExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return agentRestartExitAuth
-		}
-		return agentRestartExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return agentRestartExitAuth
-		case "AGENT_NOT_FOUND":
-			return agentRestartExitNotFound
-		case "IDEMPOTENCY_CONFLICT":
-			return agentRestartExitConflict
-		default:
-			return agentRestartExitRuntime
-		}
-	}
-	return agentRestartExitRuntime
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   agentRestartExitRuntime,
+		authExit:      agentRestartExitAuth,
+		notFoundExit:  agentRestartExitNotFound,
+		conflictExit:  agentRestartExitConflict,
+		notFoundCodes: []string{"AGENT_NOT_FOUND"},
+		conflictCodes: []string{"IDEMPOTENCY_CONFLICT"},
+	})
 }

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -107,7 +107,7 @@ func newAgentsListCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "List declared agents through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAgentListCommand(cmd.Context(), cmd.OutOrStdout(), listOpts)
+			return runAgentListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
 		},
 	}
 	cmd.Flags().StringVar(&listOpts.flow, "flow", "", "Filter by canonical flow path")
@@ -121,46 +121,54 @@ func newAgentViewCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one agent through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), opts, args[0])
+			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
 		},
 	}
 }
 
-func runAgentListCommand(ctx context.Context, out io.Writer, opts agentListCommandOptions) error {
+func runAgentListCommand(ctx context.Context, out, errOut io.Writer, opts agentListCommandOptions) error {
 	params := opts.params()
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentListAPIErrorClassifier())
 	}
 	var result agentListResult
 	if err := client.call(ctx, "agent.list", params, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentListAPIErrorClassifier())
 	}
 	if err := validateAgentListResult(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentListAPIErrorClassifier())
 	}
 	writeAgentListResult(out, result)
 	return nil
 }
 
-func runAgentViewCommand(ctx context.Context, out io.Writer, opts rootCommandOptions, agentID string) error {
+func runAgentViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, agentID string) error {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
-		return fmt.Errorf("agent id is required")
+		return returnCLIValidationError(errOut, fmt.Errorf("agent id is required"))
 	}
 	client, err := newCLIAPIClient(opts)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentViewAPIErrorClassifier())
 	}
 	var result agentDetailResult
 	if err := client.call(ctx, "agent.get", map[string]any{"agent_id": agentID}, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentViewAPIErrorClassifier())
 	}
 	if err := validateAgentDetailResult(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, agentViewAPIErrorClassifier())
 	}
 	writeAgentDetailResult(out, result)
 	return nil
+}
+
+func agentListAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func agentViewAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"AGENT_NOT_FOUND"}}
 }
 
 func (opts agentListCommandOptions) params() map[string]any {

--- a/cmd/swarm/agents_test.go
+++ b/cmd/swarm/agents_test.go
@@ -185,8 +185,8 @@ func TestAgentReadCommandsFailClosedWithoutToken(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agents", "list"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
@@ -201,6 +201,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		name       string
 		args       []string
 		handler    http.HandlerFunc
+		wantCode   int
 		wantStderr string
 	}{
 		{
@@ -209,6 +210,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
+			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
 		},
 		{
@@ -219,6 +221,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{})
 			},
+			wantCode:   3,
 			wantStderr: "malformed agent.list result: agents is required",
 		},
 		{
@@ -231,6 +234,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				delete(agent, "status")
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"agents": []map[string]any{agent}})
 			},
+			wantCode:   3,
 			wantStderr: "malformed agent.list result: agents[0]: status is required",
 		},
 		{
@@ -241,6 +245,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{})
 			},
+			wantCode:   3,
 			wantStderr: "malformed agent.get result: agent: agent_id is required",
 		},
 		{
@@ -251,6 +256,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeAgentJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
 			},
+			wantCode:   5,
 			wantStderr: "AGENT_NOT_FOUND: Application error: AGENT_NOT_FOUND",
 		},
 		{
@@ -264,6 +270,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 					"current_session_ref": map[string]any{"session_id": "session-1"},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "malformed agent.get result: current_session_ref.started_at is required",
 		},
 	} {
@@ -274,8 +281,8 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
 			if !strings.Contains(stderr.String(), tc.wantStderr) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -164,21 +164,21 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Print local Swarm binary version information.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), versionOpts)
+			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), versionOpts)
 		},
 	}
 	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
 	return cmd
 }
 
-func runVersionCommand(ctx context.Context, out io.Writer, opts versionCommandOptions) error {
+func runVersionCommand(ctx context.Context, out, errOut io.Writer, opts versionCommandOptions) error {
 	if !opts.server {
 		writeLocalVersion(out)
 		return nil
 	}
 	result, err := fetchDiagnosticHealthCheck(ctx, opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, cliAPIErrorClassifier{})
 	}
 	writeLocalVersion(out)
 	writeVersionServerIdentity(out, result)

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -56,7 +56,7 @@ func newCLIAPIClient(opts rootCommandOptions) (*cliAPIClient, error) {
 	}
 	token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN"))
 	if token == "" {
-		return nil, fmt.Errorf("SWARM_API_TOKEN is required for runtime-state CLI commands")
+		return nil, errCLIAPITokenRequired
 	}
 	client := opts.httpClient
 	if client == nil {

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	cliExitOK          = 0
+	cliExitValidation  = 2
+	cliExitRuntime     = 3
+	cliExitAuth        = 4
+	cliExitNotFound    = 5
+	cliExitConflict    = 6
+	cliExitRunTerminal = 7
+	cliExitInterrupted = 130
+)
+
+var errCLIAPITokenRequired = errors.New("SWARM_API_TOKEN is required for runtime-state CLI commands")
+
+type cliAPIErrorClassifier struct {
+	runtimeExit   int
+	authExit      int
+	notFoundExit  int
+	conflictExit  int
+	notFoundCodes []string
+	conflictCodes []string
+}
+
+func cliAPIErrorExitCode(err error, classifier cliAPIErrorClassifier) int {
+	if err == nil {
+		return cliExitOK
+	}
+	runtimeExit := classifier.runtimeExit
+	if runtimeExit == 0 {
+		runtimeExit = cliExitRuntime
+	}
+	authExit := classifier.authExit
+	if authExit == 0 {
+		authExit = cliExitAuth
+	}
+	notFoundExit := classifier.notFoundExit
+	if notFoundExit == 0 {
+		notFoundExit = cliExitNotFound
+	}
+	conflictExit := classifier.conflictExit
+	if conflictExit == 0 {
+		conflictExit = cliExitConflict
+	}
+	if errors.Is(err, errCLIAPITokenRequired) {
+		return authExit
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
+			return authExit
+		}
+		return runtimeExit
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		switch code := applicationErrorCode(rpcErr.Data); {
+		case code == "UNAUTHORIZED":
+			return authExit
+		case cliCodeInSet(code, classifier.notFoundCodes):
+			return notFoundExit
+		case cliCodeInSet(code, classifier.conflictCodes):
+			return conflictExit
+		default:
+			return runtimeExit
+		}
+	}
+	return runtimeExit
+}
+
+func returnCLIAPIError(errOut io.Writer, err error, classifier cliAPIErrorClassifier) error {
+	if errOut != nil {
+		fmt.Fprintln(errOut, err)
+	}
+	return commandExitError{code: cliAPIErrorExitCode(err, classifier)}
+}
+
+func returnCLIValidationError(errOut io.Writer, err error) error {
+	if errOut != nil {
+		fmt.Fprintln(errOut, err)
+	}
+	return commandExitError{code: cliExitValidation}
+}
+
+func cliCodeInSet(code string, codes []string) bool {
+	for _, candidate := range codes {
+		if code == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestCLIAPIErrorExitCodeClassifiesSharedCategories(t *testing.T) {
+	rpcError := func(code string) error {
+		data, err := json.Marshal(map[string]any{"code": code})
+		if err != nil {
+			t.Fatalf("marshal rpc error data: %v", err)
+		}
+		return &jsonRPCError{Code: -32010, Message: "Application error: " + code, Data: data}
+	}
+	classifier := cliAPIErrorClassifier{
+		notFoundCodes: []string{"RUN_NOT_FOUND"},
+		conflictCodes: []string{"IDEMPOTENCY_CONFLICT", "RUN_ALREADY_TERMINAL"},
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "missing token", err: errCLIAPITokenRequired, want: cliExitAuth},
+		{name: "http unauthorized", err: &cliAPIHTTPError{surface: "v1 RPC", statusCode: 401, message: "unauthorized"}, want: cliExitAuth},
+		{name: "http forbidden", err: &cliAPIHTTPError{surface: "v1 RPC", statusCode: 403, message: "forbidden"}, want: cliExitAuth},
+		{name: "http runtime", err: &cliAPIHTTPError{surface: "v1 RPC", statusCode: 502, message: "bad gateway"}, want: cliExitRuntime},
+		{name: "rpc unauthorized", err: rpcError("UNAUTHORIZED"), want: cliExitAuth},
+		{name: "rpc not found", err: rpcError("RUN_NOT_FOUND"), want: cliExitNotFound},
+		{name: "rpc conflict", err: rpcError("IDEMPOTENCY_CONFLICT"), want: cliExitConflict},
+		{name: "rpc state conflict", err: rpcError("RUN_ALREADY_TERMINAL"), want: cliExitConflict},
+		{name: "unknown rpc", err: rpcError("UNKNOWN_CODE"), want: cliExitRuntime},
+		{name: "transport", err: fmt.Errorf("v1 RPC request failed: %w", errors.New("connection refused")), want: cliExitRuntime},
+		{name: "malformed response", err: errors.New("malformed JSON-RPC response: jsonrpc=\"1.0\""), want: cliExitRuntime},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cliAPIErrorExitCode(tc.err, classifier); got != tc.want {
+				t.Fatalf("exit = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -146,7 +146,7 @@ func newMailboxListCommand(opts rootCommandOptions) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.limitSet = cmd.Flags().Changed("limit")
-			return runMailboxListCommand(cmd.Context(), cmd.OutOrStdout(), listOpts)
+			return runMailboxListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
 		},
 	}
 	cmd.Flags().StringVar(&listOpts.status, "status", listOpts.status, "Mailbox status: pending, decided, expired, or deferred")
@@ -166,7 +166,7 @@ func newMailboxViewCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), opts, args[0])
+			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
 		},
 	}
 }
@@ -182,7 +182,7 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Approve a pending mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
@@ -201,7 +201,7 @@ func newMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Reject a pending mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.reason, "reason", "", "Required rejection reason")
@@ -220,7 +220,7 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Defer a pending mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), actionOpts, args[0])
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.until, "until", "", "Required RFC3339 timestamp")
@@ -228,68 +228,83 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func runMailboxListCommand(ctx context.Context, out io.Writer, opts mailboxListCommandOptions) error {
+func runMailboxListCommand(ctx context.Context, out, errOut io.Writer, opts mailboxListCommandOptions) error {
 	params, err := opts.params()
 	if err != nil {
-		return err
+		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxListAPIErrorClassifier())
 	}
 	var result mailboxListResult
 	if err := client.call(ctx, "mailbox.list", params, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxListAPIErrorClassifier())
 	}
 	if err := validateMailboxListResult(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxListAPIErrorClassifier())
 	}
 	writeMailboxListResult(out, result)
 	return nil
 }
 
-func runMailboxViewCommand(ctx context.Context, out io.Writer, opts rootCommandOptions, mailboxID string) error {
+func runMailboxViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, mailboxID string) error {
 	mailboxID = strings.TrimSpace(mailboxID)
 	if mailboxID == "" {
-		return fmt.Errorf("mailbox item id is required")
+		return returnCLIValidationError(errOut, fmt.Errorf("mailbox item id is required"))
 	}
 	client, err := newCLIAPIClient(opts)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxReadAPIErrorClassifier())
 	}
 	var result mailboxDetailResult
 	if err := client.call(ctx, "mailbox.get", map[string]any{"mailbox_id": mailboxID}, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxReadAPIErrorClassifier())
 	}
 	if err := validateMailboxDetailResult(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxReadAPIErrorClassifier())
 	}
 	writeMailboxDetailResult(out, result)
 	return nil
 }
 
-func runMailboxDecisionCommand(ctx context.Context, out io.Writer, opts mailboxDecisionCommandOptions, mailboxID string) error {
+func runMailboxDecisionCommand(ctx context.Context, out, errOut io.Writer, opts mailboxDecisionCommandOptions, mailboxID string) error {
 	mailboxID = strings.TrimSpace(mailboxID)
 	if mailboxID == "" {
-		return fmt.Errorf("mailbox item id is required")
+		return returnCLIValidationError(errOut, fmt.Errorf("mailbox item id is required"))
 	}
 	params, err := opts.params(mailboxID)
 	if err != nil {
-		return err
+		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxDecisionAPIErrorClassifier())
 	}
 	var result mailboxDecisionResult
 	if err := client.call(ctx, opts.method, params, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxDecisionAPIErrorClassifier())
 	}
 	if err := validateMailboxDecisionResult(opts.action, result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, mailboxDecisionAPIErrorClassifier())
 	}
 	writeMailboxDecisionResult(out, opts.action, mailboxID, result)
 	return nil
+}
+
+func mailboxListAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func mailboxReadAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"MAILBOX_NOT_FOUND"}}
+}
+
+func mailboxDecisionAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{
+		notFoundCodes: []string{"MAILBOX_NOT_FOUND"},
+		conflictCodes: []string{"MAILBOX_ALREADY_DECIDED", "MAILBOX_APPROVAL_EVENT_UNCONFIGURED", "IDEMPOTENCY_CONFLICT"},
+	}
 }
 
 func validateMailboxListResult(result mailboxListResult) error {

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -323,8 +323,8 @@ func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "")
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != 4 {
+				t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
 				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
@@ -383,6 +383,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		handler    http.HandlerFunc
+		wantCode   int
 		wantStderr string
 	}{
 		{
@@ -391,6 +392,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
+			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
 		},
 		{
@@ -398,6 +400,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(`{`))
 			},
+			wantCode:   3,
 			wantStderr: "decode JSON-RPC response",
 		},
 		{
@@ -407,6 +410,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"ok": true})
 			},
+			wantCode:   3,
 			wantStderr: "mailbox_decision_id is required",
 		},
 		{
@@ -418,6 +422,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 					"status":              "decided",
 				})
 			},
+			wantCode:   3,
 			wantStderr: "malformed JSON-RPC response: id",
 		},
 		{
@@ -433,6 +438,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "malformed JSON-RPC response: id=<missing>",
 		},
 		{
@@ -455,6 +461,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   5,
 			wantStderr: "MAILBOX_NOT_FOUND",
 		},
 	} {
@@ -465,8 +472,8 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"mailbox", "approve", "mailbox-1"}, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
@@ -483,6 +490,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		name       string
 		args       []string
 		handler    http.HandlerFunc
+		wantCode   int
 		wantStderr string
 	}{
 		{
@@ -492,6 +500,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
+			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
 		},
 		{
@@ -502,6 +511,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"next_cursor": "cursor-1"})
 			},
+			wantCode:   3,
 			wantStderr: "malformed mailbox.list result: items is required",
 		},
 		{
@@ -514,6 +524,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				delete(item, "source_flow")
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"items": []map[string]any{item}})
 			},
+			wantCode:   3,
 			wantStderr: "items[0]: source_flow is required",
 		},
 		{
@@ -527,6 +538,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 					"history": []map[string]any{{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"}},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "malformed mailbox.get result: payload is required",
 		},
 		{
@@ -548,6 +560,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   5,
 			wantStderr: "MAILBOX_NOT_FOUND",
 		},
 	} {
@@ -558,8 +571,8 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
@@ -612,8 +625,8 @@ func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -337,29 +336,7 @@ func changedDeliveryCount(deliveries []runtimeNukeQuiescedDelivery) int {
 }
 
 func runtimeNukeErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return 4
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return 4
-		}
-		return 3
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return 4
-		case "RUNTIME_NUKE_IN_PROGRESS", "IDEMPOTENCY_CONFLICT":
-			return 6
-		default:
-			return 3
-		}
-	}
-	return 3
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		conflictCodes: []string{"RUNTIME_NUKE_IN_PROGRESS", "IDEMPOTENCY_CONFLICT"},
+	})
 }

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -270,31 +268,12 @@ func controlStopAllExitCode(failures []controlStopAllFailure) int {
 }
 
 func controlCommandErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return controlCommandExitCodeAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return controlCommandExitCodeAuth
-		}
-		return controlCommandExitCodeRuntimeError
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return controlCommandExitCodeAuth
-		case "RUN_NOT_FOUND":
-			return controlCommandExitCodeNotFound
-		case "IDEMPOTENCY_CONFLICT":
-			return controlCommandExitCodeConflict
-		default:
-			return controlCommandExitCodeRuntimeError
-		}
-	}
-	return controlCommandExitCodeRuntimeError
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   controlCommandExitCodeRuntimeError,
+		authExit:      controlCommandExitCodeAuth,
+		notFoundExit:  controlCommandExitCodeNotFound,
+		conflictExit:  controlCommandExitCodeConflict,
+		notFoundCodes: []string{"RUN_NOT_FOUND"},
+		conflictCodes: []string{"IDEMPOTENCY_CONFLICT"},
+	})
 }

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -120,7 +120,7 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
 				return fmt.Errorf("--limit must be between 1 and 500")
 			}
-			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), runOpts)
+			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts)
 		},
 	}
 	bindDiagnosticRunListFlags(cmd, &runOpts)
@@ -133,7 +133,7 @@ func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Print structured operator health through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), opts)
+			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
 }
@@ -149,7 +149,7 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 			if len(args) == 1 {
 				runID = args[0]
 			}
-			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), runOpts, runID)
+			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts, runID)
 		},
 	}
 	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
@@ -294,52 +294,52 @@ func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptio
 	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "Optional pagination cursor")
 }
 
-func runDiagnosticRunListCommand(ctx context.Context, out io.Writer, opts diagnosticRunListOptions) error {
+func runDiagnosticRunListCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticRunListOptions) error {
 	params, err := opts.params()
 	if err != nil {
 		return err
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	result, err := fetchDiagnosticRunList(ctx, client, params)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	writeDiagnosticRunList(out, result)
 	return nil
 }
 
-func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnosticRunOptions, runID string) error {
+func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticRunOptions, runID string) error {
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
 		runID, err = resolveActivePreferredRunID(ctx, client)
 		if err != nil {
-			return err
+			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 		}
 	}
 	if opts.noDiagnose {
 		var result diagnosticRunGetResult
 		if err := client.call(ctx, "run.get", map[string]any{"run_id": runID}, &result); err != nil {
-			return err
+			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 		}
 		if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
-			return err
+			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 		}
 		writeDiagnosticRunHeader(out, result.Run)
 		return nil
 	}
 	var result diagnosticRunDiagnosisResult
 	if err := client.call(ctx, "run.diagnose", map[string]any{"run_id": runID}, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	if err := validateDiagnosticRunDiagnosis(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	writeDiagnosticRunDiagnosis(out, result)
 	return nil
@@ -348,13 +348,13 @@ func runDiagnosticRunCommand(ctx context.Context, out io.Writer, opts diagnostic
 func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
 		runID, err = resolveActivePreferredRunID(ctx, client)
 		if err != nil {
-			return err
+			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 		}
 	}
 	if opts.follow {
@@ -363,10 +363,10 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	params := map[string]any{"run_id": runID}
 	var result diagnosticRunTraceResult
 	if err := client.call(ctx, "run.trace", params, &result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	if err := validateDiagnosticRunTraceResult(result); err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	writeDiagnosticRunTrace(out, runID, result)
 	return nil
@@ -421,13 +421,17 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	}
 }
 
-func runDiagnosticHealthCommand(ctx context.Context, out io.Writer, opts rootCommandOptions) error {
+func runDiagnosticHealthCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions) error {
 	result, err := fetchDiagnosticHealthCheck(ctx, opts)
 	if err != nil {
-		return err
+		return returnCLIAPIError(errOut, err, cliAPIErrorClassifier{})
 	}
 	writeDiagnosticHealth(out, result)
 	return nil
+}
+
+func diagnosticRunAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"RUN_NOT_FOUND"}}
 }
 
 func fetchDiagnosticHealthCheck(ctx context.Context, opts rootCommandOptions) (diagnosticHealthCheckResult, error) {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -634,8 +634,8 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != 4 {
+				t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
 				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
@@ -665,8 +665,8 @@ func TestOmittedRunResolverFailsClosedWhenNoRunsExist(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			if len(*requests) != 3 {
 				t.Fatalf("requests = %d, want 3 active-preference run.list probes", len(*requests))
@@ -688,6 +688,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		name       string
 		args       []string
 		handler    http.HandlerFunc
+		wantCode   int
 		wantStderr string
 	}{
 		{
@@ -697,6 +698,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
+			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
 		},
 		{
@@ -721,6 +723,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   5,
 			wantStderr: "RUN_NOT_FOUND",
 		},
 		{
@@ -731,6 +734,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{})
 			},
+			wantCode:   3,
 			wantStderr: "runs is required",
 		},
 		{
@@ -743,6 +747,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				delete(run, "run_id")
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"run": run})
 			},
+			wantCode:   3,
 			wantStderr: "run.run_id is required",
 		},
 		{
@@ -755,6 +760,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				run["status"] = "waiting"
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{run}})
 			},
+			wantCode:   3,
 			wantStderr: `runs[0].status="waiting" is not a valid RunStatus`,
 		},
 		{
@@ -767,6 +773,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				run["status"] = "waiting"
 				writeJSONRPCResult(t, w, req.ID, map[string]any{"run": run})
 			},
+			wantCode:   3,
 			wantStderr: `run.status="waiting" is not a valid RunStatus`,
 		},
 		{
@@ -782,6 +789,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					"heuristics":        []any{},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "blocking_layer is required",
 		},
 		{
@@ -798,6 +806,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					"heuristics":        []any{},
 				})
 			},
+			wantCode:   3,
 			wantStderr: `operational_state="blocked" is not a valid OperationalState`,
 		},
 		{
@@ -813,6 +822,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					"heuristics":        []any{},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "blocking_reason is required",
 		},
 		{
@@ -828,6 +838,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					"blocking_reason":   "",
 				})
 			},
+			wantCode:   3,
 			wantStderr: "heuristics is required",
 		},
 		{
@@ -838,6 +849,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{})
 			},
+			wantCode:   3,
 			wantStderr: "trace is required",
 		},
 		{
@@ -854,6 +866,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					"bundle":     map[string]any{},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "bundle.fingerprint is required",
 		},
 		{
@@ -873,6 +886,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "bundle.workflow_name is required",
 		},
 		{
@@ -892,6 +906,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   3,
 			wantStderr: "bundle.workflow_version is required",
 		},
 	} {
@@ -902,8 +917,8 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"regexp"
 	"strings"
 
@@ -240,36 +238,19 @@ func writeEventPublishResult(out io.Writer, eventName string, result eventPublis
 }
 
 func eventPublishErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return eventPublishExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return eventPublishExitAuth
-		}
-		return eventPublishExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return eventPublishExitAuth
-		case "RUN_NOT_FOUND":
-			return eventPublishExitNotFound
-		case "BUNDLE_MISMATCH",
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   eventPublishExitRuntime,
+		authExit:      eventPublishExitAuth,
+		notFoundExit:  eventPublishExitNotFound,
+		conflictExit:  eventPublishExitRejected,
+		notFoundCodes: []string{"RUN_NOT_FOUND"},
+		conflictCodes: []string{
+			"BUNDLE_MISMATCH",
 			"UNSUPPORTED_BUNDLE_REF",
 			"EVENT_NOT_DECLARED",
 			"PAYLOAD_VALIDATION_FAILED",
 			"RUN_ALREADY_TERMINAL",
-			"IDEMPOTENCY_CONFLICT":
-			return eventPublishExitRejected
-		default:
-			return eventPublishExitRuntime
-		}
-	}
-	return eventPublishExitRuntime
+			"IDEMPOTENCY_CONFLICT",
+		},
+	})
 }

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -937,64 +936,28 @@ func eventObservationDash(value string) string {
 }
 
 func eventObservationErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return eventObservationExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return eventObservationExitAuth
-		}
-		return eventObservationExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return eventObservationExitAuth
-		case "EVENT_NOT_FOUND":
-			return eventObservationExitNotFound
-		default:
-			return eventObservationExitRuntime
-		}
-	}
-	return eventObservationExitRuntime
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   eventObservationExitRuntime,
+		authExit:      eventObservationExitAuth,
+		notFoundExit:  eventObservationExitNotFound,
+		notFoundCodes: []string{"EVENT_NOT_FOUND"},
+	})
 }
 
 func eventReplayErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return eventReplayExitAuth
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return eventReplayExitAuth
-		}
-		return eventReplayExitRuntime
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return eventReplayExitAuth
-		case "EVENT_NOT_FOUND":
-			return eventReplayExitNotFound
-		case "EVENT_REPLAY_NO_DELIVERY_HISTORY",
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:   eventReplayExitRuntime,
+		authExit:      eventReplayExitAuth,
+		notFoundExit:  eventReplayExitNotFound,
+		conflictExit:  eventReplayExitConflict,
+		notFoundCodes: []string{"EVENT_NOT_FOUND"},
+		conflictCodes: []string{
+			"EVENT_REPLAY_NO_DELIVERY_HISTORY",
 			"EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
 			"EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
 			"EVENT_REPLAY_NOT_ELIGIBLE",
 			"PAYLOAD_VALIDATION_FAILED",
-			"IDEMPOTENCY_CONFLICT":
-			return eventReplayExitConflict
-		default:
-			return eventReplayExitRuntime
-		}
-	}
-	return eventReplayExitRuntime
+			"IDEMPOTENCY_CONFLICT",
+		},
+	})
 }

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -675,33 +674,10 @@ func runCommandTerminalExit(status string) error {
 }
 
 func runCommandErrorExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	if strings.Contains(err.Error(), "SWARM_API_TOKEN is required") {
-		return 4
-	}
-	var httpErr *cliAPIHTTPError
-	if errors.As(err, &httpErr) {
-		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {
-			return 4
-		}
-		return 3
-	}
-	var rpcErr *jsonRPCError
-	if errors.As(err, &rpcErr) {
-		switch applicationErrorCode(rpcErr.Data) {
-		case "UNAUTHORIZED":
-			return 4
-		case "RUN_NOT_FOUND":
-			return 5
-		case "BUNDLE_MISMATCH", "UNSUPPORTED_BUNDLE_REF", "IDEMPOTENCY_CONFLICT":
-			return 6
-		default:
-			return 3
-		}
-	}
-	return 3
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		notFoundCodes: []string{"RUN_NOT_FOUND"},
+		conflictCodes: []string{"BUNDLE_MISMATCH", "UNSUPPORTED_BUNDLE_REF", "IDEMPOTENCY_CONFLICT"},
+	})
 }
 
 func writeRunCommandStarted(out io.Writer, result runStartResult) {

--- a/cmd/swarm/version_command_test.go
+++ b/cmd/swarm/version_command_test.go
@@ -139,8 +139,8 @@ func TestVersionServerRequiresTokenBeforeRequest(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
 		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
@@ -157,6 +157,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		handler    http.HandlerFunc
+		wantCode   int
 		wantStderr string
 	}{
 		{
@@ -165,6 +166,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
+			wantCode:   4,
 			wantStderr: "v1 RPC HTTP 401",
 		},
 		{
@@ -183,6 +185,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 					},
 				})
 			},
+			wantCode:   4,
 			wantStderr: "UNAUTHORIZED: unauthorized",
 		},
 		{
@@ -193,6 +196,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 				w.Header().Set("content-type", "application/json")
 				_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "1.0", "id": req.ID, "result": validVersionHealthResult()})
 			},
+			wantCode:   3,
 			wantStderr: "malformed JSON-RPC response",
 		},
 		{
@@ -208,6 +212,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 				}
 				writeJSONRPCResult(t, w, req.ID, result)
 			},
+			wantCode:   3,
 			wantStderr: "bundle.workflow_version is required",
 		},
 	} {
@@ -218,8 +223,8 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, testRootCommandOptions(server))
-			if code != 2 {
-				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
@@ -241,8 +246,8 @@ func TestVersionServerFailsClosedOnTransportError(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--server"}, &stdout, &stderr, opts)
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5381,9 +5381,12 @@ cli_specification:
         tracker: '#844'
         action: Promote exact universal flag, config-file, and environment-precedence rules before implementation.
       exit_code_and_error_channel_normalization:
-        disposition: tracked_child
+        disposition: promoted_first_slice
         tracker: '#846'
-        action: Promote exact exit-code taxonomy and stderr/stdout error-channel rules before implementation.
+        action: >
+          The currently implemented API-backed command first slice is promoted in
+          cli_specification.foundations.error_channel_and_exit_code_contract. Remaining review-artifact output-mode and
+          universal flag semantics stay split to #848/#844.
       output_modes_and_shared_renderer:
         disposition: tracked_child
         tracker: '#848'
@@ -5504,6 +5507,48 @@ cli_specification:
       `swarm investigate` is retired legacy topology and MUST NOT be extended.
     output_contract: 'Default output is human/agent-readable text. `--json` emits JSON or NDJSON for streaming commands. `--quiet` prints only the load-bearing value.'
     auth_boundary: 'Runtime-state commands use v1 bearer auth through `SWARM_API_TOKEN`; legacy Builder/operator token fallback is invalid.'
+    error_channel_and_exit_code_contract:
+      implemented_by: '#846'
+      scope: >
+        First-slice normalization for currently implemented API-backed CLI commands. This applies to diagnostics/read
+        paths, mailbox list/view/decisions, version --server, agents list/view, agent mutations, control commands, event
+        list/follow/view/replay/publish, and swarm run shared API/client failures. Future command families consume this
+        contract when their API-backed implementation is promoted.
+      canonical_owner: cmd/swarm shared CLI API error classifier
+      stdout_rule: >
+        stdout is reserved for successful load-bearing command output. API/client/runtime errors, malformed API
+        responses, validation failures, and retired-namespace migration messages render to stderr.
+      root_fallback_rule: >
+        The root Cobra fallback keeps exit 2 for CLI syntax, misuse, invalid args, retired aliases, and other no-API-call
+        validation paths. Implemented API-backed commands MUST classify shared API/client/runtime errors before returning;
+        they MUST NOT leak missing-token, HTTP/RPC auth, transport, JSON-RPC envelope, malformed result, or known
+        application-code errors into the root fallback.
+      exit_codes:
+        success: 0
+        cli_validation_or_misuse_before_api_call: 2
+        runtime_transport_readiness_or_malformed_api: 3
+        auth_or_missing_token: 4
+        resource_not_found: 5
+        resource_state_or_conflict: 6
+        run_terminal_failed_or_cancelled: 7
+        interrupted_or_detached: 130
+      shared_classification:
+        missing_swarm_api_token: 4
+        http_401_or_403: 4
+        json_rpc_application_code_UNAUTHORIZED: 4
+        known_resource_not_found_application_codes: 5
+        known_resource_state_or_idempotency_conflict_application_codes: 6
+        transport_errors_http_non_auth_json_rpc_envelope_errors_unknown_rpc_codes_and_malformed_success_payloads: 3
+      command_local_preservation: >
+        Commands may define resource-specific not-found and conflict application-code sets, and `swarm run` preserves
+        terminal workflow exit 7 and interrupt/detach exit 130. Those command-local helpers still delegate shared
+        API/client categories to the canonical classifier.
+      split_siblings:
+      - '#844 universal flag/config/env precedence'
+      - '#848 --json/--quiet/output renderer normalization'
+      - '#839 retired namespace migration cleanup'
+      - absent #735 command families
+      - API/runtime method semantics
   tiers:
     must_have: 'Closure-gate command set for the promoted CLI v2 catalog.'
     should_have: 'Subsequent slices and backlog commands; each still requires a gated implementation child before code changes.'
@@ -5966,7 +6011,9 @@ cli_specification:
         columns: AGENT_ID, ROLE, TYPE, STATUS, MODEL_TIER, MODE, SCOPE
       exit_codes:
         success: 0
-        cli_validation_or_transport_or_rpc_or_malformed_response: 2
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc agent.list call with flow/role params only when provided
       - fail-closed SWARM_API_TOKEN behavior before any request
@@ -5985,7 +6032,12 @@ cli_specification:
         refs_only: optional current_session_ref and last_turn_ref lines when present
       exit_codes:
         success: 0
-        cli_validation_or_transport_or_rpc_or_malformed_response: 2
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - AGENT_NOT_FOUND
       proof_expectations:
       - exact /v1/rpc agent.get call with agent_id
       - AGENT_NOT_FOUND and malformed AgentDetail responses fail closed


### PR DESCRIPTION
Closes #846

## Governing refs/context
- Authoritative spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification`
- Approved gate: #846 lead gate outcome `approved as first slice` for currently implemented API-backed CLI exit-code/error-channel normalization.

## Semantic migration
- New canonical owner: `cmd/swarm` shared CLI API error classifier (`cliAPIErrorExitCode` / `returnCLIAPIError`).
- Old non-authoritative paths now invalid: command-local duplicated missing-token/auth/HTTP/RPC classifiers and raw read-path API/client errors leaking to the root exit-2 fallback.
- Production paths checked/migrated: diagnostics/read paths, mailbox list/view/decisions, version `--server`, agents list/view, agent mutations, control commands, event list/follow/view/replay/publish, and `swarm run` shared API/client categories.
- Migration completeness: complete for currently implemented API-backed commands; #844, #848, #839, absent #735 command families, and API/runtime semantics remain split.

## Proof
- `go test ./cmd/swarm -run 'TestCLIAPIErrorExitCodeClassifiesSharedCategories|Test.*(MissingToken|RequiresToken|FailClosed|Transport|RPC|Malformed|Exit|Auth)' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Built-binary smoke: missing token exits 4 for `swarm runs` and `swarm agent restart agent-1`.
- Grep proof: shared missing-token/auth/RPC classification logic only remains in `cmd/swarm/cli_errors.go`.