### PR TITLE
[agent-a][issue #920] Add shared CLI output renderer

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -155,7 +155,7 @@ func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 		Short:              "Validate local Swarm contract files.",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			code := runVerifyCommand(ctx, repo, args, cmd.OutOrStdout())
+			code := runVerifyCommandWithOutput(ctx, repo, args, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			if code != 0 {
 				return commandExitError{code: code}
 			}
@@ -166,7 +166,18 @@ func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 
 type versionCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 	server     bool
+}
+
+type versionOutputResult struct {
+	BinaryVersion string                       `json:"binary_version"`
+	Commit        string                       `json:"commit"`
+	Built         string                       `json:"built"`
+	GoVersion     string                       `json:"go_version"`
+	GOOS          string                       `json:"goos"`
+	GOARCH        string                       `json:"goarch"`
+	Server        *diagnosticHealthCheckResult `json:"server,omitempty"`
 }
 
 func newVersionCommand(opts rootCommandOptions) *cobra.Command {
@@ -179,26 +190,45 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 			if !versionOpts.server && cliAPIConnectionFlagsChanged(cmd) {
 				return fmt.Errorf("--api-server and --api-token-file require --server")
 			}
+			if err := versionOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), versionOpts)
 		},
 	}
 	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
+	bindCLIOutputFlags(cmd, &versionOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &versionOpts.apiOptions)
 	return cmd
 }
 
 func runVersionCommand(ctx context.Context, out, errOut io.Writer, opts versionCommandOptions) error {
-	if !opts.server {
-		writeLocalVersion(out)
-		return nil
+	result := versionOutputResult{
+		BinaryVersion: binaryVersion,
+		Commit:        binaryCommit,
+		Built:         binaryDate,
+		GoVersion:     goruntime.Version(),
+		GOOS:          goruntime.GOOS,
+		GOARCH:        goruntime.GOARCH,
 	}
-	result, err := fetchDiagnosticHealthCheck(ctx, opts.apiOptions)
+	if !opts.server {
+		return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+			writeLocalVersion(w)
+		}, func() ([]string, error) {
+			return []string{binaryVersion}, nil
+		})
+	}
+	health, err := fetchDiagnosticHealthCheck(ctx, opts.apiOptions)
 	if err != nil {
 		return returnCLIAPIError(errOut, err, cliAPIErrorClassifier{})
 	}
-	writeLocalVersion(out)
-	writeVersionServerIdentity(out, result)
-	return nil
+	result.Server = &health
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeLocalVersion(w)
+		writeVersionServerIdentity(w, health)
+	}, func() ([]string, error) {
+		return []string{binaryVersion, health.Bundle.Fingerprint}, nil
+	})
 }
 
 func writeLocalVersion(out io.Writer) {

--- a/cmd/swarm/cli_output.go
+++ b/cmd/swarm/cli_output.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+type cliOutputOptions struct {
+	asJSON bool
+	quiet  bool
+}
+
+type cliTextRenderer func(io.Writer)
+type cliQuietRenderer func() ([]string, error)
+
+func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
+	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render successful output as one JSON document")
+	cmd.Flags().BoolVar(&opts.quiet, "quiet", false, "Render only declared load-bearing value(s)")
+}
+
+func (opts cliOutputOptions) validate() error {
+	if opts.asJSON && opts.quiet {
+		return fmt.Errorf("--json and --quiet are mutually exclusive")
+	}
+	return nil
+}
+
+func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {
+	if err := opts.validate(); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	switch {
+	case opts.asJSON:
+		if out == nil {
+			return nil
+		}
+		if err := json.NewEncoder(out).Encode(value); err != nil {
+			return returnCLIValidationError(errOut, fmt.Errorf("render json output: %w", err))
+		}
+	case opts.quiet:
+		if quiet == nil {
+			return returnCLIValidationError(errOut, fmt.Errorf("--quiet is not supported for this command"))
+		}
+		values, err := quiet()
+		if err != nil {
+			return returnCLIValidationError(errOut, err)
+		}
+		for _, value := range values {
+			if out != nil {
+				fmt.Fprintln(out, value)
+			}
+		}
+	default:
+		if text != nil {
+			text(out)
+		}
+	}
+	return nil
+}

