### PR TITLE
[agent-a][issue #844] Promote CLI API config authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -341,6 +341,29 @@ func TestPlatformSpecServeUnifiedListenerBindContractPromoted(t *testing.T) {
 
 func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) {
 	spec := loadCLIAPIConnectionAuthConfigSpec(t)
+	platformSpecData, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	platformSpecText := string(platformSpecData)
+	for _, stale := range []string{
+		"Runtime-state commands use v1 bearer auth through `SWARM_API_TOKEN`",
+		"SWARM_API_TOKEN is the only user-facing API bearer-token source",
+		"SWARM_API_TOKEN is required.",
+	} {
+		if strings.Contains(platformSpecText, stale) {
+			t.Fatalf("platform spec still contains stale SWARM_API_TOKEN-only bearer-token authority %q", stale)
+		}
+	}
+	for _, want := range []string{
+		"User-facing API bearer-token sources are governed by",
+		"cli_specification.foundations.api_connection_auth_config_precedence",
+		"`SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` fallback is invalid",
+	} {
+		if !strings.Contains(platformSpecText, want) {
+			t.Fatalf("platform spec missing auth-boundary repair proof %q", want)
+		}
+	}
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
 		t.Fatalf("api connection/auth/config promoted_by = %q, want #844", spec.PromotedBy)
 	}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -391,9 +391,13 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("api_token accepted sources missing %q: %#v", want, spec.APIToken.AcceptedSources)
 		}
 	}
