### PR TITLE
[agent-e][issue #904] Gate OpenRPC examples deferral policy

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -9465,6 +9465,21 @@ api_specification:
         properties:
           operation_name:
             type: string
+  examples_policy:
+    status: deferred
+    owner: api_specification.examples_policy
+    applies_to: all_generated_methods
+    openrpc_method_examples: omitted_until_explicitly_authored
+    runtime_probe_fixtures: not_examples_source
+    future_source_model_required: true
+    reason: >
+      OpenRPC method examples are intentionally deferred for v1 because no authoritative
+      examples source model has been promoted. Runtime probe fixtures are proof inputs
+      and MUST NOT be reused as published examples.
+    requirements:
+    - generated openrpc.json MUST omit method examples while status is deferred
+    - compliance matrix examples rows MUST use policy_deferred proof status
+    - future authored or generated examples require a promoted api_specification source model and gate
   method_catalog_metadata:
     description: "All v1 methods. Each method declares: tier, description, scope.required,\nparams (array of contentDescriptors),\
       \ result (contentDescriptor), errors\n(array of error codes from components.errors). Mutating methods include\nidempotency.\

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -172,7 +172,8 @@ nodes:
       - central method transport admission can be absent, letting WS/protocol methods execute over /v1/rpc or HTTP-class methods execute over /v1/ws despite matrix transport classification
       - generated full successful-result schema validation can be absent even when runtime probes only key-smoke result payloads
       - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
-      - OpenRPC method examples and rpc.discover publication status are not explicitly tracked
+      - OpenRPC method examples can lack a merge-bearing authoring or deferral policy across the generated method catalog
+      - rpc.discover publication status is not explicitly tracked
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
       - 835
@@ -183,6 +184,7 @@ nodes:
       - 878
       - 890
       - 898
+      - 904
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -15,6 +15,12 @@ const (
 	OpenRPCVersion                     = "1.2.6"
 	OpenRPCApplicationErrorCodeStart   = -32000
 	OpenRPCApplicationErrorCodeMinimum = -32099
+
+	ExamplesPolicyStatusDeferred             = "deferred"
+	ExamplesPolicyOwner                      = "api_specification.examples_policy"
+	ExamplesPolicyAppliesToAllGenerated      = "all_generated_methods"
+	ExamplesPolicyOpenRPCExamplesOmitted     = "omitted_until_explicitly_authored"
+	ExamplesPolicyRuntimeFixturesNotExamples = "not_examples_source"
 )
 
 type PlatformSpec struct {
@@ -24,9 +30,21 @@ type PlatformSpec struct {
 type APISpecification struct {
 	Description           string            `yaml:"description" json:"description,omitempty"`
 	Components            Components        `yaml:"components" json:"components"`
+	ExamplesPolicy        ExamplesPolicy    `yaml:"examples_policy" json:"examples_policy,omitempty"`
 	MethodCatalogMetadata map[string]any    `yaml:"method_catalog_metadata" json:"method_catalog_metadata,omitempty"`
 	MethodCatalog         map[string]Method `yaml:"method_catalog" json:"method_catalog"`
 	Conventions           Conventions       `yaml:"conventions" json:"conventions"`
+}
+
+type ExamplesPolicy struct {
+	Status                    string   `yaml:"status" json:"status,omitempty"`
+	Owner                     string   `yaml:"owner" json:"owner,omitempty"`
+	AppliesTo                 string   `yaml:"applies_to" json:"applies_to,omitempty"`
+	OpenRPCMethodExamples     string   `yaml:"openrpc_method_examples" json:"openrpc_method_examples,omitempty"`
+	RuntimeProbeFixtures      string   `yaml:"runtime_probe_fixtures" json:"runtime_probe_fixtures,omitempty"`
+	Reason                    string   `yaml:"reason" json:"reason,omitempty"`
+	Requirements              []string `yaml:"requirements" json:"requirements,omitempty"`
+	FutureSourceModelRequired bool     `yaml:"future_source_model_required" json:"future_source_model_required,omitempty"`
 }
 
 type Components struct {
@@ -169,6 +187,7 @@ func Validate(api *APISpecification) (ValidationReport, error) {
 	if _, ok := api.Components.Errors["description"]; ok {
 		problems = append(problems, "components.errors.description must be metadata, not an error code")
 	}
+	problems = append(problems, validateExamplesPolicy(api.ExamplesPolicy)...)
 
 	scopeCatalog := stringSet(api.Conventions.Scopes.Catalog)
 	mutatingCatalog := stringSet(api.Conventions.Idempotency.MutatingMethods)
@@ -241,6 +260,42 @@ func Validate(api *APISpecification) (ValidationReport, error) {
 		return report, fmt.Errorf("api specification validation failed:\n- %s", strings.Join(problems, "\n- "))
 	}
 	return report, nil
+}
+
+func validateExamplesPolicy(policy ExamplesPolicy) []string {
+	var problems []string
+	if strings.TrimSpace(policy.Status) == "" {
+		problems = append(problems, "api_specification.examples_policy missing status")
+	} else if policy.Status != ExamplesPolicyStatusDeferred {
+		problems = append(problems, fmt.Sprintf("api_specification.examples_policy.status = %q, want %q", policy.Status, ExamplesPolicyStatusDeferred))
+	}
+	if policy.Owner != ExamplesPolicyOwner {
+		problems = append(problems, fmt.Sprintf("api_specification.examples_policy.owner = %q, want %q", policy.Owner, ExamplesPolicyOwner))
+	}
+	if policy.AppliesTo != ExamplesPolicyAppliesToAllGenerated {
+		problems = append(problems, fmt.Sprintf("api_specification.examples_policy.applies_to = %q, want %q", policy.AppliesTo, ExamplesPolicyAppliesToAllGenerated))
+	}
+	if policy.OpenRPCMethodExamples != ExamplesPolicyOpenRPCExamplesOmitted {
+		problems = append(problems, fmt.Sprintf("api_specification.examples_policy.openrpc_method_examples = %q, want %q", policy.OpenRPCMethodExamples, ExamplesPolicyOpenRPCExamplesOmitted))
+	}
+	if policy.RuntimeProbeFixtures != ExamplesPolicyRuntimeFixturesNotExamples {
+		problems = append(problems, fmt.Sprintf("api_specification.examples_policy.runtime_probe_fixtures = %q, want %q", policy.RuntimeProbeFixtures, ExamplesPolicyRuntimeFixturesNotExamples))
+	}
+	if strings.TrimSpace(policy.Reason) == "" {
+		problems = append(problems, "api_specification.examples_policy missing reason")
+	}
+	if len(policy.Requirements) == 0 {
+		problems = append(problems, "api_specification.examples_policy must list enforcement requirements")
+	}
+	for i, requirement := range policy.Requirements {
+		if strings.TrimSpace(requirement) == "" {
+			problems = append(problems, fmt.Sprintf("api_specification.examples_policy.requirements[%d] is empty", i))
+		}
+	}
+	if !policy.FutureSourceModelRequired {
+		problems = append(problems, "api_specification.examples_policy.future_source_model_required must be true")
+	}
+	return problems
 }
 
 func validateMailboxConventions(routes []MailboxApprovalEventRoute) []string {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -43,6 +43,7 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if _, ok := api.Components.Errors["description"]; ok {
 		t.Fatal("components.errors.description must not be a concrete error code")
 	}
+	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
 }
 
 func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
@@ -73,6 +74,7 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
 	}
+	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	methods := map[string]OpenRPCMethod{}
 	for _, method := range doc.Methods {
 		methods[method.Name] = method
@@ -119,6 +121,32 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMissingExamplesPolicy(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	api.ExamplesPolicy = ExamplesPolicy{}
+
+	_, err := Validate(api)
+	if err == nil {
+		t.Fatal("Validate() error = nil, want examples_policy rejection")
+	}
+	if got, want := err.Error(), "api_specification.examples_policy missing status"; !strings.Contains(got, want) {
+		t.Fatalf("Validate() error = %q, want substring %q", got, want)
+	}
+}
+
+func TestValidateRejectsUnsupportedExamplesPolicy(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	api.ExamplesPolicy.Status = "authored"
+
+	_, err := Validate(api)
+	if err == nil {
+		t.Fatal("Validate() error = nil, want unsupported examples_policy status rejection")
+	}
+	if got, want := err.Error(), `api_specification.examples_policy.status = "authored", want "deferred"`; !strings.Contains(got, want) {
+		t.Fatalf("Validate() error = %q, want substring %q", got, want)
+	}
+}
+
 func notificationSchemaRef(t *testing.T, methodName string, schema any) string {
 	t.Helper()
 	schemaMap, ok := schema.(map[string]any)
@@ -130,6 +158,63 @@ func notificationSchemaRef(t *testing.T, methodName string, schema any) string {
 		t.Fatalf("%s notification_schema = %#v, want $ref", methodName, schema)
 	}
 	return ref
+}
+
+func assertExamplesPolicyDeferred(t *testing.T, policy ExamplesPolicy) {
+	t.Helper()
+	if policy.Status != ExamplesPolicyStatusDeferred {
+		t.Fatalf("examples_policy.status = %q, want %q", policy.Status, ExamplesPolicyStatusDeferred)
+	}
+	if policy.Owner != ExamplesPolicyOwner {
+		t.Fatalf("examples_policy.owner = %q, want %q", policy.Owner, ExamplesPolicyOwner)
+	}
+	if policy.AppliesTo != ExamplesPolicyAppliesToAllGenerated {
+		t.Fatalf("examples_policy.applies_to = %q, want %q", policy.AppliesTo, ExamplesPolicyAppliesToAllGenerated)
+	}
+	if policy.OpenRPCMethodExamples != ExamplesPolicyOpenRPCExamplesOmitted {
+		t.Fatalf("examples_policy.openrpc_method_examples = %q, want %q", policy.OpenRPCMethodExamples, ExamplesPolicyOpenRPCExamplesOmitted)
+	}
+	if policy.RuntimeProbeFixtures != ExamplesPolicyRuntimeFixturesNotExamples {
+		t.Fatalf("examples_policy.runtime_probe_fixtures = %q, want %q", policy.RuntimeProbeFixtures, ExamplesPolicyRuntimeFixturesNotExamples)
+	}
+	if !policy.FutureSourceModelRequired {
+		t.Fatal("examples_policy.future_source_model_required = false, want true")
+	}
+	if strings.TrimSpace(policy.Reason) == "" {
+		t.Fatal("examples_policy.reason must explain examples deferral")
+	}
+	if len(policy.Requirements) == 0 {
+		t.Fatal("examples_policy.requirements must list enforcement requirements")
+	}
+}
+
+func assertGeneratedMethodsOmitExamplesUnderPolicy(t *testing.T, api *APISpecification, artifact []byte) {
+	t.Helper()
+	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
+
+	var rawDoc struct {
+		Methods []map[string]json.RawMessage `json:"methods"`
+	}
+	if err := json.Unmarshal(artifact, &rawDoc); err != nil {
+		t.Fatalf("unmarshal raw openrpc methods: %v", err)
+	}
+	for _, method := range rawDoc.Methods {
+		var name string
+		if err := json.Unmarshal(method["name"], &name); err != nil {
+			t.Fatalf("parse raw openrpc method name: %v", err)
+		}
+		if rawJSONHasContent(method["examples"]) {
+			t.Fatalf("%s publishes OpenRPC examples while examples_policy is deferred", name)
+		}
+		if rawJSONHasContent(method["example"]) {
+			t.Fatalf("%s publishes OpenRPC example while examples_policy is deferred", name)
+		}
+	}
+}
+
+func rawJSONHasContent(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null" && trimmed != "[]"
 }
 
 func TestGeneratedOpenRPCApplicationErrorCodesAreUnique(t *testing.T) {

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -89,6 +89,8 @@ type rawOpenRPCDocument struct {
 	Methods []map[string]json.RawMessage `json:"methods"`
 }
 
+const openRPCComplianceMatrixTestName = "TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod"
+
 func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	root := repoRoot(t)
 	api := loadComplianceAPISpec(t, root)
@@ -113,6 +115,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))
 	}
+	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
 	if problems := validateProofReferenceIntegrity(root, matrix); len(problems) > 0 {
 		t.Fatalf("compliance matrix proof-reference integrity failed:\n- %s", strings.Join(problems, "\n- "))
 	}
@@ -166,7 +169,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 		assertEvidence(t, methodName, "unknown_top_level_param_validation", row.UnknownTopLevelParamValidation, false)
 		assertEvidence(t, methodName, "auth", row.Auth, false)
 		assertEvidence(t, methodName, "result_schema", row.ResultSchema, true)
-		assertEvidence(t, methodName, "examples", row.Examples, true)
+		assertEvidence(t, methodName, "examples", row.Examples, false)
 		assertEvidence(t, methodName, "service_discovery_publication", row.ServiceDiscoveryPublication, false)
 
 		if len(row.GapClassification) == 0 {
@@ -192,9 +195,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 		} else {
 			assertEvidence(t, methodName, "notification_schema", row.NotificationSchema, true)
 		}
-		if !rawMethods[methodName].hasExamples && row.Examples.Status != "tracked_gap" {
-			t.Fatalf("%s examples status = %q, want tracked_gap while openrpc.json has no method examples", methodName, row.Examples.Status)
-		}
+		assertExamplesPolicyMatrixRow(t, methodName, rawMethods[methodName], row.Examples)
 		if row.ServiceDiscoveryPublication.Status != "published_without_discovery" {
 			t.Fatalf("%s service_discovery_publication status = %q, want published_without_discovery", methodName, row.ServiceDiscoveryPublication.Status)
 		}
@@ -281,6 +282,14 @@ func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 			want: "artifact proof_ref path docs/specs/missing-openrpc.json does not exist",
 		},
 		{
+			name: "policy deferred examples missing artifact proof",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.Examples.ProofRefs = []complianceProofRef{{Kind: "go_test", Name: openRPCComplianceMatrixTestName}}
+			},
+			want: "examples status policy_deferred requires an artifact proof_ref",
+		},
+		{
 			name: "legacy proof strings",
 			mutate: func(matrix *openRPCComplianceMatrix) {
 				row := complianceMatrixRow(t, matrix, "agent.get")
@@ -356,7 +365,7 @@ func loadComplianceOpenRPC(t *testing.T, path string) (apispec.OpenRPCDocument, 
 		if err := json.Unmarshal(method["name"], &name); err != nil {
 			t.Fatalf("parse raw openrpc method name: %v", err)
 		}
-		rawMethods[name] = rawOpenRPCMethodProof{hasExamples: rawJSONHasContent(method["examples"])}
+		rawMethods[name] = rawOpenRPCMethodProof{hasExamples: rawJSONHasContent(method["examples"]) || rawJSONHasContent(method["example"])}
 	}
 	return doc, rawMethods
 }
@@ -564,6 +573,13 @@ func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix o
 		if _, ok := kinds["artifact"]; !ok {
 			problems = append(problems, fmt.Sprintf("%s status published_without_discovery requires an artifact proof_ref", label))
 		}
+	case "policy_deferred":
+		if _, ok := kinds["artifact"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status policy_deferred requires an artifact proof_ref", label))
+		}
+		if _, ok := kinds["go_test"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status policy_deferred requires a go_test proof_ref", label))
+		}
 	}
 	return problems
 }
