### PR TITLE
[agent-f][issue #922] Promote agent.diagnose active turn refs

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -14,7 +14,7 @@
   "methods": [
     {
       "name": "agent.diagnose",
-      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner. It must not join conversation,\nrun, trace, token, CLI, or dashboard owners locally, and it must not\nexpose the full runtime_state enum, top-level watchdog, run_id,\nbundle_version, active task/entity, last tool outcome, token usage,\nrecent failures, or dead letters.\n",
+      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor,\nand active as selected active-session latest-turn refs. active is\nomitted when no active live session is selected or the selected session\nhas no latest turn. active.turn_id is required when active is present;\nactive.task_id and active.entity_id are omitted when empty or absent.\nactive.entity_id is the latest selected agent_turns.entity_id dispatch\nentity and must not fall back to the agent configured/effective entity,\ntask target entity, role-scoped current-entity tool context, dashboard\nprojection, conversation API response, or stale session evidence.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner and selected-turn active\nsub-owner. It must not join conversation, run, trace, token, CLI, or\ndashboard owners locally, and it must not expose the full runtime_state\nenum, top-level watchdog, run_id, bundle_version, actual in-flight\nactive work, configured/effective current entity, task target entity,\nrole-scoped current entity, last tool outcome, token usage, recent\nfailures, or dead letters.\n",
       "params": [
         {
           "name": "agent_id",
@@ -5364,6 +5364,9 @@
       "AgentDiagnosis": {
         "additionalProperties": false,
         "properties": {
+          "active": {
+            "$ref": "#/components/schemas/AgentDiagnosisActive"
+          },
           "agent_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
@@ -5390,6 +5393,26 @@
           "agent_id",
           "status",
           "queue"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosisActive": {
+        "additionalProperties": false,
+        "description": "Selected active-session latest-turn refs for agent.diagnose. This\nobject is present only when the diagnosis owner selects an active\nlive agent_sessions row for session/session_per_entity modes and that\nselected session has a latest agent_turns row. It is persisted\nselected-turn evidence, not proof of actual in-flight work. turn_id is\nthe selected latest turn. task_id is the same selected latest\nagent_turns.task_id and is omitted when empty. entity_id is the same\nselected latest agent_turns.entity_id dispatch entity and is omitted\nwhen absent. The owner must not fall back to AgentConfig\nEffectiveEntityID(), task target entity, role-scoped current-entity\ntool context, dashboard projections, conversation API composition, or\nstale/inactive session rows.\n",
+        "properties": {
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "task_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "turn_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        "required": [
+          "turn_id"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8809,6 +8809,32 @@ api_specification:
         properties:
           watchdog:
             $ref: '#/components/schemas/AgentDiagnosisWatchdog'
+      AgentDiagnosisActive:
+        type: object
+        additionalProperties: false
+        description: |
+          Selected active-session latest-turn refs for agent.diagnose. This
+          object is present only when the diagnosis owner selects an active
+          live agent_sessions row for session/session_per_entity modes and that
+          selected session has a latest agent_turns row. It is persisted
+          selected-turn evidence, not proof of actual in-flight work. turn_id is
+          the selected latest turn. task_id is the same selected latest
+          agent_turns.task_id and is omitted when empty. entity_id is the same
+          selected latest agent_turns.entity_id dispatch entity and is omitted
+          when absent. The owner must not fall back to AgentConfig
+          EffectiveEntityID(), task target entity, role-scoped current-entity
+          tool context, dashboard projections, conversation API composition, or
+          stale/inactive session rows.
+        required:
+        - turn_id
+        properties:
+          turn_id:
+            $ref: '#/components/schemas/OpaqueId'
+          task_id:
+            type: string
+            minLength: 1
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
       AgentDiagnosis:
         type: object
         additionalProperties: false
@@ -8831,6 +8857,8 @@ api_specification:
             $ref: '#/components/schemas/AgentDeliveryLifecycle'
           runtime_state:
             $ref: '#/components/schemas/AgentDiagnosisRuntimeState'
+          active:
+            $ref: '#/components/schemas/AgentDiagnosisActive'
       ConversationSummary:
         type: object
         additionalProperties: false
@@ -10685,7 +10713,15 @@ api_specification:
         limited to agent identity/status refs, current/last conversation refs,
         pending-delivery queue summary/detail evidence, and optional delivery
         lifecycle evidence. It may also return runtime_state.watchdog as a
-        narrow projection of the canonical active session watchdog descriptor.
+        narrow projection of the canonical active session watchdog descriptor,
+        and active as selected active-session latest-turn refs. active is
+        omitted when no active live session is selected or the selected session
+        has no latest turn. active.turn_id is required when active is present;
+        active.task_id and active.entity_id are omitted when empty or absent.
+        active.entity_id is the latest selected agent_turns.entity_id dispatch
+        entity and must not fall back to the agent configured/effective entity,
+        task target entity, role-scoped current-entity tool context, dashboard
+        projection, conversation API response, or stale session evidence.
         runtime_state.watchdog is omitted when no active live session or no
         active-session watchdog evidence exists, and malformed watchdog data
         fails closed. Queue details are paged with queue_limit and
@@ -10695,11 +10731,13 @@ api_specification:
         canonical recorded retry counter from event_deliveries.retry_count, with
         no API-layer +1 or status arithmetic. The API handler consumes the
         canonical agent diagnosis read owner directly, including its
-        watchdog-backed runtime_state sub-owner. It must not join conversation,
-        run, trace, token, CLI, or dashboard owners locally, and it must not
-        expose the full runtime_state enum, top-level watchdog, run_id,
-        bundle_version, active task/entity, last tool outcome, token usage,
-        recent failures, or dead letters.
+        watchdog-backed runtime_state sub-owner and selected-turn active
+        sub-owner. It must not join conversation, run, trace, token, CLI, or
+        dashboard owners locally, and it must not expose the full runtime_state
+        enum, top-level watchdog, run_id, bundle_version, actual in-flight
+        active work, configured/effective current entity, task target entity,
+        role-scoped current entity, last tool outcome, token usage, recent
+        failures, or dead letters.
       scope:
         required:
         - read:agents

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 66 {
-		t.Fatalf("schema count = %d, want 66", report.SchemaCount)
+	if report.SchemaCount != 67 {
+		t.Fatalf("schema count = %d, want 67", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 66 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 66", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 67 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 67", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -102,6 +102,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := doc.Components.Schemas["AgentDiagnosisWatchdog"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisWatchdog")
 	}
+	if _, ok := doc.Components.Schemas["AgentDiagnosisActive"]; !ok {
+		t.Fatal("generated OpenRPC missing AgentDiagnosisActive")
+	}
 	agentDiagnosisSchema, ok := doc.Components.Schemas["AgentDiagnosis"].(map[string]any)
 	if !ok {
 		t.Fatalf("generated AgentDiagnosis schema = %#v, want object", doc.Components.Schemas["AgentDiagnosis"])
@@ -116,6 +119,13 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if got, want := runtimeStateSchema["$ref"], "#/components/schemas/AgentDiagnosisRuntimeState"; got != want {
 		t.Fatalf("generated AgentDiagnosis.runtime_state ref = %#v, want %q", got, want)
+	}
+	activeSchema, ok := agentDiagnosisProperties["active"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated AgentDiagnosis.active = %#v, want object", agentDiagnosisProperties["active"])
+	}
+	if got, want := activeSchema["$ref"], "#/components/schemas/AgentDiagnosisActive"; got != want {
+		t.Fatalf("generated AgentDiagnosis.active ref = %#v, want %q", got, want)
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -264,7 +264,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 
 func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 	return map[string]readOnlyHTTPRuntimeFixture{
-		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state"}},
+		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
@@ -537,6 +537,11 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 					State:         "active",
 					BlockingLayer: "session_execution",
 				},
+				Active: &store.OperatorAgentDiagnosisActive{
+					TurnID:   "22222222-2222-2222-2222-222222222222",
+					TaskID:   "task-1",
+					EntityID: "33333333-3333-3333-3333-333333333333",
+				},
 				RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
 					Watchdog: &store.OperatorAgentDiagnosisWatchdog{
 						State:         "no_output",
@@ -684,6 +689,10 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		if delivery := asMap(t, deliveries[0]); delivery["event_id"] != "event-1" || delivery["event_name"] != "task.ready" || delivery["attempts"] != float64(1) {
 			t.Fatalf("agent.diagnose pending delivery = %#v", deliveries[0])
 		}
+		active := asMap(t, result["active"])
+		if active["turn_id"] != "22222222-2222-2222-2222-222222222222" || active["task_id"] != "task-1" || active["entity_id"] != "33333333-3333-3333-3333-333333333333" {
+			t.Fatalf("agent.diagnose active = %#v", active)
+		}
 		runtimeState := asMap(t, result["runtime_state"])
 		watchdog := asMap(t, runtimeState["watchdog"])
 		if watchdog["state"] != "no_output" || watchdog["blocking_layer"] != "session_execution" || watchdog["action"] != "session_no_output" || watchdog["outcome"] != "warning_emitted" {
@@ -692,7 +701,7 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
 			t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
 		}
-		for _, splitField := range []string{"bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+		for _, splitField := range []string{"bundle_version", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 			if _, ok := result[splitField]; ok {
 				t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, result)
 			}

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -126,6 +126,11 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 				State:         "active",
 				BlockingLayer: "session_execution",
 			},
+			Active: &store.OperatorAgentDiagnosisActive{
+				TurnID:   "22222222-2222-2222-2222-222222222222",
+				TaskID:   "task-1",
+				EntityID: "33333333-3333-3333-3333-333333333333",
+			},
 			RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
 				Watchdog: &store.OperatorAgentDiagnosisWatchdog{
 					State:         "no_output",
@@ -243,6 +248,10 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if lifecycle["state"] != "active" || lifecycle["blocking_layer"] != "session_execution" {
 		t.Fatalf("agent.diagnose lifecycle = %#v", lifecycle)
 	}
+	active := asMap(t, diagnosis["active"])
+	if active["turn_id"] != "22222222-2222-2222-2222-222222222222" || active["task_id"] != "task-1" || active["entity_id"] != "33333333-3333-3333-3333-333333333333" {
+		t.Fatalf("agent.diagnose active = %#v", active)
+	}
 	runtimeState := asMap(t, diagnosis["runtime_state"])
 	watchdog := asMap(t, runtimeState["watchdog"])
 	if watchdog["state"] != "no_output" || watchdog["blocking_layer"] != "session_execution" || watchdog["action"] != "session_no_output" || watchdog["outcome"] != "warning_emitted" {
@@ -251,7 +260,7 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
 		t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
 	}
-	for _, splitField := range []string{"bundle_version", "active", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+	for _, splitField := range []string{"bundle_version", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 		if _, ok := diagnosis[splitField]; ok {
 			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
 		}
@@ -603,6 +612,39 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedWatchdogOwnerData(t *testing
 	errorText := fmt.Sprint(resp.Error.Message, resp.Error.Data)
 	if !strings.Contains(errorText, "agent.diagnose owner returned malformed result") || !strings.Contains(errorText, "runtime_state.watchdog") {
 		t.Fatalf("error = %#v, want malformed runtime_state.watchdog owner result", resp.Error)
+	}
+}
+
+func TestOperatorAgentDiagnoseFailsClosedOnMalformedActiveOwnerData(t *testing.T) {
+	reads := &fakeAgentConversationReadStore{
+		agentDiagnosisResult: store.OperatorAgentDiagnosis{
+			AgentID: "agent-1",
+			Status:  "running",
+			Queue: store.OperatorAgentDiagnosisQueue{
+				PendingDeliveries: []store.OperatorAgentPendingDelivery{},
+			},
+			Active: &store.OperatorAgentDiagnosisActive{
+				TaskID: "task-1",
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.diagnose returned success for malformed active owner result")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	errorText := fmt.Sprint(resp.Error.Message, resp.Error.Data)
+	if !strings.Contains(errorText, "agent.diagnose owner returned malformed result") || !strings.Contains(errorText, "active.turn_id") {
+		t.Fatalf("error = %#v, want malformed active owner result", resp.Error)
 	}
 }
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -484,8 +484,21 @@ func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
 			return fmt.Errorf("agent.diagnose owner returned malformed result: delivery_lifecycle.blocking_layer is required")
 		}
 	}
+	if err := validateAgentDiagnosisActiveResult(item.Active); err != nil {
+		return err
+	}
 	if err := validateAgentDiagnosisRuntimeStateResult(item.RuntimeState); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAgentDiagnosisActiveResult(item *store.OperatorAgentDiagnosisActive) error {
+	if item == nil {
+		return nil
+	}
+	if strings.TrimSpace(item.TurnID) == "" {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: active.turn_id is required")
 	}
 	return nil
 }

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -100,7 +100,7 @@ func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 func canonicalAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -1778,7 +1778,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(turnBlocksPayload)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1840,7 +1840,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
@@ -1873,7 +1873,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
@@ -1907,7 +1907,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResul
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
 		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
@@ -1947,7 +1947,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, "turn-7", "task-7", false, "", time.Now(), []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, "turn-7", "task-7", "", false, "", time.Now(), []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -2008,7 +2008,7 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -2060,7 +2060,7 @@ func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenD
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -2225,7 +2225,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
 		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -94,6 +94,7 @@ type OperatorAgentSummary struct {
 	CurrentTaskID         string                              `json:"-"`
 	LastTool              *OperatorAgentTool                  `json:"-"`
 	LiveTurn              *OperatorLiveTurn                   `json:"-"`
+	DiagnosisActive       *OperatorAgentDiagnosisActive       `json:"-"`
 	StartedAt             time.Time                           `json:"-"`
 	DashboardStatus       string                              `json:"-"`
 	DashboardState        string                              `json:"-"`
@@ -130,6 +131,13 @@ type OperatorAgentDiagnosis struct {
 	Queue             OperatorAgentDiagnosisQueue         `json:"queue"`
 	DeliveryLifecycle *OperatorAgentDeliveryLifecycle     `json:"delivery_lifecycle,omitempty"`
 	RuntimeState      *OperatorAgentDiagnosisRuntimeState `json:"runtime_state,omitempty"`
+	Active            *OperatorAgentDiagnosisActive       `json:"active,omitempty"`
+}
+
+type OperatorAgentDiagnosisActive struct {
+	TurnID   string `json:"turn_id"`
+	TaskID   string `json:"task_id,omitempty"`
+	EntityID string `json:"entity_id,omitempty"`
 }
 
 type OperatorAgentDiagnosisRuntimeState struct {
@@ -440,6 +448,7 @@ type operatorAgentProjection struct {
 	CurrentTaskID       string
 	LastTool            *OperatorAgentTool
 	LiveTurn            *OperatorLiveTurn
+	DiagnosisActive     *OperatorAgentDiagnosisActive
 	LastTurnRef         *OperatorTurnRef
 	Watchdog            *OperatorConversationWatchdog
 }
@@ -1075,6 +1084,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			COALESCE(f.dead_letters_24h, 0),
 			COALESCE(latest_turn.turn_id, ''),
 			COALESCE(latest_turn.task_id, ''),
+			COALESCE(latest_turn.entity_id::text, ''),
 			COALESCE(latest_turn.parse_ok, false),
 			COALESCE(latest_turn.error, ''),
 			latest_turn.created_at,
@@ -1099,6 +1109,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			SELECT
 				turn_id::text AS turn_id,
 				COALESCE(task_id, '') AS task_id,
+				entity_id,
 				parse_ok,
 				COALESCE(error, '') AS error,
 				created_at,
@@ -1138,6 +1149,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			runtimeStateRaw  []byte
 			latestTurnID     string
 			latestTaskID     string
+			latestEntityID   string
 			latestParseOK    bool
 			latestError      string
 			latestCompleted  sql.NullTime
@@ -1158,6 +1170,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			&projection.DeadLetters24h,
 			&latestTurnID,
 			&latestTaskID,
+			&latestEntityID,
 			&latestParseOK,
 			&latestError,
 			&latestCompleted,
@@ -1185,6 +1198,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 		if err := enrichOperatorAgentProjectionFromLatestTurn(&projection, runtimeStateRaw, latestTurnID, latestTaskID, latestParseOK, latestTurnRaw); err != nil {
 			return nil, err
 		}
+		projection.DiagnosisActive = operatorAgentDiagnosisActiveFromLatestTurn(latestTurnID, latestTaskID, latestEntityID)
 		id = strings.TrimSpace(id)
 		out[id] = projection
 		agentIDs = append(agentIDs, id)
@@ -1256,6 +1270,7 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		CurrentTaskID:         strings.TrimSpace(projection.CurrentTaskID),
 		LastTool:              projection.LastTool,
 		LiveTurn:              projection.LiveTurn,
+		DiagnosisActive:       cloneOperatorAgentDiagnosisActive(projection.DiagnosisActive),
 		StartedAt:             row.StartedAt,
 		DashboardStatus:       strings.TrimSpace(projection.Status),
 		DashboardState:        projection.dashboardState(),
@@ -1284,6 +1299,7 @@ func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgent
 			PendingDeliveries:       []OperatorAgentPendingDelivery{},
 		},
 		RuntimeState: agent.DiagnosisRuntimeState,
+		Active:       cloneOperatorAgentDiagnosisActive(agent.DiagnosisActive),
 	}
 	if state := strings.TrimSpace(agent.DeliveryLifecycle); state != "" {
 		out.DeliveryLifecycle = &OperatorAgentDeliveryLifecycle{
@@ -1353,8 +1369,21 @@ func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
 			return fmt.Errorf("agent diagnosis delivery_lifecycle.blocking_layer is required")
 		}
 	}
+	if err := validateOperatorAgentDiagnosisActive(item.Active); err != nil {
+		return err
+	}
 	if err := validateOperatorAgentDiagnosisRuntimeState(item.RuntimeState); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateOperatorAgentDiagnosisActive(item *OperatorAgentDiagnosisActive) error {
+	if item == nil {
+		return nil
+	}
+	if strings.TrimSpace(item.TurnID) == "" {
+		return fmt.Errorf("agent diagnosis active.turn_id is required")
 	}
 	return nil
 }
@@ -1370,6 +1399,26 @@ func validateOperatorAgentDiagnosisRuntimeState(item *OperatorAgentDiagnosisRunt
 		return fmt.Errorf("agent diagnosis runtime_state.watchdog is invalid: %w", err)
 	}
 	return nil
+}
+
+func operatorAgentDiagnosisActiveFromLatestTurn(turnID, taskID, entityID string) *OperatorAgentDiagnosisActive {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	return &OperatorAgentDiagnosisActive{
+		TurnID:   turnID,
+		TaskID:   strings.TrimSpace(taskID),
+		EntityID: strings.TrimSpace(entityID),
+	}
+}
+
+func cloneOperatorAgentDiagnosisActive(in *OperatorAgentDiagnosisActive) *OperatorAgentDiagnosisActive {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func validOperatorAgentDiagnosisStatus(status string) bool {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -89,7 +89,7 @@ func canonicalAgentConversationReadCaps() StoreSchemaCapabilities {
 func operatorAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -296,7 +296,7 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", false, "model error", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", "entity-1", false, "model error", turnCompletedAt, []byte(`[]`)))
 
 	detail, err := reader.LoadOperatorAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -325,13 +325,17 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 
 	sessionID := "11111111-1111-1111-1111-111111111111"
 	turnID := "22222222-2222-2222-2222-222222222222"
+	turnEntityID := "33333333-3333-3333-3333-333333333333"
+	configuredEntityID := "44444444-4444-4444-4444-444444444444"
 	sessionStartedAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
 	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
 	eventTime := time.Date(2026, 5, 12, 8, 55, 0, 0, time.UTC)
 	runtimeState := []byte(`{"provider_session_id":"provider-sess-1","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-05-12T09:04:00Z","recorded_at":"2026-05-12T09:05:00Z"}}`)
+	agent := testOperatorAgent("agent-1")
+	agent.Config.EntityID = configuredEntityID
 	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
 		caps:   canonicalAgentConversationReadCaps(),
-		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+		agents: []runtimemanager.PersistedAgent{agent},
 		pending: map[string]PendingAgentDeliveryFacts{
 			"agent-1": {PendingCount: 99, OldestPendingAgeSec: 999},
 		},
@@ -356,7 +360,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", true, "", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", turnEntityID, true, "", turnCompletedAt, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
@@ -370,6 +374,9 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	}
 	if diagnosis.LastTurnRef == nil || diagnosis.LastTurnRef.TurnID != turnID || !diagnosis.LastTurnRef.CompletedAt.Equal(turnCompletedAt) {
 		t.Fatalf("last_turn_ref = %#v", diagnosis.LastTurnRef)
+	}
+	if diagnosis.Active == nil || diagnosis.Active.TurnID != turnID || diagnosis.Active.TaskID != "task-1" || diagnosis.Active.EntityID != turnEntityID {
+		t.Fatalf("active = %#v", diagnosis.Active)
 	}
 	if diagnosis.Queue.PendingCount != 3 || diagnosis.Queue.OldestPendingAgeSeconds != 90 {
 		t.Fatalf("queue = %#v", diagnosis.Queue)
@@ -416,7 +423,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -433,6 +440,71 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	}
 	if diagnosis.RuntimeState != nil {
 		t.Fatalf("runtime_state = %#v, want nil without active watchdog evidence", diagnosis.RuntimeState)
+	}
+	if diagnosis.Active != nil {
+		t.Fatalf("active = %#v, want nil without selected active-session latest turn", diagnosis.Active)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsActiveWithoutLatestTurn(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.Active != nil {
+		t.Fatalf("active = %#v, want nil for active session without latest turn", diagnosis.Active)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsEmptyActiveOptionalRefs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	turnID := "22222222-2222-2222-2222-222222222222"
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, 0, 0, turnID, "", "", true, "", time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC), []byte(`[]`)))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.Active == nil || diagnosis.Active.TurnID != turnID {
+		t.Fatalf("active = %#v, want turn ref", diagnosis.Active)
+	}
+	if diagnosis.Active.TaskID != "" || diagnosis.Active.EntityID != "" {
+		t.Fatalf("active optional refs = task:%q entity:%q, want omitted/empty", diagnosis.Active.TaskID, diagnosis.Active.EntityID)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -454,7 +526,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedRuntime
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "decode latest agent session runtime_state") || !strings.Contains(err.Error(), "watchdog.state") {
@@ -483,7 +555,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLifecyc
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "delivery_lifecycle.state") {
@@ -517,6 +589,29 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisPropagatesCapabilityFailure(t
 	}
 }
 
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedWithoutCanonicalTurns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	caps := canonicalAgentConversationReadCaps()
+	caps.Conversations.Turns = SchemaFlavorUnavailable
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   caps,
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if err == nil || !strings.Contains(err.Error(), "agent_turns schema is unavailable") {
+		t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want agent_turns capability failure", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessionOnly(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -535,7 +630,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
@@ -577,7 +672,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveL
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()))


### PR DESCRIPTION
## Summary

- Promote `AgentDiagnosis.active` in tracked `platform-spec.yaml` and regenerated `openrpc.json` for selected active-session latest-turn refs.
- Move the selected active turn refs into the `LoadOperatorAgentDiagnosis` / `OperatorAgentDiagnosis` owner path, including `turn_id` plus optional `task_id` and `entity_id`.
- Keep handler behavior owner-consumed and fail-closed, with no fallback to configured/effective entity, dashboard projection, conversation API composition, task target entity, stale sessions, or actual in-flight work claims.

Closes #922
Part of #852

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#spec_authority`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.agent.diagnose`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.schemas.AgentDiagnosis`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apispec` OpenRPC/spec publication tests
- `internal/apiv1` `agent.diagnose` handler/result validation
- `internal/store` `LoadOperatorAgentDiagnosis` / `OperatorAgentDiagnosis`
- #922 approved gate boundary and parent #852
- Prior sibling proofs: #891/#897, #901/#906, #913/#917

## Semantic migration

New canonical owner: tracked `AgentDiagnosis.active` / `AgentDiagnosisActive` plus the `LoadOperatorAgentDiagnosis` / `OperatorAgentDiagnosis.Active` typed owner path.

Old producer / reader / writer paths now invalid for this concept: handler-local joins, dashboard `genericAgent` projection, `conversation.current_for_agent` response composition, `AgentConfig.EffectiveEntityID()` fallback, task target entity fallback, role-scoped current-entity context, stale/inactive sessions, and ignored review drafts as authority.

Production paths checked for surviving old behavior: tracked spec/OpenRPC, `internal/apispec`, `internal/apiv1` handler validation, `internal/store` diagnosis owner, and dashboard server fixtures that share the projection shape. CLI/dashboard rebinding, last tool outcome, token usage, failures/dead letters, E conformance harness, and broad #410/#453/#777 lifecycle cleanup remain split under #852.

Migration completeness: complete for the approved selected active-session latest-turn refs slice only. Parent #852 remains open.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentDiagnosis' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorAgentDiagnose|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCSuccessfulResultSchemas' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/dashboard/server -count=1`
- `go test ./...`