### PR TITLE
[agent-a][issue #853] Promote serve listener bind contract

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -126,7 +126,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Store mode: postgres")
-	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", opts.HealthAddr, "HTTP bind address for health checks")
+	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", opts.HealthAddr, "HTTP bind address for the unified serve listener: health, readiness, API, WebSocket, MCP, and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
 	cmd.Flags().BoolVar(&opts.Dev, "dev", opts.Dev, "Enable local development mode: abandon active runs, skip bundle-match admission, emit verbose boot output, and clean up dev entity containers on shutdown")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -47,6 +47,8 @@ import (
 const (
 	defaultPlatformSpecPath = "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml"
 	defaultHealthAddr       = ":8081"
+	serveUnifiedRoutes      = "/healthz /readyz /v1/rpc /v1/ws /mcp /tools/"
+	serveReadinessRoutes    = "/healthz /readyz"
 )
 
 var (
@@ -319,14 +321,14 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("start runtime: %v", err)
 		return 1
 	}
-	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("health=%s routes=/healthz /readyz /v1/rpc /v1/ws", healthListener.Addr()))
+	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("listener=%s routes=%s", healthListener.Addr(), serveUnifiedRoutes))
 	ready.Store(true)
 	if err := waitForServeHealthEndpoints(ctx, healthListener.Addr()); err != nil {
 		reporter.emit(21, "health_endpoints_respond", "FAILED", err.Error())
 		log.Printf("health endpoint verification failed: %v", err)
 		return 1
 	}