--- a/cmd/swarm/cli_output.go
+++ b/cmd/swarm/cli_output.go
@@ -2,10 +2,18 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	cliOutputJSONFlag      = "json"
+	cliOutputJSONFlagHelp  = "Render successful output as one JSON document"
+	cliOutputQuietFlag     = "quiet"
+	cliOutputQuietFlagHelp = "Render only declared load-bearing value(s)"
 )
 
 type cliOutputOptions struct {
@@ -17,8 +25,13 @@ type cliTextRenderer func(io.Writer)
 type cliQuietRenderer func() ([]string, error)
 
 func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
-	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render successful output as one JSON document")
-	cmd.Flags().BoolVar(&opts.quiet, "quiet", false, "Render only declared load-bearing value(s)")
+	cmd.Flags().BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
+	cmd.Flags().BoolVar(&opts.quiet, cliOutputQuietFlag, false, cliOutputQuietFlagHelp)
+}
+
+func bindCLIOutputFlagSet(fs *flag.FlagSet, opts *cliOutputOptions) {
+	fs.BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
+	fs.BoolVar(&opts.quiet, cliOutputQuietFlag, false, cliOutputQuietFlagHelp)
 }
 
 func (opts cliOutputOptions) validate() error {

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -1,0 +1,508 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestCLIOutputModesForLocalConsumers(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"version", "--json"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("version --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	versionJSON := decodeOutputJSON[map[string]any](t, stdout.String())
+	if versionJSON["binary_version"] != binaryVersion || versionJSON["commit"] != binaryCommit {
+		t.Fatalf("version json = %#v, want local metadata", versionJSON)
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("version --json stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"version", "--quiet"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("version --quiet code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); got != binaryVersion+"\n" {
+		t.Fatalf("version --quiet stdout = %q, want binary version", got)
+	}
+
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, mode := range []string{"--json", "--quiet"} {
+		server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+			if req.Method != "health.check" {
+				t.Fatalf("method = %q, want health.check", req.Method)
+			}
+			return validVersionHealthResult()
+		})
+		defer server.Close()
+
+		stdout.Reset()
+		stderr.Reset()
+		code = executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"version", "--server", mode}, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 0 {
+			t.Fatalf("version --server %s code = %d stdout=%s stderr=%s", mode, code, stdout.String(), stderr.String())
+		}
+		if len(*requests) != 1 {
+			t.Fatalf("version --server %s requests = %d, want 1", mode, len(*requests))
+		}
+		if mode == "--json" {
+			result := decodeOutputJSON[versionOutputResult](t, stdout.String())
+			if result.Server == nil || result.Server.Bundle.Fingerprint != "sha256:server" {
+				t.Fatalf("version --server json = %#v, want server identity", result)
+			}
+		} else if got := stdout.String(); got != binaryVersion+"\nsha256:server\n" {
+			t.Fatalf("version --server quiet stdout = %q, want binary and fingerprint", got)
+		}
+		assertEmptyStderr(t, stderr.String())
+	}
+
+	verifyFixture := outputModeVerifyFixture(t)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("verify --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if !verifyJSON.OK || strings.TrimSpace(verifyJSON.Contracts) == "" {
+		t.Fatalf("verify json = %#v, want ok contracts", verifyJSON)
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--quiet"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("verify --quiet code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); got != "ok\n" {
+		t.Fatalf("verify --quiet stdout = %q, want ok", got)
+	}
+}
+
+func TestCLIOutputModesForDiagnosticConsumers(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	t.Run("runs", func(t *testing.T) {
+		for _, tc := range []struct {
+			mode      string
+			wantQuiet string
+		}{
+			{mode: "--json"},
+			{mode: "--quiet", wantQuiet: "run-1\nrun-2\n"},
+		} {
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != "run.list" {
+					t.Fatalf("method = %q, want run.list", req.Method)
+				}
+				return map[string]any{"runs": []any{validDiagnosticRunHeader("run-1"), validDiagnosticRunHeader("run-2")}}
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", tc.mode}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("runs %s code = %d stdout=%s stderr=%s", tc.mode, code, stdout.String(), stderr.String())
+			}
+			if len(*requests) != 1 {
+				t.Fatalf("runs %s requests = %d, want 1", tc.mode, len(*requests))
+			}
+			if tc.mode == "--json" {
+				result := decodeOutputJSON[diagnosticRunListResult](t, stdout.String())
+				if len(result.Runs) != 2 || result.Runs[0].RunID != "run-1" {
+					t.Fatalf("runs json = %#v, want run list", result)
+				}
+			} else if stdout.String() != tc.wantQuiet {
+				t.Fatalf("runs quiet stdout = %q, want %q", stdout.String(), tc.wantQuiet)
+			}
+			assertEmptyStderr(t, stderr.String())
+		}
+	})
+
+	t.Run("health", func(t *testing.T) {
+		for _, mode := range []string{"--json", "--quiet"} {
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != "health.check" {
+					t.Fatalf("method = %q, want health.check", req.Method)
+				}
+				return validVersionHealthResult()
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"health", mode}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("health %s code = %d stdout=%s stderr=%s", mode, code, stdout.String(), stderr.String())
+			}
+			if len(*requests) != 1 {
+				t.Fatalf("health %s requests = %d, want 1", mode, len(*requests))
+			}
+			if mode == "--json" {
+				result := decodeOutputJSON[diagnosticHealthCheckResult](t, stdout.String())
+				if !boolPointerValue(result.Alive) || result.Bundle.Fingerprint != "sha256:server" {
+					t.Fatalf("health json = %#v, want health.check result", result)
+				}
+			} else if got := stdout.String(); got != "unhealthy\n" {
+				t.Fatalf("health quiet stdout = %q, want unhealthy", got)
+			}
+			assertEmptyStderr(t, stderr.String())
+		}
+	})
+
+	t.Run("status", func(t *testing.T) {
+		for _, tc := range []struct {
+			args      []string
+			method    string
+			quiet     string
+			assertion func(*testing.T, string)
+		}{
+			{
+				args:   []string{"status", "run-1", "--json"},
+				method: "run.diagnose",
+				assertion: func(t *testing.T, raw string) {
+					result := decodeOutputJSON[diagnosticRunDiagnosisResult](t, raw)
+					if result.Run.RunID != "run-1" || stringPointerValue(result.OperationalState) != "stalled" {
+						t.Fatalf("status json = %#v, want diagnosis", result)
+					}
+				},
+			},
+			{
+				args:   []string{"status", "run-1", "--quiet"},
+				method: "run.diagnose",
+				quiet:  "run-1 stalled\n",
+			},
+			{
+				args:   []string{"status", "run-1", "--no-diagnose", "--json"},
+				method: "run.get",
+				assertion: func(t *testing.T, raw string) {
+					result := decodeOutputJSON[diagnosticRunGetResult](t, raw)
+					if result.Run.RunID != "run-1" || result.Run.Status != "running" {
+						t.Fatalf("status --no-diagnose json = %#v, want run header", result)
+					}
+				},
+			},
+			{
+				args:   []string{"status", "run-1", "--no-diagnose", "--quiet"},
+				method: "run.get",
+				quiet:  "run-1 running\n",
+			},
+		} {
+			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+				if req.Method != tc.method {
+					t.Fatalf("method = %q, want %s", req.Method, tc.method)
+				}
+				if tc.method == "run.get" {
+					return map[string]any{"run": validDiagnosticRunHeader("run-1")}
+				}
+				return map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "stalled",
+					"blocking_layer":    "delivery_lifecycle",
+					"blocking_reason":   "no_active_deliveries",
+					"heuristics":        []any{"dead letters exist for this run"},
+				}
+			})
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("status %v code = %d stdout=%s stderr=%s", tc.args, code, stdout.String(), stderr.String())
+			}
+			if len(*requests) != 1 {
+				t.Fatalf("status %v requests = %d, want 1", tc.args, len(*requests))
+			}
+			if tc.assertion != nil {
+				tc.assertion(t, stdout.String())
+			} else if got := stdout.String(); got != tc.quiet {
+				t.Fatalf("status quiet stdout = %q, want %q", got, tc.quiet)
+			}
+			assertEmptyStderr(t, stderr.String())
+		}
+	})
+}
+
+func TestCLIOutputModesForConversationConsumers(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		method     string
+		result     map[string]any
+		wantQuiet  string
+		assertJSON func(*testing.T, string)
+	}{
+		{
+			name:      "conversations list",
+			args:      []string{"conversations", "list"},
+			method:    conversationListMethod,
+			result:    map[string]any{"conversations": []map[string]any{validConversationSummary("sess-1")}},
+			wantQuiet: "sess-1\n",
+			assertJSON: func(t *testing.T, raw string) {
+				result := decodeOutputJSON[conversationListResult](t, raw)
+				if len(result.Conversations) != 1 || result.Conversations[0].SessionID != "sess-1" {
+					t.Fatalf("conversation list json = %#v, want sess-1", result)
+				}
+			},
+		},
+		{
+			name:      "conversation view",
+			args:      []string{"conversation", "view", "sess-1"},
+			method:    conversationGetMethod,
+			result:    validConversationDetail("sess-1"),
+			wantQuiet: "sess-1\n",
+			assertJSON: func(t *testing.T, raw string) {
+				result := decodeOutputJSON[conversationDetail](t, raw)
+				if result.Conversation.SessionID != "sess-1" || len(result.Turns) != 1 {
+					t.Fatalf("conversation view json = %#v, want detail", result)
+				}
+			},
+		},
+		{
+			name:      "conversation turn",
+			args:      []string{"conversation", "turn", "sess-1", "2"},
+			method:    conversationGetTurnMethod,
+			result:    validConversationTurnDetail("sess-1", 2),
+			wantQuiet: "sess-1 2 completed\n",
+			assertJSON: func(t *testing.T, raw string) {
+				result := decodeOutputJSON[conversationTurnDetail](t, raw)
+				if result.Session.SessionID != "sess-1" || result.Turn.TurnIndex != 2 {
+					t.Fatalf("conversation turn json = %#v, want turn detail", result)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range []string{"--json", "--quiet"} {
+				var calls atomic.Int32
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					calls.Add(1)
+					var req jsonRPCRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+						t.Errorf("decode request: %v", err)
+					}
+					if req.Method != tc.method {
+						t.Errorf("method = %q, want %s", req.Method, tc.method)
+					}
+					writeJSONRPCResult(t, w, req.ID, tc.result)
+				}))
+				defer server.Close()
+
+				args := append(append([]string{}, tc.args...), mode)
+				var stdout, stderr bytes.Buffer
+				code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+				if code != 0 {
+					t.Fatalf("%s %s code = %d stdout=%s stderr=%s", tc.name, mode, code, stdout.String(), stderr.String())
+				}
+				if calls.Load() != 1 {
+					t.Fatalf("%s %s calls = %d, want 1", tc.name, mode, calls.Load())
+				}
+				if mode == "--json" {
+					tc.assertJSON(t, stdout.String())
+				} else if stdout.String() != tc.wantQuiet {
+					t.Fatalf("%s quiet stdout = %q, want %q", tc.name, stdout.String(), tc.wantQuiet)
+				}
+				assertEmptyStderr(t, stderr.String())
+			}
+		})
+	}
+}
+
+func TestCLIOutputModeCollisionFailsBeforeSideEffects(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	for _, args := range [][]string{
+		{"version", "--server", "--json", "--quiet"},
+		{"health", "--json", "--quiet"},
+		{"runs", "--json", "--quiet"},
+		{"status", "run-1", "--json", "--quiet"},
+		{"conversations", "list", "--json", "--quiet"},
+		{"conversation", "view", "sess-1", "--json", "--quiet"},
+		{"conversation", "turn", "sess-1", "1", "--json", "--quiet"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "--json and --quiet are mutually exclusive") {
+				t.Fatalf("stderr = %q, want collision", stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--json", "--quiet"}, &stdout, &stderr)
+	if code != cliExitValidation {
+		t.Fatalf("verify collision code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--json and --quiet are mutually exclusive") {
+		t.Fatalf("verify collision stderr = %q, want collision", stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify collision stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	var rpcCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rpcCalls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var serveCalls atomic.Int32
+	opts := testRootCommandOptions(server)
+	opts.runServe = func(context.Context, string, serveOptions) int {
+		serveCalls.Add(1)
+		return 0
+	}
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "root", args: []string{"--json", "runs"}, wantStderr: "unknown flag: --json"},
+		{name: "completion", args: []string{"completion", "bash", "--json"}, wantStderr: "unknown flag"},
+		{name: "serve", args: []string{"serve", "--json"}, wantStderr: "unknown flag"},
+		{name: "retired investigate", args: []string{"investigate", "runs", "--json"}, wantStderr: "retired in CLI v2"},
+		{name: "absent forkchat", args: []string{"forkchat", "--json"}, wantStderr: "unknown command"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			beforeRPC := rpcCalls.Load()
+			beforeServe := serveCalls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if rpcCalls.Load() != beforeRPC {
+				t.Fatalf("RPC calls changed from %d to %d", beforeRPC, rpcCalls.Load())
+			}
+			if serveCalls.Load() != beforeServe {
+				t.Fatalf("serve calls changed from %d to %d", beforeServe, serveCalls.Load())
+			}
+		})
+	}
+}
+
+func decodeOutputJSON[T any](t *testing.T, raw string) T {
+	t.Helper()
+	var out T
+	dec := json.NewDecoder(strings.NewReader(raw))
+	if err := dec.Decode(&out); err != nil {
+		t.Fatalf("decode JSON output %q: %v", raw, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		t.Fatalf("JSON output contains more than one document: %q", raw)
+	}
+	return out
+}
+
+func assertEmptyStderr(t *testing.T, raw string) {
+	t.Helper()
+	if strings.TrimSpace(raw) != "" {
+		t.Fatalf("stderr = %q, want empty", raw)
+	}
+}
+
+func outputModeVerifyFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: output-mode-verify
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: output-mode-verify`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+case:
+  priority:
+    type: integer
+    _unused_reason: output-mode verification fixture field
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events: [task.assigned]
+    reads: [priority]
+  outputs:
+    events: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+task.assigned:
+  swarm:
+    source: external (output mode verify test)
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
+reader:
+  id: reader
+  execution_type: system_node
+  subscribes_to: [task.assigned]
+  event_handlers:
+    task.assigned:
+      create_entity: true
+      guard:
+        check: "entity.priority >= 0"
+      advances_to: done
+`)
+	return root
+}

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -20,6 +20,7 @@ const (
 
 type conversationListCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 
 	agentID string
 	runID   string
@@ -30,6 +31,16 @@ type conversationListCommandOptions struct {
 	runIDSet   bool
 	limitSet   bool
 	cursorSet  bool
+}
+
+type conversationViewCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+}
+
+type conversationTurnCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
 }
 
 type conversationListResult struct {
@@ -158,6 +169,9 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 			listOpts.runIDSet = cmd.Flags().Changed("run-id")
 			listOpts.limitSet = cmd.Flags().Changed("limit")
 			listOpts.cursorSet = cmd.Flags().Changed("cursor")
+			if err := listOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			return runConversationsListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
 		},
 	}
