### PR TITLE
[agent-a][issue #931] Add shared CLI color policy

### DIFF
--- a/cmd/swarm/cli_output.go
+++ b/cmd/swarm/cli_output.go
@@ -5,33 +5,42 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"regexp"
 
 	"github.com/spf13/cobra"
 )
 
 const (
-	cliOutputJSONFlag      = "json"
-	cliOutputJSONFlagHelp  = "Render successful output as one JSON document"
-	cliOutputQuietFlag     = "quiet"
-	cliOutputQuietFlagHelp = "Render only declared load-bearing value(s)"
+	cliOutputJSONFlag        = "json"
+	cliOutputJSONFlagHelp    = "Render successful output as one JSON document"
+	cliOutputQuietFlag       = "quiet"
+	cliOutputQuietFlagHelp   = "Render only declared load-bearing value(s)"
+	cliOutputNoColorFlag     = "no-color"
+	cliOutputNoColorFlagHelp = "Disable ANSI color in human-readable output"
 )
 
 type cliOutputOptions struct {
-	asJSON bool
-	quiet  bool
+	asJSON  bool
+	quiet   bool
+	noColor bool
 }
 
 type cliTextRenderer func(io.Writer)
 type cliQuietRenderer func() ([]string, error)
 
+var cliANSISequencePattern = regexp.MustCompile("\x1b\\[[0-?]*[ -/]*[@-~]")
+
 func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
 	cmd.Flags().BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
 	cmd.Flags().BoolVar(&opts.quiet, cliOutputQuietFlag, false, cliOutputQuietFlagHelp)
+	cmd.Flags().BoolVar(&opts.noColor, cliOutputNoColorFlag, false, cliOutputNoColorFlagHelp)
 }
 
 func bindCLIOutputFlagSet(fs *flag.FlagSet, opts *cliOutputOptions) {
 	fs.BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
 	fs.BoolVar(&opts.quiet, cliOutputQuietFlag, false, cliOutputQuietFlagHelp)
+	fs.BoolVar(&opts.noColor, cliOutputNoColorFlag, false, cliOutputNoColorFlagHelp)
 }
 
 func (opts cliOutputOptions) validate() error {
@@ -39,6 +48,39 @@ func (opts cliOutputOptions) validate() error {
 		return fmt.Errorf("--json and --quiet are mutually exclusive")
 	}
 	return nil
+}
+
+func (opts cliOutputOptions) colorDisabled() bool {
+	if opts.noColor {
+		return true
+	}
+	value, ok := os.LookupEnv("NO_COLOR")
+	return ok && value != ""
+}
+
+func (opts cliOutputOptions) textWriter(out io.Writer) io.Writer {
+	if !opts.colorDisabled() {
+		return out
+	}
+	return cliANSITextWriter{out: out}
+}
+
+type cliANSITextWriter struct {
+	out io.Writer
+}
+
+func (w cliANSITextWriter) Write(p []byte) (int, error) {
+	if w.out == nil {
+		return len(p), nil
+	}
+	clean := cliANSISequencePattern.ReplaceAll(p, nil)
+	if len(clean) == 0 {
+		return len(p), nil
+	}
+	if _, err := w.out.Write(clean); err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
 func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {
@@ -68,7 +110,7 @@ func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, te
 		}
 	default:
 		if text != nil {
-			text(out)
+			text(opts.textWriter(out))
 		}
 	}
 	return nil

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -325,10 +325,203 @@ func TestCLIOutputModesForConversationConsumers(t *testing.T) {
 	}
 }
 
