### PR TITLE
[agent-b][issue #928] Add trace follow recovery

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -2,12 +2,20 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	traceFollowMaxReconnects    = 3
+	traceFollowInitialBackoff   = 250 * time.Millisecond
+	traceFollowMaximumBackoff   = time.Second
+	traceFollowRetryableReadErr = "read run.subscribe_trace notification:"
 )
 
 type diagnosticRunListOptions struct {
@@ -23,6 +31,7 @@ type diagnosticRunListOptions struct {
 type diagnosticTraceOptions struct {
 	apiOptions rootCommandOptions
 	follow     bool
+	noRetry    bool
 	since      string
 	limit      int
 	cursor     string
@@ -200,6 +209,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&traceOpts.follow, "follow", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
 	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
@@ -404,7 +414,7 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 		}
 	}
 	if opts.follow {
-		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID)
+		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID, opts)
 	}
 	snapshotParams["run_id"] = runID
 	var result diagnosticRunTraceResult
@@ -458,7 +468,7 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 	return params, nil
 }
 
-func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string) error {
+func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string, opts diagnosticTraceOptions) error {
 	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
 	if err != nil {
 		if errOut != nil {
@@ -466,45 +476,169 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 		}
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
-	sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, nil)
-	if err != nil {
-		if errOut != nil {
-			fmt.Fprintln(errOut, err)
-		}
-		return commandExitError{code: runCommandErrorExitCode(err)}
+	reconnectsRemaining := traceFollowMaxReconnects
+	if opts.noRetry {
+		reconnectsRemaining = 0
 	}
-	defer sub.close()
+	retryAttempt := 0
+	var replaySince *time.Time
 	for {
-		select {
-		case <-ctx.Done():
-			if errOut != nil {
-				fmt.Fprintln(errOut, "detached from run trace")
+		sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince)
+		if err != nil {
+			if ctx.Err() != nil {
+				return traceFollowDetached(errOut)
 			}
-			return commandExitError{code: 130}
-		case row, ok := <-sub.rows:
-			if !ok {
-				select {
-				case err := <-sub.errs:
-					if err != nil {
-						if errOut != nil {
-							fmt.Fprintln(errOut, err)
-						}
-						return commandExitError{code: runCommandErrorExitCode(err)}
-					}
-				default:
-				}
-				return nil
-			}
-			writeRunCommandTraceRow(out, row)
-		case err := <-sub.errs:
-			if err != nil {
+			if reconnectsRemaining == 0 || !traceFollowRetryableSubscribeError(err) {
 				if errOut != nil {
 					fmt.Fprintln(errOut, err)
 				}
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
+			reconnectsRemaining--
+			retryAttempt++
+			if err := waitTraceFollowReconnect(ctx, errOut, retryAttempt); err != nil {
+				return err
+			}
+			continue
+		}
+		streamErr, interrupted := consumeDiagnosticTraceSubscription(ctx, out, sub, &replaySince)
+		sub.close()
+		if interrupted {
+			return traceFollowDetached(errOut)
+		}
+		if streamErr == nil {
+			if reconnectsRemaining == 0 {
+				return nil
+			}
+			reconnectsRemaining--
+			retryAttempt++
+			if err := waitTraceFollowReconnect(ctx, errOut, retryAttempt); err != nil {
+				return err
+			}
+			continue
+		}
+		if reconnectsRemaining == 0 || !traceFollowRetryableStreamError(streamErr) {
+			if errOut != nil {
+				fmt.Fprintln(errOut, streamErr)
+			}
+			return commandExitError{code: runCommandErrorExitCode(streamErr)}
+		}
+		reconnectsRemaining--
+		retryAttempt++
+		if err := waitTraceFollowReconnect(ctx, errOut, retryAttempt); err != nil {
+			return err
 		}
 	}
+}
+
+func consumeDiagnosticTraceSubscription(ctx context.Context, out io.Writer, sub *runTraceSubscription, replaySince **time.Time) (error, bool) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, true
+		case row, ok := <-sub.rows:
+			if !ok {
+				select {
+				case err := <-sub.errs:
+					if err != nil {
+						return err, false
+					}
+				default:
+				}
+				return nil, false
+			}
+			nextReplaySince, err := time.Parse(time.RFC3339Nano, row.EventCreatedAt)
+			if err != nil {
+				return fmt.Errorf("malformed run.subscribe_trace notification: event_created_at is not RFC3339: %w", err), false
+			}
+			writeRunCommandTraceRow(out, row)
+			nextReplaySince = nextReplaySince.UTC()
+			*replaySince = &nextReplaySince
+		case err := <-sub.errs:
+			if err != nil {
+				return err, false
+			}
+		}
+	}
+}
+
+func waitTraceFollowReconnect(ctx context.Context, errOut io.Writer, retryAttempt int) error {
+	timer := time.NewTimer(traceFollowBackoff(retryAttempt))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return traceFollowDetached(errOut)
+	case <-timer.C:
+		return nil
+	}
+}
+
+func traceFollowBackoff(retryAttempt int) time.Duration {
+	if retryAttempt <= 1 {
+		return traceFollowInitialBackoff
+	}
+	backoff := traceFollowInitialBackoff
+	for i := 1; i < retryAttempt; i++ {
+		backoff *= 2
+		if backoff >= traceFollowMaximumBackoff {
+			return traceFollowMaximumBackoff
+		}
+	}
+	return backoff
+}
+
+func traceFollowDetached(errOut io.Writer) error {
+	if errOut != nil {
+		fmt.Fprintln(errOut, "detached from run trace")
+	}
+	return commandExitError{code: 130}
+}
+
+func traceFollowRetryableSubscribeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		return false
+	}
+	msg := err.Error()
+	if strings.HasPrefix(msg, "v1 WS dial failed:") || strings.HasPrefix(msg, "write run.subscribe_trace request:") {
+		return true
+	}
+	if strings.HasPrefix(msg, "read run.subscribe_trace response:") {
+		return traceFollowTransportErrorText(msg)
+	}
+	return false
+}
+
+func traceFollowRetryableStreamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, traceFollowRetryableReadErr) {
+		return false
+	}
+	return traceFollowTransportErrorText(msg)
+}
+
+func traceFollowTransportErrorText(msg string) bool {
+	msg = strings.ToLower(msg)
+	for _, fragment := range []string{
+		"websocket: close",
+		"unexpected eof",
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"i/o timeout",
+		"use of closed network connection",
+	} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
 }
 
 func runDiagnosticHealthCommand(ctx context.Context, out, errOut io.Writer, opts rootCommandOptions, output cliOutputOptions) error {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -444,6 +444,9 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 		}
 		return map[string]any{}, nil
 	}