@@ -165,29 +179,42 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&listOpts.runID, "run-id", "", "Filter by run id")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	bindCLIOutputFlags(cmd, &listOpts.output)
 	return cmd
 }
 
 func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	viewOpts := conversationViewCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
 		Use:   "view <session-id>",
 		Short: "View one conversation through /v1/rpc conversation.get.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConversationViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0])
+			if err := viewOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runConversationViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), viewOpts, args[0])
 		},
 	}
+	bindCLIOutputFlags(cmd, &viewOpts.output)
+	return cmd
 }
 
 func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	turnOpts := conversationTurnCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
 		Use:   "turn <session-id> <turn-index>",
 		Short: "View one conversation turn through /v1/rpc conversation.get_turn.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConversationTurnCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args[0], args[1])
+			if err := turnOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runConversationTurnCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), turnOpts, args[0], args[1])
 		},
 	}
+	bindCLIOutputFlags(cmd, &turnOpts.output)
+	return cmd
 }
 
 func runConversationsListCommand(ctx context.Context, out, errOut io.Writer, opts conversationListCommandOptions) error {
@@ -206,16 +233,19 @@ func runConversationsListCommand(ctx context.Context, out, errOut io.Writer, opt
 	if err := validateConversationListResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, conversationListAPIErrorClassifier())
 	}
