### PR TITLE
[agent-c][issue #940] Canonicalize runtime log flight recorder blocks

### DIFF
--- a/internal/runtime/bus/turn_context.go
+++ b/internal/runtime/bus/turn_context.go
@@ -132,11 +132,21 @@ func (r *EmittedEventsRecorder) AppendRuntimeLog(entry diaglog.RunEntry) {
 		return
 	}
 	entry.NormalizeEntityID()
+	entry.Level = diaglog.NormalizeLevel(entry.Level.String())
+	entry.Message = strings.TrimSpace(entry.Message)
+	entry.Component = strings.TrimSpace(entry.Component)
+	if entry.Component == "" {
+		entry.Component = "runtime"
+	}
+	entry.Action = strings.TrimSpace(entry.Action)
+	if entry.Action == "" {
+		entry.Action = "unknown"
+	}
 	r.mu.Lock()
 	r.flightRecorder = append(r.flightRecorder, FlightRecorderEntry{
 		Kind:       "runtime_log",
 		LogLevel:   entry.Level.String(),
-		Message:    strings.TrimSpace(entry.Message),
+		Message:    entry.Message,
 		Details:    cloneJSONValue(runtimeLogDetails(entry)),
 		StackTrace: strings.TrimSpace(entry.StackTrace),
 	})
@@ -200,6 +210,19 @@ func cloneJSONValue(v any) any {
 
 func runtimeLogDetails(entry diaglog.RunEntry) map[string]any {
 	details := map[string]any{}
+	if entry.Detail != nil {
+		if detailMap, ok := cloneJSONValue(entry.Detail).(map[string]any); ok {
+			for k, v := range detailMap {
+				key := strings.TrimSpace(k)
+				if key == "" {
+					continue
+				}
+				details[key] = v
+			}
+		} else {
+			details["raw_detail"] = cloneJSONValue(entry.Detail)
+		}
+	}
 	if v := strings.TrimSpace(entry.Component); v != "" {
 		details["component"] = v
 	}
@@ -224,19 +247,6 @@ func runtimeLogDetails(entry diaglog.RunEntry) map[string]any {
 	}
 	if len(entry.Correlation) > 0 {
 		details["correlation"] = cloneStringMap(entry.Correlation)
-	}
-	if entry.Detail != nil {
-		if detailMap, ok := cloneJSONValue(entry.Detail).(map[string]any); ok {
-			for k, v := range detailMap {
-				key := strings.TrimSpace(k)
-				if key == "" {
-					continue
-				}
-				details[key] = v
-			}
-		} else {
-			details["raw_detail"] = cloneJSONValue(entry.Detail)
-		}
 	}
 	if v := strings.TrimSpace(entry.Error); v != "" {
 		details["error"] = v

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -87,6 +87,56 @@ func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
 	}
 }
 
+func TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults(t *testing.T) {
+	logger := NewRuntimeLogger(nil, nil)
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+
+	if err := logger.Log(ctx, RuntimeLogEntry{
+		Level:     "warning",
+		Message:   "  runtime warning  ",
+		Component: "  ",
+		Action:    "  ",
+		EventType: "diagnostic/actual",
+		Detail: map[string]any{
+			"component":  123,
+			"action":     false,
+			"event_name": "diagnostic/drifted",
+			"event_type": "diagnostic/drifted",
+		},
+	}); err != nil {
+		t.Fatalf("logger.Log() error = %v", err)
+	}
+
+	entries := recorder.SnapshotFlightRecorder()
+	if len(entries) != 1 {
+		t.Fatalf("flight recorder count = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.LogLevel != "warn" {
+		t.Fatalf("log_level = %q, want warn", entry.LogLevel)
+	}
+	if entry.Message != "runtime warning" {
+		t.Fatalf("message = %q", entry.Message)
+	}
+	details, ok := entry.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details type = %T, want map[string]any", entry.Details)
+	}
+	if details["component"] != "runtime" {
+		t.Fatalf("details.component = %#v, want runtime", details["component"])
+	}
+	if details["action"] != "unknown" {
+		t.Fatalf("details.action = %#v, want unknown", details["action"])
+	}
+	if details["event_name"] != "diagnostic/actual" {
+		t.Fatalf("details.event_name = %#v, want diagnostic/actual", details["event_name"])
+	}
+	if details["event_type"] != "diagnostic/actual" {
+		t.Fatalf("details.event_type = %#v, want diagnostic/actual", details["event_type"])
+	}
+}
+
 func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/llm/turn_transcript.go
+++ b/internal/runtime/llm/turn_transcript.go
@@ -81,11 +81,10 @@ func buildRuntimeLogBlock(entry runtimebus.FlightRecorderEntry) (TurnBlock, bool
 	if message == "" && len(detailsRaw) == 0 {
 		return TurnBlock{}, false
 	}
-	title := message
-	if title == "" {
-		title = "runtime log"
+	if message == "" {
+		message = "runtime log"
 	}
-	return newRuntimeLogTurnBlock(title, TurnBlockRuntimeLogData{
+	return newRuntimeLogTurnBlock(message, TurnBlockRuntimeLogData{
 		LogLevel:   strings.TrimSpace(entry.LogLevel),
 		Message:    message,
 		Details:    detailsRaw,

--- a/internal/runtime/llm/turn_transcript_test.go
+++ b/internal/runtime/llm/turn_transcript_test.go
@@ -137,6 +137,37 @@ func TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries(t *te
 	}
 }
 
+func TestBuildTurnBlocks_DefaultsRuntimeLogMessageForCanonicalValidation(t *testing.T) {
+	blocks := BuildTurnBlocks(AgentTurnRecord{
+		FlightRecorder: []runtimebus.FlightRecorderEntry{
+			{
+				Kind:     "runtime_log",
+				LogLevel: "info",
+				Details: map[string]any{
+					"component": "runtime",
+					"action":    "unknown",
+				},
+			},
+		},
+	})
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %#v", blocks)
+	}
+	if blocks[0].Title != "runtime log" {
+		t.Fatalf("title = %q, want runtime log", blocks[0].Title)
+	}
+	logs, err := DecodeCanonicalRuntimeLogTurnBlocks(blocks)
+	if err != nil {
+		t.Fatalf("DecodeCanonicalRuntimeLogTurnBlocks() error = %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("runtime log count = %d, want 1", len(logs))
+	}
+	if logs[0].Message != "runtime log" {
+		t.Fatalf("message = %q, want runtime log", logs[0].Message)
+	}
+}
+
 func TestBuildTurnBlocks_AppendsCanonicalSummaryForExplicitBlocks(t *testing.T) {
 	blocks := BuildTurnBlocks(AgentTurnRecord{
 		TurnBlocks: []TurnBlock{


### PR DESCRIPTION
## Summary

Closes #940
Part of #101
Related to #363

This PR closes the approved #940 first-slice boundary for supported runtime-log / flight-recorder read-surface reliability by aligning runtime-log flight-recorder materialization with the canonical persisted runtime-log shape:

- `EmittedEventsRecorder.AppendRuntimeLog` now normalizes the runtime-log level and materializes default `details.component = "runtime"` and `details.action = "unknown"` when the producer omits them.
- Runtime-log flight-recorder details now preserve producer detail fields while keeping canonical top-level runtime-log fields authoritative over loose-map conflicts.
- `BuildTurnBlocks` now uses the same default runtime-log display string as the canonical block message when a runtime-log flight-recorder entry has details but no message, so the block passes `DecodeCanonicalRuntimeLogTurnBlocks`.

## Governing refs / context

Exact governing spec references:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.agent_turns`: `turn_blocks` is the ordered per-turn flight-recorder projection populated from canonical `platform.runtime_log` plus turn-local context.
- `platform_tables.diagnostics_encoding.runtime_log_encoding`: `platform.runtime_log` top-level fields are `log_level`, `message`, `details`, `stack_trace`; `details` is the machine-readable source of truth.
- `flight_recorder`: flight-recorder query pattern over events, entity mutations, agent turns, and event deliveries.
- `conversation.get_turn`: composes conversation/session/turn owner with canonical persisted runtime-log owner.
- `runtime.logs` and `runtime.subscribe_logs`: expose `LogEntry` rows from the canonical persisted runtime-log read owner.

No `platform-spec.yaml` update is included because this PR does not change platform semantics or architecture; it makes the approved read/materialization implementation match the existing contract.

## Semantic migration / owner accounting

Canonical owners after this PR:

- Persisted runtime-log payload owner remains `RuntimeLogger.Log` / `logRuntimeEventSpec` / `DecodeCanonicalRuntimeLogPayload`.
- Persisted read owner remains `store.ListOperatorRuntimeLogs` / `operatorRuntimeLogEntry` and `store.ListOperatorRuntimeIncidents`.
- Runtime-log flight-recorder materialization owner is `EmittedEventsRecorder.AppendRuntimeLog` plus `runtimellm.BuildTurnBlocks` / `DecodeCanonicalRuntimeLogTurnBlocks`.

Old invalid path closed in this slice:

- Turn-local runtime-log materialization can no longer preserve raw, noncanonical `Level`, blank `component` / `action`, conflicting loose-map `component` / `action` / `event_name` / `event_type`, or an empty runtime-log block message when details exist.

Production paths checked for surviving old behavior:

- `RuntimeLogger.Log` -> `EmittedEventsRecorder.AppendRuntimeLog`
- `EmittedEventsRecorder.AppendRuntimeLog` -> `BuildTurnBlocks`
- `BuildTurnBlocks` -> `DecodeCanonicalRuntimeLogTurnBlocks`
- Store/API/dashboard runtime-log read owner consumers named in the #940 gate

Migration completeness for #940 slice: complete for the approved supported read/materialization class. The broader #363 parent remains open for write-side recorder/persist atomicity and run-centric trace/debug siblings.

## Tests

Focused new/proof tests:

- `go test ./internal/runtime -run 'TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults|TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry|TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner|TestRuntimeLogger_Log_ReturnsPersistenceFailure|TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability' -count=1`
- `go test ./internal/runtime/llm -run 'TestBuildTurnBlocks_DefaultsRuntimeLogMessageForCanonicalValidation|TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries|TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnMissingCanonicalDetailsComponent|TestDecodeCanonicalRuntimeLogTurnBlocks_FailsOnNonStringCanonicalDetailsComponent' -count=1`
- `go test ./internal/store -run 'TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor|TestOperatorRuntimeLogsFilterBySessionAndTimeWindow' -count=1`
- `go test ./internal/apiv1 -run 'TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay|TestRuntimeLogSubscriptionPreservesWatermarkAcrossPolls|TestRuntimeSubscribeLogsRejectsSnapshotControls|TestHandlerWebSocketRuntimeSubscribeLogsOwnerErrorClosesConnection|TestOperatorConversationGetTurnComposesRuntimeLogOwner|TestOperatorRuntimeLogsFiltersAndCursor' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields|TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalPayload|TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads|TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwner|TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRuntimeLogSurface|TestSQLConversationReader_GetFailsOnMalformedCanonicalRuntimeLogTurnBlock' -count=1`

Full suite:

- `go test ./...`