### PR TITLE
[agent-e][issue #878] Gate v1 transport admission probes

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -169,6 +169,7 @@ nodes:
       - stale or free-form proof references in the checked-in compliance matrix can drift silently from their test/helper/artifact/tracker owners
       - generated supported-surface runtime probes can be absent for read-only HTTP methods even when proof-accounting rows resolve
       - generated supported-surface runtime probes can be absent for mutating HTTP methods, leaving side-effect and idempotency behavior inferred from scattered handler-family tests
+      - central method transport admission can be absent, letting WS/protocol methods execute over /v1/rpc or HTTP-class methods execute over /v1/ws despite matrix transport classification
       - OpenRPC method examples and rpc.discover publication status are not explicitly tracked
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
@@ -177,6 +178,7 @@ nodes:
       - 857
       - 861
       - 872
+      - 878
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -28,6 +28,9 @@ const (
 	codeMethodNotFound = -32601
 	codeInvalidParams  = -32602
 	codeInternalError  = -32603
+
+	transportHTTP      = "http"
+	transportWebSocket = "websocket"
 )
 
 type Handler struct {
@@ -162,7 +165,7 @@ func (h *Handler) handleRPC(w http.ResponseWriter, r *http.Request) {
 		writeRPC(w, rpcResponse{JSONRPC: jsonRPCVersion, ID: nil, Error: h.standardError(codeInvalidRequest, "invalid request", correlationID, map[string]any{"reason": "read body failed"})})
 		return
 	}
-	resp := h.dispatch(r.Context(), raw, "http", correlationID, actorTokenID(token))
+	resp := h.dispatch(r.Context(), raw, transportHTTP, correlationID, actorTokenID(token))
 	writeRPC(w, resp)
 }
 
@@ -197,6 +200,9 @@ func (h *Handler) prepareRequest(raw []byte, transport, fallbackCorrelationID, a
 	req.ActorTokenID = strings.TrimSpace(actorTokenID)
 	req.RequestHash = requestBodyHash(req.Method, req.Params)
 	if method, ok := h.registry.Method(req.Method); ok {
+		if rpcErr := h.admitMethodTransport(req.Method, method, transport, correlationID); rpcErr != nil {
+			return Request{}, &rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
+		}
 		if rpcErr := validateParams(method, req.Params, req.CorrelationID); rpcErr != nil {
 			return Request{}, &rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr}
 		}
@@ -208,6 +214,24 @@ func (h *Handler) prepareRequest(raw []byte, transport, fallbackCorrelationID, a
 		}
 	}
 	return req, nil
+}
+
+func (h *Handler) admitMethodTransport(methodName string, method apispec.Method, transport, correlationID string) *rpcError {
+	expected := runtimeMethodTransport(methodName, method)
+	if strings.TrimSpace(transport) == expected {
+		return nil
+	}
+	return h.standardError(codeMethodNotFound, "method not found", correlationID, map[string]any{
+		"method":    strings.TrimSpace(methodName),
+		"transport": strings.TrimSpace(transport),
+	})
+}
+
+func runtimeMethodTransport(methodName string, method apispec.Method) string {
+	if strings.TrimSpace(methodName) == "rpc.unsubscribe" || method.NotificationSchema != nil {
+		return transportWebSocket
+	}
+	return transportHTTP
 }
 
 func (h *Handler) dispatchPrepared(ctx context.Context, req Request) rpcResponse {
@@ -309,7 +333,7 @@ func (s *webSocketSession) writeLoop() {
 }
 
 func (s *webSocketSession) handleRaw(raw []byte) bool {
-	req, failure := s.handler.prepareRequest(raw, "websocket", s.fallbackCorrelationID, s.actorTokenID)
+	req, failure := s.handler.prepareRequest(raw, transportWebSocket, s.fallbackCorrelationID, s.actorTokenID)
 	if failure != nil {
 		return s.enqueue(*failure)
 	}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -151,12 +151,12 @@ func TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics(t *testing.T) {
 		{name: "invalid request array id", body: `{"jsonrpc":"2.0","id":[],"method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, wantCode: codeInvalidRequest},
 		{name: "invalid request boolean id", body: `{"jsonrpc":"2.0","id":true,"method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, wantCode: codeInvalidRequest},
 		{name: "method not found", body: `{"jsonrpc":"2.0","id":"missing","method":"missing.method","params":{}}`, wantCode: codeMethodNotFound},
-		{name: "invalid params object", body: `{"jsonrpc":"2.0","id":"bad-params-object","method":"rpc.unsubscribe","params":["sub-1"]}`, wantCode: codeInvalidParams},
-		{name: "invalid params required", body: `{"jsonrpc":"2.0","id":"bad-params-required","method":"rpc.unsubscribe","params":{}}`, wantCode: codeInvalidParams},
+		{name: "invalid params object", body: `{"jsonrpc":"2.0","id":"bad-params-object","method":"run.get","params":["run-1"]}`, wantCode: codeInvalidParams},
+		{name: "invalid params required", body: `{"jsonrpc":"2.0","id":"bad-params-required","method":"run.get","params":{}}`, wantCode: codeInvalidParams},
 		{name: "invalid integer param", body: `{"jsonrpc":"2.0","id":"bad-integer","method":"run.list","params":{"limit":1.5}}`, wantCode: codeInvalidParams},
 		{name: "known business method unavailable", body: `{"jsonrpc":"2.0","id":"known","method":"run.list","params":{}}`, wantApp: MethodUnavailableCode},
 		{name: "internal error", body: `{"jsonrpc":"2.0","id":"internal","method":"health.ping","params":{}}`, wantCode: codeInternalError},
-		{name: "unsubscribe success", body: `{"jsonrpc":"2.0","id":"ok","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, headerCID: "trace-123", wantOK: true},
+		{name: "unsubscribe wrong transport", body: `{"jsonrpc":"2.0","id":"wrong-transport","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`, headerCID: "trace-123", wantCode: codeMethodNotFound},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/apiv1/openrpc_ws_runtime_test.go
+++ b/internal/apiv1/openrpc_ws_runtime_test.go
@@ -1,0 +1,556 @@
+package apiv1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"swarm/internal/apispec"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+)
+
+const webSocketRuntimeProbeTestName = "TestOpenRPCWebSocketRuntimeProbes"
+
+func TestOpenRPCWebSocketRuntimeProbes(t *testing.T) {
+	root := repoRoot(t)
+	api := loadComplianceAPISpec(t, root)
+	openRPC, _ := loadComplianceOpenRPC(t, filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json"))
+	matrix := loadComplianceMatrix(t, filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml"))
+
+	wsMethods, httpMethods := transportAdmissionRuntimeMethods(t, api, openRPC, matrix)
+	assertStringList(t, "websocket runtime method set", wsMethods, approvedWebSocketRuntimeMethods())
+	assertStringList(t, "http runtime transport method set", httpMethods, approvedHTTPRuntimeTransportMethods())
+	assertWebSocketRuntimeMatrixProofRefs(t, api, matrix, wsMethods)
+
+	t.Run("http rejects websocket methods before params validation or dispatch", func(t *testing.T) {
+		base := time.Unix(1700001400, 0).UTC()
+		handler, calls := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+		fixtures := webSocketRuntimeProbeFixtures(base)
+		for _, methodName := range wsMethods {
+			methodName := methodName
+			t.Run(methodName, func(t *testing.T) {
+				params := cloneProbeParams(fixtures[methodName].Params)
+				status, resp, body := callTransportProbeHTTP(t, handler, methodName, params)
+				if status != http.StatusOK {
+					t.Fatalf("status = %d, want 200 body=%s", status, body)
+				}
+				assertTransportProbeMethodNotFound(t, methodName, resp)
+				if calls[methodName] != 0 {
+					t.Fatalf("%s handler calls = %d, want 0 for wrong HTTP transport", methodName, calls[methodName])
+				}
+			})
+		}
+	})
+
+	t.Run("websocket rejects http methods before params validation or dispatch", func(t *testing.T) {
+		base := time.Unix(1700001400, 0).UTC()
+		handler, calls := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		conn := dialTestWS(t, server.URL)
+		defer conn.Close()
+
+		for _, methodName := range httpMethods {
+			writeWSRequest(t, conn, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      webSocketRuntimeProbeID(methodName),
+				"method":  methodName,
+				"params":  map[string]any{},
+			})
+			resp := readWSResponse(t, conn)
+			assertTransportProbeMethodNotFound(t, methodName, resp)
+		}
+		for _, methodName := range httpMethods {
+			if calls[methodName] != 0 {
+				t.Fatalf("%s handler calls = %d, want 0 for wrong WebSocket transport", methodName, calls[methodName])
+			}
+		}
+	})
+
+	t.Run("websocket auth boundary", func(t *testing.T) {
+		base := time.Unix(1700001400, 0).UTC()
+		handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/ws"
+
+		_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err == nil {
+			t.Fatal("missing auth websocket dial unexpectedly succeeded")
+		}
+		if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("missing auth response = %#v, want 401", resp)
+		}
+
+		_, resp, err = websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer wrong"}})
+		if err == nil {
+			t.Fatal("invalid auth websocket dial unexpectedly succeeded")
+		}
+		if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("invalid auth response = %#v, want 401", resp)
+		}
+
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer " + testToken}})
+		if err != nil {
+			t.Fatalf("valid websocket dial: %v", err)
+		}
+		conn.Close()
+	})
+
+	fixtures := webSocketRuntimeProbeFixtures(time.Unix(1700001400, 0).UTC())
+	for _, methodName := range wsMethods {
+		methodName := methodName
+		method := api.MethodCatalog[methodName]
+
+		t.Run(methodName+"/unknown_params_key", func(t *testing.T) {
+			base := time.Unix(1700001400, 0).UTC()
+			handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			conn := dialTestWS(t, server.URL)
+			defer conn.Close()
+
+			params := cloneProbeParams(fixtures[methodName].Params)
+			params["_unexpected"] = true
+			writeWSRequest(t, conn, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      webSocketRuntimeProbeID(methodName),
+				"method":  methodName,
+				"params":  params,
+			})
+			resp := readWSResponse(t, conn)
+			assertTransportProbeInvalidParams(t, methodName, resp, "_unexpected")
+		})
+
+		for _, paramName := range requiredParamNames(method) {
+			paramName := paramName
+			t.Run(methodName+"/missing_required_"+paramName, func(t *testing.T) {
+				base := time.Unix(1700001400, 0).UTC()
+				handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+				server := httptest.NewServer(handler)
+				defer server.Close()
+				conn := dialTestWS(t, server.URL)
+				defer conn.Close()
+
+				params := cloneProbeParams(fixtures[methodName].Params)
+				delete(params, paramName)
+				writeWSRequest(t, conn, map[string]any{
+					"jsonrpc": "2.0",
+					"id":      webSocketRuntimeProbeID(methodName),
+					"method":  methodName,
+					"params":  params,
+				})
+				resp := readWSResponse(t, conn)
+				assertTransportProbeInvalidParams(t, methodName, resp, paramName)
+			})
+		}
+	}
+
+	for _, methodName := range []string{"health.subscribe", "event.subscribe", "run.subscribe_trace", "runtime.subscribe_logs"} {
+		methodName := methodName
+		t.Run(methodName+"/success_and_notification_envelope", func(t *testing.T) {
+			base := time.Unix(1700001400, 0).UTC()
+			handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			conn := dialTestWS(t, server.URL)
+			defer conn.Close()
+
+			writeWSRequest(t, conn, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      webSocketRuntimeProbeID(methodName),
+				"method":  methodName,
+				"params":  webSocketRuntimeProbeFixtures(base)[methodName].Params,
+			})
+			resp := readWSResponse(t, conn)
+			subscriptionID := assertWebSocketRuntimeSubscribeSuccess(t, methodName, resp)
+			notification := readWSNotification(t, conn)
+			assertWebSocketRuntimeNotification(t, methodName, subscriptionID, notification)
+		})
+	}
+
+	t.Run("run.subscribe_trace declared RUN_NOT_FOUND", func(t *testing.T) {
+		base := time.Unix(1700001400, 0).UTC()
+		observability := webSocketRuntimeProbeObservability(base)
+		observability.traceErr = store.ErrRunNotFound
+		handler, _ := newWebSocketRuntimeProbeHandler(t, observability, time.Hour)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		conn := dialTestWS(t, server.URL)
+		defer conn.Close()
+
+		writeWSRequest(t, conn, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      webSocketRuntimeProbeID("run.subscribe_trace"),
+			"method":  "run.subscribe_trace",
+			"params": map[string]any{
+				"run_id":       "missing-run",
+				"replay_since": base.Format(time.RFC3339Nano),
+			},
+		})
+		resp := readWSResponse(t, conn)
+		assertWebSocketRuntimeApplicationError(t, "run.subscribe_trace", resp, RunNotFoundCode)
+	})
+
+	t.Run("rpc.unsubscribe same connection closeout", func(t *testing.T) {
+		base := time.Unix(1700001400, 0).UTC()
+		handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		conn := dialTestWS(t, server.URL)
+		defer conn.Close()
+
+		writeWSRequest(t, conn, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "ws-sub-for-unsubscribe",
+			"method":  "health.subscribe",
+			"params":  map[string]any{},
+		})
+		subscribe := readWSResponse(t, conn)
+		subscriptionID := assertWebSocketRuntimeSubscribeSuccess(t, "health.subscribe", subscribe)
+		notification := readWSNotification(t, conn)
+		assertWebSocketRuntimeNotification(t, "health.subscribe", subscriptionID, notification)
+
+		writeWSRequest(t, conn, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      webSocketRuntimeProbeID("rpc.unsubscribe"),
+			"method":  "rpc.unsubscribe",
+			"params":  map[string]any{"subscription_id": subscriptionID},
+		})
+		unsubscribe := readWSResponse(t, conn)
+		if unsubscribe.Error != nil {
+			t.Fatalf("rpc.unsubscribe error = %#v, want success", unsubscribe.Error)
+		}
+		if result := asMap(t, unsubscribe.Result); result["ok"] != true {
+			t.Fatalf("rpc.unsubscribe result = %#v, want ok true", unsubscribe.Result)
+		}
+	})
+}
+
+func transportAdmissionRuntimeMethods(t *testing.T, api *apispec.APISpecification, openRPC apispec.OpenRPCDocument, matrix openRPCComplianceMatrix) ([]string, []string) {
+	t.Helper()
+	openRPCMethods := map[string]struct{}{}
+	for _, method := range openRPC.Methods {
+		openRPCMethods[method.Name] = struct{}{}
+	}
+	matrixRows := map[string]openRPCMethodMatrix{}
+	for _, row := range matrix.Methods {
+		matrixRows[row.Method] = row
+	}
+
+	var wsMethods []string
+	var httpMethods []string
+	for methodName, method := range api.MethodCatalog {
+		if _, ok := openRPCMethods[methodName]; !ok {
+			t.Fatalf("%s missing from generated OpenRPC artifact", methodName)
+		}
+		row, ok := matrixRows[methodName]
+		if !ok {
+			t.Fatalf("%s missing from OpenRPC compliance matrix", methodName)
+		}
+		wantMatrixTransport := expectedComplianceTransport(methodName, method)
+		if row.Transport != wantMatrixTransport {
+			t.Fatalf("%s matrix transport = %q, want %q", methodName, row.Transport, wantMatrixTransport)
+		}
+		switch runtimeMethodTransport(methodName, method) {
+		case transportWebSocket:
+			if row.Transport != "ws" {
+				t.Fatalf("%s runtime transport is websocket but matrix transport = %q", methodName, row.Transport)
+			}
+			wsMethods = append(wsMethods, methodName)
+		case transportHTTP:
+			if row.Transport != "http" {
+				t.Fatalf("%s runtime transport is http but matrix transport = %q", methodName, row.Transport)
+			}
+			httpMethods = append(httpMethods, methodName)
+		default:
+			t.Fatalf("%s has unsupported runtime transport", methodName)
+		}
+	}
+	sort.Strings(wsMethods)
+	sort.Strings(httpMethods)
+	return wsMethods, httpMethods
+}
+
+func approvedWebSocketRuntimeMethods() []string {
+	return []string{
+		"event.subscribe",
+		"health.subscribe",
+		"rpc.unsubscribe",
+		"run.subscribe_trace",
+		"runtime.subscribe_logs",
+	}
+}
+
+func approvedHTTPRuntimeTransportMethods() []string {
+	out := append([]string{}, approvedReadOnlyHTTPRuntimeMethods()...)
+	out = append(out, approvedMutatingHTTPRuntimeMethods()...)
+	sort.Strings(out)
+	return out
+}
+
+func assertWebSocketRuntimeMatrixProofRefs(t *testing.T, api *apispec.APISpecification, matrix openRPCComplianceMatrix, methods []string) {
+	t.Helper()
+	wsMethods := complianceStringSet(methods)
+	rows := map[string]openRPCMethodMatrix{}
+	for _, row := range matrix.Methods {
+		rows[row.Method] = row
+		if _, ok := wsMethods[row.Method]; !ok && rowHasWebSocketRuntimeProof(row) {
+			t.Fatalf("%s has %s proof_ref but is outside the approved WebSocket runtime probe set", row.Method, webSocketRuntimeProbeTestName)
+		}
+	}
+
+	for _, methodName := range methods {
+		row, ok := rows[methodName]
+		if !ok {
+			t.Fatalf("%s missing from compliance matrix", methodName)
+		}
+		assertEvidenceHasWebSocketRuntimeProof(t, methodName, "happy_path", row.HappyPath)
+		assertEvidenceHasWebSocketRuntimeProof(t, methodName, "unknown_top_level_param_validation", row.UnknownTopLevelParamValidation)
+		assertEvidenceHasWebSocketRuntimeProof(t, methodName, "auth", row.Auth)
+		assertEvidenceHasWebSocketRuntimeProof(t, methodName, "result_schema", row.ResultSchema)
+		if len(requiredParamNames(api.MethodCatalog[methodName])) > 0 {
+			assertEvidenceHasWebSocketRuntimeProof(t, methodName, "required_param_validation", row.RequiredParamValidation)
+		}
+		if len(api.MethodCatalog[methodName].Errors) > 0 {
+			assertEvidenceHasWebSocketRuntimeProof(t, methodName, "declared_error_tests", row.DeclaredErrorTests)
+		}
+		if methodName != "rpc.unsubscribe" {
+			assertEvidenceHasWebSocketRuntimeProof(t, methodName, "notification_schema", row.NotificationSchema)
+		}
+	}
+}
+
+func assertEvidenceHasWebSocketRuntimeProof(t *testing.T, methodName, field string, evidence complianceEvidence) {
+	t.Helper()
+	if !evidenceHasGoTest(evidence, webSocketRuntimeProbeTestName) {
+		t.Fatalf("%s %s missing go_test proof_ref %s", methodName, field, webSocketRuntimeProbeTestName)
+	}
+}
+
+func rowHasWebSocketRuntimeProof(row openRPCMethodMatrix) bool {
+	for _, evidence := range complianceEvidenceFields(row) {
+		if evidenceHasGoTest(evidence.evidence, webSocketRuntimeProbeTestName) {
+			return true
+		}
+	}
+	return false
+}
+
+func newWebSocketRuntimeProbeHandler(t *testing.T, observability *fakeObservabilityReadStore, healthInterval time.Duration) (*Handler, map[string]int) {
+	t.Helper()
+	if observability == nil {
+		observability = webSocketRuntimeProbeObservability(time.Unix(1700001400, 0).UTC())
+	}
+	if healthInterval <= 0 {
+		healthInterval = time.Hour
+	}
+	readOpts := OperatorReadOptions{
+		Now:           func() time.Time { return time.Unix(1700001410, 0).UTC() },
+		Ready:         func() bool { return true },
+		Database:      fakePinger{err: nil},
+		Observability: observability,
+		Bundle: runtimecontracts.BundleIdentity{
+			WorkflowName:    "review",
+			WorkflowVersion: "1.2.3",
+			Fingerprint:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+	registry := testRegistry(t)
+	calls := map[string]int{}
+	handlers := map[string]MethodHandler{}
+	for _, methodName := range registry.MethodNames() {
+		method, ok := registry.Method(methodName)
+		if !ok {
+			t.Fatalf("%s missing from registry", methodName)
+		}
+		if runtimeMethodTransport(methodName, method) != transportHTTP {
+			continue
+		}
+		methodName := methodName
+		handlers[methodName] = func(context.Context, Request) (any, error) {
+			calls[methodName]++
+			return map[string]any{"ok": true}, nil
+		}
+	}
+	return testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Handlers:      handlers,
+		Subscriptions: OperatorSubscriptions(readOpts, SubscriptionRuntimeOptions{HealthInterval: healthInterval, PollInterval: time.Hour, QueueSize: 16}),
+	}), calls
+}
+
+func webSocketRuntimeProbeObservability(base time.Time) *fakeObservabilityReadStore {
+	return &fakeObservabilityReadStore{
+		events: map[string]store.OperatorEventFull{
+			"evt-1": {
+				EventID:    "evt-1",
+				EventName:  "scan.requested",
+				RunID:      "run-1",
+				EntityID:   "entity-1",
+				CreatedAt:  base.Add(time.Second),
+				Source:     "runtime",
+				Payload:    map[string]any{"ok": true},
+				Deliveries: []store.OperatorEventDelivery{},
+			},
+		},
+		traceRows: map[string][]store.RunDebugTraceRow{
+			"run-1": {{
+				EventID:        "evt-1",
+				EventName:      "scan.requested",
+				EventCreatedAt: base.Add(time.Second),
+			}},
+		},
+		logs: []store.OperatorRuntimeLogEntry{{
+			LogID:     "log-1",
+			TS:        base.Add(time.Second),
+			Level:     "error",
+			Component: "scheduler",
+			Source:    "agent-1",
+			RunID:     "run-1",
+			EntityID:  "entity-1",
+			SessionID: "sess-1",
+			ErrorCode: "E_RUNTIME",
+			Message:   "runtime failed",
+		}},
+	}
+}
+
+type webSocketRuntimeProbeFixture struct {
+	Params map[string]any
+}
+
+func webSocketRuntimeProbeFixtures(base time.Time) map[string]webSocketRuntimeProbeFixture {
+	return map[string]webSocketRuntimeProbeFixture{
+		"health.subscribe": {Params: map[string]any{}},
+		"event.subscribe": {Params: map[string]any{
+			"filter":       map[string]any{"run_id": "run-1"},
+			"replay_since": base.Format(time.RFC3339Nano),
+		}},
+		"run.subscribe_trace": {Params: map[string]any{
+			"run_id":       "run-1",
+			"replay_since": base.Format(time.RFC3339Nano),
+		}},
+		"runtime.subscribe_logs": {Params: map[string]any{
+			"run_id":       "run-1",
+			"entity_id":    "entity-1",
+			"session_id":   "sess-1",
+			"component":    "scheduler",
+			"level":        "error",
+			"error_code":   "E_RUNTIME",
+			"source":       "agent-1",
+			"replay_since": base.Format(time.RFC3339Nano),
+		}},
+		"rpc.unsubscribe": {Params: map[string]any{"subscription_id": "sub-1"}},
+	}
+}
+
+func callTransportProbeHTTP(t *testing.T, handler *Handler, methodName string, params map[string]any) (int, rpcResponse, string) {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      webSocketRuntimeProbeID(methodName),
+		"method":  methodName,
+		"params":  params,
+	})
+	if err != nil {
+		t.Fatalf("marshal %s transport probe request: %v", methodName, err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", bytes.NewReader(raw))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		return rec.Code, rpcResponse{}, rec.Body.String()
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode %s transport probe response: %v body=%s", methodName, err, rec.Body.String())
+	}
+	return rec.Code, resp, rec.Body.String()
+}
+
+func assertTransportProbeMethodNotFound(t *testing.T, methodName string, resp rpcResponse) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("%s error = nil, want method not found", methodName)
+	}
+	if resp.Error.Code != codeMethodNotFound {
+		t.Fatalf("%s error code = %d, want %d: %#v", methodName, resp.Error.Code, codeMethodNotFound, resp.Error)
+	}
+	data := asMap(t, resp.Error.Data)
+	if _, ok := data["correlation_id"].(string); !ok {
+		t.Fatalf("%s method-not-found data missing correlation_id: %#v", methodName, data)
+	}
+	details := asMap(t, data["details"])
+	if details["method"] != methodName {
+		t.Fatalf("%s method-not-found details = %#v, want method %q", methodName, details, methodName)
+	}
+}
+
+func assertTransportProbeInvalidParams(t *testing.T, methodName string, resp rpcResponse, field string) {
+	t.Helper()
+	if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+		t.Fatalf("%s error = %#v, want invalid params", methodName, resp.Error)
+	}
+	details := asMap(t, asMap(t, resp.Error.Data)["details"])
+	if details["field"] != field {
+		t.Fatalf("%s invalid params details = %#v, want field %q", methodName, details, field)
+	}
+}
+
+func assertWebSocketRuntimeSubscribeSuccess(t *testing.T, methodName string, resp rpcResponse) string {
+	t.Helper()
+	if resp.JSONRPC != jsonRPCVersion {
+		t.Fatalf("%s jsonrpc = %q, want %q", methodName, resp.JSONRPC, jsonRPCVersion)
+	}
+	if resp.Error != nil {
+		t.Fatalf("%s error = %#v, want success", methodName, resp.Error)
+	}
+	subscriptionID, ok := asMap(t, resp.Result)["subscription_id"].(string)
+	if !ok || strings.TrimSpace(subscriptionID) == "" {
+		t.Fatalf("%s result = %#v, want subscription_id", methodName, resp.Result)
+	}
+	return subscriptionID
+}
+
+func assertWebSocketRuntimeNotification(t *testing.T, methodName, subscriptionID string, notification rpcSubscriptionNotification) {
+	t.Helper()
+	if notification.JSONRPC != jsonRPCVersion || notification.Method != "rpc.subscription" {
+		t.Fatalf("%s notification = %#v, want rpc.subscription", methodName, notification)
+	}
+	if notification.Params.Subscription != subscriptionID {
+		t.Fatalf("%s notification subscription = %q, want %q", methodName, notification.Params.Subscription, subscriptionID)
+	}
+	if len(asMap(t, notification.Params.Result)) == 0 {
+		t.Fatalf("%s notification result = %#v, want non-empty object", methodName, notification.Params.Result)
+	}
+}
+
+func assertWebSocketRuntimeApplicationError(t *testing.T, methodName string, resp rpcResponse, code string) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("%s error = nil, want %s", methodName, code)
+	}
+	data := asMap(t, resp.Error.Data)
+	if data["code"] != code {
+		t.Fatalf("%s application error data = %#v, want code %s", methodName, data, code)
+	}
+	if _, ok := data["correlation_id"].(string); !ok {
+		t.Fatalf("%s application error missing correlation_id: %#v", methodName, data)
+	}
+}
+
+func webSocketRuntimeProbeID(methodName string) string {
+	return "ws-runtime-" + strings.ReplaceAll(methodName, ".", "-")
+}

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -11,10 +11,11 @@ source:
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
   generated_from: api_specification.method_catalog
 policy:
