### PR TITLE
[agent-c][issue #900] Keep event identity envelope-owned

### DIFF
--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -90,6 +90,54 @@ func TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency(t *t
 	}
 }
 
+func TestReplayEventFromOriginalUsesCanonicalEventEntityOnly(t *testing.T) {
+	now := time.Unix(1700001200, 0).UTC()
+	original := store.OperatorEventFull{
+		EventID:   "evt-original",
+		EventName: "scan.requested",
+		RunID:     "run-1",
+		Source:    "origin-agent",
+		Payload:   map[string]any{"entity_id": "payload-entity", "topic": "medicine"},
+	}
+
+	replay, err := replayEventFromOriginal(original, "evt-replay", now)
+	if err != nil {
+		t.Fatalf("replayEventFromOriginal: %v", err)
+	}
+	if replay.EntityID() != "" {
+		t.Fatalf("replay event entity_id = %q, want empty", replay.EntityID())
+	}
+	var replayPayload map[string]any
+	if err := json.Unmarshal(replay.Payload, &replayPayload); err != nil {
+		t.Fatalf("unmarshal replay payload: %v", err)
+	}
+	if replayPayload["entity_id"] != "payload-entity" {
+		t.Fatalf("replay payload = %#v, want payload entity_id preserved", replayPayload)
+	}
+
+	auditPayload, err := eventReplayAuditPayload(
+		Request{ActorTokenID: "actor-1"},
+		original,
+		"evt-replay",
+		"evt-audit",
+		[]string{"agent-a"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("eventReplayAuditPayload: %v", err)
+	}
+	var audit map[string]any
+	if err := json.Unmarshal(auditPayload, &audit); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if audit["entity_id"] == "payload-entity" {
+		t.Fatalf("audit entity_id = %#v, want canonical top-level identity only", audit["entity_id"])
+	}
+	if audit["entity_id"] != "" {
+		t.Fatalf("audit entity_id = %#v, want empty canonical identity", audit["entity_id"])
+	}
+}
+
 func TestOperatorEventReplayStoresIdempotencyBeforeAuditPublishReadiness(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -123,6 +123,67 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 	}
 }
 
