### PR TITLE
[agent-c][issue #923] Remove unsupported agent metric stubs

### DIFF
--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -187,6 +187,12 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if reads.lastAgentList.Flow != "flow/a" || reads.lastAgentList.Role != "researcher" {
 		t.Fatalf("agent.list options = %#v", reads.lastAgentList)
 	}
+	listResult := asMap(t, listAgents.Result)
+	agents, ok := listResult["agents"].([]any)
+	if !ok || len(agents) != 1 {
+		t.Fatalf("agent.list result = %#v", listResult)
+	}
+	assertUnsupportedAgentMetricStubsAbsent(t, asMap(t, agents[0]))
 
 	getAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent","method":"agent.get","params":{"agent_id":"agent-1"}}`)
 	if getAgent.Error != nil {
@@ -197,6 +203,7 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	}
 	agentResult := asMap(t, getAgent.Result)
 	agent := asMap(t, agentResult["agent"])
+	assertUnsupportedAgentMetricStubsAbsent(t, agent)
 	for _, splitField := range []string{"queue", "delivery_lifecycle", "runtime_state", "last_tool_outcome"} {
 		if _, ok := agent[splitField]; ok {
 			t.Fatalf("agent.get unexpectedly exposed diagnosis field %q: %#v", splitField, agent)
@@ -288,6 +295,15 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	currentTurns, _ := asMap(t, current.Result)["turns"].([]any)
 	if len(currentTurns) != 1 || asMap(t, currentTurns[0])["turn_index"] != float64(1) {
 		t.Fatalf("conversation.current_for_agent turns = %#v, want turn_index 1", asMap(t, current.Result)["turns"])
+	}
+}
+
+func assertUnsupportedAgentMetricStubsAbsent(t *testing.T, payload map[string]any) {
+	t.Helper()
+	for _, key := range []string{"turns_24h", "in_flight_seconds"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("agent read exposed unsupported metric stub %q: %#v", key, payload)
+		}
 	}
 }
 

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -321,14 +321,12 @@ type genericAgent struct {
 	PendingEvents       int               `json:"pending_events,omitempty"`
 	OldestPendingAgeSec int               `json:"oldest_pending_age_sec,omitempty"`
 	InFlightTurn        bool              `json:"in_flight_turn,omitempty"`
-	InFlightSeconds     int               `json:"in_flight_seconds,omitempty"`
 	LockOwner           string            `json:"lock_owner,omitempty"`
 	LockExpiresAt       string            `json:"lock_expires_at,omitempty"`
 	Failures24h         int               `json:"failures_24h,omitempty"`
 	DeadLetters24h      int               `json:"dead_letters_24h,omitempty"`
 	TurnCount           int               `json:"turn_count,omitempty"`
 	TurnLimit           int               `json:"turn_limit,omitempty"`
-	Turns24h            int               `json:"turns_24h,omitempty"`
 	TotalTokens24h      int               `json:"total_tokens_24h,omitempty"`
 	NearBreaker         bool              `json:"near_breaker,omitempty"`
 	SessionID           string            `json:"session_id,omitempty"`
@@ -1033,14 +1031,12 @@ func genericAgentFromOperatorSummary(row store.OperatorAgentSummary) genericAgen
 		PendingEvents:       row.PendingEvents,
 		OldestPendingAgeSec: row.OldestPendingAgeSec,
 		InFlightTurn:        row.InFlightTurn,
-		InFlightSeconds:     row.InFlightSeconds,
 		LockOwner:           strings.TrimSpace(row.LockOwner),
 		LockExpiresAt:       formatTime(row.LockExpiresAt),
 		Failures24h:         row.Failures24h,
 		DeadLetters24h:      row.DeadLetters24h,
 		TurnCount:           row.TurnCount,
 		TurnLimit:           row.TurnLimit,
-		Turns24h:            row.Turns24h,
 		NearBreaker:         row.NearBreaker,
 		SessionID:           strings.TrimSpace(row.SessionID),
 		ProviderSessionID:   strings.TrimSpace(row.ProviderSessionID),

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -100,7 +100,7 @@ func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 func canonicalAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -335,6 +335,62 @@ func TestHandler_InstanceHandlersReturnCanonicalEntityProjection(t *testing.T) {
 	group, _ := groups[0].(map[string]any)
 	if group["key"] != "reviewing" || group["count"] != float64(1) {
 		t.Fatalf("aggregate group = %#v, want reviewing=1", group)
+	}
+}
+
+func TestHandler_AgentHandlersDoNotExposeUnsupportedMetricStubs(t *testing.T) {
+	now := time.Date(2026, 5, 22, 3, 30, 0, 0, time.UTC)
+	h := &Handler{
+		agents: stubAgents{rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:               "agent-1",
+				Role:             "worker",
+				Type:             "managed",
+				ModelTier:        "haiku",
+				ConversationMode: "session",
+				SessionScope:     "global",
+			},
+			Status:    "active",
+			StartedAt: now,
+		}}},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	h.handleAgents(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleAgents status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var listPayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listPayload); err != nil {
+		t.Fatalf("unmarshal agents: %v", err)
+	}
+	rows, ok := listPayload["agents"].([]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("agents payload = %#v", listPayload)
+	}
+	assertUnsupportedAgentMetricStubsAbsent(t, rows[0].(map[string]any))
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/agents/agent-1", nil)
+	req.SetPathValue("id", "agent-1")
+	h.handleAgentDetail(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleAgentDetail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var detailPayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &detailPayload); err != nil {
+		t.Fatalf("unmarshal agent detail: %v", err)
+	}
+	assertUnsupportedAgentMetricStubsAbsent(t, detailPayload)
+}
+
+func assertUnsupportedAgentMetricStubsAbsent(t *testing.T, payload map[string]any) {
+	t.Helper()
+	for _, key := range []string{"turns_24h", "in_flight_seconds"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("agent payload exposed unsupported metric stub %q: %#v", key, payload)
+		}
 	}
 }
 
