### PR TITLE
[agent-c][issue #877] Expose conversation turn indexes

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -6836,9 +6836,14 @@
           },
           "turn_id": {
             "$ref": "#/components/schemas/OpaqueId"
+          },
+          "turn_index": {
+            "minimum": 1,
+            "type": "integer"
           }
         },
         "required": [
+          "turn_index",
           "turn_id",
           "trigger_event_id",
           "trigger_event_type",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8335,12 +8335,16 @@ api_specification:
         type: object
         additionalProperties: false
         required:
+        - turn_index
         - turn_id
         - trigger_event_id
         - trigger_event_type
         - parse_ok
         - latency_ms
         properties:
+          turn_index:
+            type: integer
+            minimum: 1
           turn_id:
             $ref: '#/components/schemas/OpaqueId'
           trigger_event_id:

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -510,7 +510,7 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 			}}},
 			conversationResult: store.OperatorConversationDetail{
 				Conversation: store.OperatorConversationSummary{SessionID: sessionID, AgentID: "agent-1", RunID: runID, StartedAt: now, Status: "active"},
-				Turns:        []store.OperatorConversationTurn{{TurnID: "turn-1", TriggerEventID: eventID, TriggerEventType: "scan.requested", ParseOK: true}},
+				Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-1", TriggerEventID: eventID, TriggerEventType: "scan.requested", ParseOK: true}},
 			},
 			conversationTurnResult: store.OperatorConversationTurnDetail{
 				Session: store.OperatorConversationSummary{SessionID: sessionID, AgentID: "agent-1", RunID: runID, StartedAt: now, Status: "active"},
@@ -527,7 +527,7 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 			},
 			currentConversationResult: &store.OperatorConversationDetail{
 				Conversation: store.OperatorConversationSummary{SessionID: sessionID, AgentID: "agent-1", RunID: runID, StartedAt: now, Status: "active"},
-				Turns:        []store.OperatorConversationTurn{},
+				Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-current-1", TriggerEventID: eventID, TriggerEventType: "scan.requested", ParseOK: true}},
 			},
 		},
 		Mailbox: newReadOnlyMailboxProbeStore(now),