+func TestOperatorObservabilityHandlersKeepPayloadEntityOutOfTopLevelEventIdentity(t *testing.T) {
+	now := time.Unix(1700001200, 0).UTC()
+	payloadEntityID := "11111111-1111-4111-8111-111111111111"
+	observability := &fakeObservabilityReadStore{
+		events: map[string]store.OperatorEventFull{
+			"evt-payload-only": {
+				EventID:     "evt-payload-only",
+				EventName:   "task.payload_only",
+				RunID:       "run-1",
+				CreatedAt:   now,
+				Source:      "runtime",
+				Payload:     map[string]any{"entity_id": payloadEntityID, "marker": "payload-only"},
+				Deliveries:  []store.OperatorEventDelivery{},
+				DeadLetters: []store.OperatorDeadLetterRecord{},
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Observability: observability,
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"limit":10}}`)
+	if list.Error != nil {
+		t.Fatalf("event.list error = %#v", list.Error)
+	}
+	events := asSlice(t, asMap(t, list.Result)["events"])
+	if len(events) != 1 {
+		t.Fatalf("event.list events = %#v, want one payload-only event", events)
+	}
+	listEvent := asMap(t, events[0])
+	if _, ok := listEvent["entity_id"]; ok {
+		t.Fatalf("event.list top-level entity_id = %#v, want absent", listEvent["entity_id"])
+	}
+	if payload := asMap(t, listEvent["payload"]); payload["entity_id"] != payloadEntityID {
+		t.Fatalf("event.list payload = %#v, want preserved entity_id", payload)
+	}
+
+	filtered := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events-filtered","method":"event.list","params":{"filter":{"entity_id":"`+payloadEntityID+`"},"limit":10}}`)
+	if filtered.Error != nil {
+		t.Fatalf("event.list filtered error = %#v", filtered.Error)
+	}
+	if got := asSlice(t, asMap(t, filtered.Result)["events"]); len(got) != 0 {
+		t.Fatalf("event.list filtered events = %#v, want payload-only event excluded", got)
+	}
+
+	eventGet := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"event","method":"event.get","params":{"event_id":"evt-payload-only"}}`)
+	if eventGet.Error != nil {
+		t.Fatalf("event.get error = %#v", eventGet.Error)
+	}
+	detail := asMap(t, eventGet.Result)
+	if _, ok := detail["entity_id"]; ok {
+		t.Fatalf("event.get top-level entity_id = %#v, want absent", detail["entity_id"])
+	}
+	if payload := asMap(t, detail["payload"]); payload["entity_id"] != payloadEntityID {
+		t.Fatalf("event.get payload = %#v, want preserved entity_id", payload)
+	}
+}
+
 func TestOperatorObservabilityHandlersTypedErrors(t *testing.T) {
 	observability := &fakeObservabilityReadStore{
 		traceErr: store.ErrRunNotFound,

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -96,6 +96,16 @@ func TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay(t *testing.T) {
 				Deliveries:  []store.OperatorEventDelivery{},
 				DeadLetters: []store.OperatorDeadLetterRecord{},
 			},
+			"evt-payload-only": {
+				EventID:     "evt-payload-only",
+				EventName:   "scan.requested",
+				RunID:       "run-1",
+				CreatedAt:   base.Add(2 * time.Second),
+				Source:      "runtime",
+				Payload:     map[string]any{"entity_id": "entity-1", "marker": "payload-only"},
+				Deliveries:  []store.OperatorEventDelivery{},
+				DeadLetters: []store.OperatorDeadLetterRecord{},
+			},
 		},
 	}
 	readOpts := OperatorReadOptions{
@@ -136,6 +146,12 @@ func TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay(t *testing.T) {
 	}
 	if got := asMap(t, notification.Params.Result)["event_id"]; got != "evt-1" {
 		t.Fatalf("event notification result = %#v, want evt-1", notification.Params.Result)
+	}
+	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	_, raw, err := conn.ReadMessage()
+	conn.SetReadDeadline(time.Time{})
+	if err == nil {
+		t.Fatalf("unexpected payload-only event notification: %s", raw)
 	}
 	if observability.lastEventList.Filter.RunID != "run-1" ||
 		observability.lastEventList.Filter.EntityID != "entity-1" ||

--- a/internal/builder/runs_events_test.go
+++ b/internal/builder/runs_events_test.go
@@ -50,6 +50,34 @@ func TestProjectCanonicalRunDebugReplay_UsesCanonicalEventOwnerPayload(t *testin
 	}
 }
 
+func TestProjectCanonicalRunDebugReplay_DoesNotPromotePayloadEntityToInstanceID(t *testing.T) {
+	now := time.Unix(1700001200, 0).UTC()
+	events := []store.OperatorEventFull{{
+		EventID:   "evt-payload-only",
+		EventName: "workflow.payload_only",
+		RunID:     "run-123",
+		CreatedAt: now,
+		Source:    "builder",
+		Payload:   map[string]any{"entity_id": "payload-entity", "topic": "sample"},
+	}}
+
+	replay, _ := projectCanonicalRunDebugReplay(runtimebus.RunLifecycleSnapshot{}, events, nil)
+	if len(replay) != 1 {
+		t.Fatalf("replay len = %d, want 1", len(replay))
+	}
+	if replay[0]["type"] != "event.fired" {
+		t.Fatalf("replay[0].type = %#v, want event.fired", replay[0]["type"])
+	}
+	if _, ok := replay[0]["instance_id"]; ok {
+		t.Fatalf("payload-only event instance_id = %#v, want absent", replay[0]["instance_id"])
+	}
+	payload, _ := replay[0]["payload"].(map[string]any)
+	rawPayload, _ := payload["payload"].(map[string]any)
+	if rawPayload["entity_id"] != "payload-entity" {
+		t.Fatalf("payload.payload = %#v, want payload entity_id preserved", rawPayload)
+	}
+}
+
 func TestProjectCanonicalRunDebugReplay_PreservesCanonicalRuntimeLogDetailAndTimestamp(t *testing.T) {
 	now := time.Unix(1700000000, 0).UTC()
 	runtimeLogs := []store.OperatorRuntimeLogEntry{{

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -156,6 +156,78 @@ func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T)
 	}
 }
 
+func TestSQLObservabilityReader_EventIdentityDoesNotPromotePayloadEntity(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	payloadOnlyEventID := uuid.NewString()
+	canonicalEventID := uuid.NewString()
+	base := time.Unix(1700001200, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'task.payload_only', 'global',
+			jsonb_build_object('entity_id', $3::text, 'marker', 'payload-only'),
+			'agent-a', 'agent', $4)
+	`, payloadOnlyEventID, runID, targetEntityID, base); err != nil {
+		t.Fatalf("seed payload-only event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'task.canonical_entity', $3::uuid, 'entity',
+			jsonb_build_object('entity_id', 'payload-business-value', 'marker', 'canonical'),
+			'agent-b', 'agent', $4)
+	`, canonicalEventID, runID, targetEntityID, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed canonical event: %v", err)
+	}
+
+	filtered, err := reader.ListEvents(ctx, EventFilter{EntityID: targetEntityID}, 10)
+	if err != nil {
+		t.Fatalf("ListEvents entity filter: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].EventID != canonicalEventID {
+		t.Fatalf("filtered events = %#v, want only canonical event %s", filtered, canonicalEventID)
+	}
+	if filtered[0].EntityID != targetEntityID {
+		t.Fatalf("canonical dashboard entity_id = %q, want %s", filtered[0].EntityID, targetEntityID)
+	}
+
+	payloadOnly, ok, err := reader.GetEvent(ctx, payloadOnlyEventID)
+	if err != nil {
+		t.Fatalf("GetEvent payload-only: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected payload-only event to exist")
+	}
+	if payloadOnly.EntityID != "" {
+		t.Fatalf("payload-only dashboard entity_id = %q, want empty", payloadOnly.EntityID)
+	}
+	payload, _ := payloadOnly.Payload.(map[string]any)
+	if payload["entity_id"] != targetEntityID {
+		t.Fatalf("payload-only payload = %#v, want preserved payload entity_id", payload)
+	}
+
+	canonical, ok, err := reader.GetEvent(ctx, canonicalEventID)
+	if err != nil {
+		t.Fatalf("GetEvent canonical: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected canonical event to exist")
+	}
+	if canonical.EntityID != targetEntityID {
+		t.Fatalf("canonical dashboard entity_id = %q, want %s", canonical.EntityID, targetEntityID)
+	}
+	canonicalPayload, _ := canonical.Payload.(map[string]any)
+	if canonicalPayload["entity_id"] != "payload-business-value" {
+		t.Fatalf("canonical payload = %#v, want payload business value preserved", canonicalPayload)
+	}
+}
+
 func TestHandler_EventDetailIncludesDeliveryLifecycle(t *testing.T) {
 	t.Skip("legacy dashboard/Builder operator endpoint retired under #731; canonical v1 owner tests cover this behavior")
 	handler := NewHandler(Options{

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -210,7 +210,7 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 	}
 	if opts.Filter.EntityID != "" {
 		n := add(opts.Filter.EntityID)
-		where = append(where, fmt.Sprintf("COALESCE(e.entity_id::text, e.payload->>'entity_id', '') = $%d", n))
+		where = append(where, fmt.Sprintf("e.entity_id::text = $%d", n))
 	}
 	if opts.Filter.EventName != "" {
 		n := add(opts.Filter.EventName)
@@ -367,9 +367,6 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 		return OperatorEventFull{}, fmt.Errorf("decode operator event payload: %w", err)
 	}
 	event.Payload = payload
-	if event.EntityID == "" {
-		event.EntityID = readStoreString(payload["entity_id"])
-	}
 	deliveries, err := s.loadOperatorEventDeliveries(ctx, event.EventID)
 	if err != nil {
 		return OperatorEventFull{}, err

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -116,6 +116,74 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 	}
 }
 
+func TestOperatorObservabilityEventOwnerDoesNotPromotePayloadEntityIdentity(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	payloadOnlyEventID := uuid.NewString()
+	canonicalEventID := uuid.NewString()
+	base := time.Unix(1700001200, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'task.payload_only', 'global',
+			jsonb_build_object('entity_id', $3::text, 'marker', 'payload-only'),
+			'agent-a', 'agent', $4)
+	`, payloadOnlyEventID, runID, targetEntityID, base); err != nil {
+		t.Fatalf("seed payload-only event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'task.canonical_entity', $3::uuid, 'entity',
+			jsonb_build_object('entity_id', 'payload-business-value', 'marker', 'canonical'),
+			'agent-b', 'agent', $4)
+	`, canonicalEventID, runID, targetEntityID, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed canonical event: %v", err)
+	}
+
+	filtered, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{
+		Filter: OperatorEventListFilter{EntityID: targetEntityID},
+		Limit:  10,
+		Order:  "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents entity filter: %v", err)
+	}
+	if len(filtered.Events) != 1 || filtered.Events[0].EventID != canonicalEventID {
+		t.Fatalf("filtered events = %#v, want only canonical event %s", filtered.Events, canonicalEventID)
+	}
+	if filtered.Events[0].EntityID != targetEntityID {
+		t.Fatalf("canonical event entity_id = %q, want %s", filtered.Events[0].EntityID, targetEntityID)
+	}
+
+	payloadOnly, err := pg.LoadOperatorEvent(ctx, payloadOnlyEventID)
+	if err != nil {
+		t.Fatalf("LoadOperatorEvent payload-only: %v", err)
+	}
+	if payloadOnly.EntityID != "" {
+		t.Fatalf("payload-only top-level entity_id = %q, want empty", payloadOnly.EntityID)
+	}
+	if got := readStoreString(payloadOnly.Payload["entity_id"]); got != targetEntityID {
+		t.Fatalf("payload entity_id = %q, want preserved payload value %s", got, targetEntityID)
+	}
+
+	canonical, err := pg.LoadOperatorEvent(ctx, canonicalEventID)
+	if err != nil {
+		t.Fatalf("LoadOperatorEvent canonical: %v", err)
+	}
+	if canonical.EntityID != targetEntityID {
+		t.Fatalf("canonical top-level entity_id = %q, want %s", canonical.EntityID, targetEntityID)
+	}
+	if got := readStoreString(canonical.Payload["entity_id"]); got != "payload-business-value" {
+		t.Fatalf("canonical payload entity_id = %q, want payload-business-value", got)
+	}
+}
+
 func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)


### PR DESCRIPTION
## Summary

Closes #900.

- Stops `PostgresStore.ListOperatorEvents` from matching `filter.entity_id` against loose `payload.entity_id`.
- Stops `PostgresStore.LoadOperatorEvent` from promoting `payload["entity_id"]` into top-level `OperatorEventFull.EntityID`.
- Adds focused proof for the store owner, `/v1/rpc event.list`, `/v1/rpc event.get`, `/v1/ws event.subscribe`, dashboard SQL reader list/detail, builder run-debug projection, and event replay/audit helpers.

## Governing Refs / Context

Exact governing spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EventFull`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EventListFilter`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.event.list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.event.get`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.event.subscribe`

No spec update is included because the existing contract already separates optional top-level `EventFull.entity_id` from arbitrary `payload` object data.

## Semantic Migration

- New/retained canonical owner: event envelope identity from `internal/events/types.go` (`EventEnvelope` / `Event.EntityID()`), persisted by `internal/store/events.go` (`eventStorageEnvelope` / `appendEventSpec`) into `events.entity_id`, and read by `PostgresStore.ListOperatorEvents` / `PostgresStore.LoadOperatorEvent` from the persisted row field.
- Old invalid paths removed: `ListOperatorEvents` SQL `COALESCE(e.entity_id::text, e.payload->>'entity_id', '')` filtering and `LoadOperatorEvent` fallback from decoded payload to top-level `EntityID`.
- Production paths checked: `/v1/rpc event.list`, `/v1/rpc event.get`, `/v1/ws event.subscribe`, dashboard SQL reader list/detail consumers, builder run-debug event projection, `event.replay` / `agent.replay` helper paths, and runtime-log split references.
- Migration completeness: complete for the approved #900 chosen class. Runtime-log entity handling, generated OpenRPC/conformance, entity read models, and broader observability parent work remain separate tracked concepts.

## Validation

- `go test ./internal/events -run 'TestEventEnvelopeOwnsCanonicalIdentity|TestEventWithoutEnvelopeFailsClosedToGlobalScope' -count=1`
- `go test ./internal/store -run 'TestOperatorObservabilityEventOwnerDoesNotPromotePayloadEntityIdentity|TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor|TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorObservabilityHandlersKeepPayloadEntityOutOfTopLevelEventIdentity|TestOperatorObservabilityHandlersExposePersistedReadMethods|TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay|TestReplayEventFromOriginalUsesCanonicalEventEntityOnly|TestOperatorEventReplay' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_EventIdentityDoesNotPromotePayloadEntity|TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle|TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows' -count=1`
- `go test ./internal/builder -run 'TestProjectCanonicalRunDebugReplay_DoesNotPromotePayloadEntityToInstanceID|TestProjectCanonicalRunDebugReplay_UsesCanonicalEventOwnerPayload|TestRunHubSubscribe_PrimesCanonicalReplayDedupeState|TestRunHubSyncCanonical_UsesLatestCanonicalEventWindow' -count=1`
- `git diff --check`
- `go test ./internal/store ./internal/apiv1 ./internal/dashboard/server ./internal/builder -count=1`