@@ -1722,7 +1778,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(turnBlocksPayload)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1784,7 +1840,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
@@ -1817,7 +1873,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
@@ -1851,7 +1907,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResul
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
 		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
@@ -1891,7 +1947,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, 0, "turn-7", "task-7", false, "", time.Now(), []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, "turn-7", "task-7", false, "", time.Now(), []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1952,7 +2008,7 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -2004,7 +2060,7 @@ func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenD
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -2169,7 +2225,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
 		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -82,14 +82,12 @@ type OperatorAgentSummary struct {
 	PendingEvents         int                                 `json:"-"`
 	OldestPendingAgeSec   int                                 `json:"-"`
 	InFlightTurn          bool                                `json:"-"`
-	InFlightSeconds       int                                 `json:"-"`
 	LockOwner             string                              `json:"-"`
 	LockExpiresAt         time.Time                           `json:"-"`
 	Failures24h           int                                 `json:"-"`
 	DeadLetters24h        int                                 `json:"-"`
 	TurnCount             int                                 `json:"-"`
 	TurnLimit             int                                 `json:"-"`
-	Turns24h              int                                 `json:"-"`
 	NearBreaker           bool                                `json:"-"`
 	SessionID             string                              `json:"-"`
 	ProviderSessionID     string                              `json:"-"`
@@ -433,11 +431,9 @@ type operatorAgentProjection struct {
 	LockOwner           string
 	LockExpiresAt       time.Time
 	InFlightTurn        bool
-	InFlightSeconds     int
 	Failures24h         int
 	DeadLetters24h      int
 	TurnCount           int
-	Turns24h            int
 	SessionID           string
 	SessionStartedAt    time.Time
 	ProviderSessionID   string
@@ -1077,7 +1073,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			0,
 			COALESCE(f.failures_24h, 0),
 			COALESCE(f.dead_letters_24h, 0),
-			0,
 			COALESCE(latest_turn.turn_id, ''),
 			COALESCE(latest_turn.task_id, ''),
 			COALESCE(latest_turn.parse_ok, false),
@@ -1161,7 +1156,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			&projection.OldestPendingAgeSec,
 			&projection.Failures24h,
 			&projection.DeadLetters24h,
-			&projection.Turns24h,
 			&latestTurnID,
 			&latestTaskID,
 			&latestParseOK,
@@ -1251,14 +1245,12 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		PendingEvents:         projection.PendingEvents,
 		OldestPendingAgeSec:   projection.OldestPendingAgeSec,
 		InFlightTurn:          projection.InFlightTurn,
-		InFlightSeconds:       projection.InFlightSeconds,
 		LockOwner:             strings.TrimSpace(projection.LockOwner),
 		LockExpiresAt:         projection.LockExpiresAt,
 		Failures24h:           projection.Failures24h,
 		DeadLetters24h:        projection.DeadLetters24h,
 		TurnCount:             projection.TurnCount,
 		TurnLimit:             maxStoreInt(turnLimit, 0),
-		Turns24h:              maxStoreInt(projection.Turns24h, 0),
 		SessionID:             strings.TrimSpace(projection.SessionID),
 		ProviderSessionID:     strings.TrimSpace(projection.ProviderSessionID),
 		CurrentTaskID:         strings.TrimSpace(projection.CurrentTaskID),

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -89,7 +89,7 @@ func canonicalAgentConversationReadCaps() StoreSchemaCapabilities {
 func operatorAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turns_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -296,7 +296,7 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, 0, turnID, "task-1", false, "model error", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", false, "model error", turnCompletedAt, []byte(`[]`)))
 
 	detail, err := reader.LoadOperatorAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -356,7 +356,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
@@ -416,7 +416,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -454,7 +454,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedRuntime
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "decode latest agent session runtime_state") || !strings.Contains(err.Error(), "watchdog.state") {
@@ -483,7 +483,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLifecyc
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "delivery_lifecycle.state") {
@@ -535,7 +535,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
@@ -577,7 +577,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveL
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()))


### PR DESCRIPTION
## Summary

- Removes unsupported `Turns24h` / `turns_24h` and `InFlightSeconds` / `in_flight_seconds` from the agent/operator read owner path instead of computing them.
- Removes the hardcoded `Turns24h` zero projection column/scan and the dashboard `genericAgent` DTO copies for both fields.
- Adds dashboard direct list/detail and supported v1 `agent.list` / `agent.get` absence proofs.

Closes #923
Part of #101

## Governing Refs / Context

Approved gate: #923 independent gate outcome `approved as first slice` for remove-not-compute closure of only `Turns24h` and `InFlightSeconds`.

Exact binding spec context:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.AgentSummary`: `additionalProperties: false`; no `Turns24h` / `InFlightSeconds` fields.
- `components.schemas.AgentDetail`: returns `agent`, `current_session_ref`, and `last_turn_ref` only.
- `api_specification.method_catalog.agent.list`: returns `AgentSummary[]`.
- `agent.get`: returns `AgentDetail` and states agent methods return refs only, not session/transcript content.
- `agent.diagnose`: separate bounded diagnosis owner; no widening into these dashboard metric stubs.
- Legacy disposition: `GET /api/agents -> agent.list`, `GET /api/agents/{id} -> agent.get`.

No exact platform/OpenRPC contract authorizes `Turns24h` or `InFlightSeconds`; the binding #923/#101 context requires removing these phantom fields rather than preserving or computing them.

## Semantic Migration

- Canonical owner after this change: supported agent read contracts remain `AgentSummary` / `AgentDetail` / `AgentDiagnosis`, with the code owner remaining `store.OperatorAgentConversationReadSurface` for agent/operator read projections.
- Old invalid paths removed: hardcoded `Turns24h` `0` select/scan, store projection/summary fields, dashboard `genericAgent` fields/copies, and fixtures modeling `turns_24h` as an owned projection column.
- Production paths checked for surviving old behavior: store operator projection, dashboard direct list/detail adapter, supported v1 `agent.list` / `agent.get`, and repository symbol audit for the two removed fields.
- Migration completeness: complete for the approved #923 two-field child. Split siblings remain under #101/#852/#363 as recorded in the gate.

## Validation

- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs|TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_AgentHandlersDoNotExposeUnsupportedMetricStubs|TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner|TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner' -count=1`
- `git diff --check`
- `rg -n "Turns24h|turns_24h|InFlightSeconds|in_flight_seconds" internal cmd docs -g'*.go' -g'*.yaml' -g'*.md'` (only negative-assertion test keys remain)
- `go test ./...`