### PR TITLE
[agent-e][issue #943] Retire stale OpenRPC tracker guidance

### DIFF
--- a/docs/watchlists/operator-surfaces.yaml
+++ b/docs/watchlists/operator-surfaces.yaml
@@ -65,10 +65,6 @@ active_issues:
     title: Move builder run event streams onto canonical run-bound diagnostics
     maps_to:
       - run_scoped_operator_identity
-  - id: 857
-    title: Track residual v1 OpenRPC runtime/schema/example gaps after proof-ref integrity
-    maps_to:
-      - v1_openrpc_api_conformance
 nodes:
   - id: canonical_operator_projection_truth
     title: Canonical Operator Projection Truth
@@ -163,23 +159,16 @@ nodes:
       - internal/apiv1
       - .github/workflows/ci.yml
     why_this_node_exists: v1 API compliance drifts when method coverage, OpenRPC generation, CI checks, and runtime proof accounting are inferred from scattered tests instead of a method-keyed canonical matrix
-    known_manifestations:
-      - no checked-in 42-method matrix keyed by generated OpenRPC method name
-      - required params, unknown params, auth, declared errors, idempotency, result schema, and notification schema proof status can drift silently
-      - stale or free-form proof references in the checked-in compliance matrix can drift silently from their test/helper/artifact/tracker owners
-      - generated supported-surface runtime probes can be absent for read-only HTTP methods even when proof-accounting rows resolve
-      - generated supported-surface runtime probes can be absent for mutating HTTP methods, leaving side-effect and idempotency behavior inferred from scattered handler-family tests
-      - central method transport admission can be absent, letting WS/protocol methods execute over /v1/rpc or HTTP-class methods execute over /v1/ws despite matrix transport classification
-      - generated full successful-result schema validation can be absent even when runtime probes only key-smoke result payloads
-      - generated notification-schema publication and runtime validation can be absent for subscription notifications even when WS probes only smoke-test envelopes
-      - OpenRPC method examples can lack a merge-bearing authoring or deferral policy across the generated method catalog
+    closed_manifestations:
+      - checked-in generated-method matrix, proof-reference integrity, runtime probes, result/notification schema validation, examples policy, service-discovery policy, EntityFull.accumulated schema ownership, and direct CI OpenRPC generation check have merge-bearing proof
       - rpc.discover/service-discovery non-publication is owned by api_specification.service_discovery_policy and enforced by internal/apispec plus the compliance matrix
-      - EntityFull.accumulated schema/runtime owner alignment is closed by #930 across /v1/rpc entity.get, builder, dashboard, CLI, store, OpenRPC proof, and matrix accounting; future entity-read field drift remains under this node
-      - CI can pass without a direct swarm-openrpc-gen --check step
+      - EntityFull.accumulated schema/runtime owner alignment is closed by #930 across /v1/rpc entity.get, builder, dashboard, CLI, store, OpenRPC proof, and matrix accounting
+    residual_watchpoints:
+      - future method-catalog additions must update the compliance matrix, generated OpenRPC artifact, runtime/schema proof owners, and CI/accounting checks in the same PR
+      - future OpenRPC examples publication or rpc.discover publication requires a new promoted api_specification policy and independent gate
     representative_issues:
       - 835
       - 847
-      - 857
       - 861
       - 872
       - 878
@@ -187,6 +176,8 @@ nodes:
       - 898
       - 904
       - 915
+      - 930
+      - 943
     common_framing_mistakes:
       too_broad:
         - full v1 runtime conformance can be closed by one matrix PR
@@ -194,7 +185,7 @@ nodes:
       too_narrow:
         - one handler test is enough API compliance accounting
         - generated OpenRPC drift is only an internal/apispec concern
-    current_action_pressure: active
+    current_action_pressure: watchlist_only
 reserve_backlog:
   - ordinal: 17
     title: Separate live session state from conversation/turn audit state

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -208,7 +208,7 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 	root := repoRoot(t)
 	matrixPath := filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml")
-	trackerRef := complianceProofRef{Kind: "tracker", Issue: 857, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}
+	trackerRef := complianceProofRef{Kind: "tracker", Issue: 999999, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}
 	tests := []struct {
 		name   string
 		mutate func(*openRPCComplianceMatrix)
@@ -245,6 +245,17 @@ func TestOpenRPCComplianceMatrixRejectsInvalidProofReferences(t *testing.T) {
 				row.HappyPath.ProofRefs = []complianceProofRef{{Kind: "tracker", Issue: 999999, Watchlist: "operator_surfaces.v1_openrpc_api_conformance"}}
 			},
 			want: "tracker proof_ref issue #999999 watchlist \"operator_surfaces.v1_openrpc_api_conformance\" is not in active_trackers",
+		},
+		{
+			name: "orphan active tracker",
+			mutate: func(matrix *openRPCComplianceMatrix) {
+				matrix.ActiveTrackers = append(matrix.ActiveTrackers, complianceActiveTracker{
+					Kind:      "github_issue",
+					Issue:     129,
+					Watchlist: "operator_surfaces.canonical_operator_projection_truth",
+				})
+			},
+			want: "active tracker issue #129 watchlist \"operator_surfaces.canonical_operator_projection_truth\" has no tracker proof_ref consumer",
 		},
 		{
 			name: "unknown gap class",
@@ -441,6 +452,7 @@ func loadComplianceMatrix(t *testing.T, path string) openRPCComplianceMatrix {
 
 func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix) []string {
 	index, problems := newComplianceProofIndex(root, matrix)
+	trackerConsumers := trackerProofRefConsumers(matrix)
 	if matrix.IssueRole != "provenance" {
 		problems = append(problems, fmt.Sprintf("matrix issue_role = %q, want provenance", matrix.IssueRole))
 	}
@@ -456,6 +468,10 @@ func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix
 		}
 		if strings.TrimSpace(tracker.Watchlist) == "" {
 			problems = append(problems, fmt.Sprintf("active tracker issue #%d missing watchlist", tracker.Issue))
+		}
+		key := trackerKey(tracker.Issue, tracker.Watchlist)
+		if tracker.Issue != 0 && strings.TrimSpace(tracker.Watchlist) != "" && trackerConsumers[key] == 0 {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d watchlist %q has no tracker proof_ref consumer", tracker.Issue, tracker.Watchlist))
 		}
 	}
 	for _, row := range matrix.Methods {
@@ -473,6 +489,20 @@ func validateProofReferenceIntegrity(root string, matrix openRPCComplianceMatrix
 	}
 	sort.Strings(problems)
 	return problems
+}
+
+func trackerProofRefConsumers(matrix openRPCComplianceMatrix) map[string]int {
+	consumers := map[string]int{}
+	for _, row := range matrix.Methods {
+		for _, evidence := range complianceEvidenceFields(row) {
+			for _, ref := range evidence.evidence.ProofRefs {
+				if ref.Kind == "tracker" {
+					consumers[trackerKey(ref.Issue, ref.Watchlist)]++
+				}
+			}
+		}
+	}
+	return consumers
 }
 
 type complianceProofIndex struct {

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -45,7 +45,7 @@ func TestOpenRPCMutatingHTTPRuntimeProbes(t *testing.T) {
 		mutating := complianceStringSet(methods)
 		for _, sibling := range []string{"agent.get", "event.subscribe", "rpc.unsubscribe", "health.check"} {
 			if _, ok := mutating[sibling]; ok {
-				t.Fatalf("%s classified into mutating HTTP runtime probes; sibling methods must stay under #857", sibling)
+				t.Fatalf("%s classified into mutating HTTP runtime probes; sibling methods belong to their approved probe class", sibling)
 			}
 		}
 	})

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -37,7 +37,7 @@ func TestOpenRPCReadOnlyHTTPRuntimeProbes(t *testing.T) {
 		readOnly := complianceStringSet(methods)
 		for _, sibling := range []string{"event.publish", "mailbox.reject", "event.subscribe", "rpc.unsubscribe"} {
 			if _, ok := readOnly[sibling]; ok {
-				t.Fatalf("%s classified into read-only HTTP runtime probes; sibling methods must stay under #857", sibling)
+				t.Fatalf("%s classified into read-only HTTP runtime probes; sibling methods belong to their approved probe class", sibling)
 			}
 		}
 	})

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -2,10 +2,6 @@ version: 1
 kind: openrpc_compliance_matrix
 issue: 835
 issue_role: provenance
