### PR TITLE
[agent-e][issue #915] Gate rpc.discover non-publication policy

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -9615,6 +9615,22 @@ api_specification:
     - generated openrpc.json MUST omit method examples while status is deferred
     - compliance matrix examples rows MUST use policy_deferred proof status
     - future authored or generated examples require a promoted api_specification source model and gate
+  service_discovery_policy:
+    status: not_published
+    owner: api_specification.service_discovery_policy
+    applies_to: generated_v1_method_catalog
+    rpc_discover: omitted
+    publication_artifact: generated_openrpc_json
+    runtime_behavior: out_of_catalog_method_not_found
+    reason: >
+      The v1 API publishes its method catalog through generated openrpc.json.
+      rpc.discover is intentionally not part of the v1 method catalog unless a
+      future gate promotes it as an explicit method with runtime behavior and
+      schema proof.
+    requirements:
+    - generated openrpc.json MUST omit rpc.discover while status is not_published
+    - compliance matrix service_discovery_publication rows MUST use policy_not_published proof status
+    - future rpc.discover publication requires api_specification method_catalog promotion and supported-surface runtime proof
   method_catalog_metadata:
     description: "All v1 methods. Each method declares: tier, description, scope.required,\nparams (array of contentDescriptors),\
       \ result (contentDescriptor), errors\n(array of error codes from components.errors). Mutating methods include\nidempotency.\

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,10 +65,6 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
-  - id: 857
-    title: Track residual v1 OpenRPC runtime/schema/example gaps after proof-ref integrity
-    maps_to:
-      - v1_openrpc_api_conformance
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -173,7 +169,7 @@ nodes:
       - generated full successful-result schema validation can be absent even when runtime probes only key-smoke result payloads
       - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
       - OpenRPC method examples can lack a merge-bearing authoring or deferral policy across the generated method catalog
-      - rpc.discover publication status is not explicitly tracked
+      - rpc.discover/service-discovery non-publication is owned by api_specification.service_discovery_policy and enforced by internal/apispec plus the compliance matrix
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
       - 835
@@ -185,6 +181,7 @@ nodes:
       - 890
       - 898
       - 904
+      - 915
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,6 +65,10 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
+  - id: 857
+    title: Track residual v1 OpenRPC runtime/schema/example gaps after proof-ref integrity
+    maps_to:
+      - v1_openrpc_api_conformance
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -170,6 +174,7 @@ nodes:
       - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
       - OpenRPC method examples can lack a merge-bearing authoring or deferral policy across the generated method catalog
       - rpc.discover/service-discovery non-publication is owned by api_specification.service_discovery_policy and enforced by internal/apispec plus the compliance matrix
+      - EntityFull.accumulated deep schema hardening remains tracked under #857 after #896
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
       - 835

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -21,6 +21,13 @@ const (
 	ExamplesPolicyAppliesToAllGenerated      = "all_generated_methods"
 	ExamplesPolicyOpenRPCExamplesOmitted     = "omitted_until_explicitly_authored"
 	ExamplesPolicyRuntimeFixturesNotExamples = "not_examples_source"
+
+	ServiceDiscoveryPolicyStatusNotPublished            = "not_published"
+	ServiceDiscoveryPolicyOwner                         = "api_specification.service_discovery_policy"
+	ServiceDiscoveryPolicyAppliesToGeneratedCatalog     = "generated_v1_method_catalog"
+	ServiceDiscoveryPolicyRPCDiscoverOmitted            = "omitted"
+	ServiceDiscoveryPolicyPublicationArtifactOpenRPC    = "generated_openrpc_json"
+	ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound = "out_of_catalog_method_not_found"
 )
 
 type PlatformSpec struct {
@@ -28,12 +35,13 @@ type PlatformSpec struct {
 }
 
 type APISpecification struct {
-	Description           string            `yaml:"description" json:"description,omitempty"`
-	Components            Components        `yaml:"components" json:"components"`
-	ExamplesPolicy        ExamplesPolicy    `yaml:"examples_policy" json:"examples_policy,omitempty"`
-	MethodCatalogMetadata map[string]any    `yaml:"method_catalog_metadata" json:"method_catalog_metadata,omitempty"`
-	MethodCatalog         map[string]Method `yaml:"method_catalog" json:"method_catalog"`
-	Conventions           Conventions       `yaml:"conventions" json:"conventions"`
+	Description            string                 `yaml:"description" json:"description,omitempty"`
+	Components             Components             `yaml:"components" json:"components"`
+	ExamplesPolicy         ExamplesPolicy         `yaml:"examples_policy" json:"examples_policy,omitempty"`
+	ServiceDiscoveryPolicy ServiceDiscoveryPolicy `yaml:"service_discovery_policy" json:"service_discovery_policy,omitempty"`
+	MethodCatalogMetadata  map[string]any         `yaml:"method_catalog_metadata" json:"method_catalog_metadata,omitempty"`
+	MethodCatalog          map[string]Method      `yaml:"method_catalog" json:"method_catalog"`
+	Conventions            Conventions            `yaml:"conventions" json:"conventions"`
 }
 
 type ExamplesPolicy struct {
@@ -45,6 +53,17 @@ type ExamplesPolicy struct {
 	Reason                    string   `yaml:"reason" json:"reason,omitempty"`
 	Requirements              []string `yaml:"requirements" json:"requirements,omitempty"`
 	FutureSourceModelRequired bool     `yaml:"future_source_model_required" json:"future_source_model_required,omitempty"`
+}
+
+type ServiceDiscoveryPolicy struct {
+	Status              string   `yaml:"status" json:"status,omitempty"`
+	Owner               string   `yaml:"owner" json:"owner,omitempty"`
+	AppliesTo           string   `yaml:"applies_to" json:"applies_to,omitempty"`
+	RPCDiscover         string   `yaml:"rpc_discover" json:"rpc_discover,omitempty"`
+	PublicationArtifact string   `yaml:"publication_artifact" json:"publication_artifact,omitempty"`
+	RuntimeBehavior     string   `yaml:"runtime_behavior" json:"runtime_behavior,omitempty"`
+	Reason              string   `yaml:"reason" json:"reason,omitempty"`
+	Requirements        []string `yaml:"requirements" json:"requirements,omitempty"`
 }
 
 type Components struct {
@@ -188,6 +207,12 @@ func Validate(api *APISpecification) (ValidationReport, error) {
 		problems = append(problems, "components.errors.description must be metadata, not an error code")
 	}
 	problems = append(problems, validateExamplesPolicy(api.ExamplesPolicy)...)
+	problems = append(problems, validateServiceDiscoveryPolicy(api.ServiceDiscoveryPolicy)...)
+	if api.ServiceDiscoveryPolicy.Status == ServiceDiscoveryPolicyStatusNotPublished {
+		if _, ok := api.MethodCatalog["rpc.discover"]; ok {
+			problems = append(problems, "method_catalog must not include rpc.discover while api_specification.service_discovery_policy.status is not_published")
+		}
+	}
 
 	scopeCatalog := stringSet(api.Conventions.Scopes.Catalog)
 	mutatingCatalog := stringSet(api.Conventions.Idempotency.MutatingMethods)
@@ -294,6 +319,42 @@ func validateExamplesPolicy(policy ExamplesPolicy) []string {
 	}
 	if !policy.FutureSourceModelRequired {
 		problems = append(problems, "api_specification.examples_policy.future_source_model_required must be true")
+	}
+	return problems
+}
+
+func validateServiceDiscoveryPolicy(policy ServiceDiscoveryPolicy) []string {
+	var problems []string
+	if strings.TrimSpace(policy.Status) == "" {
+		problems = append(problems, "api_specification.service_discovery_policy missing status")
+	} else if policy.Status != ServiceDiscoveryPolicyStatusNotPublished {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.status = %q, want %q", policy.Status, ServiceDiscoveryPolicyStatusNotPublished))
+	}
+	if policy.Owner != ServiceDiscoveryPolicyOwner {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.owner = %q, want %q", policy.Owner, ServiceDiscoveryPolicyOwner))
+	}
+	if policy.AppliesTo != ServiceDiscoveryPolicyAppliesToGeneratedCatalog {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.applies_to = %q, want %q", policy.AppliesTo, ServiceDiscoveryPolicyAppliesToGeneratedCatalog))
+	}
+	if policy.RPCDiscover != ServiceDiscoveryPolicyRPCDiscoverOmitted {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.rpc_discover = %q, want %q", policy.RPCDiscover, ServiceDiscoveryPolicyRPCDiscoverOmitted))
+	}
+	if policy.PublicationArtifact != ServiceDiscoveryPolicyPublicationArtifactOpenRPC {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.publication_artifact = %q, want %q", policy.PublicationArtifact, ServiceDiscoveryPolicyPublicationArtifactOpenRPC))
+	}
+	if policy.RuntimeBehavior != ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound {
+		problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.runtime_behavior = %q, want %q", policy.RuntimeBehavior, ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound))
+	}
+	if strings.TrimSpace(policy.Reason) == "" {
+		problems = append(problems, "api_specification.service_discovery_policy missing reason")
+	}
+	if len(policy.Requirements) == 0 {
+		problems = append(problems, "api_specification.service_discovery_policy must list enforcement requirements")
+	}
+	for i, requirement := range policy.Requirements {
+		if strings.TrimSpace(requirement) == "" {
+			problems = append(problems, fmt.Sprintf("api_specification.service_discovery_policy.requirements[%d] is empty", i))
+		}
 	}
 	return problems
 }

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -44,6 +44,7 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 		t.Fatal("components.errors.description must not be a concrete error code")
 	}
 	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
+	assertServiceDiscoveryPolicyNotPublished(t, api.ServiceDiscoveryPolicy)
 }
 
 func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
@@ -75,6 +76,7 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
+	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
 	methods := map[string]OpenRPCMethod{}
 	for _, method := range doc.Methods {
 		methods[method.Name] = method
@@ -150,6 +152,45 @@ func TestValidateRejectsUnsupportedExamplesPolicy(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMissingServiceDiscoveryPolicy(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	api.ServiceDiscoveryPolicy = ServiceDiscoveryPolicy{}
+
+	_, err := Validate(api)
+	if err == nil {
+		t.Fatal("Validate() error = nil, want service_discovery_policy rejection")
+	}
+	if got, want := err.Error(), "api_specification.service_discovery_policy missing status"; !strings.Contains(got, want) {
+		t.Fatalf("Validate() error = %q, want substring %q", got, want)
+	}
+}
+
+func TestValidateRejectsUnsupportedServiceDiscoveryPolicy(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	api.ServiceDiscoveryPolicy.Status = "published"
+
+	_, err := Validate(api)
+	if err == nil {
+		t.Fatal("Validate() error = nil, want unsupported service_discovery_policy status rejection")
+	}
+	if got, want := err.Error(), `api_specification.service_discovery_policy.status = "published", want "not_published"`; !strings.Contains(got, want) {
+		t.Fatalf("Validate() error = %q, want substring %q", got, want)
+	}
+}
+
+func TestValidateRejectsRPCDiscoverUnderNonPublicationPolicy(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	api.MethodCatalog["rpc.discover"] = api.MethodCatalog["rpc.unsubscribe"]
+
+	_, err := Validate(api)
+	if err == nil {
+		t.Fatal("Validate() error = nil, want rpc.discover non-publication rejection")
+	}
+	if got, want := err.Error(), "method_catalog must not include rpc.discover while api_specification.service_discovery_policy.status is not_published"; !strings.Contains(got, want) {
+		t.Fatalf("Validate() error = %q, want substring %q", got, want)
+	}
+}
+
 func notificationSchemaRef(t *testing.T, methodName string, schema any) string {
 	t.Helper()
 	schemaMap, ok := schema.(map[string]any)
@@ -191,6 +232,34 @@ func assertExamplesPolicyDeferred(t *testing.T, policy ExamplesPolicy) {
 	}
 }
 
+func assertServiceDiscoveryPolicyNotPublished(t *testing.T, policy ServiceDiscoveryPolicy) {
+	t.Helper()
+	if policy.Status != ServiceDiscoveryPolicyStatusNotPublished {
+		t.Fatalf("service_discovery_policy.status = %q, want %q", policy.Status, ServiceDiscoveryPolicyStatusNotPublished)
+	}
+	if policy.Owner != ServiceDiscoveryPolicyOwner {
+		t.Fatalf("service_discovery_policy.owner = %q, want %q", policy.Owner, ServiceDiscoveryPolicyOwner)
+	}
+	if policy.AppliesTo != ServiceDiscoveryPolicyAppliesToGeneratedCatalog {
+		t.Fatalf("service_discovery_policy.applies_to = %q, want %q", policy.AppliesTo, ServiceDiscoveryPolicyAppliesToGeneratedCatalog)
+	}
+	if policy.RPCDiscover != ServiceDiscoveryPolicyRPCDiscoverOmitted {
+		t.Fatalf("service_discovery_policy.rpc_discover = %q, want %q", policy.RPCDiscover, ServiceDiscoveryPolicyRPCDiscoverOmitted)
+	}
+	if policy.PublicationArtifact != ServiceDiscoveryPolicyPublicationArtifactOpenRPC {
+		t.Fatalf("service_discovery_policy.publication_artifact = %q, want %q", policy.PublicationArtifact, ServiceDiscoveryPolicyPublicationArtifactOpenRPC)
+	}
+	if policy.RuntimeBehavior != ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound {
+		t.Fatalf("service_discovery_policy.runtime_behavior = %q, want %q", policy.RuntimeBehavior, ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound)
+	}
+	if strings.TrimSpace(policy.Reason) == "" {
+		t.Fatal("service_discovery_policy.reason must explain rpc.discover non-publication")
+	}
+	if len(policy.Requirements) == 0 {
+		t.Fatal("service_discovery_policy.requirements must list enforcement requirements")
+	}
+}
+
 func assertGeneratedMethodsOmitExamplesUnderPolicy(t *testing.T, api *APISpecification, artifact []byte) {
 	t.Helper()
 	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
@@ -211,6 +280,19 @@ func assertGeneratedMethodsOmitExamplesUnderPolicy(t *testing.T, api *APISpecifi
 		}
 		if rawJSONHasContent(method["example"]) {
 			t.Fatalf("%s publishes OpenRPC example while examples_policy is deferred", name)
+		}
+	}
+}
+
+func assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t *testing.T, api *APISpecification, doc OpenRPCDocument) {
+	t.Helper()
+	assertServiceDiscoveryPolicyNotPublished(t, api.ServiceDiscoveryPolicy)
+	if _, ok := api.MethodCatalog["rpc.discover"]; ok {
+		t.Fatal("api_specification.method_catalog includes rpc.discover while service_discovery_policy is not_published")
+	}
+	for _, method := range doc.Methods {
+		if method.Name == "rpc.discover" {
+			t.Fatal("generated OpenRPC publishes rpc.discover while service_discovery_policy is not_published")
 		}
 	}
 }

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -255,6 +255,16 @@ func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 			want: "unknown gap_classification",
 		},
 		{
+			name: "tracked gap missing classification",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.HappyPath.Status = "tracked_gap"
+				row.HappyPath.ProofRefs = nil
+				row.GapClassification = nil
+			},
+			want: "agent.get tracked_gap evidence requires gap_classification",
+		},
+		{
 			name: "unsupported status proof kind",
 			mutate: func(matrix *openRPCComplianceMatrix) {
 				row := complianceMatrixRow(t, matrix, "agent.get")
@@ -454,6 +464,9 @@ func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix
 				problems = append(problems, fmt.Sprintf("%s unknown gap_classification %q", row.Method, gapClass))
 			}
 		}