-	for _, want := range []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file"} {
-		if !stringSliceContains(spec.APIToken.SourceOrder, want) {
-			t.Fatalf("api_token source order missing %q: %#v", want, spec.APIToken.SourceOrder)
+	wantTokenSourceOrder := []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file"}
+	if len(spec.APIToken.SourceOrder) != len(wantTokenSourceOrder) {
+		t.Fatalf("api_token source order = %#v, want %#v", spec.APIToken.SourceOrder, wantTokenSourceOrder)
+	}
+	for i, want := range wantTokenSourceOrder {
+		if spec.APIToken.SourceOrder[i] != want {
+			t.Fatalf("api_token source_order[%d] = %q, want %q", i, spec.APIToken.SourceOrder[i], want)
 		}
 	}
 	for key, want := range map[string]string{

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -339,6 +339,114 @@ func TestPlatformSpecServeUnifiedListenerBindContractPromoted(t *testing.T) {
 	}
 }
 
+func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) {
+	spec := loadCLIAPIConnectionAuthConfigSpec(t)
+	if strings.TrimSpace(spec.PromotedBy) != "#844" {
+		t.Fatalf("api connection/auth/config promoted_by = %q, want #844", spec.PromotedBy)
+	}
+	if strings.TrimSpace(spec.ImplementationStatus) != "authority_promoted_behavior_pending" {
+		t.Fatalf("api connection/auth/config implementation_status = %q, want authority_promoted_behavior_pending", spec.ImplementationStatus)
+	}
+	if !strings.Contains(spec.CanonicalOwner, "cli_specification.foundations.api_connection_auth_config_precedence") {
+		t.Fatalf("canonical owner does not point at promoted section: %s", spec.CanonicalOwner)
+	}
+	for _, want := range []string{"Cobra flags", "runtime behavior", "OpenRPC"} {
+		if !strings.Contains(spec.Scope, want) {
+			t.Fatalf("scope missing boundary %q:\n%s", want, spec.Scope)
+		}
+	}
+	wantPrecedence := []string{"flag", "environment", "config_file", "built_in_default"}
+	if len(spec.PrecedenceOrder) != len(wantPrecedence) {
+		t.Fatalf("precedence order = %#v, want %#v", spec.PrecedenceOrder, wantPrecedence)
+	}
+	for i, want := range wantPrecedence {
+		if spec.PrecedenceOrder[i] != want {
+			t.Fatalf("precedence order[%d] = %q, want %q", i, spec.PrecedenceOrder[i], want)
+		}
+	}
+	if spec.APIServer.AcceptedSources.Flag != "--api-server <url>" {
+		t.Fatalf("api_server flag = %q, want --api-server <url>", spec.APIServer.AcceptedSources.Flag)
+	}
+	if spec.APIServer.AcceptedSources.Environment != "SWARM_API_SERVER" {
+		t.Fatalf("api_server environment = %q, want SWARM_API_SERVER", spec.APIServer.AcceptedSources.Environment)
+	}
+	if spec.APIServer.AcceptedSources.ConfigKey != "api_server" {
+		t.Fatalf("api_server config key = %q, want api_server", spec.APIServer.AcceptedSources.ConfigKey)
+	}
+	if spec.APIServer.AcceptedSources.BuiltInDefault != "http://127.0.0.1:8081" {
+		t.Fatalf("api_server default = %q, want http://127.0.0.1:8081", spec.APIServer.AcceptedSources.BuiltInDefault)
+	}
+	for _, want := range []string{"base URL", "`/v1/rpc`", "`/v1/ws`"} {
+		if !strings.Contains(spec.APIServer.ValueModel, want) {
+			t.Fatalf("api_server value model missing %q:\n%s", want, spec.APIServer.ValueModel)
+		}
+	}
+	for _, want := range []string{"migration evidence", "127.0.0.1"} {
+		if !strings.Contains(spec.APIServer.Rationale, want) {
+			t.Fatalf("api_server rationale missing %q:\n%s", want, spec.APIServer.Rationale)
+		}
+	}
+	for _, want := range []string{"flag_file", "environment_token", "environment_file", "config_file_key"} {
+		if strings.TrimSpace(spec.APIToken.AcceptedSources[want]) == "" {
+			t.Fatalf("api_token accepted sources missing %q: %#v", want, spec.APIToken.AcceptedSources)
+		}
+	}
+	for _, want := range []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file"} {
+		if !stringSliceContains(spec.APIToken.SourceOrder, want) {
+			t.Fatalf("api_token source order missing %q: %#v", want, spec.APIToken.SourceOrder)
+		}
+	}
+	for key, want := range map[string]string{
+		"--api-token":      "shell history",
+		"config api_token": "inline",
+	} {
+		if !strings.Contains(spec.APIToken.RejectedSources[key], want) {
+			t.Fatalf("api_token rejected source %q missing %q:\n%s", key, want, spec.APIToken.RejectedSources[key])
+		}
+	}
+	for key, want := range map[string]string{
+		"environment": "SWARM_CONFIG",
+		"xdg_default": "swarm/config.yaml",
+	} {
+		if !strings.Contains(spec.CLIConfigFile.AcceptedSources[key], want) {
+			t.Fatalf("cli config accepted source %q missing %q:\n%s", key, want, spec.CLIConfigFile.AcceptedSources[key])
+		}
+	}
+	if !strings.Contains(spec.CLIConfigFile.RejectedSources["--config"], "dual semantic ownership") {
+		t.Fatalf("cli config --config rejection missing dual-ownership rule:\n%s", spec.CLIConfigFile.RejectedSources["--config"])
+	}
+	for _, key := range []string{"api_server", "api_token_file"} {
+		if strings.TrimSpace(spec.CLIConfigFile.AcceptedKeys[key]) == "" {
+			t.Fatalf("cli config accepted key %q missing: %#v", key, spec.CLIConfigFile.AcceptedKeys)
+		}
+	}
+	for _, key := range []string{"api_token", "output_format", "no_color", "contracts_path", "platform_spec_path", "log_level", "retry", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
+		if strings.TrimSpace(spec.CLIConfigFile.RejectedKeys[key]) == "" {
+			t.Fatalf("cli config rejected key %q missing: %#v", key, spec.CLIConfigFile.RejectedKeys)
+		}
+	}
+	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT"} {
+		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.RejectedPorts[key], "Not promoted") {
+			t.Fatalf("serve listener rejected port %q missing not-promoted rule:\n%s", key, spec.ServeListenerEnvConfigBoundary.RejectedPorts[key])
+		}
+	}
+	for _, key := range []string{"SWARM_API_LISTEN_ADDR", "SWARM_MCP_LISTEN_ADDR"} {
+		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.ReservedCandidates[key], "later #884/#750") {
+			t.Fatalf("serve listener reserved candidate %q missing split rule:\n%s", key, spec.ServeListenerEnvConfigBoundary.ReservedCandidates[key])
+		}
+	}
+	for _, want := range []string{"#848", "#884/#750", "#743", "`--no-retry`"} {
+		if !stringSliceContains(spec.SplitSiblings, want) {
+			t.Fatalf("split siblings missing %q: %#v", want, spec.SplitSiblings)
+		}
+	}
+	for _, want := range []string{"No Cobra persistent flag", "OpenRPC", "Future API-backed CLI config/auth implementation MUST consume this owner"} {
+		if !stringSliceContains(spec.ImplementationBoundaries, want) {
+			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
+		}
+	}
+}
+
 func TestCLI_ServeVerboseFlagConsumesServeOwner(t *testing.T) {
 	var captured serveOptions
 	opts := defaultRootCommandOptions()
@@ -3248,6 +3356,45 @@ type serveUnifiedListenerSpec struct {
 	UnpromotedReviewControls []string `yaml:"unpromoted_review_controls"`
 }
 
+type cliAPIConnectionAuthConfigSpec struct {
+	PromotedBy           string   `yaml:"promoted_by"`
+	ImplementationStatus string   `yaml:"implementation_status"`
+	CanonicalOwner       string   `yaml:"canonical_owner"`
+	Scope                string   `yaml:"scope"`
+	AppliesTo            []string `yaml:"applies_to"`
+	NotAppliesTo         []string `yaml:"not_applies_to"`
+	PrecedenceOrder      []string `yaml:"precedence_order"`
+	APIServer            struct {
+		AcceptedSources struct {
+			Flag           string `yaml:"flag"`
+			Environment    string `yaml:"environment"`
+			ConfigKey      string `yaml:"config_key"`
+			BuiltInDefault string `yaml:"built_in_default"`
+		} `yaml:"accepted_sources"`
+		ValueModel string `yaml:"value_model"`
+		Rationale  string `yaml:"rationale"`
+	} `yaml:"api_server"`
+	APIToken struct {
+		AcceptedSources map[string]string `yaml:"accepted_sources"`
+		SourceOrder     []string          `yaml:"source_order"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+		TokenFileRule   string            `yaml:"token_file_rule"`
+	} `yaml:"api_token"`
+	CLIConfigFile struct {
+		AcceptedSources map[string]string `yaml:"accepted_sources"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+		AcceptedKeys    map[string]string `yaml:"accepted_keys"`
+		RejectedKeys    map[string]string `yaml:"rejected_keys"`
+	} `yaml:"cli_config_file"`
+	ServeListenerEnvConfigBoundary struct {
+		RejectedPorts      map[string]string `yaml:"rejected_ports"`
+		ReservedCandidates map[string]string `yaml:"reserved_candidates"`
+		Rule               string            `yaml:"rule"`
+	} `yaml:"serve_listener_env_config_boundary"`
+	SplitSiblings            []string `yaml:"split_siblings"`
+	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
+}
+
 func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpecStep {
 	t.Helper()
 	var spec struct {
@@ -3335,6 +3482,28 @@ func loadServeUnifiedListenerSpec(t *testing.T) serveUnifiedListenerSpec {
 		t.Fatal("platform spec missing serve unified_listener_bind_contract")
 	}
 	return spec.CLISpecification.CommandCatalog.Serve.Listener
+}
+
+func loadCLIAPIConnectionAuthConfigSpec(t *testing.T) cliAPIConnectionAuthConfigSpec {
+	t.Helper()
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				APIConnectionAuthConfig cliAPIConnectionAuthConfigSpec `yaml:"api_connection_auth_config_precedence"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	if strings.TrimSpace(spec.CLISpecification.Foundations.APIConnectionAuthConfig.CanonicalOwner) == "" {
+		t.Fatal("platform spec missing api_connection_auth_config_precedence")
+	}
+	return spec.CLISpecification.Foundations.APIConnectionAuthConfig
 }
 
 func stringSliceContains(values []string, want string) bool {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5543,9 +5543,13 @@ cli_specification:
       gates from citing the ignored review artifact as merge authority.
     under_promoted_review_features:
       universal_flags_config_env_precedence:
-        disposition: tracked_child
+        disposition: promoted_first_slice
         tracker: '#844'
-        action: Promote exact universal flag, config-file, and environment-precedence rules before implementation.
+        action: >
+          API connection/auth/config authority is promoted in
+          cli_specification.foundations.api_connection_auth_config_precedence. Output/logging, retry,
+          contract-path, and serve listener environment/config behavior remain split until later children promote
+          their own merge-bearing owners.
       exit_code_and_error_channel_normalization:
         disposition: promoted_first_slice
         tracker: '#846'
@@ -5884,6 +5888,110 @@ cli_specification:
       - stdout/stderr tests proving successful machine-readable stdout is not contaminated by diagnostics/errors
       - no direct DB/store/runtime/EventBus reads for API-backed output rendering
     auth_boundary: 'Runtime-state commands use v1 bearer auth through `SWARM_API_TOKEN`; legacy Builder/operator token fallback is invalid.'
+    api_connection_auth_config_precedence:
+      promoted_by: '#844'
+      implementation_status: authority_promoted_behavior_pending
+      canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence
+      scope: >
+        Merge-bearing authority for CLI API base URL selection, bearer-token selection, and CLI config-file
+        discovery for API-backed commands. This first slice does not add Cobra flags, runtime behavior, OpenRPC
+        behavior, retry behavior, output rendering, or serve listener binding.
+      applies_to:
+      - Runtime-state CLI commands that call the platform JSON-RPC or WebSocket API.
+      - '`swarm version --server` when it queries the platform API.'
+      - '`swarm run --connect` only for shared API client/auth error categories; run mode and follow semantics remain #743.'
+      not_applies_to:
+      - '`swarm serve` runtime configuration such as the existing command-local `--config` runtime-config path.'
+      - '`swarm verify` contract-file validation, except for future separately promoted contract-path defaults.'
+      - Output mode, logging verbosity, retry, color, contract path, and platform-spec path resolution.
+      precedence_order:
+      - flag
+      - environment
+      - config_file
+      - built_in_default
+      api_server:
+        accepted_sources:
+          flag: --api-server <url>
+          environment: SWARM_API_SERVER
+          config_key: api_server
+          built_in_default: http://127.0.0.1:8081
+        value_model: >
+          The configured value is an API server base URL, not a direct `/v1/rpc` endpoint. It MUST include an
+          `http` or `https` scheme and host, MUST NOT include query or fragment components, and SHOULD use an
+          empty path or `/`. API clients derive `/v1/rpc` and `/v1/ws` from that base URL per the command's
+          transport needs.
+        rationale: >
+          The ignored review artifact used `http://localhost:8081`; the promoted spec uses `127.0.0.1` to
+          match serve listener loopback defaults and avoid hostname/IPv6 ambiguity. Current code that stores a
+          full `/v1/rpc` endpoint is migration evidence only until behavior consumes this owner.
+      api_token:
+        accepted_sources:
+          flag_file: --api-token-file <path>
+          environment_token: SWARM_API_TOKEN
+          environment_file: SWARM_API_TOKEN_FILE
+          config_file_key: api_token_file
+        source_order:
+        - --api-token-file
+        - SWARM_API_TOKEN
+        - SWARM_API_TOKEN_FILE
+        - config api_token_file
+        rejected_sources:
+          --api-token: >
+            Not promoted. Inline token flags leak secrets into shell history and process listings; operators
+            must use `SWARM_API_TOKEN` for ephemeral credentials or token-file sources for file-backed
+            credentials.
+          config api_token: >
+            Not promoted. The config file may point at a token file but MUST NOT store the bearer token inline.
+        token_file_rule: >
+          Token-file sources are read once during CLI command startup by the API client/auth resolver. Missing,
+          unreadable, or blank token-file contents classify through the shared CLI error/exit-code contract.
+      cli_config_file:
+        owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file
+        accepted_sources:
+          environment: SWARM_CONFIG
+          xdg_default: '${XDG_CONFIG_HOME:-$HOME/.config}/swarm/config.yaml'
+        rejected_sources:
+          --config: >
+            Not promoted as a root/global CLI config flag in this first slice. The current `swarm serve
+            --config` flag is command-local runtime configuration, so promoting root `--config` now would create
+            dual semantic ownership. If a flag override is needed later, prefer a separately gated `--cli-config`
+            or an explicit rename/migration of the serve runtime-config flag.
+        accepted_keys:
+          api_server: API server base URL consumed by API-backed commands.
+          api_token_file: Path to a file containing the bearer token.
+        rejected_keys:
+          api_token: Inline bearer tokens in config files are not promoted.
+          output_format: Split to #848 output renderer implementation.
+          no_color: Split to output/color universal flag work.
+          contracts_path: Split to contract-path resolution.
+          platform_spec_path: Split to contract-path resolution.
+          log_level: Split to logging/output work.
+          retry: Split to retry policy work.
+          serve_api_listen_addr: Split to #884/#750 serve listener implementation.
+          serve_mcp_listen_addr: Split to #884/#750 serve listener implementation.
+      serve_listener_env_config_boundary:
+        rejected_ports:
+          SWARM_API_PORT: 'Not promoted; final v2.1 listener topology uses full listen addresses.'
+          SWARM_MCP_PORT: 'Not promoted; final v2.1 listener topology uses full listen addresses.'
+        reserved_candidates:
+          SWARM_API_LISTEN_ADDR: 'Candidate environment name for a later #884/#750 listener implementation child; not accepted by this first-slice API client resolver.'
+          SWARM_MCP_LISTEN_ADDR: 'Candidate environment name for a later #884/#750 listener implementation child; not accepted by this first-slice API client resolver.'
+        rule: >
+          API client connection settings and serve listener bind settings are different concepts. This owner
+          governs where CLI clients connect; listener bind flags/env/config remain under the serve topology owner
+          until a later child promotes and implements them.
+      split_siblings:
+      - '#848 output modes/shared renderer; spec promoted, implementation pending'
+      - '#846 error-channel and exit-code classification; closed first slice'
+      - '#844 later behavior child for API config/auth resolver implementation'
+      - '#884/#750 serve listener runtime implementation and listener env/config keys'
+      - '#743 swarm run behavior and follow semantics'
+      - 'contract path/platform spec path defaults'
+      - '`--no-retry` retry policy'
+      implementation_boundaries:
+      - 'This #844 first slice is source-of-truth repair only.'
+      - 'No Cobra persistent flag, runtime/client resolver, OpenRPC, output renderer, retry, or listener behavior changes are implied by this PR.'
+      - 'Future API-backed CLI config/auth implementation MUST consume this owner rather than the ignored review artifact.'
     error_channel_and_exit_code_contract:
       implemented_by: '#846'
       scope: >

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5887,7 +5887,10 @@ cli_specification:
       - tests proving unsupported exception rows fail before side effects
       - stdout/stderr tests proving successful machine-readable stdout is not contaminated by diagnostics/errors
       - no direct DB/store/runtime/EventBus reads for API-backed output rendering
-    auth_boundary: 'Runtime-state commands use v1 bearer auth through `SWARM_API_TOKEN`; legacy Builder/operator token fallback is invalid.'
+    auth_boundary: >
+      Runtime-state commands use v1 bearer auth through token sources governed by
+      cli_specification.foundations.api_connection_auth_config_precedence. Legacy
+      `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` fallback is invalid.
     api_connection_auth_config_precedence:
       promoted_by: '#844'
       implementation_status: authority_promoted_behavior_pending
@@ -10889,14 +10892,20 @@ api_specification:
         directly and the legacy reset_state name remains deferred/retired."
       - "GET /api/runs/{runID}/trace \u2192 run.trace (also adds run.subscribe_trace as the live variant)"
     auth_token_disposition:
-      v1_model: SWARM_API_TOKEN is the only user-facing API bearer-token source. SWARM_BUILDER_AUTH_TOKEN and SWARM_OPERATOR_AUTH_TOKEN
-        are retired and MUST NOT authorize /v1/rpc or /v1/ws.
+      v1_model: >
+        User-facing API bearer-token sources are governed by
+        cli_specification.foundations.api_connection_auth_config_precedence. `SWARM_API_TOKEN` remains the
+        current direct environment-token implementation source until behavior consumes that owner.
+        `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` are retired and MUST NOT authorize /v1/rpc
+        or /v1/ws.
       auth_boundary_bug_fix: "The current bug where /api/rpc and /api/ws bypass operator auth is moot under v1 \u2014 one\
         \ auth surface, one token."
     cli_consumer_migration:
       make_run_clear: '`reset-dev` starts a local `swarm serve` bootstrap and consumes `/v1/rpc runtime.nuke`
-        for destructive reset with the unified `SWARM_API_TOKEN` and a `run-clear:reset-dev:<uuid>` idempotency
-        key. The helper MUST NOT stop broad Docker inventory or truncate database tables directly. Corpus startup
+        for destructive reset with the unified token source governed by
+        cli_specification.foundations.api_connection_auth_config_precedence and a
+        `run-clear:reset-dev:<uuid>` idempotency key. The helper MUST NOT stop broad Docker inventory or
+        truncate database tables directly. Corpus startup
         migrates from legacy `/api/rpc` run.start payloads with builder-token auth to `curl /v1/rpc {method: run.start,
         params: {bundle_ref?, event_name, payload, idempotency_key?}}` with the unified token. run.start is now a
         deprecated wrapper over event.publish until the helper moves to the canonical event.publish method.'
@@ -10945,7 +10954,7 @@ api_specification:
       raw Docker stop or table truncation.'
     deprecation:
     - 'Legacy /rpc, /api/rpc, /ws, /api/ws, and dashboard /api/* endpoints are removed or fail closed. They are not aliases.'
-    - SWARM_BUILDER_AUTH_TOKEN and SWARM_OPERATOR_AUTH_TOKEN are not accepted as API auth fallbacks. SWARM_API_TOKEN is required.
+    - SWARM_BUILDER_AUTH_TOKEN and SWARM_OPERATOR_AUTH_TOKEN are not accepted as API auth fallbacks. Runtime-state clients must use a token source governed by cli_specification.foundations.api_connection_auth_config_precedence.
     openrpc_artifact:
     - A generator (verify-pipeline tool) reads this YAML and emits openrpc.json from method_catalog + components. Drift between
       the two is hard_invalidity at boot verify.


### PR DESCRIPTION
## Summary

Part of #844.
Part of #794 and #735. Related to #884 and #893.

This PR promotes the approved first-slice CLI v2 API connection/auth/config authority into `platform-spec.yaml` without changing CLI/runtime/OpenRPC behavior. It defines:

- API server base URL precedence: `--api-server` > `SWARM_API_SERVER` > config `api_server` > `http://127.0.0.1:8081`.
- API bearer token precedence: `--api-token-file` > `SWARM_API_TOKEN` > `SWARM_API_TOKEN_FILE` > config `api_token_file`.
- Rejected secret/config seams: `--api-token`, inline config `api_token`, and root/global `--config` for CLI config in this slice.
- Accepted config discovery: `SWARM_CONFIG` and XDG `~/.config/swarm/config.yaml`.
- Serve listener env/config boundary: `SWARM_API_PORT` and `SWARM_MCP_PORT` remain rejected; listen-address env names remain later #884/#750 candidates only.

## Governing Refs / Context

- Merge-bearing authority: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification`.
- Approved gate boundary: #844 lead outcome `approved as first slice` for spec-promotion-only API connection/auth/config authority.
- Reconciliation input only: ignored local CLI v2 review artifact `docs/specs/swarm-platform/platform/contracts/review/platform-spec.cli-ux-v2.yaml`.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`.
- Old non-authoritative source: ignored CLI v2 review artifact prose for universal flags/config/env precedence.
- Invalid paths after promotion: using the ignored review artifact as merge authority for `--api-server`, API token sources, CLI config file discovery, or serve listener env/config names.
- Still surviving by explicit split: command/runtime behavior, Cobra flags, OpenRPC, output rendering, retry policy, contract-path defaults, and serve listener runtime implementation.
- Migration completeness: complete for the approved source-of-truth first slice only; behavior implementation remains a later gated child.

## Proof

- `git diff --check`
- `go test ./cmd/swarm -run TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "api_connection_auth_config_precedence|--api-server|SWARM_API_SERVER|--api-token-file|SWARM_API_TOKEN_FILE|SWARM_API_TOKEN|--api-token|SWARM_CONFIG|--config|SWARM_API_PORT|SWARM_MCP_PORT|SWARM_API_LISTEN_ADDR|SWARM_MCP_LISTEN_ADDR|#844" docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `git diff --name-status` showed only `platform-spec.yaml` and `cmd/swarm/main_test.go`; no command/runtime/OpenRPC behavior files changed.