-	reporter.emit(21, "health_endpoints_respond", "ok", "/healthz /readyz")
+	reporter.emit(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
 	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	logReadySummary(source, contractsRoot, opts.HealthAddr)
 
@@ -1767,7 +1769,7 @@ func shutdownHealthServer(server *http.Server) {
 
 func logReadySummary(source semanticview.Source, contractsRoot, healthAddr string) {
 	log.Printf(
-		"swarm runtime ready contracts=%s flows=%d nodes=%d agents=%d events=%d health=%s",
+		"swarm runtime ready contracts=%s flows=%d nodes=%d agents=%d events=%d listener=%s",
 		contractsRoot,
 		len(source.FlowSchemaEntries()),
 		len(source.NodeEntries()),

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -302,7 +302,7 @@ func TestPlatformSpecServeUnifiedListenerBindContractPromoted(t *testing.T) {
 	if strings.TrimSpace(spec.Flag) != "--health-addr <addr>" {
 		t.Fatalf("listener contract flag = %q, want --health-addr <addr>", spec.Flag)
 	}
-	for _, want := range []string{"single HTTP listener", "health-specific name", "API", "MCP"} {
+	for _, want := range []string{"single HTTP listener", "health-specific name", "not declare `--health-addr` to be the final CLI v2 listener", "API", "MCP"} {
 		if !strings.Contains(spec.Semantics, want) {
 			t.Fatalf("listener semantics missing %q:\n%s", want, spec.Semantics)
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -28,6 +28,7 @@ import (
 	runtimedeadletters "swarm/internal/runtime/deadletters"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	runtimerunquiescence "swarm/internal/runtime/runquiescence"
@@ -158,9 +159,14 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--contracts", "--health-addr", "unified serve listener", "MCP, and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"--api-port", "--mcp-port", "--api ", "--no-api", "--mcp ", "--no-mcp", "--log-level"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("serve help exposed unpromoted listener/topology flag %q:\n%s", notWant, stdout.String())
 		}
 	}
 }
@@ -284,6 +290,51 @@ func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 	for _, want := range []string{"Scaffold/system", "operator-managed", "unlabeled", "`kind=agent`", "`kind=flow`"} {
 		if !strings.Contains(spec.PreservationBoundary, want) {
 			t.Fatalf("dev mode preservation boundary missing %q:\n%s", want, spec.PreservationBoundary)
+		}
+	}
+}
+
+func TestPlatformSpecServeUnifiedListenerBindContractPromoted(t *testing.T) {
+	spec := loadServeUnifiedListenerSpec(t)
+	if strings.TrimSpace(spec.ImplementedBy) != "#853" {
+		t.Fatalf("listener contract implemented_by = %q, want #853", spec.ImplementedBy)
+	}
+	if strings.TrimSpace(spec.Flag) != "--health-addr <addr>" {
+		t.Fatalf("listener contract flag = %q, want --health-addr <addr>", spec.Flag)
+	}
+	for _, want := range []string{"single HTTP listener", "health-specific name", "API", "MCP"} {
+		if !strings.Contains(spec.Semantics, want) {
+			t.Fatalf("listener semantics missing %q:\n%s", want, spec.Semantics)
+		}
+	}
+	for _, want := range []string{"/healthz", "/readyz"} {
+		if !stringSliceContains(spec.Routes.Always, want) {
+			t.Fatalf("listener always routes missing %q: %#v", want, spec.Routes.Always)
+		}
+	}
+	for _, want := range []string{"/v1/rpc", "/v1/ws"} {
+		if !stringSliceContains(spec.Routes.WhenAPIHandlerInstalled, want) {
+			t.Fatalf("listener API routes missing %q: %#v", want, spec.Routes.WhenAPIHandlerInstalled)
+		}
+	}
+	for _, want := range []string{"/mcp", "/tools/"} {
+		if !stringSliceContains(spec.Routes.WhenMCPGatewayInstalled, want) {
+			t.Fatalf("listener MCP routes missing %q: %#v", want, spec.Routes.WhenMCPGatewayInstalled)
+		}
+	}
+	for _, want := range []string{"swarm run --api-port", "consumer", "second bind owner"} {
+		if !strings.Contains(spec.ConsumerBoundaries.SwarmRunAPIPort, want) {
+			t.Fatalf("api-port boundary missing %q:\n%s", want, spec.ConsumerBoundaries.SwarmRunAPIPort)
+		}
+	}
+	for _, want := range []string{"swarm run --mcp-port", "fail before API/WS calls", "explicit MCP bind ownership"} {
+		if !strings.Contains(spec.ConsumerBoundaries.SwarmRunMCPPort, want) {
+			t.Fatalf("mcp-port boundary missing %q:\n%s", want, spec.ConsumerBoundaries.SwarmRunMCPPort)
+		}
+	}
+	for _, want := range []string{"--api/--no-api", "--mcp/--no-mcp", "serve --api-port", "serve --mcp-port", "--log-level"} {
+		if !stringSliceContains(spec.UnpromotedReviewControls, want) {
+			t.Fatalf("unpromoted review controls missing %q: %#v", want, spec.UnpromotedReviewControls)
 		}
 	}
 }
@@ -578,13 +629,14 @@ func TestNewHealthServerPreservesProcessProbesAndMountsV1API(t *testing.T) {
 	var apiHit atomic.Bool
 	apiHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		apiHit.Store(true)
-		if r.URL.Path != "/v1/rpc" {
-			t.Errorf("api path = %q, want /v1/rpc", r.URL.Path)
+		if r.URL.Path != "/v1/rpc" && r.URL.Path != "/v1/ws" {
+			t.Errorf("api path = %q, want /v1/rpc or /v1/ws", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"test","result":{"ok":true}}`))
 	})
-	server := newHealthServer(":0", &ready, nil, apiHandler)
+	toolGateway := runtimemcp.NewGateway(nil, "", runtimemcp.GatewayHooks{})
+	server := newHealthServer(":0", &ready, toolGateway, apiHandler)
 	handler := server.Handler
 
 	rec := httptest.NewRecorder()
@@ -612,6 +664,24 @@ func TestNewHealthServerPreservesProcessProbesAndMountsV1API(t *testing.T) {
 	}
 	if !apiHit.Load() {
 		t.Fatal("/v1/rpc did not route to v1 API handler")
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/ws", strings.NewReader(`{"jsonrpc":"2.0","id":"test","method":"rpc.unsubscribe","params":{"subscription_id":"sub"}}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/ws status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp", nil))
+	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "ok" {
+		t.Fatalf("/mcp status/body = %d/%q, want 200 ok", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/tools/query_entities", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("/tools/ route status = %d, want mounted gateway 405", rec.Code)
 	}
 
 	for _, path := range []string{"/api", "/api/healthz", "/api/rpc", "/rpc", "/api/ws", "/ws"} {
@@ -2978,6 +3048,14 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 	if strings.Contains(out.String(), "health_endpoints_respond       ok  (/healthz /readyz /v1/rpc /v1/ws)") {
 		t.Fatalf("serve verbose output still claims unproven v1 endpoint response:\n%s", out.String())
 	}
+	for _, want := range []string{"http_listener_bind", "listener=", "routes=" + serveUnifiedRoutes, "health_endpoints_respond", serveReadinessRoutes} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve verbose output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "health=127.") {
+		t.Fatalf("serve verbose output still labels the unified listener as health-only:\n%s", out.String())
+	}
 }
 
 func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *testing.T) {
@@ -3152,6 +3230,24 @@ type serveDevModeSpec struct {
 	SiblingBoundaries    string   `yaml:"sibling_boundaries"`
 }
 
+type serveUnifiedListenerSpec struct {
+	ImplementedBy string `yaml:"implemented_by"`
+	Flag          string `yaml:"flag"`
+	Owner         string `yaml:"owner"`
+	Semantics     string `yaml:"semantics"`
+	Routes        struct {
+		Always                  []string `yaml:"always"`
+		WhenAPIHandlerInstalled []string `yaml:"when_api_handler_installed"`
+		WhenMCPGatewayInstalled []string `yaml:"when_mcp_gateway_installed"`
+	} `yaml:"routes"`
+	BindRules          []string `yaml:"bind_rules"`
+	ConsumerBoundaries struct {
+		SwarmRunAPIPort string `yaml:"swarm_run_api_port"`
+		SwarmRunMCPPort string `yaml:"swarm_run_mcp_port"`
+	} `yaml:"consumer_boundaries"`
+	UnpromotedReviewControls []string `yaml:"unpromoted_review_controls"`
+}
+
 func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpecStep {
 	t.Helper()
 	var spec struct {
@@ -3215,6 +3311,30 @@ func loadServeDevModeSpec(t *testing.T) serveDevModeSpec {
 		t.Fatal("platform spec missing serve dev_mode_lifecycle_composition")
 	}
 	return spec.CLISpecification.CommandCatalog.Serve.DevMode
+}
+
+func loadServeUnifiedListenerSpec(t *testing.T) serveUnifiedListenerSpec {
+	t.Helper()
+	var spec struct {
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					Listener serveUnifiedListenerSpec `yaml:"unified_listener_bind_contract"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	if strings.TrimSpace(spec.CLISpecification.CommandCatalog.Serve.Listener.Flag) == "" {
+		t.Fatal("platform spec missing serve unified_listener_bind_contract")
+	}
+	return spec.CLISpecification.CommandCatalog.Serve.Listener
 }
 
 func stringSliceContains(values []string, want string) bool {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5400,9 +5400,9 @@ cli_specification:
         action: >
           The current unified serve listener contract is promoted in
           cli_specification.command_catalog.serve.unified_listener_bind_contract. `swarm serve --health-addr`
-          remains the current single HTTP listener bind input despite its health-specific historical name.
-          API/MCP split listener controls from the review artifact remain unpromoted until a later tracked
-          serve-topology child accepts them.
+          remains the current single HTTP listener bind input despite its health-specific historical name; this
+          does not bless `--health-addr` as the final CLI v2 listener flag name. API/MCP split listener controls
+          from the review artifact remain unpromoted until a later tracked serve-topology child accepts them.
       trace_filters_and_subscription_recovery:
         disposition: tracked_child
         tracker: '#855'
@@ -5486,7 +5486,9 @@ cli_specification:
         reason: >
           Current Swarm serves health, readiness, `/v1/rpc`, `/v1/ws`, MCP, and tool routes from one
           `swarm serve` HTTP listener. The CLI UX v2 review artifact anticipated split API/MCP listener
-          controls, but those controls are not authoritative until promoted by a later tracked topology child.
+          controls in its primary serve flag summary; its later `--health-addr` mention describes current
+          implementation configurability, not final CLI v2 naming. Split listener controls are not authoritative
+          until promoted by a later tracked topology child.
       event_read_stream_filters:
         classification: required_current_contract
         reason: >
@@ -5788,9 +5790,10 @@ cli_specification:
         semantics: >
           `--health-addr` is the current bind address for the single HTTP listener created by `swarm serve`.
           Despite its historical health-specific name, the listener is not health-only: it exposes health,
-          readiness, API, WebSocket, MCP, and tool routes when their handlers are installed. Implementations MUST
-          NOT infer separate API or MCP listener ownership from the CLI UX v2 review artifact unless that topology
-          is promoted into this spec by a later child.
+          readiness, API, WebSocket, MCP, and tool routes when their handlers are installed. This first slice
+          records current supported behavior; it does not declare `--health-addr` to be the final CLI v2 listener
+          flag name. Implementations MUST NOT infer separate API or MCP listener ownership from the CLI UX v2
+          review artifact unless that topology is promoted into this spec by a later child.
         routes:
           always:
           - /healthz

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5395,9 +5395,14 @@ cli_specification:
           and implementation split-tail accounting are promoted in cli_specification.foundations.output_contract.
           CLI/runtime renderer implementation remains a future #794/#735 child and MUST consume that owner.
       serve_bind_listener_surface:
-        disposition: tracked_child
+        disposition: promoted_first_slice
         tracker: '#853'
-        action: Promote exact API/MCP/health bind-address and listener flag contract before implementation.
+        action: >
+          The current unified serve listener contract is promoted in
+          cli_specification.command_catalog.serve.unified_listener_bind_contract. `swarm serve --health-addr`
+          remains the current single HTTP listener bind input despite its health-specific historical name.
+          API/MCP split listener controls from the review artifact remain unpromoted until a later tracked
+          serve-topology child accepts them.
       trace_filters_and_subscription_recovery:
         disposition: tracked_child
         tracker: '#855'
@@ -5476,6 +5481,12 @@ cli_specification:
         classification: required_current_contract
         reason: >
           Platform spec carries exact `--dev` composition and dev entity-container cleanup semantics from #830.
+      serve_unified_listener_bind_contract:
+        classification: required_current_contract
+        reason: >
+          Current Swarm serves health, readiness, `/v1/rpc`, `/v1/ws`, MCP, and tool routes from one
+          `swarm serve` HTTP listener. The CLI UX v2 review artifact anticipated split API/MCP listener
+          controls, but those controls are not authoritative until promoted by a later tracked topology child.
       event_read_stream_filters:
         classification: required_current_contract
         reason: >
@@ -5766,7 +5777,52 @@ cli_specification:
       command: swarm serve [flags]
       tier: must_have
       implementation_status: partial
-      behavior: starts current runtime, process probes, /v1/rpc, /v1/ws, and MCP surfaces
+      behavior: starts current runtime and one HTTP listener for process probes, /v1/rpc, /v1/ws, MCP, and tool surfaces
+      unified_listener_bind_contract:
+        implemented_by: '#853'
+        flag: --health-addr <addr>
+        owner: >
+          `cmd/swarm serve` owns command-line bind selection; `runServeRuntime`, `newHealthServer`, and
+          `listenHealthServer` own the single runtime HTTP listener. Route handlers own their own runtime/API/MCP
+          semantics, but they do not own independent listener binding in this contract.
+        semantics: >
+          `--health-addr` is the current bind address for the single HTTP listener created by `swarm serve`.
+          Despite its historical health-specific name, the listener is not health-only: it exposes health,
+          readiness, API, WebSocket, MCP, and tool routes when their handlers are installed. Implementations MUST
+          NOT infer separate API or MCP listener ownership from the CLI UX v2 review artifact unless that topology
+          is promoted into this spec by a later child.
+        routes:
+          always:
+          - /healthz
+          - /readyz
+          when_api_handler_installed:
+          - /v1/rpc
+          - /v1/ws
+          when_mcp_gateway_installed:
+          - /mcp
+          - /tools/
+        bind_rules:
+        - 'Blank `--health-addr` uses the default serve listener address.'
+        - 'The listener is one TCP HTTP listener; API, WebSocket, MCP, tools, health, and readiness routes share it.'
+        - 'Startup fails closed when the listener cannot bind; serve MUST NOT continue to runtime readiness without the listener.'
+        - 'Readiness probing proves only `/healthz` and `/readyz`; route mounting for `/v1/rpc`, `/v1/ws`, `/mcp`, and `/tools/` is proven by the serve startup owner and focused tests.'
+        consumer_boundaries:
+          swarm_run_api_port: >
+            `swarm run --api-port` is a consumer of the existing serve startup/listener owner for local foreground
+            startup. It MUST NOT become a second bind owner or introduce a separate runtime boot path.
+          swarm_run_mcp_port: >
+            `swarm run --mcp-port` remains unsupported until explicit MCP bind ownership is promoted. It MUST
+            fail before API/WS calls, local runtime boot, or active-run mutation with CLI validation exit 2.
+        unpromoted_review_controls:
+        - --api/--no-api
+        - --mcp/--no-mcp
+        - serve --api-port
+        - serve --mcp-port
+        - --log-level
+        sibling_boundaries: >
+          Output modes remain governed by `cli_specification.foundations.output_contract`; universal config/env
+          precedence remains #844; `swarm run` foreground/follow behavior remains #743; explicit split API/MCP
+          listener topology remains unpromoted backlog under #750/#794/#735 until a later gate promotes it.
       boot_observability:
         implemented_by: '#802'
         flags:

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -69,35 +72,8 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 		t.Fatalf("mkdir capture dir: %v", err)
 	}
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
-	script := `#!/bin/sh
-set -eu
-capture_dir="${FAKE_DOCKER_CAPTURE_DIR}"
-count_file="$capture_dir/invocations"
-if [ -f "$count_file" ]; then
-  count="$(cat "$count_file")"
-else
-  count=0
-fi
-count=$((count + 1))
-printf '%s' "$count" > "$count_file"
-captured="$capture_dir/$count.stdin"
-input="$(cat)"
-printf '%s' "$input" > "$captured"
-trimmed="$(printf '%s' "$input" | sed 's/^[[:space:]]*//')"
-# CI has exposed extra CLI process invocations, so provider turn progression
-# cannot depend on invocation count. Branch only on the actual tool-result
-# payload shape: the real follow-up stdin is a JSON array emitted by
-# executeToolCalls, while prompts/system text may contain read_file examples.
-if printf '%s' "$trimmed" | grep -q '^\[' &&
-  printf '%s' "$trimmed" | grep -q '"name":"read_file"' &&
-  printf '%s' "$trimmed" | grep -q '"ok":true'; then
-  printf '%s\n' '{"type":"result","result":"done"}'
-else
-  printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}'
-  printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}'
-fi
-`
+	script := "#!/bin/sh\n" +
+		"SWARM_LLM_FIRST_TURN_FAKE_DOCKER=1 exec " + shellQuote(os.Args[0]) + " -test.run=TestClaudeCLIFirstTurnFakeDockerHelper -- \"$@\"\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
@@ -232,6 +208,70 @@ fi
 	if len(content) != len(huge) {
 		t.Fatalf("read result content len = %d, want %d", len(content), len(huge))
 	}
+}
+
+func TestClaudeCLIFirstTurnFakeDockerHelper(t *testing.T) {
+	if os.Getenv("SWARM_LLM_FIRST_TURN_FAKE_DOCKER") != "1" {
+		return
+	}
+	os.Exit(runFirstTurnFakeDockerHelper())
+}
+
+func runFirstTurnFakeDockerHelper() int {
+	captureDir := strings.TrimSpace(os.Getenv("FAKE_DOCKER_CAPTURE_DIR"))
+	if captureDir == "" {
+		fmt.Fprintln(os.Stderr, "FAKE_DOCKER_CAPTURE_DIR is required")
+		return 2
+	}
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read stdin: %v\n", err)
+		return 2
+	}
+	if err := os.MkdirAll(captureDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "mkdir capture dir: %v\n", err)
+		return 2
+	}
+	countFile := filepath.Join(captureDir, "invocations")
+	count := 0
+	if raw, err := os.ReadFile(countFile); err == nil {
+		count, _ = strconv.Atoi(strings.TrimSpace(string(raw)))
+	}
+	count++
+	if err := os.WriteFile(countFile, []byte(strconv.Itoa(count)), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write invocation count: %v\n", err)
+		return 2
+	}
+	if err := os.WriteFile(filepath.Join(captureDir, strconv.Itoa(count)+".stdin"), input, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write captured stdin: %v\n", err)
+		return 2
+	}
+	if isReadFileToolResultPayload(input) {
+		fmt.Fprintln(os.Stdout, `{"type":"result","result":"done"}`)
+		return 0
+	}
+	fmt.Fprintln(os.Stdout, `{"type":"system","subtype":"init","session_id":"provider-sess-1","mcp_servers":[{"name":"runtime-tools","status":"connected"}],"tools":["mcp__runtime-tools__emit_category_assessed","Read","Write","Edit"]}`)
+	fmt.Fprintln(os.Stdout, `{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"path":"/workspace/corpus.json"}}},"session_id":"provider-sess-1"}`)
+	fmt.Fprintln(os.Stdout, `{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"provider-sess-1"}`)
+	return 0
+}
+
+func isReadFileToolResultPayload(input []byte) bool {
+	var payload []map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(input), &payload); err != nil {
+		return false
+	}
+	for _, entry := range payload {
+		ok, _ := entry["ok"].(bool)
+		if ok && strings.TrimSpace(asString(entry["name"])) == "read_file" {
+			return true
+		}
+	}
+	return false
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func capturedToolResultInput(captureDir string) ([]byte, error) {


### PR DESCRIPTION
## Summary
- Promotes the current `swarm serve` unified HTTP listener contract into authoritative `platform-spec.yaml`.
- Clarifies `--health-addr` as the current single listener bind input for health/readiness, `/v1/rpc`, `/v1/ws`, `/mcp`, and `/tools/` routes.
- Preserves split topology controls as unpromoted and keeps `swarm run --mcp-port` fail-closed.
- Updates serve help/verbose boot wording and focused tests to prove the promoted contract.

Closes #853
Part of #750
Related to #794, #735

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification`
- `cli_specification.review_artifact_reconciliation.under_promoted_review_features.serve_bind_listener_surface`
- `cli_specification.command_catalog.serve.unified_listener_bind_contract`
- `cli_specification.command_catalog.run.dropped_flags.--mcp-port`
- #853 pre-audit and independent gate outcome: approved as first slice.

## Semantic Migration
- New canonical owner: `platform-spec.yaml#cli_specification.command_catalog.serve.unified_listener_bind_contract`, consumed by `cmd/swarm` serve startup/listener wiring.
- Old invalid interpretation: treating `--health-addr` as health-only, or treating review-artifact split API/MCP flags as merge authority.
- Checked production paths: Cobra serve help, `runServeRuntime` boot progress, `newHealthServer` route mounting, `listenHealthServer` binding, `swarm run --api-port` consumer behavior, and `swarm run --mcp-port` fail-closed validation.
- Migration complete for the chosen class; explicit API/MCP split listener topology remains unpromoted backlog unless later gated.

## Proof
- `go test ./cmd/swarm -run 'TestCLI_ServeOwnsRuntimeStartupFlags|TestPlatformSpecServeUnifiedListenerBindContractPromoted|TestNewHealthServerPreservesProcessProbesAndMountsV1API|TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence|TestRunCommandValidationAndAuthNoCallPaths|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API' -count=1`
- `go test ./cmd/swarm -count=1`
- `go build -o /tmp/swarm-853 ./cmd/swarm`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`