### PR TITLE
[agent-a][issue #844] Implement CLI API config resolver

### DIFF
--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -52,6 +52,7 @@ func newAgentDirectiveCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&directiveOpts.runID, "run-id", "", "Optional explicit nonterminal run target")
 	cmd.Flags().StringVar(&directiveOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &directiveOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -62,6 +62,7 @@ func newAgentReplayCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&replayOpts.eventID, "event-id", "", "Required event ID to replay")
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -39,6 +39,7 @@ func newAgentReplayBacklogCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -38,6 +38,7 @@ func newAgentRestartCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&restartOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &restartOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -112,18 +112,22 @@ func newAgentsListCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&listOpts.flow, "flow", "", "Filter by canonical flow path")
 	cmd.Flags().StringVar(&listOpts.role, "role", "", "Filter by agent role")
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
 	return cmd
 }
 
 func newAgentViewCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	apiOpts := opts
+	cmd := &cobra.Command{
 		Use:   "view <agent-id>",
 		Short: "View one agent through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &apiOpts)
+	return cmd
 }
 
 func runAgentListCommand(ctx context.Context, out, errOut io.Writer, opts agentListCommandOptions) error {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -168,10 +168,14 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Print local Swarm binary version information.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !versionOpts.server && cliAPIConnectionFlagsChanged(cmd) {
+				return fmt.Errorf("--api-server and --api-token-file require --server")
+			}
 			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), versionOpts)
 		},
 	}
 	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