@@ -574,15 +590,13 @@ func allowedComplianceGapClasses() map[string]struct{} {
 		"missing_generated_result_schema_validation",
 		"missing_happy_path_test",
 		"missing_idempotency_test",
-		"missing_openrpc_examples",
+		"missing_rpc_discover_policy",
 		"missing_result_schema_proof",
 	})
 }
 
 func allowedCompliancePolicyGaps() map[string]struct{} {
-	return complianceStringSet([]string{
-		"openrpc_examples_absent",
-	})
+	return complianceStringSet(nil)
 }
 
 func allowedProofRefKinds(status, field string) map[string]struct{} {
@@ -597,6 +611,8 @@ func allowedProofRefKinds(status, field string) map[string]struct{} {
 		}
 		return complianceStringSet([]string{"tracker"})
 	case "published_without_discovery":
+		return complianceStringSet([]string{"artifact", "go_test"})
+	case "policy_deferred":
 		return complianceStringSet([]string{"artifact", "go_test"})
 	default:
 		return map[string]struct{}{}
@@ -860,12 +876,59 @@ func allowedEvidenceStatuses(field string) map[string]struct{} {
 	case "result_schema", "notification_schema":
 		return complianceStringSet([]string{"covered", "spot_checked"})
 	case "examples":
-		return complianceStringSet([]string{"covered"})
+		return complianceStringSet([]string{"covered", "policy_deferred"})
 	case "service_discovery_publication":
 		return complianceStringSet([]string{"published_without_discovery"})
 	default:
 		return map[string]struct{}{}
 	}
+}
+
+func assertExamplesPolicyDeferred(t *testing.T, policy apispec.ExamplesPolicy) {
+	t.Helper()
+	if policy.Status != apispec.ExamplesPolicyStatusDeferred {
+		t.Fatalf("examples_policy.status = %q, want %q", policy.Status, apispec.ExamplesPolicyStatusDeferred)
+	}
+	if policy.Owner != apispec.ExamplesPolicyOwner {
+		t.Fatalf("examples_policy.owner = %q, want %q", policy.Owner, apispec.ExamplesPolicyOwner)
+	}
+	if policy.AppliesTo != apispec.ExamplesPolicyAppliesToAllGenerated {
+		t.Fatalf("examples_policy.applies_to = %q, want %q", policy.AppliesTo, apispec.ExamplesPolicyAppliesToAllGenerated)
+	}
+	if policy.OpenRPCMethodExamples != apispec.ExamplesPolicyOpenRPCExamplesOmitted {
+		t.Fatalf("examples_policy.openrpc_method_examples = %q, want %q", policy.OpenRPCMethodExamples, apispec.ExamplesPolicyOpenRPCExamplesOmitted)
+	}
+	if policy.RuntimeProbeFixtures != apispec.ExamplesPolicyRuntimeFixturesNotExamples {
+		t.Fatalf("examples_policy.runtime_probe_fixtures = %q, want %q", policy.RuntimeProbeFixtures, apispec.ExamplesPolicyRuntimeFixturesNotExamples)
+	}
+}
+
+func assertExamplesPolicyMatrixRow(t *testing.T, methodName string, rawProof rawOpenRPCMethodProof, evidence complianceEvidence) {
+	t.Helper()
+	if rawProof.hasExamples {
+		t.Fatalf("%s publishes OpenRPC examples while examples_policy is deferred", methodName)
+	}
+	if evidence.Status != "policy_deferred" {
+		t.Fatalf("%s examples status = %q, want policy_deferred while examples_policy is deferred", methodName, evidence.Status)
+	}
+	if !evidenceHasArtifact(evidence, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml") {
+		t.Fatalf("%s examples missing platform-spec.yaml artifact proof_ref", methodName)
+	}
+	if !evidenceHasArtifact(evidence, "docs/specs/swarm-platform/platform/contracts/openrpc.json") {
+		t.Fatalf("%s examples missing openrpc.json artifact proof_ref", methodName)
+	}
+	if !evidenceHasGoTest(evidence, openRPCComplianceMatrixTestName) {
+		t.Fatalf("%s examples missing go_test proof_ref %s", methodName, openRPCComplianceMatrixTestName)
+	}
+}
+
+func evidenceHasArtifact(evidence complianceEvidence, path string) bool {
+	for _, ref := range evidence.ProofRefs {
+		if ref.Kind == "artifact" && ref.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 func assertNotApplicable(t *testing.T, methodName, field string, evidence complianceEvidence) {

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -11,14 +11,14 @@ source:
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
   generated_from: api_specification.method_catalog
 policy:
-  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_and_notification_schema_runtime_validation
+  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_notification_schema_and_examples_policy_validation
   runtime_behavior_changes: transport_admission_repair_approved_by_878
   read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; mutating, WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
   mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
   ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, and full notification-schema validation remain tracked by #857."
   result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover remain tracked by #857."
   notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover remain tracked by #857."
-  examples_policy: OpenRPC method examples are tracked gaps in this slice.
+  examples_policy: "#904 adds merge-bearing catalog-wide OpenRPC examples deferral policy; method examples are intentionally omitted until a future approved source model exists."
   service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
 methods:
   - method: agent.diagnose
@@ -33,9 +33,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.get
     transport: http
     required_params: [agent_id]
@@ -48,9 +48,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.list
     transport: http
     required_params: []
@@ -63,9 +63,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.replay
     transport: http
     required_params: [event_id, agent_id]
@@ -78,9 +78,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.replay_backlog
     transport: http
     required_params: [agent_id]
@@ -93,9 +93,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.restart
     transport: http
     required_params: [agent_id]
@@ -108,9 +108,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: agent.send_directive
     transport: http
     required_params: [agent_id, directive]
@@ -123,9 +123,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: conversation.current_for_agent
     transport: http
     required_params: [agent_id]
@@ -138,9 +138,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: conversation.get
     transport: http
     required_params: [session_id]
@@ -153,9 +153,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: conversation.get_turn
     transport: http
     required_params: [session_id, turn_index]
@@ -168,9 +168,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorConversationGetTurnComposesRuntimeLogOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: conversation.list
     transport: http
     required_params: []
@@ -183,9 +183,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: entity.aggregate
     transport: http
     required_params: []
@@ -198,9 +198,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: entity.get
     transport: http
     required_params: [entity_id]
@@ -213,9 +213,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: entity.list
     transport: http
     required_params: []
@@ -228,9 +228,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: event.get
     transport: http
     required_params: [event_id]
@@ -243,9 +243,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: event.list
     transport: http
     required_params: []
@@ -258,9 +258,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
@@ -273,9 +273,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: event.replay
     transport: http
     required_params: [event_id]
@@ -288,9 +288,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: event.subscribe
     transport: ws
     required_params: []
@@ -303,9 +303,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: health.check
     transport: http
     required_params: []
@@ -318,9 +318,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: health.ping
     transport: http
     required_params: []
@@ -333,9 +333,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: health.subscribe
     transport: ws
     required_params: []
@@ -348,9 +348,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: mailbox.approve
     transport: http
     required_params: [mailbox_id]
@@ -363,9 +363,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: mailbox.defer
     transport: http
     required_params: [mailbox_id, until]
@@ -378,9 +378,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: mailbox.get
     transport: http
     required_params: [mailbox_id]
@@ -393,9 +393,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: mailbox.list
     transport: http
     required_params: []
@@ -408,9 +408,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: mailbox.reject
     transport: http
     required_params: [mailbox_id, reason]
@@ -423,9 +423,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: rpc.unsubscribe
     transport: ws
     required_params: [subscription_id]
@@ -438,9 +438,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.continue
     transport: http
     required_params: [run_id]
@@ -453,9 +453,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.diagnose
     transport: http
     required_params: [run_id]
@@ -468,9 +468,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.get
     transport: http
     required_params: [run_id]
@@ -483,9 +483,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.list
     transport: http
     required_params: []
@@ -498,9 +498,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.pause
     transport: http
     required_params: [run_id]
@@ -513,9 +513,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.start
     transport: http
     required_params: [event_name, payload]
@@ -528,9 +528,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.stop
     transport: http
     required_params: [run_id]
@@ -543,9 +543,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.subscribe_trace
     transport: ws
     required_params: [run_id]
@@ -558,9 +558,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: run.trace
     transport: http
     required_params: [run_id]
@@ -573,9 +573,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.incidents
     transport: http
     required_params: []
@@ -588,9 +588,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.logs
     transport: http
     required_params: []
@@ -603,9 +603,9 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.nuke
     transport: http
     required_params: []
@@ -618,9 +618,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.pause
     transport: http
     required_params: []
@@ -633,9 +633,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.resume
     transport: http
     required_params: []
@@ -648,9 +648,9 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]
   - method: runtime.subscribe_logs
     transport: ws
     required_params: []
@@ -663,6 +663,6 @@ methods:
     idempotency: {status: not_applicable}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
-    examples: {status: tracked_gap, proof_refs: [{kind: tracker, issue: 857, watchlist: operator_surfaces.v1_openrpc_api_conformance}, {kind: policy_gap, name: openrpc_examples_absent}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_openrpc_examples]
+    gap_classification: [missing_rpc_discover_policy]


### PR DESCRIPTION
## Summary

Adds a merge-bearing OpenRPC examples deferral policy under `platform-spec.yaml` `api_specification` and makes `internal/apispec` plus the OpenRPC compliance matrix enforce that examples absence is intentional for all 43 generated methods.

Closes #904
Part of #857

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apispec`
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`
- `docs/watchlists/operator-surfaces.yaml`
- #904 pre-audit and independent gate review

## Semantic migration

- New canonical owner: `api_specification.examples_policy` in `platform-spec.yaml`.
- Old non-authoritative path now invalid: raw `examples: tracked_gap` rows using `missing_openrpc_examples` / `openrpc_examples_absent` as the active examples proof state.
- Checked production paths for surviving old behavior: generated `openrpc.json` remains without method examples under the explicit deferred policy; `/v1/rpc`, `/v1/ws`, params, results, errors, result schemas, and notification schemas are unchanged.
- Migration complete for the approved child class: all 43 matrix examples rows now use `policy_deferred` proof, and stale examples gap names are no longer allowed.

`rpc.discover` / service-discovery publication remains split under #857.

## Tests

- `go test ./internal/apispec ./internal/apiv1 -run 'OpenRPC|ComplianceMatrix|ExamplesPolicy' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `git diff --check`