### PR TITLE
[agent-f][issue #913] Promote agent.diagnose watchdog evidence

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -14,7 +14,7 @@
   "methods": [
     {
       "name": "agent.diagnose",
-      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly. It must not join\nconversation, run, trace, token, CLI, or dashboard owners locally, and\nit must not expose runtime_state, run_id, bundle_version, active\ntask/entity, watchdog, last tool outcome, token usage, recent failures,\nor dead letters.\n",
+      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner. It must not join conversation,\nrun, trace, token, CLI, or dashboard owners locally, and it must not\nexpose the full runtime_state enum, top-level watchdog, run_id,\nbundle_version, active task/entity, last tool outcome, token usage,\nrecent failures, or dead letters.\n",
       "params": [
         {
           "name": "agent_id",
@@ -5379,6 +5379,9 @@
           "queue": {
             "$ref": "#/components/schemas/AgentDiagnosisQueue"
           },
+          "runtime_state": {
+            "$ref": "#/components/schemas/AgentDiagnosisRuntimeState"
+          },
           "status": {
             "$ref": "#/components/schemas/AgentStatus"
           }
@@ -5415,6 +5418,67 @@
           "pending_count",
           "oldest_pending_age_seconds",
           "pending_deliveries"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosisRuntimeState": {
+        "additionalProperties": false,
+        "description": "Narrow runtime-state container for agent.diagnose watchdog evidence.\nThe diagnosis owner reads the most-recent active agent_sessions row\nfor session/session_per_entity modes using the same active-session\nselector as LoadOperatorAgentDiagnosis, ordered by updated_at DESC then\ncreated_at DESC then session_id ASC. It ignores inactive or terminated rows, omits\nruntime_state when there is no active live session or no watchdog\nevidence, and fails closed on malformed runtime_state.watchdog data.\nMultiple active sessions use that same deterministic current-session\nselector; this schema does not promote a broader agent runtime_state\nenum.\n",
+        "properties": {
+          "watchdog": {
+            "$ref": "#/components/schemas/AgentDiagnosisWatchdog"
+          }
+        },
+        "required": [
+          "watchdog"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosisWatchdog": {
+        "additionalProperties": false,
+        "description": "Watchdog-backed runtime evidence for agent.diagnose. This object is\nthe public projection of agent_sessions.runtime_state.watchdog after\nDecodeConversationRuntimeStateDescriptor validation; it is not the\nfull #852 agent runtime_state enum and must not be derived from queue,\ndelivery lifecycle, dashboard state, active task, last tool, token,\nfailure, dead-letter, restart, or broad session lifecycle heuristics.\n",
+        "properties": {
+          "action": {
+            "enum": [
+              "turn_long_running",
+              "session_no_output"
+            ],
+            "type": "string"
+          },
+          "blocking_layer": {
+            "enum": [
+              "session_execution"
+            ],
+            "type": "string"
+          },
+          "last_output_at": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "Required when state is healthy_long_running; omitted when no output has been observed."
+          },
+          "outcome": {
+            "enum": [
+              "observed",
+              "warning_emitted"
+            ],
+            "type": "string"
+          },
+          "recorded_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "state": {
+            "enum": [
+              "healthy_long_running",
+              "no_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "state",
+          "blocking_layer",
+          "action",
+          "outcome",
+          "recorded_at"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8686,6 +8686,66 @@ api_specification:
           blocking_layer:
             type: string
             minLength: 1
+      AgentDiagnosisWatchdog:
+        type: object
+        additionalProperties: false
+        description: |
+          Watchdog-backed runtime evidence for agent.diagnose. This object is
+          the public projection of agent_sessions.runtime_state.watchdog after
+          DecodeConversationRuntimeStateDescriptor validation; it is not the
+          full #852 agent runtime_state enum and must not be derived from queue,
+          delivery lifecycle, dashboard state, active task, last tool, token,
+          failure, dead-letter, restart, or broad session lifecycle heuristics.
+        required:
+        - state
+        - blocking_layer
+        - action
+        - outcome
+        - recorded_at
+        properties:
+          state:
+            type: string
+            enum:
+            - healthy_long_running
+            - no_output
+          blocking_layer:
+            type: string
+            enum:
+            - session_execution
+          action:
+            type: string
+            enum:
+            - turn_long_running
+            - session_no_output
+          outcome:
+            type: string
+            enum:
+            - observed
+            - warning_emitted
+          last_output_at:
+            $ref: '#/components/schemas/Timestamp'
+            description: Required when state is healthy_long_running; omitted when no output has been observed.
+          recorded_at:
+            $ref: '#/components/schemas/Timestamp'
+      AgentDiagnosisRuntimeState:
+        type: object
+        additionalProperties: false
+        description: |
+          Narrow runtime-state container for agent.diagnose watchdog evidence.
+          The diagnosis owner reads the most-recent active agent_sessions row
+          for session/session_per_entity modes using the same active-session
+          selector as LoadOperatorAgentDiagnosis, ordered by updated_at DESC then
+          created_at DESC then session_id ASC. It ignores inactive or terminated rows, omits
+          runtime_state when there is no active live session or no watchdog
+          evidence, and fails closed on malformed runtime_state.watchdog data.
+          Multiple active sessions use that same deterministic current-session
+          selector; this schema does not promote a broader agent runtime_state
+          enum.
+        required:
+        - watchdog
+        properties:
+          watchdog:
+            $ref: '#/components/schemas/AgentDiagnosisWatchdog'
       AgentDiagnosis:
         type: object
         additionalProperties: false
@@ -8706,6 +8766,8 @@ api_specification:
             $ref: '#/components/schemas/AgentDiagnosisQueue'
           delivery_lifecycle:
             $ref: '#/components/schemas/AgentDeliveryLifecycle'
+          runtime_state:
+            $ref: '#/components/schemas/AgentDiagnosisRuntimeState'
       ConversationSummary:
         type: object
         additionalProperties: false
@@ -10543,17 +10605,22 @@ api_specification:
         Read the owner-backed diagnosis slice for one agent. This method is
         limited to agent identity/status refs, current/last conversation refs,
         pending-delivery queue summary/detail evidence, and optional delivery
-        lifecycle evidence. Queue details are paged with queue_limit and
+        lifecycle evidence. It may also return runtime_state.watchdog as a
+        narrow projection of the canonical active session watchdog descriptor.
+        runtime_state.watchdog is omitted when no active live session or no
+        active-session watchdog evidence exists, and malformed watchdog data
+        fails closed. Queue details are paged with queue_limit and
         queue_cursor, ordered by events.created_at ASC then events.event_id ASC.
         AgentPendingDelivery.enqueued_at uses the same timestamp owner as
         oldest_pending_age_seconds. AgentPendingDelivery.attempts is the
         canonical recorded retry counter from event_deliveries.retry_count, with
         no API-layer +1 or status arithmetic. The API handler consumes the
-        canonical agent diagnosis read owner directly. It must not join
-        conversation, run, trace, token, CLI, or dashboard owners locally, and
-        it must not expose runtime_state, run_id, bundle_version, active
-        task/entity, watchdog, last tool outcome, token usage, recent failures,
-        or dead letters.
+        canonical agent diagnosis read owner directly, including its
+        watchdog-backed runtime_state sub-owner. It must not join conversation,
+        run, trace, token, CLI, or dashboard owners locally, and it must not
+        expose the full runtime_state enum, top-level watchdog, run_id,
+        bundle_version, active task/entity, last tool outcome, token usage,
+        recent failures, or dead letters.
       scope:
         required:
         - read:agents

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 64 {
-		t.Fatalf("schema count = %d, want 64", report.SchemaCount)
+	if report.SchemaCount != 66 {
+		t.Fatalf("schema count = %d, want 66", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -68,8 +68,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 64 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 64", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 66 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 66", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -93,6 +93,27 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := doc.Components.Schemas["AgentPendingDelivery"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentPendingDelivery")
+	}
+	if _, ok := doc.Components.Schemas["AgentDiagnosisRuntimeState"]; !ok {
+		t.Fatal("generated OpenRPC missing AgentDiagnosisRuntimeState")
+	}
+	if _, ok := doc.Components.Schemas["AgentDiagnosisWatchdog"]; !ok {
+		t.Fatal("generated OpenRPC missing AgentDiagnosisWatchdog")
+	}
+	agentDiagnosisSchema, ok := doc.Components.Schemas["AgentDiagnosis"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated AgentDiagnosis schema = %#v, want object", doc.Components.Schemas["AgentDiagnosis"])
+	}
+	agentDiagnosisProperties, ok := agentDiagnosisSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated AgentDiagnosis properties = %#v, want object", agentDiagnosisSchema["properties"])
+	}
+	runtimeStateSchema, ok := agentDiagnosisProperties["runtime_state"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated AgentDiagnosis.runtime_state = %#v, want object", agentDiagnosisProperties["runtime_state"])
+	}
+	if got, want := runtimeStateSchema["$ref"], "#/components/schemas/AgentDiagnosisRuntimeState"; got != want {
+		t.Fatalf("generated AgentDiagnosis.runtime_state ref = %#v, want %q", got, want)
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -264,7 +264,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 
 func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 	return map[string]readOnlyHTTPRuntimeFixture{
-		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue"}},
+		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
@@ -537,6 +537,15 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 					State:         "active",
 					BlockingLayer: "session_execution",
 				},
+				RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
+					Watchdog: &store.OperatorAgentDiagnosisWatchdog{
+						State:         "no_output",
+						BlockingLayer: "session_execution",
+						Action:        "session_no_output",
+						Outcome:       "warning_emitted",
+						RecordedAt:    "2026-05-21T10:01:00Z",
+					},
+				},
 			},
 			listConversationsResult: store.OperatorConversationListResult{Conversations: []store.OperatorConversationSummary{{
 				SessionID:    sessionID,
@@ -675,7 +684,15 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		if delivery := asMap(t, deliveries[0]); delivery["event_id"] != "event-1" || delivery["event_name"] != "task.ready" || delivery["attempts"] != float64(1) {
 			t.Fatalf("agent.diagnose pending delivery = %#v", deliveries[0])
 		}
-		for _, splitField := range []string{"runtime_state", "bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+		runtimeState := asMap(t, result["runtime_state"])
+		watchdog := asMap(t, runtimeState["watchdog"])
+		if watchdog["state"] != "no_output" || watchdog["blocking_layer"] != "session_execution" || watchdog["action"] != "session_no_output" || watchdog["outcome"] != "warning_emitted" {
+			t.Fatalf("agent.diagnose runtime_state.watchdog = %#v", watchdog)
+		}
+		if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
+			t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
+		}
+		for _, splitField := range []string{"bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 			if _, ok := result[splitField]; ok {
 				t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, result)
 			}

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -126,6 +126,15 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 				State:         "active",
 				BlockingLayer: "session_execution",
 			},
+			RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
+				Watchdog: &store.OperatorAgentDiagnosisWatchdog{
+					State:         "no_output",
+					BlockingLayer: "session_execution",
+					Action:        "session_no_output",
+					Outcome:       "warning_emitted",
+					RecordedAt:    "2026-05-21T10:01:00Z",
+				},
+			},
 		},
 		listConversationsResult: store.OperatorConversationListResult{
 			Conversations: []store.OperatorConversationSummary{{
@@ -227,7 +236,15 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if lifecycle["state"] != "active" || lifecycle["blocking_layer"] != "session_execution" {
 		t.Fatalf("agent.diagnose lifecycle = %#v", lifecycle)
 	}
-	for _, splitField := range []string{"runtime_state", "bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+	runtimeState := asMap(t, diagnosis["runtime_state"])
+	watchdog := asMap(t, runtimeState["watchdog"])
+	if watchdog["state"] != "no_output" || watchdog["blocking_layer"] != "session_execution" || watchdog["action"] != "session_no_output" || watchdog["outcome"] != "warning_emitted" {
+		t.Fatalf("agent.diagnose runtime_state.watchdog = %#v", watchdog)
+	}
+	if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
+		t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
+	}
+	for _, splitField := range []string{"bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 		if _, ok := diagnosis[splitField]; ok {
 			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
 		}
@@ -531,6 +548,45 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData(t *testing.T) {
 	}
 	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.diagnose owner returned malformed result") {
 		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
+	}
+}
+
+func TestOperatorAgentDiagnoseFailsClosedOnMalformedWatchdogOwnerData(t *testing.T) {
+	reads := &fakeAgentConversationReadStore{
+		agentDiagnosisResult: store.OperatorAgentDiagnosis{
+			AgentID: "agent-1",
+			Status:  "running",
+			Queue: store.OperatorAgentDiagnosisQueue{
+				PendingDeliveries: []store.OperatorAgentPendingDelivery{},
+			},
+			RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
+				Watchdog: &store.OperatorAgentDiagnosisWatchdog{
+					State:         "healthy_long_running",
+					BlockingLayer: "session_execution",
+					Action:        "turn_long_running",
+					Outcome:       "observed",
+					RecordedAt:    "2026-05-21T10:01:00Z",
+				},
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.diagnose returned success for malformed watchdog owner result")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	errorText := fmt.Sprint(resp.Error.Message, resp.Error.Data)
+	if !strings.Contains(errorText, "agent.diagnose owner returned malformed result") || !strings.Contains(errorText, "runtime_state.watchdog") {
+		t.Fatalf("error = %#v, want malformed runtime_state.watchdog owner result", resp.Error)
 	}
 }
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -484,6 +484,30 @@ func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
 			return fmt.Errorf("agent.diagnose owner returned malformed result: delivery_lifecycle.blocking_layer is required")
 		}
 	}
+	if err := validateAgentDiagnosisRuntimeStateResult(item.RuntimeState); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAgentDiagnosisRuntimeStateResult(item *store.OperatorAgentDiagnosisRuntimeState) error {
+	if item == nil {
+		return nil
+	}
+	if item.Watchdog == nil {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: runtime_state.watchdog is required")
+	}
+	watchdog := store.ConversationRuntimeWatchdogDescriptor{
+		State:         strings.TrimSpace(item.Watchdog.State),
+		BlockingLayer: strings.TrimSpace(item.Watchdog.BlockingLayer),
+		Action:        strings.TrimSpace(item.Watchdog.Action),
+		Outcome:       strings.TrimSpace(item.Watchdog.Outcome),
+		LastOutputAt:  strings.TrimSpace(item.Watchdog.LastOutputAt),
+		RecordedAt:    strings.TrimSpace(item.Watchdog.RecordedAt),
+	}
+	if err := store.ValidateConversationRuntimeWatchdogDescriptor(watchdog); err != nil {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: runtime_state.watchdog is invalid: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/conversation_runtime_state.go
+++ b/internal/store/conversation_runtime_state.go
@@ -52,31 +52,31 @@ func DecodeConversationRuntimeStateDescriptor(raw []byte) (ConversationRuntimeSt
 		payload.Watchdog.Outcome = strings.TrimSpace(payload.Watchdog.Outcome)
 		payload.Watchdog.LastOutputAt = strings.TrimSpace(payload.Watchdog.LastOutputAt)
 		payload.Watchdog.RecordedAt = strings.TrimSpace(payload.Watchdog.RecordedAt)
-		if err := validateConversationRuntimeWatchdogDescriptor(*payload.Watchdog); err != nil {
+		if err := ValidateConversationRuntimeWatchdogDescriptor(*payload.Watchdog); err != nil {
 			return ConversationRuntimeStateDescriptor{}, err
 		}
 	}
 	return payload, nil
 }
 
-func validateConversationRuntimeWatchdogDescriptor(payload ConversationRuntimeWatchdogDescriptor) error {
+func ValidateConversationRuntimeWatchdogDescriptor(payload ConversationRuntimeWatchdogDescriptor) error {
 	switch payload.State {
-	case "", "healthy_long_running", "no_output":
+	case "healthy_long_running", "no_output":
 	default:
 		return fmt.Errorf("canonical runtime_state watchdog.state %q is invalid", payload.State)
 	}
 	switch payload.BlockingLayer {
-	case "", "session_execution":
+	case "session_execution":
 	default:
 		return fmt.Errorf("canonical runtime_state watchdog.blocking_layer %q is invalid", payload.BlockingLayer)
 	}
 	switch payload.Action {
-	case "", "turn_long_running", "session_no_output":
+	case "turn_long_running", "session_no_output":
 	default:
 		return fmt.Errorf("canonical runtime_state watchdog.action %q is invalid", payload.Action)
 	}
 	switch payload.Outcome {
-	case "", "observed", "warning_emitted":
+	case "observed", "warning_emitted":
 	default:
 		return fmt.Errorf("canonical runtime_state watchdog.outcome %q is invalid", payload.Outcome)
 	}

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -805,13 +805,17 @@ func marshalConversationRuntimeStatePatch(summary *string, watchdog *runtimellm.
 		payload["summary"] = *summary
 	}
 	if watchdog != nil {
+		descriptor := conversationRuntimeWatchdogDescriptorFromRuntime(watchdog)
+		if err := ValidateConversationRuntimeWatchdogDescriptor(descriptor); err != nil {
+			return "", err
+		}
 		payload["watchdog"] = map[string]any{
-			"state":          strings.TrimSpace(watchdog.State),
-			"blocking_layer": strings.TrimSpace(watchdog.BlockingLayer),
-			"action":         strings.TrimSpace(watchdog.Action),
-			"outcome":        strings.TrimSpace(watchdog.Outcome),
-			"last_output_at": strings.TrimSpace(watchdog.LastOutputAt),
-			"recorded_at":    strings.TrimSpace(watchdog.RecordedAt),
+			"state":          descriptor.State,
+			"blocking_layer": descriptor.BlockingLayer,
+			"action":         descriptor.Action,
+			"outcome":        descriptor.Outcome,
+			"last_output_at": descriptor.LastOutputAt,
+			"recorded_at":    descriptor.RecordedAt,
 		}
 	}
 	raw, err := json.Marshal(payload)
@@ -819,6 +823,20 @@ func marshalConversationRuntimeStatePatch(summary *string, watchdog *runtimellm.
 		return "", err
 	}
 	return string(raw), nil
+}
+
+func conversationRuntimeWatchdogDescriptorFromRuntime(watchdog *runtimellm.ConversationWatchdog) ConversationRuntimeWatchdogDescriptor {
+	if watchdog == nil {
+		return ConversationRuntimeWatchdogDescriptor{}
+	}
+	return ConversationRuntimeWatchdogDescriptor{
+		State:         strings.TrimSpace(watchdog.State),
+		BlockingLayer: strings.TrimSpace(watchdog.BlockingLayer),
+		Action:        strings.TrimSpace(watchdog.Action),
+		Outcome:       strings.TrimSpace(watchdog.Outcome),
+		LastOutputAt:  strings.TrimSpace(watchdog.LastOutputAt),
+		RecordedAt:    strings.TrimSpace(watchdog.RecordedAt),
+	}
 }
 
 func (s *PostgresStore) LoadActiveConversation(ctx context.Context, agentID, mode, sessionScope, scopeKey string) (runtimellm.ConversationRecord, bool, error) {

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -69,40 +69,41 @@ type OperatorAgentSummary struct {
 	SessionScope     string `json:"session_scope"`
 	Status           string `json:"status"`
 
-	Mode                string              `json:"-"`
-	FlowInstance        string              `json:"-"`
-	EntityID            string              `json:"-"`
-	ParentAgentID       string              `json:"-"`
-	CoordinatorID       string              `json:"-"`
-	HiredBy             string              `json:"-"`
-	TemplateVersion     string              `json:"-"`
-	BudgetEnvelope      float64             `json:"-"`
-	Subscriptions       []string            `json:"-"`
-	Permissions         []string            `json:"-"`
-	PendingEvents       int                 `json:"-"`
-	OldestPendingAgeSec int                 `json:"-"`
-	InFlightTurn        bool                `json:"-"`
-	InFlightSeconds     int                 `json:"-"`
-	LockOwner           string              `json:"-"`
-	LockExpiresAt       time.Time           `json:"-"`
-	Failures24h         int                 `json:"-"`
-	DeadLetters24h      int                 `json:"-"`
-	TurnCount           int                 `json:"-"`
-	TurnLimit           int                 `json:"-"`
-	Turns24h            int                 `json:"-"`
-	NearBreaker         bool                `json:"-"`
-	SessionID           string              `json:"-"`
-	ProviderSessionID   string              `json:"-"`
-	CurrentTaskID       string              `json:"-"`
-	LastTool            *OperatorAgentTool  `json:"-"`
-	LiveTurn            *OperatorLiveTurn   `json:"-"`
-	StartedAt           time.Time           `json:"-"`
-	DashboardStatus     string              `json:"-"`
-	DashboardState      string              `json:"-"`
-	DeliveryLifecycle   string              `json:"-"`
-	BlockingLayer       string              `json:"-"`
-	CurrentSessionRef   *OperatorSessionRef `json:"-"`
-	LastTurnRef         *OperatorTurnRef    `json:"-"`
+	Mode                  string                              `json:"-"`
+	FlowInstance          string                              `json:"-"`
+	EntityID              string                              `json:"-"`
+	ParentAgentID         string                              `json:"-"`
+	CoordinatorID         string                              `json:"-"`
+	HiredBy               string                              `json:"-"`
+	TemplateVersion       string                              `json:"-"`
+	BudgetEnvelope        float64                             `json:"-"`
+	Subscriptions         []string                            `json:"-"`
+	Permissions           []string                            `json:"-"`
+	PendingEvents         int                                 `json:"-"`
+	OldestPendingAgeSec   int                                 `json:"-"`
+	InFlightTurn          bool                                `json:"-"`
+	InFlightSeconds       int                                 `json:"-"`
+	LockOwner             string                              `json:"-"`
+	LockExpiresAt         time.Time                           `json:"-"`
+	Failures24h           int                                 `json:"-"`
+	DeadLetters24h        int                                 `json:"-"`
+	TurnCount             int                                 `json:"-"`
+	TurnLimit             int                                 `json:"-"`
+	Turns24h              int                                 `json:"-"`
+	NearBreaker           bool                                `json:"-"`
+	SessionID             string                              `json:"-"`
+	ProviderSessionID     string                              `json:"-"`
+	CurrentTaskID         string                              `json:"-"`
+	LastTool              *OperatorAgentTool                  `json:"-"`
+	LiveTurn              *OperatorLiveTurn                   `json:"-"`
+	StartedAt             time.Time                           `json:"-"`
+	DashboardStatus       string                              `json:"-"`
+	DashboardState        string                              `json:"-"`
+	DeliveryLifecycle     string                              `json:"-"`
+	BlockingLayer         string                              `json:"-"`
+	CurrentSessionRef     *OperatorSessionRef                 `json:"-"`
+	LastTurnRef           *OperatorTurnRef                    `json:"-"`
+	DiagnosisRuntimeState *OperatorAgentDiagnosisRuntimeState `json:"-"`
 }
 
 type OperatorSessionRef struct {
@@ -124,12 +125,26 @@ type OperatorAgentDetail struct {
 }
 
 type OperatorAgentDiagnosis struct {
-	AgentID           string                          `json:"agent_id"`
-	Status            string                          `json:"status"`
-	CurrentSessionRef *OperatorSessionRef             `json:"current_session_ref,omitempty"`
-	LastTurnRef       *OperatorTurnRef                `json:"last_turn_ref,omitempty"`
-	Queue             OperatorAgentDiagnosisQueue     `json:"queue"`
-	DeliveryLifecycle *OperatorAgentDeliveryLifecycle `json:"delivery_lifecycle,omitempty"`
+	AgentID           string                              `json:"agent_id"`
+	Status            string                              `json:"status"`
+	CurrentSessionRef *OperatorSessionRef                 `json:"current_session_ref,omitempty"`
+	LastTurnRef       *OperatorTurnRef                    `json:"last_turn_ref,omitempty"`
+	Queue             OperatorAgentDiagnosisQueue         `json:"queue"`
+	DeliveryLifecycle *OperatorAgentDeliveryLifecycle     `json:"delivery_lifecycle,omitempty"`
+	RuntimeState      *OperatorAgentDiagnosisRuntimeState `json:"runtime_state,omitempty"`
+}
+
+type OperatorAgentDiagnosisRuntimeState struct {
+	Watchdog *OperatorAgentDiagnosisWatchdog `json:"watchdog"`
+}
+
+type OperatorAgentDiagnosisWatchdog struct {
+	State         string `json:"state"`
+	BlockingLayer string `json:"blocking_layer"`
+	Action        string `json:"action"`
+	Outcome       string `json:"outcome"`
+	LastOutputAt  string `json:"last_output_at,omitempty"`
+	RecordedAt    string `json:"recorded_at"`
 }
 
 type OperatorAgentDiagnosisQueue struct {
@@ -430,6 +445,7 @@ type operatorAgentProjection struct {
 	LastTool            *OperatorAgentTool
 	LiveTurn            *OperatorLiveTurn
 	LastTurnRef         *OperatorTurnRef
+	Watchdog            *OperatorConversationWatchdog
 }
 
 type conversationPositionCursor struct {
@@ -1081,7 +1097,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			WHERE agent_id = a.agent_id
 			  AND status = 'active'
 			  AND runtime_mode IN ($1, $2)
-			ORDER BY updated_at DESC, created_at DESC
+			ORDER BY updated_at DESC, created_at DESC, session_id ASC
 			LIMIT 1
 		) sess ON true
 		LEFT JOIN LATERAL (
@@ -1215,46 +1231,47 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		scope = runtimesessions.SessionScopeGlobal.String()
 	}
 	out := OperatorAgentSummary{
-		AgentID:             strings.TrimSpace(row.Config.ID),
-		Role:                strings.TrimSpace(row.Config.Role),
-		Type:                agentPersistedType(row.Config, agentModelTier(row.Config)),
-		ModelTier:           agentModelTier(row.Config),
-		ConversationMode:    mode,
-		SessionScope:        scope,
-		Status:              projection.v1Status(),
-		Mode:                strings.TrimSpace(row.Config.Mode),
-		FlowInstance:        strings.TrimSpace(row.Config.CanonicalFlowPath()),
-		EntityID:            strings.TrimSpace(row.Config.EffectiveEntityID()),
-		ParentAgentID:       strings.TrimSpace(row.ParentAgentID),
-		CoordinatorID:       strings.TrimSpace(row.CoordinatorID),
-		HiredBy:             strings.TrimSpace(row.HiredBy),
-		TemplateVersion:     strings.TrimSpace(row.TemplateVersion),
-		BudgetEnvelope:      row.Config.BudgetEnvelope,
-		Subscriptions:       append([]string(nil), row.Config.Subscriptions...),
-		Permissions:         append([]string(nil), row.Config.Permissions...),
-		PendingEvents:       projection.PendingEvents,
-		OldestPendingAgeSec: projection.OldestPendingAgeSec,
-		InFlightTurn:        projection.InFlightTurn,
-		InFlightSeconds:     projection.InFlightSeconds,
-		LockOwner:           strings.TrimSpace(projection.LockOwner),
-		LockExpiresAt:       projection.LockExpiresAt,
-		Failures24h:         projection.Failures24h,
-		DeadLetters24h:      projection.DeadLetters24h,
-		TurnCount:           projection.TurnCount,
-		TurnLimit:           maxStoreInt(turnLimit, 0),
-		Turns24h:            maxStoreInt(projection.Turns24h, 0),
-		SessionID:           strings.TrimSpace(projection.SessionID),
-		ProviderSessionID:   strings.TrimSpace(projection.ProviderSessionID),
-		CurrentTaskID:       strings.TrimSpace(projection.CurrentTaskID),
-		LastTool:            projection.LastTool,
-		LiveTurn:            projection.LiveTurn,
-		StartedAt:           row.StartedAt,
-		DashboardStatus:     strings.TrimSpace(projection.Status),
-		DashboardState:      projection.dashboardState(),
-		DeliveryLifecycle:   strings.TrimSpace(projection.LifecycleState),
-		BlockingLayer:       projection.dashboardBlockingLayer(),
-		CurrentSessionRef:   projection.currentSessionRef(),
-		LastTurnRef:         projection.LastTurnRef,
+		AgentID:               strings.TrimSpace(row.Config.ID),
+		Role:                  strings.TrimSpace(row.Config.Role),
+		Type:                  agentPersistedType(row.Config, agentModelTier(row.Config)),
+		ModelTier:             agentModelTier(row.Config),
+		ConversationMode:      mode,
+		SessionScope:          scope,
+		Status:                projection.v1Status(),
+		Mode:                  strings.TrimSpace(row.Config.Mode),
+		FlowInstance:          strings.TrimSpace(row.Config.CanonicalFlowPath()),
+		EntityID:              strings.TrimSpace(row.Config.EffectiveEntityID()),
+		ParentAgentID:         strings.TrimSpace(row.ParentAgentID),
+		CoordinatorID:         strings.TrimSpace(row.CoordinatorID),
+		HiredBy:               strings.TrimSpace(row.HiredBy),
+		TemplateVersion:       strings.TrimSpace(row.TemplateVersion),
+		BudgetEnvelope:        row.Config.BudgetEnvelope,
+		Subscriptions:         append([]string(nil), row.Config.Subscriptions...),
+		Permissions:           append([]string(nil), row.Config.Permissions...),
+		PendingEvents:         projection.PendingEvents,
+		OldestPendingAgeSec:   projection.OldestPendingAgeSec,
+		InFlightTurn:          projection.InFlightTurn,
+		InFlightSeconds:       projection.InFlightSeconds,
+		LockOwner:             strings.TrimSpace(projection.LockOwner),
+		LockExpiresAt:         projection.LockExpiresAt,
+		Failures24h:           projection.Failures24h,
+		DeadLetters24h:        projection.DeadLetters24h,
+		TurnCount:             projection.TurnCount,
+		TurnLimit:             maxStoreInt(turnLimit, 0),
+		Turns24h:              maxStoreInt(projection.Turns24h, 0),
+		SessionID:             strings.TrimSpace(projection.SessionID),
+		ProviderSessionID:     strings.TrimSpace(projection.ProviderSessionID),
+		CurrentTaskID:         strings.TrimSpace(projection.CurrentTaskID),
+		LastTool:              projection.LastTool,
+		LiveTurn:              projection.LiveTurn,
+		StartedAt:             row.StartedAt,
+		DashboardStatus:       strings.TrimSpace(projection.Status),
+		DashboardState:        projection.dashboardState(),
+		DeliveryLifecycle:     strings.TrimSpace(projection.LifecycleState),
+		BlockingLayer:         projection.dashboardBlockingLayer(),
+		CurrentSessionRef:     projection.currentSessionRef(),
+		LastTurnRef:           projection.LastTurnRef,
+		DiagnosisRuntimeState: operatorAgentDiagnosisRuntimeStateFromConversationWatchdog(projection.Watchdog),
 	}
 	if out.TurnLimit > 0 {
 		out.NearBreaker = out.TurnCount*100 >= out.TurnLimit*85
@@ -1274,6 +1291,7 @@ func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgent
 			OldestPendingAgeSeconds: agent.OldestPendingAgeSec,
 			PendingDeliveries:       []OperatorAgentPendingDelivery{},
 		},
+		RuntimeState: agent.DiagnosisRuntimeState,
 	}
 	if state := strings.TrimSpace(agent.DeliveryLifecycle); state != "" {
 		out.DeliveryLifecycle = &OperatorAgentDeliveryLifecycle{
@@ -1342,6 +1360,22 @@ func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
 		if strings.TrimSpace(item.DeliveryLifecycle.BlockingLayer) == "" {
 			return fmt.Errorf("agent diagnosis delivery_lifecycle.blocking_layer is required")
 		}
+	}
+	if err := validateOperatorAgentDiagnosisRuntimeState(item.RuntimeState); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateOperatorAgentDiagnosisRuntimeState(item *OperatorAgentDiagnosisRuntimeState) error {
+	if item == nil {
+		return nil
+	}
+	if item.Watchdog == nil {
+		return fmt.Errorf("agent diagnosis runtime_state.watchdog is required")
+	}
+	if err := ValidateConversationRuntimeWatchdogDescriptor(conversationWatchdogDescriptorFromAgentDiagnosis(*item.Watchdog)); err != nil {
+		return fmt.Errorf("agent diagnosis runtime_state.watchdog is invalid: %w", err)
 	}
 	return nil
 }
@@ -1423,6 +1457,7 @@ func enrichOperatorAgentProjectionFromLatestTurn(projection *operatorAgentProjec
 		return fmt.Errorf("decode latest agent session runtime_state: %w", err)
 	}
 	projection.ProviderSessionID = strings.TrimSpace(runtimeState.ProviderSessionID)
+	projection.Watchdog = operatorConversationWatchdogFromDescriptor(runtimeState.Watchdog)
 	projection.LiveTurn, err = projectOperatorLatestTurn(taskID, parseOK, turnID, turnBlocksRaw)
 	if err != nil {
 		return fmt.Errorf("decode latest agent turn live_turn: %w", err)
@@ -1926,16 +1961,7 @@ func projectOperatorConversationSummaryMetadata(p ConversationRuntimeStateDescri
 		RetryReason:          p.RetryReason,
 		RetriesFromSessionID: p.RetriesFromSessionID,
 	}
-	if p.Watchdog != nil {
-		meta.Watchdog = &OperatorConversationWatchdog{
-			State:         p.Watchdog.State,
-			BlockingLayer: p.Watchdog.BlockingLayer,
-			Action:        p.Watchdog.Action,
-			Outcome:       p.Watchdog.Outcome,
-			LastOutputAt:  p.Watchdog.LastOutputAt,
-			RecordedAt:    p.Watchdog.RecordedAt,
-		}
-	}
+	meta.Watchdog = operatorConversationWatchdogFromDescriptor(p.Watchdog)
 	return meta
 }
 
@@ -1949,17 +1975,49 @@ func projectOperatorConversationState(p ConversationRuntimeStateDescriptor) Oper
 	if p.LastTurn != nil {
 		state.LastTurn = &OperatorConversationLastTurn{TaskID: p.LastTurn.TaskID, ParseOK: p.LastTurn.ParseOK}
 	}
-	if p.Watchdog != nil {
-		state.Watchdog = &OperatorConversationWatchdog{
-			State:         p.Watchdog.State,
-			BlockingLayer: p.Watchdog.BlockingLayer,
-			Action:        p.Watchdog.Action,
-			Outcome:       p.Watchdog.Outcome,
-			LastOutputAt:  p.Watchdog.LastOutputAt,
-			RecordedAt:    p.Watchdog.RecordedAt,
-		}
-	}
+	state.Watchdog = operatorConversationWatchdogFromDescriptor(p.Watchdog)
 	return state
+}
+
+func operatorConversationWatchdogFromDescriptor(p *ConversationRuntimeWatchdogDescriptor) *OperatorConversationWatchdog {
+	if p == nil {
+		return nil
+	}
+	return &OperatorConversationWatchdog{
+		State:         p.State,
+		BlockingLayer: p.BlockingLayer,
+		Action:        p.Action,
+		Outcome:       p.Outcome,
+		LastOutputAt:  p.LastOutputAt,
+		RecordedAt:    p.RecordedAt,
+	}
+}
+
+func operatorAgentDiagnosisRuntimeStateFromConversationWatchdog(w *OperatorConversationWatchdog) *OperatorAgentDiagnosisRuntimeState {
+	if w == nil {
+		return nil
+	}
+	return &OperatorAgentDiagnosisRuntimeState{
+		Watchdog: &OperatorAgentDiagnosisWatchdog{
+			State:         strings.TrimSpace(w.State),
+			BlockingLayer: strings.TrimSpace(w.BlockingLayer),
+			Action:        strings.TrimSpace(w.Action),
+			Outcome:       strings.TrimSpace(w.Outcome),
+			LastOutputAt:  strings.TrimSpace(w.LastOutputAt),
+			RecordedAt:    strings.TrimSpace(w.RecordedAt),
+		},
+	}
+}
+
+func conversationWatchdogDescriptorFromAgentDiagnosis(w OperatorAgentDiagnosisWatchdog) ConversationRuntimeWatchdogDescriptor {
+	return ConversationRuntimeWatchdogDescriptor{
+		State:         strings.TrimSpace(w.State),
+		BlockingLayer: strings.TrimSpace(w.BlockingLayer),
+		Action:        strings.TrimSpace(w.Action),
+		Outcome:       strings.TrimSpace(w.Outcome),
+		LastOutputAt:  strings.TrimSpace(w.LastOutputAt),
+		RecordedAt:    strings.TrimSpace(w.RecordedAt),
+	}
 }
 
 func projectOperatorLatestTurn(taskID string, parseOK bool, turnID string, turnBlocksRaw []byte) (*OperatorLiveTurn, error) {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -293,7 +293,7 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
 	}, 0)
 
-	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
 			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", false, "model error", turnCompletedAt, []byte(`[]`)))
@@ -328,6 +328,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	sessionStartedAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
 	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
 	eventTime := time.Date(2026, 5, 12, 8, 55, 0, 0, time.UTC)
+	runtimeState := []byte(`{"provider_session_id":"provider-sess-1","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-05-12T09:04:00Z","recorded_at":"2026-05-12T09:05:00Z"}}`)
 	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
 		caps:   canonicalAgentConversationReadCaps(),
 		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
@@ -352,10 +353,10 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 		},
 	}, 0)
 
-	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
@@ -385,6 +386,16 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	if diagnosis.DeliveryLifecycle == nil || diagnosis.DeliveryLifecycle.State != "active" || diagnosis.DeliveryLifecycle.BlockingLayer != "session_execution" {
 		t.Fatalf("delivery_lifecycle = %#v", diagnosis.DeliveryLifecycle)
 	}
+	if diagnosis.RuntimeState == nil || diagnosis.RuntimeState.Watchdog == nil {
+		t.Fatalf("runtime_state.watchdog = %#v", diagnosis.RuntimeState)
+	}
+	watchdog := diagnosis.RuntimeState.Watchdog
+	if watchdog.State != "healthy_long_running" || watchdog.BlockingLayer != "session_execution" || watchdog.Action != "turn_long_running" || watchdog.Outcome != "observed" {
+		t.Fatalf("runtime_state.watchdog = %#v", watchdog)
+	}
+	if watchdog.LastOutputAt != "2026-05-12T09:04:00Z" || watchdog.RecordedAt != "2026-05-12T09:05:00Z" {
+		t.Fatalf("runtime_state.watchdog timestamps = %#v", watchdog)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
@@ -402,7 +413,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
 	}, 0)
 
-	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
 			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
@@ -419,6 +430,35 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	}
 	if diagnosis.DeliveryLifecycle != nil {
 		t.Fatalf("delivery_lifecycle = %#v, want nil", diagnosis.DeliveryLifecycle)
+	}
+	if diagnosis.RuntimeState != nil {
+		t.Fatalf("runtime_state = %#v, want nil without active watchdog evidence", diagnosis.RuntimeState)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedRuntimeState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if err == nil || !strings.Contains(err.Error(), "decode latest agent session runtime_state") || !strings.Contains(err.Error(), "watchdog.state") {
+		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want runtime_state watchdog validation failure", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3720,6 +3720,41 @@ func TestManagerStore_UpdateLiveSessionWatchdog_RoundTripsThroughLoadActiveConve
 	}
 }
 
+func TestManagerStore_UpdateLiveSessionWatchdogRejectsMalformedWrite(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+	sessionID := acquireLiveTestSession(t, ctx, db, "a1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "global")
+
+	err := pg.UpdateLiveSessionWatchdog(ctx, runtimellm.ConversationWatchdogUpdate{
+		SessionID:    sessionID,
+		AgentID:      "a1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Watchdog: &runtimellm.ConversationWatchdog{
+			State:         "healthy_long_running",
+			BlockingLayer: "session_execution",
+			Action:        "turn_long_running",
+			Outcome:       "observed",
+			RecordedAt:    "2026-04-10T12:00:30Z",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "watchdog.last_output_at") {
+		t.Fatalf("UpdateLiveSessionWatchdog err = %v, want watchdog.last_output_at validation", err)
+	}
+
+	rec, ok, err := pg.LoadActiveConversation(ctx, "a1", "session", "global", "global")
+	if err != nil || !ok {
+		t.Fatalf("LoadActiveConversation ok=%v err=%v", ok, err)
+	}
+	if rec.Watchdog != nil {
+		t.Fatalf("malformed watchdog write poisoned runtime_state: %+v", rec.Watchdog)
+	}
+}
+
 func TestManagerStore_UpdateLiveSessionWatchdog_PreservesCanonicalSummary(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary

Promotes the #913 watchdog-backed `agent.diagnose` runtime-state slice into tracked merge-bearing API artifacts and implementation.

- Adds `AgentDiagnosisRuntimeState` and `AgentDiagnosisWatchdog` to `platform-spec.yaml` and regenerates `openrpc.json`.
- Wires `LoadOperatorAgentDiagnosis` to project `runtime_state.watchdog` from the canonical active session `agent_sessions.runtime_state.watchdog` evidence.
- Reuses the canonical conversation runtime-state watchdog validation and adds API fail-closed owner-result validation.
- Preserves the approved split siblings: full runtime-state enum, top-level watchdog, `agent.get` / `agent.list`, queue detail, delivery lifecycle, conversation APIs, CLI, dashboard, active task/entity, last tool outcome, token usage, failures, and dead letters.

Closes #913
Part of #852

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.agent.diagnose`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.components.schemas.AgentDiagnosis`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.components.schemas.AgentDiagnosisRuntimeState`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.components.schemas.AgentDiagnosisWatchdog`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apispec` generated artifact checks
- `internal/apiv1` `agent.diagnose` handler validation
- `internal/store` `LoadOperatorAgentDiagnosis`, `DecodeConversationRuntimeStateDescriptor`, `ValidateConversationRuntimeWatchdogDescriptor`, and active session diagnosis projection
- #913 pre-audit and independent gate outcome
- #891/#897 and #901/#906 proof audits for prior diagnosis and queue-detail slices

## Semantic Migration

New canonical owner for this child:

- Public contract: tracked `platform-spec.yaml` plus generated `openrpc.json`.
- Diagnosis read owner: `LoadOperatorAgentDiagnosis` / `OperatorAgentDiagnosis.RuntimeState`.
- Watchdog evidence and validation: `agent_sessions.runtime_state.watchdog` decoded through `DecodeConversationRuntimeStateDescriptor` and `ValidateConversationRuntimeWatchdogDescriptor`.

Old invalid paths:

- API handler-local conversation/dashboard/runtime joins are non-authoritative for `agent.diagnose`.
- Top-level `watchdog` remains invalid for `agent.diagnose`.
- Full #852 `runtime_state: idle|working|blocked|restarting|stopped` remains unpromoted and split.
- Delivery lifecycle, queue detail, active task/entity, last tool outcome, token usage, failures, and dead letters remain separate owners.

Production paths checked for surviving old behavior:

- `internal/apiv1` handler still consumes only `LoadOperatorAgentDiagnosis`; no local runtime-state assembly added.
- `agent.get` / `agent.list` remain without diagnosis-only fields.
- Conversation/dashboard projections remain consumers of conversation/session watchdog evidence, not `agent.diagnose` authority.
- Queue detail and delivery lifecycle behavior are unchanged.

Migration complete for the approved #913 watchdog-backed `agent.diagnose` runtime-state child only. Parent #852 remains open.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1`
- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentDiagnosis|TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs|TestOperatorConversationReadSurfaceCurrentForAgent'`
- `go test ./internal/store`
- `git diff --check`