-	writeConversationListResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeConversationListResult(w, result)
+	}, func() ([]string, error) {
+		return quietConversationList(result), nil
+	})
 }
 
-func runConversationViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, sessionID string) error {
+func runConversationViewCommand(ctx context.Context, out, errOut io.Writer, opts conversationViewCommandOptions, sessionID string) error {
 	sessionID = strings.TrimSpace(sessionID)
 	if err := validateConversationOpaqueIDArg("session id", sessionID); err != nil {
 		return returnCLIValidationError(errOut, err)
 	}
-	client, err := newCLIAPIClient(opts)
+	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
 		return returnCLIAPIError(errOut, err, conversationViewAPIErrorClassifier())
 	}
@@ -226,11 +256,14 @@ func runConversationViewCommand(ctx context.Context, out, errOut io.Writer, opts
 	if err := validateConversationDetailResult("conversation.get result", result); err != nil {
 		return returnCLIAPIError(errOut, err, conversationViewAPIErrorClassifier())
 	}
-	writeConversationDetailResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeConversationDetailResult(w, result)
+	}, func() ([]string, error) {
+		return []string{result.Conversation.SessionID}, nil
+	})
 }
 
-func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, sessionID, turnIndexRaw string) error {
+func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts conversationTurnCommandOptions, sessionID, turnIndexRaw string) error {
 	sessionID = strings.TrimSpace(sessionID)
 	if err := validateConversationOpaqueIDArg("session id", sessionID); err != nil {
 		return returnCLIValidationError(errOut, err)
@@ -239,7 +272,7 @@ func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts
 	if err != nil {
 		return returnCLIValidationError(errOut, err)
 	}
-	client, err := newCLIAPIClient(opts)
+	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
 		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
 	}
@@ -251,8 +284,19 @@ func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts
 	if err := validateConversationTurnDetailResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
 	}
