### PR TITLE
[agent-c][issue #911] Align operator entity projections

### DIFF
--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -210,11 +210,7 @@ func (h *handler) dispatchRPC(ctx context.Context, method string, params map[str
 		if err != nil {
 			return nil, internalError(err)
 		}
-		return map[string]any{
-			"entity":      legacyBuilderEntityPayload(entity),
-			"gates":       entity.Gates,
-			"accumulated": entity.Accumulated,
-		}, nil
+		return entity, nil
 	case "credentials.list":
 		if h.credentials == nil {
 			return nil, methodUnavailable("credential store is not configured")

--- a/internal/builder/handler_state.go
+++ b/internal/builder/handler_state.go
@@ -88,27 +88,6 @@ func (h *handler) runFullValidation(_ context.Context) ValidationResult {
 	return result
 }
 
-func legacyBuilderEntityPayload(full store.OperatorEntityFull) map[string]any {
-	entity := map[string]any{"state": strings.TrimSpace(full.Entity.CurrentState)}
-	for key, value := range full.Fields {
-		key = strings.TrimSpace(key)
-		if key == "" || key == "gates" {
-			continue
-		}
-		entity[key] = value
-	}
-	if full.Entity.Slug != "" {
-		entity["slug"] = full.Entity.Slug
-	}
-	if full.Entity.Name != "" {
-		entity["name"] = full.Entity.Name
-	}
-	if full.Entity.EntityType != "" {
-		entity["entity_type"] = full.Entity.EntityType
-	}
-	return entity
-}
-
 func (h *handler) legacyBuilderListEntities(ctx context.Context) ([]store.OperatorEntitySummary, error) {
 	if h == nil || h.entities == nil {
 		return nil, fmt.Errorf("entity reader is not configured")

--- a/internal/builder/handler_test.go
+++ b/internal/builder/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
@@ -16,8 +17,12 @@ import (
 const testBuilderAuthToken = "builder-test-token"
 
 type pagedEntityReader struct {
-	pages []store.OperatorEntityListResult
-	calls int
+	pages        []store.OperatorEntityListResult
+	calls        int
+	getResult    store.OperatorEntityFull
+	getErr       error
+	lastEntityID string
+	lastRunID    string
 }
 
 func (r *pagedEntityReader) ListOperatorEntities(_ context.Context, opts store.OperatorEntityListOptions) (store.OperatorEntityListResult, error) {
@@ -29,8 +34,16 @@ func (r *pagedEntityReader) ListOperatorEntities(_ context.Context, opts store.O
 	return page, nil
 }
 
-func (r *pagedEntityReader) LoadOperatorEntity(context.Context, string, string) (store.OperatorEntityFull, error) {
-	return store.OperatorEntityFull{}, store.ErrEntityNotFound
+func (r *pagedEntityReader) LoadOperatorEntity(_ context.Context, entityID, runID string) (store.OperatorEntityFull, error) {
+	r.lastEntityID = entityID
+	r.lastRunID = runID
+	if r.getErr != nil {
+		return store.OperatorEntityFull{}, r.getErr
+	}
+	if r.getResult.Entity.EntityID == "" {
+		return store.OperatorEntityFull{}, store.ErrEntityNotFound
+	}
+	return r.getResult, nil
 }
 
 func TestHandler_CredentialsListSetDelete(t *testing.T) {
@@ -142,6 +155,72 @@ func TestHandler_StateListInstancesDrainsCanonicalEntityPages(t *testing.T) {
 	}
 	if reader.calls != 2 {
 		t.Fatalf("ListOperatorEntities calls = %d, want 2", reader.calls)
+	}
+}
+
+func TestHandler_StateGetEntityReturnsCanonicalEntityFull(t *testing.T) {
+	reader := &pagedEntityReader{
+		getResult: store.OperatorEntityFull{
+			Entity: store.OperatorEntitySummary{
+				EntityID:     runtimeflowidentity.EntityID("wf-1"),
+				RunID:        "run-1",
+				FlowInstance: "order/wf-1",
+				EntityType:   "order",
+				CurrentState: "reviewing",
+				Slug:         "order-1",
+				Name:         "Order 1",
+			},
+			Fields:      map[string]any{"priority": "high"},
+			Gates:       map[string]bool{"review_gate": true},
+			Accumulated: map[string]any{"score": float64(3)},
+		},
+	}
+	handler := NewHandler(Options{
+		AuthToken: testBuilderAuthToken,
+		Entities:  reader,
+	})
+
+	resp := callBuilderRPC(t, handler, Request{
+		JSONRPC: "2.0",
+		ID:      "1",
+		Method:  "state.get_entity",
+		Params: map[string]any{
+			"instance_id": "wf-1",
+			"run_id":      "run-1",
+		},
+	})
+	full, ok := resp.Result.(store.OperatorEntityFull)
+	if !ok {
+		t.Fatalf("state.get_entity result type = %T, want OperatorEntityFull", resp.Result)
+	}
+	if reader.lastEntityID != runtimeflowidentity.EntityID("wf-1") || reader.lastRunID != "run-1" {
+		t.Fatalf("LoadOperatorEntity args = entity_id=%q run_id=%q", reader.lastEntityID, reader.lastRunID)
+	}
+	if full.Entity.CurrentState != "reviewing" || full.Fields["priority"] != "high" || !full.Gates["review_gate"] || full.Accumulated["score"] != float64(3) {
+		t.Fatalf("state.get_entity canonical result = %#v", full)
+	}
+
+	raw, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal state.get_entity result: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal state.get_entity result: %v", err)
+	}
+	if _, ok := payload["state"]; ok {
+		t.Fatalf("state.get_entity leaked legacy top-level state payload: %#v", payload)
+	}
+	entity := payload["entity"].(map[string]any)
+	if entity["current_state"] != "reviewing" {
+		t.Fatalf("entity.current_state = %#v, want reviewing", entity["current_state"])
+	}
+	if _, ok := entity["state"]; ok {
+		t.Fatalf("state.get_entity leaked legacy entity.state payload: %#v", entity)
+	}
+	fields := payload["fields"].(map[string]any)
+	if fields["priority"] != "high" {
+		t.Fatalf("fields = %#v, want priority", fields)
 	}
 }
 

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -248,6 +248,96 @@ func (s stubInstances) AggregateOperatorEntities(_ context.Context, opts store.O
 	return store.OperatorEntityAggregateResult{Counts: counts}, nil
 }
 
+func TestHandler_InstanceHandlersReturnCanonicalEntityProjection(t *testing.T) {
+	entityID := runtimeflowidentity.EntityID("wf-1")
+	lastAggregate := &store.OperatorEntityAggregateOptions{}
+	h := &Handler{
+		entities: stubInstances{
+			rows: []store.OperatorEntitySummary{{
+				EntityID:     entityID,
+				RunID:        "run-1",
+				FlowInstance: "order/wf-1",
+				EntityType:   "order",
+				CurrentState: "reviewing",
+			}},
+			byID: map[string]store.OperatorEntityFull{
+				entityID: {
+					Entity: store.OperatorEntitySummary{
+						EntityID:     entityID,
+						RunID:        "run-1",
+						FlowInstance: "order/wf-1",
+						EntityType:   "order",
+						CurrentState: "reviewing",
+					},
+					Fields:      map[string]any{"business_status": "approved"},
+					Gates:       map[string]bool{"review_gate": true},
+					Accumulated: map[string]any{"score": float64(9)},
+				},
+			},
+			lastAggregate: lastAggregate,
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/instances?current_state=reviewing&type=order&limit=1", nil)
+	h.handleInstances(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleInstances status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var listPayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listPayload); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	rows, ok := listPayload["instances"].([]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("instances payload = %#v", listPayload)
+	}
+	row := rows[0].(map[string]any)
+	if row["current_state"] != "reviewing" {
+		t.Fatalf("instances current_state = %#v, want reviewing", row["current_state"])
+	}
+	if _, ok := row["state"]; ok {
+		t.Fatalf("instances leaked legacy state field: %#v", row)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/instances/wf-1?run_id=run-1", nil)
+	req.SetPathValue("id", "wf-1")
+	h.handleInstanceDetail(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleInstanceDetail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var detail store.OperatorEntityFull
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal instance detail: %v", err)
+	}
+	if detail.Entity.CurrentState != "reviewing" || detail.Fields["business_status"] != "approved" || !detail.Gates["review_gate"] || detail.Accumulated["score"] != float64(9) {
+		t.Fatalf("detail payload = %#v", detail)
+	}
+	if _, ok := detail.Fields["status"]; ok {
+		t.Fatalf("detail leaked control status field: %#v", detail.Fields)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/instances/aggregate?group_by=current_state&type=order", nil)
+	h.handleInstanceAggregate(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleInstanceAggregate status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var aggregate map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	groups, _ := aggregate["groups"].([]any)
+	if lastAggregate.GroupBy != "current_state" || len(groups) != 1 {
+		t.Fatalf("aggregate = %#v opts=%#v, want current_state reviewing=1", aggregate, *lastAggregate)
+	}
+	group, _ := groups[0].(map[string]any)
+	if group["key"] != "reviewing" || group["count"] != float64(1) {
+		t.Fatalf("aggregate group = %#v, want reviewing=1", group)
+	}
+}
+
 type stubConversations struct {
 	list      []ConversationSummary
 	bySession map[string]ConversationDetail
@@ -3357,28 +3447,23 @@ func TestHandler_BuilderRPC(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &entityResp); err != nil {
 		t.Fatalf("unmarshal entity response: %v", err)
 	}
-	result, ok = entityResp.Result.(map[string]any)
-	if !ok {
-		t.Fatalf("unexpected entity result: %#v", entityResp.Result)
+	rawEntity, err := json.Marshal(entityResp.Result)
+	if err != nil {
+		t.Fatalf("marshal entity result: %v", err)
 	}
-	entity, ok := result["entity"].(map[string]any)
-	if !ok {
-		t.Fatalf("unexpected entity payload: %#v", result)
+	var builderEntity store.OperatorEntityFull
+	if err := json.Unmarshal(rawEntity, &builderEntity); err != nil {
+		t.Fatalf("unmarshal canonical entity result: %v", err)
 	}
-	if entity["state"] != "active" || entity["score"] != 3.7 {
-		t.Fatalf("unexpected entity payload: %#v", entity)
+	if builderEntity.Entity.CurrentState != "active" || builderEntity.Fields["score"] != float64(3.7) {
+		t.Fatalf("unexpected canonical entity payload: %#v", builderEntity)
 	}
-	gates, ok := result["gates"].(map[string]any)
-	if !ok || gates["review_gate"] != true {
-		t.Fatalf("unexpected gates payload: %#v", result["gates"])
+	if !builderEntity.Gates["review_gate"] {
+		t.Fatalf("unexpected gates payload: %#v", builderEntity.Gates)
 	}
-	accumulated, ok := result["accumulated"].(map[string]any)
-	if !ok {
-		t.Fatalf("unexpected accumulated payload: %#v", result["accumulated"])
-	}
-	accBucket, ok := accumulated["accumulator"].(map[string]any)
+	accBucket, ok := builderEntity.Accumulated["accumulator"].(map[string]any)
 	if !ok || accBucket["count"] != float64(2) {
-		t.Fatalf("unexpected accumulated payload: %#v", accumulated)
+		t.Fatalf("unexpected accumulated payload: %#v", builderEntity.Accumulated)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -745,6 +745,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t 
 	if got := strings.TrimSpace(asString(instance.Metadata["repo_url"])); got != "swarm-artifact://repos/"+initial["repo_id"].(string) {
 		t.Fatalf("repo_url = %q", got)
 	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "committed" {
+		t.Fatalf("artifact entity status = %q, want committed", got)
+	}
+	assertEntityStateField(t, db, entityID, "status", "committed")
 	ref := strings.TrimSpace(asString(instance.Metadata["current_ref"]))
 	if len(ref) != 40 {
 		t.Fatalf("current_ref length = %d ref=%q", len(ref), ref)

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -130,6 +130,7 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 	fields := mutationFieldsForEntity(t, db, entityID)
 	for _, want := range []string{
 		"current_state",
+		"status",
 		"business_status",
 		"gates.g_ready",
 		"gates.g_done",
@@ -139,9 +140,6 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		if !containsMutationField(fields, want) {
 			t.Fatalf("mutation fields missing %q: %v", want, fields)
 		}
-	}
-	if containsMutationField(fields, "status") {
-		t.Fatalf("mutation fields leaked control status as entity field: %v", fields)
 	}
 
 	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -93,7 +93,8 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "queued",
 		Metadata: map[string]any{
-			"status": "open",
+			"status":          "open",
+			"business_status": "pending",
 			"gates": map[string]any{
 				"g_ready": true,
 			},
@@ -112,7 +113,8 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "done",
 		Metadata: map[string]any{
-			"status": "closed",
+			"status":          "closed",
+			"business_status": "approved",
 			"gates": map[string]any{
 				"g_done": true,
 			},
@@ -128,7 +130,7 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 	fields := mutationFieldsForEntity(t, db, entityID)
 	for _, want := range []string{
 		"current_state",
-		"status",
+		"business_status",
 		"gates.g_ready",
 		"gates.g_done",
 		"accumulator.evidence",
@@ -137,6 +139,9 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 		if !containsMutationField(fields, want) {
 			t.Fatalf("mutation fields missing %q: %v", want, fields)
 		}
+	}
+	if containsMutationField(fields, "status") {
+		t.Fatalf("mutation fields leaked control status as entity field: %v", fields)
 	}
 
 	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -91,6 +91,76 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 	}
 }
 
+func TestExecuteNodeContractHandlerSelectEntityMatchesControlStatus(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pc, source := newSelectEntityTestCoordinator(t, db)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	budgetEntityID := seedSelectEntityBudgetWithMetadata(t, pc.workflowStore, ctx, source, "budget-1", map[string]any{
+		"vertical_id":      "vertical-1",
+		"status":           "pending",
+		"business_status":  "approved",
+		"spent_usd":        0,
+		"control_status":   "not-a-selector",
+		"domain_status_id": "status-field-regression",
+	})
+
+	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", runtimecontracts.SystemNodeEventHandler{
+		SelectEntity: &runtimecontracts.SelectEntitySpec{
+			By: map[string]string{
+				"vertical_id": "payload.vertical_id",
+				"status":      "payload.status",
+			},
+			Bindings: []runtimecontracts.SelectEntityKeyBinding{
+				{
+					Field:   "vertical_id",
+					Ref:     "payload.vertical_id",
+					RefPath: runtimecontracts.RefExpression("payload.vertical_id").RefPath,
+				},
+				{
+					Field:   "status",
+					Ref:     "payload.status",
+					RefPath: runtimecontracts.RefExpression("payload.status").RefPath,
+				},
+			},
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				SourceField: "amount_usd",
+				TargetField: "spent_usd",
+			}},
+		},
+	}, workflowTriggerContext{
+		Event: events.Event{
+			Type:    events.EventType("opco.spend_recorded"),
+			Payload: mustJSON(map[string]any{"vertical_id": "vertical-1", "status": "pending", "amount_usd": 42}),
+		}.WithEntityID("22222222-2222-2222-2222-222222222222"),
+		State: WorkflowState{},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected selected handler to run")
+	}
+
+	instance, ok, err := pc.workflowStore.Load(ctx, budgetEntityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected budget entity to exist")
+	}
+	if got := instance.Metadata["spent_usd"]; got != float64(42) && got != 42 {
+		t.Fatalf("spent_usd = %#v, want 42", got)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "pending" {
+		t.Fatalf("control status metadata = %q, want pending", got)
+	}
+	assertEntityStateFieldMissing(t, db, budgetEntityID, "status")
+}
+
 func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -846,21 +916,35 @@ func seedSelectEntityBudgetWithInstance(t *testing.T, store *WorkflowInstanceSto
 
 func seedSelectEntityBudgetWithState(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID, verticalID string, spent any, currentState string) string {
 	t.Helper()
+	return seedSelectEntityBudgetWithMetadataAndState(t, store, ctx, source, instanceID, map[string]any{
+		"vertical_id": verticalID,
+		"spent_usd":   spent,
+	}, currentState)
+}
+
+func seedSelectEntityBudgetWithMetadata(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any) string {
+	t.Helper()
+	return seedSelectEntityBudgetWithMetadataAndState(t, store, ctx, source, instanceID, metadata, "active")
+}
+
+func seedSelectEntityBudgetWithMetadataAndState(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any, currentState string) string {
+	t.Helper()
 	identity := DeriveFlowInstanceIdentity(source, "treasury", instanceID)
+	metadata = cloneStringAnyMap(metadata)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	metadata["flow_path"] = identity.InstancePath
+	metadata["instance_id"] = identity.InstanceID
+	metadata["storage_ref"] = identity.InstancePath
+	metadata["entity_type"] = "opco_budget"
 	instance := WorkflowInstance{
 		InstanceID:      identity.EntityID,
 		StorageRef:      identity.InstancePath,
 		WorkflowName:    "treasury",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    strings.TrimSpace(currentState),
-		Metadata: map[string]any{
-			"flow_path":   identity.InstancePath,
-			"instance_id": identity.InstanceID,
-			"vertical_id": verticalID,
-			"spent_usd":   spent,
-			"storage_ref": identity.InstancePath,
-			"entity_type": "opco_budget",
-		},
+		Metadata:        metadata,
 	}
 	if err := store.Upsert(ctx, instance); err != nil {
 		t.Fatalf("seed budget entity: %v", err)
@@ -883,6 +967,21 @@ func assertSelectEntityReceiptRow(t *testing.T, db *sql.DB, eventID, nodeID stri
 	}
 	if count != 1 {
 		t.Fatalf("select_entity event_receipts rows = %d, want 1", count)
+	}
+}
+
+func assertEntityStateFieldMissing(t *testing.T, db *sql.DB, entityID, field string) {
+	t.Helper()
+	var exists bool
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT fields ? $3
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, testPipelineRunID, entityID, field).Scan(&exists); err != nil {
+		t.Fatalf("load entity_state fields for %s: %v", entityID, err)
+	}
+	if exists {
+		t.Fatalf("entity_state.fields unexpectedly contains %q", field)
 	}
 }
 

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -91,7 +92,7 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 	}
 }
 
-func TestExecuteNodeContractHandlerSelectEntityMatchesControlStatus(t *testing.T) {
+func TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 
@@ -102,9 +103,8 @@ func TestExecuteNodeContractHandlerSelectEntityMatchesControlStatus(t *testing.T
 		"status":           "pending",
 		"business_status":  "approved",
 		"spent_usd":        0,
-		"control_status":   "not-a-selector",
 		"domain_status_id": "status-field-regression",
-	})
+	}, map[string]any{"status": "waiting"})
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", runtimecontracts.SystemNodeEventHandler{
 		SelectEntity: &runtimecontracts.SelectEntitySpec{
@@ -156,9 +156,10 @@ func TestExecuteNodeContractHandlerSelectEntityMatchesControlStatus(t *testing.T
 		t.Fatalf("spent_usd = %#v, want 42", got)
 	}
 	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "pending" {
-		t.Fatalf("control status metadata = %q, want pending", got)
+		t.Fatalf("typed status metadata = %q, want pending", got)
 	}
-	assertEntityStateFieldMissing(t, db, budgetEntityID, "status")
+	assertEntityStateField(t, db, budgetEntityID, "status", "pending")
+	assertFlowInstanceControlConfig(t, db, instance.StorageRef, "status", "waiting")
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(t *testing.T) {
@@ -919,21 +920,22 @@ func seedSelectEntityBudgetWithState(t *testing.T, store *WorkflowInstanceStore,
 	return seedSelectEntityBudgetWithMetadataAndState(t, store, ctx, source, instanceID, map[string]any{
 		"vertical_id": verticalID,
 		"spent_usd":   spent,
-	}, currentState)
+	}, nil, currentState)
 }
 
-func seedSelectEntityBudgetWithMetadata(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any) string {
+func seedSelectEntityBudgetWithMetadata(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any, config map[string]any) string {
 	t.Helper()
-	return seedSelectEntityBudgetWithMetadataAndState(t, store, ctx, source, instanceID, metadata, "active")
+	return seedSelectEntityBudgetWithMetadataAndState(t, store, ctx, source, instanceID, metadata, config, "active")
 }
 
-func seedSelectEntityBudgetWithMetadataAndState(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any, currentState string) string {
+func seedSelectEntityBudgetWithMetadataAndState(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, source semanticview.Source, instanceID string, metadata map[string]any, config map[string]any, currentState string) string {
 	t.Helper()
 	identity := DeriveFlowInstanceIdentity(source, "treasury", instanceID)
 	metadata = cloneStringAnyMap(metadata)
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
+	config = cloneStringAnyMap(config)
 	metadata["flow_path"] = identity.InstancePath
 	metadata["instance_id"] = identity.InstanceID
 	metadata["storage_ref"] = identity.InstancePath
@@ -944,6 +946,7 @@ func seedSelectEntityBudgetWithMetadataAndState(t *testing.T, store *WorkflowIns
 		WorkflowName:    "treasury",
 		WorkflowVersion: "1.0.0",
 		CurrentState:    strings.TrimSpace(currentState),
+		Config:          config,
 		Metadata:        metadata,
 	}
 	if err := store.Upsert(ctx, instance); err != nil {
@@ -970,18 +973,41 @@ func assertSelectEntityReceiptRow(t *testing.T, db *sql.DB, eventID, nodeID stri
 	}
 }
 
-func assertEntityStateFieldMissing(t *testing.T, db *sql.DB, entityID, field string) {
+func assertEntityStateField(t *testing.T, db *sql.DB, entityID, field string, want any) {
 	t.Helper()
-	var exists bool
+	var gotRaw []byte
 	if err := db.QueryRowContext(context.Background(), `
-		SELECT fields ? $3
+		SELECT fields -> $3
 		FROM entity_state
 		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, testPipelineRunID, entityID, field).Scan(&exists); err != nil {
+	`, testPipelineRunID, entityID, field).Scan(&gotRaw); err != nil {
 		t.Fatalf("load entity_state fields for %s: %v", entityID, err)
 	}
-	if exists {
-		t.Fatalf("entity_state.fields unexpectedly contains %q", field)
+	wantRaw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal wanted entity_state field %s: %v", field, err)
+	}
+	if string(gotRaw) != string(wantRaw) {
+		t.Fatalf("entity_state.fields[%q] = %s, want %s", field, gotRaw, wantRaw)
+	}
+}
+
+func assertFlowInstanceControlConfig(t *testing.T, db *sql.DB, storageRef, field string, want any) {
+	t.Helper()
+	var gotRaw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT config -> $2
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, storageRef, field).Scan(&gotRaw); err != nil {
+		t.Fatalf("load flow_instances config for %s: %v", storageRef, err)
+	}
+	wantRaw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal wanted flow instance config %s: %v", field, err)
+	}
+	if string(gotRaw) != string(wantRaw) {
+		t.Fatalf("flow_instances.config[%q] = %s, want %s", field, gotRaw, wantRaw)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -467,6 +467,13 @@ func (s *WorkflowInstanceStore) selectActiveByFieldsSpec(ctx context.Context, sc
 		if err != nil {
 			return nil, fmt.Errorf("marshal workflow instance selector %s: %w", selector.Field, err)
 		}
+		if workflowInstanceControlStatusSelector(segments) {
+			args = append(args, string(valueJSON))
+			where.WriteString(fmt.Sprintf(`
+		  AND COALESCE(fi.config, '{}'::jsonb) #> '{status}' = $%d::jsonb
+		`, len(args)))
+			continue
+		}
 		args = append(args, pq.Array(segments), string(valueJSON))
 		where.WriteString(fmt.Sprintf(`
 		  AND es.fields #> $%d::text[] = $%d::jsonb
@@ -632,6 +639,10 @@ func workflowInstanceFieldSelectorPath(field string) []string {
 		out = append(out, part)
 	}
 	return out
+}
+
+func workflowInstanceControlStatusSelector(segments []string) bool {
+	return len(segments) == 1 && segments[0] == "status"
 }
 
 func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRef string, instance WorkflowInstance) error {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -467,13 +467,6 @@ func (s *WorkflowInstanceStore) selectActiveByFieldsSpec(ctx context.Context, sc
 		if err != nil {
 			return nil, fmt.Errorf("marshal workflow instance selector %s: %w", selector.Field, err)
 		}
-		if workflowInstanceControlStatusSelector(segments) {
-			args = append(args, string(valueJSON))
-			where.WriteString(fmt.Sprintf(`
-		  AND COALESCE(fi.config, '{}'::jsonb) #> '{status}' = $%d::jsonb
-		`, len(args)))
-			continue
-		}
 		args = append(args, pq.Array(segments), string(valueJSON))
 		where.WriteString(fmt.Sprintf(`
 		  AND es.fields #> $%d::text[] = $%d::jsonb
@@ -639,10 +632,6 @@ func workflowInstanceFieldSelectorPath(field string) []string {
 		out = append(out, part)
 	}
 	return out
-}
-
-func workflowInstanceControlStatusSelector(segments []string) bool {
-	return len(segments) == 1 && segments[0] == "status"
 }
 
 func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRef string, instance WorkflowInstance) error {
@@ -1026,7 +1015,7 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 		InstanceKind:      strings.TrimSpace(asString(instance.Metadata["instance_kind"])),
 		TemplateVersion:   strings.TrimSpace(asString(instance.Metadata["template_version"])),
 		LastSourceEvent:   strings.TrimSpace(asString(instance.Metadata["last_source_event"])),
-		Status:            strings.TrimSpace(asString(instance.Metadata["status"])),
+		Status:            strings.TrimSpace(asString(instance.Config["status"])),
 		ParentEntityID:    strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
 		TransitionHistory: append([]WorkflowTransitionRecord{}, instance.TransitionHistory...),
 	}
@@ -1036,7 +1025,7 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 	for _, key := range []string{
 		"slug", "name", "entity_type", "parent_entity_id",
 		"instance_id", "storage_ref", "flow_path", "instance_kind",
-		"template_version", "workflow_version", "transition_history", "status",
+		"template_version", "workflow_version", "transition_history",
 	} {
 		delete(metadata, key)
 	}
@@ -1083,9 +1072,6 @@ func (p workflowInstancePersistedProjection) Metadata() map[string]any {
 	}
 	if strings.TrimSpace(p.Control.LastSourceEvent) != "" {
 		metadata["last_source_event"] = strings.TrimSpace(p.Control.LastSourceEvent)
-	}
-	if strings.TrimSpace(p.Control.Status) != "" {
-		metadata["status"] = strings.TrimSpace(p.Control.Status)
 	}
 	if strings.TrimSpace(p.Control.ParentEntityID) != "" {
 		metadata["parent_entity_id"] = strings.TrimSpace(p.Control.ParentEntityID)
@@ -1223,7 +1209,6 @@ func decodeWorkflowInstanceConfigPayload(raw []byte, control workflowInstancePer
 	delete(config, "instance_kind")
 	delete(config, "template_version")
 	delete(config, "last_source_event")
-	delete(config, "status")
 	delete(config, "parent_entity_id")
 	delete(config, "transition_history")
 	control.InstanceID = strings.TrimSpace(instanceID)

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -1025,7 +1025,7 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 	for _, key := range []string{
 		"slug", "name", "entity_type", "parent_entity_id",
 		"instance_id", "storage_ref", "flow_path", "instance_kind",
-		"template_version", "workflow_version", "transition_history",
+		"template_version", "workflow_version", "transition_history", "status",
 	} {
 		delete(metadata, key)
 	}

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -130,6 +130,74 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	}
 }
 
+func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	workflowStore := NewWorkflowInstanceStore(db)
+	storageRef := uuid.NewString()
+	ctx := testWorkflowStoreRunContext(t, workflowStore)
+	instance := WorkflowInstance{
+		InstanceID:      "inst-1",
+		StorageRef:      storageRef,
+		WorkflowName:    "projection-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "reviewing",
+		EnteredStageAt:  time.Now().UTC().Round(time.Microsecond),
+		Metadata: map[string]any{
+			"status":          "waiting",
+			"business_status": "approved",
+			"entity_type":     "workflow_subject",
+			"slug":            "projection",
+			"name":            "Projection Flow",
+		},
+		StateBuckets: map[string]any{
+			"score": float64(9),
+		},
+	}
+
+	if err := workflowStore.Upsert(ctx, instance); err != nil {
+		t.Fatalf("upsert workflow instance: %v", err)
+	}
+
+	loaded, ok, err := workflowStore.Load(ctx, storageRef)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	if got := loaded.CurrentState; got != "reviewing" {
+		t.Fatalf("CurrentState = %q, want reviewing", got)
+	}
+	if got := strings.TrimSpace(asString(loaded.Metadata["status"])); got != "waiting" {
+		t.Fatalf("Metadata status = %#v, want waiting", loaded.Metadata["status"])
+	}
+
+	var currentState string
+	var fieldsRaw []byte
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_state, fields
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, testPipelineRunID, workflowInstanceRowID(storageRef)).Scan(&currentState, &fieldsRaw); err != nil {
+		t.Fatalf("query entity_state projection: %v", err)
+	}
+	if got := strings.TrimSpace(currentState); got != "reviewing" {
+		t.Fatalf("entity_state.current_state = %q, want reviewing", got)
+	}
+	fields, err := decodeWorkflowInstanceJSONMap("entity_state.fields", fieldsRaw)
+	if err != nil {
+		t.Fatalf("decode entity_state.fields: %v", err)
+	}
+	if _, ok := fields["status"]; ok {
+		t.Fatalf("entity_state.fields leaked control status: %#v", fields)
+	}
+	if got := fields["business_status"]; got != "approved" {
+		t.Fatalf("entity_state.fields business_status = %#v, want approved", got)
+	}
+}
+
 func TestWorkflowInstanceStoreProjection_StaticRowsDoNotGainMaterializedFlowPathOnRoundTrip(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -144,12 +144,14 @@ func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField
 		WorkflowVersion: "1.0.0",
 		CurrentState:    "reviewing",
 		EnteredStageAt:  time.Now().UTC().Round(time.Microsecond),
+		Config: map[string]any{
+			"status": "waiting",
+		},
 		Metadata: map[string]any{
-			"status":          "waiting",
-			"business_status": "approved",
-			"entity_type":     "workflow_subject",
-			"slug":            "projection",
-			"name":            "Projection Flow",
+			"status":      "entity-open",
+			"entity_type": "workflow_subject",
+			"slug":        "projection",
+			"name":        "Projection Flow",
 		},
 		StateBuckets: map[string]any{
 			"score": float64(9),
@@ -170,17 +172,19 @@ func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField
 	if got := loaded.CurrentState; got != "reviewing" {
 		t.Fatalf("CurrentState = %q, want reviewing", got)
 	}
-	if got := strings.TrimSpace(asString(loaded.Metadata["status"])); got != "waiting" {
-		t.Fatalf("Metadata status = %#v, want waiting", loaded.Metadata["status"])
+	if got := strings.TrimSpace(asString(loaded.Metadata["status"])); got != "entity-open" {
+		t.Fatalf("Metadata status = %#v, want entity-open", loaded.Metadata["status"])
 	}
 
 	var currentState string
 	var fieldsRaw []byte
+	var controlStatus string
 	if err := db.QueryRowContext(ctx, `
-		SELECT current_state, fields
-		FROM entity_state
-		WHERE run_id = $1::uuid AND entity_id = $2::uuid
-	`, testPipelineRunID, workflowInstanceRowID(storageRef)).Scan(&currentState, &fieldsRaw); err != nil {
+		SELECT es.current_state, es.fields, COALESCE(fi.config->>'status', '')
+		FROM entity_state es
+		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = $1::uuid AND es.entity_id = $2::uuid
+	`, testPipelineRunID, workflowInstanceRowID(storageRef)).Scan(&currentState, &fieldsRaw, &controlStatus); err != nil {
 		t.Fatalf("query entity_state projection: %v", err)
 	}
 	if got := strings.TrimSpace(currentState); got != "reviewing" {
@@ -190,11 +194,11 @@ func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField
 	if err != nil {
 		t.Fatalf("decode entity_state.fields: %v", err)
 	}
-	if _, ok := fields["status"]; ok {
-		t.Fatalf("entity_state.fields leaked control status: %#v", fields)
+	if got := fields["status"]; got != "entity-open" {
+		t.Fatalf("entity_state.fields status = %#v, want entity-open", got)
 	}
-	if got := fields["business_status"]; got != "approved" {
-		t.Fatalf("entity_state.fields business_status = %#v, want approved", got)
+	if got := controlStatus; got != "waiting" {
+		t.Fatalf("flow_instances.config status = %q, want waiting", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #911
Part of #101

- Returns Builder direct-dispatch `state.get_entity` as the canonical entity-native `OperatorEntityFull` shape instead of the flat legacy `entity.state` projection.
- Separates workflow-control `status` from typed entity `fields.status`: control status is sourced from explicit workflow config, while declared/entity-owned `status` remains in `EntityFull.fields` and selector fields.
- Adds parity proof for Builder direct dispatch, dashboard direct handlers, runtime materialization, selector semantics, artifact-repo typed status, mutation logging, and existing v1/store entity read owners.

## Governing Refs / Context

Exact binding spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EntitySummary`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.EntityFull`
- `api_specification.method_catalog.entity.list`
- `api_specification.method_catalog.entity.get`
- `api_specification.method_catalog.entity.aggregate`
- legacy transport/operator API disposition mapping `state.list_instances -> entity.list`, `state.get_entity -> entity.get`, `GET /api/instances -> entity.list`, and `GET /api/instances/{id} -> entity.get`

Approved gate boundary: #911 independent gate approved this as a first slice covering Builder detail projection drift plus `status`/`current_state` materialization drift, while keeping legacy route reachability/retirement split and fail-closed.

## Semantic Migration

Canonical owner after this PR:

- Entity read shape: `store.OperatorEntitySummary` / `store.OperatorEntityFull`, consumed by `ListOperatorEntities`, `LoadOperatorEntity`, and `AggregateOperatorEntities`.
- Typed entity fields: `entity_state.fields`, including legitimate contract-visible `fields.status`.
- Workflow-control status: explicit workflow config status handled by `workflowInstancePersistedProjectionFromInstance` / `flow_instances.config`, not by global deletion of `Metadata["status"]`.

Old non-authoritative paths now invalid:

- `legacyBuilderEntityPayload` flat projection has been removed.
- Builder direct `state.get_entity` no longer emits `entity.state` or flattens typed fields into the `entity` object.
- Workflow-control status no longer overwrites typed entity status in `Metadata()` / `EntityFull.fields`.

Production paths checked for surviving old behavior:

- Builder legacy HTTP routes remain fail-closed.
- Dashboard legacy REST aliases remain fail-closed through `NewHandler`.
- Dashboard direct handlers consume the store entity owner.
- v1 `entity.list`, `entity.get`, and `entity.aggregate` continue to consume the store owner.
- `select_entity.by.status` continues to target typed entity fields, per spec boundary.

Migration completeness: complete for the approved #911 child class. The broader #101 operator-surface watchpoint remains open.

## Tests

- `go test ./internal/runtime/pipeline -run 'TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField|TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField|TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLog|TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef' -count=1`
- `go test ./internal/runtime/pipeline`
- `go test ./internal/builder -run 'TestHandler_LegacyRoutesFailClosed|TestHandler_StateListInstancesDrainsCanonicalEntityPages|TestHandler_StateGetEntityReturnsCanonicalEntityFull' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_InstanceHandlersReturnCanonicalEntityProjection|TestHandler_LegacyDashboardRoutesFailClosedWithoutAuthBoundary|TestHandler_HealthzOnlyKeepsProcessProbeAndRetiresAliases' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEntityHandlersExposeEntityNativeReads|TestOperatorEntityHandlersServeContractEntityTypesFromPostgres' -count=1`
- `go test ./internal/store -run 'TestOperatorEntityReadOwnerListGetAggregateAndCursor' -count=1`