### PR TITLE
[agent-f][issue #865] Clarify CLI v2 promotion target

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -55,9 +55,14 @@ spec_authority:
       authority_language_risk: true
       disposition: Runtime descriptor/config ownership is promoted in tracked agent/session sections; draft is evidence only.
     - path: docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux-v2.yaml
-      classification: stale_header_repair
+      classification: promote_commit_needed
       authority_language_risk: true
-      disposition: Superseded by platform-spec.yaml#cli_specification.source_of_truth; local AUTHORITATIVE/source-of-truth claims are invalid.
+      disposition: >
+        Promotion target for the full CLI v2 implementation stream under
+        #794/#735. Residual CLI v2 behavior must be promoted into
+        platform-spec.yaml#cli_specification with matching implementation or a
+        tracked child before it becomes merge-bearing. The ignored file's local
+        AUTHORITATIVE/source-of-truth header is invalid until that promotion.
     - path: docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux.yaml
       classification: stale_header_repair
       authority_language_risk: true


### PR DESCRIPTION
## Summary

- Refines the #865 review-artifact inventory entry for `platform-spec.cli-ux-v2.yaml`.
- Marks the ignored CLI v2 artifact as `promote_commit_needed` rather than only stale/header repair.
- Clarifies that the full CLI v2 design remains the intended #794/#735 promotion and implementation target, while the ignored file itself is still not merge-bearing until content is promoted into `platform-spec.yaml#cli_specification` with matching implementation or tracked children.

## Governing Context

- Authoritative spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`.
- Existing #865 authority policy: `platform-spec.yaml#spec_authority`.
- CLI owner: `platform-spec.yaml#cli_specification.source_of_truth`.
- Tracker context: #794 / #735 own the full CLI v2 promotion and implementation stream.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec`
- `git diff --check`

Related to #865