### PR TITLE
[agent-f][issue #901] Promote agent.diagnose queue details

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -14,13 +14,32 @@
   "methods": [
     {
       "name": "agent.diagnose",
-      "description": "Read the first owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, pending delivery count/oldest age,\nand optional delivery lifecycle evidence. The API handler consumes the\ncanonical agent diagnosis read owner directly. It must not join\nconversation, run, trace, token, queue-detail, CLI, or dashboard owners\nlocally, and it must not expose runtime_state, run_id, bundle_version,\nactive task/entity, watchdog, last tool outcome, token usage, recent\nfailures, dead letters, pending delivery details, attempts, or cursors.\n",
+      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly. It must not join\nconversation, run, trace, token, CLI, or dashboard owners locally, and\nit must not expose runtime_state, run_id, bundle_version, active\ntask/entity, watchdog, last tool outcome, token usage, recent failures,\nor dead letters.\n",
       "params": [
         {
           "name": "agent_id",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "queue_limit",
+          "required": false,
+          "description": "Max pending-delivery detail rows to return. pending_count remains the total pending count for the selected queue, not the page length.",
+          "schema": {
+            "default": 50,
+            "maximum": 200,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "queue_cursor",
+          "required": false,
+          "description": "Opaque cursor returned by queue.next_cursor for the next pending-delivery detail page.",
+          "schema": {
+            "$ref": "#/components/schemas/Cursor"
           }
         }
       ],
@@ -5366,6 +5385,9 @@
       "AgentDiagnosisQueue": {
         "additionalProperties": false,
         "properties": {
+          "next_cursor": {
+            "$ref": "#/components/schemas/Cursor"
+          },
           "oldest_pending_age_seconds": {
             "minimum": 0,
             "type": "integer"
@@ -5373,11 +5395,46 @@
           "pending_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "pending_deliveries": {
+            "items": {
+              "$ref": "#/components/schemas/AgentPendingDelivery"
+            },
+            "type": "array"
           }
         },
         "required": [
           "pending_count",
-          "oldest_pending_age_seconds"
+          "oldest_pending_age_seconds",
+          "pending_deliveries"
+        ],
+        "type": "object"
+      },
+      "AgentPendingDelivery": {
+        "additionalProperties": false,
+        "properties": {
+          "attempts": {
+            "description": "Canonical recorded delivery retry counter from event_deliveries.retry_count; the API must not add one or reinterpret by status.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "enqueued_at": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "Same timestamp owner as AgentDiagnosisQueue.oldest_pending_age_seconds; currently events.created_at."
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_name": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "event_name",
+          "enqueued_at",
+          "attempts"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8526,12 +8526,34 @@ api_specification:
         - active
         - retrying
         - exhausted
+      AgentPendingDelivery:
+        type: object
+        additionalProperties: false
+        required:
+        - event_id
+        - event_name
+        - enqueued_at
+        - attempts
+        properties:
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_name:
+            type: string
+            minLength: 1
+          enqueued_at:
+            $ref: '#/components/schemas/Timestamp'
+            description: Same timestamp owner as AgentDiagnosisQueue.oldest_pending_age_seconds; currently events.created_at.
+          attempts:
+            type: integer
+            minimum: 0
+            description: Canonical recorded delivery retry counter from event_deliveries.retry_count; the API must not add one or reinterpret by status.
       AgentDiagnosisQueue:
         type: object
         additionalProperties: false
         required:
         - pending_count
         - oldest_pending_age_seconds
+        - pending_deliveries
         properties:
           pending_count:
             type: integer
@@ -8539,6 +8561,12 @@ api_specification:
           oldest_pending_age_seconds:
             type: integer
             minimum: 0
+          pending_deliveries:
+            type: array
+            items:
+              $ref: '#/components/schemas/AgentPendingDelivery'
+          next_cursor:
+            $ref: '#/components/schemas/Cursor'
       AgentDeliveryLifecycle:
         type: object
         additionalProperties: false
@@ -10383,14 +10411,20 @@ api_specification:
     agent.diagnose:
       tier: should_have
       description: |
-        Read the first owner-backed diagnosis slice for one agent. This method is
-        limited to agent identity/status refs, pending delivery count/oldest age,
-        and optional delivery lifecycle evidence. The API handler consumes the
+        Read the owner-backed diagnosis slice for one agent. This method is
+        limited to agent identity/status refs, current/last conversation refs,
+        pending-delivery queue summary/detail evidence, and optional delivery
+        lifecycle evidence. Queue details are paged with queue_limit and
+        queue_cursor, ordered by events.created_at ASC then events.event_id ASC.
+        AgentPendingDelivery.enqueued_at uses the same timestamp owner as
+        oldest_pending_age_seconds. AgentPendingDelivery.attempts is the
+        canonical recorded retry counter from event_deliveries.retry_count, with
+        no API-layer +1 or status arithmetic. The API handler consumes the
         canonical agent diagnosis read owner directly. It must not join
-        conversation, run, trace, token, queue-detail, CLI, or dashboard owners
-        locally, and it must not expose runtime_state, run_id, bundle_version,
-        active task/entity, watchdog, last tool outcome, token usage, recent
-        failures, dead letters, pending delivery details, attempts, or cursors.
+        conversation, run, trace, token, CLI, or dashboard owners locally, and
+        it must not expose runtime_state, run_id, bundle_version, active
+        task/entity, watchdog, last tool outcome, token usage, recent failures,
+        or dead letters.
       scope:
         required:
         - read:agents
@@ -10399,6 +10433,19 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/OpaqueId'
+      - name: queue_limit
+        required: false
+        description: Max pending-delivery detail rows to return. pending_count remains the total pending count for the selected queue, not the page length.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 50
+      - name: queue_cursor
+        required: false
+        description: Opaque cursor returned by queue.next_cursor for the next pending-delivery detail page.
+        schema:
+          $ref: '#/components/schemas/Cursor'
       result:
         name: result
         required: true

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 63 {
-		t.Fatalf("schema count = %d, want 63", report.SchemaCount)
+	if report.SchemaCount != 64 {
+		t.Fatalf("schema count = %d, want 64", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -67,8 +67,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 63 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 63", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 64 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 64", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -88,6 +88,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["agent.diagnose"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.diagnose")
+	}
+	if _, ok := doc.Components.Schemas["AgentPendingDelivery"]; !ok {
+		t.Fatal("generated OpenRPC missing AgentPendingDelivery")
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -526,6 +526,12 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 				Queue: store.OperatorAgentDiagnosisQueue{
 					PendingCount:            2,
 					OldestPendingAgeSeconds: 30,
+					PendingDeliveries: []store.OperatorAgentPendingDelivery{{
+						EventID:    "event-1",
+						EventName:  "task.ready",
+						EnqueuedAt: time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC),
+						Attempts:   1,
+					}},
 				},
 				DeliveryLifecycle: &store.OperatorAgentDeliveryLifecycle{
 					State:         "active",
@@ -661,6 +667,13 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		queue := asMap(t, result["queue"])
 		if queue["pending_count"] != float64(2) || queue["oldest_pending_age_seconds"] != float64(30) {
 			t.Fatalf("agent.diagnose queue = %#v", queue)
+		}
+		deliveries, ok := queue["pending_deliveries"].([]any)
+		if !ok || len(deliveries) != 1 {
+			t.Fatalf("agent.diagnose pending_deliveries = %#v", queue["pending_deliveries"])
+		}
+		if delivery := asMap(t, deliveries[0]); delivery["event_id"] != "event-1" || delivery["event_name"] != "task.ready" || delivery["attempts"] != float64(1) {
+			t.Fatalf("agent.diagnose pending delivery = %#v", deliveries[0])
 		}
 		for _, splitField := range []string{"runtime_state", "bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 			if _, ok := result[splitField]; ok {

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -31,6 +31,7 @@ type fakeAgentConversationReadStore struct {
 	lastConversationList          store.OperatorConversationListOptions
 	lastAgentID                   string
 	lastAgentDiagnosisID          string
+	lastAgentDiagnosisOptions     store.OperatorAgentDiagnosisOptions
 	lastConversationSessionID     string
 	lastConversationTurnSessionID string
 	lastConversationTurnIndex     int
@@ -47,8 +48,9 @@ func (s *fakeAgentConversationReadStore) LoadOperatorAgent(_ context.Context, ag
 	return s.agentResult, s.agentErr
 }
 
-func (s *fakeAgentConversationReadStore) LoadOperatorAgentDiagnosis(_ context.Context, agentID string) (store.OperatorAgentDiagnosis, error) {
+func (s *fakeAgentConversationReadStore) LoadOperatorAgentDiagnosis(_ context.Context, agentID string, opts store.OperatorAgentDiagnosisOptions) (store.OperatorAgentDiagnosis, error) {
 	s.lastAgentDiagnosisID = agentID
+	s.lastAgentDiagnosisOptions = opts
 	return s.agentDiagnosisResult, s.agentDiagnosisErr
 }
 
@@ -112,6 +114,13 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 			Queue: store.OperatorAgentDiagnosisQueue{
 				PendingCount:            2,
 				OldestPendingAgeSeconds: 45,
+				PendingDeliveries: []store.OperatorAgentPendingDelivery{{
+					EventID:    "event-1",
+					EventName:  "task.ready",
+					EnqueuedAt: time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC),
+					Attempts:   1,
+				}},
+				NextCursor: "cursor-2",
 			},
 			DeliveryLifecycle: &store.OperatorAgentDeliveryLifecycle{
 				State:         "active",
@@ -185,12 +194,15 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		}
 	}
 
-	diagnoseAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+	diagnoseAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1","queue_limit":1,"queue_cursor":"cursor-1"}}`)
 	if diagnoseAgent.Error != nil {
 		t.Fatalf("agent.diagnose error = %#v", diagnoseAgent.Error)
 	}
 	if reads.lastAgentDiagnosisID != "agent-1" {
 		t.Fatalf("agent.diagnose id = %q", reads.lastAgentDiagnosisID)
+	}
+	if reads.lastAgentDiagnosisOptions.QueueLimit != 1 || reads.lastAgentDiagnosisOptions.QueueCursor != "cursor-1" {
+		t.Fatalf("agent.diagnose options = %#v", reads.lastAgentDiagnosisOptions)
 	}
 	diagnosis := asMap(t, diagnoseAgent.Result)
 	if diagnosis["agent_id"] != "agent-1" || diagnosis["status"] != "running" {
@@ -199,6 +211,17 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	queue := asMap(t, diagnosis["queue"])
 	if queue["pending_count"] != float64(2) || queue["oldest_pending_age_seconds"] != float64(45) {
 		t.Fatalf("agent.diagnose queue = %#v", queue)
+	}
+	deliveries, ok := queue["pending_deliveries"].([]any)
+	if !ok || len(deliveries) != 1 {
+		t.Fatalf("agent.diagnose pending_deliveries = %#v", queue["pending_deliveries"])
+	}
+	delivery := asMap(t, deliveries[0])
+	if delivery["event_id"] != "event-1" || delivery["event_name"] != "task.ready" || delivery["attempts"] != float64(1) {
+		t.Fatalf("agent.diagnose pending delivery = %#v", delivery)
+	}
+	if queue["next_cursor"] != "cursor-2" {
+		t.Fatalf("agent.diagnose next_cursor = %#v", queue["next_cursor"])
 	}
 	lifecycle := asMap(t, diagnosis["delivery_lifecycle"])
 	if lifecycle["state"] != "active" || lifecycle["blocking_layer"] != "session_execution" {
@@ -483,8 +506,13 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData(t *testing.T) {
 	reads := &fakeAgentConversationReadStore{
 		agentDiagnosisResult: store.OperatorAgentDiagnosis{
 			AgentID: "agent-1",
-			Status:  "working",
-			Queue:   store.OperatorAgentDiagnosisQueue{},
+			Status:  "running",
+			Queue: store.OperatorAgentDiagnosisQueue{
+				PendingDeliveries: []store.OperatorAgentPendingDelivery{{
+					EventName:  "task.ready",
+					EnqueuedAt: time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC),
+				}},
+			},
 		},
 	}
 	handler := testHandler(t, Options{
@@ -504,4 +532,34 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData(t *testing.T) {
 	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.diagnose owner returned malformed result") {
 		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
 	}
+}
+
+func TestOperatorAgentDiagnoseRejectsQueueLimit(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: &fakeAgentConversationReadStore{},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1","queue_limit":0}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.diagnose returned success for invalid queue_limit")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.diagnose", resp, "queue_limit")
+}
+
+func TestOperatorAgentDiagnoseRejectsBadQueueCursor(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: &fakeAgentConversationReadStore{agentDiagnosisErr: store.ErrInvalidPendingAgentDeliveryCursor},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1","queue_cursor":"bad"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.diagnose returned success for invalid queue_cursor")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.diagnose", resp, "queue_cursor")
 }

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -40,7 +40,7 @@ type EntityReadStore interface {
 type AgentConversationReadStore interface {
 	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
-	LoadOperatorAgentDiagnosis(context.Context, string) (store.OperatorAgentDiagnosis, error)
+	LoadOperatorAgentDiagnosis(context.Context, string, store.OperatorAgentDiagnosisOptions) (store.OperatorAgentDiagnosis, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
 	LoadOperatorConversationTurn(context.Context, string, int) (store.OperatorConversationTurnDetail, error)
@@ -307,9 +307,23 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			if err != nil {
 				return nil, err
 			}
-			result, err := reads.LoadOperatorAgentDiagnosis(ctx, agentID)
+			queueLimit, err := boundedIntegerParam(req.Params, "queue_limit", 1, store.MaxAgentDiagnosisQueueLimit)
+			if err != nil {
+				return nil, err
+			}
+			queueCursor, _, err := optionalStringParam(req.Params, "queue_cursor")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorAgentDiagnosis(ctx, agentID, store.OperatorAgentDiagnosisOptions{
+				QueueLimit:  queueLimit,
+				QueueCursor: queueCursor,
+			})
 			if errors.Is(err, store.ErrAgentNotFound) {
 				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			if errors.Is(err, store.ErrInvalidPendingAgentDeliveryCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "queue_cursor", "reason": "invalid agent.diagnose queue cursor"})
 			}
 			if err != nil {
 				return nil, err
@@ -444,6 +458,23 @@ func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
 	}
 	if item.Queue.OldestPendingAgeSeconds < 0 {
 		return fmt.Errorf("agent.diagnose owner returned malformed result: queue.oldest_pending_age_seconds must be non-negative")
+	}
+	if item.Queue.PendingDeliveries == nil {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_deliveries must be an array")
+	}
+	for i, detail := range item.Queue.PendingDeliveries {
+		if strings.TrimSpace(detail.EventID) == "" {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_deliveries[%d].event_id is required", i)
+		}
+		if strings.TrimSpace(detail.EventName) == "" {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_deliveries[%d].event_name is required", i)
+		}
+		if detail.EnqueuedAt.IsZero() {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_deliveries[%d].enqueued_at is required", i)
+		}
+		if detail.Attempts < 0 {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: queue.pending_deliveries[%d].attempts must be non-negative", i)
+		}
 	}
 	if item.DeliveryLifecycle != nil {
 		if !validAgentDeliveryLifecycleState(item.DeliveryLifecycle.State) {

--- a/internal/dashboard/server/agents_sql.go
+++ b/internal/dashboard/server/agents_sql.go
@@ -81,6 +81,10 @@ type pendingAgentDeliveryFactSource interface {
 	ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]store.PendingAgentDeliveryFacts, error)
 }
 
+type pendingAgentDeliveryDetailSource interface {
+	ListPendingAgentDeliveryDetails(ctx context.Context, opts store.PendingAgentDeliveryListOptions) (store.PendingAgentDeliveryPage, error)
+}
+
 type agentLifecycleFactSource interface {
 	ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error)
 }
@@ -107,6 +111,14 @@ func (s *dashboardAgentReadSource) ListPendingAgentDeliveryFacts(ctx context.Con
 		return nil, errors.New("missing pending agent delivery fact source")
 	}
 	return source.ListPendingAgentDeliveryFacts(ctx, agentIDs, since)
+}
+
+func (s *dashboardAgentReadSource) ListPendingAgentDeliveryDetails(ctx context.Context, opts store.PendingAgentDeliveryListOptions) (store.PendingAgentDeliveryPage, error) {
+	source, ok := s.source.(pendingAgentDeliveryDetailSource)
+	if !ok || source == nil {
+		return store.PendingAgentDeliveryPage{}, errors.New("missing pending agent delivery detail source")
+	}
+	return source.ListPendingAgentDeliveryDetails(ctx, opts)
 }
 
 func (s *dashboardAgentReadSource) ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]store.AgentLifecycleFacts, error) {

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -26,6 +26,8 @@ var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")
 
 var ErrInvalidConversationCursor = errors.New("store: invalid conversation cursor")
 
+var ErrInvalidPendingAgentDeliveryCursor = errors.New("store: invalid pending agent delivery cursor")
+
 var ErrOperatorConversationRunIDCapability = errors.New("store: operator conversation read surface run_id capability unavailable")
 
 var ErrInvalidEntityReadParam = errors.New("store: invalid entity read parameter")

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -57,10 +57,6 @@ func (s *PostgresStore) UpsertEventReceipt(ctx context.Context, eventID, agentID
 }
 
 func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return nil, err
-	}
 	if agentID == "" {
 		return nil, nil
 	}
@@ -70,10 +66,19 @@ func (s *PostgresStore) ListPendingEventsForAgent(ctx context.Context, agentID s
 	if since.IsZero() {
 		since = time.Now().Add(-30 * 24 * time.Hour)
 	}
-	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+	page, err := s.ListPendingAgentDeliveryDetails(ctx, PendingAgentDeliveryListOptions{
+		AgentID: agentID,
+		Since:   since,
+		Limit:   limit,
+	})
+	if err != nil {
 		return nil, err
 	}
-	return s.listPendingEventsForAgentSpec(ctx, agentID, since, limit)
+	out := make([]events.Event, 0, len(page.PendingDeliveries))
+	for _, detail := range page.PendingDeliveries {
+		out = append(out, detail.Event)
+	}
+	return out, nil
 }
 
 func (s *PostgresStore) ListPendingSubscribedEvents(
@@ -460,44 +465,6 @@ func (s *PostgresStore) ServeAbandonDeliveryQuiesced(ctx context.Context, eventI
 		return false, fmt.Errorf("check serve abandon delivery quiescence: %w", err)
 	}
 	return ok, nil
-}
-
-func (s *PostgresStore) listPendingEventsForAgentSpec(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT
-			d.subscriber_id,
-			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
-			COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(e.scope, 'global'),
-			e.payload, e.created_at,
-			COALESCE(e.source_event_id::text, ''),
-			TRUE,
-			COALESCE(d.status, ''),
-			COALESCE(d.retry_count, 0),
-			d.created_at,
-			d.delivered_at,
-			CASE WHEN r.event_id IS NULL THEN FALSE ELSE TRUE END
-		FROM event_deliveries d
-		INNER JOIN events e ON e.event_id = d.event_id
-		LEFT JOIN event_receipts r
-			ON r.event_id = d.event_id
-			AND r.subscriber_type = 'agent'
-			AND r.subscriber_id = d.subscriber_id
-		WHERE d.subscriber_type = 'agent'
-		  AND d.subscriber_id = $1
-		  AND e.created_at >= $2
-		  AND `+canonicalPendingDeliveryPredicateSQL("d", "r")+`
-		ORDER BY e.created_at ASC
-		LIMIT $3
-	`, agentID, since, limit)
-	if err != nil {
-		return nil, fmt.Errorf("query pending events for %s: %w", agentID, err)
-	}
-	defer rows.Close()
-	records, err := scanPendingAgentDeliveryRecords(rows)
-	if err != nil {
-		return nil, err
-	}
-	return pendingEventsFromRecords(records, time.Now(), limit), nil
 }
 
 func (s *PostgresStore) listPendingSubscribedEventsSpec(ctx context.Context, agentID string, subscriptions []events.EventType, since time.Time, limit int) ([]events.Event, error) {

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -746,6 +747,127 @@ func TestListPendingAgentDeliveryFacts_AlignsWithCanonicalPendingStates_V2(t *te
 	}
 	if facts.OldestPendingAgeSec <= 0 {
 		t.Fatalf("oldest_pending_age_sec = %d, want > 0", facts.OldestPendingAgeSec)
+	}
+}
+
+func TestListPendingAgentDeliveryDetails_PagesCanonicalQueueTruth_V2(t *testing.T) {
+	pg, cleanup := newTestPostgresStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
+
+	pendingEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.pending")
+	retryableEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.failed")
+	inProgressEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.in_progress")
+	deadEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.dead")
+	deliveredEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.delivered")
+	legacyEvt := seedEvent(t, ctx, pg, entityID, "test.pending_details.legacy_receipt_only")
+
+	for _, eventID := range []string{pendingEvt.ID, retryableEvt.ID, inProgressEvt.ID, deadEvt.ID, deliveredEvt.ID} {
+		if err := pg.InsertEventDeliveries(ctx, eventID, []string{agentID}); err != nil {
+			t.Fatalf("insert deliveries for %s: %v", eventID, err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	eventTimes := map[string]time.Time{
+		pendingEvt.ID:    now.Add(-30 * time.Minute),
+		retryableEvt.ID:  now.Add(-20 * time.Minute),
+		inProgressEvt.ID: now.Add(-10 * time.Minute),
+		deadEvt.ID:       now.Add(-5 * time.Minute),
+		deliveredEvt.ID:  now.Add(-4 * time.Minute),
+		legacyEvt.ID:     now.Add(-3 * time.Minute),
+	}
+	for eventID, createdAt := range eventTimes {
+		if _, err := pg.DB.ExecContext(ctx, `
+			UPDATE events
+			SET created_at = $2
+			WHERE event_id = $1::uuid
+		`, eventID, createdAt); err != nil {
+			t.Fatalf("set event created_at for %s: %v", eventID, err)
+		}
+	}
+
+	if err := pg.UpsertEventReceipt(ctx, retryableEvt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert retryable receipt: %v", err)
+	}
+	rewindCanonicalDeliveryAttempt(t, ctx, pg, retryableEvt.ID, agentID, now.Add(-2*time.Minute))
+	if err := pg.MarkEventDeliveryInProgress(ctx, inProgressEvt.ID, agentID, ""); err != nil {
+		t.Fatalf("mark in progress: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, deadEvt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert dead-letter first error: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, deadEvt.ID, agentID, runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("upsert dead-letter second error: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, deliveredEvt.ID, agentID, runtimemanager.ReceiptStatusProcessed, "done"); err != nil {
+		t.Fatalf("upsert delivered receipt: %v", err)
+	}
+	insertLegacyAgentReceiptState(t, ctx, pg, legacyEvt.ID, agentID, runtimemanager.ReceiptStatusError, 1, "handler_error", "boom", now.Add(-2*time.Minute))
+
+	firstPage, err := pg.ListPendingAgentDeliveryDetails(ctx, store.PendingAgentDeliveryListOptions{
+		AgentID: agentID,
+		Since:   now.Add(-2 * time.Hour),
+		Limit:   2,
+	})
+	if err != nil {
+		t.Fatalf("ListPendingAgentDeliveryDetails first page: %v", err)
+	}
+	if firstPage.PendingCount != 3 {
+		t.Fatalf("pending_count = %d, want 3", firstPage.PendingCount)
+	}
+	if firstPage.OldestPendingAgeSec <= 0 {
+		t.Fatalf("oldest_pending_age_sec = %d, want > 0", firstPage.OldestPendingAgeSec)
+	}
+	if len(firstPage.PendingDeliveries) != 2 || firstPage.NextCursor == "" {
+		t.Fatalf("first page = %+v, want 2 rows with next cursor", firstPage)
+	}
+	assertPendingDeliveryDetail(t, firstPage.PendingDeliveries[0], pendingEvt.ID, string(pendingEvt.Type), eventTimes[pendingEvt.ID], 0)
+	assertPendingDeliveryDetail(t, firstPage.PendingDeliveries[1], retryableEvt.ID, string(retryableEvt.Type), eventTimes[retryableEvt.ID], 1)
+
+	secondPage, err := pg.ListPendingAgentDeliveryDetails(ctx, store.PendingAgentDeliveryListOptions{
+		AgentID: agentID,
+		Since:   now.Add(-2 * time.Hour),
+		Limit:   2,
+		Cursor:  firstPage.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("ListPendingAgentDeliveryDetails second page: %v", err)
+	}
+	if secondPage.PendingCount != 3 || secondPage.OldestPendingAgeSec != firstPage.OldestPendingAgeSec {
+		t.Fatalf("second page summary = %+v, want stable full-count summary", secondPage)
+	}
+	if len(secondPage.PendingDeliveries) != 1 || secondPage.NextCursor != "" {
+		t.Fatalf("second page = %+v, want final single row", secondPage)
+	}
+	assertPendingDeliveryDetail(t, secondPage.PendingDeliveries[0], inProgressEvt.ID, string(inProgressEvt.Type), eventTimes[inProgressEvt.ID], 0)
+
+	runtimeEvents, err := pg.ListPendingEventsForAgent(ctx, agentID, now.Add(-2*time.Hour), 2)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	if len(runtimeEvents) != 2 || runtimeEvents[0].ID != pendingEvt.ID || runtimeEvents[1].ID != retryableEvt.ID {
+		t.Fatalf("runtime pending events = %#v, want shared first detail page order", runtimeEvents)
+	}
+
+	_, err = pg.ListPendingAgentDeliveryDetails(ctx, store.PendingAgentDeliveryListOptions{
+		AgentID: agentID,
+		Cursor:  "not-a-valid-cursor",
+	})
+	if !errors.Is(err, store.ErrInvalidPendingAgentDeliveryCursor) {
+		t.Fatalf("bad cursor error = %v, want ErrInvalidPendingAgentDeliveryCursor", err)
+	}
+}
+
+func assertPendingDeliveryDetail(t *testing.T, got store.PendingAgentDeliveryDetail, eventID, eventName string, enqueuedAt time.Time, attempts int) {
+	t.Helper()
+	if got.EventID != eventID || got.EventName != eventName || !got.EnqueuedAt.Equal(enqueuedAt) || got.Attempts != attempts {
+		t.Fatalf("pending delivery detail = %+v, want event_id=%s event_name=%s enqueued_at=%s attempts=%d", got, eventID, eventName, enqueuedAt, attempts)
+	}
+	if got.Event.ID != eventID {
+		t.Fatalf("pending delivery embedded event id = %q, want %q", got.Event.ID, eventID)
 	}
 }
 

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -22,6 +22,7 @@ type OperatorAgentConversationReadSource interface {
 	OperatorConversationReadSource
 	LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error)
 	ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]PendingAgentDeliveryFacts, error)
+	ListPendingAgentDeliveryDetails(ctx context.Context, opts PendingAgentDeliveryListOptions) (PendingAgentDeliveryPage, error)
 	ListAgentLifecycleFacts(ctx context.Context, agentIDs []string) (map[string]AgentLifecycleFacts, error)
 }
 
@@ -132,13 +133,27 @@ type OperatorAgentDiagnosis struct {
 }
 
 type OperatorAgentDiagnosisQueue struct {
-	PendingCount            int `json:"pending_count"`
-	OldestPendingAgeSeconds int `json:"oldest_pending_age_seconds"`
+	PendingCount            int                            `json:"pending_count"`
+	OldestPendingAgeSeconds int                            `json:"oldest_pending_age_seconds"`
+	PendingDeliveries       []OperatorAgentPendingDelivery `json:"pending_deliveries"`
+	NextCursor              string                         `json:"next_cursor,omitempty"`
+}
+
+type OperatorAgentPendingDelivery struct {
+	EventID    string    `json:"event_id"`
+	EventName  string    `json:"event_name"`
+	EnqueuedAt time.Time `json:"enqueued_at"`
+	Attempts   int       `json:"attempts"`
 }
 
 type OperatorAgentDeliveryLifecycle struct {
 	State         string `json:"state"`
 	BlockingLayer string `json:"blocking_layer"`
+}
+
+type OperatorAgentDiagnosisOptions struct {
+	QueueLimit  int
+	QueueCursor string
 }
 
 type OperatorAgentTool struct {
@@ -435,8 +450,8 @@ func (s *PostgresStore) LoadOperatorAgent(ctx context.Context, agentID string) (
 	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgent(ctx, agentID)
 }
 
-func (s *PostgresStore) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string) (OperatorAgentDiagnosis, error) {
-	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentDiagnosis(ctx, agentID)
+func (s *PostgresStore) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string, opts OperatorAgentDiagnosisOptions) (OperatorAgentDiagnosis, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentDiagnosis(ctx, agentID, opts)
 }
 
 func (s *PostgresStore) ListOperatorConversations(ctx context.Context, opts OperatorConversationListOptions) (OperatorConversationListResult, error) {
@@ -511,13 +526,25 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorAgent(ctx context.Con
 	return OperatorAgentDetail{}, ErrAgentNotFound
 }
 
-func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string) (OperatorAgentDiagnosis, error) {
+func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentDiagnosis(ctx context.Context, agentID string, opts OperatorAgentDiagnosisOptions) (OperatorAgentDiagnosis, error) {
 	detail, err := r.LoadOperatorAgent(ctx, agentID)
 	if err != nil {
 		return OperatorAgentDiagnosis{}, err
 	}
 	diagnosis, err := operatorAgentDiagnosisFromDetail(detail)
 	if err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	queue, err := r.source.ListPendingAgentDeliveryDetails(ctx, PendingAgentDeliveryListOptions{
+		AgentID: strings.TrimSpace(agentID),
+		Limit:   opts.QueueLimit,
+		Cursor:  opts.QueueCursor,
+	})
+	if err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	diagnosis.Queue = operatorAgentDiagnosisQueueFromPendingPage(queue)
+	if err := validateOperatorAgentDiagnosis(diagnosis); err != nil {
 		return OperatorAgentDiagnosis{}, err
 	}
 	return diagnosis, nil
@@ -1245,6 +1272,7 @@ func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgent
 		Queue: OperatorAgentDiagnosisQueue{
 			PendingCount:            agent.PendingEvents,
 			OldestPendingAgeSeconds: agent.OldestPendingAgeSec,
+			PendingDeliveries:       []OperatorAgentPendingDelivery{},
 		},
 	}
 	if state := strings.TrimSpace(agent.DeliveryLifecycle); state != "" {
@@ -1259,6 +1287,24 @@ func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgent
 	return out, nil
 }
 
+func operatorAgentDiagnosisQueueFromPendingPage(page PendingAgentDeliveryPage) OperatorAgentDiagnosisQueue {
+	queue := OperatorAgentDiagnosisQueue{
+		PendingCount:            page.PendingCount,
+		OldestPendingAgeSeconds: page.OldestPendingAgeSec,
+		PendingDeliveries:       make([]OperatorAgentPendingDelivery, 0, len(page.PendingDeliveries)),
+		NextCursor:              strings.TrimSpace(page.NextCursor),
+	}
+	for _, detail := range page.PendingDeliveries {
+		queue.PendingDeliveries = append(queue.PendingDeliveries, OperatorAgentPendingDelivery{
+			EventID:    strings.TrimSpace(detail.EventID),
+			EventName:  strings.TrimSpace(detail.EventName),
+			EnqueuedAt: detail.EnqueuedAt.UTC(),
+			Attempts:   detail.Attempts,
+		})
+	}
+	return queue
+}
+
 func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
 	if strings.TrimSpace(item.AgentID) == "" {
 		return fmt.Errorf("agent diagnosis agent_id is required")
@@ -1271,6 +1317,23 @@ func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
 	}
 	if item.Queue.OldestPendingAgeSeconds < 0 {
 		return fmt.Errorf("agent diagnosis queue.oldest_pending_age_seconds must be non-negative")
+	}
+	if item.Queue.PendingDeliveries == nil {
+		return fmt.Errorf("agent diagnosis queue.pending_deliveries must be an array")
+	}
+	for i, detail := range item.Queue.PendingDeliveries {
+		if strings.TrimSpace(detail.EventID) == "" {
+			return fmt.Errorf("agent diagnosis queue.pending_deliveries[%d].event_id is required", i)
+		}
+		if strings.TrimSpace(detail.EventName) == "" {
+			return fmt.Errorf("agent diagnosis queue.pending_deliveries[%d].event_name is required", i)
+		}
+		if detail.EnqueuedAt.IsZero() {
+			return fmt.Errorf("agent diagnosis queue.pending_deliveries[%d].enqueued_at is required", i)
+		}
+		if detail.Attempts < 0 {
+			return fmt.Errorf("agent diagnosis queue.pending_deliveries[%d].attempts must be non-negative", i)
+		}
 	}
 	if item.DeliveryLifecycle != nil {
 		if !validOperatorAgentDeliveryLifecycleState(item.DeliveryLifecycle.State) {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -26,8 +26,10 @@ type fakeAgentConversationReadSource struct {
 	caps      StoreSchemaCapabilities
 	agents    []runtimemanager.PersistedAgent
 	pending   map[string]PendingAgentDeliveryFacts
+	details   map[string]PendingAgentDeliveryPage
 	lifecycle map[string]AgentLifecycleFacts
 	err       error
+	detailErr error
 }
 
 func (s fakeAgentConversationReadSource) ResolveSchemaCapabilities(context.Context) (StoreSchemaCapabilities, error) {
@@ -44,6 +46,20 @@ func (s fakeAgentConversationReadSource) ListPendingAgentDeliveryFacts(_ context
 		out[agentID] = s.pending[agentID]
 	}
 	return out, s.err
+}
+
+func (s fakeAgentConversationReadSource) ListPendingAgentDeliveryDetails(_ context.Context, opts PendingAgentDeliveryListOptions) (PendingAgentDeliveryPage, error) {
+	if s.detailErr != nil {
+		return PendingAgentDeliveryPage{}, s.detailErr
+	}
+	page, ok := s.details[strings.TrimSpace(opts.AgentID)]
+	if !ok {
+		return PendingAgentDeliveryPage{PendingDeliveries: []PendingAgentDeliveryDetail{}}, s.err
+	}
+	if page.PendingDeliveries == nil {
+		page.PendingDeliveries = []PendingAgentDeliveryDetail{}
+	}
+	return page, s.err
 }
 
 func (s fakeAgentConversationReadSource) ListAgentLifecycleFacts(_ context.Context, agentIDs []string) (map[string]AgentLifecycleFacts, error) {
@@ -311,11 +327,25 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	turnID := "22222222-2222-2222-2222-222222222222"
 	sessionStartedAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
 	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
+	eventTime := time.Date(2026, 5, 12, 8, 55, 0, 0, time.UTC)
 	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
 		caps:   canonicalAgentConversationReadCaps(),
 		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
 		pending: map[string]PendingAgentDeliveryFacts{
-			"agent-1": {PendingCount: 3, OldestPendingAgeSec: 90},
+			"agent-1": {PendingCount: 99, OldestPendingAgeSec: 999},
+		},
+		details: map[string]PendingAgentDeliveryPage{
+			"agent-1": {
+				PendingCount:        3,
+				OldestPendingAgeSec: 90,
+				PendingDeliveries: []PendingAgentDeliveryDetail{{
+					EventID:    "event-1",
+					EventName:  "task.ready",
+					EnqueuedAt: eventTime,
+					Attempts:   1,
+				}},
+				NextCursor: "cursor-2",
+			},
 		},
 		lifecycle: map[string]AgentLifecycleFacts{
 			"agent-1": {CurrentState: "active", BlockingLayer: "session_execution"},
@@ -327,7 +357,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
 			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
 
-	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
 		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
 	}
@@ -342,6 +372,15 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	}
 	if diagnosis.Queue.PendingCount != 3 || diagnosis.Queue.OldestPendingAgeSeconds != 90 {
 		t.Fatalf("queue = %#v", diagnosis.Queue)
+	}
+	if len(diagnosis.Queue.PendingDeliveries) != 1 {
+		t.Fatalf("pending deliveries = %#v", diagnosis.Queue.PendingDeliveries)
+	}
+	if got := diagnosis.Queue.PendingDeliveries[0]; got.EventID != "event-1" || got.EventName != "task.ready" || !got.EnqueuedAt.Equal(eventTime) || got.Attempts != 1 {
+		t.Fatalf("pending delivery = %#v", got)
+	}
+	if diagnosis.Queue.NextCursor != "cursor-2" {
+		t.Fatalf("next cursor = %q", diagnosis.Queue.NextCursor)
 	}
 	if diagnosis.DeliveryLifecycle == nil || diagnosis.DeliveryLifecycle.State != "active" || diagnosis.DeliveryLifecycle.BlockingLayer != "session_execution" {
 		t.Fatalf("delivery_lifecycle = %#v", diagnosis.DeliveryLifecycle)
@@ -368,12 +407,15 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
 			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
-	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
 		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
 	}
 	if diagnosis.Queue.PendingCount != 0 || diagnosis.Queue.OldestPendingAgeSeconds != 0 {
 		t.Fatalf("queue = %#v, want zero facts", diagnosis.Queue)
+	}
+	if diagnosis.Queue.PendingDeliveries == nil || len(diagnosis.Queue.PendingDeliveries) != 0 {
+		t.Fatalf("pending_deliveries = %#v, want empty array", diagnosis.Queue.PendingDeliveries)
 	}
 	if diagnosis.DeliveryLifecycle != nil {
 		t.Fatalf("delivery_lifecycle = %#v, want nil", diagnosis.DeliveryLifecycle)
@@ -403,7 +445,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLifecyc
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
 			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
-	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "delivery_lifecycle.state") {
 		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want delivery_lifecycle.state failure", err)
 	}
@@ -426,7 +468,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisPropagatesCapabilityFailure(t
 		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
 	}, 0)
 
-	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1")
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "events schema is unsupported") {
 		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want events capability failure", err)
 	}

--- a/internal/store/pending_delivery_read_surface.go
+++ b/internal/store/pending_delivery_read_surface.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -12,10 +14,37 @@ import (
 )
 
 const canonicalPendingDeliveryBackoff = time.Minute
+const pendingAgentDeliveryCursorKind = "agent.diagnose.queue"
+
+const DefaultPendingAgentDeliveryDetailLimit = 50
+const MaxPendingAgentDeliveryDetailLimit = 500
+const MaxAgentDiagnosisQueueLimit = 200
 
 type PendingAgentDeliveryFacts struct {
 	PendingCount        int
 	OldestPendingAgeSec int
+}
+
+type PendingAgentDeliveryListOptions struct {
+	AgentID string
+	Since   time.Time
+	Limit   int
+	Cursor  string
+}
+
+type PendingAgentDeliveryPage struct {
+	PendingCount        int
+	OldestPendingAgeSec int
+	PendingDeliveries   []PendingAgentDeliveryDetail
+	NextCursor          string
+}
+
+type PendingAgentDeliveryDetail struct {
+	EventID    string
+	EventName  string
+	EnqueuedAt time.Time
+	Attempts   int
+	Event      events.Event `json:"-"`
 }
 
 type pendingAgentDeliveryRecord struct {
@@ -27,6 +56,17 @@ type pendingAgentDeliveryRecord struct {
 	DeliveryCreatedAt   time.Time
 	DeliveryDeliveredAt sql.NullTime
 	ReceiptFound        bool
+}
+
+type pendingAgentDeliveryCursor struct {
+	Kind       string `json:"kind"`
+	EnqueuedAt string `json:"enqueued_at"`
+	EventID    string `json:"event_id"`
+}
+
+type pendingAgentDeliveryCursorPosition struct {
+	EnqueuedAt time.Time
+	EventID    string
 }
 
 func (r pendingAgentDeliveryRecord) isPending(now time.Time) bool {
@@ -149,7 +189,7 @@ func (s *PostgresStore) ListPendingAgentDeliveryFacts(ctx context.Context, agent
 	if len(normalized) == 0 {
 		return map[string]PendingAgentDeliveryFacts{}, nil
 	}
-	records, err := s.listPendingAgentDeliveryFactRecordsSpec(ctx, normalized, since)
+	records, err := s.listPendingAgentDeliveryRecordsSpec(ctx, normalized, since)
 	if err != nil {
 		return nil, err
 	}
@@ -166,6 +206,40 @@ func (s *PostgresStore) ListPendingAgentDeliveryFacts(ctx context.Context, agent
 		out[agentID] = pendingAgentDeliveryFactsFromRecords(grouped[agentID], now)
 	}
 	return out, nil
+}
+
+func (s *PostgresStore) ListPendingAgentDeliveryDetails(ctx context.Context, opts PendingAgentDeliveryListOptions) (PendingAgentDeliveryPage, error) {
+	opts.AgentID = strings.TrimSpace(opts.AgentID)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.AgentID == "" {
+		return PendingAgentDeliveryPage{PendingDeliveries: []PendingAgentDeliveryDetail{}}, nil
+	}
+	if opts.Limit == 0 {
+		opts.Limit = DefaultPendingAgentDeliveryDetailLimit
+	}
+	if opts.Limit < 0 || opts.Limit > MaxPendingAgentDeliveryDetailLimit {
+		return PendingAgentDeliveryPage{}, fmt.Errorf("pending agent delivery detail limit must be from 1 to %d", MaxPendingAgentDeliveryDetailLimit)
+	}
+	var cursor *pendingAgentDeliveryCursorPosition
+	if opts.Cursor != "" {
+		decoded, err := decodePendingAgentDeliveryCursor(opts.Cursor)
+		if err != nil {
+			return PendingAgentDeliveryPage{}, err
+		}
+		cursor = &decoded
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return PendingAgentDeliveryPage{}, err
+	}
+	if err := RequireCanonicalPendingAgentDeliveryCapabilities(caps); err != nil {
+		return PendingAgentDeliveryPage{}, err
+	}
+	records, err := s.listPendingAgentDeliveryRecordsSpec(ctx, []string{opts.AgentID}, opts.Since)
+	if err != nil {
+		return PendingAgentDeliveryPage{}, err
+	}
+	return pendingAgentDeliveryPageFromRecords(records, time.Now(), opts.Limit, cursor)
 }
 
 func normalizePendingAgentIDs(agentIDs []string) []string {
@@ -185,7 +259,7 @@ func normalizePendingAgentIDs(agentIDs []string) []string {
 	return out
 }
 
-func (s *PostgresStore) listPendingAgentDeliveryFactRecordsSpec(ctx context.Context, agentIDs []string, since time.Time) ([]pendingAgentDeliveryRecord, error) {
+func (s *PostgresStore) listPendingAgentDeliveryRecordsSpec(ctx context.Context, agentIDs []string, since time.Time) ([]pendingAgentDeliveryRecord, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
 			d.subscriber_id,
@@ -218,7 +292,7 @@ func (s *PostgresStore) listPendingAgentDeliveryFactRecordsSpec(ctx context.Cont
 		ORDER BY d.subscriber_id ASC, e.created_at ASC, e.event_id ASC
 	`, pq.Array(agentIDs), pendingDeliverySinceArg(since))
 	if err != nil {
-		return nil, fmt.Errorf("query pending agent delivery facts: %w", err)
+		return nil, fmt.Errorf("query pending agent delivery records: %w", err)
 	}
 	defer rows.Close()
 	return scanPendingAgentDeliveryRecords(rows)
@@ -272,6 +346,105 @@ func scanPendingAgentDeliveryRecords(rows *sql.Rows) ([]pendingAgentDeliveryReco
 		return nil, fmt.Errorf("read pending agent delivery records: %w", err)
 	}
 	return out, nil
+}
+
+func pendingAgentDeliveryPageFromRecords(records []pendingAgentDeliveryRecord, now time.Time, limit int, cursor *pendingAgentDeliveryCursorPosition) (PendingAgentDeliveryPage, error) {
+	if limit <= 0 {
+		limit = DefaultPendingAgentDeliveryDetailLimit
+	}
+	facts := pendingAgentDeliveryFactsFromRecords(records, now)
+	out := PendingAgentDeliveryPage{
+		PendingCount:        facts.PendingCount,
+		OldestPendingAgeSec: facts.OldestPendingAgeSec,
+		PendingDeliveries:   []PendingAgentDeliveryDetail{},
+	}
+	for _, record := range records {
+		if !record.isPending(now) {
+			continue
+		}
+		if cursor != nil && !pendingAgentDeliveryRecordAfterCursor(record, *cursor) {
+			continue
+		}
+		detail, err := pendingAgentDeliveryDetailFromRecord(record)
+		if err != nil {
+			return PendingAgentDeliveryPage{}, err
+		}
+		out.PendingDeliveries = append(out.PendingDeliveries, detail)
+		if len(out.PendingDeliveries) > limit {
+			break
+		}
+	}
+	if len(out.PendingDeliveries) > limit {
+		lastVisible := out.PendingDeliveries[limit-1]
+		out.NextCursor = encodePendingAgentDeliveryCursor(lastVisible)
+		out.PendingDeliveries = out.PendingDeliveries[:limit]
+	}
+	return out, nil
+}
+
+func pendingAgentDeliveryDetailFromRecord(record pendingAgentDeliveryRecord) (PendingAgentDeliveryDetail, error) {
+	detail := PendingAgentDeliveryDetail{
+		EventID:    strings.TrimSpace(record.Event.ID),
+		EventName:  strings.TrimSpace(string(record.Event.Type)),
+		EnqueuedAt: record.Event.CreatedAt.UTC(),
+		Attempts:   record.DeliveryRetryCount,
+		Event:      record.Event,
+	}
+	if detail.EventID == "" {
+		return PendingAgentDeliveryDetail{}, fmt.Errorf("pending agent delivery detail event_id is required")
+	}
+	if detail.EventName == "" {
+		return PendingAgentDeliveryDetail{}, fmt.Errorf("pending agent delivery detail event_name is required")
+	}
+	if detail.EnqueuedAt.IsZero() {
+		return PendingAgentDeliveryDetail{}, fmt.Errorf("pending agent delivery detail enqueued_at is required")
+	}
+	if detail.Attempts < 0 {
+		return PendingAgentDeliveryDetail{}, fmt.Errorf("pending agent delivery detail attempts must be non-negative")
+	}
+	return detail, nil
+}
+
+func pendingAgentDeliveryRecordAfterCursor(record pendingAgentDeliveryRecord, cursor pendingAgentDeliveryCursorPosition) bool {
+	enqueuedAt := record.Event.CreatedAt.UTC()
+	if enqueuedAt.After(cursor.EnqueuedAt) {
+		return true
+	}
+	if enqueuedAt.Before(cursor.EnqueuedAt) {
+		return false
+	}
+	return strings.TrimSpace(record.Event.ID) > cursor.EventID
+}
+
+func encodePendingAgentDeliveryCursor(detail PendingAgentDeliveryDetail) string {
+	raw, _ := json.Marshal(pendingAgentDeliveryCursor{
+		Kind:       pendingAgentDeliveryCursorKind,
+		EnqueuedAt: detail.EnqueuedAt.UTC().Format(time.RFC3339Nano),
+		EventID:    strings.TrimSpace(detail.EventID),
+	})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodePendingAgentDeliveryCursor(raw string) (pendingAgentDeliveryCursorPosition, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return pendingAgentDeliveryCursorPosition{}, ErrInvalidPendingAgentDeliveryCursor
+	}
+	var cursor pendingAgentDeliveryCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return pendingAgentDeliveryCursorPosition{}, ErrInvalidPendingAgentDeliveryCursor
+	}
+	if strings.TrimSpace(cursor.Kind) != pendingAgentDeliveryCursorKind || strings.TrimSpace(cursor.EventID) == "" || strings.TrimSpace(cursor.EnqueuedAt) == "" {
+		return pendingAgentDeliveryCursorPosition{}, ErrInvalidPendingAgentDeliveryCursor
+	}
+	enqueuedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(cursor.EnqueuedAt))
+	if err != nil {
+		return pendingAgentDeliveryCursorPosition{}, ErrInvalidPendingAgentDeliveryCursor
+	}
+	return pendingAgentDeliveryCursorPosition{
+		EnqueuedAt: enqueuedAt.UTC(),
+		EventID:    strings.TrimSpace(cursor.EventID),
+	}, nil
 }
 
 func min(a, b int) int {

--- a/internal/store/pending_delivery_read_surface_test.go
+++ b/internal/store/pending_delivery_read_surface_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListPendingAgentDeliveryDetailsFailsClosedOnNonCanonicalCapabilities(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	pg := &PostgresStore{DB: db}
+	pg.schemaCaps = StoreSchemaCapabilities{
+		Events: EventSchemaCapabilities{
+			Log:        SchemaFlavorCanonical,
+			Deliveries: SchemaFlavorCanonical,
+			Receipts:   SchemaFlavorLegacy,
+		},
+	}
+	pg.schemaCapsBound = true
+
+	page, err := pg.ListPendingAgentDeliveryDetails(context.Background(), PendingAgentDeliveryListOptions{AgentID: "agent-1"})
+	if err == nil || !strings.Contains(err.Error(), "event_receipts schema is unsupported") {
+		t.Fatalf("ListPendingAgentDeliveryDetails err=%v page=%+v, want event_receipts capability failure", err, page)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1529,9 +1529,17 @@ func TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle(t *testing.T) 
 	}
 }
 
-func TestPostgresStore_ListPendingEventsForAgentSpec_PreservesRunID(t *testing.T) {
+func TestPostgresStore_ListPendingEventsForAgent_PreservesRunID(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
+	pg.schemaCaps = StoreSchemaCapabilities{
+		Events: EventSchemaCapabilities{
+			Log:        SchemaFlavorCanonical,
+			Deliveries: SchemaFlavorCanonical,
+			Receipts:   SchemaFlavorCanonical,
+		},
+	}
+	pg.schemaCapsBound = true
 	ctx := context.Background()
 
 	stmts := []string{
@@ -1606,9 +1614,9 @@ func TestPostgresStore_ListPendingEventsForAgentSpec_PreservesRunID(t *testing.T
 		t.Fatalf("seed delivery: %v", err)
 	}
 
-	got, err := pg.listPendingEventsForAgentSpec(ctx, "analysis-agent", time.Now().Add(-time.Hour), 10)
+	got, err := pg.ListPendingEventsForAgent(ctx, "analysis-agent", time.Now().Add(-time.Hour), 10)
 	if err != nil {
-		t.Fatalf("listPendingEventsForAgentSpec: %v", err)
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
 	}
 	if len(got) != 1 {
 		t.Fatalf("pending events = %d, want 1", len(got))
@@ -1618,7 +1626,7 @@ func TestPostgresStore_ListPendingEventsForAgentSpec_PreservesRunID(t *testing.T
 	}
 }
 
-func TestPostgresStore_ListPendingEventsForAgentSpec_UsesTypedEnvelopeMetadata(t *testing.T) {
+func TestPostgresStore_ListPendingEventsForAgent_UsesTypedEnvelopeMetadata(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()


### PR DESCRIPTION
Closes #901
Part of #852

## Summary
- Promotes the `agent.diagnose` pending-delivery queue detail contract into tracked `platform-spec.yaml` and regenerated `openrpc.json`.
- Adds typed pending-delivery page ownership in `internal/store`, including detail rows, attempts, stable cursor order, and fail-closed capability/cursor behavior.
- Wires `agent.diagnose` through the promoted diagnosis owner with `queue_limit` / `queue_cursor`, and rewires `ListPendingEventsForAgent` to consume the shared typed owner.

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.agent.diagnose`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.components.schemas.AgentDiagnosisQueue`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.components.schemas.AgentPendingDelivery`
- Generated proof artifact: `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- Binding gate: #901 approved as first slice under parent #852 after #891/#897.

## Semantic Migration
- New canonical owner: `PostgresStore.ListPendingAgentDeliveryDetails(ctx, PendingAgentDeliveryListOptions)` returning `PendingAgentDeliveryPage` / `PendingAgentDeliveryDetail`.
- Old producer / reader / writer path now invalid: direct public diagnosis reconstruction from handler-local SQL or event-only pending-event readers; the old unexported `listPendingEventsForAgentSpec` path was removed.
- Production paths checked for surviving old behavior: `agent.diagnose`, `LoadOperatorAgentDiagnosis`, `ListPendingEventsForAgent`, `ListPendingSubscribedEvents`, `agent.get`, `agent.list`, CLI/dashboard split consumers.
- Migration complete for the selected #901 queue-detail child. Parent #852 remains open for watchdog/runtime_state, active work, tool outcome, token usage, failures/dead letters, CLI, dashboard, and broader lifecycle/model cleanup.

## Proof
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1`
- `go test ./internal/store`