+		if rowHasTrackedGap(row) && len(row.GapClassification) == 0 {
+			problems = append(problems, fmt.Sprintf("%s tracked_gap evidence requires gap_classification", row.Method))
+		}
 		for _, evidence := range complianceEvidenceFields(row) {
 			problems = append(problems, validateEvidenceProofRefs(root, index, matrix, row.Method, evidence.field, evidence.evidence)...)
 		}
@@ -524,6 +537,15 @@ func complianceEvidenceFields(row openRPCMethodMatrix) []namedComplianceEvidence
 		{field: "examples", evidence: row.Examples},
 		{field: "service_discovery_publication", evidence: row.ServiceDiscoveryPublication},
 	}
+}
+
+func rowHasTrackedGap(row openRPCMethodMatrix) bool {
+	for _, evidence := range complianceEvidenceFields(row) {
+		if strings.TrimSpace(evidence.evidence.Status) == "tracked_gap" {
+			return true
+		}
+	}
+	return false
 }
 
 func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix openRPCComplianceMatrix, methodName, field string, evidence complianceEvidence) []string {

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -6,6 +6,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -90,6 +92,7 @@ type rawOpenRPCDocument struct {
 }
 
 const openRPCComplianceMatrixTestName = "TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod"
+const serviceDiscoveryPolicyRuntimeTestName = "TestServiceDiscoveryPolicyDoesNotServeRPCDiscover"
 
 func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	root := repoRoot(t)
@@ -116,6 +119,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))
 	}
 	assertExamplesPolicyDeferred(t, api.ExamplesPolicy)