+	if o.noRetry {
+		return nil, fmt.Errorf("--no-retry requires --follow")
+	}
 	params := map[string]any{}
 	if o.limitSet {
 		if o.limit < 1 || o.limit > 2000 {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -625,6 +625,9 @@ func traceFollowRetryableStreamError(err error) bool {
 
 func traceFollowTransportErrorText(msg string) bool {
 	msg = strings.ToLower(msg)
+	if msg == "eof" || strings.HasSuffix(msg, ": eof") {
+		return true
+	}
 	for _, fragment := range []string{
 		"websocket: close",
 		"unexpected eof",

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -904,6 +904,7 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace invalid limit high", args: []string{"trace", "run-1", "--limit", "2001"}, wantStderr: "--limit must be between 1 and 2000"},
 		{name: "trace invalid since", args: []string{"trace", "run-1", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
 		{name: "trace blank cursor", args: []string{"trace", "run-1", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
+		{name: "trace no retry requires follow", args: []string{"trace", "run-1", "--no-retry"}, wantStderr: "--no-retry requires --follow"},
 		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -642,6 +642,98 @@ func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
 	}
 }
 
+func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var mu sync.Mutex
+	wsRequests := []jsonRPCRequest{}
+	recoveredRowSent := make(chan struct{})
+	var signalRecoveredRow sync.Once
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/ws" {
+			t.Errorf("path = %q, want only /v1/ws", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("WS Authorization = %q, want bearer token", got)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		var req jsonRPCRequest
+		if err := conn.ReadJSON(&req); err != nil {
+			t.Errorf("read ws request: %v", err)
+			return
+		}
+		mu.Lock()
+		wsRequests = append(wsRequests, req)
+		callIndex := len(wsRequests)
+		mu.Unlock()
+		if req.Method != "run.subscribe_trace" {
+			t.Errorf("ws method = %q, want run.subscribe_trace", req.Method)
+		}
+		subscriptionID := fmt.Sprintf("sub-retry-%d", callIndex)
+		if err := conn.WriteJSON(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  map[string]any{"subscription_id": subscriptionID},
+		}); err != nil {
+			t.Errorf("write ws subscription response: %v", err)
+			return
+		}
+		if callIndex == 1 {
+			_ = conn.UnderlyingConn().Close()
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "rpc.subscription",
+			"params": map[string]any{
+				"subscription": subscriptionID,
+				"result":       validRunCommandTraceRow("evt-recovered"),
+			},
+		}); err != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+		signalRecoveredRow.Do(func() { close(recoveredRowSent) })
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-recoveredRowSent
+		cancel()
+	}()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "run-retry", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 130 {
+		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(wsRequests) != 2 {
+		t.Fatalf("ws requests = %#v, want retry after read failure", wsRequests)
+	}
+	for i, req := range wsRequests {
+		if got := req.Params["run_id"]; got != "run-retry" {
+			t.Fatalf("ws run_id[%d] = %#v, want run-retry", i, got)
+		}
+		if _, ok := req.Params["replay_since"]; ok {
+			t.Fatalf("ws replay_since[%d] = %#v, want omitted because no row was rendered before retry", i, req.Params["replay_since"])
+		}
+	}
+	if !strings.Contains(stdout.String(), "trace event_id=evt-recovered") {
+		t.Fatalf("stdout = %q, want recovered row", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "detached from run trace") {
+		t.Fatalf("stderr = %q, want detach message", stderr.String())
+	}
+}
+
 func TestTraceFollowCtrlCDetachesWithoutRunStop(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	wsSubscribed := make(chan struct{})

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -4,12 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestRunsUseRunListV1RPC(t *testing.T) {
@@ -458,7 +463,7 @@ func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-follow", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-follow", "--follow", "--no-retry"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -490,7 +495,7 @@ func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--follow", "--no-retry"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -498,6 +503,142 @@ func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
 	assertRunCommandTraceSubscription(t, wsRequests, "active-run", false)
 	if !strings.Contains(stdout.String(), "trace event_id=evt-active") {
 		t.Fatalf("stdout = %q, want trace row", stdout.String())
+	}
+}
+
+func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	opts := defaultRootCommandOptions()
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--help"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "--no-retry") {
+		t.Fatalf("help missing --no-retry:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "--replay-since") {
+		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
+	}
+}
+
+func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var mu sync.Mutex
+	rpcRequests := []jsonRPCRequest{}
+	wsRequests := []jsonRPCRequest{}
+	secondRowSent := make(chan struct{})
+	var signalSecondRow sync.Once
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/rpc":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Errorf("Authorization = %q, want bearer token", got)
+			}
+			var req jsonRPCRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode request: %v", err)
+				return
+			}
+			mu.Lock()
+			rpcRequests = append(rpcRequests, req)
+			mu.Unlock()
+			if req.Method != "run.list" {
+				t.Errorf("method = %q, want run.list", req.Method)
+			}
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{validDiagnosticRunHeaderWithStatus("active-run", "running")}})
+		case "/v1/ws":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Errorf("WS Authorization = %q, want bearer token", got)
+			}
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade websocket: %v", err)
+				return
+			}
+			defer conn.Close()
+			var req jsonRPCRequest
+			if err := conn.ReadJSON(&req); err != nil {
+				t.Errorf("read ws request: %v", err)
+				return
+			}
+			mu.Lock()
+			wsRequests = append(wsRequests, req)
+			callIndex := len(wsRequests)
+			mu.Unlock()
+			if req.Method != "run.subscribe_trace" {
+				t.Errorf("ws method = %q, want run.subscribe_trace", req.Method)
+			}
+			subscriptionID := fmt.Sprintf("sub-%d", callIndex)
+			if err := conn.WriteJSON(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  map[string]any{"subscription_id": subscriptionID},
+			}); err != nil {
+				t.Errorf("write ws subscription response: %v", err)
+				return
+			}
+			row := validRunCommandTraceRow(fmt.Sprintf("evt-%d", callIndex))
+			row["event_created_at"] = fmt.Sprintf("2026-05-13T10:00:0%dZ", callIndex)
+			if err := conn.WriteJSON(map[string]any{
+				"jsonrpc": "2.0",
+				"method":  "rpc.subscription",
+				"params": map[string]any{
+					"subscription": subscriptionID,
+					"result":       row,
+				},
+			}); err != nil {
+				return
+			}
+			if callIndex == 1 {
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+			signalSecondRow.Do(func() { close(secondRowSent) })
+			<-r.Context().Done()
+		default:
+			t.Errorf("path = %q, want /v1/rpc or /v1/ws", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-secondRowSent
+		cancel()
+	}()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 130 {
+		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, &rpcRequests, []string{"run.list"})
+	if len(wsRequests) != 2 {
+		t.Fatalf("ws requests = %#v, want initial subscribe and one recovery subscribe", wsRequests)
+	}
+	for i, req := range wsRequests {
+		if req.Method != "run.subscribe_trace" {
+			t.Fatalf("ws method[%d] = %q, want run.subscribe_trace", i, req.Method)
+		}
+		if got := req.Params["run_id"]; got != "active-run" {
+			t.Fatalf("ws run_id[%d] = %#v, want active-run", i, got)
+		}
+	}
+	if _, ok := wsRequests[0].Params["replay_since"]; ok {
+		t.Fatalf("initial replay_since = %#v, want omitted", wsRequests[0].Params["replay_since"])
+	}
+	if got := wsRequests[1].Params["replay_since"]; got != "2026-05-13T10:00:01Z" {
+		t.Fatalf("recovery replay_since = %#v, want first row timestamp", got)
+	}
+	for _, want := range []string{"trace event_id=evt-1", "trace event_id=evt-2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if !strings.Contains(stderr.String(), "detached from run trace") {
+		t.Fatalf("stderr = %q, want detach message", stderr.String())
 	}
 }
 
