### PR TITLE
[agent-b][issue #855] Promote run trace filter contract

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -4635,6 +4635,14 @@
           "schema": {
             "$ref": "#/components/schemas/Cursor"
           }
+        },
+        {
+          "name": "since",
+          "required": false,
+          "description": "Optional RFC3339/RFC3339Nano materialization watermark. Returns rows whose canonical trace materialization watermark is strictly after this timestamp.\n",
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
         }
       ],
       "result": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5584,9 +5584,16 @@ cli_specification:
           runtime listener wiring, OpenRPC, and `swarm run` behavior remain unchanged until follow-up
           implementation children consume the promoted owner.
       trace_filters_and_subscription_recovery:
-        disposition: tracked_child
+        disposition: promoted_first_slice
         tracker: '#855'
-        action: Promote rich trace filters, follow semantics, and recovery rules before implementation.
+        action: >
+          The bounded snapshot trace filter contract is promoted in
+          api_specification.method_catalog.run.trace and
+          cli_specification.command_catalog.trace.promoted_trace_filter_contract. The promoted API owner accepts
+          `limit`, `cursor`, and `since`; `since` filters by the canonical RunTraceRow materialization watermark
+          used by the run-debug trace owner. Review-artifact `until`, event-name, subscriber, entity-id,
+          delivery-status, `--include-payload`, `-f`, subscription retry/`--no-retry`, and multi-run `--all`
+          remain explicitly unpromoted split tails until later gated children promote their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: tracked_child
         tracker: '#856'
@@ -6541,6 +6548,31 @@ cli_specification:
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run trace rendering over API-owned RunTraceRow facts only; no CLI reconstruction from tables.
+      promoted_trace_filter_contract:
+        status: api_owner_promoted_cli_pending
+        snapshot_owner: /v1/rpc run.trace
+        promoted_params:
+        - run_id
+        - limit
+        - cursor
+        - since
+        since_semantics: >
+          `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
+          materialization watermark is strictly after `since`, where that watermark is the greatest available
+          timestamp across the joined event, delivery, session, and turn fields owned by RunTraceRow.
+        current_cli_consumer_status: >
+          The current implemented CLI command remains `swarm trace [<run-id>] [--follow]`; CLI flags that consume
+          the promoted snapshot filter contract require a later implementation child and MUST use this API owner.
+        split_tail:
+          until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
+          event_name: Not promoted; event-name filtering requires a typed RunTraceFilter owner before CLI use.
+          subscriber: Not promoted; subscriber filtering requires a typed RunTraceFilter owner before CLI use.
+          entity_id: Not promoted; entity filtering requires a typed RunTraceFilter owner before CLI use.
+          delivery_status: Not promoted; delivery-status filtering requires a typed RunTraceFilter owner before CLI use.
+          include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
+          shorthand_follow: Not promoted in this source-of-truth repair; `-f` is CLI UX only and must be gated separately.
+          subscription_retry: Not promoted; retry/`--no-retry` affects shared run.subscribe_trace consumers and is split.
+          all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
     mailbox_list:
       command: swarm mailbox list
       tier: must_have
@@ -10001,6 +10033,13 @@ api_specification:
         required: false
         schema:
           $ref: '#/components/schemas/Cursor'
+      - name: since
+        required: false
+        description: >
+          Optional RFC3339/RFC3339Nano materialization watermark. Returns rows whose canonical trace
+          materialization watermark is strictly after this timestamp.
+        schema:
+          $ref: '#/components/schemas/Timestamp'
       result:
         name: result
         required: true

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -66,12 +66,20 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		}),
 	})
 
-	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1}}`)
+	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1,"since":"2023-11-14T22:12:00Z"}}`)
 	if trace.Error != nil {
 		t.Fatalf("run.trace error = %#v", trace.Error)
 	}
 	if rows, _ := asMap(t, trace.Result)["trace"].([]any); len(rows) != 1 {
 		t.Fatalf("run.trace rows = %#v", asMap(t, trace.Result)["trace"])
+	}
+	if observability.lastTrace.Since == nil || observability.lastTrace.Limit != 1 {
+		t.Fatalf("run.trace options = %#v", observability.lastTrace)
+	}
+
+	invalidTraceSince := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-since","method":"run.trace","params":{"run_id":"run-1","since":"not-a-time"}}`)
+	if invalidTraceSince.Error == nil || invalidTraceSince.Error.Code != codeInvalidParams {
+		t.Fatalf("run.trace invalid since error = %#v, want invalid params", invalidTraceSince.Error)
 	}
 
 	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"filter":{"run_id":"run-1","event_name":"scan.requested","has_dead_letter":false},"limit":10}}`)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -596,7 +596,11 @@ func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHa
 			if err != nil {
 				return nil, err
 			}
-			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor})
+			since, err := timestampParam(req.Params, "since")
+			if err != nil {
+				return nil, err
+			}
+			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since})
 			if errors.Is(err, store.ErrRunNotFound) {
 				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 			}


### PR DESCRIPTION
## Summary
- Promote the bounded `run.trace` snapshot filter contract in merge-bearing `platform-spec.yaml` and generated OpenRPC.
- Add the `since` materialization watermark to `/v1/rpc run.trace`, wired to the existing canonical `RunDebugTraceQueryOptions.Since` store owner.
- Explicitly split the richer review-artifact trace tails that are not promoted here: `until`, event-name, subscriber, entity-id, delivery-status, payload/output, `-f`, subscription retry/`--no-retry`, and multi-run `--all`.

Part of #855

## Governing refs/context
- #855 Pre-Implementation Coverage Audit refresh and independent gate outcome.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.review_artifact_reconciliation.under_promoted_review_features.trace_filters_and_subscription_recovery`
  - `cli_specification.command_catalog.trace.promoted_trace_filter_contract`
  - `api_specification.method_catalog.run.trace`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` generated from the authoritative platform spec.
- Binding implementation boundary: approved first slice only for `runtime.cli.trace_filter_api_contract_under_promoted`; no CLI flag behavior, subscription recovery, payload/output, or multi-run trace changes.

## Semantic migration
- New canonical owner: `/v1/rpc run.trace` owns the promoted snapshot filter params `run_id`, `limit`, `cursor`, and `since`.
- Old producer/reader/writer path now invalid: store-level `RunDebugTraceQueryOptions.Since` is no longer an unpromoted local capability for API consumers; the API/spec owner now exposes it as `since`.
- Production paths checked for surviving old behavior: current `cmd/swarm trace` remains a base `run.trace`/`run.subscribe_trace` consumer and does not expose CLI filter flags; `swarm investigate trace` remains fail-closed; no CLI DB/store/runtime/EventBus/dashboard/Builder bypass is introduced.
- Migration completeness: complete for the chosen API/spec filter-contract slice. CLI filter flags and split richer trace tails remain future gated work under #855/#735/#794.

## Proof
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'TestOperatorObservabilityHandlersExposePersistedReadMethods|TestRegistryMethodNamesMatchGeneratedOpenRPC|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCReadOnlyRuntimeCallShapes' -count=1`
- `go test ./cmd/swarm -run 'TestTrace|TestDiagnosticTrace|TestInvestigateTrace' -count=1`
- `go test ./internal/apiv1 ./cmd/swarm -count=1`
- `git diff --check`
- Static no-bypass grep: `rg -n "internal/store|database/sql|EventBus|LoadRunDebug|QueryContext|/api/|/api/rpc|/api/ws|dashboard|Builder" cmd/swarm/diagnostics.go cmd/swarm/run_command.go` returned no matches.
