### PR TITLE
[agent-b][issue #876] Implement swarm logs CLI

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -72,6 +72,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newStatusCommand(opts),
 		newTraceCommand(opts),
 		newHealthCommand(opts),
+		newLogsCommand(opts),
 		newInvestigateCommand(opts),
 		newEventsCommand(opts),
 		newEventCommand(opts),

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -1,0 +1,534 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/spf13/cobra"
+)
+
+const (
+	runtimeLogsMethodList      = "runtime.logs"
+	runtimeLogsMethodSubscribe = "runtime.subscribe_logs"
+)
+
+type runtimeLogCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	runID     string
+	entityID  string
+	sessionID string
+	component string
+	level     string
+	errorCode string
+	source    string
+
+	follow      bool
+	replaySince string
+
+	since  string
+	until  string
+	limit  int
+	cursor string
+	order  string
+
+	limitSet  bool
+	cursorSet bool
+	orderSet  bool
+	sinceSet  bool
+	untilSet  bool
+}
+
+type runtimeLogListResult struct {
+	Logs       []runtimeLogEntry `json:"logs"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type runtimeLogEntry struct {
+	LogID     string         `json:"log_id"`
+	TS        string         `json:"ts"`
+	Level     string         `json:"level"`
+	Component string         `json:"component"`
+	Source    string         `json:"source"`
+	RunID     string         `json:"run_id,omitempty"`
+	EntityID  string         `json:"entity_id,omitempty"`
+	SessionID string         `json:"session_id,omitempty"`
+	ErrorCode string         `json:"error_code,omitempty"`
+	Message   string         `json:"message"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+type runtimeLogSubscriptionResult struct {
+	SubscriptionID string `json:"subscription_id"`
+}
+
+type runtimeLogSubscriptionNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  struct {
+		Subscription string          `json:"subscription"`
+		Result       runtimeLogEntry `json:"result"`
+	} `json:"params"`
+}
+
+type runtimeLogSubscription struct {
+	conn           *websocket.Conn
+	subscriptionID string
+	logs           chan runtimeLogEntry
+	errs           chan error
+}
+
+var runtimeLogValidLevels = map[string]struct{}{
+	"debug": {},
+	"info":  {},
+	"warn":  {},
+	"error": {},
+}
+
+var runtimeLogValidOrders = map[string]struct{}{
+	"asc":  {},
+	"desc": {},
+}
+
+func newLogsCommand(opts rootCommandOptions) *cobra.Command {
+	logOpts := runtimeLogCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "logs [filters]",
+		Short: "List or follow runtime logs through v1 API owners.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logOpts.limitSet = cmd.Flags().Changed("limit")
+			logOpts.cursorSet = cmd.Flags().Changed("cursor")
+			logOpts.orderSet = cmd.Flags().Changed("order")
+			logOpts.sinceSet = cmd.Flags().Changed("since")
+			logOpts.untilSet = cmd.Flags().Changed("until")
+			return runLogsCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), logOpts)
+		},
+	}
+	cmd.Flags().StringVar(&logOpts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().StringVar(&logOpts.entityID, "entity-id", "", "Filter by entity id")
+	cmd.Flags().StringVar(&logOpts.sessionID, "session-id", "", "Filter by session id")
+	cmd.Flags().StringVar(&logOpts.component, "component", "", "Filter by runtime component")
+	cmd.Flags().StringVar(&logOpts.level, "level", "", "Filter by log level: debug, info, warn, or error")
+	cmd.Flags().StringVar(&logOpts.errorCode, "error-code", "", "Filter by error code")
+	cmd.Flags().StringVar(&logOpts.source, "source", "", "Filter by log source")
+	cmd.Flags().BoolVar(&logOpts.follow, "follow", false, "Follow matching runtime logs through /v1/ws runtime.subscribe_logs")
+	cmd.Flags().StringVar(&logOpts.replaySince, "replay-since", "", "With --follow, optional RFC3339 catch-up window start")
+	cmd.Flags().StringVar(&logOpts.since, "since", "", "Snapshot-only RFC3339 lower timestamp bound")
+	cmd.Flags().StringVar(&logOpts.until, "until", "", "Snapshot-only RFC3339 upper timestamp bound")
+	cmd.Flags().IntVar(&logOpts.limit, "limit", 0, "Snapshot-only page size, 1-1000")
+	cmd.Flags().StringVar(&logOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
+	cmd.Flags().StringVar(&logOpts.order, "order", "", "Snapshot-only sort order: asc or desc")
+	return cmd
+}
+
+func runLogsCommand(ctx context.Context, out, errOut io.Writer, opts runtimeLogCommandOptions) error {
+	if opts.follow {
+		return runLogsFollowCommand(ctx, out, errOut, opts)
+	}
+	return runLogsSnapshotCommand(ctx, out, errOut, opts)
+}
+
+func runLogsSnapshotCommand(ctx context.Context, out, errOut io.Writer, opts runtimeLogCommandOptions) error {
+	params, err := opts.snapshotParams()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	var result runtimeLogListResult
+	if err := client.call(ctx, runtimeLogsMethodList, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	if err := validateRuntimeLogListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	writeRuntimeLogListResult(out, result)
+	return nil
+}
+
+func runLogsFollowCommand(ctx context.Context, out, errOut io.Writer, opts runtimeLogCommandOptions) error {
+	params, err := opts.followParams()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	sub, err := subscribeRuntimeLogs(ctx, wsEndpoint, client.token, params)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
+	defer sub.close()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Fprintln(errOut, "detached from runtime log stream")
+			return commandExitError{code: cliExitInterrupted}
+		case log, ok := <-sub.logs:
+			if !ok {
+				select {
+				case err := <-sub.errs:
+					if err != nil {
+						return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+					}
+				default:
+				}
+				return nil
+			}
+			writeRuntimeLogFollowEntry(out, log)
+		case err := <-sub.errs:
+			if err != nil {
+				return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+			}
+		}
+	}
+}
+
+func (opts runtimeLogCommandOptions) snapshotParams() (map[string]any, error) {
+	if strings.TrimSpace(opts.replaySince) != "" {
+		return nil, fmt.Errorf("--replay-since requires --follow")
+	}
+	params, err := opts.commonParams()
+	if err != nil {
+		return nil, err
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 1000 {
+			return nil, fmt.Errorf("--limit must be between 1 and 1000")
+		}
+		params["limit"] = opts.limit
+	}
+	if cursor := strings.TrimSpace(opts.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	if order := strings.ToLower(strings.TrimSpace(opts.order)); order != "" {
+		if _, ok := runtimeLogValidOrders[order]; !ok {
+			return nil, fmt.Errorf("--order must be one of asc, desc")
+		}
+		params["order"] = order
+	}
+	since := strings.TrimSpace(opts.since)
+	until := strings.TrimSpace(opts.until)
+	if since != "" {
+		if err := validateRFC3339Flag("--since", since); err != nil {
+			return nil, err
+		}
+		params["since"] = since
+	}
+	if until != "" {
+		if err := validateRFC3339Flag("--until", until); err != nil {
+			return nil, err
+		}
+		params["until"] = until
+	}
+	if since != "" && until != "" {
+		sinceTime, _ := time.Parse(time.RFC3339Nano, since)
+		untilTime, _ := time.Parse(time.RFC3339Nano, until)
+		if untilTime.Before(sinceTime) {
+			return nil, fmt.Errorf("--until must be greater than or equal to --since")
+		}
+	}
+	return params, nil
+}
+
+func (opts runtimeLogCommandOptions) followParams() (map[string]any, error) {
+	for _, flag := range []struct {
+		name string
+		set  bool
+	}{
+		{name: "--limit", set: opts.limitSet},
+		{name: "--cursor", set: opts.cursorSet},
+		{name: "--order", set: opts.orderSet},
+		{name: "--since", set: opts.sinceSet},
+		{name: "--until", set: opts.untilSet},
+	} {
+		if flag.set {
+			if flag.name == "--since" {
+				return nil, fmt.Errorf("--since is not supported with --follow; use --replay-since")
+			}
+			return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
+		}
+	}
+	params, err := opts.commonParams()
+	if err != nil {
+		return nil, err
+	}
+	if replaySince := strings.TrimSpace(opts.replaySince); replaySince != "" {
+		if err := validateRFC3339Flag("--replay-since", replaySince); err != nil {
+			return nil, err
+		}
+		params["replay_since"] = replaySince
+	}
+	return params, nil
+}
+
+func (opts runtimeLogCommandOptions) commonParams() (map[string]any, error) {
+	params := map[string]any{}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "run_id", value: opts.runID},
+		{name: "entity_id", value: opts.entityID},
+		{name: "session_id", value: opts.sessionID},
+		{name: "component", value: opts.component},
+		{name: "error_code", value: opts.errorCode},
+		{name: "source", value: opts.source},
+	} {
+		if value := strings.TrimSpace(field.value); value != "" {
+			params[field.name] = value
+		}
+	}
+	if level := strings.ToLower(strings.TrimSpace(opts.level)); level != "" {
+		if _, ok := runtimeLogValidLevels[level]; !ok {
+			return nil, fmt.Errorf("--level must be one of debug, info, warn, error")
+		}
+		params["level"] = level
+	}
+	return params, nil
+}
+
+func validateRuntimeLogListResult(result runtimeLogListResult) error {
+	if result.Logs == nil {
+		return fmt.Errorf("malformed runtime.logs result: logs is required")
+	}
+	for i, log := range result.Logs {
+		if err := validateRuntimeLogEntry(fmt.Sprintf("runtime.logs result: logs[%d]", i), log); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuntimeLogEntry(prefix string, log runtimeLogEntry) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "log_id", value: log.LogID},
+		{name: "ts", value: log.TS},
+		{name: "level", value: log.Level},
+		{name: "component", value: log.Component},
+		{name: "source", value: log.Source},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateRequiredTimestamp(prefix+".ts", log.TS); err != nil {
+		return err
+	}
+	level := strings.TrimSpace(log.Level)
+	if _, ok := runtimeLogValidLevels[level]; !ok {
+		return fmt.Errorf("malformed %s: level=%q is not a valid LogLevel", prefix, log.Level)
+	}
+	return nil
+}
+
+func subscribeRuntimeLogs(ctx context.Context, wsEndpoint, token string, params map[string]any) (*runtimeLogSubscription, error) {
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
+	if err != nil {
+		if resp != nil {
+			return nil, runtimeLogsWSHTTPError(resp)
+		}
+		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
+	}
+	requestID := "swarm-cli:" + runtimeLogsMethodSubscribe
+	if err := conn.WriteJSON(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      requestID,
+		Method:  runtimeLogsMethodSubscribe,
+		Params:  params,
+	}); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("write runtime.subscribe_logs request: %w", err)
+	}
+	var envelope jsonRPCResponse
+	if err := conn.ReadJSON(&envelope); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("read runtime.subscribe_logs response: %w", err)
+	}
+	if envelope.JSONRPC != "2.0" {
+		conn.Close()
+		return nil, fmt.Errorf("malformed runtime.subscribe_logs response: jsonrpc=%q", envelope.JSONRPC)
+	}
+	if id, ok := envelope.ID.(string); !ok || id != requestID {
+		conn.Close()
+		return nil, fmt.Errorf("malformed runtime.subscribe_logs response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+	}
+	if envelope.Error != nil {
+		conn.Close()
+		return nil, envelope.Error
+	}
+	var result runtimeLogSubscriptionResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("decode runtime.subscribe_logs result: %w", err)
+	}
+	if strings.TrimSpace(result.SubscriptionID) == "" {
+		conn.Close()
+		return nil, fmt.Errorf("malformed runtime.subscribe_logs result: subscription_id is required")
+	}
+	sub := &runtimeLogSubscription{
+		conn:           conn,
+		subscriptionID: result.SubscriptionID,
+		logs:           make(chan runtimeLogEntry, 16),
+		errs:           make(chan error, 1),
+	}
+	go sub.readLoop()
+	return sub, nil
+}
+
+func runtimeLogsWSHTTPError(resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	message := http.StatusText(resp.StatusCode)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err == nil && strings.TrimSpace(string(raw)) != "" {
+			message = strings.TrimSpace(string(raw))
+		}
+	}
+	return &cliAPIHTTPError{surface: "v1 WS", statusCode: resp.StatusCode, message: message}
+}
+
+func (s *runtimeLogSubscription) readLoop() {
+	defer close(s.logs)
+	for {
+		var notification runtimeLogSubscriptionNotification
+		if err := s.conn.ReadJSON(&notification); err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || strings.Contains(err.Error(), "use of closed network connection") {
+				return
+			}
+			s.reportError(fmt.Errorf("read runtime.subscribe_logs notification: %w", err))
+			return
+		}
+		if notification.JSONRPC != "2.0" || notification.Method != "rpc.subscription" {
+			s.reportError(fmt.Errorf("malformed runtime.subscribe_logs notification"))
+			return
+		}
+		if notification.Params.Subscription != s.subscriptionID {
+			s.reportError(fmt.Errorf("malformed runtime.subscribe_logs notification: subscription mismatch"))
+			return
+		}
+		log := notification.Params.Result
+		if err := validateRuntimeLogEntry("runtime.subscribe_logs notification", log); err != nil {
+			s.reportError(err)
+			return
+		}
+		select {
+		case s.logs <- log:
+		default:
+			s.reportError(fmt.Errorf("runtime.subscribe_logs notification queue overflow"))
+			return
+		}
+	}
+}
+
+func (s *runtimeLogSubscription) reportError(err error) {
+	select {
+	case s.errs <- err:
+	default:
+	}
+}
+
+func (s *runtimeLogSubscription) close() {
+	if s == nil || s.conn == nil {
+		return
+	}
+	_ = s.conn.Close()
+}
+
+func writeRuntimeLogListResult(out io.Writer, result runtimeLogListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Logs) == 0 {
+		fmt.Fprintln(out, "No runtime logs match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "TIME\tLEVEL\tCOMPONENT\tSOURCE\tRUN\tENTITY\tSESSION\tERROR\tMESSAGE")
+	for _, log := range result.Logs {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			log.TS,
+			log.Level,
+			log.Component,
+			log.Source,
+			runtimeLogDash(log.RunID),
+			runtimeLogDash(log.EntityID),
+			runtimeLogDash(log.SessionID),
+			runtimeLogDash(log.ErrorCode),
+			log.Message,
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry) {
+	if out == nil {
+		return
+	}
+	fields := []string{
+		"log_id=" + log.LogID,
+		"ts=" + log.TS,
+		"level=" + log.Level,
+		"component=" + log.Component,
+		"source=" + log.Source,
+	}
+	if log.RunID != "" {
+		fields = append(fields, "run_id="+log.RunID)
+	}
+	if log.EntityID != "" {
+		fields = append(fields, "entity_id="+log.EntityID)
+	}
+	if log.SessionID != "" {
+		fields = append(fields, "session_id="+log.SessionID)
+	}
+	if log.ErrorCode != "" {
+		fields = append(fields, "error_code="+log.ErrorCode)
+	}
+	fields = append(fields, "message="+log.Message)
+	if len(log.Details) > 0 {
+		fields = append(fields, "details="+runtimeLogCompactJSON(log.Details))
+	}
+	fmt.Fprintf(out, "log %s\n", strings.Join(fields, " "))
+}
+
+func runtimeLogCompactJSON(value map[string]any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func runtimeLogDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func runtimeLogErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -60,7 +60,7 @@ type runtimeLogEntry struct {
 	EntityID  string         `json:"entity_id,omitempty"`
 	SessionID string         `json:"session_id,omitempty"`
 	ErrorCode string         `json:"error_code,omitempty"`
-	Message   string         `json:"message"`
+	Message   *string        `json:"message"`
 	Details   map[string]any `json:"details,omitempty"`
 }
 
@@ -336,6 +336,9 @@ func validateRuntimeLogEntry(prefix string, log runtimeLogEntry) error {
 	if _, ok := runtimeLogValidLevels[level]; !ok {
 		return fmt.Errorf("malformed %s: level=%q is not a valid LogLevel", prefix, log.Level)
 	}
+	if log.Message == nil {
+		return fmt.Errorf("malformed %s: message is required", prefix)
+	}
 	return nil
 }
 
@@ -475,7 +478,7 @@ func writeRuntimeLogListResult(out io.Writer, result runtimeLogListResult) {
 			runtimeLogDash(log.EntityID),
 			runtimeLogDash(log.SessionID),
 			runtimeLogDash(log.ErrorCode),
-			log.Message,
+			runtimeLogMessage(log),
 		)
 	}
 	if strings.TrimSpace(result.NextCursor) != "" {
@@ -506,7 +509,7 @@ func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry) {
 	if log.ErrorCode != "" {
 		fields = append(fields, "error_code="+log.ErrorCode)
 	}
-	fields = append(fields, "message="+log.Message)
+	fields = append(fields, "message="+runtimeLogMessage(log))
 	if len(log.Details) > 0 {
 		fields = append(fields, "details="+runtimeLogCompactJSON(log.Details))
 	}
@@ -527,6 +530,13 @@ func runtimeLogDash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+func runtimeLogMessage(log runtimeLogEntry) string {
+	if log.Message == nil {
+		return ""
+	}
+	return *log.Message
 }
 
 func runtimeLogErrorClassifier() cliAPIErrorClassifier {

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -1,0 +1,508 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"logs":        []any{validRuntimeLogEntry("log-1")},
+			"next_cursor": "log-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"logs",
+		"--run-id", "run-1",
+		"--entity-id", "entity-1",
+		"--session-id", "session-1",
+		"--component", "scheduler",
+		"--level", "WARN",
+		"--error-code", "DELIVERY_FAILED",
+		"--source", "runtime",
+		"--since", "2026-05-19T10:00:00Z",
+		"--until", "2026-05-19T11:00:00Z",
+		"--limit", "25",
+		"--cursor", "cursor-1",
+		"--order", "ASC",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != runtimeLogsMethodList {
+		t.Fatalf("method = %q, want %s", captured.Method, runtimeLogsMethodList)
+	}
+	wantParams := map[string]any{
+		"run_id":     "run-1",
+		"entity_id":  "entity-1",
+		"session_id": "session-1",
+		"component":  "scheduler",
+		"level":      "warn",
+		"error_code": "DELIVERY_FAILED",
+		"source":     "runtime",
+		"since":      "2026-05-19T10:00:00Z",
+		"until":      "2026-05-19T11:00:00Z",
+		"limit":      float64(25),
+		"cursor":     "cursor-1",
+		"order":      "asc",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"TIME", "log message", "run-1", "entity-1", "session-1", "DELIVERY_FAILED", "next_cursor=log-cursor-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestLogsFollowUsesRuntimeSubscribeLogsV1WS(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, wsRequests := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
+		logs:           []map[string]any{validRuntimeLogEntry("log-live-1")},
+		closeAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"logs",
+		"--follow",
+		"--run-id", "run-1",
+		"--entity-id", "entity-1",
+		"--session-id", "session-1",
+		"--component", "scheduler",
+		"--level", "info",
+		"--error-code", "DELIVERY_FAILED",
+		"--source", "runtime",
+		"--replay-since", "2026-05-19T10:00:00Z",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*wsRequests) != 1 {
+		t.Fatalf("ws requests = %d, want 1", len(*wsRequests))
+	}
+	req := (*wsRequests)[0]
+	if req.Method != runtimeLogsMethodSubscribe {
+		t.Fatalf("method = %q, want %s", req.Method, runtimeLogsMethodSubscribe)
+	}
+	wantParams := map[string]any{
+		"run_id":       "run-1",
+		"entity_id":    "entity-1",
+		"session_id":   "session-1",
+		"component":    "scheduler",
+		"level":        "info",
+		"error_code":   "DELIVERY_FAILED",
+		"source":       "runtime",
+		"replay_since": "2026-05-19T10:00:00Z",
+	}
+	if !reflect.DeepEqual(req.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
+	}
+	for _, want := range []string{"log log_id=log-live-1", "run_id=run-1", "message=log message", "details={\"attempt\":2}"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestLogsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"logs": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "invalid level", args: []string{"logs", "--level", "fatal"}, wantStderr: "--level must be one of"},
+		{name: "invalid order", args: []string{"logs", "--order", "sideways"}, wantStderr: "--order must be one of"},
+		{name: "invalid limit", args: []string{"logs", "--limit", "0"}, wantStderr: "--limit must be between 1 and 1000"},
+		{name: "invalid since", args: []string{"logs", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "invalid window", args: []string{"logs", "--since", "2026-05-19T11:00:00Z", "--until", "2026-05-19T10:00:00Z"}, wantStderr: "--until must be greater than or equal to --since"},
+		{name: "replay without follow", args: []string{"logs", "--replay-since", "2026-05-19T10:00:00Z"}, wantStderr: "--replay-since requires --follow"},
+		{name: "follow rejects limit", args: []string{"logs", "--follow", "--limit", "10"}, wantStderr: "--limit is not supported with --follow"},
+		{name: "follow rejects since", args: []string{"logs", "--follow", "--since", "2026-05-19T10:00:00Z"}, wantStderr: "--since is not supported with --follow; use --replay-since"},
+		{name: "follow rejects cursor", args: []string{"logs", "--follow", "--cursor", "cursor-1"}, wantStderr: "--cursor is not supported with --follow"},
+		{name: "follow invalid replay since", args: []string{"logs", "--follow", "--replay-since", "not-time"}, wantStderr: "--replay-since must be an RFC3339 timestamp"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestLogsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"logs": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"logs"},
+		{"logs", "--follow"},
+	} {
+		calls.Store(0)
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 4 {
+			t.Fatalf("args=%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			t.Fatalf("stderr = %q, want token failure", stderr.String())
+		}
+		if calls.Load() != 0 {
+			t.Fatalf("args=%v calls = %d, want 0", args, calls.Load())
+		}
+	}
+}
+
+func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth exits four",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "unknown rpc error exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeRuntimeLogJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "unauthorized rpc exits four",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeRuntimeLogJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "malformed list missing logs exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "logs is required",
+		},
+		{
+			name: "malformed log row exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				log := validRuntimeLogEntry("log-1")
+				delete(log, "log_id")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"logs": []any{log}})
+			},
+			wantCode:   3,
+			wantStderr: "log_id is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestLogsFollowMalformedWSFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		subscriptionResult map[string]any
+		logs               []map[string]any
+		wantStderr         string
+	}{
+		{
+			name:               "missing subscription id",
+			subscriptionResult: map[string]any{},
+			wantStderr:         "subscription_id is required",
+		},
+		{
+			name: "malformed notification",
+			logs: []map[string]any{
+				func() map[string]any {
+					log := validRuntimeLogEntry("log-1")
+					delete(log, "ts")
+					return log
+				}(),
+			},
+			wantStderr: "ts is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
+				subscriptionResult: tc.subscriptionResult,
+				logs:               tc.logs,
+				closeAfterRows:     true,
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"logs", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestLogsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var rpcCalls atomic.Int32
+	var wsCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/rpc":
+			rpcCalls.Add(1)
+			t.Errorf("unexpected RPC request for log follow")
+			http.Error(w, "unexpected rpc", http.StatusInternalServerError)
+		case "/v1/ws":
+			wsCalls.Add(1)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"logs", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if rpcCalls.Load() != 0 {
+		t.Fatalf("rpc calls = %d, want 0", rpcCalls.Load())
+	}
+	if wsCalls.Load() != 1 {
+		t.Fatalf("ws calls = %d, want 1", wsCalls.Load())
+	}
+	if !strings.Contains(stderr.String(), "v1 WS HTTP 401") {
+		t.Fatalf("stderr = %q, want WS auth status", stderr.String())
+	}
+}
+
+func TestLogsFollowCancellationReturnsInterrupted(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	ctx, cancel := context.WithCancel(context.Background())
+	server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
+		afterSubscription: cancel,
+	})
+	defer server.Close()
+
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"logs", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 130 {
+		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "detached from runtime log stream") {
+		t.Fatalf("stderr = %q, want detach message", stderr.String())
+	}
+}
+
+type runtimeLogWSServerOptions struct {
+	subscriptionResult map[string]any
+	logs               []map[string]any
+	closeAfterRows     bool
+	afterSubscription  func()
+}
+
+func newRuntimeLogWSServer(t *testing.T, opts runtimeLogWSServerOptions) (*httptest.Server, *[]jsonRPCRequest) {
+	t.Helper()
+	var mu sync.Mutex
+	wsRequests := []jsonRPCRequest{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/rpc":
+			t.Fatalf("unexpected RPC request for log follow")
+		case "/v1/ws":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Errorf("WS Authorization = %q, want bearer token", got)
+			}
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade websocket: %v", err)
+				return
+			}
+			defer conn.Close()
+			var req jsonRPCRequest
+			if err := conn.ReadJSON(&req); err != nil {
+				t.Errorf("read ws request: %v", err)
+				return
+			}
+			mu.Lock()
+			wsRequests = append(wsRequests, req)
+			mu.Unlock()
+			result := opts.subscriptionResult
+			if result == nil {
+				result = map[string]any{"subscription_id": "sub-logs"}
+			}
+			if err := conn.WriteJSON(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  result,
+			}); err != nil {
+				t.Errorf("write ws subscription response: %v", err)
+				return
+			}
+			if opts.afterSubscription != nil {
+				opts.afterSubscription()
+			}
+			for _, log := range opts.logs {
+				if err := conn.WriteJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"method":  "rpc.subscription",
+					"params": map[string]any{
+						"subscription": "sub-logs",
+						"result":       log,
+					},
+				}); err != nil {
+					return
+				}
+			}
+			if opts.closeAfterRows {
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
+			}
+			<-r.Context().Done()
+		default:
+			t.Errorf("path = %q, want /v1/ws", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	return server, &wsRequests
+}
+
+func validRuntimeLogEntry(logID string) map[string]any {
+	return map[string]any{
+		"log_id":     logID,
+		"ts":         "2026-05-19T10:00:01Z",
+		"level":      "info",
+		"component":  "scheduler",
+		"source":     "runtime",
+		"run_id":     "run-1",
+		"entity_id":  "entity-1",
+		"session_id": "session-1",
+		"error_code": "DELIVERY_FAILED",
+		"message":    "log message",
+		"details": map[string]any{
+			"attempt": 2,
+		},
+	}
+}
+
+func writeRuntimeLogJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -280,6 +280,19 @@ func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantCode:   3,
 			wantStderr: "log_id is required",
 		},