@@ -660,6 +801,7 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace follow direct replay since remains unpromoted", args: []string{"trace", "run-1", "--follow", "--replay-since", "2026-05-13T10:00:00Z"}, wantStderr: "unknown flag"},
 		{name: "trace richer filter still unpromoted", args: []string{"trace", "run-1", "--event-name", "scan.requested"}, wantStderr: "unknown flag"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
@@ -689,6 +831,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"trace", "run-1"},
 		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z"},
 		{"trace", "run-1", "--follow"},
+		{"trace", "run-1", "--follow", "--no-retry"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "")

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -734,6 +734,20 @@ func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
 	}
 }
 
+func TestTraceFollowClassifiesPlainEOFAsRetryableTransportClose(t *testing.T) {
+	for _, msg := range []string{
+		"read run.subscribe_trace response: EOF",
+		"read run.subscribe_trace notification: EOF",
+		"EOF",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			if !traceFollowTransportErrorText(msg) {
+				t.Fatalf("traceFollowTransportErrorText(%q) = false, want true", msg)
+			}
+		})
+	}
+}
+
 func TestTraceFollowCtrlCDetachesWithoutRunStop(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	wsSubscribed := make(chan struct{})

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5591,9 +5591,12 @@ cli_specification:
           api_specification.method_catalog.run.trace and
           cli_specification.command_catalog.trace.promoted_trace_filter_contract. The promoted API owner accepts
           `limit`, `cursor`, and `since`; `since` filters by the canonical RunTraceRow materialization watermark
-          used by the run-debug trace owner. Review-artifact `until`, event-name, subscriber, entity-id,
-          delivery-status, `--include-payload`, `-f`, subscription retry/`--no-retry`, and multi-run `--all`
-          remain explicitly unpromoted split tails until later gated children promote their own canonical owners.
+          used by the run-debug trace owner. Trace-specific `swarm trace --follow` subscription recovery and
+          `--no-retry` are promoted in
+          cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract by #928. Review-artifact
+          `until`, event-name, subscriber, entity-id, delivery-status, `--include-payload`, `-f`, shared `swarm run`
+          recovery, and multi-run `--all` remain explicitly unpromoted split tails until later gated children promote
+          their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: tracked_child
         tracker: '#856'
@@ -6666,6 +6669,7 @@ cli_specification:
         - --since with --follow
         - --limit with --follow
         - --cursor with --follow
+        - --no-retry without --follow
         - direct --replay-since flag; replay_since is an internal recovery parameter, not a user-facing trace flag
         proof_expectations:
         - initial and recovered WebSocket request-shape tests prove exact run.subscribe_trace params and replay_since handling

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6600,7 +6600,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow]
+      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow] [--no-retry]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow
@@ -6628,6 +6628,53 @@ cli_specification:
         - invalid --since, out-of-range --limit, blank --cursor, and --follow plus snapshot filters fail before API/WS calls
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
+      promoted_trace_follow_recovery_contract:
+        status: api_owner_promoted_cli_implemented
+        implemented_by: '#928'
+        follow_owner: /v1/ws run.subscribe_trace
+        scope: >
+          Applies only to `swarm trace --follow`. `swarm run` foreground follow, connected follow, and reattach keep their
+          existing lifecycle policy and may continue to use the shared one-shot `subscribeRunTrace` helper without inheriting
+          this trace-specific reconnect policy.
+        retry_policy: >
+          By default, `swarm trace --follow` may reconnect after at most three retryable subscription interruptions after the
+          initial subscription attempt. The retry backoff is bounded exponential delay of 250ms, 500ms, then 1s. If a clean
+          subscription close exhausts the reconnect budget, the command exits successfully after rendering all received rows.
+          If a retryable transport error exhausts the budget, the command exits with the CLI runtime/transport error code.
+        retryable_classes:
+        - websocket dial failure
+        - websocket request write failure
+        - websocket subscription-response read failure caused by transport close/reset/timeout
+        - websocket notification read failure caused by transport close/reset/timeout
+        terminal_classes:
+        - JSON-RPC application errors such as RUN_NOT_FOUND
+        - malformed subscription responses or malformed result envelopes
+        - malformed subscription notifications, schema validation failures, or subscription mismatches
+        - notification queue overflow
+        - CLI validation failures, missing token, and snapshot flags combined with --follow
+        - operator interrupt / context cancellation
+        replay_watermark: >
+          Initial `run.subscribe_trace` requests omit `replay_since`. Recovered subscriptions set `replay_since` to the
+          RFC3339Nano `event_created_at` timestamp of the last successfully rendered RunTraceRow. If no row has been
+          rendered, recovered requests also omit `replay_since`. The CLI does not deduplicate rows; recovery is at-least-once
+          and the server/API owner remains responsible for trace ordering and retention semantics.
+        no_retry_flag: >
+          `--no-retry` disables this recovery loop for `swarm trace --follow` only. With `--no-retry`, the command performs
+          exactly one `run.subscribe_trace` request, never sends `replay_since`, exits 0 on a clean close, and fails closed on
+          the first subscription or notification error.
+        invalid_combinations:
+        - --since with --follow
+        - --limit with --follow
+        - --cursor with --follow
+        - direct --replay-since flag; replay_since is an internal recovery parameter, not a user-facing trace flag
+        proof_expectations:
+        - initial and recovered WebSocket request-shape tests prove exact run.subscribe_trace params and replay_since handling
+        - omitted-run follow resolves through /v1/rpc run.list once before recovered subscriptions for the resolved run id
+        - --no-retry proves one-shot close behavior and no replay_since
+        - malformed subscription responses and notifications fail closed without retrying indefinitely
+        - Ctrl-C detaches with exit 130 and does not call run.stop
+        - '`swarm run` foreground/follow and reattach regression proof remains unchanged'
+        - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
         split_tail:
           until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
           event_name: Not promoted; event-name filtering requires a typed RunTraceFilter owner before CLI use.
