### PR TITLE
[agent-c][issue #864] Return empty run diagnose heuristics

### DIFF
--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -603,6 +603,15 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 			t.Fatalf("%s result missing top-level key %q: %#v", methodName, key, result)
 		}
 	}
+	if methodName == "run.diagnose" {
+		heuristics, ok := result["heuristics"].([]any)
+		if !ok {
+			t.Fatalf("run.diagnose heuristics = %#v, want array", result["heuristics"])
+		}
+		if len(heuristics) != 0 {
+			t.Fatalf("run.diagnose heuristics = %#v, want empty array", heuristics)
+		}
+	}
 }
 
 func assertReadOnlyProbeInvalidParams(t *testing.T, methodName string, resp rpcResponse, field string) {

--- a/internal/store/run_operational_status_read_surface.go
+++ b/internal/store/run_operational_status_read_surface.go
@@ -60,7 +60,7 @@ func ProjectRunOperationalStatus(report RunDebugReport) RunOperationalStatus {
 
 func runOperationalStatusHeuristics(report RunDebugReport) []string {
 	if len(report.DeadLetters) == 0 {
-		return nil
+		return []string{}
 	}
 	return []string{"dead letters exist for this run"}
 }

--- a/internal/store/run_operational_status_read_surface_test.go
+++ b/internal/store/run_operational_status_read_surface_test.go
@@ -93,4 +93,31 @@ func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveries
 	if got.BlockingLayer != "" || got.BlockingReason != "" {
 		t.Fatalf("unexpected blocking projection: %#v", got)
 	}
+	if got.Heuristics == nil {
+		t.Fatal("heuristics = nil, want empty slice")
+	}
+	if len(got.Heuristics) != 0 {
+		t.Fatalf("heuristics = %#v, want empty", got.Heuristics)
+	}
+}
+
+func TestProjectRunOperationalStatus_EmitsDeadLetterHeuristic(t *testing.T) {
+	report := RunDebugReport{
+		RunTableStatus: "running",
+		LastEventAt:    time.Unix(1700000000, 0).UTC(),
+		Deliveries: []RunDebugDeliveryCount{
+			{SubscriberID: "agent-1", Status: "in_progress", Count: 1},
+		},
+		DeadLetters: []RunDebugDeadLetter{
+			{OriginalEvent: "evt-1", FailureType: "handler_error"},
+		},
+	}
+
+	got := ProjectRunOperationalStatus(report)
+	if len(got.Heuristics) != 1 {
+		t.Fatalf("heuristics = %#v, want one item", got.Heuristics)
+	}
+	if got.Heuristics[0] != "dead letters exist for this run" {
+		t.Fatalf("heuristic = %q, want dead letters note", got.Heuristics[0])
+	}
 }


### PR DESCRIPTION
## Summary

Part of #864.

This first-slice PR repairs only the approved API contract bug: `run.diagnose` now returns `heuristics: []` instead of `heuristics: null` when the canonical run diagnosis projection has no heuristic notes.

The Empire/product `entity_type: "default"` projection and `entity.aggregate(type: "vertical")` concern remains out of scope for a separate owner audit.

## Spec References

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.RunDiagnosis`: `heuristics` is a required array of strings.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `method_catalog.run.diagnose`: `run.diagnose` returns `RunDiagnosis` and routes the operator-state projection through the API.
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` `components.schemas.RunDiagnosis`: generated OpenRPC marks `heuristics` required and array-typed.
- Runtime note: `run.diagnose` exposes `internal/store/run_operational_status_read_surface.go.ProjectRunOperationalStatus` over JSON-RPC; the projection remains the canonical owner.

## Canonical Owner / Migration

- New canonical owner: unchanged, `internal/store/run_operational_status_read_surface.go.ProjectRunOperationalStatus` / `runOperationalStatusHeuristics`.
- Old invalid path: nil empty heuristic slice from the projection is no longer valid for the `RunDiagnosis` wire contract.
- Production paths checked: store projection and `/v1/rpc` `run.diagnose` supported-surface serialization through `Handler.ServeHTTP`.
- Migration: not applicable; no persisted data/schema change.

## Tests

- `go test ./internal/store -run TestProjectRunOperationalStatus -count=1`
- `go test ./internal/apiv1 -run 'TestOpenRPCReadOnlyHTTPRuntimeProbes/run.diagnose/success_smoke|TestOperatorReadHandlersExposeHealthAndRunReadMethods' -count=1`
- `go test ./internal/apiv1 -run TestOpenRPCReadOnlyHTTPRuntimeProbes -count=1`

## Residual Risk

This PR proves the method-specific `RunDiagnosis.heuristics` empty-array contract. It does not claim full generated result-schema validation for all OpenRPC methods; that parent remains tracked by #857 / `operator_surfaces.v1_openrpc_api_conformance`.