+	bindCLIAPIConnectionFlags(cmd, &versionOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -29,6 +29,12 @@ func executeRootCommand(ctx context.Context, repo string, args []string, out, er
 }
 
 func executeRootCommandWithOptions(ctx context.Context, repo string, args []string, out, errOut io.Writer, opts rootCommandOptions) int {
+	if err := validateCLIAPIConnectionFlagPlacement(args); err != nil {
+		if errOut != nil {
+			fmt.Fprintln(errOut, err)
+		}
+		return cliExitValidation
+	}
 	cmd := newRootCommandWithOptions(ctx, repo, out, errOut, opts)
 	cmd.SetArgs(args)
 	if err := cmd.ExecuteContext(ctx); err != nil {

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -286,11 +286,25 @@ func normalizeCLIAPIServerBase(raw, source string) (*url.URL, error) {
 		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must not include query or fragment", source)}
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	switch parsed.Path {
-	case cliAPIRPCPath, cliAPIWSPath:
-		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must be an API server base URL, not a direct %s endpoint", source, parsed.Path)}
+	if endpointPath := cliAPIEndpointShapedPath(parsed.Path); endpointPath != "" {
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must be an API server base URL, not a direct %s endpoint", source, endpointPath)}
 	}
 	return parsed, nil
+}
+
+func cliAPIEndpointShapedPath(rawPath string) string {
+	trimmed := strings.TrimRight(rawPath, "/")
+	if trimmed == "" || trimmed == "/" {
+		return ""
+	}
+	switch {
+	case trimmed == cliAPIRPCPath || strings.HasSuffix(trimmed, cliAPIRPCPath):
+		return cliAPIRPCPath
+	case trimmed == cliAPIWSPath || strings.HasSuffix(trimmed, cliAPIWSPath):
+		return cliAPIWSPath
+	default:
+		return ""
+	}
 }
 
 func joinURLPath(basePath, suffix string) string {

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -4,30 +4,43 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
-const defaultCLIAPIEndpoint = "http://127.0.0.1:8081/v1/rpc"
+const (
+	defaultCLIAPIServer = "http://127.0.0.1:8081"
+	cliAPIRPCPath       = "/v1/rpc"
+	cliAPIWSPath        = "/v1/ws"
+)
 
 type rootCommandOptions struct {
-	apiEndpoint     string
-	httpClient      *http.Client
-	input           io.Reader
-	stdinIsTerminal func() bool
-	runServe        func(context.Context, string, serveOptions) int
-	runReadyTimeout time.Duration
-	runReadyPoll    time.Duration
-	runStatusPoll   time.Duration
+	apiServer string
+	// apiRPCEndpointOverride is for test injection and run-owned connection URLs after
+	// those paths have already resolved their own API endpoint semantics.
+	apiRPCEndpointOverride string
+	apiTokenFile           string
+	httpClient             *http.Client
+	input                  io.Reader
+	stdinIsTerminal        func() bool
+	runServe               func(context.Context, string, serveOptions) int
+	runReadyTimeout        time.Duration
+	runReadyPoll           time.Duration
+	runStatusPoll          time.Duration
 }
 
 func defaultRootCommandOptions() rootCommandOptions {
 	return rootCommandOptions{
-		apiEndpoint:     defaultCLIAPIEndpoint,
 		httpClient:      &http.Client{Timeout: 30 * time.Second},
 		input:           os.Stdin,
 		stdinIsTerminal: processStdinIsTerminal,
@@ -50,19 +63,238 @@ type cliAPIClient struct {
 }
 
 func newCLIAPIClient(opts rootCommandOptions) (*cliAPIClient, error) {
-	endpoint := strings.TrimSpace(opts.apiEndpoint)
-	if endpoint == "" {
-		endpoint = defaultCLIAPIEndpoint
-	}
-	token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN"))
-	if token == "" {
-		return nil, errCLIAPITokenRequired
+	settings, err := resolveCLIAPISettings(opts)
+	if err != nil {
+		return nil, err
 	}
 	client := opts.httpClient
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &cliAPIClient{endpoint: endpoint, token: token, httpClient: client}, nil
+	return &cliAPIClient{endpoint: settings.rpcEndpoint, token: settings.token, httpClient: client}, nil
+}
+
+type cliAPISettings struct {
+	rpcEndpoint string
+	token       string
+}
+
+type cliAPIConfigFile struct {
+	APIServer    string `yaml:"api_server"`
+	APITokenFile string `yaml:"api_token_file"`
+}
+
+type cliAPIValidationError struct {
+	message string
+}
+
+func (e *cliAPIValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+type cliAPIAuthConfigError struct {
+	message string
+}
+
+func (e *cliAPIAuthConfigError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+func resolveCLIAPISettings(opts rootCommandOptions) (cliAPISettings, error) {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return cliAPISettings{}, err
+	}
+	endpoint, err := resolveCLIAPIRPCEndpoint(opts, cfg)
+	if err != nil {
+		return cliAPISettings{}, err
+	}
+	token, err := resolveCLIAPIToken(opts, cfg)
+	if err != nil {
+		return cliAPISettings{}, err
+	}
+	return cliAPISettings{rpcEndpoint: endpoint, token: token}, nil
+}
+
+func resolveCLIAPIRPCEndpoint(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {
+	if endpoint := strings.TrimSpace(opts.apiRPCEndpointOverride); endpoint != "" {
+		return normalizeCLIAPIRPCEndpoint(endpoint, "internal API endpoint")
+	}
+	server := firstNonEmpty(
+		opts.apiServer,
+		os.Getenv("SWARM_API_SERVER"),
+		cfg.APIServer,
+		defaultCLIAPIServer,
+	)
+	return cliAPIRPCEndpointFromServer(server, "API server")
+}
+
+func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {
+	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
+		return readCLIAPITokenFile(tokenFile, "--api-token-file")
+	}
+	if token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")); token != "" {
+		return token, nil
+	}
+	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
+		return readCLIAPITokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
+	}
+	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
+		return readCLIAPITokenFile(tokenFile, "config api_token_file")
+	}
+	return "", errCLIAPITokenRequired
+}
+
+func readCLIAPITokenFile(tokenFile, source string) (string, error) {
+	raw, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", &cliAPIAuthConfigError{message: fmt.Sprintf("read %s: %v", source, err)}
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", &cliAPIAuthConfigError{message: fmt.Sprintf("%s is blank", source)}
+	}
+	return token, nil
+}
+
+func loadCLIAPIConfigFile() (cliAPIConfigFile, error) {
+	configPath, explicit, err := cliAPIConfigPath()
+	if err != nil {
+		return cliAPIConfigFile{}, err
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		if !explicit && errors.Is(err, os.ErrNotExist) {
+			return cliAPIConfigFile{}, nil
+		}
+		source := "CLI config"
+		if explicit {
+			source = "SWARM_CONFIG"
+		}
+		return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("read %s: %v", source, err)}
+	}
+	return parseCLIAPIConfigFile(configPath, raw)
+}
+
+func cliAPIConfigPath() (string, bool, error) {
+	if raw, ok := os.LookupEnv("SWARM_CONFIG"); ok && strings.TrimSpace(raw) != "" {
+		return strings.TrimSpace(raw), true, nil
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", false, &cliAPIValidationError{message: fmt.Sprintf("resolve XDG CLI config path: %v", err)}
+	}
+	return filepath.Join(dir, "swarm", "config.yaml"), false, nil
+}
+
+func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, error) {
+	var decoded map[string]any
+	if err := yaml.Unmarshal(raw, &decoded); err != nil {
+		return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("parse CLI config %s: %v", configPath, err)}
+	}
+	if decoded == nil {
+		return cliAPIConfigFile{}, nil
+	}
+	for key, value := range decoded {
+		switch key {
+		case "api_server", "api_token_file":
+			if value == nil {
+				continue
+			}
+			if _, ok := value.(string); !ok {
+				return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("CLI config %s must be a string", key)}
+			}
+		default:
+			return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("unsupported CLI config key %q", key)}
+		}
+	}
+	var cfg cliAPIConfigFile
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("decode CLI config %s: %v", configPath, err)}
+	}
+	return cfg, nil
+}
+
+func normalizeCLIAPIRPCEndpoint(raw, source string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must be a valid http(s) URL: %v", source, err)}
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must use http or https", source)}
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must include a host", source)}
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must not include query or fragment", source)}
+	}
+	if strings.TrimRight(parsed.Path, "/") != strings.TrimSuffix(cliAPIRPCPath, "/") {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s path must be %s", source, cliAPIRPCPath)}
+	}
+	return parsed.String(), nil
+}
+
+func cliAPIRPCEndpointFromServer(raw, source string) (string, error) {
+	parsed, err := normalizeCLIAPIServerBase(raw, source)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = joinURLPath(parsed.Path, cliAPIRPCPath)
+	return parsed.String(), nil
+}
+
+func cliAPIWebSocketEndpointFromRPC(rpcEndpoint string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rpcEndpoint))
+	if err != nil {
+		return "", fmt.Errorf("derive /v1/ws endpoint: %w", err)
+	}
+	switch parsed.Scheme {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("derive /v1/ws endpoint: unsupported API scheme %q", parsed.Scheme)
+	}
+	apiPath := strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(apiPath, cliAPIRPCPath) {
+		return "", fmt.Errorf("derive /v1/ws endpoint: API endpoint must end in /v1/rpc")
+	}
+	parsed.Path = strings.TrimSuffix(apiPath, cliAPIRPCPath) + cliAPIWSPath
+	return parsed.String(), nil
+}
+
+func normalizeCLIAPIServerBase(raw, source string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must be a valid http(s) URL: %v", source, err)}
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must use http or https", source)}
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must include a host", source)}
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must not include query or fragment", source)}
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return parsed, nil
+}
+
+func joinURLPath(basePath, suffix string) string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" || basePath == "/" {
+		return suffix
+	}
+	return path.Join(basePath, suffix)
 }
 
 type jsonRPCRequest struct {

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -286,6 +286,10 @@ func normalizeCLIAPIServerBase(raw, source string) (*url.URL, error) {
 		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must not include query or fragment", source)}
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	switch parsed.Path {
+	case cliAPIRPCPath, cliAPIWSPath:
+		return nil, &cliAPIValidationError{message: fmt.Sprintf("%s must be an API server base URL, not a direct %s endpoint", source, parsed.Path)}
+	}
 	return parsed, nil
 }
 

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 func bindCLIAPIConnectionFlags(cmd *cobra.Command, opts *rootCommandOptions) {
 	cmd.Flags().StringVar(&opts.apiServer, "api-server", "", "Swarm API server base URL")
@@ -9,4 +13,79 @@ func bindCLIAPIConnectionFlags(cmd *cobra.Command, opts *rootCommandOptions) {
 
 func cliAPIConnectionFlagsChanged(cmd *cobra.Command) bool {
 	return cmd.Flags().Changed("api-server") || cmd.Flags().Changed("api-token-file")
+}
+
+func validateCLIAPIConnectionFlagPlacement(args []string) error {
+	index, flag := firstCLIAPIConnectionFlagIndex(args)
+	if index < 0 || cliAPIConnectionFlagAfterLeafCommand(args[:index]) {
+		return nil
+	}
+	return &cliAPIValidationError{message: "unknown flag: " + flag}
+}
+
+func firstCLIAPIConnectionFlagIndex(args []string) (int, string) {
+	for i, arg := range args {
+		switch {
+		case arg == "--api-server" || arg == "--api-token-file":
+			return i, arg
+		case strings.HasPrefix(arg, "--api-server="):
+			return i, "--api-server"
+		case strings.HasPrefix(arg, "--api-token-file="):
+			return i, "--api-token-file"
+		}
+	}
+	return -1, ""
+}
+
+func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
+	leafCommands := [][]string{
+		{"runs"},
+		{"status"},
+		{"trace"},
+		{"health"},
+		{"logs"},
+		{"incidents"},
+		{"version"},
+		{"events", "list"},
+		{"events", "follow"},
+		{"event", "view"},
+		{"event", "publish"},
+		{"event", "replay"},
+		{"agents", "list"},
+		{"agent", "view"},
+		{"agent", "restart"},
+		{"agent", "replay"},
+		{"agent", "replay-backlog"},
+		{"agent", "directive"},
+		{"entities", "list"},
+		{"entity", "view"},
+		{"entity", "aggregate"},
+		{"mailbox", "list"},
+		{"mailbox", "view"},
+		{"mailbox", "approve"},
+		{"mailbox", "reject"},
+		{"mailbox", "defer"},
+		{"control", "pause"},
+		{"control", "continue"},
+		{"control", "stop"},
+		{"control", "nuke"},
+	}
+	for _, command := range leafCommands {
+		if argsHaveCommandPrefix(prefix, command) {
+			return true
+		}
+	}
+	return false
+}
+
+func argsHaveCommandPrefix(args, command []string) bool {
+	if len(args) < len(command) {
+		return false
+	}
+	for i, want := range command {
+		if args[i] != want {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -1,0 +1,12 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func bindCLIAPIConnectionFlags(cmd *cobra.Command, opts *rootCommandOptions) {
+	cmd.Flags().StringVar(&opts.apiServer, "api-server", "", "Swarm API server base URL")
+	cmd.Flags().StringVar(&opts.apiTokenFile, "api-token-file", "", "Path to file containing the Swarm API bearer token")
+}
+
+func cliAPIConnectionFlagsChanged(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed("api-server") || cmd.Flags().Changed("api-token-file")
+}

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -196,6 +196,37 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 			wantExit: cliExitValidation,
 			wantErr:  "must not include query or fragment",
 		},
+		{
+			name: "flag API server rejects direct RPC endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{apiServer: "http://127.0.0.1:8081/v1/rpc"}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/rpc endpoint",
+		},
+		{
+			name: "environment API server rejects direct websocket endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:8081/v1/ws")
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/ws endpoint",
+		},
+		{
+			name: "config API server rejects direct RPC endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+					"api_server": "http://127.0.0.1:8081/v1/rpc",
+				}))
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/rpc endpoint",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -317,15 +348,85 @@ func TestCLIAPIConfigDrivesRuntimeStateCommand(t *testing.T) {
 	}
 }
 
