### PR TITLE
[agent-e][issue #898] Gate generated notification schemas

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2614,6 +2614,9 @@
         "schema": {
           "$ref": "#/components/schemas/SubscriptionId"
         }
+      },
+      "notification_schema": {
+        "$ref": "#/components/schemas/EventFull"
       }
     },
     {
@@ -2664,6 +2667,9 @@
         "schema": {
           "$ref": "#/components/schemas/SubscriptionId"
         }
+      },
+      "notification_schema": {
+        "$ref": "#/components/schemas/HealthCheckResult"
       }
     },
     {
@@ -4539,6 +4545,9 @@
           "$ref": "#/components/schemas/SubscriptionId"
         }
       },
+      "notification_schema": {
+        "$ref": "#/components/schemas/RunTraceRow"
+      },
       "errors": [
         {
           "code": -32023,
@@ -5272,6 +5281,9 @@
         "schema": {
           "$ref": "#/components/schemas/SubscriptionId"
         }
+      },
+      "notification_schema": {
+        "$ref": "#/components/schemas/LogEntry"
       }
     }
   ],

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -171,6 +171,7 @@ nodes:
       - generated supported-surface runtime probes can be absent for mutating HTTP methods, leaving side-effect and idempotency behavior inferred from scattered handler-family tests
       - central method transport admission can be absent, letting WS/protocol methods execute over /v1/rpc or HTTP-class methods execute over /v1/ws despite matrix transport classification
       - generated full successful-result schema validation can be absent even when runtime probes only key-smoke result payloads
+      - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
       - OpenRPC method examples and rpc.discover publication status are not explicitly tracked
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
@@ -181,6 +182,7 @@ nodes:
       - 872
       - 878
       - 890