+		{
+			name: "malformed log row missing message exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				log := validRuntimeLogEntry("log-1")
+				delete(log, "message")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"logs": []any{log}})
+			},
+			wantCode:   3,
+			wantStderr: "message is required",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -320,6 +333,17 @@ func TestLogsFollowMalformedWSFailsClosed(t *testing.T) {
 				}(),
 			},
 			wantStderr: "ts is required",
+		},
+		{
+			name: "malformed notification missing message",
+			logs: []map[string]any{
+				func() map[string]any {
+					log := validRuntimeLogEntry("log-1")
+					delete(log, "message")
+					return log
+				}(),
+			},
+			wantStderr: "message is required",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5432,9 +5432,9 @@ cli_specification:
         tracker: '#735'
         action: '`swarm entities list`, `swarm entity view`, and `swarm entity aggregate` require separate gated children.'
       logs:
-        disposition: future_child
-        tracker: '#735'
-        action: '`swarm logs` snapshot/follow semantics require a separate gated child.'
+        disposition: promoted_first_slice
+        tracker: '#876'
+        action: '`swarm logs` snapshot and follow semantics are promoted as one bounded CLI child over runtime.logs and runtime.subscribe_logs; richer output-mode work remains split to #848.'
       incidents:
         disposition: future_child
         tracker: '#735'
@@ -6548,10 +6548,56 @@ cli_specification:
       implementation_status: absent
       owner: /v1/rpc entity.aggregate
     logs:
-      command: swarm logs [filters]
+      command: swarm logs [filters] [--follow]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owners: /v1/rpc runtime.logs for snapshot; /v1/ws runtime.subscribe_logs for --follow
+      behavior: >-
+        Runtime-log observation CLI consumer. Snapshot mode sends runtime.logs filter, time-window, pagination, and order
+        params through the shared v1 API client. Follow mode sends only runtime-log identity/content filters plus optional
+        replay_since through /v1/ws runtime.subscribe_logs. The CLI renders server-owned LogEntry rows and never reads
+        runtime logs directly from DB/store/runtime/EventBus/dashboard/process logs/container logs.
+      flags:
+        shared_filters:
+        - --run-id <run-id>
+        - --entity-id <entity-id>
+        - --session-id <session-id>
+        - --component <component>
+        - --level <debug|info|warn|error>
+        - --error-code <code>
+        - --source <source>
+        snapshot_only:
+        - --since <RFC3339>
+        - --until <RFC3339>
+        - --limit <1-1000>
+        - --cursor <cursor>
+        - --order <asc|desc>
+        follow_only:
+        - --follow
+        - --replay-since <RFC3339>
+        follow_rejected_snapshot_flags:
+        - --since
+        - --until
+        - --limit
+        - --cursor
+        - --order
+      output:
+        snapshot_table: TIME / LEVEL / COMPONENT / SOURCE / RUN / ENTITY / SESSION / ERROR / MESSAGE plus next_cursor when present
+        snapshot_empty: No runtime logs match the filter.
+        follow_notification_line: log log_id=<id> ts=<timestamp> level=<level> component=<component> source=<source> [run_id=<run>] [entity_id=<entity>] [session_id=<session>] [error_code=<code>] message=<message> [details=<compact-json>]
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        interrupted: 130
+      proof_expectations:
+      - exact /v1/rpc runtime.logs call with run_id, entity_id, session_id, component, level, error_code, source, since, until, limit, cursor, and order params only
+      - exact /v1/ws runtime.subscribe_logs call with run_id, entity_id, session_id, component, level, error_code, source, and replay_since params only
+      - follow rejects --since, --until, --limit, --cursor, and --order before opening the WebSocket; --replay-since is accepted only with --follow
+      - invalid flags and missing SWARM_API_TOKEN make zero API or WS calls
+      - malformed runtime.logs results, malformed runtime.subscribe_logs subscription results/notifications, auth/HTTP/RPC/WS failures, and cancellation are tested with closed exit-code behavior
+      - no direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and no legacy /api/*, /rpc, /api/rpc, /ws, or /api/ws usage
     incidents:
       command: swarm incidents [filters]
       tier: should_have
@@ -6633,6 +6679,7 @@ cli_specification:
     - swarm event view
     - swarm event replay
     - swarm event publish
+    - swarm logs
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6645,7 +6692,6 @@ cli_specification:
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     - swarm entities list / entity view / entity aggregate
-    - swarm logs
     - swarm incidents
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5618,7 +5618,14 @@ cli_specification:
         - event_view
         - event_replay
         - event_publish
+        - logs
         - run
+        implemented_consumer_residuals:
+          logs: >
+            `swarm logs` is implemented for default-text snapshot and follow in #876 and is no longer an absent
+            command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
+            implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #876 does not add
+            command-local output-mode flags or semantics.
       exception_rules:
         root_help_completion:
           commands:
@@ -5656,7 +5663,6 @@ cli_specification:
           - entities_list
           - entity_view
           - entity_aggregate
-          - logs
           - incidents
           rule: >
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future


### PR DESCRIPTION
## Summary
- Implements `swarm logs` snapshot mode over `/v1/rpc runtime.logs`.
- Implements `swarm logs --follow` over `/v1/ws runtime.subscribe_logs`.
- Promotes the merge-bearing CLI catalog row in `platform-spec.yaml` with exact flags, output, exit codes, and proof expectations.

Closes #876
Part of #735

## Governing refs/context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.logs`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.runtime.logs`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.runtime.subscribe_logs`
- #876 Pre-Implementation Coverage Audit and approved gate outcome: first slice for `swarm logs` snapshot/follow only.

## Semantic migration / owner boundary
- New CLI consumer: `swarm logs [filters] [--follow]`.
- Canonical owners consumed: `/v1/rpc runtime.logs` for snapshot; `/v1/ws runtime.subscribe_logs` for follow.
- Old producer/reader/writer paths now invalid for this CLI surface: direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and legacy `/api/*`, `/rpc`, `/ws` transports.
- Production paths checked for surviving old behavior: `cmd/swarm` implementation and tests; no legacy or direct runtime-log reads are introduced.
- Migration completeness: complete for the #876 CLI logs snapshot/follow child. Conversations, entities, incidents, output modes, and richer UX remain separately tracked.

## Proof
- `go test ./cmd/swarm -run 'Logs|RuntimeLog' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep: `rg -n 'swarm/internal|database/sql|EventBus|ListOperatorRuntimeLogs|operatorRuntime|Docker|docker|container|dashboard|Builder|/api/|/api/rpc|/api/ws' cmd/swarm/logs.go cmd/swarm/logs_test.go` returned no matches.