+func TestEndpointShapedAPIServerRejectedBeforeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		setup func(t *testing.T, serverURL string, tokenFile string)
+		want  string
+	}{
+		{
+			name: "flag direct RPC endpoint",
+			args: []string{"runs", "--api-server", "{server}/v1/rpc", "--api-token-file", "{token}"},
+			want: "not a direct /v1/rpc endpoint",
+		},
+		{
+			name: "environment direct websocket endpoint",
+			args: []string{"runs"},
+			setup: func(t *testing.T, serverURL string, _ string) {
+				t.Setenv("SWARM_API_SERVER", serverURL+"/v1/ws")
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+			},
+			want: "not a direct /v1/ws endpoint",
+		},
+		{
+			name: "config direct RPC endpoint",
+			args: []string{"runs"},
+			setup: func(t *testing.T, serverURL string, tokenFile string) {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+					"api_server":     serverURL + "/v1/rpc",
+					"api_token_file": tokenFile,
+				}))
+			},
+			want: "not a direct /v1/rpc endpoint",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			tokenFile := writeCLIAPITokenFile(t, "test-token")
+			var sawRequest bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawRequest = true
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			args := append([]string(nil), tc.args...)
+			for i, arg := range args {
+				arg = strings.ReplaceAll(arg, "{server}", server.URL)
+				arg = strings.ReplaceAll(arg, "{token}", tokenFile)
+				args[i] = arg
+			}
+			if tc.setup != nil {
+				tc.setup(t, server.URL, tokenFile)
+			}
+			opts := defaultRootCommandOptions()
+			opts.httpClient = server.Client()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, opts)
+			if code != cliExitValidation {
+				t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.want)
+			}
+			if sawRequest {
+				t.Fatal("endpoint-shaped API server value reached the HTTP server")
+			}
+		})
+	}
+}
+
 func TestAPIConnectionFlagsRejectedOnNonAPISurfaces(t *testing.T) {
 	for _, tc := range []struct {
 		args       []string
 		wantStderr string
 	}{
 		{args: []string{"--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
+		{args: []string{"--api-server", "http://127.0.0.1:9", "runs"}, wantStderr: "unknown flag: --api-server"},
 		{args: []string{"serve", "--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
 		{args: []string{"verify", "--api-server", "http://127.0.0.1:9"}},
 		{args: []string{"run", "--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
+		{args: []string{"events", "--api-server", "http://127.0.0.1:9", "list"}, wantStderr: "unknown flag: --api-server"},
 	} {
 		var stdout, stderr bytes.Buffer
 		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, defaultRootCommandOptions())

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
+	t.Run("flag sources beat env config and defaults", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configToken := writeCLIAPITokenFile(t, "config-token")
+		envToken := writeCLIAPITokenFile(t, "env-file-token")
+		flagToken := writeCLIAPITokenFile(t, "flag-token")
+		configPath := writeCLIAPIConfigFile(t, map[string]string{
+			"api_server":     "http://127.0.0.1:4444",
+			"api_token_file": configToken,
+		})
+		t.Setenv("SWARM_CONFIG", configPath)
+		t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:5555")
+		t.Setenv("SWARM_API_TOKEN", "env-token")
+		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
+
+		client, err := newCLIAPIClient(rootCommandOptions{
+			apiServer:    "http://127.0.0.1:6666",
+			apiTokenFile: flagToken,
+		})
+		if err != nil {
+			t.Fatalf("newCLIAPIClient: %v", err)
+		}
+		if client.endpoint != "http://127.0.0.1:6666/v1/rpc" {
+			t.Fatalf("endpoint = %q", client.endpoint)
+		}
+		if client.token != "flag-token" {
+			t.Fatalf("token = %q", client.token)
+		}
+	})
+
+	t.Run("environment token beats token file and config", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configToken := writeCLIAPITokenFile(t, "config-token")
+		envToken := writeCLIAPITokenFile(t, "env-file-token")
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"api_server":     "http://127.0.0.1:4444",
+			"api_token_file": configToken,
+		}))
+		t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:5555")
+		t.Setenv("SWARM_API_TOKEN", "env-token")
+		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
+
+		client, err := newCLIAPIClient(rootCommandOptions{})
+		if err != nil {
+			t.Fatalf("newCLIAPIClient: %v", err)
+		}
+		if client.endpoint != "http://127.0.0.1:5555/v1/rpc" {
+			t.Fatalf("endpoint = %q", client.endpoint)
+		}
+		if client.token != "env-token" {
+			t.Fatalf("token = %q", client.token)
+		}
+	})
+
+	t.Run("environment token file beats config", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configToken := writeCLIAPITokenFile(t, "config-token")
+		envToken := writeCLIAPITokenFile(t, "env-file-token")
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"api_server":     "http://127.0.0.1:4444",
+			"api_token_file": configToken,
+		}))
+		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
+
+		client, err := newCLIAPIClient(rootCommandOptions{})
+		if err != nil {
+			t.Fatalf("newCLIAPIClient: %v", err)
+		}
+		if client.endpoint != "http://127.0.0.1:4444/v1/rpc" {
+			t.Fatalf("endpoint = %q", client.endpoint)
+		}
+		if client.token != "env-file-token" {
+			t.Fatalf("token = %q", client.token)
+		}
+	})
+
+	t.Run("config feeds endpoint and token file", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configToken := writeCLIAPITokenFile(t, "config-token")
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"api_server":     "http://127.0.0.1:4444",
+			"api_token_file": configToken,
+		}))
+
+		client, err := newCLIAPIClient(rootCommandOptions{})
+		if err != nil {
+			t.Fatalf("newCLIAPIClient: %v", err)
+		}
+		if client.endpoint != "http://127.0.0.1:4444/v1/rpc" {
+			t.Fatalf("endpoint = %q", client.endpoint)
+		}
+		if client.token != "config-token" {
+			t.Fatalf("token = %q", client.token)
+		}
+	})
+
+	t.Run("built in API server default remains loopback base", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		t.Setenv("SWARM_API_TOKEN", "env-token")
+
+		client, err := newCLIAPIClient(rootCommandOptions{})
+		if err != nil {
+			t.Fatalf("newCLIAPIClient: %v", err)
+		}
+		if client.endpoint != "http://127.0.0.1:8081/v1/rpc" {
+			t.Fatalf("endpoint = %q", client.endpoint)
+		}
+		if client.token != "env-token" {
+			t.Fatalf("token = %q", client.token)
+		}
+	})
+}
+
+func TestCLIAPISettingsFailClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T) rootCommandOptions
+		wantExit int
+		wantErr  string
+	}{
+		{
+			name: "explicit missing config",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "read SWARM_CONFIG",
+		},
+		{
+			name: "malformed config",
+			setup: func(t *testing.T) rootCommandOptions {
+				path := filepath.Join(t.TempDir(), "config.yaml")
+				if err := os.WriteFile(path, []byte("api_server: ["), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+				t.Setenv("SWARM_CONFIG", path)
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "parse CLI config",
+		},
+		{
+			name: "unsupported inline config token",
+			setup: func(t *testing.T) rootCommandOptions {
+				path := filepath.Join(t.TempDir(), "config.yaml")
+				if err := os.WriteFile(path, []byte("api_token: secret\n"), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+				t.Setenv("SWARM_CONFIG", path)
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  `unsupported CLI config key "api_token"`,
+		},
+		{
+			name: "missing token file",
+			setup: func(t *testing.T) rootCommandOptions {
+				return rootCommandOptions{apiTokenFile: filepath.Join(t.TempDir(), "missing-token")}
+			},
+			wantExit: cliExitAuth,
+			wantErr:  "read --api-token-file",
+		},
+		{
+			name: "blank token file",
+			setup: func(t *testing.T) rootCommandOptions {
+				return rootCommandOptions{apiTokenFile: writeCLIAPITokenFile(t, "  \n")}
+			},
+			wantExit: cliExitAuth,
+			wantErr:  "--api-token-file is blank",
+		},
+		{
+			name: "invalid API server query",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{apiServer: "http://127.0.0.1:8081?x=1"}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "must not include query or fragment",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			opts := tc.setup(t)
+			_, err := newCLIAPIClient(opts)
+			if err == nil {
+				t.Fatal("newCLIAPIClient returned nil error")
+			}
+			if got := cliAPIErrorExitCode(err, cliAPIErrorClassifier{}); got != tc.wantExit {
+				t.Fatalf("exit = %d, want %d; err=%v", got, tc.wantExit, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
+	root := newRootCommandWithOptions(context.Background(), t.TempDir(), ioDiscard{}, ioDiscard{}, defaultRootCommandOptions())
+	withFlags := []string{
+		"runs", "status", "trace", "health", "logs", "incidents",
+		"events list", "events follow", "event view", "event publish", "event replay",
+		"agents list", "agent view", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
+		"entities list", "entity view", "entity aggregate",
+		"mailbox list", "mailbox view", "mailbox approve", "mailbox reject", "mailbox defer",
+		"control pause", "control continue", "control stop", "control nuke",
+		"version",
+	}
+	for _, path := range withFlags {
+		cmd := mustFindCLICommand(t, root, path)
+		if cmd.Flags().Lookup("api-server") == nil {
+			t.Fatalf("%s missing --api-server", path)
+		}
+		if cmd.Flags().Lookup("api-token-file") == nil {
+			t.Fatalf("%s missing --api-token-file", path)
+		}
+	}
+
+	withoutFlags := []string{
+		"", "serve", "verify", "completion", "run",
+		"events", "event", "agents", "agent", "entities", "entity", "mailbox", "control",
+		"investigate", "investigate health", "fork",
+	}
+	for _, path := range withoutFlags {
+		cmd := mustFindCLICommand(t, root, path)
+		if cmd.Flags().Lookup("api-server") != nil || cmd.Flags().Lookup("api-token-file") != nil {
+			t.Fatalf("%s unexpectedly accepts API connection flags", path)
+		}
+	}
+}
+
+func TestAPIConnectionFlagsDriveRuntimeStateCommand(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "flag-token")
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer flag-token" {
+			t.Errorf("Authorization = %q, want bearer flag-token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method != "run.list" {
+			t.Errorf("method = %q, want run.list", req.Method)
+		}
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+
+	opts := defaultRootCommandOptions()
+	opts.httpClient = server.Client()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", "--api-server", server.URL, "--api-token-file", tokenFile}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestCLIAPIConfigDrivesRuntimeStateCommand(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "config-token")
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if got := r.Header.Get("Authorization"); got != "Bearer config-token" {
+			t.Errorf("Authorization = %q, want bearer config-token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"api_server":     server.URL,
+		"api_token_file": tokenFile,
+	}))
+
+	opts := defaultRootCommandOptions()
+	opts.httpClient = server.Client()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestAPIConnectionFlagsRejectedOnNonAPISurfaces(t *testing.T) {
+	for _, tc := range []struct {
+		args       []string
+		wantStderr string
+	}{
+		{args: []string{"--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
+		{args: []string{"serve", "--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
+		{args: []string{"verify", "--api-server", "http://127.0.0.1:9"}},
+		{args: []string{"run", "--api-server", "http://127.0.0.1:9"}, wantStderr: "unknown flag: --api-server"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, defaultRootCommandOptions())
+		if code != cliExitValidation {
+			t.Fatalf("%v exit = %d stderr=%q", tc.args, code, stderr.String())
+		}
+		if tc.wantStderr != "" && !strings.Contains(stderr.String(), tc.wantStderr) {
+			t.Fatalf("%v stderr = %q, want %q", tc.args, stderr.String(), tc.wantStderr)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"version", "--api-server", "http://127.0.0.1:9"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("version exit = %d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "require --server") {
+		t.Fatalf("version stderr = %q, want --server requirement", stderr.String())
+	}
+}
+
+func isolateCLIAPIConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SWARM_CONFIG", "")
+	t.Setenv("SWARM_API_SERVER", "")
+	t.Setenv("SWARM_API_TOKEN", "")
+	t.Setenv("SWARM_API_TOKEN_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+}
+
+func writeCLIAPITokenFile(t *testing.T, token string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return path
+}
+
+func writeCLIAPIConfigFile(t *testing.T, values map[string]string) string {
+	t.Helper()
+	var body strings.Builder
+	for _, key := range []string{"api_server", "api_token_file"} {
+		if value, ok := values[key]; ok {
+			body.WriteString(key)
+			body.WriteString(": ")
+			body.WriteString(strconvQuoteYAML(value))
+			body.WriteString("\n")
+		}
+	}
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body.String()), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	return path
+}
+
+func strconvQuoteYAML(value string) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+func mustFindCLICommand(t *testing.T, root *cobra.Command, commandPath string) *cobra.Command {
+	t.Helper()
+	if strings.TrimSpace(commandPath) == "" {
+		return root
+	}
+	cmd, _, err := root.Find(strings.Fields(commandPath))
+	if err != nil {
+		t.Fatalf("find %s: %v", commandPath, err)
+	}
+	if cmd == nil {
+		t.Fatalf("find %s returned nil", commandPath)
+	}
+	return cmd
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -206,9 +206,28 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 			wantErr:  "not a direct /v1/rpc endpoint",
 		},
 		{
+			name: "flag API server rejects prefixed RPC endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{apiServer: "http://127.0.0.1:8081/proxy/v1/rpc"}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/rpc endpoint",
+		},
+		{
 			name: "environment API server rejects direct websocket endpoint",
 			setup: func(t *testing.T) rootCommandOptions {
 				t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:8081/v1/ws")
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/ws endpoint",
+		},
+		{
+			name: "environment API server rejects prefixed websocket endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:8081/proxy/v1/ws")
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
 			},
@@ -220,6 +239,18 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 			setup: func(t *testing.T) rootCommandOptions {
 				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 					"api_server": "http://127.0.0.1:8081/v1/rpc",
+				}))
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+				return rootCommandOptions{}
+			},
+			wantExit: cliExitValidation,
+			wantErr:  "not a direct /v1/rpc endpoint",
+		},
+		{
+			name: "config API server rejects prefixed RPC endpoint",
+			setup: func(t *testing.T) rootCommandOptions {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+					"api_server": "http://127.0.0.1:8081/proxy/v1/rpc",
 				}))
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
@@ -315,6 +346,41 @@ func TestAPIConnectionFlagsDriveRuntimeStateCommand(t *testing.T) {
 	}
 }
 
+func TestAPIConnectionFlagsPreserveServerBasePathPrefix(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "flag-token")
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if r.URL.Path != "/proxy/v1/rpc" {
+			t.Errorf("path = %q, want /proxy/v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer flag-token" {
+			t.Errorf("Authorization = %q, want bearer flag-token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method != "run.list" {
+			t.Errorf("method = %q, want run.list", req.Method)
+		}
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+
+	opts := defaultRootCommandOptions()
+	opts.httpClient = server.Client()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", "--api-server", server.URL + "/proxy", "--api-token-file", tokenFile}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+}
+
 func TestCLIAPIConfigDrivesRuntimeStateCommand(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	tokenFile := writeCLIAPITokenFile(t, "config-token")
@@ -361,6 +427,16 @@ func TestEndpointShapedAPIServerRejectedBeforeRequest(t *testing.T) {
 			want: "not a direct /v1/rpc endpoint",
 		},
 		{
+			name: "flag prefixed RPC endpoint",
+			args: []string{"runs", "--api-server", "{server}/proxy/v1/rpc", "--api-token-file", "{token}"},
+			want: "not a direct /v1/rpc endpoint",
+		},
+		{
+			name: "flag prefixed websocket endpoint",
+			args: []string{"runs", "--api-server", "{server}/proxy/v1/ws", "--api-token-file", "{token}"},
+			want: "not a direct /v1/ws endpoint",
+		},
+		{
 			name: "environment direct websocket endpoint",
 			args: []string{"runs"},
 			setup: func(t *testing.T, serverURL string, _ string) {
@@ -370,11 +446,31 @@ func TestEndpointShapedAPIServerRejectedBeforeRequest(t *testing.T) {
 			want: "not a direct /v1/ws endpoint",
 		},
 		{
+			name: "environment prefixed RPC endpoint",
+			args: []string{"runs"},
+			setup: func(t *testing.T, serverURL string, _ string) {
+				t.Setenv("SWARM_API_SERVER", serverURL+"/proxy/v1/rpc")
+				t.Setenv("SWARM_API_TOKEN", "env-token")
+			},
+			want: "not a direct /v1/rpc endpoint",
+		},
+		{
 			name: "config direct RPC endpoint",
 			args: []string{"runs"},
 			setup: func(t *testing.T, serverURL string, tokenFile string) {
 				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 					"api_server":     serverURL + "/v1/rpc",
+					"api_token_file": tokenFile,
+				}))
+			},
+			want: "not a direct /v1/rpc endpoint",
+		},
+		{
+			name: "config prefixed RPC endpoint",
+			args: []string{"runs"},
+			setup: func(t *testing.T, serverURL string, tokenFile string) {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+					"api_server":     serverURL + "/proxy/v1/rpc",
 					"api_token_file": tokenFile,
 				}))
 			},

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -52,6 +52,14 @@ func cliAPIErrorExitCode(err error, classifier cliAPIErrorClassifier) int {
 	if errors.Is(err, errCLIAPITokenRequired) {
 		return authExit
 	}
+	var authConfigErr *cliAPIAuthConfigError
+	if errors.As(err, &authConfigErr) {
+		return authExit
+	}
+	var validationErr *cliAPIValidationError
+	if errors.As(err, &validationErr) {
+		return cliExitValidation
+	}
 	var httpErr *cliAPIHTTPError
 	if errors.As(err, &httpErr) {
 		if httpErr.statusCode == http.StatusUnauthorized || httpErr.statusCode == http.StatusForbidden {

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -157,18 +157,22 @@ func newMailboxListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&listOpts.priority, "priority", "", "Mailbox priority: normal, high, or critical")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Page size from 1 to 200; omitted uses the API default")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Continuation cursor")
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
 	return cmd
 }
 
 func newMailboxViewCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	apiOpts := opts
+	cmd := &cobra.Command{
 		Use:   "view <mailbox-item-id>",
 		Short: "View one mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &apiOpts)
+	return cmd
 }
 
 func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
@@ -187,6 +191,7 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadJSON, "decision-payload-json", "", "Optional JSON object attached to the approval event")
+	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
 	return cmd
 }
 
@@ -206,6 +211,7 @@ func newMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&actionOpts.reason, "reason", "", "Required rejection reason")
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
 	return cmd
 }
 
@@ -225,6 +231,7 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&actionOpts.until, "until", "", "Required RFC3339 timestamp")
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -668,7 +668,7 @@ func decisionForMailboxStatus(status string) string {
 
 func testRootCommandOptions(server *httptest.Server) rootCommandOptions {
 	opts := defaultRootCommandOptions()
-	opts.apiEndpoint = server.URL + "/v1/rpc"
+	opts.apiRPCEndpointOverride = server.URL + "/v1/rpc"
 	opts.httpClient = server.Client()
 	return opts
 }

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -127,6 +127,7 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&nukeOpts.yes, "yes", "y", false, "Skip the destructive confirmation prompt")
 	cmd.Flags().BoolVar(&nukeOpts.dryRun, "dry-run", false, "Preview the destructive reset without applying it")
+	bindCLIAPIConnectionFlags(cmd, &nukeOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -258,7 +258,7 @@ func TestControlNukeTransportFailureExitsThree(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var stdout, stderr bytes.Buffer
 	opts := defaultRootCommandOptions()
-	opts.apiEndpoint = "http://127.0.0.1:1/v1/rpc"
+	opts.apiRPCEndpointOverride = "http://127.0.0.1:1/v1/rpc"
 	opts.httpClient = &http.Client{Transport: errRoundTripper{}}
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--yes"}, &stdout, &stderr, opts)
 	if code != 3 {

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -81,6 +81,7 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&cmdOpts.all, "all", false, "Apply the supported all-runs scope for this action")
+	bindCLIAPIConnectionFlags(cmd, &cmdOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -124,18 +124,22 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	bindDiagnosticRunListFlags(cmd, &runOpts)
+	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }
 
 func newHealthCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	apiOpts := opts
+	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Print structured operator health through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
+			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts)
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &apiOpts)
+	return cmd
 }
 
 func newStatusCommand(opts rootCommandOptions) *cobra.Command {
@@ -153,6 +157,7 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
+	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }
 
@@ -171,6 +176,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&traceOpts.follow, "follow", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	bindCLIAPIConnectionFlags(cmd, &traceOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/entities.go
+++ b/cmd/swarm/entities.go
@@ -151,6 +151,7 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&listOpts.currentState, "current-state", "", "Filter by current entity state")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
 	return cmd
 }
 