-  closure_level: coverage_accounting_proof_ownership_read_only_and_mutating_http_runtime_probes
-  runtime_behavior_changes: forbidden_by_gate
+  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_and_ws_transport_runtime_probes
+  runtime_behavior_changes: transport_admission_repair_approved_by_878
   read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; mutating, WS/protocol, examples, rpc.discover, full result-schema validation, and notification-schema validation remain tracked by #857."
   mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; WS/protocol, examples, rpc.discover, full result-schema validation, and notification-schema validation remain tracked by #857."
+  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 42 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, full result-schema validation, and full notification-schema validation remain tracked by #857."
   examples_policy: OpenRPC method examples are tracked gaps in this slice.
   service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
 methods:
@@ -277,14 +278,14 @@ methods:
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
-    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
@@ -322,14 +323,14 @@ methods:
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
-    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
@@ -412,13 +413,13 @@ methods:
     transport: ws
     required_params: [subscription_id]
     declared_errors: []
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}, {kind: go_test, name: TestWebSocketSessionBackpressureAndUnsubscribeCancelState}]}
-    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
-    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
-    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}, {kind: go_test, name: TestWebSocketSessionBackpressureAndUnsubscribeCancelState}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: not_applicable}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
@@ -532,14 +533,14 @@ methods:
     transport: ws
     required_params: [run_id]
     declared_errors: [RUN_NOT_FOUND]
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
-    required_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
-    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
-    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
-    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]
@@ -637,14 +638,14 @@ methods:
     transport: ws
     required_params: []
     declared_errors: []
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     required_param_validation: {status: not_applicable}
-    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_helper, name: validateParams}]}
-    auth: {status: shared, proof_refs: [{kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
-    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    result_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
     gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_generated_result_schema_validation, missing_openrpc_examples]


### PR DESCRIPTION
## Summary

Closes #878.

This PR closes the approved #878 child class: central v1 method transport admission plus generated supported-surface WS/subscription runtime probes.

Changes:

- adds one central `internal/apiv1` transport-admission owner in request preparation, consumed by both `/v1/rpc` and `/v1/ws` before params validation and dispatch;
- rejects wrong-transport calls with JSON-RPC `-32601` method not found for all 42 generated methods;
- adds `TestOpenRPCWebSocketRuntimeProbes` as the generated proof owner for the five WS/protocol methods;
- rewrites the old HTTP `rpc.unsubscribe` success case into wrong-transport rejection proof;
- updates the compliance matrix and watchlist for #878.

## Governing refs / context

Exact spec authority:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.transport.json_rpc_over_http`: `POST /v1/rpc` request/response transport.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.transport.json_rpc_over_websocket`: `GET /v1/ws` subscription transport and `rpc.subscription` notification envelope.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.conventions.subscriptions`: subscribe establishment over WebSocket and `rpc.unsubscribe({subscription_id}) -> {ok}`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.rpc.unsubscribe`: current-connection WebSocket subscription protocol method.

Binding issue/gate context:

- #878 pre-audit repair / full transport-admission class: https://github.com/yazzaoui/Swarm/issues/878#issuecomment-4502088961
- #878 independent approval: https://github.com/yazzaoui/Swarm/issues/878#issuecomment-4502119843
- Parent tracker: #857

## Semantic migration

New canonical owner:

- `internal/apiv1.Handler.prepareRequest` through `admitMethodTransport` / `runtimeMethodTransport` is the runtime transport-admission owner.

Old non-authoritative path now invalid:

- HTTP `/v1/rpc` `rpc.unsubscribe` success through the default handler is no longer reachable.
- WebSocket `/v1/ws` fallback dispatch for HTTP-class methods is no longer reachable.

Production paths checked for surviving old behavior:

- HTTP `/v1/rpc` rejects all five WS/protocol methods before params validation/dispatch.
- WS `/v1/ws` rejects all 37 HTTP-class methods before params validation/dispatch.
- WS `/v1/ws` still accepts and proves `health.subscribe`, `event.subscribe`, `run.subscribe_trace`, `runtime.subscribe_logs`, and `rpc.unsubscribe`.

Migration completeness:

- Complete for the approved #878 transport-admission / WS runtime-probe class.
- The #857 parent remains open for full result-schema validation, notification-schema validation, OpenRPC examples, and `rpc.discover` policy.

## Proof

Commands run:

- `go test ./internal/apiv1 -run 'TestOpenRPCWebSocketRuntimeProbes|TestOpenRPCComplianceMatrix|TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`

All passed.