-	writeConversationTurnDetailResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeConversationTurnDetailResult(w, result)
+	}, func() ([]string, error) {
+		return []string{fmt.Sprintf("%s %d %s", result.Session.SessionID, result.Turn.TurnIndex, firstNonEmpty(result.Turn.Outcome, result.Session.Status))}, nil
+	})
+}
+
+func quietConversationList(result conversationListResult) []string {
+	out := make([]string, 0, len(result.Conversations))
+	for _, conversation := range result.Conversations {
+		out = append(out, conversation.SessionID)
+	}
+	return out
 }
 
 func (opts conversationListCommandOptions) params() (map[string]any, error) {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -12,6 +12,7 @@ import (
 
 type diagnosticRunListOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 	status     string
 	since      string
 	until      string
@@ -26,6 +27,7 @@ type diagnosticTraceOptions struct {
 
 type diagnosticRunOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 	noDiagnose bool
 }
 
@@ -120,24 +122,33 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
 				return fmt.Errorf("--limit must be between 1 and 500")
 			}
+			if err := runOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			return runDiagnosticRunListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts)
 		},
 	}
 	bindDiagnosticRunListFlags(cmd, &runOpts)
+	bindCLIOutputFlags(cmd, &runOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }
 
 func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 	apiOpts := opts