@@ -166,6 +167,7 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&viewOpts.runID, "run-id", "", "Disambiguate entities reused across runs")
+	bindCLIAPIConnectionFlags(cmd, &viewOpts.apiOptions)
 	return cmd
 }
 
@@ -185,6 +187,7 @@ func newEntityAggregateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&aggregateOpts.runID, "run-id", "", "Filter by run id")
 	cmd.Flags().StringVar(&aggregateOpts.groupBy, "group-by", "", "Group by current_state, flow, flow_instance, workflow_name, workflow_version, type, entity_type, slug, name, or fields.<path>")
 	cmd.Flags().StringVar(&aggregateOpts.typeName, "type", "", "Filter by entity type")
+	bindCLIAPIConnectionFlags(cmd, &aggregateOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -70,6 +70,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
 	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
 	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &publishOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -206,6 +206,7 @@ func newEventsListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&listOpts.until, "until", "", "Optional RFC3339 upper created_at bound")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-1000")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Optional pagination cursor")
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
 	return cmd
 }
 
@@ -222,18 +223,22 @@ func newEventsFollowCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	bindEventFilterFlags(cmd, &followOpts.filter)
 	cmd.Flags().StringVar(&followOpts.replaySince, "replay-since", "", "Optional RFC3339 catch-up window start")