-active_trackers:
-  - kind: github_issue
-    issue: 857
-    watchlist: operator_surfaces.v1_openrpc_api_conformance
 source:
   platform_spec: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
   openrpc_artifact: docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -13,11 +9,11 @@ source:
 policy:
   closure_level: coverage_accounting_proof_ownership_read_only_mutating_http_ws_transport_result_schema_notification_schema_examples_policy_and_service_discovery_policy_validation
   runtime_behavior_changes: transport_admission_repair_approved_by_878
-  read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; siblings were tracked by later #857 children."
-  mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; siblings were tracked by later #857 children."
-  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; siblings were tracked by later #857 children."
-  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover were tracked by later #857 children."
-  notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover were tracked by later #857 children."
+  read_only_runtime_probe_policy: "#861 adds generated supported-surface runtime probes for read-only HTTP methods only; sibling classes are covered by later closed child slices."
+  mutating_runtime_probe_policy: "#872 adds generated supported-surface runtime probes for all 16 mutating HTTP methods only; sibling classes are covered by later closed child slices."
+  ws_transport_runtime_probe_policy: "#878 adds central method transport admission proof for all 43 methods and generated supported-surface WebSocket runtime probes for the five WS/protocol methods; sibling classes are covered by later closed child slices."
+  result_schema_runtime_validation_policy: "#890 adds generated full successful-result schema validation for all 43 methods; examples and rpc.discover are covered by later closed policy child slices."
+  notification_schema_runtime_validation_policy: "#898 adds generated notification-schema publication and supported-surface runtime validation for all four subscription methods; examples and rpc.discover are covered by later closed policy child slices."
   examples_policy: "#904 adds merge-bearing catalog-wide OpenRPC examples deferral policy; method examples are intentionally omitted until a future approved source model exists."
   service_discovery_policy: "#915 adds merge-bearing catalog-wide rpc.discover non-publication policy; method publication remains the generated OpenRPC artifact."
   entity_accumulated_schema_hardening_policy: "#930 aligns EntityFull.accumulated schema ownership to the runtime accumulator-state owner across /v1/rpc entity.get, builder state.get_entity, dashboard /api/instances/{id}, CLI, store, generated OpenRPC proof, and matrix accounting."


