### PR TITLE
[agent-b][issue #856] Add mailbox decision sheet API detail

### DIFF
--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -46,9 +46,29 @@ type mailboxListResult struct {
 }
 
 type mailboxDetailResult struct {
-	Item    mailboxItem           `json:"item"`
-	Payload map[string]any        `json:"payload"`
-	History []mailboxHistoryEntry `json:"history"`
+	Item          mailboxItem           `json:"item"`
+	Payload       map[string]any        `json:"payload"`
+	History       []mailboxHistoryEntry `json:"history"`
+	DecisionSheet *mailboxDecisionSheet `json:"decision_sheet"`
+}
+
+type mailboxDecisionSheet struct {
+	EntityContext     mailboxEntityContext     `json:"entity_context"`
+	DownstreamPreview mailboxDownstreamPreview `json:"downstream_preview"`
+}
+
+type mailboxEntityContext struct {
+	Available bool        `json:"available"`
+	Reason    string      `json:"reason,omitempty"`
+	Entity    *entityFull `json:"entity,omitempty"`
+}
+
+type mailboxDownstreamPreview struct {
+	Available        bool     `json:"available"`
+	Reason           string   `json:"reason,omitempty"`
+	EventName        string   `json:"event_name,omitempty"`
+	Subscribers      []string `json:"subscribers"`
+	SubscriberSource string   `json:"subscriber_source"`
 }
 
 type mailboxListCommandOptions struct {
@@ -336,6 +356,12 @@ func validateMailboxDetailResult(result mailboxDetailResult) error {
 	if result.History == nil {
 		return fmt.Errorf("malformed mailbox.get result: history is required")
 	}
+	if result.DecisionSheet == nil {
+		return fmt.Errorf("malformed mailbox.get result: decision_sheet is required")
+	}
+	if err := validateMailboxDecisionSheet(*result.DecisionSheet); err != nil {
+		return err
+	}
 	for i, entry := range result.History {
 		if strings.TrimSpace(entry.Action) == "" {
 			return fmt.Errorf("malformed mailbox.get result: history[%d].action is required", i)
@@ -346,6 +372,35 @@ func validateMailboxDetailResult(result mailboxDetailResult) error {
 		if strings.TrimSpace(entry.TS) == "" {
 			return fmt.Errorf("malformed mailbox.get result: history[%d].ts is required", i)
 		}
+	}
+	return nil
+}
+
+func validateMailboxDecisionSheet(sheet mailboxDecisionSheet) error {
+	entityCtx := sheet.EntityContext
+	if entityCtx.Available {
+		if entityCtx.Entity == nil {
+			return fmt.Errorf("malformed mailbox.get result: decision_sheet.entity_context.entity is required when available")
+		}
+		if err := validateEntityFullResult("mailbox.get result.decision_sheet.entity_context", *entityCtx.Entity); err != nil {
+			return err
+		}
+	} else if strings.TrimSpace(entityCtx.Reason) == "" {
+		return fmt.Errorf("malformed mailbox.get result: decision_sheet.entity_context.reason is required when unavailable")
+	}
+	preview := sheet.DownstreamPreview
+	if preview.Subscribers == nil {
+		return fmt.Errorf("malformed mailbox.get result: decision_sheet.downstream_preview.subscribers is required")
+	}
+	if strings.TrimSpace(preview.SubscriberSource) == "" {
+		return fmt.Errorf("malformed mailbox.get result: decision_sheet.downstream_preview.subscriber_source is required")
+	}
+	if preview.Available {
+		if strings.TrimSpace(preview.EventName) == "" {
+			return fmt.Errorf("malformed mailbox.get result: decision_sheet.downstream_preview.event_name is required when available")
+		}
+	} else if strings.TrimSpace(preview.Reason) == "" {
+		return fmt.Errorf("malformed mailbox.get result: decision_sheet.downstream_preview.reason is required when unavailable")
 	}
 	return nil
 }
@@ -553,6 +608,7 @@ func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
 	if item.Decision != "" || item.DecidedAt != "" {
 		fmt.Fprintf(out, "decision=%s decided_at=%s\n", mailboxDash(item.Decision), mailboxDash(item.DecidedAt))
 	}
+	writeMailboxDecisionSheet(out, *result.DecisionSheet)
 	writeMailboxObject(out, "payload", result.Payload)
 	if len(result.History) > 0 {
 		fmt.Fprintln(out, "history:")
@@ -568,6 +624,38 @@ func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
 			fmt.Fprintln(out)
 		}
 	}
+}
+
+func writeMailboxDecisionSheet(out io.Writer, sheet mailboxDecisionSheet) {
+	fmt.Fprintln(out, "decision_sheet:")
+	if sheet.EntityContext.Available && sheet.EntityContext.Entity != nil {
+		entity := sheet.EntityContext.Entity.Entity
+		fmt.Fprintf(out, "  entity_context: entity_id=%s run_id=%s flow=%s type=%s state=%s revision=%d\n",
+			entity.EntityID,
+			entity.RunID,
+			entity.FlowInstance,
+			entity.EntityType,
+			entity.CurrentState,
+			entity.Revision,
+		)
+		fmt.Fprintf(out, "  entity_fields=%s\n", entityCompactJSON(sheet.EntityContext.Entity.Fields))
+		fmt.Fprintf(out, "  entity_gates=%s\n", entityCompactJSON(sheet.EntityContext.Entity.Gates))
+		fmt.Fprintf(out, "  entity_accumulated=%s\n", entityCompactJSON(sheet.EntityContext.Entity.Accumulated))
+	} else {
+		fmt.Fprintf(out, "  entity_context: unavailable reason=%s\n", mailboxDash(sheet.EntityContext.Reason))
+	}
+	if sheet.DownstreamPreview.Available {
+		fmt.Fprintf(out, "  downstream_preview: event_name=%s subscribers=%s subscriber_source=%s\n",
+			sheet.DownstreamPreview.EventName,
+			mailboxStringList(sheet.DownstreamPreview.Subscribers),
+			mailboxDash(sheet.DownstreamPreview.SubscriberSource),
+		)
+		return
+	}
+	fmt.Fprintf(out, "  downstream_preview: unavailable reason=%s subscriber_source=%s\n",
+		mailboxDash(sheet.DownstreamPreview.Reason),
+		mailboxDash(sheet.DownstreamPreview.SubscriberSource),
+	)
 }
 
 func writeMailboxDecisionResult(out io.Writer, action, mailboxID string, result mailboxDecisionResult) {
@@ -605,4 +693,18 @@ func mailboxDash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+func mailboxStringList(values []string) string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	if len(out) == 0 {
+		return "-"
+	}
+	return strings.Join(out, ",")
 }

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -215,8 +215,9 @@ func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
 		item := mailboxItemResult("mailbox-1", "pending", "high")
 		delete(item, "source_event_id")
 		writeJSONRPCResult(t, w, captured.ID, map[string]any{
-			"item":    item,
-			"payload": map[string]any{"summary": "needs review"},
+			"item":           item,
+			"payload":        map[string]any{"summary": "needs review"},
+			"decision_sheet": mailboxDecisionSheetResult(),
 			"history": []map[string]any{
 				{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"},
 			},
@@ -239,6 +240,12 @@ func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
 		"Mailbox mailbox-1",
 		"status=pending priority=high type=review_request",
 		"source_event_id=- source_flow=validation",
+		"decision_sheet:",
+		"entity_context: entity_id=entity-1 run_id=run-1 flow=flows/review type=vertical state=collecting revision=3",
+		`entity_fields={"score":7}`,
+		`entity_gates={"ready":true}`,
+		`entity_accumulated={"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
+		"downstream_preview: event_name=mailbox.item_decided subscribers=approval-agent,review-agent subscriber_source=event_catalog",
 		`payload={"summary":"needs review"}`,
 		"history:",
 		"- action=created actor=system ts=2026-05-13T12:00:00Z",
@@ -542,6 +549,21 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantStderr: "malformed mailbox.get result: payload is required",
 		},
 		{
+			name: "view malformed missing decision sheet",
+			args: []string{"mailbox", "view", "mailbox-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"item":    mailboxItemResult("mailbox-1", "pending", "normal"),
+					"payload": map[string]any{"summary": "needs review"},
+					"history": []map[string]any{{"action": "created", "actor_token_id": "system", "ts": "2026-05-13T12:00:00Z"}},
+				})
+			},
+			wantCode:   3,
+			wantStderr: "malformed mailbox.get result: decision_sheet is required",
+		},
+		{
 			name: "view mailbox not found",
 			args: []string{"mailbox", "view", "missing"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -650,6 +672,21 @@ func mailboxItemResult(mailboxID, status, priority string) map[string]any {
 		"payload":          map[string]any{"summary": "needs review"},
 		"created_at":       "2026-05-13T12:00:00Z",
 		"decision":         decisionForMailboxStatus(status),
+	}
+}
+
+func mailboxDecisionSheetResult() map[string]any {
+	return map[string]any{
+		"entity_context": map[string]any{
+			"available": true,
+			"entity":    validEntityFullResult("entity-1"),
+		},
+		"downstream_preview": map[string]any{
+			"available":         true,
+			"event_name":        "mailbox.item_decided",
+			"subscribers":       []string{"approval-agent", "review-agent"},
+			"subscriber_source": "event_catalog",
+		},
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -3152,7 +3152,7 @@
     },
     {
       "name": "mailbox.get",
-      "description": "Read one mailbox item with full payload and decision history.",
+      "description": "Read one mailbox item with full payload, decision history, and the server-owned decision sheet used by CLI/operator review surfaces.\n",
       "params": [
         {
           "name": "mailbox_id",
@@ -6516,6 +6516,88 @@
         ],
         "type": "object"
       },
+      "MailboxDecisionSheet": {
+        "additionalProperties": false,
+        "properties": {
+          "downstream_preview": {
+            "$ref": "#/components/schemas/MailboxDownstreamPreview"
+          },
+          "entity_context": {
+            "$ref": "#/components/schemas/MailboxEntityContext"
+          }
+        },
+        "required": [
+          "entity_context",
+          "downstream_preview"
+        ],
+        "type": "object"
+      },
+      "MailboxDownstreamPreview": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "type": "boolean"
+          },
+          "event_name": {
+            "description": "Approval event name when a downstream route exists.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Present when available is false.",
+            "enum": [
+              "no_approval_route"
+            ],
+            "type": "string"
+          },
+          "subscriber_source": {
+            "enum": [
+              "event_catalog",
+              "unavailable",
+              "none"
+            ],
+            "type": "string"
+          },
+          "subscribers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "available",
+          "subscribers",
+          "subscriber_source"
+        ],
+        "type": "object"
+      },
+      "MailboxEntityContext": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "type": "boolean"
+          },
+          "entity": {
+            "$ref": "#/components/schemas/EntityFull",
+            "description": "Present when available is true."
+          },
+          "reason": {
+            "description": "Present when available is false.",
+            "enum": [
+              "no_source_entity",
+              "entity_reader_unavailable",
+              "entity_not_found",
+              "ambiguous_run_id",
+              "invalid_entity_ref"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "available"
+        ],
+        "type": "object"
+      },
       "MailboxHistoryEntry": {
         "additionalProperties": false,
         "properties": {
@@ -6608,6 +6690,9 @@
       "MailboxItemDetail": {
         "additionalProperties": false,
         "properties": {
+          "decision_sheet": {
+            "$ref": "#/components/schemas/MailboxDecisionSheet"
+          },
           "history": {
             "items": {
               "$ref": "#/components/schemas/MailboxHistoryEntry"
@@ -6625,7 +6710,8 @@
         "required": [
           "item",
           "payload",
-          "history"
+          "history",
+          "decision_sheet"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5598,9 +5598,15 @@ cli_specification:
           recovery, and multi-run `--all` remain explicitly unpromoted split tails until later gated children promote
           their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
-        disposition: tracked_child
+        disposition: promoted_first_slice
         tracker: '#856'
-        action: Promote rich decision-sheet, downstream preview, file-backed decision payload, and result rendering rules before implementation.
+        action: >
+          Rich mailbox decision-sheet ownership is promoted on /v1/rpc mailbox.get:
+          the server/API owns entity context and downstream preview fields consumed by
+          `swarm mailbox view`. File-backed decision payload, richer mutation result
+          rendering, priority enum/prose repair, shared output/payload policy, and
+          broader trace/run/mailbox UX remain split until separate gated children promote
+          their own canonical owners.
       control_idempotency_and_stop_all_confirmation:
         disposition: tracked_child
         tracker: '#859'
@@ -6763,8 +6769,20 @@ cli_specification:
       tier: must_have
       implementation_status: implemented
       owner: /v1/rpc mailbox.get
-      behavior: Primary mailbox item detail view through canonical API owner; no direct DB/store/dashboard REST/mailbox reads.
-      split_tail: Richer entity/downstream composition remains under #735.
+      behavior: >
+        Primary mailbox item detail view through canonical API owner; no direct
+        DB/store/dashboard REST/mailbox reads. The API-owned detail result includes
+        a required decision_sheet with server-owned entity_context and
+        downstream_preview for operator decision review.
+      proof_expectations:
+      - mailbox view renders decision_sheet from mailbox.get without local entity/downstream reconstruction
+      - missing or malformed decision_sheet fails closed as a malformed RPC result
+      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
+      split_tail: >
+        File-backed decision payload, richer approve/reject/defer mutation result
+        rendering, priority enum/prose repair, and shared output/payload policy remain
+        split under #856/#735/#794.
     mailbox_approve:
       command: swarm mailbox approve <mailbox-item-id>
       tier: must_have
@@ -8686,6 +8704,7 @@ api_specification:
         - item
         - payload
         - history
+        - decision_sheet
         properties:
           item:
             $ref: '#/components/schemas/MailboxItem'
@@ -8696,6 +8715,67 @@ api_specification:
             type: array
             items:
               $ref: '#/components/schemas/MailboxHistoryEntry'
+          decision_sheet:
+            $ref: '#/components/schemas/MailboxDecisionSheet'
+      MailboxDecisionSheet:
+        type: object
+        additionalProperties: false
+        required:
+        - entity_context
+        - downstream_preview
+        properties:
+          entity_context:
+            $ref: '#/components/schemas/MailboxEntityContext'
+          downstream_preview:
+            $ref: '#/components/schemas/MailboxDownstreamPreview'
+      MailboxEntityContext:
+        type: object
+        additionalProperties: false
+        required:
+        - available
+        properties:
+          available:
+            type: boolean
+          reason:
+            type: string
+            enum:
+            - no_source_entity
+            - entity_reader_unavailable
+            - entity_not_found
+            - ambiguous_run_id
+            - invalid_entity_ref
+            description: Present when available is false.
+          entity:
+            $ref: '#/components/schemas/EntityFull'
+            description: Present when available is true.
+      MailboxDownstreamPreview:
+        type: object
+        additionalProperties: false
+        required:
+        - available
+        - subscribers
+        - subscriber_source
+        properties:
+          available:
+            type: boolean
+          reason:
+            type: string
+            enum:
+            - no_approval_route
+            description: Present when available is false.
+          event_name:
+            type: string
+            description: Approval event name when a downstream route exists.
+          subscribers:
+            type: array
+            items:
+              type: string
+          subscriber_source:
+            type: string
+            enum:
+            - event_catalog
+            - unavailable
+            - none
       MailboxDecisionResult:
         type: object
         additionalProperties: false
@@ -10660,7 +10740,9 @@ api_specification:
       errors: []
     mailbox.get:
       tier: must_have
-      description: Read one mailbox item with full payload and decision history.
+      description: >
+        Read one mailbox item with full payload, decision history, and the
+        server-owned decision sheet used by CLI/operator review surfaces.
       scope:
         required:
         - read:mailbox

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 67 {
-		t.Fatalf("schema count = %d, want 67", report.SchemaCount)
+	if report.SchemaCount != 70 {
+		t.Fatalf("schema count = %d, want 70", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 67 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 67", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 70 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 70", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -104,6 +104,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := doc.Components.Schemas["AgentDiagnosisActive"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisActive")
+	}
+	for _, schemaName := range []string{"MailboxDecisionSheet", "MailboxEntityContext", "MailboxDownstreamPreview"} {
+		if _, ok := doc.Components.Schemas[schemaName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", schemaName)
+		}
 	}
 	agentDiagnosisSchema, ok := doc.Components.Schemas["AgentDiagnosis"].(map[string]any)
 	if !ok {

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -278,7 +278,7 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"event.list":                     {Params: map[string]any{}, ResultKeys: []string{"events"}},
 		"health.check":                   {Params: map[string]any{}, ResultKeys: []string{"alive", "ready", "db_ok", "runtime_ok", "bundle"}},
 		"health.ping":                    {Params: map[string]any{}, ResultKeys: []string{"ok", "ts"}},
-		"mailbox.get":                    {Params: map[string]any{"mailbox_id": "mailbox-1"}, ResultKeys: []string{"item", "payload", "history"}},
+		"mailbox.get":                    {Params: map[string]any{"mailbox_id": "mailbox-1"}, ResultKeys: []string{"item", "payload", "history", "decision_sheet"}},
 		"mailbox.list":                   {Params: map[string]any{}, ResultKeys: []string{"items"}},
 		"run.diagnose":                   {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run", "operational_state", "blocking_layer", "blocking_reason", "heuristics"}},
 		"run.get":                        {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run"}},
@@ -708,6 +708,20 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		for _, splitField := range []string{"bundle_version", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
 			if _, ok := result[splitField]; ok {
 				t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, result)
+			}
+		}
+		if methodName == "mailbox.get" {
+			sheet := asMap(t, result["decision_sheet"])
+			entityContext := asMap(t, sheet["entity_context"])
+			if entityContext["available"] != false || entityContext["reason"] != "no_source_entity" {
+				t.Fatalf("mailbox.get decision_sheet.entity_context = %#v", entityContext)
+			}
+			downstream := asMap(t, sheet["downstream_preview"])
+			if downstream["available"] != false || downstream["reason"] != "no_approval_route" || downstream["subscriber_source"] != "none" {
+				t.Fatalf("mailbox.get decision_sheet.downstream_preview = %#v", downstream)
+			}
+			if subscribers, ok := downstream["subscribers"].([]any); !ok || len(subscribers) != 0 {
+				t.Fatalf("mailbox.get decision_sheet.downstream_preview.subscribers = %#v", downstream["subscribers"])
 			}
 		}
 	}

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
@@ -73,6 +74,10 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 			if err != nil {
 				return nil, err
 			}
+			detail.DecisionSheet, err = mailboxDecisionSheet(ctx, detail.Item, opts)
+			if err != nil {
+				return nil, err
+			}
 			return detail, nil
 		},
 		"mailbox.approve": func(ctx context.Context, req Request) (any, error) {
@@ -112,6 +117,92 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 			})
 		},
 	}
+}
+
+func mailboxDecisionSheet(ctx context.Context, item store.MailboxV1Item, opts OperatorReadOptions) (*store.MailboxV1DecisionSheet, error) {
+	entityContext, err := mailboxEntityContext(ctx, item, opts.Entities)
+	if err != nil {
+		return nil, err
+	}
+	return &store.MailboxV1DecisionSheet{
+		EntityContext:     entityContext,
+		DownstreamPreview: mailboxDownstreamPreview(item, opts),
+	}, nil
+}
+
+func mailboxEntityContext(ctx context.Context, item store.MailboxV1Item, entities EntityReadStore) (store.MailboxV1EntityContext, error) {
+	entityID := strings.TrimSpace(item.SourceEntityID)
+	if entityID == "" {
+		return store.MailboxV1EntityContext{Available: false, Reason: "no_source_entity"}, nil
+	}
+	if entities == nil {
+		return store.MailboxV1EntityContext{Available: false, Reason: "entity_reader_unavailable"}, nil
+	}
+	entity, err := entities.LoadOperatorEntity(ctx, entityID, strings.TrimSpace(item.SourceRunID))
+	if err == nil {
+		return store.MailboxV1EntityContext{Available: true, Entity: &entity}, nil
+	}
+	switch {
+	case errors.Is(err, store.ErrEntityNotFound):
+		return store.MailboxV1EntityContext{Available: false, Reason: "entity_not_found"}, nil
+	case errors.Is(err, store.ErrAmbiguousEntityRunID):
+		return store.MailboxV1EntityContext{Available: false, Reason: "ambiguous_run_id"}, nil
+	}
+	if paramErr := entityReadParamError(err); paramErr != nil {
+		return store.MailboxV1EntityContext{Available: false, Reason: "invalid_entity_ref"}, nil
+	}
+	return store.MailboxV1EntityContext{}, err
+}
+
+func mailboxDownstreamPreview(item store.MailboxV1Item, opts OperatorReadOptions) store.MailboxV1DownstreamPreview {
+	eventName := strings.TrimSpace(opts.MailboxApprovalRoutes[strings.TrimSpace(item.Type)])
+	if eventName == "" {
+		return store.MailboxV1DownstreamPreview{
+			Available:        false,
+			Reason:           "no_approval_route",
+			Subscribers:      []string{},
+			SubscriberSource: "none",
+		}
+	}
+	subscribers, subscriberSource := mailboxDownstreamSubscribers(eventName, opts)
+	return store.MailboxV1DownstreamPreview{
+		Available:        true,
+		EventName:        eventName,
+		Subscribers:      subscribers,
+		SubscriberSource: subscriberSource,
+	}
+}
+
+func mailboxDownstreamSubscribers(eventName string, opts OperatorReadOptions) ([]string, string) {
+	if opts.Source == nil {
+		return []string{}, "unavailable"
+	}
+	entry, ok := opts.Source.EventEntry(eventName)
+	if !ok {
+		return []string{}, "unavailable"
+	}
+	subscribers := append([]string(nil), entry.SwarmConsumer()...)
+	subscribers = append(subscribers, entry.Consumer...)
+	subscribers = uniqueNonEmptyStrings(subscribers)
+	sort.Strings(subscribers)
+	return subscribers, "event_catalog"
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadOptions, decision store.MailboxV1DecisionRequest) (any, error) {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -74,10 +74,7 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 			if err != nil {
 				return nil, err
 			}
-			detail.DecisionSheet, err = mailboxDecisionSheet(ctx, detail.Item, opts)
-			if err != nil {
-				return nil, err
-			}
+			detail.DecisionSheet = mailboxDecisionSheet(ctx, detail.Item, opts)
 			return detail, nil
 		},
 		"mailbox.approve": func(ctx context.Context, req Request) (any, error) {
@@ -119,39 +116,36 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 	}
 }
 
-func mailboxDecisionSheet(ctx context.Context, item store.MailboxV1Item, opts OperatorReadOptions) (*store.MailboxV1DecisionSheet, error) {
-	entityContext, err := mailboxEntityContext(ctx, item, opts.Entities)
-	if err != nil {
-		return nil, err
-	}
+func mailboxDecisionSheet(ctx context.Context, item store.MailboxV1Item, opts OperatorReadOptions) *store.MailboxV1DecisionSheet {
+	entityContext := mailboxEntityContext(ctx, item, opts.Entities)
 	return &store.MailboxV1DecisionSheet{
 		EntityContext:     entityContext,
 		DownstreamPreview: mailboxDownstreamPreview(item, opts),
-	}, nil
+	}
 }
 
-func mailboxEntityContext(ctx context.Context, item store.MailboxV1Item, entities EntityReadStore) (store.MailboxV1EntityContext, error) {
+func mailboxEntityContext(ctx context.Context, item store.MailboxV1Item, entities EntityReadStore) store.MailboxV1EntityContext {
 	entityID := strings.TrimSpace(item.SourceEntityID)
 	if entityID == "" {
-		return store.MailboxV1EntityContext{Available: false, Reason: "no_source_entity"}, nil
+		return store.MailboxV1EntityContext{Available: false, Reason: "no_source_entity"}
 	}
 	if entities == nil {
-		return store.MailboxV1EntityContext{Available: false, Reason: "entity_reader_unavailable"}, nil
+		return store.MailboxV1EntityContext{Available: false, Reason: "entity_reader_unavailable"}
 	}
 	entity, err := entities.LoadOperatorEntity(ctx, entityID, strings.TrimSpace(item.SourceRunID))
 	if err == nil {
-		return store.MailboxV1EntityContext{Available: true, Entity: &entity}, nil
+		return store.MailboxV1EntityContext{Available: true, Entity: &entity}
 	}
 	switch {
 	case errors.Is(err, store.ErrEntityNotFound):
-		return store.MailboxV1EntityContext{Available: false, Reason: "entity_not_found"}, nil
+		return store.MailboxV1EntityContext{Available: false, Reason: "entity_not_found"}
 	case errors.Is(err, store.ErrAmbiguousEntityRunID):
-		return store.MailboxV1EntityContext{Available: false, Reason: "ambiguous_run_id"}, nil
+		return store.MailboxV1EntityContext{Available: false, Reason: "ambiguous_run_id"}
 	}
 	if paramErr := entityReadParamError(err); paramErr != nil {
-		return store.MailboxV1EntityContext{Available: false, Reason: "invalid_entity_ref"}, nil
+		return store.MailboxV1EntityContext{Available: false, Reason: "invalid_entity_ref"}
 	}
-	return store.MailboxV1EntityContext{}, err
+	return store.MailboxV1EntityContext{Available: false, Reason: "entity_reader_unavailable"}
 }
 
 func mailboxDownstreamPreview(item store.MailboxV1Item, opts OperatorReadOptions) store.MailboxV1DownstreamPreview {

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -243,6 +243,32 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	}
 }
 
+func TestOperatorMailboxGetDegradesEntityContextReadFailure(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	mailbox := newReadOnlyMailboxProbeStore(now)
+	detail := mailbox.details["mailbox-1"]
+	detail.Item.SourceEntityID = "entity-1"
+	detail.Item.SourceRunID = "run-1"
+	mailbox.details["mailbox-1"] = detail
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Mailbox:  mailbox,
+			Entities: &fakeEntityReadStore{getErr: errors.New("entity reader temporarily unavailable")},
+		}),
+	})
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"mailbox.get","params":{"mailbox_id":"mailbox-1"}}`)
+	if get.Error != nil {
+		t.Fatalf("mailbox.get error = %#v", get.Error)
+	}
+	sheet := asMap(t, asMap(t, get.Result)["decision_sheet"])
+	entityContext := asMap(t, sheet["entity_context"])
+	if entityContext["available"] != false || entityContext["reason"] != "entity_reader_unavailable" {
+		t.Fatalf("entity_context = %#v, want unavailable entity_reader_unavailable", entityContext)
+	}
+}
+
 func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -15,6 +15,7 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimeingress "swarm/internal/runtime/ingress"
 	runtimemanager "swarm/internal/runtime/manager"
+	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -31,6 +32,23 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
+	base := time.Date(2026, 5, 10, 11, 0, 0, 0, time.UTC)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'empire/review', 'review_case', 'review-case-1', 'Review Case 1',
+			'awaiting_decision', '{"ready":true}'::jsonb, '{"score":9}'::jsonb, '{"notes":["needs approval"]}'::jsonb, 7,
+			$3, $3, $3
+		)
+	`, runID, entityID, base); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
 	if err := pg.AppendEvent(ctx, events.Event{
 		ID:      sourceEventID,
 		Type:    "review.requested",
@@ -54,6 +72,11 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `UPDATE mailbox SET flow_instance = 'empire/review' WHERE item_id = $1::uuid`, mailboxID); err != nil {
 		t.Fatalf("set flow instance: %v", err)
 	}
+	bundle := runStartTestBundle("mailbox.item_decided")
+	bundle.Events["mailbox.item_decided"] = runtimecontracts.EventCatalogEntry{
+		Consumer: []string{"approval-agent", "review-agent"},
+	}
+	source := semanticview.Wrap(bundle)
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
@@ -62,9 +85,11 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 				return true
 			},
 			Database:    fakePinger{},
+			Entities:    pg,
 			Mailbox:     pg,
 			Idempotency: pg,
 			Events:      bus,
+			Source:      source,
 			MailboxApprovalRoutes: map[string]string{
 				"review_request": "mailbox.item_decided",
 			},
@@ -98,6 +123,27 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	}
 	if history := asMap(t, get.Result)["history"].([]any); len(history) != 1 {
 		t.Fatalf("mailbox.get history = %#v", history)
+	}
+	decisionSheet := asMap(t, asMap(t, get.Result)["decision_sheet"])
+	entityContext := asMap(t, decisionSheet["entity_context"])
+	if entityContext["available"] != true {
+		t.Fatalf("mailbox.get entity_context = %#v", entityContext)
+	}
+	entityFull := asMap(t, entityContext["entity"])
+	entity := asMap(t, entityFull["entity"])
+	if entity["entity_id"] != entityID || entity["run_id"] != runID || entity["current_state"] != "awaiting_decision" {
+		t.Fatalf("mailbox.get decision_sheet entity = %#v", entityFull)
+	}
+	if fields := asMap(t, entityFull["fields"]); fields["score"] != float64(9) {
+		t.Fatalf("mailbox.get decision_sheet fields = %#v", fields)
+	}
+	downstream := asMap(t, decisionSheet["downstream_preview"])
+	if downstream["available"] != true || downstream["event_name"] != "mailbox.item_decided" || downstream["subscriber_source"] != "event_catalog" {
+		t.Fatalf("mailbox.get downstream_preview = %#v", downstream)
+	}
+	subscribers := downstream["subscribers"].([]any)
+	if len(subscribers) != 2 || subscribers[0] != "approval-agent" || subscribers[1] != "review-agent" {
+		t.Fatalf("mailbox.get downstream subscribers = %#v", subscribers)
 	}
 
 	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-approve"}}`

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -35,6 +35,7 @@ type MailboxV1Item struct {
 	Status         string         `json:"status"`
 	Priority       string         `json:"priority"`
 	SourceEventID  string         `json:"source_event_id"`
+	SourceRunID    string         `json:"-"`
 	SourceFlow     string         `json:"source_flow"`
 	SourceEntityID string         `json:"source_entity_id,omitempty"`
 	Payload        map[string]any `json:"payload"`
@@ -52,9 +53,29 @@ type MailboxV1HistoryEntry struct {
 }
 
 type MailboxV1ItemDetail struct {
-	Item    MailboxV1Item           `json:"item"`
-	Payload map[string]any          `json:"payload"`
-	History []MailboxV1HistoryEntry `json:"history"`
+	Item          MailboxV1Item           `json:"item"`
+	Payload       map[string]any          `json:"payload"`
+	History       []MailboxV1HistoryEntry `json:"history"`
+	DecisionSheet *MailboxV1DecisionSheet `json:"decision_sheet,omitempty"`
+}
+
+type MailboxV1DecisionSheet struct {
+	EntityContext     MailboxV1EntityContext     `json:"entity_context"`
+	DownstreamPreview MailboxV1DownstreamPreview `json:"downstream_preview"`
+}
+
+type MailboxV1EntityContext struct {
+	Available bool                `json:"available"`
+	Reason    string              `json:"reason,omitempty"`
+	Entity    *OperatorEntityFull `json:"entity,omitempty"`
+}
+
+type MailboxV1DownstreamPreview struct {
+	Available        bool     `json:"available"`
+	Reason           string   `json:"reason,omitempty"`
+	EventName        string   `json:"event_name,omitempty"`
+	Subscribers      []string `json:"subscribers"`
+	SubscriberSource string   `json:"subscriber_source"`
 }
 
 type MailboxV1DecisionRequest struct {
@@ -610,6 +631,7 @@ func (r mailboxV1Row) projectItem() MailboxV1Item {
 		Status:         mailboxV1APIStatus(r.Status, r.Decision),
 		Priority:       mailboxV1PriorityForSeverity(r.Priority),
 		SourceEventID:  strings.TrimSpace(r.SourceEventID),
+		SourceRunID:    strings.TrimSpace(r.RunID),
 		SourceFlow:     mailboxV1SourceFlow(r.FlowInstance),
 		SourceEntityID: strings.TrimSpace(r.EntityID),
 		Payload:        cloneMailboxV1Payload(r.Payload),


### PR DESCRIPTION
Part of #856
Part of #735
Part of #794

## Governing Context
- Issue: #856 rich mailbox decision-sheet / decision-result UX.
- Approved gate: https://github.com/yazzaoui/Swarm/issues/856#issuecomment-4519822201 (`approved as first slice`).
- Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/856#issuecomment-4519752285.
- Exact spec owner updated in this PR: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.mailbox_view`, `api_specification.method_catalog.mailbox.get`, and schemas `MailboxItemDetail`, `MailboxDecisionSheet`, `MailboxEntityContext`, `MailboxDownstreamPreview`.

## Semantic Migration
- New canonical owner: `/v1/rpc mailbox.get` owns the mailbox decision sheet consumed by `swarm mailbox view`.
- Old invalid path: CLI-local reconstruction of entity context, downstream routes, subscribers, or decision preview is non-authoritative and not used.
- Checked production paths: `cmd/swarm/control_mailbox.go` consumes only `mailbox.get`; no dashboard/Builder REST, legacy transports, direct DB/store/runtime/EventBus, or local entity.get composition is introduced.
- Migration completeness: complete for the approved first-slice class, `cli.mailbox.rich_decision_sheet_owner_gap`. File-backed decision payload, richer mutation results, priority prose/enum repair, shared output/payload policy, trace/run/forkchat siblings remain split.

## Changes
- Promotes `decision_sheet` into `MailboxItemDetail` and generated OpenRPC.
- Adds API-side decision-sheet composition from server owners: entity context through `EntityReadStore` and downstream preview through mailbox approval routes plus event catalog subscriber metadata.
- Updates `swarm mailbox view` to require, validate, and render the server-owned decision sheet.

## Proof
- `go test ./cmd/swarm -run Mailbox -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run 'Mailbox|OpenRPCReadOnly' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./internal/apispec -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./...`
- Static no-bypass grep over `cmd/swarm/control_mailbox.go` found only expected `mailbox.get` RPC/error strings and no direct DB/store/runtime/EventBus/dashboard/Builder/legacy transport reads.