+	assertServiceDiscoveryPolicyNotPublished(t, api.ServiceDiscoveryPolicy)
 	if problems := validateProofReferenceIntegrity(root, matrix); len(problems) > 0 {
 		t.Fatalf("compliance matrix proof-reference integrity failed:\n- %s", strings.Join(problems, "\n- "))
 	}
@@ -131,9 +135,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 		}
 		openRPCByName[name] = method
 	}
-	if _, ok := openRPCByName["rpc.discover"]; ok {
-		t.Fatal("rpc.discover is not part of the approved #835 v1 publication boundary")
-	}
+	assertRPCDiscoverNotPublishedUnderPolicy(t, api.ServiceDiscoveryPolicy, openRPCByName)
 
 	rowsByName := map[string]openRPCMethodMatrix{}
 	for _, row := range matrix.Methods {
@@ -172,9 +174,6 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 		assertEvidence(t, methodName, "examples", row.Examples, false)
 		assertEvidence(t, methodName, "service_discovery_publication", row.ServiceDiscoveryPublication, false)
 
-		if len(row.GapClassification) == 0 {
-			t.Fatalf("%s gap_classification must classify remaining proof gaps", methodName)
-		}
 		if len(row.RequiredParams) == 0 {
 			assertNotApplicable(t, methodName, "required_param_validation", row.RequiredParamValidation)
 		} else {
@@ -196,9 +195,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 			assertEvidence(t, methodName, "notification_schema", row.NotificationSchema, true)
 		}
 		assertExamplesPolicyMatrixRow(t, methodName, rawMethods[methodName], row.Examples)
-		if row.ServiceDiscoveryPublication.Status != "published_without_discovery" {
-			t.Fatalf("%s service_discovery_publication status = %q, want published_without_discovery", methodName, row.ServiceDiscoveryPublication.Status)
-		}
+		assertServiceDiscoveryPolicyMatrixRow(t, methodName, api.ServiceDiscoveryPolicy, row.ServiceDiscoveryPublication)
 	}
 
 	for methodName := range rowsByName {
@@ -290,6 +287,22 @@ func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 			want: "examples status policy_deferred requires an artifact proof_ref",
 		},
 		{
+			name: "policy not published service discovery missing artifact proof",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.ServiceDiscoveryPublication.ProofRefs = []complianceProofRef{{Kind: "go_test", Name: openRPCComplianceMatrixTestName}}
+			},
+			want: "service_discovery_publication status policy_not_published requires an artifact proof_ref",
+		},
+		{
+			name: "stale service discovery status",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				row := complianceMatrixRow(t, matrix, "agent.get")
+				row.ServiceDiscoveryPublication.Status = "published_without_discovery"
+			},
+			want: `service_discovery_publication status "published_without_discovery" is not allowed`,
+		},
+		{
 			name: "legacy proof strings",
 			mutate: func(matrix *openRPCComplianceMatrix) {
 				row := complianceMatrixRow(t, matrix, "agent.get")
@@ -329,6 +342,39 @@ proof_refs:
 	problems := validateProofReferenceIntegrity(root, matrix)
 	if !problemContains(problems, "agent.get happy_path uses legacy proof strings") {
 		t.Fatalf("validateProofReferenceIntegrity() problems = %v, want empty legacy proof key rejection", problems)
+	}
+}
+
+func TestServiceDiscoveryPolicyDoesNotServeRPCDiscover(t *testing.T) {
+	root := repoRoot(t)
+	api := loadComplianceAPISpec(t, root)
+	assertServiceDiscoveryPolicyNotPublished(t, api.ServiceDiscoveryPolicy)
+	if _, ok := api.MethodCatalog["rpc.discover"]; ok {
+		t.Fatal("api_specification.method_catalog includes rpc.discover while service_discovery_policy is not_published")
+	}
+	registry := testRegistry(t)
+	if _, ok := registry.Method("rpc.discover"); ok {
+		t.Fatal("runtime registry serves rpc.discover while service_discovery_policy is not_published")
+	}
+
+	handler := testHandler(t, Options{AuthTokens: []string{testToken}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"discover","method":"rpc.discover","params":{}}`))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/rpc status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode rpc response: %v body=%s", err, rec.Body.String())
+	}
+	if resp.Error == nil {
+		t.Fatalf("rpc.discover response error = nil, want method not found: %#v", resp.Result)
+	}
+	if resp.Error.Code != codeMethodNotFound {
+		t.Fatalf("rpc.discover error code = %d, want %d body=%s", resp.Error.Code, codeMethodNotFound, rec.Body.String())
 	}
 }
 
@@ -387,9 +433,6 @@ func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix
 	index, problems := newComplianceProofIndex(root, matrix)
 	if matrix.IssueRole != "provenance" {
 		problems = append(problems, fmt.Sprintf("matrix issue_role = %q, want provenance", matrix.IssueRole))
-	}
-	if len(matrix.ActiveTrackers) == 0 {
-		problems = append(problems, "matrix active_trackers must list at least one active tracker")
 	}
 	for _, tracker := range matrix.ActiveTrackers {
 		if strings.TrimSpace(tracker.Kind) != "github_issue" {
@@ -500,6 +543,11 @@ func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix o
 		problems = append(problems, fmt.Sprintf("%s status %s requires proof_refs", label, status))
 		return problems
 	}
+	if allowedStatuses := allowedEvidenceStatuses(field); len(allowedStatuses) > 0 {
+		if _, ok := allowedStatuses[status]; !ok && status != "tracked_gap" {
+			problems = append(problems, fmt.Sprintf("%s status %q is not allowed for %s", label, status, field))
+		}
+	}
 	allowedKinds := allowedProofRefKinds(status, field)
 	kinds := map[string]struct{}{}
 	for _, ref := range evidence.ProofRefs {
@@ -569,9 +617,12 @@ func validateEvidenceProofRefs(root string, index complianceProofIndex, matrix o
 		if _, ok := kinds["tracker"]; !ok {
 			problems = append(problems, fmt.Sprintf("%s status tracked_gap requires a tracker proof_ref", label))
 		}
-	case "published_without_discovery":
+	case "policy_not_published":
 		if _, ok := kinds["artifact"]; !ok {
-			problems = append(problems, fmt.Sprintf("%s status published_without_discovery requires an artifact proof_ref", label))
+			problems = append(problems, fmt.Sprintf("%s status policy_not_published requires an artifact proof_ref", label))
+		}
+		if _, ok := kinds["go_test"]; !ok {
+			problems = append(problems, fmt.Sprintf("%s status policy_not_published requires a go_test proof_ref", label))
 		}
 	case "policy_deferred":
 		if _, ok := kinds["artifact"]; !ok {
@@ -590,7 +641,6 @@ func allowedComplianceGapClasses() map[string]struct{} {
 		"missing_generated_result_schema_validation",
 		"missing_happy_path_test",
 		"missing_idempotency_test",
-		"missing_rpc_discover_policy",
 		"missing_result_schema_proof",
 	})
 }
@@ -610,7 +660,7 @@ func allowedProofRefKinds(status, field string) map[string]struct{} {
 			return complianceStringSet([]string{"tracker", "policy_gap"})
 		}
 		return complianceStringSet([]string{"tracker"})
-	case "published_without_discovery":
+	case "policy_not_published":
 		return complianceStringSet([]string{"artifact", "go_test"})
 	case "policy_deferred":
 		return complianceStringSet([]string{"artifact", "go_test"})
@@ -878,7 +928,7 @@ func allowedEvidenceStatuses(field string) map[string]struct{} {
 	case "examples":
 		return complianceStringSet([]string{"covered", "policy_deferred"})
 	case "service_discovery_publication":
-		return complianceStringSet([]string{"published_without_discovery"})
+		return complianceStringSet([]string{"policy_not_published"})
 	default:
 		return map[string]struct{}{}
 	}
@@ -903,6 +953,36 @@ func assertExamplesPolicyDeferred(t *testing.T, policy apispec.ExamplesPolicy) {
 	}
 }
 
+func assertServiceDiscoveryPolicyNotPublished(t *testing.T, policy apispec.ServiceDiscoveryPolicy) {
+	t.Helper()
+	if policy.Status != apispec.ServiceDiscoveryPolicyStatusNotPublished {
+		t.Fatalf("service_discovery_policy.status = %q, want %q", policy.Status, apispec.ServiceDiscoveryPolicyStatusNotPublished)
+	}
+	if policy.Owner != apispec.ServiceDiscoveryPolicyOwner {
+		t.Fatalf("service_discovery_policy.owner = %q, want %q", policy.Owner, apispec.ServiceDiscoveryPolicyOwner)
+	}
+	if policy.AppliesTo != apispec.ServiceDiscoveryPolicyAppliesToGeneratedCatalog {
+		t.Fatalf("service_discovery_policy.applies_to = %q, want %q", policy.AppliesTo, apispec.ServiceDiscoveryPolicyAppliesToGeneratedCatalog)
+	}
+	if policy.RPCDiscover != apispec.ServiceDiscoveryPolicyRPCDiscoverOmitted {
+		t.Fatalf("service_discovery_policy.rpc_discover = %q, want %q", policy.RPCDiscover, apispec.ServiceDiscoveryPolicyRPCDiscoverOmitted)
+	}
+	if policy.PublicationArtifact != apispec.ServiceDiscoveryPolicyPublicationArtifactOpenRPC {
+		t.Fatalf("service_discovery_policy.publication_artifact = %q, want %q", policy.PublicationArtifact, apispec.ServiceDiscoveryPolicyPublicationArtifactOpenRPC)
+	}
+	if policy.RuntimeBehavior != apispec.ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound {
+		t.Fatalf("service_discovery_policy.runtime_behavior = %q, want %q", policy.RuntimeBehavior, apispec.ServiceDiscoveryPolicyRuntimeBehaviorMethodNotFound)
+	}
+}
+
+func assertRPCDiscoverNotPublishedUnderPolicy(t *testing.T, policy apispec.ServiceDiscoveryPolicy, methods map[string]apispec.OpenRPCMethod) {
+	t.Helper()
+	assertServiceDiscoveryPolicyNotPublished(t, policy)
+	if _, ok := methods["rpc.discover"]; ok {
+		t.Fatal("generated OpenRPC publishes rpc.discover while service_discovery_policy is not_published")
+	}
+}
+
 func assertExamplesPolicyMatrixRow(t *testing.T, methodName string, rawProof rawOpenRPCMethodProof, evidence complianceEvidence) {
 	t.Helper()
 	if rawProof.hasExamples {
@@ -919,6 +999,26 @@ func assertExamplesPolicyMatrixRow(t *testing.T, methodName string, rawProof raw
 	}
 	if !evidenceHasGoTest(evidence, openRPCComplianceMatrixTestName) {
 		t.Fatalf("%s examples missing go_test proof_ref %s", methodName, openRPCComplianceMatrixTestName)
+	}
+}
+
+func assertServiceDiscoveryPolicyMatrixRow(t *testing.T, methodName string, policy apispec.ServiceDiscoveryPolicy, evidence complianceEvidence) {
+	t.Helper()
+	assertServiceDiscoveryPolicyNotPublished(t, policy)
+	if evidence.Status != "policy_not_published" {
+		t.Fatalf("%s service_discovery_publication status = %q, want policy_not_published while service_discovery_policy is not_published", methodName, evidence.Status)
+	}
+	if !evidenceHasArtifact(evidence, "docs/specs/swarm-platform/platform/contracts/platform-spec.yaml") {
+		t.Fatalf("%s service_discovery_publication missing platform-spec.yaml artifact proof_ref", methodName)
+	}
+	if !evidenceHasArtifact(evidence, "docs/specs/swarm-platform/platform/contracts/openrpc.json") {
+		t.Fatalf("%s service_discovery_publication missing openrpc.json artifact proof_ref", methodName)
+	}
+	if !evidenceHasGoTest(evidence, openRPCComplianceMatrixTestName) {
+		t.Fatalf("%s service_discovery_publication missing go_test proof_ref %s", methodName, openRPCComplianceMatrixTestName)
+	}
+	if !evidenceHasGoTest(evidence, serviceDiscoveryPolicyRuntimeTestName) {
+		t.Fatalf("%s service_discovery_publication missing go_test proof_ref %s", methodName, serviceDiscoveryPolicyRuntimeTestName)
 	}
 }
 

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -2,24 +2,21 @@ version: 1
 kind: openrpc_compliance_matrix
 issue: 835
 issue_role: provenance
-active_trackers:
-  - kind: github_issue
-    issue: 857
-    watchlist: operator_surfaces.v1_openrpc_api_conformance
+active_trackers: []
 source:
   platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
   generated_from: api_specification.method_catalog
 policy:
-  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_notification_schema_and_examples_policy_validation
+  closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_notification_schema_examples_policy_and_service_discovery_policy_validation
   runtime_behavior_changes: transport_admission_repair_approved_by_878
-  read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; mutating, WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
-  mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; WS/protocol, examples, rpc.discover, and notification-schema validation remain tracked separately."
-  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; examples, rpc.discover, and full notification-schema validation remain tracked by #857."
-  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover remain tracked by #857."
-  notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover remain tracked by #857."
+  read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; siblings were tracked by later #857 children."
+  mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; siblings were tracked by later #857 children."
+  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; siblings were tracked by later #857 children."
+  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover were tracked by later #857 children."
+  notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover were tracked by later #857 children."
   examples_policy: "#904 adds merge-bearing catalog-wide OpenRPC examples deferral policy; method examples are intentionally omitted until a future approved source model exists."
-  service_discovery_policy: rpc.discover is not published by the v1 contract; method publication is tracked through the generated OpenRPC artifact.
+  service_discovery_policy: "#915 adds merge-bearing catalog-wide rpc.discover non-publication policy; method publication remains the generated OpenRPC artifact."
 methods:
   - method: agent.diagnose
     transport: http
@@ -34,8 +31,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.get
     transport: http
     required_params: [agent_id]
@@ -49,8 +46,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.list
     transport: http
     required_params: []
@@ -64,8 +61,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.replay
     transport: http
     required_params: [event_id, agent_id]
@@ -79,8 +76,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentReplayProjectsSingletonEventReplayOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.replay_backlog
     transport: http
     required_params: [agent_id]
@@ -94,8 +91,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.restart
     transport: http
     required_params: [agent_id]
@@ -109,8 +106,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.send_directive
     transport: http
     required_params: [agent_id, directive]
@@ -124,8 +121,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.current_for_agent
     transport: http
     required_params: [agent_id]
@@ -139,8 +136,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.get
     transport: http
     required_params: [session_id]
@@ -154,8 +151,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.get_turn
     transport: http
     required_params: [session_id, turn_index]
@@ -169,8 +166,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorConversationGetTurnComposesRuntimeLogOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.list
     transport: http
     required_params: []
@@ -184,8 +181,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: entity.aggregate
     transport: http
     required_params: []
@@ -199,8 +196,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: entity.get
     transport: http
     required_params: [entity_id]
@@ -214,8 +211,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: entity.list
     transport: http
     required_params: []
@@ -229,8 +226,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: event.get
     transport: http
     required_params: [event_id]
@@ -244,8 +241,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: event.list
     transport: http
     required_params: []
@@ -259,8 +256,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
@@ -274,8 +271,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: event.replay
     transport: http
     required_params: [event_id]
@@ -289,8 +286,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: event.subscribe
     transport: ws
     required_params: []
@@ -304,8 +301,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: health.check
     transport: http
     required_params: []
@@ -319,8 +316,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: health.ping
     transport: http
     required_params: []
@@ -334,8 +331,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: health.subscribe
     transport: ws
     required_params: []
@@ -349,8 +346,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: mailbox.approve
     transport: http
     required_params: [mailbox_id]
@@ -364,8 +361,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: mailbox.defer
     transport: http
     required_params: [mailbox_id, until]
@@ -379,8 +376,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: mailbox.get
     transport: http
     required_params: [mailbox_id]
@@ -394,8 +391,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: mailbox.list
     transport: http
     required_params: []
@@ -409,8 +406,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorMailboxHandlersSupportedRPCPath}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: mailbox.reject
     transport: http
     required_params: [mailbox_id, reason]
@@ -424,8 +421,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: rpc.unsubscribe
     transport: ws
     required_params: [subscription_id]
@@ -439,8 +436,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketHealthSubscribeAndUnsubscribe}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.continue
     transport: http
     required_params: [run_id]
@@ -454,8 +451,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.diagnose
     transport: http
     required_params: [run_id]
@@ -469,8 +466,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.get
     transport: http
     required_params: [run_id]
@@ -484,8 +481,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.list
     transport: http
     required_params: []
@@ -499,8 +496,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.pause
     transport: http
     required_params: [run_id]
@@ -514,8 +511,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.start
     transport: http
     required_params: [event_name, payload]
@@ -529,8 +526,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.stop
     transport: http
     required_params: [run_id]
@@ -544,8 +541,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.subscribe_trace
     transport: ws
     required_params: [run_id]
@@ -559,8 +556,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: run.trace
     transport: http
     required_params: [run_id]
@@ -574,8 +571,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.incidents
     transport: http
     required_params: []
@@ -589,8 +586,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.logs
     transport: http
     required_params: []
@@ -604,8 +601,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.nuke
     transport: http
     required_params: []
@@ -619,8 +616,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners}, {kind: go_test, name: TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.pause
     transport: http
     required_params: []
@@ -634,8 +631,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.resume
     transport: http
     required_params: []
@@ -649,8 +646,8 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.subscribe_logs
     transport: ws
     required_params: []
@@ -664,5 +661,5 @@ methods:
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}]}
     notification_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSubscriptionNotificationSchemas}]}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: published_without_discovery, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}]}
-    gap_classification: [missing_rpc_discover_policy]
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -2,7 +2,10 @@ version: 1
 kind: openrpc_compliance_matrix
 issue: 835
 issue_role: provenance
-active_trackers: []
+active_trackers:
+  - kind: github_issue
+    issue: 857
+    watchlist: operator_surfaces.v1_openrpc_api_conformance
 source:
   platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -17,6 +20,7 @@ policy:
   notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover were tracked by later #857 children."
   examples_policy: "#904 adds merge-bearing catalog-wide OpenRPC examples deferral policy; method examples are intentionally omitted until a future approved source model exists."
   service_discovery_policy: "#915 adds merge-bearing catalog-wide rpc.discover non-publication policy; method publication remains the generated OpenRPC artifact."
+  entity_accumulated_schema_hardening_policy: "#896 leaves EntityFull.accumulated deep schema hardening tracked under #857; #915 does not close that parent residual."
 methods:
   - method: agent.diagnose
     transport: http


### PR DESCRIPTION
## Summary

- Add merge-bearing `api_specification.service_discovery_policy` for v1 `rpc.discover` non-publication.
- Add typed `internal/apispec` model/validation that fails closed on missing/unsupported policy and rejects accidental `rpc.discover` method-catalog promotion under the non-publication policy.
- Move all 43 compliance-matrix `service_discovery_publication` rows to `policy_not_published` with platform/OpenRPC/test proof, remove stale `missing_rpc_discover_policy`, and keep #857 active for the remaining `EntityFull.accumulated` schema-hardening residual.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification`, specifically the new `service_discovery_policy`.
- Generated `docs/specs/swarm-platform/platform/contracts/openrpc.json` remains the publication artifact for the v1 generated method catalog.
- `internal/apispec` owns loading, validation, and generated OpenRPC emission from `api_specification.method_catalog`.
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml` remains the checked-in proof-accounting source.
- Approved #915 pre-audit gate under parent #857.
- #857 remains open/active for the `EntityFull.accumulated` deep schema-hardening residual recorded in #857 and #896 review comments; this PR closes #915 only.

## Semantic Migration

- New canonical owner: `api_specification.service_discovery_policy`, consumed by `internal/apispec` validation and `internal/apiv1` compliance tests.
- Old non-authoritative paths now invalid: matrix-only `service_discovery_policy` prose, `published_without_discovery` row status, `missing_rpc_discover_policy`, hard-coded `#835` `rpc.discover` absence text, and raw OpenRPC absence without policy ownership.
- Production paths checked for surviving old behavior: generated OpenRPC method catalog, `internal/apiv1` registry, handler catalog admission, and `/v1/rpc` out-of-catalog request behavior.
- Migration complete: yes for the approved v1 service-discovery non-publication policy class. This PR does not add `rpc.discover` to `method_catalog`, generated OpenRPC, handlers, `/v1/rpc`, or `/v1/ws` runtime behavior, and it does not close the broader #857 parent.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'OpenRPCComplianceMatrix|ServiceDiscovery' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -run 'OpenRPC|ComplianceMatrix|ServiceDiscovery|Registry' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `git diff --check`
- Artifact probes: generated OpenRPC has 43 methods, `rpc.discover` index is `null`, only `rpc.*` method is `rpc.unsubscribe`, 43 matrix rows use `policy_not_published`, and there are 0 stale `missing_rpc_discover_policy` / `published_without_discovery` matrix refs.

Closes #915
Part of #857