@@ -6636,7 +6683,7 @@ cli_specification:
           delivery_status: Not promoted; delivery-status filtering requires a typed RunTraceFilter owner before CLI use.
           include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
           shorthand_follow: Not promoted in this source-of-truth repair; `-f` is CLI UX only and must be gated separately.
-          subscription_retry: Not promoted; retry/`--no-retry` affects shared run.subscribe_trace consumers and is split.
+          shared_run_follow_recovery: Not promoted; `swarm run` follow and reattach have distinct lifecycle semantics and remain split.
           all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
     mailbox_list:
       command: swarm mailbox list


### PR DESCRIPTION
## Summary

Implements trace-specific recovery for `swarm trace --follow` over `/v1/ws run.subscribe_trace` and adds `--no-retry` as the explicit one-shot opt-out. The shared `subscribeRunTrace` helper remains one-shot, and `swarm run` follow/reattach behavior is unchanged.

Closes #928.
Part of #855.
Part of #735.
Part of #794.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.trace`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.run.subscribe_trace`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.foundations.subscriptions`
- #928 pre-audit and independent gate outcome

## Semantic Migration

- New canonical command-policy owner: `platform-spec.yaml` trace `promoted_trace_follow_recovery_contract`, consuming `/v1/ws run.subscribe_trace`.
- Old behavior now invalid by default: `swarm trace --follow` one-shot close/error behavior without recovery.
- Explicit retained one-shot mode: `swarm trace --follow --no-retry`, as the promoted opt-out, not a compatibility fallback.
- Production paths checked for surviving old behavior: `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, trace tests, run follow/reattach tests, OpenRPC/spec checks, and static no-bypass grep.
- Migration complete for the approved #928 trace-follow recovery slice only. Shared `swarm run` recovery remains split under #855/#735.

## Proof

- `go test ./cmd/swarm -run 'TestTraceFollow|TestTraceHelp|TestTraceUsesRunTraceSnapshot|TestTraceSnapshotFilters|TestDiagnosticsRejectInvalidInputBeforeRequest|TestDiagnosticsRequireAPITokenBeforeRequest' -count=1`
- `go test ./cmd/swarm -run 'TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet|TestRunCommandReattachActiveCtrlCDetachesWithoutRunStop|TestRunCommandStartCtrlCCallsRunStopAfterRunID|TestRunCommandClosedTraceChannelStillWaitsForRunGet' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run 'TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound|TestOpenRPCSubscriptionNotificationSchemas|TestOpenRPCWebSocketRuntimeProbes|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go run ./cmd/swarm trace --help`
- `git diff --check`
- `rg -n "database/sql|sqlx|pgx|internal/store|EventBus|dashboard|Builder|/api/|/api/rpc|/api/ws|SWARM_BUILDER|BUILDER|fallback" cmd/swarm/diagnostics.go cmd/swarm/run_command.go` returned no matches
- `go test ./...`