+	outputOpts := cliOutputOptions{}
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Print structured operator health through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts)
+			if err := outputOpts.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runDiagnosticHealthCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, outputOpts)
 		},
 	}
+	bindCLIOutputFlags(cmd, &outputOpts)
 	bindCLIAPIConnectionFlags(cmd, &apiOpts)
 	return cmd
 }
@@ -153,10 +164,14 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 			if len(args) == 1 {
 				runID = args[0]
 			}
+			if err := runOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			return runDiagnosticRunCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts, runID)
 		},
 	}
 	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
+	bindCLIOutputFlags(cmd, &runOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }
@@ -313,8 +328,11 @@ func runDiagnosticRunListCommand(ctx context.Context, out, errOut io.Writer, opt
 	if err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
-	writeDiagnosticRunList(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeDiagnosticRunList(w, result)
+	}, func() ([]string, error) {
+		return quietDiagnosticRunList(result), nil
+	})
 }
 
 func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticRunOptions, runID string) error {
@@ -337,8 +355,11 @@ func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts di
 		if err := validateDiagnosticRunHeader("run", result.Run); err != nil {
 			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 		}
-		writeDiagnosticRunHeader(out, result.Run)
-		return nil
+		return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+			writeDiagnosticRunHeader(w, result.Run)
+		}, func() ([]string, error) {
+			return []string{fmt.Sprintf("%s %s", result.Run.RunID, result.Run.Status)}, nil
+		})
 	}
 	var result diagnosticRunDiagnosisResult
 	if err := client.call(ctx, "run.diagnose", map[string]any{"run_id": runID}, &result); err != nil {
@@ -347,8 +368,11 @@ func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts di
 	if err := validateDiagnosticRunDiagnosis(result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
-	writeDiagnosticRunDiagnosis(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeDiagnosticRunDiagnosis(w, result)
+	}, func() ([]string, error) {
+		return []string{fmt.Sprintf("%s %s", result.Run.RunID, stringPointerValue(result.OperationalState))}, nil
+	})
 }
 
 func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
@@ -427,13 +451,31 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	}
 }
 
-func runDiagnosticHealthCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions) error {
+func runDiagnosticHealthCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, output cliOutputOptions) error {
 	result, err := fetchDiagnosticHealthCheck(ctx, opts)
 	if err != nil {
 		return returnCLIAPIError(errOut, err, cliAPIErrorClassifier{})
 	}
-	writeDiagnosticHealth(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, output, result, func(w io.Writer) {
+		writeDiagnosticHealth(w, result)
+	}, func() ([]string, error) {
+		return []string{quietDiagnosticHealth(result)}, nil
+	})
+}
+
+func quietDiagnosticRunList(result diagnosticRunListResult) []string {
+	out := make([]string, 0, len(result.Runs))
+	for _, run := range result.Runs {
+		out = append(out, run.RunID)
+	}
+	return out
+}
+
+func quietDiagnosticHealth(result diagnosticHealthCheckResult) string {
+	if boolPointerValue(result.Alive) && boolPointerValue(result.Ready) && boolPointerValue(result.DBOK) && boolPointerValue(result.RuntimeOK) {
+		return "healthy"
+	}
+	return "unhealthy"
 }
 
 func diagnosticRunAPIErrorClassifier() cliAPIErrorClassifier {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -381,8 +381,7 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string,
 	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	outputOpts := cliOutputOptions{}
-	fs.BoolVar(&outputOpts.asJSON, "json", false, "Render successful output as one JSON document")
-	fs.BoolVar(&outputOpts.quiet, "quiet", false, "Render only declared load-bearing value(s)")
+	bindCLIOutputFlagSet(fs, &outputOpts)
 	if err := fs.Parse(args); err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "verify failed: %v\n", err)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -357,20 +357,47 @@ func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor
 	return errors.Join(shutdownErr, cleanupErr)
 }
 
