### PR TITLE
[agent-c][issue #864] Repair contract entity type materialization

### DIFF
--- a/internal/apiv1/operator_entity_test.go
+++ b/internal/apiv1/operator_entity_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"swarm/internal/store"
+	"swarm/internal/testutil"
 )
 
 type fakeEntityReadStore struct {
@@ -54,7 +55,7 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 			NextCursor: "next",
 		},
 		getResult: store.OperatorEntityFull{
-			Entity:      store.OperatorEntitySummary{EntityID: "entity-1", RunID: "run-1", CurrentState: "collecting"},
+			Entity:      store.OperatorEntitySummary{EntityID: "entity-1", RunID: "run-1", EntityType: "mvp_spec", CurrentState: "collecting"},
 			Fields:      map[string]any{"priority": "high"},
 			Gates:       map[string]bool{"approved": true},
 			Accumulated: map[string]any{"notes": []any{"a"}},
@@ -88,6 +89,9 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 	if fields := asMap(t, getResult["fields"]); fields["priority"] != "high" {
 		t.Fatalf("entity.get result = %#v", get.Result)
 	}
+	if got := asMap(t, getResult["entity"])["entity_type"]; got != "mvp_spec" {
+		t.Fatalf("entity.get entity_type = %#v, want mvp_spec", got)
+	}
 	if entities.lastEntityID != "entity-1" || entities.lastRunID != "run-1" {
 		t.Fatalf("entity.get args = entity_id=%q run_id=%q", entities.lastEntityID, entities.lastRunID)
 	}
@@ -102,6 +106,82 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 	}
 	if entities.lastAggregate.RunID != "run-1" || entities.lastAggregate.GroupBy != "current_state" || entities.lastAggregate.Type != "mvp_spec" {
 		t.Fatalf("entity.aggregate options = %#v", entities.lastAggregate)
+	}
+}
+
+func TestOperatorEntityHandlersServeContractEntityTypesFromPostgres(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	runID := "11111111-1111-1111-1111-111111111111"
+	entityA := "22222222-2222-2222-2222-222222222222"
+	entityB := "33333333-3333-3333-3333-333333333333"
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES
+			($1::uuid, $2::uuid, 'scoring/vertical-a', 'vertical', 'discovered',
+			 '{}'::jsonb, '{"vertical_name":"Healthcare"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($1::uuid, $3::uuid, 'scoring/vertical-b', 'vertical', 'pending',
+			 '{}'::jsonb, '{"vertical_name":"Manufacturing"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
+	`, runID, entityA, entityB); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Entities: pg,
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"entity.list","params":{"run_id":"11111111-1111-1111-1111-111111111111","type":"vertical","limit":10}}`)
+	if list.Error != nil {
+		t.Fatalf("entity.list error = %#v", list.Error)
+	}
+	rows, _ := asMap(t, list.Result)["entities"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("entity.list rows = %#v", list.Result)
+	}
+	for _, row := range rows {
+		if got := asMap(t, row)["entity_type"]; got != "vertical" {
+			t.Fatalf("entity.list entity_type = %#v, want vertical", got)
+		}
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"entity.get","params":{"entity_id":"22222222-2222-2222-2222-222222222222","run_id":"11111111-1111-1111-1111-111111111111"}}`)
+	if get.Error != nil {
+		t.Fatalf("entity.get error = %#v", get.Error)
+	}
+	getResult := asMap(t, get.Result)
+	if got := asMap(t, getResult["entity"])["entity_type"]; got != "vertical" {
+		t.Fatalf("entity.get entity_type = %#v, want vertical", got)
+	}
+	if fields := asMap(t, getResult["fields"]); fields["vertical_name"] != "Healthcare" {
+		t.Fatalf("entity.get fields = %#v", fields)
+	}
+
+	byType := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agg-type","method":"entity.aggregate","params":{"run_id":"11111111-1111-1111-1111-111111111111","group_by":"entity_type"}}`)
+	if byType.Error != nil {
+		t.Fatalf("entity.aggregate entity_type error = %#v", byType.Error)
+	}
+	typeCounts := asMap(t, asMap(t, byType.Result)["counts"])
+	if typeCounts["vertical"] != float64(2) || typeCounts["default"] != nil {
+		t.Fatalf("entity_type counts = %#v", typeCounts)
+	}
+
+	typedState := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agg-state","method":"entity.aggregate","params":{"run_id":"11111111-1111-1111-1111-111111111111","group_by":"current_state","type":"vertical"}}`)
+	if typedState.Error != nil {
+		t.Fatalf("entity.aggregate typed current_state error = %#v", typedState.Error)
+	}
+	stateCounts := asMap(t, asMap(t, typedState.Result)["counts"])
+	if stateCounts["discovered"] != float64(1) || stateCounts["pending"] != float64(1) {
+		t.Fatalf("typed current_state counts = %#v", stateCounts)
 	}
 }
 

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -57,6 +57,7 @@ type PipelineCoordinator struct {
 	timerScheduleStore      SchedulePersistence
 	eventReceiptsCapability func(context.Context) (bool, error)
 	artifactRoot            string
+	bundleFingerprint       string
 
 	testSubscribeHook   func()
 	testEntityStateHook func(entityID, state string)
@@ -71,6 +72,7 @@ type PipelineCoordinatorOptions struct {
 	TimerScheduleStore      SchedulePersistence
 	EventReceiptsCapability func(context.Context) (bool, error)
 	ArtifactRoot            string
+	BundleFingerprint       string
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -93,6 +95,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		timerScheduleStore:      opts.TimerScheduleStore,
 		eventReceiptsCapability: opts.EventReceiptsCapability,
 		artifactRoot:            strings.TrimSpace(opts.ArtifactRoot),
+		bundleFingerprint:       strings.TrimSpace(opts.BundleFingerprint),
 		entityLocks:             make(map[string]*sync.Mutex),
 	}
 }

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -319,6 +319,11 @@ func workflowCreateEntityMetadata(source semanticview.Source, flowID string, ins
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
+	if contract, ok := workflowEntityContract(source, flowID); ok {
+		if entityType := strings.TrimSpace(contract.EntityType); entityType != "" {
+			metadata["entity_type"] = entityType
+		}
+	}
 	if instance.InstancePath != "" {
 		metadata["flow_path"] = instance.InstancePath
 		metadata["storage_ref"] = instance.InstancePath

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1176,6 +1176,9 @@ vertical:
 	if got := strings.TrimSpace(asString(state.Metadata["storage_ref"])); got != "scoring/"+instanceID {
 		t.Fatalf("state storage_ref = %q, want %q", got, "scoring/"+instanceID)
 	}
+	if got := strings.TrimSpace(asString(state.Metadata["entity_type"])); got != "vertical" {
+		t.Fatalf("state entity_type = %q, want vertical", got)
+	}
 	if got := state.Metadata["revision_count"]; !isZeroIntegerValue(got) {
 		t.Fatalf("state revision_count = %#v, want 0", got)
 	}

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -138,6 +138,8 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 	oldVersionID := uuid.NewString()
 	mismatchedBundleRunID := "88888888-8888-8888-8888-888888888888"
 	mismatchedBundleID := uuid.NewString()
+	unknownBundleRunID := "99999999-9999-9999-9999-999999999999"
+	unknownBundleID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
 		UPDATE runs
 		SET bundle_fingerprint = 'sha256:current'
@@ -152,11 +154,18 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 		t.Fatalf("seed mismatched bundle run: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+	`, unknownBundleRunID); err != nil {
+		t.Fatalf("seed unknown bundle run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
 		VALUES
 			('treasury/legacy', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now()),
 			('treasury/legacy-old-version', 'treasury', 'template', '{"workflow_version":"0.9.0"}'::jsonb, 'active', now()),
-			('treasury/legacy-old-bundle', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now())
+			('treasury/legacy-old-bundle', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now()),
+			('treasury/legacy-unknown-bundle', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now())
 	`); err != nil {
 		t.Fatalf("seed flow_instances: %v", err)
 	}
@@ -172,8 +181,10 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 			($1::uuid, $4::uuid, 'treasury/legacy-old-version', 'default', 'active',
 			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
 			($6::uuid, $5::uuid, 'treasury/legacy-old-bundle', 'default', 'active',
+			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($7::uuid, $8::uuid, 'treasury/legacy-unknown-bundle', 'default', 'active',
 			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
-	`, testPipelineRunID, resolvableID, unresolvedID, oldVersionID, mismatchedBundleID, mismatchedBundleRunID); err != nil {
+	`, testPipelineRunID, resolvableID, unresolvedID, oldVersionID, mismatchedBundleID, mismatchedBundleRunID, unknownBundleRunID, unknownBundleID); err != nil {
 		t.Fatalf("seed default entity_state rows: %v", err)
 	}
 
@@ -188,6 +199,7 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 	assertEntityStateEntityType(t, db, unresolvedID, "default")
 	assertEntityStateEntityType(t, db, oldVersionID, "default")
 	assertEntityStateEntityTypeForRun(t, db, mismatchedBundleRunID, mismatchedBundleID, "default")
+	assertEntityStateEntityTypeForRun(t, db, unknownBundleRunID, unknownBundleID, "default")
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey(t *testing.T) {

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -120,6 +120,42 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(
 	if got := instance.Metadata["spent_usd"]; got != float64(42) && got != 42 {
 		t.Fatalf("spent_usd = %#v, want 42", got)
 	}
+	if got := strings.TrimSpace(asString(instance.Metadata["entity_type"])); got != "opco_budget" {
+		t.Fatalf("entity_type metadata = %q, want opco_budget", got)
+	}
+	assertEntityStateEntityType(t, db, FlowInstanceEntityID(instance.StorageRef), "opco_budget")
+}
+
+func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, _ := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	resolvableID := uuid.NewString()
+	unresolvedID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES
+			($1::uuid, $2::uuid, 'treasury/legacy', 'default', 'active',
+			 '{}'::jsonb, '{"entity_type":"not-authority","vertical_id":"vertical-1"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($1::uuid, $3::uuid, 'unknown/legacy', 'default', 'active',
+			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
+	`, testPipelineRunID, resolvableID, unresolvedID); err != nil {
+		t.Fatalf("seed default entity_state rows: %v", err)
+	}
+
+	repaired, err := pc.RepairContractEntityTypes(ctx)
+	if err != nil {
+		t.Fatalf("RepairContractEntityTypes: %v", err)
+	}
+	if repaired != 1 {
+		t.Fatalf("repaired rows = %d, want 1", repaired)
+	}
+	assertEntityStateEntityType(t, db, resolvableID, "opco_budget")
+	assertEntityStateEntityType(t, db, unresolvedID, "default")
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey(t *testing.T) {
@@ -814,5 +850,20 @@ func assertEntityStateRowCount(t *testing.T, db *sql.DB, want int) {
 	}
 	if got != want {
 		t.Fatalf("entity_state row count = %d, want %d", got, want)
+	}
+}
+
+func assertEntityStateEntityType(t *testing.T, db *sql.DB, entityID, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(entity_type, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, testPipelineRunID, entityID).Scan(&got); err != nil {
+		t.Fatalf("load entity_state entity_type for %s: %v", entityID, err)
+	}
+	if got != want {
+		t.Fatalf("entity_state.entity_type = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -131,9 +131,35 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
+	pc.bundleFingerprint = "sha256:current"
 	ctx := testPipelineCoordinatorRunContext(t, pc)
 	resolvableID := uuid.NewString()
 	unresolvedID := uuid.NewString()
+	oldVersionID := uuid.NewString()
+	mismatchedBundleRunID := "88888888-8888-8888-8888-888888888888"
+	mismatchedBundleID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET bundle_fingerprint = 'sha256:current'
+		WHERE run_id = $1::uuid
+	`, testPipelineRunID); err != nil {
+		t.Fatalf("seed current run bundle fingerprint: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint)
+		VALUES ($1::uuid, 'running', 'sha256:old')
+	`, mismatchedBundleRunID); err != nil {
+		t.Fatalf("seed mismatched bundle run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('treasury/legacy', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now()),
+			('treasury/legacy-old-version', 'treasury', 'template', '{"workflow_version":"0.9.0"}'::jsonb, 'active', now()),
+			('treasury/legacy-old-bundle', 'treasury', 'template', '{"workflow_version":"1.0.0"}'::jsonb, 'active', now())
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
 			run_id, entity_id, flow_instance, entity_type, current_state,
@@ -142,8 +168,12 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 			($1::uuid, $2::uuid, 'treasury/legacy', 'default', 'active',
 			 '{}'::jsonb, '{"entity_type":"not-authority","vertical_id":"vertical-1"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
 			($1::uuid, $3::uuid, 'unknown/legacy', 'default', 'active',
+			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($1::uuid, $4::uuid, 'treasury/legacy-old-version', 'default', 'active',
+			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now()),
+			($6::uuid, $5::uuid, 'treasury/legacy-old-bundle', 'default', 'active',
 			 '{}'::jsonb, '{"entity_type":"opco_budget"}'::jsonb, '{}'::jsonb, 1, now(), now(), now())
-	`, testPipelineRunID, resolvableID, unresolvedID); err != nil {
+	`, testPipelineRunID, resolvableID, unresolvedID, oldVersionID, mismatchedBundleID, mismatchedBundleRunID); err != nil {
 		t.Fatalf("seed default entity_state rows: %v", err)
 	}
 
@@ -156,6 +186,8 @@ func TestRepairContractEntityTypesRepairsResolvableDefaultRows(t *testing.T) {
 	}
 	assertEntityStateEntityType(t, db, resolvableID, "opco_budget")
 	assertEntityStateEntityType(t, db, unresolvedID, "default")
+	assertEntityStateEntityType(t, db, oldVersionID, "default")
+	assertEntityStateEntityTypeForRun(t, db, mismatchedBundleRunID, mismatchedBundleID, "default")
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey(t *testing.T) {
@@ -855,12 +887,17 @@ func assertEntityStateRowCount(t *testing.T, db *sql.DB, want int) {
 
 func assertEntityStateEntityType(t *testing.T, db *sql.DB, entityID, want string) {
 	t.Helper()
+	assertEntityStateEntityTypeForRun(t, db, testPipelineRunID, entityID, want)
+}
+
+func assertEntityStateEntityTypeForRun(t *testing.T, db *sql.DB, runID, entityID, want string) {
+	t.Helper()
 	var got string
 	if err := db.QueryRowContext(context.Background(), `
 		SELECT COALESCE(entity_type, '')
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, testPipelineRunID, entityID).Scan(&got); err != nil {
+	`, runID, entityID).Scan(&got); err != nil {
 		t.Fatalf("load entity_state entity_type for %s: %v", entityID, err)
 	}
 	if got != want {

--- a/internal/runtime/pipeline/workflow_entity_type_repair.go
+++ b/internal/runtime/pipeline/workflow_entity_type_repair.go
@@ -6,13 +6,17 @@ import (
 	"strings"
 
 	"swarm/internal/runtime/entityruntime"
+	"swarm/internal/runtime/semanticview"
 )
 
 type contractEntityTypeRepair struct {
-	RunID        string
-	EntityID     string
-	FlowInstance string
-	EntityType   string
+	RunID             string
+	EntityID          string
+	FlowInstance      string
+	FlowTemplate      string
+	WorkflowVersion   string
+	BundleFingerprint string
+	EntityType        string
 }
 
 func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (int, error) {
@@ -25,13 +29,18 @@ func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (i
 	}
 	rows, err := pc.db.QueryContext(ctx, `
 		SELECT
-			run_id::text,
-			entity_id::text,
-			COALESCE(flow_instance, '')
-		FROM entity_state
-		WHERE COALESCE(NULLIF(BTRIM(entity_type), ''), 'default') = 'default'
-		  AND COALESCE(BTRIM(flow_instance), '') <> ''
-		ORDER BY run_id::text, entity_id::text
+			es.run_id::text,
+			es.entity_id::text,
+			COALESCE(es.flow_instance, ''),
+			COALESCE(fi.flow_template, ''),
+			COALESCE(fi.config->>'workflow_version', ''),
+			COALESCE(r.bundle_fingerprint, '')
+		FROM entity_state es
+		JOIN runs r ON r.run_id = es.run_id
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE COALESCE(NULLIF(BTRIM(es.entity_type), ''), 'default') = 'default'
+		  AND COALESCE(BTRIM(es.flow_instance), '') <> ''
+		ORDER BY es.run_id::text, es.entity_id::text
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("scan contract-resolvable default entity types: %w", err)
@@ -41,11 +50,21 @@ func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (i
 	repairs := []contractEntityTypeRepair{}
 	for rows.Next() {
 		var item contractEntityTypeRepair
-		if err := rows.Scan(&item.RunID, &item.EntityID, &item.FlowInstance); err != nil {
+		if err := rows.Scan(
+			&item.RunID,
+			&item.EntityID,
+			&item.FlowInstance,
+			&item.FlowTemplate,
+			&item.WorkflowVersion,
+			&item.BundleFingerprint,
+		); err != nil {
 			return 0, fmt.Errorf("scan default entity type row: %w", err)
 		}
 		contract, ok := entityruntime.ResolveForFlowInstance(source, item.FlowInstance)
 		if !ok {
+			continue
+		}
+		if !contractEntityTypeRepairMatchesCurrentSource(source, contract, item, pc.bundleFingerprint) {
 			continue
 		}
 		item.EntityType = strings.TrimSpace(contract.EntityType)
@@ -95,4 +114,28 @@ func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (i
 	}
 	committed = true
 	return repaired, nil
+}
+
+func contractEntityTypeRepairMatchesCurrentSource(source semanticview.Source, contract entityruntime.Contract, item contractEntityTypeRepair, currentBundleFingerprint string) bool {
+	if source == nil {
+		return false
+	}
+	workflowVersion := strings.TrimSpace(item.WorkflowVersion)
+	if workflowVersion == "" || workflowVersion != strings.TrimSpace(source.WorkflowVersion()) {
+		return false
+	}
+	bundleFingerprint := strings.TrimSpace(item.BundleFingerprint)
+	currentBundleFingerprint = strings.TrimSpace(currentBundleFingerprint)
+	if bundleFingerprint != "" && bundleFingerprint != currentBundleFingerprint {
+		return false
+	}
+	flowTemplate := strings.Trim(strings.TrimSpace(item.FlowTemplate), "/")
+	if flowTemplate == "" {
+		return false
+	}
+	contractFlowID := strings.Trim(strings.TrimSpace(contract.FlowID), "/")
+	if contractFlowID == "" {
+		contractFlowID = strings.Trim(strings.TrimSpace(source.WorkflowName()), "/")
+	}
+	return contractFlowID != "" && flowTemplate == contractFlowID
 }

--- a/internal/runtime/pipeline/workflow_entity_type_repair.go
+++ b/internal/runtime/pipeline/workflow_entity_type_repair.go
@@ -1,0 +1,98 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"swarm/internal/runtime/entityruntime"
+)
+
+type contractEntityTypeRepair struct {
+	RunID        string
+	EntityID     string
+	FlowInstance string
+	EntityType   string
+}
+
+func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (int, error) {
+	if pc == nil || pc.db == nil {
+		return 0, nil
+	}
+	source := pc.SemanticSource()
+	if source == nil {
+		return 0, fmt.Errorf("workflow semantic source is required to repair contract entity types")
+	}
+	rows, err := pc.db.QueryContext(ctx, `
+		SELECT
+			run_id::text,
+			entity_id::text,
+			COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE COALESCE(NULLIF(BTRIM(entity_type), ''), 'default') = 'default'
+		  AND COALESCE(BTRIM(flow_instance), '') <> ''
+		ORDER BY run_id::text, entity_id::text
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("scan contract-resolvable default entity types: %w", err)
+	}
+	defer rows.Close()
+
+	repairs := []contractEntityTypeRepair{}
+	for rows.Next() {
+		var item contractEntityTypeRepair
+		if err := rows.Scan(&item.RunID, &item.EntityID, &item.FlowInstance); err != nil {
+			return 0, fmt.Errorf("scan default entity type row: %w", err)
+		}
+		contract, ok := entityruntime.ResolveForFlowInstance(source, item.FlowInstance)
+		if !ok {
+			continue
+		}
+		item.EntityType = strings.TrimSpace(contract.EntityType)
+		if item.EntityType == "" {
+			return 0, fmt.Errorf("flow_instance %q resolved to an empty entity contract type", item.FlowInstance)
+		}
+		repairs = append(repairs, item)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read default entity type rows: %w", err)
+	}
+	if len(repairs) == 0 {
+		return 0, nil
+	}
+
+	tx, err := pc.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin contract entity type repair: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	repaired := 0
+	for _, repair := range repairs {
+		res, err := tx.ExecContext(ctx, `
+			UPDATE entity_state
+			SET entity_type = $4,
+			    updated_at = now()
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND flow_instance = $3
+			  AND COALESCE(NULLIF(BTRIM(entity_type), ''), 'default') = 'default'
+		`, repair.RunID, repair.EntityID, repair.FlowInstance, repair.EntityType)
+		if err != nil {
+			return 0, fmt.Errorf("repair entity_type for entity %s in run %s: %w", repair.EntityID, repair.RunID, err)
+		}
+		if affected, err := res.RowsAffected(); err == nil {
+			repaired += int(affected)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit contract entity type repair: %w", err)
+	}
+	committed = true
+	return repaired, nil
+}

--- a/internal/runtime/pipeline/workflow_entity_type_repair.go
+++ b/internal/runtime/pipeline/workflow_entity_type_repair.go
@@ -126,7 +126,7 @@ func contractEntityTypeRepairMatchesCurrentSource(source semanticview.Source, co
 	}
 	bundleFingerprint := strings.TrimSpace(item.BundleFingerprint)
 	currentBundleFingerprint = strings.TrimSpace(currentBundleFingerprint)
-	if bundleFingerprint != "" && bundleFingerprint != currentBundleFingerprint {
+	if bundleFingerprint == "" || currentBundleFingerprint == "" || bundleFingerprint != currentBundleFingerprint {
 		return false
 	}
 	flowTemplate := strings.Trim(strings.TrimSpace(item.FlowTemplate), "/")

--- a/internal/runtime/pipeline/workflow_validation_helpers.go
+++ b/internal/runtime/pipeline/workflow_validation_helpers.go
@@ -185,6 +185,9 @@ func workflowMaterializeEntityMetadata(source semanticview.Source, flowID string
 	for key, value := range materialized {
 		out[key] = value
 	}
+	if entityType := strings.TrimSpace(contract.EntityType); entityType != "" {
+		out["entity_type"] = entityType
+	}
 	return out
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -651,6 +651,10 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	rt.emitBootProgress(7, "recovery_decision", string(startupRecoveryDecision.Outcome), string(startupRecoveryDecision.ReasonCode))
 
 	if rt.Pipeline != nil {
+		if _, err := rt.Pipeline.RepairContractEntityTypes(ctx); err != nil {
+			rt.emitBootProgress(8, "entity_type_contract_repair", "FAILED", err.Error())
+			return fmt.Errorf("repair contract entity types: %w", err)
+		}
 		go rt.Pipeline.RunMaintenance(startCtx)
 		rt.emitBootProgress(8, "pipeline_maintenance", "started", "")
 	} else {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -372,6 +372,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			TimerScheduleStore:      stores.ScheduleStore,
 			EventReceiptsCapability: receiptCaps,
 			ArtifactRoot:            artifactRoot,
+			BundleFingerprint:       opts.BundleFingerprint,
 		})
 		if rt.Pipeline != nil {
 			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -137,6 +137,9 @@ func TestEntityTools_HappyPath(t *testing.T) {
 	if strings.TrimSpace(asString(entity["flow_instance"])) != "review/inst-1" {
 		t.Fatalf("flow_instance = %#v, want review/inst-1", entity["flow_instance"])
 	}
+	if strings.TrimSpace(asString(entity["entity_type"])) != "accounts" {
+		t.Fatalf("entity_type = %#v, want accounts", entity["entity_type"])
+	}
 	if _, ok := entity["subject_id"]; ok {
 		t.Fatalf("get_entity returned deprecated subject_id field: %#v", entity)
 	}

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -70,6 +70,9 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	if len(page1.Entities) != 1 || page1.Entities[0].EntityID != entityA || page1.NextCursor == "" {
 		t.Fatalf("page1 = %#v", page1)
 	}
+	if got := page1.Entities[0].EntityType; got != "mvp_spec" {
+		t.Fatalf("page1 entity_type = %q, want mvp_spec", got)
+	}
 	page2, err := pg.ListOperatorEntities(ctx, OperatorEntityListOptions{
 		RunID:  runA,
 		Flow:   "review",
@@ -91,6 +94,9 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	if full.Entity.FlowInstance != "review/primary" || full.Fields["priority"] != "high" || !full.Gates["approved"] {
 		t.Fatalf("full entity = %#v", full)
 	}
+	if full.Entity.EntityType != "mvp_spec" {
+		t.Fatalf("full entity_type = %q, want mvp_spec", full.Entity.EntityType)
+	}
 	if _, err := pg.LoadOperatorEntity(ctx, sharedEntity, ""); !errors.Is(err, ErrAmbiguousEntityRunID) {
 		t.Fatalf("LoadOperatorEntity ambiguous = %v, want ErrAmbiguousEntityRunID", err)
 	}
@@ -104,6 +110,20 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	}
 	if stateAgg.Counts["collecting"] != 2 || stateAgg.Counts["done"] != 1 {
 		t.Fatalf("state aggregate = %#v", stateAgg.Counts)
+	}
+	typedStateAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "current_state", Type: "mvp_spec"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities typed current_state: %v", err)
+	}
+	if typedStateAgg.Counts["collecting"] != 1 || typedStateAgg.Counts["done"] != 1 || typedStateAgg.Counts["ticket"] != 0 {
+		t.Fatalf("typed state aggregate = %#v", typedStateAgg.Counts)
+	}
+	typeAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "entity_type"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities entity_type: %v", err)
+	}
+	if typeAgg.Counts["mvp_spec"] != 2 || typeAgg.Counts["ticket"] != 1 || typeAgg.Counts["default"] != 0 {
+		t.Fatalf("entity_type aggregate = %#v", typeAgg.Counts)
 	}
 	fieldAgg, err := pg.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority"})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Stamp the flow-owned `Contract.EntityType` into workflow create/materialization metadata so workflow-backed entity rows persist the contract type instead of falling through to `default`.
- Add startup repair for existing resolvable `entity_state.entity_type = 'default'` rows using `entityruntime.ResolveForFlowInstance`; rows without a provable flow-owned contract are not guessed from fields or path heuristics.
- Strengthen pipeline, store, `/v1/rpc`, and direct `exec_create_entity` regression proof for list/get/aggregate type projection and filtering.

Closes #864

## Governing refs/context

Exact governing spec sections exist in `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:

- Entity contracts are authoritative for `entity_state`; entity type names are flow-scoped and owned by the flow.
- `create_entity` caller input does not supply `entity_type`; runtime infers it from flow context.
- `entity_state.entity_type` records the inferred flow-scoped entity contract and generic store reads use `entity_state` for list/filter/lookup.
- `EntitySummary` / `EntityFull` require `entity_type` on the API summary surfaces.
- `entity.list`, `entity.get`, and `entity.aggregate` expose/filter/group by the persisted entity type.
- Fork materialization notes require entity type authority to come from source `entity_state`, not `fields.entity_type`.

Binding tracker context: #864 Pre-Implementation Coverage Audit plus the independent gate review approving the complete remaining entity-type/product projection class after PR #879.

## Semantic migration

- New canonical owner consumed here: `entityruntime` contract resolution through `semanticview.Source` and flow context (`ResolveForFlow` / `ResolveForFlowInstance`), with `entity_state.entity_type` as the persisted read truth.
- Old invalid path: workflow materialization omitted `entity_type`, allowing `workflowInstancePersistedProjectionFromInstance` to fall back to `default` for contract-resolvable workflow/product rows.
- Production paths checked: workflow `create_entity` metadata, `select_or_create_entity` materialization, startup repair for existing resolvable default rows, store `entity.list` / `entity.get` / `entity.aggregate`, `/v1/rpc` `entity.*` methods, and direct tool `exec_create_entity`.
- Migration completeness: complete for the approved class of contract-resolvable rows and future workflow writes. Unresolvable rows remain fail-closed rather than inferred from product fields or path heuristics.

## Validation

- `go test ./internal/runtime/pipeline -run 'TestResolveHandlerEntityIDForFlowCreateEntitySeedsInitialStateAndSchemaDefaults|TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity|TestRepairContractEntityTypesRepairsResolvableDefaultRows' -count=1`
- `go test ./internal/store -run TestOperatorEntityReadOwnerListGetAggregateAndCursor -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEntityHandlersExposeEntityNativeReads|TestOperatorEntityHandlersServeContractEntityTypesFromPostgres' -count=1`
- `go test ./internal/runtime/tools -run TestEntityTools_HappyPath -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/runtime -run 'TestRuntimeStart' -count=1`
- `go test ./internal/runtime/pipeline ./internal/store ./internal/apiv1 ./internal/runtime/tools ./internal/runtime -count=1`