@@ -610,6 +610,15 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		}
 		if len(heuristics) != 0 {
 			t.Fatalf("run.diagnose heuristics = %#v, want empty array", heuristics)
+		}
+	}
+	if methodName == "conversation.get" || methodName == "conversation.current_for_agent" {
+		turns, ok := result["turns"].([]any)
+		if !ok || len(turns) == 0 {
+			t.Fatalf("%s turns = %#v, want non-empty array", methodName, result["turns"])
+		}
+		if got := asMap(t, turns[0])["turn_index"]; got != float64(1) {
+			t.Fatalf("%s first turn_index = %#v, want 1", methodName, got)
 		}
 	}
 }

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -112,7 +112,7 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		},
 		conversationResult: store.OperatorConversationDetail{
 			Conversation: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", StartedAt: now, Status: "active"},
-			Turns:        []store.OperatorConversationTurn{{TurnID: "turn-1", TriggerEventID: "evt-1", TriggerEventType: "task.started", ParseOK: true}},
+			Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-1", TriggerEventID: "evt-1", TriggerEventType: "task.started", ParseOK: true}},
 		},
 		conversationTurnResult: store.OperatorConversationTurnDetail{
 			Session: store.OperatorConversationSummary{SessionID: "sess-1", AgentID: "agent-1", StartedAt: now, Status: "active"},
@@ -132,6 +132,7 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		},
 		currentConversationResult: &store.OperatorConversationDetail{
 			Conversation: store.OperatorConversationSummary{SessionID: "sess-current", AgentID: "agent-1", StartedAt: now, Status: "active"},
+			Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-current-1", TriggerEventID: "evt-current-1", TriggerEventType: "task.started", ParseOK: true}},
 		},
 	}
 	handler := testHandler(t, Options{
@@ -172,6 +173,10 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if reads.lastConversationSessionID != "sess-1" {
 		t.Fatalf("conversation.get session = %q", reads.lastConversationSessionID)
 	}
+	conversationTurns, _ := asMap(t, getConversation.Result)["turns"].([]any)
+	if len(conversationTurns) != 1 || asMap(t, conversationTurns[0])["turn_index"] != float64(1) {
+		t.Fatalf("conversation.get turns = %#v, want turn_index 1", asMap(t, getConversation.Result)["turns"])
+	}
 
 	getTurn := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"turn","method":"conversation.get_turn","params":{"session_id":"sess-1","turn_index":1,"include_logs":false}}`)
 	if getTurn.Error != nil {
@@ -187,6 +192,10 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	}
 	if reads.lastCurrentConversationFor != "agent-1" {
 		t.Fatalf("current_for_agent id = %q", reads.lastCurrentConversationFor)
+	}
+	currentTurns, _ := asMap(t, current.Result)["turns"].([]any)
+	if len(currentTurns) != 1 || asMap(t, currentTurns[0])["turn_index"] != float64(1) {
+		t.Fatalf("conversation.current_for_agent turns = %#v, want turn_index 1", asMap(t, current.Result)["turns"])
 	}
 }
 

--- a/internal/dashboard/server/conversations_sql.go
+++ b/internal/dashboard/server/conversations_sql.go
@@ -206,6 +206,7 @@ func conversationMessagesFromOperator(items []store.OperatorConversationMessage)
 
 func conversationTurnFromOperator(item store.OperatorConversationTurn) ConversationTurn {
 	return ConversationTurn{
+		TurnIndex:              item.TurnIndex,
 		TurnID:                 strings.TrimSpace(item.TurnID),
 		AgentID:                strings.TrimSpace(item.AgentID),
 		SessionID:              strings.TrimSpace(item.SessionID),

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -79,6 +79,7 @@ type ConversationDetail struct {
 }
 
 type ConversationTurn struct {
+	TurnIndex              int                      `json:"turn_index,omitempty"`
 	TurnID                 string                   `json:"turn_id"`
 	AgentID                string                   `json:"agent_id,omitempty"`
 	SessionID              string                   `json:"session_id,omitempty"`

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -319,6 +319,7 @@ func (s stubConversations) LoadOperatorConversation(_ context.Context, sessionID
 	}
 	for _, turn := range item.Turns {
 		out.Turns = append(out.Turns, store.OperatorConversationTurn{
+			TurnIndex:              turn.TurnIndex,
 			TurnID:                 turn.TurnID,
 			AgentID:                turn.AgentID,
 			SessionID:              turn.SessionID,
@@ -1042,6 +1043,7 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 					UpdatedAt: now.Format(time.RFC3339),
 					Messages:  []ConversationMessage{{Role: "assistant", Content: "hi"}},
 					Turns: []ConversationTurn{{
+						TurnIndex:              1,
 						TurnID:                 "turn-1",
 						AssistantVisibleOutput: "done",
 					}},
@@ -1117,6 +1119,9 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 	}
 	if detail.AgentID != "agent-1" || len(detail.Messages) != 1 || len(detail.Turns) != 1 {
 		t.Fatalf("unexpected conversation detail: %+v", detail)
+	}
+	if detail.Turns[0].TurnIndex != 1 {
+		t.Fatalf("turn_index = %d, want 1", detail.Turns[0].TurnIndex)
 	}
 
 	rec = httptest.NewRecorder()
@@ -1545,6 +1550,56 @@ func TestSQLConversationReader_ListAndGet(t *testing.T) {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
 	}
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLConversationReader_ListAndGetProjectsTurnIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLConversationReader(db, stubConversationCaps{caps: store.StoreSchemaCapabilities{
+		Conversations: store.ConversationSchemaCapabilities{
+			Sessions:   store.SchemaFlavorCanonical,
+			Turns:      store.SchemaFlavorCanonical,
+			TurnBlocks: true,
+		},
+	}})
+	now := time.Date(2026, 3, 17, 15, 0, 0, 0, time.UTC)
+	turnBlocksPayload := `[{"kind":"turn_summary","data":{"assistant_visible_output":"done","outcome":"complete"}}]`
+
+	mock.ExpectQuery("SELECT\\s+session_id,\\s+agent_id,\\s+kind,.*COALESCE\\(conversation, '\\[\\]'::jsonb\\).*FROM \\(").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id", "agent_id", "kind", "scope_key", "scope", "runtime_mode", "status", "turn_count", "runtime_state", "conversation", "updated_at",
+		}).AddRow("sess-1", "agent-1", "live_session", "global", "global", "session", "active", 1, []byte(`{"summary":"brief"}`), []byte(`[]`), now))
+
+	mock.ExpectQuery("SELECT\\s+turn_id::text,.*FROM agent_turns").
+		WithArgs("agent-1", "sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"turn_id", "agent_id", "session_id", "runtime_mode", "scope_key", "entity_id", "trigger_event_id", "trigger_event_type", "task_id",
+			"available_tools", "tool_calls", "emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
+			"request_payload", "response_payload", "turn_blocks", "parse_ok", "latency_ms", "retry_count", "error", "created_at",
+		}).AddRow(
+			"turn-1", "agent-1", "sess-1", "session", "global", "", "evt-1", "task.started", "task-1",
+			[]byte(`[]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`),
+			[]byte(`{}`), []byte(`{}`), []byte(turnBlocksPayload), true, 7, 0, "", now,
+		))
+
+	item, ok, err := reader.Get(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if !ok || len(item.Turns) != 1 {
+		t.Fatalf("unexpected detail: %+v", item)
+	}
+	if item.Turns[0].TurnIndex != 1 {
+		t.Fatalf("turn_index = %d, want 1", item.Turns[0].TurnIndex)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -321,6 +321,7 @@ type OperatorConversationWatchdog struct {
 }
 
 type OperatorConversationTurn struct {
+	TurnIndex        int                             `json:"turn_index"`
 	TurnID           string                          `json:"turn_id"`
 	TriggerEventID   string                          `json:"trigger_event_id"`
 	TriggerEventType string                          `json:"trigger_event_type"`
@@ -1666,6 +1667,7 @@ func (r *OperatorAgentConversationReadSurface) loadConversationTurns(ctx context
 		if err != nil {
 			return nil, err
 		}
+		item.TurnIndex = len(out) + 1
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -377,6 +377,48 @@ func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveL
 	}
 }
 
+func TestOperatorConversationReadSurfaceLoadConversationAssignsTurnIndexes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	runID := "33333333-3333-3333-3333-333333333333"
+	firstTurnID := "44444444-4444-4444-4444-444444444444"
+	secondTurnID := "55555555-5555-5555-5555-555555555555"
+	startedAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+session_id,\\s+agent_id,.*FROM \\(.*\\) conversations\\s+WHERE session_id = \\$1").
+		WithArgs(sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
+			AddRow(sessionID, "agent-1", runID, "live_session", "global", "global", "session", "active", 2, 1, []byte(`{"summary":"active session"}`), []byte(`[{"role":"assistant","content":"ready"}]`), startedAt, nil, startedAt))
+	mock.ExpectQuery("(?s)SELECT\\s+turn_id::text,.*FROM agent_turns.*ORDER BY created_at ASC, turn_id ASC").
+		WithArgs("agent-1", sessionID).
+		WillReturnRows(sqlmock.NewRows(operatorConversationTurnColumns()).
+			AddRow(firstTurnID, "agent-1", sessionID, "session", "global", "", "66666666-6666-6666-6666-666666666666", "input.received", "task-1", []byte(`["emit_done"]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`), []byte(`{"turn":1}`), []byte(`{"ok":true}`), []byte(`[]`), true, 1000, 0, "", startedAt).
+			AddRow(secondTurnID, "agent-1", sessionID, "session", "global", "", "77777777-7777-7777-7777-777777777777", "input.received", "task-2", []byte(`["emit_done"]`), []byte(`[]`), []byte(`[]`), []byte(`{}`), []byte(`[]`), []byte(`[]`), []byte(`{"turn":2}`), []byte(`{"ok":true}`), []byte(`[]`), true, 1500, 0, "", startedAt.Add(time.Second)))
+
+	detail, err := reader.LoadOperatorConversation(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversation: %v", err)
+	}
+	if len(detail.Turns) != 2 {
+		t.Fatalf("turn count = %d, want 2", len(detail.Turns))
+	}
+	if detail.Turns[0].TurnIndex != 1 || detail.Turns[0].TurnID != firstTurnID || detail.Turns[1].TurnIndex != 2 || detail.Turns[1].TurnID != secondTurnID {
+		t.Fatalf("turn indexes = %#v", detail.Turns)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestOperatorConversationReadSurfaceLoadTurnComposesConversationOwner(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #877.

Adds the current-spec 1-based `turn_index` selector to shallow `ConversationDetail.turns[]` / `Turn` records so clients can pass the selected row directly to the existing `conversation.get_turn({ session_id, turn_index })` contract.

This PR does not add `conversation.get_turn({ turn_id })`; that remains a separately gated stable-ID selector contract class.

## Governing refs / context

Binding spec refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.Turn`
- `components.schemas.ConversationDetail`
- `method_catalog.conversation.get`
- `method_catalog.conversation.current_for_agent`
- `method_catalog.conversation.get_turn`, whose `turn_index` param is documented as the 1-based position matching `conversation.get` turn order: `agent_turns.created_at ASC, turn_id ASC`

Generated artifact:

- `docs/specs/swarm-platform/platform/contracts/openrpc.json` regenerated from `platform-spec.yaml`

## Semantic migration

New canonical owner:

- Contract: `platform-spec.yaml` `Turn` / `ConversationDetail` plus existing `conversation.get_turn` indexed selector contract.
- Runtime/store owner: `OperatorAgentConversationReadSurface.loadConversationTurns`, which already materializes canonical `created_at ASC, turn_id ASC` order and now assigns `TurnIndex` as `1..n` on the shared `OperatorConversationTurn` DTO.

Old producer / reader / writer path now invalid:

- Clients no longer need to infer `turn_index = arrayIndex + 1` from shallow `turns[]` array position for the supported OpenRPC surfaces.
- Handler-side or client-side `turn_id` selector interpretation remains non-authoritative in this PR.

Production paths checked for surviving old behavior:

- `/v1/rpc conversation.get`
- `/v1/rpc conversation.current_for_agent`
- `/v1/rpc conversation.get_turn` indexed selector handoff
- Dashboard REST conversation adapter that consumes the shared store DTO

Migration complete for the approved OpenRPC indexed selector-discoverability class. Broader stable-ID selector ergonomics and full generated result-schema validation remain outside this PR and tracked by the existing issue/watchlist state (#857/#890 context).

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec -run TestGeneratedOpenRPCArtifactMatchesPlatformSpec -count=1`
- `go test ./internal/apispec -run 'TestGeneratedOpenRPCArtifactMatchesPlatformSpec|TestOpenRPC' -count=1`
- `go test ./internal/store -run 'TestOperatorConversationReadSurfaceLoadConversationAssignsTurnIndexes|TestOperatorConversationReadSurfaceLoadTurnComposesConversationOwner|TestOperatorConversationReadSurfaceLoadTurnOutOfRange' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorConversationGetTurnComposesRuntimeLogOwner|TestOpenRPCReadOnlyHTTPRuntimeProbes' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_ConversationsAndAggregates|TestSQLConversationReader_ListAndGet|TestHandler_ConversationDetail_PreservesParseOKFalse' -count=1`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server ./internal/apispec`