+type verifyCommandResult struct {
+	OK           bool                  `json:"ok"`
+	Contracts    string                `json:"contracts"`
+	Warnings     []verifyFindingOutput `json:"warnings"`
+	LintEvidence []verifyFindingOutput `json:"lint_evidence"`
+}
+
+type verifyFindingOutput struct {
+	CheckID  string `json:"check_id"`
+	Severity string `json:"severity"`
+	Location string `json:"location"`
+	Message  string `json:"message"`
+}
+
 func runVerifyCommand(ctx context.Context, repo string, args []string, out io.Writer) int {
+	return runVerifyCommandWithOutput(ctx, repo, args, out, out)
+}
+
+func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string, out, errOut io.Writer) int {
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
+	outputOpts := cliOutputOptions{}
+	fs.BoolVar(&outputOpts.asJSON, "json", false, "Render successful output as one JSON document")
+	fs.BoolVar(&outputOpts.quiet, "quiet", false, "Render only declared load-bearing value(s)")
 	if err := fs.Parse(args); err != nil {
-		if out != nil {
-			fmt.Fprintf(out, "verify failed: %v\n", err)
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: %v\n", err)
+		}
+		return 2
+	}
+	if err := outputOpts.validate(); err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: %v\n", err)
 		}
 		return 2
 	}
 	if err := loadRepoDotEnv(repo); err != nil {
-		if out != nil {
-			fmt.Fprintf(out, "verify failed: load .env: %v\n", err)
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: load .env: %v\n", err)
 		}
 		return 1
 	}
@@ -378,31 +405,56 @@ func runVerifyCommand(ctx context.Context, repo string, args []string, out io.Wr
 	resolvedPlatformSpecPath := resolvePath(repo, *platformSpecPath)
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
-		if out != nil {
-			fmt.Fprintf(out, "verify failed: resolve contracts: %v\n", err)
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: resolve contracts: %v\n", err)
 		}
 		return 1
 	}
 	if _, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPlatformSpecPath); err != nil {
-		if out != nil {
-			fmt.Fprintf(out, "verify failed: load Swarm contracts: %v\n", err)
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: load Swarm contracts: %v\n", err)
 		}
 		return 1
 	} else {
 		result, err := verifyBundleResult(ctx, semanticview.Wrap(bundle))
 		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "verify failed: %v\n", err)
+			if errOut != nil {
+				fmt.Fprintf(errOut, "verify failed: %v\n", err)
 			}
 			return 1
 		}
-		if out != nil {
-			writeVerifyFindings(out, "warning", result.BootReport.Warnings())
-			writeVerifyFindings(out, "lint_evidence", result.BootReport.LintEvidence())
-			fmt.Fprintf(out, "verify ok: contracts=%s\n", contractsRoot)
+		output := verifyCommandResult{
+			OK:           true,
+			Contracts:    contractsRoot,
+			Warnings:     verifyFindingOutputs(result.BootReport.Warnings()),
+			LintEvidence: verifyFindingOutputs(result.BootReport.LintEvidence()),
+		}
+		if err := renderCLIOutput(out, errOut, outputOpts, output, func(w io.Writer) {
+			writeVerifyFindings(w, "warning", result.BootReport.Warnings())
+			writeVerifyFindings(w, "lint_evidence", result.BootReport.LintEvidence())
+			if w != nil {
+				fmt.Fprintf(w, "verify ok: contracts=%s\n", contractsRoot)
+			}
+		}, func() ([]string, error) {
+			return []string{"ok"}, nil
+		}); err != nil {
+			return 2
 		}
 	}
 	return 0
