### PR TITLE
[agent-b][issue #918] Consume run trace snapshot filters

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -22,6 +22,12 @@ type diagnosticRunListOptions struct {
 type diagnosticTraceOptions struct {
 	apiOptions rootCommandOptions
 	follow     bool
+	since      string
+	limit      int
+	cursor     string
+	sinceSet   bool
+	limitSet   bool
+	cursorSet  bool
 }
 
 type diagnosticRunOptions struct {
@@ -168,6 +174,9 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Print or follow a run trace through v1 API owners.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			traceOpts.sinceSet = cmd.Flags().Changed("since")
+			traceOpts.limitSet = cmd.Flags().Changed("limit")
+			traceOpts.cursorSet = cmd.Flags().Changed("cursor")
 			runID := ""
 			if len(args) == 1 {
 				runID = args[0]
@@ -176,6 +185,9 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&traceOpts.follow, "follow", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
+	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
+	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
 	bindCLIAPIConnectionFlags(cmd, &traceOpts.apiOptions)
 	return cmd
 }
@@ -352,6 +364,10 @@ func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts di
 }
 
 func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
+	snapshotParams, err := opts.snapshotParams()
+	if err != nil {
+		return err
+	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
@@ -366,9 +382,9 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	if opts.follow {
 		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID)
 	}
-	params := map[string]any{"run_id": runID}
+	snapshotParams["run_id"] = runID
 	var result diagnosticRunTraceResult
-	if err := client.call(ctx, "run.trace", params, &result); err != nil {
+	if err := client.call(ctx, "run.trace", snapshotParams, &result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	if err := validateDiagnosticRunTraceResult(result); err != nil {
@@ -376,6 +392,46 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	}
 	writeDiagnosticRunTrace(out, runID, result)
 	return nil
+}
+
+func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
+	if o.follow {
+		for _, flag := range []struct {
+			name string
+			set  bool
+		}{
+			{name: "--since", set: o.sinceSet},
+			{name: "--limit", set: o.limitSet},
+			{name: "--cursor", set: o.cursorSet},
+		} {
+			if flag.set {
+				return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
+			}
+		}
+		return map[string]any{}, nil
+	}
+	params := map[string]any{}
+	if o.limitSet {
+		if o.limit < 1 || o.limit > 2000 {
+			return nil, fmt.Errorf("--limit must be between 1 and 2000")
+		}
+		params["limit"] = o.limit
+	}
+	if o.cursorSet {
+		cursor := strings.TrimSpace(o.cursor)
+		if cursor == "" {
+			return nil, fmt.Errorf("--cursor must not be empty")
+		}
+		params["cursor"] = cursor
+	}
+	if o.sinceSet {
+		since := strings.TrimSpace(o.since)
+		if err := validateRFC3339Flag("--since", since); err != nil {
+			return nil, err
+		}
+		params["since"] = since
+	}
+	return params, nil
 }
 
 func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string) error {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -352,7 +352,12 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 		if req.Method != "run.trace" {
 			t.Fatalf("method = %q, want run.trace", req.Method)
 		}
-		wantParams := map[string]any{"run_id": "run-1"}
+		wantParams := map[string]any{
+			"run_id": "run-1",
+			"limit":  float64(2),
+			"cursor": "trace-cur",
+			"since":  "2026-05-13T10:00:00Z",
+		}
 		if !reflect.DeepEqual(req.Params, wantParams) {
 			t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
 		}
@@ -373,7 +378,7 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-1", "--limit", "2", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -384,6 +389,60 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
+		switch callIndex {
+		case 0:
+			if req.Method != "run.list" {
+				t.Fatalf("method[%d] = %q, want run.list", callIndex, req.Method)
+			}
+			wantParams := map[string]any{"status": "running", "limit": float64(1)}
+			if !reflect.DeepEqual(req.Params, wantParams) {
+				t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, wantParams)
+			}
+			return map[string]any{"runs": []any{validDiagnosticRunHeaderWithStatus("active-run", "running")}}
+		case 1:
+			if req.Method != "run.trace" {
+				t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
+			}
+			wantParams := map[string]any{
+				"run_id": "active-run",
+				"limit":  float64(3),
+				"cursor": "trace-cur",
+				"since":  "2026-05-13T10:00:00Z",
+			}
+			if !reflect.DeepEqual(req.Params, wantParams) {
+				t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, wantParams)
+			}
+			return map[string]any{"trace": []any{map[string]any{
+				"event_id":         "event-active",
+				"event_name":       "scan.requested",
+				"event_created_at": "2026-05-13T10:00:01Z",
+			}}}
+		default:
+			t.Fatalf("unexpected request[%d]: %#v", callIndex, req)
+		}
+		return nil
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--limit", "3", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 2 {
+		t.Fatalf("requests = %d, want run.list then run.trace", len(*requests))
+	}
+	if !strings.Contains(stdout.String(), "run trace: run_id=active-run") {
+		t.Fatalf("stdout = %q, want resolved run trace header", stdout.String())
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -594,7 +653,14 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "runs invalid limit", args: []string{"runs", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
 		{name: "runs invalid since", args: []string{"runs", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
 		{name: "trace extra arg", args: []string{"trace", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
-		{name: "trace unknown legacy flag", args: []string{"trace", "run-1", "--limit", "5"}, wantStderr: "unknown flag"},
+		{name: "trace invalid limit low", args: []string{"trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
+		{name: "trace invalid limit high", args: []string{"trace", "run-1", "--limit", "2001"}, wantStderr: "--limit must be between 1 and 2000"},
+		{name: "trace invalid since", args: []string{"trace", "run-1", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "trace blank cursor", args: []string{"trace", "run-1", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
+		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
+		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
+		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace richer filter still unpromoted", args: []string{"trace", "run-1", "--event-name", "scan.requested"}, wantStderr: "unknown flag"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -621,6 +687,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 	for _, args := range [][]string{
 		{"runs"},
 		{"trace", "run-1"},
+		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z"},
 		{"trace", "run-1", "--follow"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6544,7 +6544,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--follow]
+      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow
@@ -6562,9 +6562,16 @@ cli_specification:
           `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
           materialization watermark is strictly after `since`, where that watermark is the greatest available
           timestamp across the joined event, delivery, session, and turn fields owned by RunTraceRow.
-        current_cli_consumer_status: >
-          The current implemented CLI command remains `swarm trace [<run-id>] [--follow]`; CLI flags that consume
-          the promoted snapshot filter contract require a later implementation child and MUST use this API owner.
+        current_cli_consumer_status: implemented_by_918
+        cli_consumer_behavior: >
+          Snapshot `swarm trace` consumes `--since`, `--limit`, and `--cursor` by sending the exact promoted params
+          to `/v1/rpc run.trace`. These snapshot flags are invalid with `--follow` and must fail before any API or
+          WebSocket request; follow mode remains the base `/v1/ws run.subscribe_trace` consumer.
+        proof_expectations:
+        - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
+        - invalid --since, out-of-range --limit, blank --cursor, and --follow plus snapshot filters fail before API/WS calls
+        - missing token fails before API calls through the shared CLI API client
+        - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
         split_tail:
           until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
           event_name: Not promoted; event-name filtering requires a typed RunTraceFilter owner before CLI use.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6551,7 +6551,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run trace rendering over API-owned RunTraceRow facts only; no CLI reconstruction from tables.
       promoted_trace_filter_contract:
-        status: api_owner_promoted_cli_pending
+        status: api_owner_promoted_cli_implemented
         snapshot_owner: /v1/rpc run.trace
         promoted_params:
         - run_id


### PR DESCRIPTION
## Summary
- Add snapshot-only `swarm trace` flags for the promoted `/v1/rpc run.trace` contract: `--since`, `--limit`, and `--cursor`.
- Send those flags as exact `run.trace` params for explicit run ids and omitted-run resolution through `run.list`.
- Reject snapshot filter flags with `--follow` before any API/WS call; subscription recovery, `--no-retry`, `swarm run`, payload/output, `-f`, `--all`, and richer typed filters remain split.
- Update `platform-spec.yaml` so the trace filter CLI consumer is no longer marked pending.

Closes #918
Part of #855

## Governing refs/context
- #918 Pre-Implementation Coverage Audit and independent gate outcome.
- #855 trace filter/recovery tracker and PR #914 closeout.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.command_catalog.trace.promoted_trace_filter_contract`
  - `api_specification.method_catalog.run.trace`
- Generated OpenRPC already contains the promoted `run.trace` params from PR #914: `run_id`, `limit`, `cursor`, `since`.

## Semantic migration
- New canonical owner consumed by CLI: `/v1/rpc run.trace` for snapshot params `run_id`, `limit`, `cursor`, and `since`.
- Old producer/reader/writer path now invalid: CLI-side local filtering/pagination or DB/store/runtime/EventBus/dashboard/Builder reads remain invalid; `swarm trace` now forwards promoted snapshot filters to the API owner.
- Production paths checked for surviving old behavior: `swarm investigate trace` remains fail-closed; `swarm trace --follow` remains a separate `/v1/ws run.subscribe_trace` consumer and rejects snapshot filters; `swarm run`/`subscribeRunTrace` untouched.
- Migration completeness: complete for the #918 promoted snapshot filter CLI consumer class. Remaining #855 tails stay split.

## Proof
- `go test ./cmd/swarm -run 'TestTrace|TestDiagnosticTrace|TestInvestigateTrace|TestDiagnosticsRejectInvalidInputBeforeRequest' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep: `rg -n "internal/store|database/sql|EventBus|LoadRunDebug|QueryContext|dashboard|Builder|/api/|/api/rpc|/api/ws" cmd/swarm/diagnostics.go cmd/swarm/run_command.go` returned no matches.
