### PR TITLE
[agent-b][issue #892] Add entity CLI read consumers

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -79,6 +79,8 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newEventCommand(opts),
 		newAgentsCommand(opts),
 		newAgentCommand(opts),
+		newEntitiesCommand(opts),
+		newEntityCommand(opts),
 		newMailboxCommand(opts),
 		newControlCommand(opts),
 		newRetiredForkCommand(),

--- a/cmd/swarm/entities.go
+++ b/cmd/swarm/entities.go
@@ -74,10 +74,10 @@ type entitySummary struct {
 }
 
 type entityFull struct {
-	Entity      entitySummary               `json:"entity"`
-	Fields      map[string]any              `json:"fields"`
-	Gates       map[string]bool             `json:"gates"`
-	Accumulated map[string][]map[string]any `json:"accumulated"`
+	Entity      entitySummary   `json:"entity"`
+	Fields      map[string]any  `json:"fields"`
+	Gates       map[string]bool `json:"gates"`
+	Accumulated map[string]any  `json:"accumulated"`
 }
 
 type entityAggregateResult struct {

--- a/cmd/swarm/entities.go
+++ b/cmd/swarm/entities.go
@@ -1,0 +1,554 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	entityListMethod      = "entity.list"
+	entityGetMethod       = "entity.get"
+	entityAggregateMethod = "entity.aggregate"
+)
+
+type entityListCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	runID        string
+	flow         string
+	entityType   string
+	currentState string
+	limit        int
+	cursor       string
+
+	runIDSet        bool
+	flowSet         bool
+	entityTypeSet   bool
+	currentStateSet bool
+	limitSet        bool
+	cursorSet       bool
+}
+
+type entityViewCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	runID    string
+	runIDSet bool
+}
+
+type entityAggregateCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	runID    string
+	groupBy  string
+	typeName string
+
+	runIDSet   bool
+	groupBySet bool
+	typeSet    bool
+}
+
+type entityListResult struct {
+	Entities   []entitySummary `json:"entities"`
+	NextCursor string          `json:"next_cursor,omitempty"`
+}
+
+type entitySummary struct {
+	EntityID     string `json:"entity_id"`
+	RunID        string `json:"run_id"`
+	FlowInstance string `json:"flow_instance"`
+	EntityType   string `json:"entity_type"`
+	CurrentState string `json:"current_state"`
+	Slug         string `json:"slug,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Revision     int    `json:"revision"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+type entityFull struct {
+	Entity      entitySummary               `json:"entity"`
+	Fields      map[string]any              `json:"fields"`
+	Gates       map[string]bool             `json:"gates"`
+	Accumulated map[string][]map[string]any `json:"accumulated"`
+}
+
+type entityAggregateResult struct {
+	Counts map[string]int `json:"counts"`
+}
+
+var (
+	entityOpaqueIDPattern   = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
+	entityFieldGroupPattern = regexp.MustCompile(`^fields\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$`)
+	entityGroupFields       = map[string]struct{}{
+		"current_state":    {},
+		"flow":             {},
+		"flow_instance":    {},
+		"workflow_name":    {},
+		"workflow_version": {},
+		"type":             {},
+		"entity_type":      {},
+		"slug":             {},
+		"name":             {},
+	}
+)
+
+func newEntitiesCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "entities",
+		Short: "List entities through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newEntitiesListCommand(opts))
+	return cmd
+}
+
+func newEntityCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "entity",
+		Short: "View or aggregate entities through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newEntityViewCommand(opts),
+		newEntityAggregateCommand(opts),
+	)
+	return cmd
+}
+
+func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := entityListCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List entities through /v1/rpc entity.list.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listOpts.runIDSet = cmd.Flags().Changed("run-id")
+			listOpts.flowSet = cmd.Flags().Changed("flow")
+			listOpts.entityTypeSet = cmd.Flags().Changed("type")
+			listOpts.currentStateSet = cmd.Flags().Changed("current-state")
+			listOpts.limitSet = cmd.Flags().Changed("limit")
+			listOpts.cursorSet = cmd.Flags().Changed("cursor")
+			return runEntitiesListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
+		},
+	}
+	cmd.Flags().StringVar(&listOpts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().StringVar(&listOpts.flow, "flow", "", "Filter by flow instance")
+	cmd.Flags().StringVar(&listOpts.entityType, "type", "", "Filter by entity type")
+	cmd.Flags().StringVar(&listOpts.currentState, "current-state", "", "Filter by current entity state")
+	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
+	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	return cmd
+}
+
+func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
+	viewOpts := entityViewCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "view <entity-id>",
+		Short: "View one entity through /v1/rpc entity.get.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			viewOpts.runIDSet = cmd.Flags().Changed("run-id")
+			return runEntityViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], viewOpts)
+		},
+	}
+	cmd.Flags().StringVar(&viewOpts.runID, "run-id", "", "Disambiguate entities reused across runs")
+	return cmd
+}
+
+func newEntityAggregateCommand(opts rootCommandOptions) *cobra.Command {
+	aggregateOpts := entityAggregateCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "aggregate",
+		Short: "Aggregate entity counts through /v1/rpc entity.aggregate.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			aggregateOpts.runIDSet = cmd.Flags().Changed("run-id")
+			aggregateOpts.groupBySet = cmd.Flags().Changed("group-by")
+			aggregateOpts.typeSet = cmd.Flags().Changed("type")
+			return runEntityAggregateCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), aggregateOpts)
+		},
+	}
+	cmd.Flags().StringVar(&aggregateOpts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().StringVar(&aggregateOpts.groupBy, "group-by", "", "Group by current_state, flow, flow_instance, workflow_name, workflow_version, type, entity_type, slug, name, or fields.<path>")
+	cmd.Flags().StringVar(&aggregateOpts.typeName, "type", "", "Filter by entity type")
+	return cmd
+}
+
+func runEntitiesListCommand(ctx context.Context, out, errOut io.Writer, opts entityListCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
+	}
+	var result entityListResult
+	if err := client.call(ctx, entityListMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
+	}
+	if err := validateEntityListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
+	}
+	writeEntityListResult(out, result)
+	return nil
+}
+
+func runEntityViewCommand(ctx context.Context, out, errOut io.Writer, entityID string, opts entityViewCommandOptions) error {
+	entityID = strings.TrimSpace(entityID)
+	if err := validateEntityOpaqueIDArg("entity id", entityID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	params := map[string]any{"entity_id": entityID}
+	if opts.runIDSet {
+		runID, err := entityNonEmptyFlag("--run-id", opts.runID)
+		if err != nil {
+			return returnCLIValidationError(errOut, err)
+		}
+		if err := validateEntityOpaqueIDArg("--run-id", runID); err != nil {
+			return returnCLIValidationError(errOut, err)
+		}
+		params["run_id"] = runID
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, entityViewAPIErrorClassifier())
+	}
+	var result entityFull
+	if err := client.call(ctx, entityGetMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, entityViewAPIErrorClassifier())
+	}
+	if err := validateEntityFullResult("entity.get result", result); err != nil {
+		return returnCLIAPIError(errOut, err, entityViewAPIErrorClassifier())
+	}
+	writeEntityFullResult(out, result)
+	return nil
+}
+
+func runEntityAggregateCommand(ctx context.Context, out, errOut io.Writer, opts entityAggregateCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, entityAggregateAPIErrorClassifier())
+	}
+	var result entityAggregateResult
+	if err := client.call(ctx, entityAggregateMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, entityAggregateAPIErrorClassifier())
+	}
+	if err := validateEntityAggregateResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, entityAggregateAPIErrorClassifier())
+	}
+	writeEntityAggregateResult(out, result)
+	return nil
+}
+
+func (opts entityListCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.runIDSet {
+		runID, err := entityNonEmptyFlag("--run-id", opts.runID)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateEntityOpaqueIDArg("--run-id", runID); err != nil {
+			return nil, err
+		}
+		params["run_id"] = runID
+	}
+	if opts.flowSet {
+		flow, err := entityNonEmptyFlag("--flow", opts.flow)
+		if err != nil {
+			return nil, err
+		}
+		params["flow"] = flow
+	}
+	if opts.entityTypeSet {
+		entityType, err := entityNonEmptyFlag("--type", opts.entityType)
+		if err != nil {
+			return nil, err
+		}
+		params["type"] = entityType
+	}
+	if opts.currentStateSet {
+		currentState, err := entityNonEmptyFlag("--current-state", opts.currentState)
+		if err != nil {
+			return nil, err
+		}
+		params["current_state"] = currentState
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = opts.limit
+	}
+	if opts.cursorSet {
+		cursor, err := entityNonEmptyFlag("--cursor", opts.cursor)
+		if err != nil {
+			return nil, err
+		}
+		params["cursor"] = cursor
+	}
+	return params, nil
+}
+
+func (opts entityAggregateCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.runIDSet {
+		runID, err := entityNonEmptyFlag("--run-id", opts.runID)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateEntityOpaqueIDArg("--run-id", runID); err != nil {
+			return nil, err
+		}
+		params["run_id"] = runID
+	}
+	if opts.groupBySet {
+		groupBy, err := entityNonEmptyFlag("--group-by", opts.groupBy)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateEntityGroupBy(groupBy); err != nil {
+			return nil, err
+		}
+		params["group_by"] = groupBy
+	}
+	if opts.typeSet {
+		entityType, err := entityNonEmptyFlag("--type", opts.typeName)
+		if err != nil {
+			return nil, err
+		}
+		params["type"] = entityType
+	}
+	return params, nil
+}
+
+func entityNonEmptyFlag(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s must not be empty", name)
+	}
+	return value, nil
+}
+
+func validateEntityOpaqueIDArg(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if len(value) > 256 {
+		return fmt.Errorf("%s must be at most 256 characters", name)
+	}
+	if !entityOpaqueIDPattern.MatchString(value) {
+		return fmt.Errorf("%s must match OpaqueId pattern", name)
+	}
+	return nil
+}
+
+func validateEntityOpaqueIDField(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if len(value) > 256 {
+		return fmt.Errorf("%s must be at most 256 characters", field)
+	}
+	if !entityOpaqueIDPattern.MatchString(value) {
+		return fmt.Errorf("%s must match OpaqueId pattern", field)
+	}
+	return nil
+}
+
+func validateEntityGroupBy(groupBy string) error {
+	if _, ok := entityGroupFields[groupBy]; ok {
+		return nil
+	}
+	if entityFieldGroupPattern.MatchString(groupBy) {
+		return nil
+	}
+	return fmt.Errorf("--group-by must be one of current_state, flow, flow_instance, workflow_name, workflow_version, type, entity_type, slug, name, or fields.<path>")
+}
+
+func validateEntityListResult(result entityListResult) error {
+	if result.Entities == nil {
+		return fmt.Errorf("malformed entity.list result: entities is required")
+	}
+	for i, entity := range result.Entities {
+		if err := validateEntitySummary(fmt.Sprintf("entity.list result: entities[%d]", i), entity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEntityFullResult(prefix string, result entityFull) error {
+	if err := validateEntitySummary(prefix+".entity", result.Entity); err != nil {
+		return err
+	}
+	if result.Fields == nil {
+		return fmt.Errorf("malformed %s: fields is required", prefix)
+	}
+	if result.Gates == nil {
+		return fmt.Errorf("malformed %s: gates is required", prefix)
+	}
+	if result.Accumulated == nil {
+		return fmt.Errorf("malformed %s: accumulated is required", prefix)
+	}
+	return nil
+}
+
+func validateEntitySummary(prefix string, entity entitySummary) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "entity_id", value: entity.EntityID},
+		{name: "run_id", value: entity.RunID},
+		{name: "flow_instance", value: entity.FlowInstance},
+		{name: "entity_type", value: entity.EntityType},
+		{name: "current_state", value: entity.CurrentState},
+		{name: "created_at", value: entity.CreatedAt},
+		{name: "updated_at", value: entity.UpdatedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateEntityOpaqueIDField(prefix+".entity_id", entity.EntityID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if err := validateEntityOpaqueIDField(prefix+".run_id", entity.RunID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if entity.Revision < 0 {
+		return fmt.Errorf("malformed %s: revision must be non-negative", prefix)
+	}
+	if err := validateRequiredTimestamp(prefix+".created_at", entity.CreatedAt); err != nil {
+		return err
+	}
+	if err := validateRequiredTimestamp(prefix+".updated_at", entity.UpdatedAt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateEntityAggregateResult(result entityAggregateResult) error {
+	if result.Counts == nil {
+		return fmt.Errorf("malformed entity.aggregate result: counts is required")
+	}
+	for key, count := range result.Counts {
+		if count < 0 {
+			return fmt.Errorf("malformed entity.aggregate result: counts[%q] must be non-negative", key)
+		}
+	}
+	return nil
+}
+
+func writeEntityListResult(out io.Writer, result entityListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Entities) == 0 {
+		fmt.Fprintln(out, "No entities match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "ENTITY_ID\tRUN_ID\tFLOW\tTYPE\tSTATE\tREVISION\tUPDATED\tSLUG\tNAME")
+	for _, entity := range result.Entities {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
+			entity.EntityID,
+			entity.RunID,
+			entity.FlowInstance,
+			entity.EntityType,
+			entity.CurrentState,
+			entity.Revision,
+			entity.UpdatedAt,
+			entityDash(entity.Slug),
+			entityDash(entity.Name),
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeEntityFullResult(out io.Writer, result entityFull) {
+	if out == nil {
+		return
+	}
+	entity := result.Entity
+	fmt.Fprintf(out, "Entity %s\n", entity.EntityID)
+	fmt.Fprintf(out, "run_id=%s flow=%s type=%s state=%s revision=%d created_at=%s updated_at=%s\n",
+		entity.RunID,
+		entity.FlowInstance,
+		entity.EntityType,
+		entity.CurrentState,
+		entity.Revision,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+	)
+	fmt.Fprintf(out, "slug=%s name=%s\n", entityDash(entity.Slug), entityDash(entity.Name))
+	fmt.Fprintf(out, "fields=%s\n", entityCompactJSON(result.Fields))
+	fmt.Fprintf(out, "gates=%s\n", entityCompactJSON(result.Gates))
+	fmt.Fprintf(out, "accumulated=%s\n", entityCompactJSON(result.Accumulated))
+}
+
+func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Counts) == 0 {
+		fmt.Fprintln(out, "No entity aggregate rows match the filter.")
+		return
+	}
+	keys := make([]string, 0, len(result.Counts))
+	for key := range result.Counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	fmt.Fprintln(out, "GROUP\tCOUNT")
+	for _, key := range keys {
+		fmt.Fprintf(out, "%s\t%d\n", entityDash(key), result.Counts[key])
+	}
+}
+
+func entityListAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func entityViewAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"ENTITY_NOT_FOUND"}}
+}
+
+func entityAggregateAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func entityCompactJSON(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func entityDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -127,7 +127,7 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 		"slug=vertical-1 name=Vertical One",
 		`fields={"score":7}`,
 		`gates={"ready":true}`,
-		`accumulated={"notes":[{"text":"ok"}]}`,
+		`accumulated={"notes":["a"]}`,
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
@@ -389,7 +389,7 @@ func validEntityFullResult(entityID string) map[string]any {
 		"entity":      validEntitySummary(entityID),
 		"fields":      map[string]any{"score": 7},
 		"gates":       map[string]any{"ready": true},
-		"accumulated": map[string]any{"notes": []map[string]any{{"text": "ok"}}},
+		"accumulated": map[string]any{"notes": []any{"a"}},
 	}
 }
 

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities":    []map[string]any{validEntitySummary("entity-1")},
+			"next_cursor": "entity-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"entities", "list",
+		"--run-id", "run-1",
+		"--flow", "flows/review",
+		"--type", "vertical",
+		"--current-state", "collecting",
+		"--limit", "25",
+		"--cursor", "cursor-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != entityListMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, entityListMethod)
+	}
+	wantParams := map[string]any{
+		"run_id":        "run-1",
+		"flow":          "flows/review",
+		"type":          "vertical",
+		"current_state": "collecting",
+		"limit":         float64(25),
+		"cursor":        "cursor-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"ENTITY_ID", "RUN_ID", "entity-1", "run-1", "flows/review", "vertical", "collecting", "next_cursor=entity-cursor-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"entities": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entities", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != entityListMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, entityListMethod)
+	}
+	if len(captured.Params) != 0 {
+		t.Fatalf("params = %#v, want empty", captured.Params)
+	}
+	if !strings.Contains(stdout.String(), "No entities match the filter.") {
+		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
+	}
+}
+
+func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEntityFullResult("entity-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != entityGetMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, entityGetMethod)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"entity_id": "entity-1", "run_id": "run-1"}) {
+		t.Fatalf("params = %#v, want entity_id/run_id", captured.Params)
+	}
+	for _, want := range []string{
+		"Entity entity-1",
+		"run_id=run-1 flow=flows/review type=vertical state=collecting revision=3",
+		"slug=vertical-1 name=Vertical One",
+		`fields={"score":7}`,
+		`gates={"ready":true}`,
+		`accumulated={"notes":[{"text":"ok"}]}`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		captured = append(captured, req)
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"counts": map[string]any{"collecting": 2, "reviewing": 1}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "aggregate"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("default code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured[0].Method != entityAggregateMethod {
+		t.Fatalf("method = %q, want %s", captured[0].Method, entityAggregateMethod)
+	}
+	if len(captured[0].Params) != 0 {
+		t.Fatalf("default params = %#v, want empty for server-owned default group", captured[0].Params)
+	}
+	if !strings.Contains(stdout.String(), "GROUP\tCOUNT") || !strings.Contains(stdout.String(), "collecting\t2") {
+		t.Fatalf("stdout = %q, want aggregate table", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"entity", "aggregate",
+		"--run-id", "run-1",
+		"--group-by", "fields.priority",
+		"--type", "vertical",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("filtered code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{"run_id": "run-1", "group_by": "fields.priority", "type": "vertical"}
+	if !reflect.DeepEqual(captured[1].Params, wantParams) {
+		t.Fatalf("filtered params = %#v, want %#v", captured[1].Params, wantParams)
+	}
+}
+
+func TestEntityCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"entities": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "list invalid limit low", args: []string{"entities", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "list invalid run id", args: []string{"entities", "list", "--run-id", "bad id!"}, wantStderr: "--run-id must match OpaqueId pattern"},
+		{name: "list blank flow", args: []string{"entities", "list", "--flow", " "}, wantStderr: "--flow must not be empty"},
+		{name: "view missing id", args: []string{"entity", "view"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "view blank id", args: []string{"entity", "view", " "}, wantStderr: "entity id is required"},
+		{name: "view invalid id", args: []string{"entity", "view", "bad id!"}, wantStderr: "entity id must match OpaqueId pattern"},
+		{name: "view invalid run id", args: []string{"entity", "view", "entity-1", "--run-id", "bad id!"}, wantStderr: "--run-id must match OpaqueId pattern"},
+		{name: "aggregate invalid group", args: []string{"entity", "aggregate", "--group-by", "bad field"}, wantStderr: "--group-by must be one of"},
+		{name: "aggregate blank type", args: []string{"entity", "aggregate", "--type", " "}, wantStderr: "--type must not be empty"},
+		{name: "aggregate extra arg", args: []string{"entity", "aggregate", "extra"}, wantStderr: "unknown command"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestEntityCommandsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"entities": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"entities", "list"},
+		{"entity", "view", "entity-1"},
+		{"entity", "aggregate"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 4 {
+			t.Fatalf("%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			t.Fatalf("%v stderr = %q, want token failure", args, stderr.String())
+		}
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "list http auth exits four",
+			args: []string{"entities", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "list missing entities exits three",
+			args: []string{"entities", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "entities is required",
+		},
+		{
+			name: "list malformed entity exits three",
+			args: []string{"entities", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				entity := validEntitySummary("entity-1")
+				delete(entity, "current_state")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+			},
+			wantCode:   3,
+			wantStderr: "current_state is required",
+		},
+		{
+			name: "view entity not found exits five",
+			args: []string{"entity", "view", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEntityJSONRPCError(t, w, req.ID, "ENTITY_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "ENTITY_NOT_FOUND",
+		},
+		{
+			name: "view missing fields exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				delete(result, "fields")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "fields is required",
+		},
+		{
+			name: "aggregate unknown rpc exits three",
+			args: []string{"entity", "aggregate"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEntityJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+		{
+			name: "aggregate missing counts exits three",
+			args: []string{"entity", "aggregate"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "counts is required",
+		},
+		{
+			name: "aggregate negative count exits three",
+			args: []string{"entity", "aggregate"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"counts": map[string]any{"collecting": -1}})
+			},
+			wantCode:   3,
+			wantStderr: "counts[\"collecting\"] must be non-negative",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func validEntitySummary(entityID string) map[string]any {
+	return map[string]any{
+		"entity_id":     entityID,
+		"run_id":        "run-1",
+		"flow_instance": "flows/review",
+		"entity_type":   "vertical",
+		"current_state": "collecting",
+		"slug":          "vertical-1",
+		"name":          "Vertical One",
+		"revision":      3,
+		"created_at":    "2026-05-20T01:00:00Z",
+		"updated_at":    "2026-05-20T01:05:00Z",
+	}
+}
+
+func validEntityFullResult(entityID string) map[string]any {
+	return map[string]any{
+		"entity":      validEntitySummary(entityID),
+		"fields":      map[string]any{"score": 7},
+		"gates":       map[string]any{"ready": true},
+		"accumulated": map[string]any{"notes": []map[string]any{{"text": "ok"}}},
+	}
+}
+
+func writeEntityJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5599,9 +5599,9 @@ cli_specification:
         tracker: '#735'
         action: '`swarm conversations list`, `swarm conversation view`, and `swarm conversation turn` require separate gated children.'
       entities:
-        disposition: future_child
-        tracker: '#735'
-        action: '`swarm entities list`, `swarm entity view`, and `swarm entity aggregate` require separate gated children.'
+        disposition: promoted_first_slice
+        tracker: '#892'
+        action: '`swarm entities list`, `swarm entity view`, and `swarm entity aggregate` are promoted as one bounded read-only CLI child over /v1/rpc entity.list, entity.get, and entity.aggregate; conversations and forkchat remain split.'
       logs:
         disposition: promoted_first_slice
         tracker: '#876'
@@ -5799,6 +5799,9 @@ cli_specification:
         - event_publish
         - logs
         - incidents
+        - entities_list
+        - entity_view
+        - entity_aggregate
         - run
         implemented_consumer_residuals:
           logs: >
@@ -5811,6 +5814,11 @@ cli_specification:
             command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
             implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #886 does not add
             command-local output-mode flags or semantics.
+          entities: >
+            `swarm entities list`, `swarm entity view`, and `swarm entity aggregate` are implemented for
+            default-text read-only entity discovery in #892 and are no longer absent command rows. JSON/quiet/shared-renderer
+            behavior remains governed by the output_contract and may be implemented by the separate #794/#848/#735
+            output-mode/shared-renderer tail; #892 does not add command-local output-mode flags or semantics.
       exception_rules:
         root_help_completion:
           commands:
@@ -5845,9 +5853,6 @@ cli_specification:
           - conversation_view
           - conversation_turn
           - forkchat
-          - entities_list
-          - entity_view
-          - entity_aggregate
           rule: >
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future
             implementation children consume this contract only after their command/API/runtime owner is promoted.
@@ -5871,8 +5876,8 @@ cli_specification:
       scope: >
         First-slice normalization for currently implemented API-backed CLI commands. This applies to diagnostics/read
         paths, mailbox list/view/decisions, version --server, agents list/view, agent mutations, control commands, event
-        list/follow/view/replay/publish, and swarm run shared API/client failures. Future command families consume this
-        contract when their API-backed implementation is promoted.
+        list/follow/view/replay/publish, entity list/view/aggregate, and swarm run shared API/client failures. Future
+        command families consume this contract when their API-backed implementation is promoted.
       canonical_owner: cmd/swarm shared CLI API error classifier
       stdout_rule: >
         stdout is reserved for successful load-bearing command output. API/client/runtime errors, malformed API
@@ -6771,18 +6776,119 @@ cli_specification:
     entities_list:
       command: swarm entities list
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc entity.list
+      params:
+      - name: run_id
+        flag: --run-id <run-id>
+        required: false
+        api_param: run_id
+        validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
+      - name: flow
+        flag: --flow <flow-instance>
+        required: false
+        api_param: flow
+      - name: type
+        flag: --type <entity-type>
+        required: false
+        api_param: type
+      - name: current_state
+        flag: --current-state <state>
+        required: false
+        api_param: current_state
+      - name: limit
+        flag: --limit <1-500>
+        required: false
+        api_param: limit
+        rule: Omitted by the CLI when absent; server applies the entity.list default.
+      - name: cursor
+        flag: --cursor <cursor>
+        required: false
+        api_param: cursor
+      output:
+        table: ENTITY_ID / RUN_ID / FLOW / TYPE / STATE / REVISION / UPDATED / SLUG / NAME plus next_cursor when present
+        empty: No entities match the filter.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+      proof_expectations:
+      - exact /v1/rpc entity.list call with run_id, flow, type, current_state, limit, and cursor params only when supplied
+      - missing SWARM_API_TOKEN, blank optional flags, invalid run_id OpaqueId envelope, invalid limit, invalid args, and unsupported flags make zero API calls
+      - empty result, next_cursor rendering, auth/HTTP/RPC failures, malformed result, and malformed EntitySummary rows fail closed with tested exit-code behavior
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
     entity_view:
       command: swarm entity view <entity-id>
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc entity.get
+      params:
+      - name: entity_id
+        argument: <entity-id>
+        required: true
+        api_param: entity_id
+        validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
+      - name: run_id
+        flag: --run-id <run-id>
+        required: false
+        api_param: run_id
+        validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
+      output:
+        heading: Entity <entity-id>
+        summary_line: run_id / flow / type / state / revision / created_at / updated_at
+        optional_line: slug / name with '-' for omitted optional fields
+        structured_lines: compact JSON for server-owned fields, gates, and accumulated maps
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        entity_not_found: 5
+      proof_expectations:
+      - exact /v1/rpc entity.get call with required entity_id and optional run_id params only
+      - missing/blank/invalid entity id, blank or invalid --run-id, invalid args, unsupported flags, and missing SWARM_API_TOKEN make zero API calls
+      - ENTITY_NOT_FOUND maps to resource-not-found exit 5
+      - auth/HTTP/RPC failures, malformed EntityFull result, malformed nested EntitySummary, and missing fields/gates/accumulated maps fail closed with tested exit-code behavior
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
     entity_aggregate:
-      command: swarm entity aggregate --group-by <field>
+      command: swarm entity aggregate [--group-by <field>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc entity.aggregate
+      params:
+      - name: run_id
+        flag: --run-id <run-id>
+        required: false
+        api_param: run_id
+        validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
+      - name: group_by
+        flag: --group-by <field>
+        required: false
+        api_param: group_by
+        default: current_state
+        validation: >
+          CLI accepts current_state, flow, flow_instance, workflow_name, workflow_version, type,
+          entity_type, slug, name, or fields.<path> where path segments match [A-Za-z0-9_]+.
+          When omitted, the CLI sends no group_by and lets the server apply the API default.
+      - name: type
+        flag: --type <entity-type>
+        required: false
+        api_param: type
+      output:
+        table: GROUP / COUNT sorted by group value, with '-' for an empty group key
+        empty: No entity aggregate rows match the filter.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+      proof_expectations:
+      - exact /v1/rpc entity.aggregate call with run_id, group_by, and type params only when supplied
+      - missing SWARM_API_TOKEN, blank optional flags, invalid run_id OpaqueId envelope, unsupported group_by, invalid args, and unsupported flags make zero API calls
+      - omitted --group-by sends no group_by and relies on the server default current_state
+      - empty result, deterministic aggregate rendering, auth/HTTP/RPC failures, missing counts, and negative counts fail closed with tested exit-code behavior
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
     logs:
       command: swarm logs [filters] [--follow]
       tier: should_have
@@ -6961,6 +7067,9 @@ cli_specification:
     - swarm event publish
     - swarm logs
     - swarm incidents
+    - swarm entities list
+    - swarm entity view
+    - swarm entity aggregate
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -6972,7 +7081,6 @@ cli_specification:
     remaining_should_have_not_implemented:
     - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
-    - swarm entities list / entity view / entity aggregate
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
 api_specification:


### PR DESCRIPTION
## Summary

Implements the approved #892 entity CLI read-consumer slice:

- Adds `swarm entities list` over `/v1/rpc entity.list`.
- Adds `swarm entity view <entity-id>` over `/v1/rpc entity.get`.
- Adds `swarm entity aggregate [--group-by <field>]` over `/v1/rpc entity.aggregate`.
- Repairs merge-bearing `platform-spec.yaml` rows, output/exit/proof expectations, output-contract accounting, and #735 remaining-tail accounting for the entity family.

Closes #892
Part of #735

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.entities_list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.entity_view`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.entity_aggregate`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.entity.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.entity.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.entity.aggregate`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.EntitySummary`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.EntityFull`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.EntityAggregateResult`
- #892 Pre-Implementation Coverage Audit and independent gate approval.

## Semantic Migration

- New canonical CLI consumers: `cmd/swarm` entity commands consuming `/v1/rpc entity.list`, `/v1/rpc entity.get`, and `/v1/rpc entity.aggregate` through the shared CLI v1 API client.
- Canonical owners after this PR: merge-bearing `platform-spec.yaml` command/API/schema rows, `internal/apiv1` entity handlers, and typed `PostgresStore` entity read owners.
- Old producer/reader/writer path now invalid for CLI: any direct DB/store/runtime/EventBus/dashboard/Builder/legacy transport entity read from `cmd/swarm`.
- Production paths checked for surviving old behavior: `cmd/swarm`, `internal/apiv1`, `internal/store`, `internal/dashboard/server`, generated OpenRPC, docs/scripts probes recorded in the audit.
- Migration completeness: complete for the approved #892 entity CLI read-consumer slice; #735 remains open for conversations, forkchat, output-mode/richer UX residuals, and separately tracked parent lanes.

## Proof

- `go test ./cmd/swarm -run 'Entit|Entity' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'OperatorEntity|OpenRPCReadOnly' -count=1`
- `go test ./internal/store -run 'OperatorEntityReadOwner|OperatorEntity|EntityRead' -count=1`
- `go test ./internal/dashboard/server -run 'Instances|Entity|Aggregate' -count=1`
- `git diff --cached --check`
- Static no-bypass grep over `cmd/swarm/entities.go` for DB/store/runtime/EventBus/dashboard/Builder/legacy entity paths: no matches.
