### PR TITLE
[agent-b][issue #903] Add conversation CLI read consumers

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -77,6 +77,8 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newInvestigateCommand(opts),
 		newEventsCommand(opts),
 		newEventCommand(opts),
+		newConversationsCommand(opts),
+		newConversationCommand(opts),
 		newAgentsCommand(opts),
 		newAgentCommand(opts),
 		newEntitiesCommand(opts),

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -481,6 +481,9 @@ func validateConversationDeepTurn(prefix string, turn conversationDeepTurn) erro
 	if turn.ParseOK == nil {
 		return fmt.Errorf("malformed %s: parse_ok is required", prefix)
 	}
+	if turn.RetryCount < 0 {
+		return fmt.Errorf("malformed %s: retry_count must be non-negative", prefix)
+	}
 	if turn.DispatchMetadata == nil {
 		return fmt.Errorf("malformed %s: dispatch_metadata is required", prefix)
 	}

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -1,0 +1,688 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	conversationListMethod    = "conversation.list"
+	conversationGetMethod     = "conversation.get"
+	conversationGetTurnMethod = "conversation.get_turn"
+)
+
+type conversationListCommandOptions struct {
+	apiOptions rootCommandOptions
+
+	agentID string
+	runID   string
+	limit   int
+	cursor  string
+
+	agentIDSet bool
+	runIDSet   bool
+	limitSet   bool
+	cursorSet  bool
+}
+
+type conversationListResult struct {
+	Conversations []conversationSummary `json:"conversations"`
+	NextCursor    string                `json:"next_cursor,omitempty"`
+}
+
+type conversationSummary struct {
+	SessionID    string `json:"session_id"`
+	AgentID      string `json:"agent_id"`
+	RunID        string `json:"run_id,omitempty"`
+	StartedAt    string `json:"started_at"`
+	EndedAt      string `json:"ended_at,omitempty"`
+	TurnCount    int    `json:"turn_count"`
+	MessageCount int    `json:"message_count"`
+	Status       string `json:"status"`
+}
+
+type conversationDetail struct {
+	Conversation conversationSummary `json:"conversation"`
+	Turns        []conversationTurn  `json:"turns"`
+}
+
+type conversationTurn struct {
+	TurnIndex        int              `json:"turn_index"`
+	TurnID           string           `json:"turn_id"`
+	TriggerEventID   string           `json:"trigger_event_id"`
+	TriggerEventType string           `json:"trigger_event_type"`
+	RequestPayload   map[string]any   `json:"request_payload,omitempty"`
+	ResponsePayload  map[string]any   `json:"response_payload,omitempty"`
+	ToolCalls        []map[string]any `json:"tool_calls,omitempty"`
+	TurnBlocks       []map[string]any `json:"turn_blocks,omitempty"`
+	ParseOK          *bool            `json:"parse_ok"`
+	LatencyMS        *int             `json:"latency_ms"`
+	Error            string           `json:"error,omitempty"`
+}
+
+type conversationTurnDetail struct {
+	Session       conversationSummary  `json:"session"`
+	Turn          conversationDeepTurn `json:"turn"`
+	TurnBlocksRaw []map[string]any     `json:"turn_blocks_raw"`
+}
+
+type conversationDeepTurn struct {
+	TurnIndex                   int                           `json:"turn_index"`
+	TurnID                      string                        `json:"turn_id"`
+	Scope                       string                        `json:"scope,omitempty"`
+	StartedAt                   string                        `json:"started_at"`
+	CompletedAt                 string                        `json:"completed_at"`
+	DurationMS                  *int                          `json:"duration_ms"`
+	Outcome                     string                        `json:"outcome,omitempty"`
+	ParseOK                     *bool                         `json:"parse_ok"`
+	Error                       string                        `json:"error,omitempty"`
+	RetryCount                  int                           `json:"retry_count,omitempty"`
+	DispatchMetadata            *conversationDispatchMetadata `json:"dispatch_metadata"`
+	AdvertisedTools             []string                      `json:"advertised_tools"`
+	MCPToolsListed              []string                      `json:"mcp_tools_listed,omitempty"`
+	MCPToolsVisible             []string                      `json:"mcp_tools_visible,omitempty"`
+	ReasoningBlocks             []string                      `json:"reasoning_blocks,omitempty"`
+	ProgressUpdates             []string                      `json:"progress_updates,omitempty"`
+	ToolCalls                   []map[string]any              `json:"tool_calls,omitempty"`
+	ToolResults                 []map[string]any              `json:"tool_results,omitempty"`
+	EmittedEvents               []string                      `json:"emitted_events,omitempty"`
+	RuntimeLogEntries           []runtimeLogEntry             `json:"runtime_log_entries"`
+	ProviderMetadata            *conversationProviderMetadata `json:"provider_metadata"`
+	RequestPayload              map[string]any                `json:"request_payload,omitempty"`
+	ResponsePayload             map[string]any                `json:"response_payload,omitempty"`
+	FullPromptContext           json.RawMessage               `json:"full_prompt_context"`
+	FullPromptContextV2Reserved *bool                         `json:"full_prompt_context_v2_reserved"`
+	RawLLMResponse              json.RawMessage               `json:"raw_llm_response"`
+	RawLLMResponseV2Reserved    *bool                         `json:"raw_llm_response_v2_reserved"`
+	AssistantVisibleOutput      string                        `json:"assistant_visible_output,omitempty"`
+}
+
+type conversationDispatchMetadata struct {
+	TriggerEventID   string `json:"trigger_event_id,omitempty"`
+	TriggerEventType string `json:"trigger_event_type,omitempty"`
+	EntityID         string `json:"entity_id,omitempty"`
+	TaskID           string `json:"task_id,omitempty"`
+	RunID            string `json:"run_id,omitempty"`
+}
+
+type conversationProviderMetadata struct {
+	LatencyMS *int `json:"latency_ms"`
+}
+
+var conversationOpaqueIDPattern = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
+
+func newConversationsCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conversations",
+		Short: "List conversations through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newConversationsListCommand(opts))
+	return cmd
+}
+
+func newConversationCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conversation",
+		Short: "View conversation details and turns through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newConversationViewCommand(opts),
+		newConversationTurnCommand(opts),
+	)
+	return cmd
+}
+
+func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := conversationListCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List conversations through /v1/rpc conversation.list.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listOpts.agentIDSet = cmd.Flags().Changed("agent-id")
+			listOpts.runIDSet = cmd.Flags().Changed("run-id")
+			listOpts.limitSet = cmd.Flags().Changed("limit")
+			listOpts.cursorSet = cmd.Flags().Changed("cursor")
+			return runConversationsListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
+		},
+	}
+	cmd.Flags().StringVar(&listOpts.agentID, "agent-id", "", "Filter by agent id")
+	cmd.Flags().StringVar(&listOpts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
+	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	return cmd
+}
+
+func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <session-id>",
+		Short: "View one conversation through /v1/rpc conversation.get.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConversationViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+		},
+	}
+}
+
+func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "turn <session-id> <turn-index>",
+		Short: "View one conversation turn through /v1/rpc conversation.get_turn.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConversationTurnCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0], args[1])
+		},
+	}
+}
+
+func runConversationsListCommand(ctx context.Context, out, errOut io.Writer, opts conversationListCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, conversationListAPIErrorClassifier())
+	}
+	var result conversationListResult
+	if err := client.call(ctx, conversationListMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationListAPIErrorClassifier())
+	}
+	if err := validateConversationListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationListAPIErrorClassifier())
+	}
+	writeConversationListResult(out, result)
+	return nil
+}
+
+func runConversationViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, sessionID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if err := validateConversationOpaqueIDArg("session id", sessionID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, conversationViewAPIErrorClassifier())
+	}
+	var result conversationDetail
+	if err := client.call(ctx, conversationGetMethod, map[string]any{"session_id": sessionID}, &result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationViewAPIErrorClassifier())
+	}
+	if err := validateConversationDetailResult("conversation.get result", result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationViewAPIErrorClassifier())
+	}
+	writeConversationDetailResult(out, result)
+	return nil
+}
+
+func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, sessionID, turnIndexRaw string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if err := validateConversationOpaqueIDArg("session id", sessionID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	turnIndex, err := parseConversationTurnIndex(turnIndexRaw)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
+	}
+	params := map[string]any{"session_id": sessionID, "turn_index": turnIndex}
+	var result conversationTurnDetail
+	if err := client.call(ctx, conversationGetTurnMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
+	}
+	if err := validateConversationTurnDetailResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
+	}
+	writeConversationTurnDetailResult(out, result)
+	return nil
+}
+
+func (opts conversationListCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.agentIDSet {
+		agentID, err := conversationNonEmptyFlag("--agent-id", opts.agentID)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateConversationOpaqueIDArg("--agent-id", agentID); err != nil {
+			return nil, err
+		}
+		params["agent_id"] = agentID
+	}
+	if opts.runIDSet {
+		runID, err := conversationNonEmptyFlag("--run-id", opts.runID)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateConversationOpaqueIDArg("--run-id", runID); err != nil {
+			return nil, err
+		}
+		params["run_id"] = runID
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = opts.limit
+	}
+	if opts.cursorSet {
+		cursor, err := conversationNonEmptyFlag("--cursor", opts.cursor)
+		if err != nil {
+			return nil, err
+		}
+		params["cursor"] = cursor
+	}
+	return params, nil
+}
+
+func parseConversationTurnIndex(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, fmt.Errorf("turn index is required")
+	}
+	index, err := strconv.Atoi(raw)
+	if err != nil || index < 1 || index > 1000000 {
+		return 0, fmt.Errorf("turn index must be an integer from 1 to 1000000")
+	}
+	return index, nil
+}
+
+func conversationNonEmptyFlag(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s must not be empty", name)
+	}
+	return value, nil
+}
+
+func validateConversationOpaqueIDArg(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if len(value) > 256 {
+		return fmt.Errorf("%s must be at most 256 characters", name)
+	}
+	if !conversationOpaqueIDPattern.MatchString(value) {
+		return fmt.Errorf("%s must match OpaqueId pattern", name)
+	}
+	return nil
+}
+
+func validateConversationListResult(result conversationListResult) error {
+	if result.Conversations == nil {
+		return fmt.Errorf("malformed conversation.list result: conversations is required")
+	}
+	for i, item := range result.Conversations {
+		if err := validateConversationSummary(fmt.Sprintf("conversation.list result: conversations[%d]", i), item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConversationDetailResult(prefix string, result conversationDetail) error {
+	if err := validateConversationSummary(prefix+".conversation", result.Conversation); err != nil {
+		return err
+	}
+	if result.Turns == nil {
+		return fmt.Errorf("malformed %s: turns is required", prefix)
+	}
+	for i, turn := range result.Turns {
+		if err := validateConversationTurn(fmt.Sprintf("%s.turns[%d]", prefix, i), turn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConversationTurnDetailResult(result conversationTurnDetail) error {
+	if err := validateConversationSummary("conversation.get_turn result.session", result.Session); err != nil {
+		return err
+	}
+	if err := validateConversationDeepTurn("conversation.get_turn result.turn", result.Turn); err != nil {
+		return err
+	}
+	if result.TurnBlocksRaw == nil {
+		return fmt.Errorf("malformed conversation.get_turn result: turn_blocks_raw is required")
+	}
+	return nil
+}
+
+func validateConversationSummary(prefix string, item conversationSummary) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "session_id", value: item.SessionID},
+		{name: "agent_id", value: item.AgentID},
+		{name: "started_at", value: item.StartedAt},
+		{name: "status", value: item.Status},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".session_id", item.SessionID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".agent_id", item.AgentID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if strings.TrimSpace(item.RunID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".run_id", item.RunID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if item.TurnCount < 0 {
+		return fmt.Errorf("malformed %s: turn_count must be non-negative", prefix)
+	}
+	if item.MessageCount < 0 {
+		return fmt.Errorf("malformed %s: message_count must be non-negative", prefix)
+	}
+	switch strings.TrimSpace(item.Status) {
+	case "active", "terminated":
+	default:
+		return fmt.Errorf("malformed %s: status=%q is not a valid conversation status", prefix, item.Status)
+	}
+	if err := validateRequiredTimestamp(prefix+".started_at", item.StartedAt); err != nil {
+		return err
+	}
+	if endedAt := strings.TrimSpace(item.EndedAt); endedAt != "" {
+		if err := validateRequiredTimestamp(prefix+".ended_at", endedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConversationTurn(prefix string, turn conversationTurn) error {
+	if turn.TurnIndex < 1 {
+		return fmt.Errorf("malformed %s: turn_index must be at least 1", prefix)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "turn_id", value: turn.TurnID},
+		{name: "trigger_event_id", value: turn.TriggerEventID},
+		{name: "trigger_event_type", value: turn.TriggerEventType},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".turn_id", turn.TurnID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".trigger_event_id", turn.TriggerEventID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if turn.ParseOK == nil {
+		return fmt.Errorf("malformed %s: parse_ok is required", prefix)
+	}
+	if turn.LatencyMS == nil {
+		return fmt.Errorf("malformed %s: latency_ms is required", prefix)
+	}
+	if *turn.LatencyMS < 0 {
+		return fmt.Errorf("malformed %s: latency_ms must be non-negative", prefix)
+	}
+	return nil
+}
+
+func validateConversationDeepTurn(prefix string, turn conversationDeepTurn) error {
+	if turn.TurnIndex < 1 {
+		return fmt.Errorf("malformed %s: turn_index must be at least 1", prefix)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "turn_id", value: turn.TurnID},
+		{name: "started_at", value: turn.StartedAt},
+		{name: "completed_at", value: turn.CompletedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".turn_id", turn.TurnID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if err := validateRequiredTimestamp(prefix+".started_at", turn.StartedAt); err != nil {
+		return err
+	}
+	if err := validateRequiredTimestamp(prefix+".completed_at", turn.CompletedAt); err != nil {
+		return err
+	}
+	if turn.DurationMS == nil {
+		return fmt.Errorf("malformed %s: duration_ms is required", prefix)
+	}
+	if *turn.DurationMS < 0 {
+		return fmt.Errorf("malformed %s: duration_ms must be non-negative", prefix)
+	}
+	if turn.ParseOK == nil {
+		return fmt.Errorf("malformed %s: parse_ok is required", prefix)
+	}
+	if turn.DispatchMetadata == nil {
+		return fmt.Errorf("malformed %s: dispatch_metadata is required", prefix)
+	}
+	if strings.TrimSpace(turn.DispatchMetadata.TriggerEventID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".dispatch_metadata.trigger_event_id", turn.DispatchMetadata.TriggerEventID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if strings.TrimSpace(turn.DispatchMetadata.EntityID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".dispatch_metadata.entity_id", turn.DispatchMetadata.EntityID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if strings.TrimSpace(turn.DispatchMetadata.RunID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".dispatch_metadata.run_id", turn.DispatchMetadata.RunID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if turn.AdvertisedTools == nil {
+		return fmt.Errorf("malformed %s: advertised_tools is required", prefix)
+	}
+	if turn.RuntimeLogEntries == nil {
+		return fmt.Errorf("malformed %s: runtime_log_entries is required", prefix)
+	}
+	for i, log := range turn.RuntimeLogEntries {
+		if err := validateRuntimeLogEntry(fmt.Sprintf("%s.runtime_log_entries[%d]", prefix, i), log); err != nil {
+			return err
+		}
+	}
+	if turn.ProviderMetadata == nil {
+		return fmt.Errorf("malformed %s: provider_metadata is required", prefix)
+	}
+	if turn.ProviderMetadata.LatencyMS == nil {
+		return fmt.Errorf("malformed %s: provider_metadata.latency_ms is required", prefix)
+	}
+	if *turn.ProviderMetadata.LatencyMS < 0 {
+		return fmt.Errorf("malformed %s: provider_metadata.latency_ms must be non-negative", prefix)
+	}
+	if turn.FullPromptContext == nil {
+		return fmt.Errorf("malformed %s: full_prompt_context is required", prefix)
+	}
+	if turn.FullPromptContextV2Reserved == nil || !*turn.FullPromptContextV2Reserved {
+		return fmt.Errorf("malformed %s: full_prompt_context_v2_reserved must be true", prefix)
+	}
+	if turn.RawLLMResponse == nil {
+		return fmt.Errorf("malformed %s: raw_llm_response is required", prefix)
+	}
+	if turn.RawLLMResponseV2Reserved == nil || !*turn.RawLLMResponseV2Reserved {
+		return fmt.Errorf("malformed %s: raw_llm_response_v2_reserved must be true", prefix)
+	}
+	return nil
+}
+
+func writeConversationListResult(out io.Writer, result conversationListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Conversations) == 0 {
+		fmt.Fprintln(out, "No conversations match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "SESSION_ID\tAGENT\tRUN\tSTATUS\tTURNS\tMESSAGES\tSTARTED\tENDED")
+	for _, item := range result.Conversations {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+			item.SessionID,
+			item.AgentID,
+			conversationDash(item.RunID),
+			item.Status,
+			item.TurnCount,
+			item.MessageCount,
+			item.StartedAt,
+			conversationDash(item.EndedAt),
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeConversationDetailResult(out io.Writer, result conversationDetail) {
+	if out == nil {
+		return
+	}
+	item := result.Conversation
+	fmt.Fprintf(out, "Conversation %s\n", item.SessionID)
+	fmt.Fprintf(out, "agent_id=%s run_id=%s status=%s turns=%d messages=%d started_at=%s ended_at=%s\n",
+		item.AgentID,
+		conversationDash(item.RunID),
+		item.Status,
+		item.TurnCount,
+		item.MessageCount,
+		item.StartedAt,
+		conversationDash(item.EndedAt),
+	)
+	if len(result.Turns) == 0 {
+		fmt.Fprintln(out, "No turns recorded.")
+		return
+	}
+	fmt.Fprintln(out, "TURN\tTURN_ID\tEVENT_ID\tEVENT_TYPE\tPARSE_OK\tLATENCY_MS\tERROR")
+	for _, turn := range result.Turns {
+		fmt.Fprintf(out, "%d\t%s\t%s\t%s\t%t\t%d\t%s\n",
+			turn.TurnIndex,
+			turn.TurnID,
+			turn.TriggerEventID,
+			turn.TriggerEventType,
+			*turn.ParseOK,
+			*turn.LatencyMS,
+			conversationDash(turn.Error),
+		)
+	}
+}
+
+func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDetail) {
+	if out == nil {
+		return
+	}
+	session := result.Session
+	turn := result.Turn
+	fmt.Fprintf(out, "Conversation %s turn %d\n", session.SessionID, turn.TurnIndex)
+	fmt.Fprintf(out, "turn_id=%s agent_id=%s run_id=%s status=%s started_at=%s completed_at=%s duration_ms=%d parse_ok=%t outcome=%s error=%s\n",
+		turn.TurnID,
+		session.AgentID,
+		conversationDash(session.RunID),
+		session.Status,
+		turn.StartedAt,
+		turn.CompletedAt,
+		*turn.DurationMS,
+		*turn.ParseOK,
+		conversationDash(turn.Outcome),
+		conversationDash(turn.Error),
+	)
+	dispatch := turn.DispatchMetadata
+	fmt.Fprintf(out, "dispatch trigger_event_id=%s trigger_event_type=%s entity_id=%s task_id=%s run_id=%s\n",
+		conversationDash(dispatch.TriggerEventID),
+		conversationDash(dispatch.TriggerEventType),
+		conversationDash(dispatch.EntityID),
+		conversationDash(dispatch.TaskID),
+		conversationDash(dispatch.RunID),
+	)
+	fmt.Fprintf(out, "advertised_tools=%s runtime_log_entries=%d turn_blocks_raw=%s\n",
+		conversationListDash(turn.AdvertisedTools),
+		len(turn.RuntimeLogEntries),
+		conversationCompactJSON(result.TurnBlocksRaw),
+	)
+	if strings.TrimSpace(turn.AssistantVisibleOutput) != "" {
+		fmt.Fprintf(out, "assistant_visible_output=%s\n", strings.TrimSpace(turn.AssistantVisibleOutput))
+	}
+	if len(turn.RuntimeLogEntries) > 0 {
+		fmt.Fprintln(out, "Runtime logs:")
+		for _, log := range turn.RuntimeLogEntries {
+			fmt.Fprintf(out, "log_id=%s ts=%s level=%s component=%s source=%s message=%s\n",
+				log.LogID,
+				log.TS,
+				log.Level,
+				log.Component,
+				log.Source,
+				runtimeLogMessage(log),
+			)
+		}
+	}
+}
+
+func conversationListAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{}
+}
+
+func conversationViewAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"SESSION_NOT_FOUND"}}
+}
+
+func conversationTurnAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"SESSION_NOT_FOUND", "TURN_NOT_FOUND"}}
+}
+
+func conversationDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func conversationListDash(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	if len(out) == 0 {
+		return "-"
+	}
+	return strings.Join(out, ",")
+}
+
+func conversationCompactJSON(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "[]"
+	}
+	return string(raw)
+}

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -332,6 +332,20 @@ func TestConversationCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T)
 			wantStderr: "advertised_tools is required",
 		},
 		{
+			name: "turn negative retry count exits three",
+			args: []string{"conversation", "turn", "sess-1", "1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validConversationTurnDetail("sess-1", 1)
+				turn := result["turn"].(map[string]any)
+				turn["retry_count"] = -1
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "retry_count must be non-negative",
+		},
+		{
 			name: "turn unknown rpc exits three",
 			args: []string{"conversation", "turn", "sess-1", "1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -1,0 +1,473 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestConversationsListUsesConversationListV1RPCWithFilters(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"conversations": []map[string]any{validConversationSummary("sess-1")},
+			"next_cursor":   "conversation-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"conversations", "list",
+		"--agent-id", "agent-1",
+		"--run-id", "run-1",
+		"--limit", "25",
+		"--cursor", "cursor-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != conversationListMethod {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/%s", captured.JSONRPC, captured.Method, conversationListMethod)
+	}
+	wantParams := map[string]any{
+		"agent_id": "agent-1",
+		"run_id":   "run-1",
+		"limit":    float64(25),
+		"cursor":   "cursor-1",
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"SESSION_ID", "sess-1", "agent-1", "run-1", "active", "next_cursor=conversation-cursor-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestConversationsListEmptyResultOmitsUnsetParams(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"conversations": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"conversations", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != conversationListMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, conversationListMethod)
+	}
+	if len(captured.Params) != 0 {
+		t.Fatalf("params = %#v, want empty", captured.Params)
+	}
+	if !strings.Contains(stdout.String(), "No conversations match the filter.") {
+		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
+	}
+}
+
+func TestConversationViewUsesConversationGetAndRendersTurns(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validConversationDetail("sess-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"conversation", "view", "sess-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != conversationGetMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, conversationGetMethod)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"session_id": "sess-1"}) {
+		t.Fatalf("params = %#v", captured.Params)
+	}
+	for _, want := range []string{
+		"Conversation sess-1",
+		"agent_id=agent-1 run_id=run-1 status=active turns=1 messages=2",
+		"TURN\tTURN_ID",
+		"1\tturn-1\tevent-1\ttask.started\ttrue\t150\t-",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestConversationTurnUsesConversationGetTurnAndRendersDeepTurn(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validConversationTurnDetail("sess-1", 2))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"conversation", "turn", "sess-1", "2"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != conversationGetTurnMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, conversationGetTurnMethod)
+	}
+	wantParams := map[string]any{"session_id": "sess-1", "turn_index": float64(2)}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"Conversation sess-1 turn 2",
+		"turn_id=turn-2",
+		"dispatch trigger_event_id=event-2 trigger_event_type=task.completed",
+		"advertised_tools=emit_done,read_state runtime_log_entries=1",
+		"assistant_visible_output=done",
+		"log_id=log-1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestConversationCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"conversations": []any{}})
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "list invalid limit low", args: []string{"conversations", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "list blank agent id", args: []string{"conversations", "list", "--agent-id", " "}, wantStderr: "--agent-id must not be empty"},
+		{name: "list invalid run id", args: []string{"conversations", "list", "--run-id", "bad id!"}, wantStderr: "--run-id must match OpaqueId pattern"},
+		{name: "list blank cursor", args: []string{"conversations", "list", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
+		{name: "view missing session", args: []string{"conversation", "view"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "view blank session", args: []string{"conversation", "view", " "}, wantStderr: "session id is required"},
+		{name: "view invalid session", args: []string{"conversation", "view", "bad id!"}, wantStderr: "session id must match OpaqueId pattern"},
+		{name: "turn missing index", args: []string{"conversation", "turn", "sess-1"}, wantStderr: "accepts 2 arg(s)"},
+		{name: "turn invalid session", args: []string{"conversation", "turn", "bad id!", "1"}, wantStderr: "session id must match OpaqueId pattern"},
+		{name: "turn index zero", args: []string{"conversation", "turn", "sess-1", "0"}, wantStderr: "turn index must be an integer from 1 to 1000000"},
+		{name: "turn index not integer", args: []string{"conversation", "turn", "sess-1", "first"}, wantStderr: "turn index must be an integer from 1 to 1000000"},
+		{name: "turn index too high", args: []string{"conversation", "turn", "sess-1", "1000001"}, wantStderr: "turn index must be an integer from 1 to 1000000"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestConversationCommandsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"conversations": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"conversations", "list"},
+		{"conversation", "view", "sess-1"},
+		{"conversation", "turn", "sess-1", "1"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 4 {
+			t.Fatalf("%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			t.Fatalf("%v stderr = %q, want token failure", args, stderr.String())
+		}
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestConversationCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "list http auth exits four",
+			args: []string{"conversations", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   4,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "list missing conversations exits three",
+			args: []string{"conversations", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{})
+			},
+			wantCode:   3,
+			wantStderr: "conversations is required",
+		},
+		{
+			name: "list malformed summary exits three",
+			args: []string{"conversations", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				item := validConversationSummary("sess-1")
+				delete(item, "status")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"conversations": []map[string]any{item}})
+			},
+			wantCode:   3,
+			wantStderr: "status is required",
+		},
+		{
+			name: "view session not found exits five",
+			args: []string{"conversation", "view", "missing"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeConversationJSONRPCError(t, w, req.ID, "SESSION_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "SESSION_NOT_FOUND",
+		},
+		{
+			name: "view missing turns exits three",
+			args: []string{"conversation", "view", "sess-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validConversationDetail("sess-1")
+				delete(result, "turns")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "turns is required",
+		},
+		{
+			name: "turn missing turn exits five",
+			args: []string{"conversation", "turn", "sess-1", "99"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeConversationJSONRPCError(t, w, req.ID, "TURN_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "TURN_NOT_FOUND",
+		},
+		{
+			name: "turn missing advertised tools exits three",
+			args: []string{"conversation", "turn", "sess-1", "1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validConversationTurnDetail("sess-1", 1)
+				turn := result["turn"].(map[string]any)
+				delete(turn, "advertised_tools")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "advertised_tools is required",
+		},
+		{
+			name: "turn unknown rpc exits three",
+			args: []string{"conversation", "turn", "sess-1", "1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeConversationJSONRPCError(t, w, req.ID, "METHOD_UNAVAILABLE")
+			},
+			wantCode:   3,
+			wantStderr: "METHOD_UNAVAILABLE",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func validConversationSummary(sessionID string) map[string]any {
+	return map[string]any{
+		"session_id":    sessionID,
+		"agent_id":      "agent-1",
+		"run_id":        "run-1",
+		"started_at":    "2026-05-20T01:00:00Z",
+		"ended_at":      "2026-05-20T01:10:00Z",
+		"turn_count":    1,
+		"message_count": 2,
+		"status":        "active",
+	}
+}
+
+func validConversationDetail(sessionID string) map[string]any {
+	return map[string]any{
+		"conversation": validConversationSummary(sessionID),
+		"turns": []map[string]any{
+			validConversationTurn(1, "turn-1", "event-1", "task.started"),
+		},
+	}
+}
+
+func validConversationTurn(index int, turnID, eventID, eventType string) map[string]any {
+	return map[string]any{
+		"turn_index":         index,
+		"turn_id":            turnID,
+		"trigger_event_id":   eventID,
+		"trigger_event_type": eventType,
+		"parse_ok":           true,
+		"latency_ms":         150,
+		"request_payload":    map[string]any{"prompt": "go"},
+		"response_payload":   map[string]any{"ok": true},
+		"tool_calls":         []map[string]any{},
+		"turn_blocks":        []map[string]any{{"kind": "assistant", "text": "done"}},
+	}
+}
+
+func validConversationTurnDetail(sessionID string, index int) map[string]any {
+	return map[string]any{
+		"session": validConversationSummary(sessionID),
+		"turn": map[string]any{
+			"turn_index":   index,
+			"turn_id":      "turn-2",
+			"scope":        "global",
+			"started_at":   "2026-05-20T01:01:00Z",
+			"completed_at": "2026-05-20T01:01:01Z",
+			"duration_ms":  1000,
+			"outcome":      "completed",
+			"parse_ok":     true,
+			"retry_count":  0,
+			"dispatch_metadata": map[string]any{
+				"trigger_event_id":   "event-2",
+				"trigger_event_type": "task.completed",
+				"entity_id":          "entity-1",
+				"task_id":            "task-1",
+				"run_id":             "run-1",
+			},
+			"advertised_tools":                []any{"emit_done", "read_state"},
+			"mcp_tools_listed":                []any{},
+			"mcp_tools_visible":               []any{},
+			"reasoning_blocks":                []any{},
+			"progress_updates":                []any{},
+			"tool_calls":                      []map[string]any{},
+			"tool_results":                    []map[string]any{},
+			"emitted_events":                  []any{"event-3"},
+			"runtime_log_entries":             []map[string]any{validConversationRuntimeLog()},
+			"provider_metadata":               map[string]any{"latency_ms": 1000},
+			"request_payload":                 map[string]any{"prompt": "go"},
+			"response_payload":                map[string]any{"ok": true},
+			"full_prompt_context":             nil,
+			"full_prompt_context_v2_reserved": true,
+			"raw_llm_response":                nil,
+			"raw_llm_response_v2_reserved":    true,
+			"assistant_visible_output":        "done",
+		},
+		"turn_blocks_raw": []map[string]any{{"kind": "assistant", "text": "done"}},
+	}
+}
+
+func validConversationRuntimeLog() map[string]any {
+	return map[string]any{
+		"log_id":     "log-1",
+		"ts":         "2026-05-20T01:01:01Z",
+		"level":      "info",
+		"component":  "agent",
+		"source":     "runtime",
+		"run_id":     "run-1",
+		"entity_id":  "entity-1",
+		"session_id": "sess-1",
+		"message":    "turn completed",
+		"details":    map[string]any{"turn": 2},
+	}
+}
+
+func writeConversationJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": code,
+			"data": map[string]any{
+				"code": code,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5871,9 +5871,6 @@ cli_specification:
             machine-readable output.
         absent_command_rows:
           commands:
-          - conversations_list
-          - conversation_view
-          - conversation_turn
           - forkchat
           rule: >
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future
@@ -7015,20 +7012,94 @@ cli_specification:
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
       relation_to_run_start: '`run.start` remains usable for #743 until a separate migration changes the CLI internals to event.publish.'
     conversations_list:
-      command: swarm conversations list
+      command: swarm conversations list [--agent-id <agent-id>] [--run-id <run-id>] [--limit <n>] [--cursor <cursor>]
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc conversation.list
+      behavior: Read-only conversation summary CLI consumer. The CLI validates optional filters locally, sends exactly the corresponding params to /v1/rpc conversation.list through the shared v1 API client, and renders only server-owned ConversationSummary rows plus next_cursor.
+      flags:
+      - name: --agent-id <agent-id>
+        maps_to: agent_id
+        behavior: Optional OpaqueId filter for one agent.
+      - name: --run-id <run-id>
+        maps_to: run_id
+        behavior: Optional OpaqueId filter for one run.
+      - name: --limit <n>
+        maps_to: limit
+        behavior: Optional page size from 1 through 500.
+      - name: --cursor <cursor>
+        maps_to: cursor
+        behavior: Optional opaque pagination cursor returned by the server.
+      output:
+        success_table: SESSION_ID, AGENT, RUN, STATUS, TURNS, MESSAGES, STARTED, ENDED; followed by next_cursor=<cursor> when present.
+        empty: No conversations match the filter.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+      proof_expectations:
+      - exact /v1/rpc conversation.list call with agent_id, run_id, limit, and cursor params only when corresponding CLI flags are provided
+      - invalid flags, blank OpaqueId flags, out-of-range --limit, and missing SWARM_API_TOKEN make zero API calls
+      - success output renders only ConversationSummary fields and next_cursor returned by the server
+      - empty conversations array, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, conversation.get_turn, or forkchat usage
     conversation_view:
       command: swarm conversation view <session-id>
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc conversation.get
+      behavior: Read-only conversation detail CLI consumer. The CLI validates the required session_id locally, calls /v1/rpc conversation.get through the shared v1 API client, and renders server-owned ConversationDetail metadata and shallow Turn rows. Turn rows use the server-owned 1-based turn_index selector promoted by #877/#895.
+      output:
+        success_detail: Conversation header with session_id, agent_id, run_id, status, counts, started/ended timestamps, followed by a turn table with turn_index, turn_id, trigger_event_id, trigger_event_type, parse_ok, latency_ms, and error.
+        empty_turns: No turns recorded.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - SESSION_NOT_FOUND
+      proof_expectations:
+      - exact /v1/rpc conversation.get call with session_id param only
+      - missing/blank/invalid session id and missing SWARM_API_TOKEN make zero API calls
+      - success output renders only ConversationDetail and shallow Turn fields returned by the server, including turn_index
+      - SESSION_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, conversation.get_turn reconstruction, or forkchat usage
     conversation_turn:
       command: swarm conversation turn <session-id> <turn-index>
       tier: should_have
-      implementation_status: absent
+      implementation_status: implemented
       owner: /v1/rpc conversation.get_turn
+      behavior: Read-only deep turn drilldown CLI consumer. The CLI validates session_id and a 1-based integer turn_index locally, calls /v1/rpc conversation.get_turn through the shared v1 API client, omits include_logs to accept the API default of true, and renders only the server-owned ConversationTurnDetail. The CLI MUST NOT accept turn_id as an alternate selector and MUST NOT reconstruct the turn by joining conversation.get, runtime.logs, run.trace, or dashboard audit tables.
+      params:
+      - name: session_id
+        arg: <session-id>
+        required: true
+        api_param: session_id
+      - name: turn_index
+        arg: <turn-index>
+        required: true
+        api_param: turn_index
+        validation: CLI validates integer range 1 through 1000000, matching the v1 handler bound.
+      output:
+        success_detail: Conversation/turn header with session_id, turn_index, turn_id, timing, parse_ok, dispatch metadata, advertised tool summary, runtime_log_entries count, raw turn-block summary, optional assistant_visible_output, and compact runtime log lines when returned by the API.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - SESSION_NOT_FOUND
+        - TURN_NOT_FOUND
+      proof_expectations:
+      - exact /v1/rpc conversation.get_turn call with session_id and turn_index params only; include_logs is omitted so the API default remains authoritative
+      - missing/blank/invalid session id, invalid turn_index, turn_id-shaped selector attempts, and missing SWARM_API_TOKEN make zero API calls
+      - success output renders only ConversationTurnDetail fields returned by the server; runtime logs are consumed from the API result, not independently queried
+      - SESSION_NOT_FOUND, TURN_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, runtime.logs, run.trace, or forkchat usage
     forkchat:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
@@ -7336,6 +7407,9 @@ cli_specification:
     - swarm entities list
     - swarm entity view
     - swarm entity aggregate
+    - swarm conversations list
+    - swarm conversation view
+    - swarm conversation turn
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -7345,7 +7419,6 @@ cli_specification:
     - swarm investigate trace
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm conversations list / conversation view / conversation turn
     - swarm forkchat new|resume|list|view|delete
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 


### PR DESCRIPTION
Closes #903

## Governing refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.conversations_list`, `conversation_view`, `conversation_turn`
- `api_specification.method_catalog.conversation.list`, `conversation.get`, `conversation.get_turn`
- Schemas: `ConversationSummary`, `ConversationDetail`, `Turn`, `ConversationTurnDetail`, `ConversationDeepTurn`
- Binding gate: #903 Pre-Implementation Coverage Audit and approved first-slice gate
- Prerequisite context checked: #877/#895 turn-index selector safety and #851/#873 run-id projection safety

## Semantic migration
- New canonical CLI owners: `swarm conversations list`, `swarm conversation view <session-id>`, and `swarm conversation turn <session-id> <turn-index>` consuming `/v1/rpc conversation.list`, `conversation.get`, and `conversation.get_turn` through the shared CLI v1 API client.
- Old producer/reader/interpreter paths now invalid for this CLI slice: absent CLI catalog rows, direct DB/store/runtime/EventBus/dashboard reads, legacy transports, `conversation.current_for_agent`, turn-id selectors, and client-side reconstruction from `runtime.logs` or `run.trace`.
- Production paths checked for surviving old behavior: `cmd/swarm`, `internal/apiv1`, `internal/store`, OpenRPC generation, dashboard adapter as separate non-CLI surface, and static no-bypass grep over the new CLI implementation.
- Migration complete for the approved read-only conversation CLI family; broader #735 residuals remain outside this child.

## Proof
- `go test ./cmd/swarm -run 'Conversation|Conversations' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/store -run 'TestOperatorConversationReadSurfaceLoadConversationAssignsTurnIndexes|TestOperatorConversationReadSurfaceLoadTurnComposesConversationOwner|TestOperatorConversationReadSurfaceLoadTurnOutOfRange' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorConversationGetTurnComposesRuntimeLogOwner|TestOpenRPCReadOnlyHTTPRuntimeProbes' -count=1`
- `git diff --check`
- Static no-bypass grep over `cmd/swarm/conversations.go` for DB/store/runtime/EventBus/dashboard/legacy/reconstruction paths returned no matches.