### PR DESCRIPTION
Closes #943
Closes #857

## Summary

- Remove stale active #857 tracker state from the OpenRPC compliance matrix and refine the operator-surfaces watchlist to `watchlist_only` for the completed v1 OpenRPC conformance lane.
- Add fail-closed matrix integrity proof that active trackers cannot remain without a live tracker proof-ref consumer.
- Rewrite read-only/mutating runtime probe sibling guidance so checked-in tests no longer instruct future work to keep siblings under #857 after the lane closes.

## Governing refs / context

Exact governing context exists:

- #943 repaired Pre-Implementation Coverage Audit comment `4520180045`.
- #943 independent gate approval comment `4520206374`.
- #857 parent tracker and closeout comment `4519997111`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.source_of_truth`, `examples_policy`, and `service_discovery_policy`.
- Generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`.
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`.
- `internal/apiv1/openrpc_compliance_test.go`.
- `internal/apiv1/openrpc_readonly_runtime_test.go` and `internal/apiv1/openrpc_mutating_runtime_test.go`.
- `docs/watchlists/operator-surfaces.yaml`.
- `.github/workflows/ci.yml`.

## Semantic migration

- New canonical owner state: the checked-in compliance matrix has no active tracker unless at least one live tracker proof ref consumes it; the operator-surfaces watchlist keeps the OpenRPC conformance node as `watchlist_only` rather than active pressure.
- Old producer/reader/writer path now invalid: active #857 tracker/watchlist state and runtime-probe failure guidance that treated #857 as the live parent after all known child slices closed.
- Production paths checked for surviving old behavior: repo-wide #857/OpenRPC-conformance reference scan across `docs`, `internal`, and `.github`; no `/v1/rpc` or `/v1/ws` runtime/API behavior changes.
- Migration completeness: complete for the #943 widened stale checked-in #857 closure/accounting guidance class.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod|TestOpenRPCComplianceMatrixRejectsInvalidProofReferences|TestServiceDiscoveryPolicyDoesNotServeRPCDiscover|TestOpenRPCExamplesPolicyOmitsMethodExamples|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCMutatingHTTPRuntimeProbes' -count=1`
- `rg -n "#857|857|v1_openrpc_api_conformance|tracked_gap|kind: tracker|OpenRPC API Conformance" docs internal .github --glob '!docs/specs/swarm-platform/platform/contracts/openrpc.json'`
- `git diff --check`
- `go test ./...`