### PR TITLE
[agent-c][issue #934] Canonicalize agent lifecycle projection

### DIFF
--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -307,6 +307,58 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	}
 }
 
+func TestOperatorAgentHandlersSerializeLifecycleStatusFromReadOwner(t *testing.T) {
+	summary := store.OperatorAgentSummary{
+		AgentID:          "agent-1",
+		Role:             "researcher",
+		Type:             "managed",
+		ModelTier:        "haiku",
+		ConversationMode: "session",
+		SessionScope:     "global",
+		Status:           "idle",
+	}
+	reads := &fakeAgentConversationReadStore{
+		listAgentsResult: store.OperatorAgentListResult{Agents: []store.OperatorAgentSummary{summary}},
+		agentResult:      store.OperatorAgentDetail{Agent: summary},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	listAgents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agents","method":"agent.list","params":{}}`)
+	if listAgents.Error != nil {
+		t.Fatalf("agent.list error = %#v", listAgents.Error)
+	}
+	listResult := asMap(t, listAgents.Result)
+	agents, ok := listResult["agents"].([]any)
+	if !ok || len(agents) != 1 {
+		t.Fatalf("agent.list result = %#v", listResult)
+	}
+	listAgent := asMap(t, agents[0])
+	if listAgent["status"] != "idle" {
+		t.Fatalf("agent.list status = %#v, want idle from read owner", listAgent["status"])
+	}
+	if _, ok := listAgent["in_flight_turn"]; ok {
+		t.Fatalf("agent.list exposed dashboard lifecycle field: %#v", listAgent)
+	}
+
+	getAgent := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent","method":"agent.get","params":{"agent_id":"agent-1"}}`)
+	if getAgent.Error != nil {
+		t.Fatalf("agent.get error = %#v", getAgent.Error)
+	}
+	agentResult := asMap(t, getAgent.Result)
+	agent := asMap(t, agentResult["agent"])
+	if agent["status"] != "idle" {
+		t.Fatalf("agent.get status = %#v, want idle from read owner", agent["status"])
+	}
+	if _, ok := agent["in_flight_turn"]; ok {
+		t.Fatalf("agent.get exposed dashboard lifecycle field: %#v", agent)
+	}
+}
+
 func assertUnsupportedAgentMetricStubsAbsent(t *testing.T, payload map[string]any) {
 	t.Helper()
 	for _, key := range []string{"turns_24h", "in_flight_seconds"} {

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -320,7 +320,6 @@ type genericAgent struct {
 	Permissions         []string          `json:"permissions,omitempty"`
 	PendingEvents       int               `json:"pending_events,omitempty"`
 	OldestPendingAgeSec int               `json:"oldest_pending_age_sec,omitempty"`
-	InFlightTurn        bool              `json:"in_flight_turn,omitempty"`
 	LockOwner           string            `json:"lock_owner,omitempty"`
 	LockExpiresAt       string            `json:"lock_expires_at,omitempty"`
 	Failures24h         int               `json:"failures_24h,omitempty"`
@@ -1030,7 +1029,6 @@ func genericAgentFromOperatorSummary(row store.OperatorAgentSummary) genericAgen
 		Permissions:         append([]string(nil), row.Permissions...),
 		PendingEvents:       row.PendingEvents,
 		OldestPendingAgeSec: row.OldestPendingAgeSec,
-		InFlightTurn:        row.InFlightTurn,
 		LockOwner:           strings.TrimSpace(row.LockOwner),
 		LockExpiresAt:       formatTime(row.LockExpiresAt),
 		Failures24h:         row.Failures24h,

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -2031,7 +2031,7 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	}
 }
 
-func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenDeliveryLifecycleIsAbsent(t *testing.T) {
+func TestSQLAgentReader_ListGenericAgents_DoesNotDeriveLifecycleFromActiveLeaseWhenFactsAbsent(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -2069,14 +2069,83 @@ func TestSQLAgentReader_ListGenericAgents_FallsBackToActiveSessionLifecycleWhenD
 	if len(items) != 1 {
 		t.Fatalf("expected one agent, got %+v", items)
 	}
-	if items[0].State != "active" {
-		t.Fatalf("state = %q, want active from live session fallback", items[0].State)
+	if items[0].State != "idle" {
+		t.Fatalf("state = %q, want idle from empty canonical lifecycle facts", items[0].State)
 	}
-	if items[0].BlockingLayer != "session_execution" {
-		t.Fatalf("blocking_layer = %q, want session_execution from live session fallback", items[0].BlockingLayer)
+	if items[0].BlockingLayer != "" {
+		t.Fatalf("blocking_layer = %q, want empty without canonical lifecycle blocker", items[0].BlockingLayer)
 	}
+	if items[0].LockOwner != "lease-owner" || items[0].LockExpiresAt == "" {
+		t.Fatalf("raw lock metadata not preserved as debug data: %+v", items[0])
+	}
+	assertGenericAgentJSONFieldAbsent(t, items[0], "in_flight_turn")
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLAgentReader_GetGenericAgent_DoesNotDeriveLifecycleFromActiveLeaseWhenFactsAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewSQLAgentReader(db, stubSQLAgents{
+		rows: []runtimemanager.PersistedAgent{{
+			Config: runtimeactors.AgentConfig{
+				ID:   "agent-1",
+				Role: "researcher",
+				Mode: "global",
+				Type: "managed",
+			},
+			Status: "active",
+		}},
+		caps: canonicalEventAndConversationCaps(),
+		facts: map[string]store.PendingAgentDeliveryFacts{
+			"agent-1": {},
+		},
+		lifecycleFacts: map[string]store.AgentLifecycleFacts{
+			"agent-1": {},
+		},
+	}, 12)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+
+	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("GetGenericAgent: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected agent to exist")
+	}
+	if item.State != "idle" {
+		t.Fatalf("state = %q, want idle from empty canonical lifecycle facts", item.State)
+	}
+	if item.BlockingLayer != "" {
+		t.Fatalf("blocking_layer = %q, want empty without canonical lifecycle blocker", item.BlockingLayer)
+	}
+	assertGenericAgentJSONFieldAbsent(t, item, "in_flight_turn")
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func assertGenericAgentJSONFieldAbsent(t *testing.T, item genericAgent, field string) {
+	t.Helper()
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal generic agent: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal generic agent: %v", err)
+	}
+	if _, ok := payload[field]; ok {
+		t.Fatalf("generic agent payload exposed %q: %#v", field, payload)
 	}
 }
 

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -81,7 +81,6 @@ type OperatorAgentSummary struct {
 	Permissions           []string                            `json:"-"`
 	PendingEvents         int                                 `json:"-"`
 	OldestPendingAgeSec   int                                 `json:"-"`
-	InFlightTurn          bool                                `json:"-"`
 	LockOwner             string                              `json:"-"`
 	LockExpiresAt         time.Time                           `json:"-"`
 	Failures24h           int                                 `json:"-"`
@@ -438,7 +437,6 @@ type operatorAgentProjection struct {
 	OldestPendingAgeSec int
 	LockOwner           string
 	LockExpiresAt       time.Time
-	InFlightTurn        bool
 	Failures24h         int
 	DeadLetters24h      int
 	TurnCount           int
@@ -1183,9 +1181,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 		}
 		if lockExpiresAt.Valid {
 			projection.LockExpiresAt = lockExpiresAt.Time
-			if lockExpiresAt.Time.After(time.Now()) && strings.TrimSpace(projection.LockOwner) != "" {
-				projection.InFlightTurn = true
-			}
 		}
 		if latestCompleted.Valid && strings.TrimSpace(latestTurnID) != "" {
 			projection.LastTurnRef = &OperatorTurnRef{
@@ -1258,7 +1253,6 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		Permissions:           append([]string(nil), row.Config.Permissions...),
 		PendingEvents:         projection.PendingEvents,
 		OldestPendingAgeSec:   projection.OldestPendingAgeSec,
-		InFlightTurn:          projection.InFlightTurn,
 		LockOwner:             strings.TrimSpace(projection.LockOwner),
 		LockExpiresAt:         projection.LockExpiresAt,
 		Failures24h:           projection.Failures24h,
@@ -1454,18 +1448,12 @@ func (p operatorAgentProjection) dashboardState() string {
 	if state := strings.TrimSpace(p.LifecycleState); state != "" {
 		return state
 	}
-	if p.InFlightTurn {
-		return "active"
-	}
 	return "idle"
 }
 
 func (p operatorAgentProjection) dashboardBlockingLayer() string {
 	if layer := strings.TrimSpace(p.BlockingLayer); layer != "" {
 		return layer
-	}
-	if p.InFlightTurn {
-		return "session_execution"
 	}
 	return ""
 }
@@ -1482,9 +1470,6 @@ func (p operatorAgentProjection) v1Status() string {
 		return "running"
 	case "exhausted":
 		return "failed"
-	}
-	if p.InFlightTurn {
-		return "running"
 	}
 	return "idle"
 }

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -296,7 +296,7 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", "entity-1", false, "model error", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", "entity-1", false, "model error", turnCompletedAt, []byte(`[]`)))
 
 	detail, err := reader.LoadOperatorAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -308,8 +308,65 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	if detail.LastTurnRef == nil || detail.LastTurnRef.TurnID != turnID || !detail.LastTurnRef.CompletedAt.Equal(turnCompletedAt) || detail.LastTurnRef.ParseOK || detail.LastTurnRef.Error != "model error" {
 		t.Fatalf("last_turn_ref = %#v", detail.LastTurnRef)
 	}
+	if detail.Agent.Status != "idle" {
+		t.Fatalf("agent.status = %q, want idle from empty canonical lifecycle facts", detail.Agent.Status)
+	}
+	if detail.Agent.DashboardState != "idle" {
+		t.Fatalf("dashboard state = %q, want idle from empty canonical lifecycle facts", detail.Agent.DashboardState)
+	}
+	if detail.Agent.BlockingLayer != "" {
+		t.Fatalf("blocking_layer = %q, want empty without canonical lifecycle blocker", detail.Agent.BlockingLayer)
+	}
 	if detail.Agent.CurrentSessionRef == nil || detail.Agent.LastTurnRef == nil {
 		t.Fatalf("agent summary refs not populated: %+v", detail.Agent)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+		pending: map[string]PendingAgentDeliveryFacts{
+			"agent-1": {},
+		},
+		lifecycle: map[string]AgentLifecycleFacts{
+			"agent-1": {},
+		},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+
+	result, err := reader.ListOperatorAgents(context.Background(), OperatorAgentListOptions{})
+	if err != nil {
+		t.Fatalf("ListOperatorAgents: %v", err)
+	}
+	if len(result.Agents) != 1 {
+		t.Fatalf("agent count = %d, want 1", len(result.Agents))
+	}
+	agent := result.Agents[0]
+	if agent.Status != "idle" {
+		t.Fatalf("status = %q, want idle from empty canonical lifecycle facts", agent.Status)
+	}
+	if agent.DashboardState != "idle" {
+		t.Fatalf("dashboard state = %q, want idle from empty canonical lifecycle facts", agent.DashboardState)
+	}
+	if agent.BlockingLayer != "" {
+		t.Fatalf("blocking_layer = %q, want empty without canonical lifecycle blocker", agent.BlockingLayer)
+	}
+	if agent.LockOwner != "lease-owner" || agent.LockExpiresAt.IsZero() {
+		t.Fatalf("raw lease metadata not preserved as debug data: %+v", agent)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -443,6 +500,41 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	}
 	if diagnosis.Active != nil {
 		t.Fatalf("active = %#v, want nil without selected active-session latest turn", diagnosis.Active)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisDoesNotDeriveStatusFromActiveLease(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+		lifecycle: map[string]AgentLifecycleFacts{
+			"agent-1": {},
+		},
+	}, 0)
+
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.Status != "idle" {
+		t.Fatalf("status = %q, want idle from empty canonical lifecycle facts", diagnosis.Status)
+	}
+	if diagnosis.DeliveryLifecycle != nil {
+		t.Fatalf("delivery_lifecycle = %#v, want nil", diagnosis.DeliveryLifecycle)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
## Summary

- Removes active-session lease-derived lifecycle fallback from supported agent/operator read projection.
- Makes empty canonical lifecycle facts produce `AgentStatus=idle`, dashboard `state=idle`, no dashboard `blocking_layer`, and no dashboard `in_flight_turn` signal even when an active lease exists.
- Keeps raw `lock_owner` / `lock_expires_at` as debug metadata only; they no longer drive lifecycle status/state/blocking projection.

Closes #934
Part of #101

## Governing Refs / Context

Exact spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `components.schemas.AgentStatus`
- `components.schemas.AgentSummary`
- `components.schemas.AgentDetail`
- `agent.list`
- `agent.get`
- `agent.diagnose`
- agent session lifecycle / live owner query context
- retired `/api/agents` disposition mapping to `agent.list` / `agent.get`

Approved gate boundary: #934 independent gate approved this as a first slice for removing lease-derived lifecycle fallback from `status`, dashboard `state`, dashboard `blocking_layer`, and dashboard `in_flight_turn` across `agent.list`, `agent.get`, and dashboard direct list/detail only.

## Semantic Migration

- New canonical owner: `store.ListAgentLifecycleFacts` / `canonicalAgentLifecycleFactsFromRecords`, consumed through `OperatorAgentConversationReadSurface`.
- Old non-authoritative path now invalid: `operatorAgentProjection.InFlightTurn` derived from `agent_sessions.lease_expires_at > now()` and used by `v1Status`, `dashboardState`, `dashboardBlockingLayer`, and dashboard `genericAgent.in_flight_turn`.
- Production paths checked for surviving old behavior: `internal/store`, `internal/dashboard/server`, and `internal/apiv1` symbol probes for `InFlightTurn` / `in_flight_turn` / lifecycle fallback helpers.
- Migration completeness: complete for the approved #934 child class. #101 parent remains open for #852, #363, CLI, OpenRPC/conformance, and broader lifecycle/debug architecture siblings.

## Validation

- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs|TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease|TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners|TestOperatorAgentReadSurfaceLoadAgentDiagnosisDoesNotDeriveStatusFromActiveLease|TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle|TestPostgresStore_ListAgentLifecycleFacts_UsesCanonicalLiveLifecycle|TestPostgresStore_ListAgentLifecycleFacts_UsesCanonicalTerminalLifecycleWhenNoLiveWorkRemains' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner|TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection|TestSQLAgentReader_ListGenericAgents_DoesNotDeriveLifecycleFromActiveLeaseWhenFactsAbsent|TestSQLAgentReader_GetGenericAgent_DoesNotDeriveLifecycleFromActiveLeaseWhenFactsAbsent|TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorAgentHandlersSerializeLifecycleStatusFromReadOwner' -count=1`
- `go test ./...`