+func TestCLIOutputNoColorStripsDefaultText(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts cliOutputOptions
+		env  string
+		want string
+	}{
+		{name: "default preserves ansi", want: "\x1b[32mok\x1b[0m\n"},
+		{name: "flag strips ansi", opts: cliOutputOptions{noColor: true}, want: "ok\n"},
+		{name: "environment strips ansi", env: "1", want: "ok\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", tc.env)
+
+			var stdout, stderr bytes.Buffer
+			err := renderCLIOutput(&stdout, &stderr, tc.opts, map[string]string{"status": "ok"}, func(w io.Writer) {
+				_, _ = io.WriteString(w, "\x1b[32mok\x1b[0m\n")
+			}, nil)
+			if err != nil {
+				t.Fatalf("renderCLIOutput returned error: %v", err)
+			}
+			if got := stdout.String(); got != tc.want {
+				t.Fatalf("stdout = %q, want %q", got, tc.want)
+			}
+			assertEmptyStderr(t, stderr.String())
+		})
+	}
+}
+
+func TestCLIOutputNoColorForSharedRendererConsumers(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   func(*testing.T) []string
+		repo   func(*testing.T) string
+		method string
+		result map[string]any
+	}{
+		{
+			name: "version local",
+			args: func(*testing.T) []string { return []string{"version"} },
+			repo: func(*testing.T) string { return repoRoot() },
+		},
+		{
+			name:   "version server",
+			args:   func(*testing.T) []string { return []string{"version", "--server"} },
+			method: "health.check",
+			result: validVersionHealthResult(),
+		},
+		{
+			name: "verify",
+			args: func(t *testing.T) []string {
+				return []string{"verify", "--contracts", outputModeVerifyFixture(t)}
+			},
+			repo: func(*testing.T) string { return repoRoot() },
+		},
+		{
+			name:   "health",
+			args:   func(*testing.T) []string { return []string{"health"} },
+			method: "health.check",
+			result: validVersionHealthResult(),
+		},
+		{
+			name:   "runs",
+			args:   func(*testing.T) []string { return []string{"runs"} },
+			method: "run.list",
+			result: map[string]any{"runs": []any{validDiagnosticRunHeader("run-1"), validDiagnosticRunHeader("run-2")}},
+		},
+		{
+			name:   "status",
+			args:   func(*testing.T) []string { return []string{"status", "run-1"} },
+			method: "run.diagnose",
+			result: map[string]any{
+				"run":               validDiagnosticRunHeader("run-1"),
+				"operational_state": "stalled",
+				"blocking_layer":    "delivery_lifecycle",
+				"blocking_reason":   "no_active_deliveries",
+				"heuristics":        []any{"dead letters exist for this run"},
+			},
+		},
+		{
+			name:   "conversations list",
+			args:   func(*testing.T) []string { return []string{"conversations", "list"} },
+			method: conversationListMethod,
+			result: map[string]any{"conversations": []map[string]any{validConversationSummary("sess-1")}},
+		},
+		{
+			name:   "conversation view",
+			args:   func(*testing.T) []string { return []string{"conversation", "view", "sess-1"} },
+			method: conversationGetMethod,
+			result: validConversationDetail("sess-1"),
+		},
+		{
+			name:   "conversation turn",
+			args:   func(*testing.T) []string { return []string{"conversation", "turn", "sess-1", "2"} },
+			method: conversationGetTurnMethod,
+			result: validConversationTurnDetail("sess-1", 2),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range []struct {
+				name       string
+				outputMode string
+				env        string
+				flag       bool
+			}{
+				{name: "default"},
+				{name: "flag", flag: true},
+				{name: "environment", env: "1"},
+				{name: "json flag", outputMode: "--json", flag: true},
+				{name: "json environment", outputMode: "--json", env: "1"},
+				{name: "quiet flag", outputMode: "--quiet", flag: true},
+				{name: "quiet environment", outputMode: "--quiet", env: "1"},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					t.Setenv("SWARM_API_TOKEN", "test-token")
+					t.Setenv("NO_COLOR", mode.env)
+
+					args := append([]string{}, tc.args(t)...)
+					if mode.outputMode != "" {
+						args = append(args, mode.outputMode)
+					}
+					if mode.flag {
+						args = append(args, "--no-color")
+					}
+					repo := t.TempDir()
+					if tc.repo != nil {
+						repo = tc.repo(t)
+					}
+					opts := defaultRootCommandOptions()
+					var calls *atomic.Int32
+					if tc.method != "" {
+						server, rpcCalls := newCLIOutputColorPolicyRPCServer(t, tc.method, tc.result)
+						defer server.Close()
+						opts = testRootCommandOptions(server)
+						calls = rpcCalls
+					}
+
+					var stdout, stderr bytes.Buffer
+					code := executeRootCommandWithOptions(context.Background(), repo, args, &stdout, &stderr, opts)
+					if code != 0 {
+						t.Fatalf("%s code = %d stdout=%s stderr=%s", strings.Join(args, " "), code, stdout.String(), stderr.String())
+					}
+					if strings.TrimSpace(stdout.String()) == "" {
+						t.Fatalf("%s stdout is empty, want successful output", strings.Join(args, " "))
+					}
+					assertNoANSI(t, stdout.String())
+					if mode.outputMode == "--json" {
+						decodeOutputJSON[map[string]any](t, stdout.String())
+					}
+					assertEmptyStderr(t, stderr.String())
+					if calls != nil && calls.Load() != 1 {
+						t.Fatalf("%s RPC calls = %d, want 1", strings.Join(args, " "), calls.Load())
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCLIOutputNoColorDoesNotRewriteMachineModes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		env  string
+	}{
+		{name: "json flag", args: []string{"version", "--json", "--no-color"}},
+		{name: "json environment", args: []string{"version", "--json"}, env: "1"},
+		{name: "quiet flag", args: []string{"version", "--quiet", "--no-color"}},
+		{name: "quiet environment", args: []string{"version", "--quiet"}, env: "1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", tc.env)
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), tc.args, &stdout, &stderr, defaultRootCommandOptions())
+			if code != 0 {
+				t.Fatalf("%s code = %d stdout=%s stderr=%s", strings.Join(tc.args, " "), code, stdout.String(), stderr.String())
+			}
+			assertNoANSI(t, stdout.String())
+			assertEmptyStderr(t, stderr.String())
+			if stringSliceContains(tc.args, "--json") {
+				result := decodeOutputJSON[versionOutputResult](t, stdout.String())
+				if result.BinaryVersion != binaryVersion {
+					t.Fatalf("version json = %#v, want binary version %q", result, binaryVersion)
+				}
+			} else if got := stdout.String(); got != binaryVersion+"\n" {
+				t.Fatalf("version quiet stdout = %q, want binary version", got)
+			}
+		})
+	}
+}
+
 func TestCLIOutputModeCollisionFailsBeforeSideEffects(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 
 	for _, args := range [][]string{
+		{"version", "--json", "--quiet", "--no-color"},
 		{"version", "--server", "--json", "--quiet"},
 		{"health", "--json", "--quiet"},
 		{"runs", "--json", "--quiet"},
@@ -398,10 +591,17 @@ func TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects(t *testing.T) {
 		wantStderr string
 	}{
 		{name: "root", args: []string{"--json", "runs"}, wantStderr: "unknown flag: --json"},
+		{name: "root no-color", args: []string{"--no-color", "runs"}, wantStderr: "unknown flag: --no-color"},
 		{name: "completion", args: []string{"completion", "bash", "--json"}, wantStderr: "unknown flag"},
+		{name: "completion no-color", args: []string{"completion", "bash", "--no-color"}, wantStderr: "unknown flag"},
 		{name: "serve", args: []string{"serve", "--json"}, wantStderr: "unknown flag"},
+		{name: "serve no-color", args: []string{"serve", "--no-color"}, wantStderr: "unknown flag"},
+		{name: "serve log-level", args: []string{"serve", "--log-level", "debug"}, wantStderr: "unknown flag"},
 		{name: "retired investigate", args: []string{"investigate", "runs", "--json"}, wantStderr: "retired in CLI v2"},
+		{name: "retired investigate no-color", args: []string{"investigate", "runs", "--no-color"}, wantStderr: "retired in CLI v2"},
 		{name: "absent forkchat", args: []string{"forkchat", "--json"}, wantStderr: "unknown command"},
+		{name: "absent forkchat no-color", args: []string{"forkchat", "--no-color"}, wantStderr: "unknown command"},
+		{name: "split log-level", args: []string{"runs", "--log-level", "debug"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			beforeRPC := rpcCalls.Load()
@@ -446,6 +646,30 @@ func assertEmptyStderr(t *testing.T, raw string) {
 	if strings.TrimSpace(raw) != "" {
 		t.Fatalf("stderr = %q, want empty", raw)
 	}
+}
+
+func assertNoANSI(t *testing.T, raw string) {
+	t.Helper()
+	if cliANSISequencePattern.MatchString(raw) {
+		t.Fatalf("output contains ANSI escape sequence: %q", raw)
+	}
+}
+
+func newCLIOutputColorPolicyRPCServer(t *testing.T, wantMethod string, result map[string]any) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if req.Method != wantMethod {
+			t.Errorf("method = %q, want %s", req.Method, wantMethod)
+		}
+		writeJSONRPCResult(t, w, req.ID, result)
+	}))
+	return server, &calls
 }
 
 func outputModeVerifyFixture(t *testing.T) string {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5719,12 +5719,12 @@ cli_specification:
     output_contract:
       promoted_by: '#848'
       canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.output_contract
-      future_runtime_owner: cmd/swarm shared output-mode renderer
+      future_runtime_owner: cmd/swarm shared output-mode/color policy renderer
       scope: >
         Merge-bearing CLI v2 authority for successful command output mode selection and shared rendering.
-        This contract covers default text, `--json`, streaming NDJSON, `--quiet`, stdout/stderr separation,
-        command exceptions, and downstream implementation obligations. It does not implement CLI flags or
-        renderer code by itself.
+        This contract covers default text, `--json`, streaming NDJSON, `--quiet`, successful-output color
+        control, stdout/stderr separation, command exceptions, and downstream implementation obligations. It does
+        not implement CLI flags or renderer code by itself.
       mode_selection:
         default_mode: default_text
         explicit_modes:
@@ -5739,6 +5739,46 @@ cli_specification:
           A command MUST NOT accept an output-mode flag unless that invocation renders through the shared
           output-mode owner or is explicitly listed as an exception that fails before side effects. Adding flags
           that silently fall back to text output is invalid.
+      color_control:
+        promoted_by: '#931'
+        implementation_status: implemented for current shared-renderer first-slice consumers only
+        canonical_owner: cmd/swarm shared output-mode/color policy renderer
+        accepted_sources:
+          flag: --no-color
+          environment: NO_COLOR
+        precedence_rule: >
+          `--no-color` and any non-empty `NO_COLOR` value disable ANSI color in human-readable default text for
+          command invocations that consume the shared output owner. They are orthogonal controls, not output modes,
+          and they MUST NOT change `--json`, streaming JSON/NDJSON, `--quiet`, error exit-code classification, or
+          stderr diagnostics.
+        default_text_rule: >
+          Shared-renderer consumers route default text through the color policy owner. If color is disabled, ANSI
+          escape sequences are removed by the shared owner before stdout emission. Current first-slice default text
+          is ANSI-free by default, and that invariant is tested through the same shared owner.
+        machine_output_rule: >
+          JSON and quiet output are machine-readable and MUST remain ANSI-free by command contract. The color policy
+          MUST NOT post-process or reshape machine output; `--no-color --json` and `--no-color --quiet` are valid
+          and produce the same successful output as their machine mode without `--no-color`.
+        unsupported_surface_rule: >
+          `--no-color` is not a root/global flag and is not accepted by command surfaces that do not consume the
+          shared output owner. Root/help/completion, `swarm serve`, retired namespaces, blocked/absent command rows,
+          and split sibling command families MUST fail before side effects if `--no-color` is supplied there.
+        split_sources:
+          config_no_color: >
+            A config-file `no_color` key is not promoted by this first slice. Color config-file precedence remains
+            split from the shared renderer flag/env owner until a later #844 child promotes it.
+          log_level: >
+            `--log-level`, config-file `log_level`, and universal/repeatable verbosity are not color controls and
+            remain split logging/output work.
+        consumers:
+        - version
+        - verify
+        - health
+        - runs
+        - status
+        - conversations_list
+        - conversation_view
+        - conversation_turn
       stdout_stderr_boundary: >
         Successful load-bearing output renders only to stdout. Errors, warnings, retired-namespace migration text,
         validation failures, auth failures, transport/API failures, and diagnostics render to stderr under
@@ -5888,6 +5928,24 @@ cli_specification:
               json_shape: conversation.get_turn result object
               quiet_values:
               - session_id, turn_index, and outcome/status summary
+        implemented_color_policy_first_slice:
+          implemented_by: '#931'
+          failure_class: runtime.cli.v2.output_color_precedence_for_shared_renderer_consumers
+          owner: cmd/swarm shared output-mode/color policy renderer
+          status: implemented
+          rule: >
+            These consumers accept `--no-color` and consume non-empty `NO_COLOR` through the shared renderer owner.
+            The policy applies only to default human text. Machine-readable JSON/quiet output and error rendering
+            are not rewritten by the color policy. Unsupported surfaces remain fail-closed before side effects.
+          consumers:
+          - version
+          - verify
+          - health
+          - runs
+          - status
+          - conversations_list
+          - conversation_view
+          - conversation_turn
         implemented_consumer_residuals:
           logs: >
             `swarm logs` is implemented for default-text snapshot and follow in #876 and is no longer an absent
@@ -5939,7 +5997,7 @@ cli_specification:
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future
             implementation children consume this contract only after their command/API/runtime owner is promoted.
       split_siblings:
-      - '#844 universal flag/config/env precedence'
+      - '#844 universal flag/config/env precedence; config-file no_color and logging precedence remain split'
       - '#846 error-channel and exit-code classification; closed first slice'
       - '#839 retired namespace migration cleanup'
       - '#743 swarm run behavior and follow semantics; output-mode implementation may consume this contract later'
@@ -5947,8 +6005,10 @@ cli_specification:
       - API/runtime method semantics
       - JSON error-body or rich structured-error output unless a later tracked child promotes it
       implementation_proof_requirements:
-      - grep proof that implemented output-mode behavior consumes one shared cmd/swarm output-mode owner
+      - grep proof that implemented output-mode/color behavior consumes one shared cmd/swarm output owner
       - tests proving default text, JSON/NDJSON, and quiet behavior for every command row in the approved slice
+      - tests proving `--no-color` and `NO_COLOR` consume the shared owner, strip ANSI from default text, and do not
+        reshape JSON/quiet output
       - tests proving unsupported exception rows fail before side effects
       - stdout/stderr tests proving successful machine-readable stdout is not contaminated by diagnostics/errors
       - no direct DB/store/runtime/EventBus reads for API-backed output rendering
@@ -6032,7 +6092,9 @@ cli_specification:
         rejected_keys:
           api_token: Inline bearer tokens in config files are not promoted.
           output_format: Split to #848 output renderer implementation.
-          no_color: Split to output/color universal flag work.
+          no_color: >
+            Not promoted as a config-file key by #931. #931 accepts only `--no-color` and non-empty `NO_COLOR`
+            through the shared output owner for current first-slice consumers.
           contracts_path: Split to contract-path resolution.
           platform_spec_path: Split to contract-path resolution.
           log_level: Split to logging/output work.


### PR DESCRIPTION
Closes #931

## Governing Context

- Binding authority: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.output_contract`.
- Pre-audit: #931, including the independent approval for `runtime.cli.v2.output_color_precedence_for_shared_renderer_consumers`.
- Approved boundary: #924 shared-renderer consumers only: `version`, `verify`, `health`, `runs`, `status`, `conversations list`, `conversation view`, and `conversation turn`.

## Change

- Promotes the shared-renderer color/no-color policy into `platform-spec.yaml` for the approved first-slice consumers.
- Extends `cmd/swarm/cli_output.go` as the single CLI output owner for `--no-color` and non-empty `NO_COLOR`.
- Strips ANSI only in default human text mode when color is disabled; `--json` and `--quiet` are not rewritten.
- Keeps root/help/completion, `serve`, retired namespaces, absent command rows, `--log-level`, config-file `no_color`, and non-#924 command families split/fail-closed.

## Semantic Migration

- New canonical owner: `cmd/swarm/cli_output.go` shared output-mode/color policy renderer, backed by `platform-spec.yaml#cli_specification.foundations.output_contract.color_control`.
- Invalid old paths: command-local `--no-color`, command-local `NO_COLOR`, and command-local ANSI/color stripping for the approved consumers.
- Checked for surviving old behavior: grep proof shows `NO_COLOR`, `--no-color`, and `noColor` handling only in the shared output owner and tests.
- Migration completeness: complete for the approved #924 consumer slice only; broader #844/#794/#735 output/logging tails remain open.

## Proof

- `go test ./cmd/swarm -run 'TestCLIOutput' -count=1`
- `go test ./cmd/swarm -run 'TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted|TestCLIOutput' -count=1`
- `go test ./cmd/swarm -count=1`
- `git diff --check`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
- `rg -n 'NO_COLOR|no-color|noColor|cliANSI|bindCLIOutput' cmd/swarm --glob '*.go'`
- `rg -n 'os\.LookupEnv\("NO_COLOR"\)|BoolVar\(&[^\n]*noColor|BoolVar\(&opts\.noColor' cmd/swarm --glob '*.go'`