+	bindCLIAPIConnectionFlags(cmd, &followOpts.apiOptions)
 	return cmd
 }
 
 func newEventViewCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	apiOpts := opts
+	cmd := &cobra.Command{
 		Use:   "view <event-id>",
 		Short: "View one event through /v1/rpc event.get.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runEventViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+			return runEventViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &apiOpts)
+	return cmd
 }
 
 func newEventReplayCommand(opts rootCommandOptions) *cobra.Command {
@@ -248,6 +253,7 @@ func newEventReplayCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringArrayVar(&replayOpts.subscribers, "subscriber", nil, "Original agent subscriber to replay to; repeat to select a subset")
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/incidents.go
+++ b/cmd/swarm/incidents.go
@@ -72,6 +72,7 @@ func newIncidentsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&incidentOpts.mcpOnly, "mcp-only", false, "Only show incidents from MCP-prefixed components")
 	cmd.Flags().IntVar(&incidentOpts.limit, "limit", 0, "Page size, 1-500")
 	cmd.Flags().StringVar(&incidentOpts.cursor, "cursor", "", "Pagination cursor")
+	bindCLIAPIConnectionFlags(cmd, &incidentOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -125,6 +125,7 @@ func newLogsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().IntVar(&logOpts.limit, "limit", 0, "Snapshot-only page size, 1-1000")
 	cmd.Flags().StringVar(&logOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
 	cmd.Flags().StringVar(&logOpts.order, "order", "", "Snapshot-only sort order: asc or desc")
+	bindCLIAPIConnectionFlags(cmd, &logOpts.apiOptions)
 	return cmd
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -367,13 +367,13 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
 		t.Fatalf("api connection/auth/config promoted_by = %q, want #844", spec.PromotedBy)
 	}
-	if strings.TrimSpace(spec.ImplementationStatus) != "authority_promoted_behavior_pending" {
-		t.Fatalf("api connection/auth/config implementation_status = %q, want authority_promoted_behavior_pending", spec.ImplementationStatus)
+	if strings.TrimSpace(spec.ImplementationStatus) != "implemented" {
+		t.Fatalf("api connection/auth/config implementation_status = %q, want implemented", spec.ImplementationStatus)
 	}
 	if !strings.Contains(spec.CanonicalOwner, "cli_specification.foundations.api_connection_auth_config_precedence") {
 		t.Fatalf("canonical owner does not point at promoted section: %s", spec.CanonicalOwner)
 	}
-	for _, want := range []string{"Cobra flags", "runtime behavior", "OpenRPC"} {
+	for _, want := range []string{"API-backed command leaves consume", "OpenRPC", "root/global `--config`"} {
 		if !strings.Contains(spec.Scope, want) {
 			t.Fatalf("scope missing boundary %q:\n%s", want, spec.Scope)
 		}
@@ -404,7 +404,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("api_server value model missing %q:\n%s", want, spec.APIServer.ValueModel)
 		}
 	}
-	for _, want := range []string{"migration evidence", "127.0.0.1"} {
+	for _, want := range []string{"base URL", "127.0.0.1"} {
 		if !strings.Contains(spec.APIServer.Rationale, want) {
 			t.Fatalf("api_server rationale missing %q:\n%s", want, spec.APIServer.Rationale)
 		}
@@ -467,7 +467,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("split siblings missing %q: %#v", want, spec.SplitSiblings)
 		}
 	}
-	for _, want := range []string{"No Cobra persistent flag", "OpenRPC", "Future API-backed CLI config/auth implementation MUST consume this owner"} {
+	for _, want := range []string{"API-backed command leaves consume", "OpenRPC", "Future API-backed CLI commands MUST consume this owner"} {
 		if !stringSliceContains(spec.ImplementationBoundaries, want) {
 			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
 		}

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -240,9 +240,13 @@ func (o runCommandOptions) runtimeEndpoints() (rootCommandOptions, string, error
 		rpcEndpoint = "http://127.0.0.1:" + strconv.Itoa(o.apiPort) + "/v1/rpc"
 		wsEndpoint = "ws://127.0.0.1:" + strconv.Itoa(o.apiPort) + "/v1/ws"
 	} else {
-		rpcEndpoint = strings.TrimSpace(opts.apiEndpoint)
+		rpcEndpoint = strings.TrimSpace(opts.apiRPCEndpointOverride)
 		if rpcEndpoint == "" {
-			rpcEndpoint = defaultCLIAPIEndpoint
+			var err error
+			rpcEndpoint, err = cliAPIRPCEndpointFromServer(defaultCLIAPIServer, "API server")
+			if err != nil {
+				return opts, "", err
+			}
 		}
 		var err error
 		wsEndpoint, err = runCommandWebSocketEndpoint(rpcEndpoint)
@@ -250,7 +254,7 @@ func (o runCommandOptions) runtimeEndpoints() (rootCommandOptions, string, error
 			return opts, "", err
 		}
 	}
-	opts.apiEndpoint = rpcEndpoint
+	opts.apiRPCEndpointOverride = rpcEndpoint
 	return opts, wsEndpoint, nil
 }
 
@@ -285,25 +289,7 @@ func normalizeRunCommandConnectURL(raw string) (string, string, error) {
 }
 
 func runCommandWebSocketEndpoint(rpcEndpoint string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(rpcEndpoint))
-	if err != nil {
-		return "", fmt.Errorf("derive /v1/ws endpoint: %w", err)
-	}
-	switch parsed.Scheme {
-	case "http":
-		parsed.Scheme = "ws"
-	case "https":
-		parsed.Scheme = "wss"
-	default:
-		return "", fmt.Errorf("derive /v1/ws endpoint: unsupported API scheme %q", parsed.Scheme)
-	}
-	path := strings.TrimRight(parsed.Path, "/")
-	if strings.HasSuffix(path, "/v1/rpc") {
-		parsed.Path = strings.TrimSuffix(path, "/v1/rpc") + "/v1/ws"
-	} else {
-		return "", fmt.Errorf("derive /v1/ws endpoint: API endpoint must end in /v1/rpc")
-	}
-	return parsed.String(), nil
+	return cliAPIWebSocketEndpointFromRPC(rpcEndpoint)
 }
 
 func loadRunCommandPayload(path string) (map[string]any, error) {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -644,7 +644,7 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 func testRunCommandOptions(server *httptest.Server) rootCommandOptions {
 	opts := defaultRootCommandOptions()
 	if server != nil {
-		opts.apiEndpoint = server.URL + "/v1/rpc"
+		opts.apiRPCEndpointOverride = server.URL + "/v1/rpc"
 		opts.httpClient = server.Client()
 	}
 	opts.runReadyTimeout = time.Second

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5898,12 +5898,14 @@ cli_specification:
       `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` fallback is invalid.
     api_connection_auth_config_precedence:
       promoted_by: '#844'
-      implementation_status: authority_promoted_behavior_pending
+      implementation_status: implemented
       canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence
       scope: >
         Merge-bearing authority for CLI API base URL selection, bearer-token selection, and CLI config-file
-        discovery for API-backed commands. This first slice does not add Cobra flags, runtime behavior, OpenRPC
-        behavior, retry behavior, output rendering, or serve listener binding.
+        discovery for API-backed commands. API-backed command leaves consume `--api-server`, `--api-token-file`,
+        `SWARM_API_SERVER`, `SWARM_API_TOKEN`, `SWARM_API_TOKEN_FILE`, `SWARM_CONFIG`, XDG config, and built-in
+        defaults through one shared resolver. This contract does not add OpenRPC behavior, retry behavior,
+        output rendering, root/global `--config`, inline token flags, or serve listener binding.
       applies_to:
       - Runtime-state CLI commands that call the platform JSON-RPC or WebSocket API.
       - '`swarm version --server` when it queries the platform API.'
@@ -5930,8 +5932,8 @@ cli_specification:
           transport needs.
         rationale: >
           The ignored review artifact used `http://localhost:8081`; the promoted spec uses `127.0.0.1` to
-          match serve listener loopback defaults and avoid hostname/IPv6 ambiguity. Current code that stores a
-          full `/v1/rpc` endpoint is migration evidence only until behavior consumes this owner.
+          match serve listener loopback defaults and avoid hostname/IPv6 ambiguity. API-backed command users
+          configure the base URL; the client derives concrete transport endpoints from this owner.
       api_token:
         accepted_sources:
           flag_file: --api-token-file <path>
@@ -5997,9 +5999,9 @@ cli_specification:
       - 'contract path/platform spec path defaults'
       - '`--no-retry` retry policy'
       implementation_boundaries:
-      - 'This #844 first slice is source-of-truth repair only.'
-      - 'No Cobra persistent flag, runtime/client resolver, OpenRPC, output renderer, retry, or listener behavior changes are implied by this PR.'
-      - 'Future API-backed CLI config/auth implementation MUST consume this owner rather than the ignored review artifact.'
+      - 'API-backed command leaves consume one cmd/swarm resolver for this owner.'
+      - 'No root/global --config, inline --api-token, OpenRPC, output renderer, retry, or listener behavior changes are implied by this owner.'
+      - 'Future API-backed CLI commands MUST consume this owner rather than the ignored review artifact.'
     error_channel_and_exit_code_contract:
       implemented_by: '#846'
       scope: >


### PR DESCRIPTION
## Summary
- Implements one shared CLI API connection/auth/config resolver for current API-backed command consumers.
- Wires `--api-server` and `--api-token-file` only onto approved API-backed leaf commands, leaving root/global `--config`, inline `--api-token`, output/logging, retry/follow, serve listener config, and absent command families out of scope.
- Updates `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence` from pending to implemented and adds focused resolver/surface tests.

Part of #844.

## Governing Refs
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- #844 implementer pre-audit and approved first-slice gate
- Parent trackers: #794 and #735

## Semantic Migration
- New canonical owner: `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence` consumed by `cmd/swarm` shared API resolver.
- Old producer/reader path now invalid: direct `newCLIAPIClient` ownership of hardcoded `/v1/rpc` default plus direct `SWARM_API_TOKEN`-only lookup.
- Production paths checked: all current `newCLIAPIClient` consumers under `cmd/swarm`, API-backed leaf command flag surfaces, WebSocket endpoint derivation, missing-token read and mutation commands, retired namespace non-consumers, and non-API surfaces (`serve`, `verify`, `run`, root-only).
- Migration completeness: complete for the chosen class of current API-backed command consumers. Broader #844 universal output/retry/contract-path tails remain split.

## Proof
- `go test ./cmd/swarm -run 'TestCLIAPISettingsFailClosed|TestEndpointShapedAPIServerRejectedBeforeRequest|TestAPIConnectionFlagsPreserveServerBasePathPrefix|TestAPIConnectionFlagsDriveRuntimeStateCommand|TestAPIConnectionFlagsRejectedOnNonAPISurfaces' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Smoke/test proof: root-position `swarm --api-server ... runs` exits 2 as an unpromoted global placement.
- Smoke/test proof: endpoint-shaped exact and segment-suffix `--api-server` values ending in `/v1/rpc` or `/v1/ws` exit 2 before request.
- Smoke/test proof: endpoint-shaped `SWARM_API_SERVER` and config `api_server` values ending in `/v1/rpc` exit 2 before request.
- Positive proof: base prefix `--api-server <server>/proxy` is preserved and sends the request to `/proxy/v1/rpc`.
- Smoke: missing-token `swarm runs` exits 4 before request.
- Smoke: missing-token `swarm control nuke --yes` exits 4 before request.