+      - 898
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -104,12 +104,13 @@ type OpenRPCServer struct {
 }
 
 type OpenRPCMethod struct {
-	Name        string              `json:"name"`
-	Deprecated  bool                `json:"deprecated,omitempty"`
-	Description string              `json:"description,omitempty"`
-	Params      []ContentDescriptor `json:"params"`
-	Result      *ContentDescriptor  `json:"result,omitempty"`
-	Errors      []OpenRPCError      `json:"errors,omitempty"`
+	Name               string              `json:"name"`
+	Deprecated         bool                `json:"deprecated,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Params             []ContentDescriptor `json:"params"`
+	Result             *ContentDescriptor  `json:"result,omitempty"`
+	NotificationSchema any                 `json:"notification_schema,omitempty"`
+	Errors             []OpenRPCError      `json:"errors,omitempty"`
 }
 
 type OpenRPCError struct {
@@ -280,12 +281,13 @@ func GenerateOpenRPC(api *APISpecification) ([]byte, error) {
 			errors = append(errors, openRPCApplicationError(code, api.Components.Errors[code], errorCodes[code]))
 		}
 		methods = append(methods, OpenRPCMethod{
-			Name:        methodName,
-			Deprecated:  method.Deprecated,
-			Description: method.Description,
-			Params:      normalizeDescriptors(method.Params),
-			Result:      normalizeDescriptorPointer(method.Result),
-			Errors:      errors,
+			Name:               methodName,
+			Deprecated:         method.Deprecated,
+			Description:        method.Description,
+			Params:             normalizeDescriptors(method.Params),
+			Result:             normalizeDescriptorPointer(method.Result),
+			NotificationSchema: normalizeValue(method.NotificationSchema),
+			Errors:             errors,
 		})
 	}
 	componentErrors := make(map[string]OpenRPCError, len(api.Components.Errors))

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -98,6 +98,38 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if !methods["run.start"].Deprecated {
 		t.Fatal("generated OpenRPC run.start deprecated flag = false, want true")
 	}
+	expectedNotifications := map[string]string{
+		"event.subscribe":        "#/components/schemas/EventFull",
+		"health.subscribe":       "#/components/schemas/HealthCheckResult",
+		"run.subscribe_trace":    "#/components/schemas/RunTraceRow",
+		"runtime.subscribe_logs": "#/components/schemas/LogEntry",
+	}
+	for methodName, wantRef := range expectedNotifications {
+		if got := notificationSchemaRef(t, methodName, methods[methodName].NotificationSchema); got != wantRef {
+			t.Fatalf("%s notification_schema ref = %q, want %q", methodName, got, wantRef)
+		}
+	}
+	for methodName, method := range methods {
+		if _, ok := expectedNotifications[methodName]; ok {
+			continue
+		}
+		if method.NotificationSchema != nil {
+			t.Fatalf("%s unexpectedly publishes notification_schema: %#v", methodName, method.NotificationSchema)
+		}
+	}
+}
+
+func notificationSchemaRef(t *testing.T, methodName string, schema any) string {
+	t.Helper()
+	schemaMap, ok := schema.(map[string]any)
+	if !ok {
+		t.Fatalf("%s notification_schema = %#v, want object", methodName, schema)
+	}
+	ref, ok := schemaMap["$ref"].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		t.Fatalf("%s notification_schema = %#v, want $ref", methodName, schema)
+	}
+	return ref
 }
 
 func TestGeneratedOpenRPCApplicationErrorCodesAreUnique(t *testing.T) {

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -576,7 +576,6 @@ func allowedComplianceGapClasses() map[string]struct{} {
 		"missing_idempotency_test",
 		"missing_openrpc_examples",
 		"missing_result_schema_proof",
-		"notification_schema_not_emitted_in_openrpc_method",
 	})
 }
 

--- a/internal/apiv1/openrpc_result_schema_test.go
+++ b/internal/apiv1/openrpc_result_schema_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 const resultSchemaProbeTestName = "TestOpenRPCSuccessfulResultSchemas"
+const notificationSchemaProbeTestName = "TestOpenRPCSubscriptionNotificationSchemas"
 
 func TestOpenRPCSuccessfulResultSchemas(t *testing.T) {
 	root := repoRoot(t)
@@ -67,6 +68,27 @@ func TestOpenRPCResultSchemaPreflightRejectsUnreachableBranches(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "x-unsupported-probe") {
 		t.Fatalf("preflight error = %v, want unsupported keyword path", err)
+	}
+}
+
+func TestOpenRPCSubscriptionNotificationSchemas(t *testing.T) {
+	root := repoRoot(t)
+	api := loadComplianceAPISpec(t, root)
+	openRPC, _ := loadComplianceOpenRPC(t, filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json"))
+	matrix := loadComplianceMatrix(t, filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml"))
+
+	methods := notificationSchemaRuntimeMethods(t, api, openRPC, matrix)
+	assertStringList(t, "subscription notification-schema method set", methods, approvedNotificationSchemaRuntimeMethods())
+	assertNotificationSchemaMatrixProofRefs(t, matrix, methods)
+
+	validator := newOpenRPCResultSchemaValidator(t, openRPC)
+	validator.preflightMethodNotificationSchemas(t, methods)
+	for _, methodName := range methods {
+		methodName := methodName
+		t.Run(methodName, func(t *testing.T) {
+			result := successfulWebSocketRuntimeNotificationResult(t, methodName)
+			validator.validateMethodNotificationResult(t, methodName, result)
+		})
 	}
 }
 
@@ -123,6 +145,73 @@ func approvedResultSchemaRuntimeMethods() []string {
 	return out
 }
 
+func notificationSchemaRuntimeMethods(t *testing.T, api *apispec.APISpecification, openRPC apispec.OpenRPCDocument, matrix openRPCComplianceMatrix) []string {
+	t.Helper()
+	openRPCMethods := map[string]apispec.OpenRPCMethod{}
+	for _, method := range openRPC.Methods {
+		name := strings.TrimSpace(method.Name)
+		if name == "" {
+			t.Fatal("generated OpenRPC method missing name")
+		}
+		if _, exists := openRPCMethods[name]; exists {
+			t.Fatalf("generated OpenRPC method %s appears more than once", name)
+		}
+		openRPCMethods[name] = method
+	}
+	rows := map[string]openRPCMethodMatrix{}
+	for _, row := range matrix.Methods {
+		rows[row.Method] = row
+	}
+
+	fixtures := complianceStringSet(approvedNotificationSchemaRuntimeMethods())
+	out := make([]string, 0, len(fixtures))
+	for methodName, method := range api.MethodCatalog {
+		openRPCMethod, ok := openRPCMethods[methodName]
+		if !ok {
+			t.Fatalf("%s missing from generated OpenRPC artifact", methodName)
+		}
+		if _, ok := rows[methodName]; !ok {
+			t.Fatalf("%s missing from OpenRPC compliance matrix", methodName)
+		}
+		if method.NotificationSchema == nil {
+			if openRPCMethod.NotificationSchema != nil {
+				t.Fatalf("%s unexpectedly publishes notification_schema: %s", methodName, compactJSON(openRPCMethod.NotificationSchema))
+			}
+			continue
+		}
+		if _, ok := fixtures[methodName]; !ok {
+			t.Fatalf("%s declares notification_schema but is outside the approved notification-schema runtime set", methodName)
+		}
+		if openRPCMethod.NotificationSchema == nil {
+			t.Fatalf("%s generated OpenRPC method missing notification_schema", methodName)
+		}
+		if !jsonValueEqual(method.NotificationSchema, openRPCMethod.NotificationSchema) {
+			t.Fatalf("%s generated notification_schema = %s, want platform spec schema %s", methodName, compactJSON(openRPCMethod.NotificationSchema), compactJSON(method.NotificationSchema))
+		}
+		out = append(out, methodName)
+	}
+	for methodName := range fixtures {
+		method, ok := api.MethodCatalog[methodName]
+		if !ok {
+			t.Fatalf("%s fixture absent from platform spec method_catalog", methodName)
+		}
+		if method.NotificationSchema == nil {
+			t.Fatalf("%s fixture has no platform notification_schema", methodName)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func approvedNotificationSchemaRuntimeMethods() []string {
+	return []string{
+		"event.subscribe",
+		"health.subscribe",
+		"run.subscribe_trace",
+		"runtime.subscribe_logs",
+	}
+}
+
 func assertResultSchemaMatrixProofRefs(t *testing.T, matrix openRPCComplianceMatrix, methods []string) {
 	t.Helper()
 	methodSet := complianceStringSet(methods)
@@ -143,6 +232,31 @@ func assertResultSchemaMatrixProofRefs(t *testing.T, matrix openRPCComplianceMat
 		for _, gap := range row.GapClassification {
 			if gap == "missing_generated_result_schema_validation" {
 				t.Fatalf("%s still carries missing_generated_result_schema_validation after generated result-schema proof", row.Method)
+			}
+		}
+	}
+}
+
+func assertNotificationSchemaMatrixProofRefs(t *testing.T, matrix openRPCComplianceMatrix, methods []string) {
+	t.Helper()
+	methodSet := complianceStringSet(methods)
+	for _, row := range matrix.Methods {
+		_, inScope := methodSet[row.Method]
+		if !inScope && evidenceHasGoTest(row.NotificationSchema, notificationSchemaProbeTestName) {
+			t.Fatalf("%s has %s notification_schema proof_ref but is outside the approved notification-schema set", row.Method, notificationSchemaProbeTestName)
+		}
+		if !inScope {
+			continue
+		}
+		if row.NotificationSchema.Status != "covered" {
+			t.Fatalf("%s notification_schema status = %q, want covered", row.Method, row.NotificationSchema.Status)
+		}
+		if !evidenceHasGoTest(row.NotificationSchema, notificationSchemaProbeTestName) {
+			t.Fatalf("%s notification_schema missing go_test proof_ref %s", row.Method, notificationSchemaProbeTestName)
+		}
+		for _, gap := range row.GapClassification {
+			if gap == "notification_schema_not_emitted_in_openrpc_method" {
+				t.Fatalf("%s still carries notification_schema_not_emitted_in_openrpc_method after generated notification-schema proof", row.Method)
 			}
 		}
 	}
@@ -222,6 +336,32 @@ func successfulWebSocketRuntimeResult(t *testing.T, methodName string) any {
 	return resp.Result
 }
 
+func successfulWebSocketRuntimeNotificationResult(t *testing.T, methodName string) any {
+	t.Helper()
+	base := time.Unix(1700001400, 0).UTC()
+	handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+
+	fixture, ok := webSocketRuntimeProbeFixtures(base)[methodName]
+	if !ok {
+		t.Fatalf("%s missing websocket notification runtime fixture", methodName)
+	}
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      webSocketRuntimeProbeID(methodName),
+		"method":  methodName,
+		"params":  fixture.Params,
+	})
+	resp := readWSResponse(t, conn)
+	subscriptionID := assertWebSocketRuntimeSubscribeSuccess(t, methodName, resp)
+	notification := readWSNotification(t, conn)
+	assertWebSocketRuntimeNotification(t, methodName, subscriptionID, notification)
+	return notification.Params.Result
+}
+
 func assertSuccessfulResultProbeResponse(t *testing.T, methodName string, status int, resp rpcResponse, body string) {
 	t.Helper()
 	if status != http.StatusOK {
@@ -270,6 +410,26 @@ func (v openRPCResultSchemaValidator) preflightMethodResultSchema(methodName str
 		return fmt.Errorf("%s missing generated OpenRPC result descriptor", methodName)
 	}
 	return v.preflightSchema("$."+methodName+".result", method.Result.Schema, map[string]bool{})
+}
+
+func (v openRPCResultSchemaValidator) preflightMethodNotificationSchemas(t *testing.T, methods []string) {
+	t.Helper()
+	for _, methodName := range methods {
+		if err := v.preflightMethodNotificationSchema(methodName); err != nil {
+			t.Fatalf("%s generated OpenRPC notification schema preflight failed: %v", methodName, err)
+		}
+	}
+}
+
+func (v openRPCResultSchemaValidator) preflightMethodNotificationSchema(methodName string) error {
+	method, ok := v.methods[methodName]
+	if !ok {
+		return fmt.Errorf("%s missing from generated OpenRPC methods", methodName)
+	}
+	if method.NotificationSchema == nil {
+		return fmt.Errorf("%s missing generated OpenRPC notification_schema", methodName)
+	}
+	return v.preflightSchema("$."+methodName+".notification_schema", method.NotificationSchema, map[string]bool{})
 }
 
 func (v openRPCResultSchemaValidator) preflightSchema(path string, schema any, refStack map[string]bool) error {
@@ -403,6 +563,20 @@ func (v openRPCResultSchemaValidator) validateMethodResult(t *testing.T, methodN
 	}
 	if err := v.validateValue("$."+methodName+".result", method.Result.Schema, result); err != nil {
 		t.Fatalf("%s result does not match generated OpenRPC schema: %v\nresult=%s", methodName, err, compactJSON(result))
+	}
+}
+
+func (v openRPCResultSchemaValidator) validateMethodNotificationResult(t *testing.T, methodName string, result any) {
+	t.Helper()
+	method, ok := v.methods[methodName]
+	if !ok {
+		t.Fatalf("%s missing from generated OpenRPC methods", methodName)
+	}
+	if method.NotificationSchema == nil {
+		t.Fatalf("%s missing generated OpenRPC notification_schema", methodName)
+	}
+	if err := v.validateValue("$."+methodName+".notification_schema", method.NotificationSchema, result); err != nil {
+		t.Fatalf("%s notification result does not match generated OpenRPC notification_schema: %v\nresult=%s", methodName, err, compactJSON(result))
 	}
 }
 

--- a/internal/apiv1/openrpc_ws_runtime_test.go
+++ b/internal/apiv1/openrpc_ws_runtime_test.go
@@ -324,9 +324,6 @@ func assertWebSocketRuntimeMatrixProofRefs(t *testing.T, api *apispec.APISpecifi
 		if len(api.MethodCatalog[methodName].Errors) > 0 {
 			assertEvidenceHasWebSocketRuntimeProof(t, methodName, "declared_error_tests", row.DeclaredErrorTests)
 		}
-		if methodName != "rpc.unsubscribe" {
-			assertEvidenceHasWebSocketRuntimeProof(t, methodName, "notification_schema", row.NotificationSchema)
-		}
 	}
 }
 
@@ -393,14 +390,15 @@ func webSocketRuntimeProbeObservability(base time.Time) *fakeObservabilityReadSt
 	return &fakeObservabilityReadStore{
 		events: map[string]store.OperatorEventFull{
 			"evt-1": {
-				EventID:    "evt-1",
-				EventName:  "scan.requested",
-				RunID:      "run-1",
-				EntityID:   "entity-1",
-				CreatedAt:  base.Add(time.Second),
-				Source:     "runtime",
-				Payload:    map[string]any{"ok": true},
-				Deliveries: []store.OperatorEventDelivery{},
+				EventID:     "evt-1",
+				EventName:   "scan.requested",
+				RunID:       "run-1",
+				EntityID:    "entity-1",
+				CreatedAt:   base.Add(time.Second),
+				Source:      "runtime",
+				Payload:     map[string]any{"ok": true},
+				Deliveries:  []store.OperatorEventDelivery{},
+				DeadLetters: []store.OperatorDeadLetterRecord{},
 			},
 		},
 		traceRows: map[string][]store.RunDebugTraceRow{

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -11,12 +11,13 @@ source:
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
   generated_from: api_specification.method_catalog
 policy:
-  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_and_result_schema_runtime_validation
+  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_and_notification_schema_runtime_validation
   runtime_behavior_changes: transport_admission_repair_approved_by_878
   read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; mutating, WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
   mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
   ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, and full notification-schema validation remain tracked by #857."
-  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; notification-schema validation/publication, examples, and rpc.discover remain tracked by #857."
+  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover remain tracked by #857."
+  notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover remain tracked by #857."
   examples_policy: OpenRPC method examples are tracked gaps in this slice.
   service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
 methods:
@@ -301,10 +302,10 @@ methods:
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
+    notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_openrpc_examples]
+    gap_classification: [missing_openrpc_examples]
   - method: health.check
     transport: http
     required_params: []
@@ -346,10 +347,10 @@ methods:
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
+    notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_openrpc_examples]
+    gap_classification: [missing_openrpc_examples]
   - method: mailbox.approve
     transport: http
     required_params: [mailbox_id]
@@ -556,10 +557,10 @@ methods:
     declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
+    notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_openrpc_examples]
+    gap_classification: [missing_openrpc_examples]
   - method: run.trace
     transport: http
     required_params: [run_id]
@@ -661,7 +662,7 @@ methods:
     declared_error_tests: {status: not_applicable}
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
-    notification_schema: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
+    notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [notification_schema_not_emitted_in_openrpc_method, missing_openrpc_examples]
+    gap_classification: [missing_openrpc_examples]


### PR DESCRIPTION
## Summary

Closes #898
Part of #857

Adds generated notification-schema publication and supported-surface runtime validation for the four v1 subscription notification streams:

- `health.subscribe` -> `HealthCheckResult`
- `event.subscribe` -> `EventFull`
- `run.subscribe_trace` -> `RunTraceRow`
- `runtime.subscribe_logs` -> `LogEntry`

This keeps OpenRPC examples and `rpc.discover` as separate #857 tails.

## Governing Refs / Context

Exact governing spec refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.source_of_truth.authority_rule`
- `api_specification.foundations.transport.json_rpc_over_websocket`
- `api_specification.conventions.subscriptions`
- `api_specification.components.schemas.RpcSubscriptionNotification`
- `api_specification.method_catalog_metadata`
- `api_specification.method_catalog` entries for `health.subscribe`, `event.subscribe`, `run.subscribe_trace`, and `runtime.subscribe_logs`

Binding gate/context:

- #898 Pre-Implementation Coverage Audit
- #898 Independent Pre-Implementation Gate Review
- Parent #857
- Prior closed slices #878/#887 and #890/#894

## Semantic Migration

New canonical proof owner:

- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json` method-level `notification_schema`
- `internal/apispec.GenerateOpenRPC` publication of `Method.NotificationSchema`
- `TestOpenRPCSubscriptionNotificationSchemas`, which validates real `/v1/ws` `rpc.subscription.params.result` payloads against the generated OpenRPC notification schema

Old non-authoritative paths now invalid for closure claims:

- matrix `notification_schema` rows marked only `spot_checked`
- `notification_schema_not_emitted_in_openrpc_method` gap classification
- WS envelope smoke proof as the owner for full notification-schema conformance
- generic `RpcSubscriptionNotification.params.result` prose without per-method generated schema publication

Production paths checked for surviving old behavior:

- `webSocketSession.notify`
- `SubscriptionRuntime` producers for health, events, run trace, and runtime logs
- existing WS runtime probes
- downstream CLI notification readers were kept split per the gate because this PR does not change payload shape or production runtime behavior

Migration completeness: complete for generated notification-schema publication and runtime validation across all four subscription methods. Parent #857 remains open for OpenRPC examples and `rpc.discover` policy.

## Tests

- `go test ./internal/apiv1 -run 'TestOpenRPCSubscriptionNotificationSchemas|TestOpenRPCWebSocketRuntimeProbes|TestOpenRPCComplianceMatrix' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -count=1`