### PR TITLE
[agent-b][issue #886] Implement swarm incidents CLI

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -73,6 +73,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newTraceCommand(opts),
 		newHealthCommand(opts),
 		newLogsCommand(opts),
+		newIncidentsCommand(opts),
 		newInvestigateCommand(opts),
 		newEventsCommand(opts),
 		newEventCommand(opts),

--- a/cmd/swarm/incidents.go
+++ b/cmd/swarm/incidents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,6 +50,8 @@ var runtimeIncidentValidLevels = map[string]struct{}{
 	"warn":  {},
 	"error": {},
 }
+
+var runtimeIncidentOpaqueIDPattern = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
 
 func newIncidentsCommand(opts rootCommandOptions) *cobra.Command {
 	incidentOpts := runtimeIncidentCommandOptions{apiOptions: opts}
@@ -157,6 +160,9 @@ func validateRuntimeIncident(prefix string, incident runtimeIncident) error {
 	if err := validateRequiredTimestamp(prefix+".last_seen", incident.LastSeen); err != nil {
 		return err
 	}
+	if err := validateRuntimeIncidentOpaqueID(prefix+".incident_id", incident.IncidentID); err != nil {
+		return err
+	}
 	if incident.Count < 1 {
 		return fmt.Errorf("malformed %s: count must be at least 1", prefix)
 	}
@@ -168,6 +174,24 @@ func validateRuntimeIncident(prefix string, incident runtimeIncident) error {
 	}
 	if incident.SampleLogIDs == nil {
 		return fmt.Errorf("malformed %s: sample_log_ids is required", prefix)
+	}
+	for i, logID := range incident.SampleLogIDs {
+		if err := validateRuntimeIncidentOpaqueID(fmt.Sprintf("%s.sample_log_ids[%d]", prefix, i), logID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuntimeIncidentOpaqueID(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("malformed result: %s must not be empty", field)
+	}
+	if len(value) > 256 {
+		return fmt.Errorf("malformed result: %s must be at most 256 characters", field)
+	}
+	if !runtimeIncidentOpaqueIDPattern.MatchString(value) {
+		return fmt.Errorf("malformed result: %s must match OpaqueId pattern", field)
 	}
 	return nil
 }

--- a/cmd/swarm/incidents.go
+++ b/cmd/swarm/incidents.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const runtimeIncidentsMethod = "runtime.incidents"
+
+type runtimeIncidentCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	sinceHours int
+	component  string
+	level      string
+	mcpOnly    bool
+	limit      int
+	cursor     string
+
+	sinceHoursSet bool
+	mcpOnlySet    bool
+	limitSet      bool
+}
+
+type runtimeIncidentListResult struct {
+	Incidents  []runtimeIncident `json:"incidents"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type runtimeIncident struct {
+	IncidentID    string   `json:"incident_id"`
+	FirstSeen     string   `json:"first_seen"`
+	LastSeen      string   `json:"last_seen"`
+	Count         int      `json:"count"`
+	Level         string   `json:"level"`
+	Component     string   `json:"component"`
+	ErrorCode     string   `json:"error_code,omitempty"`
+	SampleMessage *string  `json:"sample_message"`
+	SampleLogIDs  []string `json:"sample_log_ids"`
+}
+
+var runtimeIncidentValidLevels = map[string]struct{}{
+	"debug": {},
+	"info":  {},
+	"warn":  {},
+	"error": {},
+}
+
+func newIncidentsCommand(opts rootCommandOptions) *cobra.Command {
+	incidentOpts := runtimeIncidentCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "incidents [filters]",
+		Short: "List runtime incidents through /v1/rpc runtime.incidents.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			incidentOpts.sinceHoursSet = cmd.Flags().Changed("since-hours")
+			incidentOpts.mcpOnlySet = cmd.Flags().Changed("mcp-only")
+			incidentOpts.limitSet = cmd.Flags().Changed("limit")
+			return runIncidentsCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), incidentOpts)
+		},
+	}
+	cmd.Flags().IntVar(&incidentOpts.sinceHours, "since-hours", 0, "Look back this many hours, 1-720")
+	cmd.Flags().StringVar(&incidentOpts.component, "component", "", "Filter by runtime component")
+	cmd.Flags().StringVar(&incidentOpts.level, "level", "", "Filter by incident level: debug, info, warn, or error")
+	cmd.Flags().BoolVar(&incidentOpts.mcpOnly, "mcp-only", false, "Only show incidents from MCP-prefixed components")
+	cmd.Flags().IntVar(&incidentOpts.limit, "limit", 0, "Page size, 1-500")
+	cmd.Flags().StringVar(&incidentOpts.cursor, "cursor", "", "Pagination cursor")
+	return cmd
+}
+
+func runIncidentsCommand(ctx context.Context, out, errOut io.Writer, opts runtimeIncidentCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, runtimeIncidentErrorClassifier())
+	}
+	var result runtimeIncidentListResult
+	if err := client.call(ctx, runtimeIncidentsMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, runtimeIncidentErrorClassifier())
+	}
+	if err := validateRuntimeIncidentListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, runtimeIncidentErrorClassifier())
+	}
+	writeRuntimeIncidentListResult(out, result)
+	return nil
+}
+
+func (opts runtimeIncidentCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.sinceHoursSet {
+		if opts.sinceHours < 1 || opts.sinceHours > 720 {
+			return nil, fmt.Errorf("--since-hours must be between 1 and 720")
+		}
+		params["since_hours"] = opts.sinceHours
+	}
+	if component := strings.TrimSpace(opts.component); component != "" {
+		params["component"] = component
+	}
+	if level := strings.ToLower(strings.TrimSpace(opts.level)); level != "" {
+		if _, ok := runtimeIncidentValidLevels[level]; !ok {
+			return nil, fmt.Errorf("--level must be one of debug, info, warn, error")
+		}
+		params["level"] = level
+	}
+	if opts.mcpOnlySet {
+		params["mcp_only"] = opts.mcpOnly
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = opts.limit
+	}
+	if cursor := strings.TrimSpace(opts.cursor); cursor != "" {
+		params["cursor"] = cursor
+	}
+	return params, nil
+}
+
+func validateRuntimeIncidentListResult(result runtimeIncidentListResult) error {
+	if result.Incidents == nil {
+		return fmt.Errorf("malformed runtime.incidents result: incidents is required")
+	}
+	for i, incident := range result.Incidents {
+		if err := validateRuntimeIncident(fmt.Sprintf("runtime.incidents result: incidents[%d]", i), incident); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuntimeIncident(prefix string, incident runtimeIncident) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "incident_id", value: incident.IncidentID},
+		{name: "first_seen", value: incident.FirstSeen},
+		{name: "last_seen", value: incident.LastSeen},
+		{name: "level", value: incident.Level},
+		{name: "component", value: incident.Component},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateRequiredTimestamp(prefix+".first_seen", incident.FirstSeen); err != nil {
+		return err
+	}
+	if err := validateRequiredTimestamp(prefix+".last_seen", incident.LastSeen); err != nil {
+		return err
+	}
+	if incident.Count < 1 {
+		return fmt.Errorf("malformed %s: count must be at least 1", prefix)
+	}
+	if _, ok := runtimeIncidentValidLevels[strings.TrimSpace(incident.Level)]; !ok {
+		return fmt.Errorf("malformed %s: level=%q is not a valid LogLevel", prefix, incident.Level)
+	}
+	if incident.SampleMessage == nil {
+		return fmt.Errorf("malformed %s: sample_message is required", prefix)
+	}
+	if incident.SampleLogIDs == nil {
+		return fmt.Errorf("malformed %s: sample_log_ids is required", prefix)
+	}
+	return nil
+}
+
+func writeRuntimeIncidentListResult(out io.Writer, result runtimeIncidentListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Incidents) == 0 {
+		fmt.Fprintln(out, "No runtime incidents match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "LAST SEEN\tLEVEL\tCOMPONENT\tERROR\tCOUNT\tINCIDENT ID\tSAMPLE")
+	for _, incident := range result.Incidents {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			incident.LastSeen,
+			incident.Level,
+			incident.Component,
+			runtimeIncidentDash(incident.ErrorCode),
+			incident.Count,
+			incident.IncidentID,
+			runtimeIncidentSampleMessage(incident),
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func runtimeIncidentErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func runtimeIncidentDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func runtimeIncidentSampleMessage(incident runtimeIncident) string {
+	if incident.SampleMessage == nil {
+		return ""
+	}
+	return *incident.SampleMessage
+}

--- a/cmd/swarm/incidents_test.go
+++ b/cmd/swarm/incidents_test.go
@@ -234,6 +234,28 @@ func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "last_seen must be an RFC3339 timestamp",
 		},
 		{
+			name: "malformed incident invalid opaque incident id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("bad id!")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "incident_id must match OpaqueId pattern",
+		},
+		{
+			name: "malformed incident too long incident id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident(strings.Repeat("a", 257))
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "incident_id must be at most 256 characters",
+		},
+		{
 			name: "malformed incident invalid count exits three",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
@@ -280,6 +302,30 @@ func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "sample_log_ids is required",
+		},
+		{
+			name: "malformed incident invalid sample log id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				incident["sample_log_ids"] = []string{"log-1", "bad log id!"}
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "sample_log_ids[1] must match OpaqueId pattern",
+		},
+		{
+			name: "malformed incident empty sample log id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				incident["sample_log_ids"] = []string{"log-1", ""}
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "sample_log_ids[1] must not be empty",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/incidents_test.go
+++ b/cmd/swarm/incidents_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestIncidentsUsesRuntimeIncidentsV1RPCWithFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"incidents":   []any{validRuntimeIncident("incident-1")},
+			"next_cursor": "incident-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"incidents",
+		"--since-hours", "48",
+		"--component", "mcp.tools",
+		"--level", "WARN",
+		"--mcp-only",
+		"--limit", "25",
+		"--cursor", "cursor-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != runtimeIncidentsMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, runtimeIncidentsMethod)
+	}
+	wantParams := map[string]any{
+		"since_hours": float64(48),
+		"component":   "mcp.tools",
+		"level":       "warn",
+		"mcp_only":    true,
+		"limit":       float64(25),
+		"cursor":      "cursor-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"LAST SEEN", "incident-1", "mcp.tools", "WARN_DELIVERY_FAILED", "sample incident", "next_cursor=incident-cursor-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestIncidentsOmitOptionalParamsWhenUnset(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"incidents": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"incidents"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != runtimeIncidentsMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, runtimeIncidentsMethod)
+	}
+	if len(captured.Params) != 0 {
+		t.Fatalf("params = %#v, want empty map", captured.Params)
+	}
+	if !strings.Contains(stdout.String(), "No runtime incidents match the filter.") {
+		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
+	}
+}
+
+func TestIncidentsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"incidents": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "invalid since hours low", args: []string{"incidents", "--since-hours", "0"}, wantStderr: "--since-hours must be between 1 and 720"},
+		{name: "invalid since hours high", args: []string{"incidents", "--since-hours", "721"}, wantStderr: "--since-hours must be between 1 and 720"},
+		{name: "invalid level", args: []string{"incidents", "--level", "fatal"}, wantStderr: "--level must be one of"},
+		{name: "invalid limit low", args: []string{"incidents", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "invalid limit high", args: []string{"incidents", "--limit", "501"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "unexpected arg", args: []string{"incidents", "incident-1"}, wantStderr: "unknown command"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestIncidentsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"incidents": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"incidents"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "http runtime exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			wantCode:   3,
+			wantStderr: "v1 RPC HTTP 503",
+		},
+		{
+			name: "unknown rpc error exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeRuntimeIncidentJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "unauthorized rpc exits four",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeRuntimeIncidentJSONRPCError(t, w, req.ID, "UNAUTHORIZED")
+			},
+			wantCode:   4,
+			wantStderr: "UNAUTHORIZED",
+		},
+		{
+			name: "malformed list missing incidents exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "incidents is required",
+		},
+		{
+			name: "malformed incident missing id exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				delete(incident, "incident_id")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "incident_id is required",
+		},
+		{
+			name: "malformed incident invalid timestamp exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				incident["last_seen"] = "not-time"
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "last_seen must be an RFC3339 timestamp",
+		},
+		{
+			name: "malformed incident invalid count exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				incident["count"] = 0
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "count must be at least 1",
+		},
+		{
+			name: "malformed incident invalid level exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				incident["level"] = "fatal"
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "not a valid LogLevel",
+		},
+		{
+			name: "malformed incident missing sample message exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				delete(incident, "sample_message")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "sample_message is required",
+		},
+		{
+			name: "malformed incident missing sample log ids exits three",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				incident := validRuntimeIncident("incident-1")
+				delete(incident, "sample_log_ids")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"incidents": []any{incident}})
+			},
+			wantCode:   3,
+			wantStderr: "sample_log_ids is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"incidents"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func validRuntimeIncident(incidentID string) map[string]any {
+	return map[string]any{
+		"incident_id":    incidentID,
+		"first_seen":     "2026-05-19T09:00:00Z",
+		"last_seen":      "2026-05-19T10:00:00Z",
+		"count":          3,
+		"level":          "warn",
+		"component":      "mcp.tools",
+		"error_code":     "WARN_DELIVERY_FAILED",
+		"sample_message": "sample incident",
+		"sample_log_ids": []string{"log-1", "log-2"},
+	}
+}
+
+func writeRuntimeIncidentJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5602,9 +5602,9 @@ cli_specification:
         tracker: '#876'
         action: '`swarm logs` snapshot and follow semantics are promoted as one bounded CLI child over runtime.logs and runtime.subscribe_logs; richer output-mode work remains split to #848.'
       incidents:
-        disposition: future_child
-        tracker: '#735'
-        action: '`swarm incidents` read semantics require a separate gated child.'
+        disposition: promoted_first_slice
+        tracker: '#886'
+        action: '`swarm incidents` default-text read semantics are promoted as one bounded CLI child over runtime.incidents; richer output-mode work remains split to #848/#794.'
       forkchat:
         disposition: blocked
         tracker: '#749'
@@ -5785,12 +5785,18 @@ cli_specification:
         - event_replay
         - event_publish
         - logs
+        - incidents
         - run
         implemented_consumer_residuals:
           logs: >
             `swarm logs` is implemented for default-text snapshot and follow in #876 and is no longer an absent
             command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
             implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #876 does not add
+            command-local output-mode flags or semantics.
+          incidents: >
+            `swarm incidents` is implemented for default-text read-only listing in #886 and is no longer an absent
+            command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
+            implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #886 does not add
             command-local output-mode flags or semantics.
       exception_rules:
         root_help_completion:
@@ -5829,7 +5835,6 @@ cli_specification:
           - entities_list
           - entity_view
           - entity_aggregate
-          - incidents
           rule: >
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future
             implementation children consume this contract only after their command/API/runtime owner is promoted.
@@ -6773,8 +6778,52 @@ cli_specification:
     incidents:
       command: swarm incidents [filters]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc runtime.incidents
+      params:
+      - name: since_hours
+        flag: --since-hours <1-720>
+        required: false
+        api_param: since_hours
+        rule: Omitted by the CLI when the flag is absent; the server applies its runtime.incidents default.
+      - name: component
+        flag: --component <component>
+        required: false
+        api_param: component
+      - name: level
+        flag: --level <debug|info|warn|error>
+        required: false
+        api_param: level
+        validation: CLI lowercases the value and rejects unsupported levels before any API call.
+      - name: mcp_only
+        flag: --mcp-only
+        required: false
+        api_param: mcp_only
+        rule: Sent only when the flag is explicitly supplied.
+      - name: limit
+        flag: --limit <1-500>
+        required: false
+        api_param: limit
+        rule: Omitted by the CLI when the flag is absent; the server applies its runtime.incidents default.
+      - name: cursor
+        flag: --cursor <cursor>
+        required: false
+        api_param: cursor
+      output:
+        table: LAST SEEN / LEVEL / COMPONENT / ERROR / COUNT / INCIDENT ID / SAMPLE plus next_cursor when present
+        empty: No runtime incidents match the filter.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+      proof_expectations:
+      - exact /v1/rpc runtime.incidents call with since_hours, component, level, mcp_only, limit, and cursor params only when supplied
+      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - since_hours is validated as 1-720 and limit as 1-500 before API calls
+      - level is validated as debug, info, warn, or error before API calls
+      - empty result, next_cursor rendering, auth/HTTP/RPC failures, malformed result, and malformed Incident rows are tested with closed exit-code behavior
+      - no direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and no legacy /api/*, /rpc, /api/rpc, /ws, or /api/ws usage
   retired_namespaces:
     investigate:
       command: swarm investigate *
@@ -6852,6 +6901,7 @@ cli_specification:
     - swarm event replay
     - swarm event publish
     - swarm logs
+    - swarm incidents
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6864,7 +6914,6 @@ cli_specification:
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     - swarm entities list / entity view / entity aggregate
-    - swarm incidents
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
 api_specification:


### PR DESCRIPTION
## Summary
- Adds `swarm incidents [filters]` as the CLI consumer of `/v1/rpc runtime.incidents`.
- Validates `--since-hours`, `--level`, and `--limit` before token/API setup and preserves missing-token zero-call behavior.
- Repairs `platform-spec.yaml` command/output-contract accounting so incidents is implemented for default-text read-only listing while JSON/quiet renderer work remains split.

Closes #886
Part of #735

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.incidents`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.runtime.incidents`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.Incident`
- #886 Pre-Implementation Coverage Audit and approved first-slice gate.

## Semantic Migration
- New canonical CLI owner: `swarm incidents [filters]` consuming `/v1/rpc runtime.incidents` through the shared CLI v1 API client.
- Old invalid paths remain non-authoritative: direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and legacy `/api/*`, `/rpc`, `/ws` transports.
- Production paths checked for surviving old behavior: `cmd/swarm` command registration and incidents implementation, plus static no-bypass grep over the new incidents files.
- Migration is complete for the #886 default-text read-only incidents CLI row. Parent #735 remains open for conversations, entities, forkchat, and output-mode/richer UX residuals.

## Proof
- `go test ./cmd/swarm -run 'Incidents|RuntimeIncident' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./internal/apiv1 -run 'RuntimeIncident|RuntimeIncidents|OperatorObservability|OpenRPCReadOnly' -count=1`
- `go test ./internal/store -run 'OperatorRuntimeIncidents|OperatorObservability|ObservabilityPositionCursor' -count=1`
- `go test ./internal/dashboard/server -run 'RuntimeIncidents|ListIncidents' -count=1`
- Static no-bypass grep over `cmd/swarm/incidents.go` and `cmd/swarm/incidents_test.go` returned no matches.