+}
+
+func verifyFindingOutputs(findings []runtimebootverify.Finding) []verifyFindingOutput {
+	out := make([]verifyFindingOutput, 0, len(findings))
+	for _, finding := range findings {
+		out = append(out, verifyFindingOutput{
+			CheckID:  strings.TrimSpace(finding.CheckID),
+			Severity: strings.TrimSpace(finding.Severity),
+			Location: strings.TrimSpace(finding.Location),
+			Message:  strings.TrimSpace(finding.Message),
+		})
+	}
+	return out
 }
 
 type runStatusReport struct {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -708,8 +708,11 @@ func TestCLI_VerifyPreservesLocalContractCarveOut(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("verify code = %d, want 1 stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "verify failed: resolve contracts") {
-		t.Fatalf("verify output = %q, want local contract resolution failure", stdout.String())
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty on error", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "verify failed: resolve contracts") {
+		t.Fatalf("verify stderr = %q, want local contract resolution failure", stderr.String())
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5831,7 +5831,63 @@ cli_specification:
         - entities_list
         - entity_view
         - entity_aggregate
+        - conversations_list
+        - conversation_view
+        - conversation_turn
         - run
+        implemented_output_mode_first_slice:
+          implemented_by: '#920'
+          failure_class: runtime.cli.v2.output_mode_renderer_first_slice_diagnostic_local_conversation_read_consumers
+          owner: cmd/swarm shared output-mode renderer
+          status: implemented
+          rule: >
+            These currently implemented consumers accept `--json` and `--quiet` through the shared output-mode
+            owner. `--json` renders exactly one JSON document plus newline using canonical local/API result structs.
+            `--quiet` renders only the declared load-bearing values below. `--json --quiet` fails with CLI validation
+            exit 2 before local contract verification, API calls, runtime boot, or other side effects.
+          consumers:
+            version:
+              fact_owner: local binary metadata; /v1/rpc health.check when --server is supplied
+              json_shape: local binary metadata object; with --server includes a server health.check object
+              quiet_values:
+              - binary_version
+              - server_bundle_fingerprint when --server is supplied
+            verify:
+              fact_owner: local contract verification
+              json_shape: object with ok, contracts, warnings, and lint_evidence
+              quiet_values:
+              - ok
+            health:
+              fact_owner: /v1/rpc health.check
+              json_shape: health.check result object
+              quiet_values:
+              - healthy when alive, ready, db_ok, and runtime_ok are all true; unhealthy otherwise
+            runs:
+              fact_owner: /v1/rpc run.list
+              json_shape: run.list result object
+              quiet_values:
+              - run_id, one per returned run, in API result order
+            status:
+              fact_owner: /v1/rpc run.diagnose; /v1/rpc run.get when --no-diagnose is supplied
+              json_shape: run.diagnose result object, or run.get result object for --no-diagnose
+              quiet_values:
+              - run_id and operational_state for diagnose mode
+              - run_id and run status for --no-diagnose mode
+            conversations_list:
+              fact_owner: /v1/rpc conversation.list
+              json_shape: conversation.list result object
+              quiet_values:
+              - session_id, one per returned conversation, in API result order
+            conversation_view:
+              fact_owner: /v1/rpc conversation.get
+              json_shape: conversation.get result object
+              quiet_values:
+              - session_id
+            conversation_turn:
+              fact_owner: /v1/rpc conversation.get_turn
+              json_shape: conversation.get_turn result object
+              quiet_values:
+              - session_id, turn_index, and outcome/status summary
         implemented_consumer_residuals:
           logs: >
             `swarm logs` is implemented for default-text snapshot and follow in #876 and is no longer an absent


### PR DESCRIPTION
## Summary

Closes #920.

Implements the approved first-slice class `runtime.cli.v2.output_mode_renderer_first_slice_diagnostic_local_conversation_read_consumers`:

- Adds one shared `cmd/swarm` output-mode renderer for `--json`, `--quiet`, collision validation, JSON encoding, quiet rendering, and stdout/stderr handling.
- Wires the approved consumers only: `version`, `verify`, `health`, `runs`, `status`, `conversations list`, `conversation view`, and `conversation turn`.
- Updates authoritative `platform-spec.yaml#cli_specification.foundations.output_contract` with the first-slice consumer accounting, conversation consumer registration, JSON shapes, and quiet values.

## Governing Refs / Context

- Binding spec: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.output_contract`.
- Adjacent binding spec: `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`.
- Binding issue/gate context: #920 repaired pre-audit and independent gate approval.

## Semantic Migration

New canonical owner: shared `cmd/swarm` output-mode renderer (`cmd/swarm/cli_output.go`).

Old producer/reader/writer path now invalid for this slice: command-local acceptance of output flags, command-local JSON/quiet rendering, accepted output flags silently falling back to text, and verify success output bypassing the shared output owner.

Production paths checked for surviving old behavior: the approved consumers now call `renderCLIOutput`; root/help/completion, `serve`, retired namespaces, absent `forkchat`, stream/follow commands, mutating command families, color/logging, and universal config/env behavior remain split per the gate.

Migration completeness: complete for the approved first slice only; parent output-contract tails remain open under #844/#794/#735.

## Proof

- `go test ./cmd/swarm -run '^TestCLIOutput' -count=1` passed.
- `go test ./cmd/swarm -run 'TestCLIOutput|TestVersion|TestRunsUse|TestStatusUses|TestConversations|TestConversation|TestCLI_VerifyPreservesLocalContractCarveOut|TestRunVerifyCommand' -count=1` passed.
- `git diff --check` passed.
- Grep proof: `rg -n "renderCLIOutput\(|bindCLIOutputFlags\(|cliOutputOptions" cmd/swarm/cli.go cmd/swarm/diagnostics.go cmd/swarm/conversations.go cmd/swarm/main.go cmd/swarm/cli_output.go` shows all accepted output modes consume the shared renderer/flags owner.

Full required suite note: `go test ./cmd/swarm -count=1` currently fails on `TestLoadRunStatusReport_PreservesRunningTruthWhileManagerWorkIsActive` with `last same-run event ... is after ended_at ...`. I reproduced the same failure on a clean detached `origin/master` worktree at `dc26d2537f4086c102e1fc9794195178efdc0e29`, so this is a pre-existing baseline failure outside the approved #920 output-renderer class.