### PR TITLE
[agent-e][issue #930] Align EntityFull accumulated schema owner

### DIFF
--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -127,7 +127,7 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 		"slug=vertical-1 name=Vertical One",
 		`fields={"score":7}`,
 		`gates={"ready":true}`,
-		`accumulated={"notes":["a"]}`,
+		`accumulated={"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
@@ -386,10 +386,14 @@ func validEntitySummary(entityID string) map[string]any {
 
 func validEntityFullResult(entityID string) map[string]any {
 	return map[string]any{
-		"entity":      validEntitySummary(entityID),
-		"fields":      map[string]any{"score": 7},
-		"gates":       map[string]any{"ready": true},
-		"accumulated": map[string]any{"notes": []any{"a"}},
+		"entity": validEntitySummary(entityID),
+		"fields": map[string]any{"score": 7},
+		"gates":  map[string]any{"ready": true},
+		"accumulated": map[string]any{
+			"score":       3,
+			"accumulator": map[string]any{"count": 2},
+			"notes":       []any{"a", map[string]any{"text": "probe"}},
+		},
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -6042,13 +6042,8 @@
         "description": "Entity-native shape: typed fields, gates, accumulator state. This\nis the destination shape entity.get returns. v1 implementation\nmay need to translate from the existing instance-shaped readers\nin internal/dashboard/server/server.go (which return flat\nWorkflowInstance structs without the typed-fields/gates/\naccumulated decomposition). The spec commits to the entity-native\nshape; implementations are responsible for providing it. A real\nentity-read owner may need to land before entity.* methods can\nhonor this shape, which is why the entity.* methods are\nshould_have rather than must_have for v1.\n",
         "properties": {
           "accumulated": {
-            "additionalProperties": {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            },
-            "description": "Per-handler accumulator buckets. Map of bucket_key → array of typed items.",
+            "additionalProperties": true,
+            "description": "Accumulator state. Map of accumulator key → JSON value; values may be scalars, objects, or arrays depending on accumulate, data_accumulation, compute, or projection writers.",
             "type": "object"
           },
           "entity": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8342,11 +8342,9 @@ api_specification:
               type: boolean
           accumulated:
             type: object
-            description: "Per-handler accumulator buckets. Map of bucket_key \u2192 array of typed items."
-            additionalProperties:
-              type: array
-              items:
-                type: object
+            description: "Accumulator state. Map of accumulator key \u2192 JSON value; values may be scalars, objects, or\
+              \ arrays depending on accumulate, data_accumulation, compute, or projection writers."
+            additionalProperties: true
       EntityAggregateResult:
         type: object
         additionalProperties: false

--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -174,7 +174,7 @@ nodes:
       - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
       - OpenRPC method examples can lack a merge-bearing authoring or deferral policy across the generated method catalog
       - rpc.discover/service-discovery non-publication is owned by api_specification.service_discovery_policy and enforced by internal/apispec plus the compliance matrix
-      - EntityFull.accumulated deep schema hardening remains tracked under #857 after #896
+      - EntityFull.accumulated schema/runtime owner alignment is closed by #930 across /v1/rpc entity.get, builder, dashboard, CLI, store, OpenRPC proof, and matrix accounting; future entity-read field drift remains under this node
       - CI can pass without a direct swarm-openrpc-gen --check step
     representative_issues:
       - 835

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -157,6 +157,66 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 }
 
+func TestEntityFullAccumulatedSchemaPublishesRuntimeAccumulatorState(t *testing.T) {
+	api := loadRepoAPISpec(t)
+	entityFull, ok := api.Components.Schemas["EntityFull"].(map[string]any)
+	if !ok {
+		t.Fatalf("EntityFull schema = %#v, want object", api.Components.Schemas["EntityFull"])
+	}
+	properties, ok := entityFull["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("EntityFull.properties = %#v, want object", entityFull["properties"])
+	}
+	accumulated, ok := properties["accumulated"].(map[string]any)
+	if !ok {
+		t.Fatalf("EntityFull.accumulated = %#v, want object schema", properties["accumulated"])
+	}
+	if got, want := accumulated["type"], "object"; got != want {
+		t.Fatalf("EntityFull.accumulated.type = %#v, want %q", got, want)
+	}
+	if got, ok := accumulated["additionalProperties"].(bool); !ok || !got {
+		t.Fatalf("EntityFull.accumulated.additionalProperties = %#v, want true", accumulated["additionalProperties"])
+	}
+	if _, ok := accumulated["items"]; ok {
+		t.Fatalf("EntityFull.accumulated must not use array items at the map boundary: %#v", accumulated)
+	}
+	method := api.MethodCatalog["entity.get"]
+	if method.Result == nil {
+		t.Fatal("entity.get missing result descriptor")
+	}
+	resultSchema, ok := method.Result.Schema.(map[string]any)
+	if !ok {
+		t.Fatalf("entity.get result schema = %#v, want object", method.Result.Schema)
+	}
+	if got, want := resultSchema["$ref"], "#/components/schemas/EntityFull"; got != want {
+		t.Fatalf("entity.get result ref = %#v, want %q", got, want)
+	}
+
+	generated, err := GenerateOpenRPC(api)
+	if err != nil {
+		t.Fatalf("GenerateOpenRPC() error = %v", err)
+	}
+	var doc OpenRPCDocument
+	if err := json.Unmarshal(generated, &doc); err != nil {
+		t.Fatalf("unmarshal generated openrpc: %v", err)
+	}
+	generatedEntityFull, ok := doc.Components.Schemas["EntityFull"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated EntityFull schema = %#v, want object", doc.Components.Schemas["EntityFull"])
+	}
+	generatedProperties, ok := generatedEntityFull["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated EntityFull.properties = %#v, want object", generatedEntityFull["properties"])
+	}
+	generatedAccumulated, ok := generatedProperties["accumulated"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated EntityFull.accumulated = %#v, want object schema", generatedProperties["accumulated"])
+	}
+	if got, ok := generatedAccumulated["additionalProperties"].(bool); !ok || !got {
+		t.Fatalf("generated EntityFull.accumulated.additionalProperties = %#v, want true", generatedAccumulated["additionalProperties"])
+	}
+}
+
 func TestValidateRejectsMissingExamplesPolicy(t *testing.T) {
 	api := loadRepoAPISpec(t)
 	api.ExamplesPolicy = ExamplesPolicy{}

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -494,10 +494,14 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 				UpdatedAt:    now,
 			}}},
 			getResult: store.OperatorEntityFull{
-				Entity:      store.OperatorEntitySummary{EntityID: "entity-1", RunID: runID, CurrentState: "collecting"},
-				Fields:      map[string]any{"priority": "high"},
-				Gates:       map[string]bool{"approved": true},
-				Accumulated: map[string]any{"notes": []any{map[string]any{"text": "probe"}}},
+				Entity: store.OperatorEntitySummary{EntityID: "entity-1", RunID: runID, CurrentState: "collecting"},
+				Fields: map[string]any{"priority": "high"},
+				Gates:  map[string]bool{"approved": true},
+				Accumulated: map[string]any{
+					"score":       float64(3),
+					"accumulator": map[string]any{"count": float64(2)},
+					"notes":       []any{"a", map[string]any{"text": "probe"}},
+				},
 			},
 			aggregate: store.OperatorEntityAggregateResult{Counts: map[string]int{"collecting": 1}},
 		},

--- a/internal/apiv1/openrpc_result_schema_test.go
+++ b/internal/apiv1/openrpc_result_schema_test.go
@@ -71,6 +71,33 @@ func TestOpenRPCResultSchemaPreflightRejectsUnreachableBranches(t *testing.T) {
 	}
 }
 
+func TestOpenRPCEntityFullAccumulatedSchemaMatchesRuntimeOwner(t *testing.T) {
+	root := repoRoot(t)
+	openRPC, _ := loadComplianceOpenRPC(t, filepath.Join(root, "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json"))
+	validator := newOpenRPCResultSchemaValidator(t, openRPC)
+
+	result := map[string]any{
+		"entity": map[string]any{
+			"entity_id":     "entity-1",
+			"run_id":        "run-1",
+			"flow_instance": "review/primary",
+			"entity_type":   "mvp_spec",
+			"current_state": "collecting",
+			"revision":      float64(2),
+			"created_at":    "2026-05-20T01:00:00Z",
+			"updated_at":    "2026-05-20T01:05:00Z",
+		},
+		"fields": map[string]any{"priority": "high"},
+		"gates":  map[string]any{"approved": true},
+		"accumulated": map[string]any{
+			"score":       float64(3),
+			"accumulator": map[string]any{"count": float64(2)},
+			"notes":       []any{"a", map[string]any{"text": "probe"}},
+		},
+	}
+	validator.validateMethodResult(t, "entity.get", result)
+}
+
 func TestOpenRPCSubscriptionNotificationSchemas(t *testing.T) {
 	root := repoRoot(t)
 	api := loadComplianceAPISpec(t, root)

--- a/internal/apiv1/operator_entity_test.go
+++ b/internal/apiv1/operator_entity_test.go
@@ -55,10 +55,14 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 			NextCursor: "next",
 		},
 		getResult: store.OperatorEntityFull{
-			Entity:      store.OperatorEntitySummary{EntityID: "entity-1", RunID: "run-1", EntityType: "mvp_spec", CurrentState: "collecting"},
-			Fields:      map[string]any{"priority": "high"},
-			Gates:       map[string]bool{"approved": true},
-			Accumulated: map[string]any{"notes": []any{"a"}},
+			Entity: store.OperatorEntitySummary{EntityID: "entity-1", RunID: "run-1", EntityType: "mvp_spec", CurrentState: "collecting"},
+			Fields: map[string]any{"priority": "high"},
+			Gates:  map[string]bool{"approved": true},
+			Accumulated: map[string]any{
+				"score":       float64(3),
+				"accumulator": map[string]any{"count": float64(2)},
+				"notes":       []any{"a", map[string]any{"text": "probe"}},
+			},
 		},
 		aggregate: store.OperatorEntityAggregateResult{Counts: map[string]int{"collecting": 1}},
 	}
@@ -88,6 +92,13 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 	getResult := asMap(t, get.Result)
 	if fields := asMap(t, getResult["fields"]); fields["priority"] != "high" {
 		t.Fatalf("entity.get result = %#v", get.Result)
+	}
+	accumulated := asMap(t, getResult["accumulated"])
+	if accumulated["score"] != float64(3) {
+		t.Fatalf("entity.get accumulated = %#v, want score", accumulated)
+	}
+	if bucket := asMap(t, accumulated["accumulator"]); bucket["count"] != float64(2) {
+		t.Fatalf("entity.get accumulated bucket = %#v, want count", accumulated["accumulator"])
 	}
 	if got := asMap(t, getResult["entity"])["entity_type"]; got != "mvp_spec" {
 		t.Fatalf("entity.get entity_type = %#v, want mvp_spec", got)

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -20,7 +20,7 @@ policy:
   notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover were tracked by later #857 children."
   examples_policy: "#904 adds merge-bearing catalog-wide OpenRPC examples deferral policy; method examples are intentionally omitted until a future approved source model exists."
   service_discovery_policy: "#915 adds merge-bearing catalog-wide rpc.discover non-publication policy; method publication remains the generated OpenRPC artifact."
-  entity_accumulated_schema_hardening_policy: "#896 leaves EntityFull.accumulated deep schema hardening tracked under #857; #915 does not close that parent residual."
+  entity_accumulated_schema_hardening_policy: "#930 aligns EntityFull.accumulated schema ownership to the runtime accumulator-state owner across /v1/rpc entity.get, builder state.get_entity, dashboard /api/instances/{id}, CLI, store, generated OpenRPC proof, and matrix accounting."
 methods:
   - method: agent.diagnose
     transport: http
@@ -212,7 +212,7 @@ methods:
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersTypedErrors}]}
     idempotency: {status: not_applicable}
-    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCEntityFullAccumulatedSchemaMatchesRuntimeOwner}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}

--- a/internal/builder/handler_test.go
+++ b/internal/builder/handler_test.go
@@ -170,9 +170,13 @@ func TestHandler_StateGetEntityReturnsCanonicalEntityFull(t *testing.T) {
 				Slug:         "order-1",
 				Name:         "Order 1",
 			},
-			Fields:      map[string]any{"priority": "high"},
-			Gates:       map[string]bool{"review_gate": true},
-			Accumulated: map[string]any{"score": float64(3)},
+			Fields: map[string]any{"priority": "high"},
+			Gates:  map[string]bool{"review_gate": true},
+			Accumulated: map[string]any{
+				"score":       float64(3),
+				"accumulator": map[string]any{"count": float64(2)},
+				"notes":       []any{"a", map[string]any{"text": "probe"}},
+			},
 		},
 	}
 	handler := NewHandler(Options{
@@ -198,6 +202,9 @@ func TestHandler_StateGetEntityReturnsCanonicalEntityFull(t *testing.T) {
 	}
 	if full.Entity.CurrentState != "reviewing" || full.Fields["priority"] != "high" || !full.Gates["review_gate"] || full.Accumulated["score"] != float64(3) {
 		t.Fatalf("state.get_entity canonical result = %#v", full)
+	}
+	if bucket, ok := full.Accumulated["accumulator"].(map[string]any); !ok || bucket["count"] != float64(2) {
+		t.Fatalf("state.get_entity accumulated bucket = %#v, want count", full.Accumulated["accumulator"])
 	}
 
 	raw, err := json.Marshal(resp.Result)

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -269,9 +269,13 @@ func TestHandler_InstanceHandlersReturnCanonicalEntityProjection(t *testing.T) {
 						EntityType:   "order",
 						CurrentState: "reviewing",
 					},
-					Fields:      map[string]any{"business_status": "approved"},
-					Gates:       map[string]bool{"review_gate": true},
-					Accumulated: map[string]any{"score": float64(9)},
+					Fields: map[string]any{"business_status": "approved"},
+					Gates:  map[string]bool{"review_gate": true},
+					Accumulated: map[string]any{
+						"score":       float64(9),
+						"accumulator": map[string]any{"count": float64(2)},
+						"notes":       []any{"a", map[string]any{"text": "probe"}},
+					},
 				},
 			},
 			lastAggregate: lastAggregate,
@@ -313,6 +317,9 @@ func TestHandler_InstanceHandlersReturnCanonicalEntityProjection(t *testing.T) {
 	}
 	if detail.Entity.CurrentState != "reviewing" || detail.Fields["business_status"] != "approved" || !detail.Gates["review_gate"] || detail.Accumulated["score"] != float64(9) {
 		t.Fatalf("detail payload = %#v", detail)
+	}
+	if bucket, ok := detail.Accumulated["accumulator"].(map[string]any); !ok || bucket["count"] != float64(2) {
+		t.Fatalf("detail accumulated bucket = %#v, want count", detail.Accumulated["accumulator"])
 	}
 	if _, ok := detail.Fields["status"]; ok {
 		t.Fatalf("detail leaked control status field: %#v", detail.Fields)

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -44,7 +44,7 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 			t.Fatalf("seed entity %s/%s: %v", runID, entityID, err)
 		}
 	}
-	seedEntity(runA, entityA, "review/primary", "mvp_spec", "collecting", `{"priority":"high","score":3}`, `{"approved":true}`, `{"notes":["a"]}`, base.Add(time.Minute))
+	seedEntity(runA, entityA, "review/primary", "mvp_spec", "collecting", `{"priority":"high","score":3}`, `{"approved":true}`, `{"score":3,"accumulator":{"count":2},"notes":["a",{"text":"probe"}]}`, base.Add(time.Minute))
 	seedEntity(runA, entityB, "review/secondary", "mvp_spec", "done", `{"priority":"low"}`, `{}`, `{}`, base)
 	seedEntity(runA, sharedEntity, "triage", "ticket", "collecting", `{"priority":"high"}`, `{}`, `{}`, base.Add(-time.Minute))
 	seedEntity(runB, sharedEntity, "triage", "ticket", "done", `{"priority":"low"}`, `{}`, `{}`, base.Add(-2*time.Minute))
@@ -96,6 +96,15 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	}
 	if full.Entity.EntityType != "mvp_spec" {
 		t.Fatalf("full entity_type = %q, want mvp_spec", full.Entity.EntityType)
+	}
+	if full.Accumulated["score"] != float64(3) {
+		t.Fatalf("full accumulated = %#v, want score", full.Accumulated)
+	}
+	if bucket, ok := full.Accumulated["accumulator"].(map[string]any); !ok || bucket["count"] != float64(2) {
+		t.Fatalf("full accumulated bucket = %#v, want count", full.Accumulated["accumulator"])
+	}
+	if notes, ok := full.Accumulated["notes"].([]any); !ok || len(notes) != 2 {
+		t.Fatalf("full accumulated notes = %#v, want two entries", full.Accumulated["notes"])
 	}
 	if _, err := pg.LoadOperatorEntity(ctx, sharedEntity, ""); !errors.Is(err, ErrAmbiguousEntityRunID) {
 		t.Fatalf("LoadOperatorEntity ambiguous = %v, want ErrAmbiguousEntityRunID", err)


### PR DESCRIPTION
Closes #930
Part of #857

## Summary

- Align `EntityFull.accumulated` in `platform-spec.yaml` and generated `openrpc.json` to the live accumulator-state owner: `map accumulator key -> JSON value`.
- Add OpenRPC/API proof that `entity.get` result-schema validation accepts scalar, object, and array accumulated values from the runtime owner shape.
- Update same-owner consumer fixtures/proofs for `/v1/rpc entity.get`, builder `state.get_entity`, dashboard `/api/instances/{id}`, CLI `entity view`, store read owner, compliance matrix, and watchlist state.

## Governing refs / context

Exact governing spec sections exist:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.EntityFull.properties.accumulated`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.method_catalog.entity.get.result`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` migration mapping: `state.get_entity -> entity.get` and `GET /api/instances/{id} -> entity.get`
- Generated `docs/specs/swarm-platform/platform/contracts/openrpc.json` `EntityFull` and `entity.get` result schema
- `internal/apispec`, `internal/apiv1`, and `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`
- #930 pre-audit comments `4519586551` and gate approval `4519646371`

## Semantic migration

- New canonical owner: `platform-spec.yaml` `EntityFull.accumulated` now explicitly describes the runtime accumulator-state owner as an object with arbitrary JSON values per key; generated OpenRPC consumes that owner.
- Old non-authoritative path now invalid: the previous `bucket_key -> array<object>` OpenRPC/schema interpretation, which contradicted the live `store.OperatorEntityFull.Accumulated map[string]any` owner and same-owner consumers.
- Production paths checked for surviving old behavior: `/v1/rpc entity.get`, builder `state.get_entity`, dashboard `/api/instances/{id}`, CLI `entity view`, store `LoadOperatorEntity`, generated result-schema proof, and compliance matrix accounting.
- Migration completeness: complete for the #930 chosen class. No production API/runtime behavior code changed; this PR makes the merge-bearing API schema and proof ownership match the already-live runtime owner.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -run 'OpenRPCSuccessfulResultSchemas|OpenRPCEntityFullAccumulatedSchemaMatchesRuntimeOwner|OpenRPCReadOnlyHTTPRuntimeProbes|OperatorEntity|ComplianceMatrix|EntityFullAccumulatedSchema' -count=1`
- `go test ./internal/builder -run 'TestHandler_StateGetEntityReturnsCanonicalEntityFull' -count=1`
- `go test ./internal/dashboard/server -run 'TestHandler_InstanceHandlersReturnCanonicalEntityProjection|TestHandler_BuilderRPC' -count=1`
- `go test ./internal/store -run 'TestOperatorEntityReadOwnerListGetAggregateAndCursor' -count=1`
- `go test ./cmd/swarm -run 'TestEntityViewUsesEntityGetAndRendersEntityNativeDetail|TestEntityCommandsMapRuntimeFailuresAndMalformedResults' -count=1`
- `git diff --check`
- `go test ./...`