### PR TITLE
[agent-f][issue #891] Add owner-backed agent.diagnose slice

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -13,6 +13,66 @@
   ],
   "methods": [
     {
+      "name": "agent.diagnose",
+      "description": "Read the first owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, pending delivery count/oldest age,\nand optional delivery lifecycle evidence. The API handler consumes the\ncanonical agent diagnosis read owner directly. It must not join\nconversation, run, trace, token, queue-detail, CLI, or dashboard owners\nlocally, and it must not expose runtime_state, run_id, bundle_version,\nactive task/entity, watchdog, last tool outcome, token usage, recent\nfailures, dead letters, pending delivery details, attempts, or cursors.\n",
+      "params": [
+        {
+          "name": "agent_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/AgentDiagnosis"
+        }
+      },
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Application error: AGENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "AGENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "agent_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "agent.get",
       "description": "Read one agent's identity, current operational status, and references\nto its current session and last turn. Returns refs only — full session\nand transcript content is read via conversation.* methods. Ownership\nboundary: agent.* never returns transcripts.\n",
       "params": [
@@ -5217,6 +5277,33 @@
   ],
   "components": {
     "schemas": {
+      "AgentDeliveryLifecycle": {
+        "additionalProperties": false,
+        "properties": {
+          "blocking_layer": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/AgentDeliveryLifecycleState"
+          }
+        },
+        "required": [
+          "state",
+          "blocking_layer"
+        ],
+        "type": "object"
+      },
+      "AgentDeliveryLifecycleState": {
+        "enum": [
+          "queued",
+          "launching",
+          "active",
+          "retrying",
+          "exhausted"
+        ],
+        "type": "string"
+      },
       "AgentDetail": {
         "additionalProperties": false,
         "properties": {
@@ -5232,6 +5319,53 @@
         },
         "required": [
           "agent"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosis": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "current_session_ref": {
+            "$ref": "#/components/schemas/SessionRef"
+          },
+          "delivery_lifecycle": {
+            "$ref": "#/components/schemas/AgentDeliveryLifecycle"
+          },
+          "last_turn_ref": {
+            "$ref": "#/components/schemas/TurnRef"
+          },
+          "queue": {
+            "$ref": "#/components/schemas/AgentDiagnosisQueue"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentStatus"
+          }
+        },
+        "required": [
+          "agent_id",
+          "status",
+          "queue"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosisQueue": {
+        "additionalProperties": false,
+        "properties": {
+          "oldest_pending_age_seconds": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pending_count",
+          "oldest_pending_age_seconds"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8299,6 +8299,59 @@ api_specification:
             $ref: '#/components/schemas/SessionRef'
           last_turn_ref:
             $ref: '#/components/schemas/TurnRef'
+      AgentDeliveryLifecycleState:
+        type: string
+        enum:
+        - queued
+        - launching
+        - active
+        - retrying
+        - exhausted
+      AgentDiagnosisQueue:
+        type: object
+        additionalProperties: false
+        required:
+        - pending_count
+        - oldest_pending_age_seconds
+        properties:
+          pending_count:
+            type: integer
+            minimum: 0
+          oldest_pending_age_seconds:
+            type: integer
+            minimum: 0
+      AgentDeliveryLifecycle:
+        type: object
+        additionalProperties: false
+        required:
+        - state
+        - blocking_layer
+        properties:
+          state:
+            $ref: '#/components/schemas/AgentDeliveryLifecycleState'
+          blocking_layer:
+            type: string
+            minLength: 1
+      AgentDiagnosis:
+        type: object
+        additionalProperties: false
+        required:
+        - agent_id
+        - status
+        - queue
+        properties:
+          agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          status:
+            $ref: '#/components/schemas/AgentStatus'
+          current_session_ref:
+            $ref: '#/components/schemas/SessionRef'
+          last_turn_ref:
+            $ref: '#/components/schemas/TurnRef'
+          queue:
+            $ref: '#/components/schemas/AgentDiagnosisQueue'
+          delivery_lifecycle:
+            $ref: '#/components/schemas/AgentDeliveryLifecycle'
       ConversationSummary:
         type: object
         additionalProperties: false
@@ -10106,6 +10159,32 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/AgentDetail'
+      errors:
+      - AGENT_NOT_FOUND
+    agent.diagnose:
+      tier: should_have
+      description: |
+        Read the first owner-backed diagnosis slice for one agent. This method is
+        limited to agent identity/status refs, pending delivery count/oldest age,
+        and optional delivery lifecycle evidence. The API handler consumes the
+        canonical agent diagnosis read owner directly. It must not join
+        conversation, run, trace, token, queue-detail, CLI, or dashboard owners
+        locally, and it must not expose runtime_state, run_id, bundle_version,
+        active task/entity, watchdog, last tool outcome, token usage, recent
+        failures, dead letters, pending delivery details, attempts, or cursors.
+      scope:
+        required:
+        - read:agents
+      params:
+      - name: agent_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/AgentDiagnosis'
       errors:
       - AGENT_NOT_FOUND
     agent.send_directive:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,11 +16,11 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 42 {
-		t.Fatalf("method count = %d, want 42", report.MethodCount)
+	if report.MethodCount != 43 {
+		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 59 {
-		t.Fatalf("schema count = %d, want 59", report.SchemaCount)
+	if report.SchemaCount != 63 {
+		t.Fatalf("schema count = %d, want 63", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -64,11 +64,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 42 {
-		t.Fatalf("generated OpenRPC methods = %d, want 42", len(doc.Methods))
+	if len(doc.Methods) != 43 {
+		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 59 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 59", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 63 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 63", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -85,6 +85,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["agent.replay"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.replay")
+	}
+	if _, ok := methods["agent.diagnose"]; !ok {
+		t.Fatal("generated OpenRPC missing agent.diagnose")
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 42 {
-		t.Fatalf("method count = %d, want 42", len(openRPCNames))
+	if len(openRPCNames) != 43 {
+		t.Fatalf("method count = %d, want 43", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -107,8 +107,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 42 {
-		t.Fatalf("generated OpenRPC methods = %d, want 42", len(doc.Methods))
+	if len(doc.Methods) != 43 {
+		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -237,6 +237,7 @@ func readOnlyHTTPRuntimeMethods(t *testing.T, api *apispec.APISpecification, ope
 
 func approvedReadOnlyHTTPRuntimeMethods() []string {
 	return []string{
+		"agent.diagnose",
 		"agent.get",
 		"agent.list",
 		"conversation.current_for_agent",
@@ -263,6 +264,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 
 func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 	return map[string]readOnlyHTTPRuntimeFixture{
+		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
@@ -289,6 +291,16 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 
 func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 	return []readOnlyHTTPRuntimeErrorProbe{
+		{
+			Method: "agent.diagnose",
+			Params: map[string]any{"agent_id": "missing"},
+			Code:   AgentNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.AgentConversations = &fakeAgentConversationReadStore{agentDiagnosisErr: store.ErrAgentNotFound}
+				return opts
+			},
+		},
 		{
 			Method: "agent.get",
 			Params: map[string]any{"agent_id": "missing"},
@@ -508,6 +520,18 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 				SessionScope:     "global",
 				Status:           "running",
 			}},
+			agentDiagnosisResult: store.OperatorAgentDiagnosis{
+				AgentID: "agent-1",
+				Status:  "running",
+				Queue: store.OperatorAgentDiagnosisQueue{
+					PendingCount:            2,
+					OldestPendingAgeSeconds: 30,
+				},
+				DeliveryLifecycle: &store.OperatorAgentDeliveryLifecycle{
+					State:         "active",
+					BlockingLayer: "session_execution",
+				},
+			},
 			listConversationsResult: store.OperatorConversationListResult{Conversations: []store.OperatorConversationSummary{{
 				SessionID:    sessionID,
 				AgentID:      "agent-1",
@@ -631,6 +655,17 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		}
 		if got := asMap(t, turns[0])["turn_index"]; got != float64(1) {
 			t.Fatalf("%s first turn_index = %#v, want 1", methodName, got)
+		}
+	}
+	if methodName == "agent.diagnose" {
+		queue := asMap(t, result["queue"])
+		if queue["pending_count"] != float64(2) || queue["oldest_pending_age_seconds"] != float64(30) {
+			t.Fatalf("agent.diagnose queue = %#v", queue)
+		}
+		for _, splitField := range []string{"runtime_state", "bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+			if _, ok := result[splitField]; ok {
+				t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, result)
+			}
 		}
 	}
 }

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -17,6 +17,8 @@ type fakeAgentConversationReadStore struct {
 	listAgentsErr                 error
 	agentResult                   store.OperatorAgentDetail
 	agentErr                      error
+	agentDiagnosisResult          store.OperatorAgentDiagnosis
+	agentDiagnosisErr             error
 	listConversationsResult       store.OperatorConversationListResult
 	listConversationsErr          error
 	conversationResult            store.OperatorConversationDetail
@@ -28,6 +30,7 @@ type fakeAgentConversationReadStore struct {
 	lastAgentList                 store.OperatorAgentListOptions
 	lastConversationList          store.OperatorConversationListOptions
 	lastAgentID                   string
+	lastAgentDiagnosisID          string
 	lastConversationSessionID     string
 	lastConversationTurnSessionID string
 	lastConversationTurnIndex     int
@@ -42,6 +45,11 @@ func (s *fakeAgentConversationReadStore) ListOperatorAgents(_ context.Context, o
 func (s *fakeAgentConversationReadStore) LoadOperatorAgent(_ context.Context, agentID string) (store.OperatorAgentDetail, error) {
 	s.lastAgentID = agentID
 	return s.agentResult, s.agentErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorAgentDiagnosis(_ context.Context, agentID string) (store.OperatorAgentDiagnosis, error) {
+	s.lastAgentDiagnosisID = agentID
+	return s.agentDiagnosisResult, s.agentDiagnosisErr
 }
 
 func (s *fakeAgentConversationReadStore) ListOperatorConversations(_ context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error) {
@@ -98,6 +106,18 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 			Status:           "running",
 		}}},
 		agentResult: store.OperatorAgentDetail{Agent: store.OperatorAgentSummary{AgentID: "agent-1", Role: "researcher"}},
+		agentDiagnosisResult: store.OperatorAgentDiagnosis{
+			AgentID: "agent-1",
+			Status:  "running",
+			Queue: store.OperatorAgentDiagnosisQueue{
+				PendingCount:            2,
+				OldestPendingAgeSeconds: 45,
+			},
+			DeliveryLifecycle: &store.OperatorAgentDeliveryLifecycle{
+				State:         "active",
+				BlockingLayer: "session_execution",
+			},
+		},
 		listConversationsResult: store.OperatorConversationListResult{
 			Conversations: []store.OperatorConversationSummary{{
 				SessionID:    "sess-1",
@@ -156,6 +176,38 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	}
 	if reads.lastAgentID != "agent-1" {
 		t.Fatalf("agent.get id = %q", reads.lastAgentID)
+	}
+	agentResult := asMap(t, getAgent.Result)
+	agent := asMap(t, agentResult["agent"])
+	for _, splitField := range []string{"queue", "delivery_lifecycle", "runtime_state", "last_tool_outcome"} {
+		if _, ok := agent[splitField]; ok {
+			t.Fatalf("agent.get unexpectedly exposed diagnosis field %q: %#v", splitField, agent)
+		}
+	}
+
+	diagnoseAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+	if diagnoseAgent.Error != nil {
+		t.Fatalf("agent.diagnose error = %#v", diagnoseAgent.Error)
+	}
+	if reads.lastAgentDiagnosisID != "agent-1" {
+		t.Fatalf("agent.diagnose id = %q", reads.lastAgentDiagnosisID)
+	}
+	diagnosis := asMap(t, diagnoseAgent.Result)
+	if diagnosis["agent_id"] != "agent-1" || diagnosis["status"] != "running" {
+		t.Fatalf("agent.diagnose identity/status = %#v", diagnosis)
+	}
+	queue := asMap(t, diagnosis["queue"])
+	if queue["pending_count"] != float64(2) || queue["oldest_pending_age_seconds"] != float64(45) {
+		t.Fatalf("agent.diagnose queue = %#v", queue)
+	}
+	lifecycle := asMap(t, diagnosis["delivery_lifecycle"])
+	if lifecycle["state"] != "active" || lifecycle["blocking_layer"] != "session_execution" {
+		t.Fatalf("agent.diagnose lifecycle = %#v", lifecycle)
+	}
+	for _, splitField := range []string{"runtime_state", "bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+		if _, ok := diagnosis[splitField]; ok {
+			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
+		}
 	}
 
 	listConversations := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"convs","method":"conversation.list","params":{"agent_id":"agent-1","run_id":"11111111-1111-1111-1111-111111111111","limit":10,"cursor":"abc"}}`)
@@ -372,6 +424,13 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 			wantApp: AgentNotFoundCode,
 		},
 		{
+			name:    "agent diagnosis missing",
+			method:  "agent.diagnose",
+			body:    `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{agentDiagnosisErr: store.ErrAgentNotFound},
+			wantApp: AgentNotFoundCode,
+		},
+		{
 			name:    "conversation missing",
 			method:  "conversation.get",
 			body:    `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"missing"}}`,
@@ -417,5 +476,32 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 				t.Fatalf("error code = %#v, want %s", data["code"], tc.wantApp)
 			}
 		})
+	}
+}
+
+func TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData(t *testing.T) {
+	reads := &fakeAgentConversationReadStore{
+		agentDiagnosisResult: store.OperatorAgentDiagnosis{
+			AgentID: "agent-1",
+			Status:  "working",
+			Queue:   store.OperatorAgentDiagnosisQueue{},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.diagnose returned success for malformed owner result")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.diagnose owner returned malformed result") {
+		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
 	}
 }

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -40,6 +40,7 @@ type EntityReadStore interface {
 type AgentConversationReadStore interface {
 	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
+	LoadOperatorAgentDiagnosis(context.Context, string) (store.OperatorAgentDiagnosis, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
 	LoadOperatorConversationTurn(context.Context, string, int) (store.OperatorConversationTurnDetail, error)
@@ -297,6 +298,27 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			}
 			return result, nil
 		},
+		"agent.diagnose": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			agentID, err := requiredStringParam(req.Params, "agent_id")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorAgentDiagnosis(ctx, agentID)
+			if errors.Is(err, store.ErrAgentNotFound) {
+				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if err := validateAgentDiagnosisResult(result); err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
 		"conversation.list": func(ctx context.Context, req Request) (any, error) {
 			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
 			if err != nil {
@@ -407,6 +429,48 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			}
 			return result, nil
 		},
+	}
+}
+
+func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
+	if strings.TrimSpace(item.AgentID) == "" {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: agent_id is required")
+	}
+	if !validAgentDiagnosisStatus(item.Status) {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: status=%q is not a valid AgentStatus", item.Status)
+	}
+	if item.Queue.PendingCount < 0 {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_count must be non-negative")
+	}
+	if item.Queue.OldestPendingAgeSeconds < 0 {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: queue.oldest_pending_age_seconds must be non-negative")
+	}
+	if item.DeliveryLifecycle != nil {
+		if !validAgentDeliveryLifecycleState(item.DeliveryLifecycle.State) {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: delivery_lifecycle.state=%q is not valid", item.DeliveryLifecycle.State)
+		}
+		if strings.TrimSpace(item.DeliveryLifecycle.BlockingLayer) == "" {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: delivery_lifecycle.blocking_layer is required")
+		}
+	}
+	return nil
+}
+
+func validAgentDiagnosisStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "idle", "running", "paused", "failed", "terminated":
+		return true
+	default:
+		return false
+	}
+}
+
+func validAgentDeliveryLifecycleState(state string) bool {
+	switch strings.TrimSpace(state) {
+	case "queued", "launching", "active", "retrying", "exhausted":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -15,11 +15,26 @@ policy:
   runtime_behavior_changes: transport_admission_repair_approved_by_878
   read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; mutating, WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
   mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
-  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 42 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, and full notification-schema validation remain tracked by #857."
-  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 42 methods; notification-schema validation/publication, examples, and rpc.discover remain tracked by #857."
+  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, and full notification-schema validation remain tracked by #857."
+  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; notification-schema validation/publication, examples, and rpc.discover remain tracked by #857."
   examples_policy: OpenRPC method examples are tracked gaps in this slice.
   service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
 methods:
+  - method: agent.diagnose
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
+    gap_classification: [missing_openrpc_examples]
   - method: agent.get
     transport: http
     required_params: [agent_id]

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -98,6 +98,7 @@ type OperatorAgentSummary struct {
 	StartedAt           time.Time           `json:"-"`
 	DashboardStatus     string              `json:"-"`
 	DashboardState      string              `json:"-"`
+	DeliveryLifecycle   string              `json:"-"`
 	BlockingLayer       string              `json:"-"`
 	CurrentSessionRef   *OperatorSessionRef `json:"-"`
 	LastTurnRef         *OperatorTurnRef    `json:"-"`
@@ -119,6 +120,25 @@ type OperatorAgentDetail struct {
 	Agent             OperatorAgentSummary `json:"agent"`
 	CurrentSessionRef *OperatorSessionRef  `json:"current_session_ref,omitempty"`
 	LastTurnRef       *OperatorTurnRef     `json:"last_turn_ref,omitempty"`
+}
+
+type OperatorAgentDiagnosis struct {
+	AgentID           string                          `json:"agent_id"`
+	Status            string                          `json:"status"`
+	CurrentSessionRef *OperatorSessionRef             `json:"current_session_ref,omitempty"`
+	LastTurnRef       *OperatorTurnRef                `json:"last_turn_ref,omitempty"`
+	Queue             OperatorAgentDiagnosisQueue     `json:"queue"`
+	DeliveryLifecycle *OperatorAgentDeliveryLifecycle `json:"delivery_lifecycle,omitempty"`
+}
+
+type OperatorAgentDiagnosisQueue struct {
+	PendingCount            int `json:"pending_count"`
+	OldestPendingAgeSeconds int `json:"oldest_pending_age_seconds"`
+}
+
+type OperatorAgentDeliveryLifecycle struct {
+	State         string `json:"state"`
+	BlockingLayer string `json:"blocking_layer"`
 }
 
 type OperatorAgentTool struct {
@@ -415,6 +435,10 @@ func (s *PostgresStore) LoadOperatorAgent(ctx context.Context, agentID string) (
 	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgent(ctx, agentID)
 }
 
+func (s *PostgresStore) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string) (OperatorAgentDiagnosis, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentDiagnosis(ctx, agentID)
+}
+
 func (s *PostgresStore) ListOperatorConversations(ctx context.Context, opts OperatorConversationListOptions) (OperatorConversationListResult, error) {
 	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).ListOperatorConversations(ctx, opts)
 }
@@ -485,6 +509,18 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorAgent(ctx context.Con
 		}
 	}
 	return OperatorAgentDetail{}, ErrAgentNotFound
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string) (OperatorAgentDiagnosis, error) {
+	detail, err := r.LoadOperatorAgent(ctx, agentID)
+	if err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	diagnosis, err := operatorAgentDiagnosisFromDetail(detail)
+	if err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	return diagnosis, nil
 }
 
 func (r *OperatorAgentConversationReadSurface) ListOperatorConversations(ctx context.Context, opts OperatorConversationListOptions) (OperatorConversationListResult, error) {
@@ -1188,6 +1224,7 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		StartedAt:           row.StartedAt,
 		DashboardStatus:     strings.TrimSpace(projection.Status),
 		DashboardState:      projection.dashboardState(),
+		DeliveryLifecycle:   strings.TrimSpace(projection.LifecycleState),
 		BlockingLayer:       projection.dashboardBlockingLayer(),
 		CurrentSessionRef:   projection.currentSessionRef(),
 		LastTurnRef:         projection.LastTurnRef,
@@ -1196,6 +1233,72 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		out.NearBreaker = out.TurnCount*100 >= out.TurnLimit*85
 	}
 	return out
+}
+
+func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgentDiagnosis, error) {
+	agent := detail.Agent
+	out := OperatorAgentDiagnosis{
+		AgentID:           strings.TrimSpace(agent.AgentID),
+		Status:            strings.TrimSpace(agent.Status),
+		CurrentSessionRef: detail.CurrentSessionRef,
+		LastTurnRef:       detail.LastTurnRef,
+		Queue: OperatorAgentDiagnosisQueue{
+			PendingCount:            agent.PendingEvents,
+			OldestPendingAgeSeconds: agent.OldestPendingAgeSec,
+		},
+	}
+	if state := strings.TrimSpace(agent.DeliveryLifecycle); state != "" {
+		out.DeliveryLifecycle = &OperatorAgentDeliveryLifecycle{
+			State:         state,
+			BlockingLayer: strings.TrimSpace(agent.BlockingLayer),
+		}
+	}
+	if err := validateOperatorAgentDiagnosis(out); err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	return out, nil
+}
+
+func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
+	if strings.TrimSpace(item.AgentID) == "" {
+		return fmt.Errorf("agent diagnosis agent_id is required")
+	}
+	if !validOperatorAgentDiagnosisStatus(item.Status) {
+		return fmt.Errorf("agent diagnosis status %q is not valid", item.Status)
+	}
+	if item.Queue.PendingCount < 0 {
+		return fmt.Errorf("agent diagnosis queue.pending_count must be non-negative")
+	}
+	if item.Queue.OldestPendingAgeSeconds < 0 {
+		return fmt.Errorf("agent diagnosis queue.oldest_pending_age_seconds must be non-negative")
+	}
+	if item.DeliveryLifecycle != nil {
+		if !validOperatorAgentDeliveryLifecycleState(item.DeliveryLifecycle.State) {
+			return fmt.Errorf("agent diagnosis delivery_lifecycle.state %q is not valid", item.DeliveryLifecycle.State)
+		}
+		if strings.TrimSpace(item.DeliveryLifecycle.BlockingLayer) == "" {
+			return fmt.Errorf("agent diagnosis delivery_lifecycle.blocking_layer is required")
+		}
+	}
+	return nil
+}
+
+func validOperatorAgentDiagnosisStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "idle", "running", "paused", "failed", "terminated":
+		return true
+	default:
+		return false
+	}
+}
+
+func validOperatorAgentDeliveryLifecycleState(state string) bool {
+	switch strings.TrimSpace(state) {
+	case "queued", "launching", "active", "retrying", "exhausted":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p operatorAgentProjection) currentSessionRef() *OperatorSessionRef {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -300,6 +300,141 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	}
 }
 
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	turnID := "22222222-2222-2222-2222-222222222222"
+	sessionStartedAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+		pending: map[string]PendingAgentDeliveryFacts{
+			"agent-1": {PendingCount: 3, OldestPendingAgeSec: 90},
+		},
+		lifecycle: map[string]AgentLifecycleFacts{
+			"agent-1": {CurrentState: "active", BlockingLayer: "session_execution"},
+		},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.AgentID != "agent-1" || diagnosis.Status != "running" {
+		t.Fatalf("identity/status = %#v", diagnosis)
+	}
+	if diagnosis.CurrentSessionRef == nil || diagnosis.CurrentSessionRef.SessionID != sessionID || !diagnosis.CurrentSessionRef.StartedAt.Equal(sessionStartedAt) {
+		t.Fatalf("current_session_ref = %#v", diagnosis.CurrentSessionRef)
+	}
+	if diagnosis.LastTurnRef == nil || diagnosis.LastTurnRef.TurnID != turnID || !diagnosis.LastTurnRef.CompletedAt.Equal(turnCompletedAt) {
+		t.Fatalf("last_turn_ref = %#v", diagnosis.LastTurnRef)
+	}
+	if diagnosis.Queue.PendingCount != 3 || diagnosis.Queue.OldestPendingAgeSeconds != 90 {
+		t.Fatalf("queue = %#v", diagnosis.Queue)
+	}
+	if diagnosis.DeliveryLifecycle == nil || diagnosis.DeliveryLifecycle.State != "active" || diagnosis.DeliveryLifecycle.BlockingLayer != "session_execution" {
+		t.Fatalf("delivery_lifecycle = %#v", diagnosis.DeliveryLifecycle)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.Queue.PendingCount != 0 || diagnosis.Queue.OldestPendingAgeSeconds != 0 {
+		t.Fatalf("queue = %#v, want zero facts", diagnosis.Queue)
+	}
+	if diagnosis.DeliveryLifecycle != nil {
+		t.Fatalf("delivery_lifecycle = %#v, want nil", diagnosis.DeliveryLifecycle)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLifecycle(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+		lifecycle: map[string]AgentLifecycleFacts{
+			"agent-1": {CurrentState: "blocked", BlockingLayer: "session_execution"},
+		},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	if err == nil || !strings.Contains(err.Error(), "delivery_lifecycle.state") {
+		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want delivery_lifecycle.state failure", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisPropagatesCapabilityFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	caps := canonicalAgentConversationReadCaps()
+	caps.Events.Log = SchemaFlavorLegacy
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   caps,
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	if err == nil || !strings.Contains(err.Error(), "events schema is unsupported") {
+		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want events capability failure", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessionOnly(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #891
Part of #852

Promotes the approved first `agent.diagnose` API/read-model slice into tracked merge-bearing sources and implementation proof:

- adds `agent.diagnose` plus `AgentDiagnosis` schemas to `platform-spec.yaml#api_specification`
- regenerates `openrpc.json`
- registers `/v1/rpc agent.diagnose`
- adds `LoadOperatorAgentDiagnosis(ctx, agentID)` as the typed read owner consumed directly by the handler
- adds API/spec/runtime-probe/store proof for success, validation, missing-agent, owner/capability failure, malformed owner data, selected field ownership, zero/absent lifecycle, and refs-only `agent.get`

## Governing Refs

Binding authority:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#spec_authority`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.source_of_truth`
- `api_specification.namespaces` agent/conversation ownership rule
- adjacent tracked methods: `agent.list`, `agent.get`, `conversation.current_for_agent`, `conversation.get_turn`, `run.trace`, `run.diagnose`
- #891 Pre-Implementation Coverage Audit and independent gate outcome `approved as first slice`

Ignored review drafts are not source-of-truth for this PR.

## Semantic Migration

New canonical owner for the selected child class: `store.LoadOperatorAgentDiagnosis(ctx, agentID)` / `OperatorAgentDiagnosis`.

Old invalid path: handler-local joins across agent, conversation, run, trace, token, queue-detail, CLI, or dashboard readers. The API handler now calls the typed diagnosis owner directly and validates the returned owner shape fail-closed.

Production paths checked for surviving old behavior:

- `agent.get` / `agent.list` remain refs/summary surfaces and do not expose queue/lifecycle diagnosis fields
- `conversation.current_for_agent`, `conversation.get_turn`, `run.trace`, and `run.diagnose` remain distinct adjacent owners
- CLI/dashboard consumers are not claimed closed in this child
- split #852 fields are not present in the `agent.diagnose` params/result schema

Migration completeness: complete for #891's selected first-slice API/read-model class only. #852 remains open for runtime_state, run_id scoping, watchdog migration, queue detail/attempts/cursors, active work, last tool outcome, token rollups, failures/dead letters, CLI, dashboard, and broad lifecycle/model tails.

## Tests

- `go run ./cmd/swarm-openrpc-gen`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentDiagnosis|TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs|TestListPending|TestPostgresStore_ListPending|TestOperatorAgent|Test.*AgentLifecycle'`
- `go test ./internal/apispec ./internal/apiv1`
- `go test ./internal/store ./internal/apispec ./internal/apiv1`
- `git diff --check`