### PR TITLE
[agent-a][issue #944] Add shared CLI log-level resolver

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -35,6 +35,12 @@ func executeRootCommandWithOptions(ctx context.Context, repo string, args []stri
 		}
 		return cliExitValidation
 	}
+	if err := validateCLILoggingFlagPlacement(args); err != nil {
+		if errOut != nil {
+			fmt.Fprintln(errOut, err)
+		}
+		return cliExitValidation
+	}
 	cmd := newRootCommandWithOptions(ctx, repo, out, errOut, opts)
 	cmd.SetArgs(args)
 	if err := cmd.ExecuteContext(ctx); err != nil {
@@ -167,6 +173,7 @@ func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 type versionCommandOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 	server     bool
 }
 
@@ -190,6 +197,9 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 			if !versionOpts.server && cliAPIConnectionFlagsChanged(cmd) {
 				return fmt.Errorf("--api-server and --api-token-file require --server")
 			}
+			if err := versionOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := versionOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -198,6 +208,7 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
 	bindCLIOutputFlags(cmd, &versionOpts.output)
+	bindCLILoggingFlags(cmd, &versionOpts.logging)
 	bindCLIAPIConnectionFlags(cmd, &versionOpts.apiOptions)
 	return cmd
 }

--- a/cmd/swarm/cli_logging.go
+++ b/cmd/swarm/cli_logging.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	cliLogLevelFlag     = "log-level"
+	cliLogLevelFlagHelp = "Set CLI diagnostic logging level: debug, info, warn, error"
+	cliLogLevelDefault  = "info"
+)
+
+type cliLogLevel string
+
+const (
+	cliLogLevelDebug cliLogLevel = "debug"
+	cliLogLevelInfo  cliLogLevel = "info"
+	cliLogLevelWarn  cliLogLevel = "warn"
+	cliLogLevelError cliLogLevel = "error"
+)
+
+type cliLoggingOptions struct {
+	level string
+}
+
+type cliLoggingPolicy struct {
+	level cliLogLevel
+}
+
+func defaultCLILoggingOptions() cliLoggingOptions {
+	return cliLoggingOptions{level: cliLogLevelDefault}
+}
+
+func bindCLILoggingFlags(cmd *cobra.Command, opts *cliLoggingOptions) {
+	*opts = defaultCLILoggingOptions()
+	cmd.Flags().StringVar(&opts.level, cliLogLevelFlag, opts.level, cliLogLevelFlagHelp)
+}
+
+func bindCLILoggingFlagSet(fs *flag.FlagSet, opts *cliLoggingOptions) {
+	*opts = defaultCLILoggingOptions()
+	fs.StringVar(&opts.level, cliLogLevelFlag, opts.level, cliLogLevelFlagHelp)
+}
+
+func validateCLILoggingFlagPlacement(args []string) error {
+	index, flag := firstCLILoggingFlagIndex(args)
+	if index < 0 || cliLoggingFlagAfterSupportedLeafCommand(args[:index]) || cliLoggingFlagUnderRetiredNamespace(args[:index]) {
+		return nil
+	}
+	return fmt.Errorf("unknown flag: %s", flag)
+}
+
+func firstCLILoggingFlagIndex(args []string) (int, string) {
+	for i, arg := range args {
+		switch {
+		case arg == "--":
+			return -1, ""
+		case arg == "--"+cliLogLevelFlag:
+			return i, "--" + cliLogLevelFlag
+		case strings.HasPrefix(arg, "--"+cliLogLevelFlag+"="):
+			return i, "--" + cliLogLevelFlag
+		}
+	}
+	return -1, ""
+}
+
+func cliLoggingFlagAfterSupportedLeafCommand(prefix []string) bool {
+	leafCommands := [][]string{
+		{"version"},
+		{"verify"},
+		{"runs"},
+		{"health"},
+		{"status"},
+		{"conversations", "list"},
+		{"conversation", "view"},
+		{"conversation", "turn"},
+	}
+	for _, command := range leafCommands {
+		if argsHaveCommandPrefix(prefix, command) {
+			return true
+		}
+	}
+	return false
+}
+
+func cliLoggingFlagUnderRetiredNamespace(prefix []string) bool {
+	return len(prefix) > 0 && prefix[0] == "investigate"
+}
+
+func (opts cliLoggingOptions) validate() error {
+	_, err := opts.resolve()
+	return err
+}
+
+func (opts cliLoggingOptions) resolve() (cliLoggingPolicy, error) {
+	level, err := parseCLILogLevel(opts.level)
+	if err != nil {
+		return cliLoggingPolicy{}, err
+	}
+	return cliLoggingPolicy{level: level}, nil
+}
+
+func parseCLILogLevel(raw string) (cliLogLevel, error) {
+	switch cliLogLevel(raw) {
+	case cliLogLevelDebug:
+		return cliLogLevelDebug, nil
+	case cliLogLevelInfo:
+		return cliLogLevelInfo, nil
+	case cliLogLevelWarn:
+		return cliLogLevelWarn, nil
+	case cliLogLevelError:
+		return cliLogLevelError, nil
+	default:
+		return "", fmt.Errorf("--log-level must be one of debug, info, warn, error")
+	}
+}

--- a/cmd/swarm/cli_logging.go
+++ b/cmd/swarm/cli_logging.go
@@ -45,6 +45,27 @@ func bindCLILoggingFlagSet(fs *flag.FlagSet, opts *cliLoggingOptions) {
 	fs.StringVar(&opts.level, cliLogLevelFlag, opts.level, cliLogLevelFlagHelp)
 }
 
+func applyCLILoggingFlagSetArgs(args []string, opts *cliLoggingOptions) error {
+	level := opts.level
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			i = len(args)
+		case arg == "--"+cliLogLevelFlag:
+			if i+1 >= len(args) {
+				return fmt.Errorf("flag needs an argument: -%s", cliLogLevelFlag)
+			}
+			level = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--"+cliLogLevelFlag+"="):
+			level = strings.TrimPrefix(arg, "--"+cliLogLevelFlag+"=")
+		}
+	}
+	opts.level = level
+	return opts.validate()
+}
+
 func validateCLILoggingFlagPlacement(args []string) error {
 	index, flag := firstCLILoggingFlagIndex(args)
 	if index < 0 || cliLoggingFlagAfterSupportedLeafCommand(args[:index]) || cliLoggingFlagUnderRetiredNamespace(args[:index]) {

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -217,6 +217,22 @@ func TestCLILoggingInvalidLevelFailsBeforeSideEffects(t *testing.T) {
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Fatalf("verify stdout = %q, want empty", stdout.String())
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "positional", "--log-level", "fatal"}, &stdout, &stderr)
+	if code != cliExitValidation {
+		t.Fatalf("verify positional invalid log-level code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--log-level must be one of debug, info, warn, error") {
+		t.Fatalf("verify positional stderr = %q, want log-level validation", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "resolve contracts") || strings.Contains(stderr.String(), "load Swarm contracts") {
+		t.Fatalf("verify positional stderr = %q, local verification path ran before log-level validation", stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify positional stdout = %q, want empty", stdout.String())
+	}
 }
 
 func TestCLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects(t *testing.T) {

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestCLILoggingPolicyResolver(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			policy, err := (cliLoggingOptions{level: level}).resolve()
+			if err != nil {
+				t.Fatalf("resolve returned error: %v", err)
+			}
+			if string(policy.level) != level {
+				t.Fatalf("level = %q, want %q", policy.level, level)
+			}
+		})
+	}
+
+	policy, err := defaultCLILoggingOptions().resolve()
+	if err != nil {
+		t.Fatalf("default resolve returned error: %v", err)
+	}
+	if policy.level != cliLogLevelInfo {
+		t.Fatalf("default level = %q, want %q", policy.level, cliLogLevelInfo)
+	}
+
+	for _, level := range []string{"", "fatal", "WARN", "debug "} {
+		t.Run("reject "+level, func(t *testing.T) {
+			if _, err := (cliLoggingOptions{level: level}).resolve(); err == nil {
+				t.Fatalf("resolve(%q) returned nil error, want validation error", level)
+			}
+		})
+	}
+}
+
+func TestCLILoggingForSharedOutputConsumers(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   func(*testing.T) []string
+		repo   func(*testing.T) string
+		method string
+		result map[string]any
+	}{
+		{
+			name: "version local",
+			args: func(*testing.T) []string { return []string{"version"} },
+			repo: func(*testing.T) string { return repoRoot() },
+		},
+		{
+			name: "verify",
+			args: func(t *testing.T) []string {
+				return []string{"verify", "--contracts", outputModeVerifyFixture(t)}
+			},
+			repo: func(*testing.T) string { return repoRoot() },
+		},
+		{
+			name:   "health",
+			args:   func(*testing.T) []string { return []string{"health"} },
+			method: "health.check",
+			result: validVersionHealthResult(),
+		},
+		{
+			name:   "runs",
+			args:   func(*testing.T) []string { return []string{"runs"} },
+			method: "run.list",
+			result: map[string]any{"runs": []any{validDiagnosticRunHeader("run-1"), validDiagnosticRunHeader("run-2")}},
+		},
+		{
+			name:   "status",
+			args:   func(*testing.T) []string { return []string{"status", "run-1"} },
+			method: "run.diagnose",
+			result: map[string]any{
+				"run":               validDiagnosticRunHeader("run-1"),
+				"operational_state": "stalled",
+				"blocking_layer":    "delivery_lifecycle",
+				"blocking_reason":   "no_active_deliveries",
+				"heuristics":        []any{"dead letters exist for this run"},
+			},
+		},
+		{
+			name:   "conversations list",
+			args:   func(*testing.T) []string { return []string{"conversations", "list"} },
+			method: conversationListMethod,
+			result: map[string]any{"conversations": []map[string]any{validConversationSummary("sess-1")}},
+		},
+		{
+			name:   "conversation view",
+			args:   func(*testing.T) []string { return []string{"conversation", "view", "sess-1"} },
+			method: conversationGetMethod,
+			result: validConversationDetail("sess-1"),
+		},
+		{
+			name:   "conversation turn",
+			args:   func(*testing.T) []string { return []string{"conversation", "turn", "sess-1", "2"} },
+			method: conversationGetTurnMethod,
+			result: validConversationTurnDetail("sess-1", 2),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range []string{"", "--json", "--quiet"} {
+				t.Run("mode "+mode, func(t *testing.T) {
+					t.Setenv("SWARM_API_TOKEN", "test-token")
+
+					args := append([]string{}, tc.args(t)...)
+					if mode != "" {
+						args = append(args, mode)
+					}
+					args = append(args, "--log-level", "debug")
+
+					repo := t.TempDir()
+					if tc.repo != nil {
+						repo = tc.repo(t)
+					}
+					opts := defaultRootCommandOptions()
+					var calls *atomic.Int32
+					if tc.method != "" {
+						server, rpcCalls := newCLILoggingRPCServer(t, tc.method, tc.result)
+						defer server.Close()
+						opts = testRootCommandOptions(server)
+						calls = rpcCalls
+					}
+
+					var stdout, stderr bytes.Buffer
+					code := executeRootCommandWithOptions(context.Background(), repo, args, &stdout, &stderr, opts)
+					if code != 0 {
+						t.Fatalf("%s code = %d stdout=%s stderr=%s", strings.Join(args, " "), code, stdout.String(), stderr.String())
+					}
+					if strings.TrimSpace(stdout.String()) == "" {
+						t.Fatalf("%s stdout is empty, want successful output", strings.Join(args, " "))
+					}
+					assertEmptyStderr(t, stderr.String())
+					if mode == "--json" {
+						decodeOutputJSON[map[string]any](t, stdout.String())
+					}
+					if calls != nil && calls.Load() != 1 {
+						t.Fatalf("%s RPC calls = %d, want 1", strings.Join(args, " "), calls.Load())
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCLILoggingAcceptedLevelsOnConsumer(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"version", "--log-level", level}, &stdout, &stderr, defaultRootCommandOptions())
+			if code != 0 {
+				t.Fatalf("version --log-level %s code = %d stdout=%s stderr=%s", level, code, stdout.String(), stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) == "" {
+				t.Fatalf("stdout is empty, want version output")
+			}
+			assertEmptyStderr(t, stderr.String())
+		})
+	}
+}
+
+func TestCLILoggingInvalidLevelFailsBeforeSideEffects(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"version", "--server", "--log-level", "fatal"},
+		{"health", "--log-level", "fatal"},
+		{"runs", "--log-level", "WARN"},
+		{"status", "run-1", "--log-level", ""},
+		{"conversations", "list", "--log-level", "debug "},
+		{"conversation", "view", "sess-1", "--log-level", "fatal"},
+		{"conversation", "turn", "sess-1", "2", "--log-level", "fatal"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			before := calls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "--log-level must be one of debug, info, warn, error") {
+				t.Fatalf("stderr = %q, want log-level validation", stderr.String())
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if calls.Load() != before {
+				t.Fatalf("RPC calls changed from %d to %d", before, calls.Load())
+			}
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", "missing", "--log-level", "fatal"}, &stdout, &stderr)
+	if code != cliExitValidation {
+		t.Fatalf("verify invalid log-level code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--log-level must be one of debug, info, warn, error") {
+		t.Fatalf("verify stderr = %q, want log-level validation", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "resolve contracts") {
+		t.Fatalf("verify stderr = %q, local verification path ran before log-level validation", stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestCLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	var rpcCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rpcCalls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var serveCalls atomic.Int32
+	opts := testRootCommandOptions(server)
+	opts.runServe = func(context.Context, string, serveOptions) int {
+		serveCalls.Add(1)
+		return 0
+	}
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "root", args: []string{"--log-level", "debug", "version"}, wantStderr: "unknown flag"},
+		{name: "completion", args: []string{"completion", "bash", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "serve", args: []string{"serve", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "logs", args: []string{"logs", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "incidents", args: []string{"incidents", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "trace", args: []string{"trace", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "run", args: []string{"run", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "retired investigate", args: []string{"investigate", "runs", "--log-level", "debug"}, wantStderr: "retired in CLI v2"},
+		{name: "absent forkchat", args: []string{"forkchat", "--log-level", "debug"}, wantStderr: "unknown flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			beforeRPC := rpcCalls.Load()
+			beforeServe := serveCalls.Load()
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if rpcCalls.Load() != beforeRPC {
+				t.Fatalf("RPC calls changed from %d to %d", beforeRPC, rpcCalls.Load())
+			}
+			if serveCalls.Load() != beforeServe {
+				t.Fatalf("serve calls changed from %d to %d", beforeServe, serveCalls.Load())
+			}
+		})
+	}
+}
+
+func TestCLILoggingIgnoresRejectedEnvironmentSource(t *testing.T) {
+	t.Setenv("SWARM_LOG_LEVEL", "fatal")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"version"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("version with SWARM_LOG_LEVEL code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) == "" {
+		t.Fatalf("stdout is empty, want version output")
+	}
+	assertEmptyStderr(t, stderr.String())
+}
+
+func newCLILoggingRPCServer(t *testing.T, wantMethod string, result map[string]any) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if req.Method != wantMethod {
+			t.Errorf("method = %q, want %s", req.Method, wantMethod)
+		}
+		writeJSONRPCResult(t, w, req.ID, result)
+	}))
+	return server, &calls
+}

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -601,7 +601,7 @@ func TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects(t *testing.T) {
 		{name: "retired investigate no-color", args: []string{"investigate", "runs", "--no-color"}, wantStderr: "retired in CLI v2"},
 		{name: "absent forkchat", args: []string{"forkchat", "--json"}, wantStderr: "unknown command"},
 		{name: "absent forkchat no-color", args: []string{"forkchat", "--no-color"}, wantStderr: "unknown command"},
-		{name: "split log-level", args: []string{"runs", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "split log-level", args: []string{"logs", "--log-level", "debug"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			beforeRPC := rpcCalls.Load()

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -21,6 +21,7 @@ const (
 type conversationListCommandOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 
 	agentID string
 	runID   string
@@ -36,11 +37,13 @@ type conversationListCommandOptions struct {
 type conversationViewCommandOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 }
 
 type conversationTurnCommandOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 }
 
 type conversationListResult struct {
@@ -169,6 +172,9 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 			listOpts.runIDSet = cmd.Flags().Changed("run-id")
 			listOpts.limitSet = cmd.Flags().Changed("limit")
 			listOpts.cursorSet = cmd.Flags().Changed("cursor")
+			if err := listOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := listOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -180,6 +186,7 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
 	bindCLIOutputFlags(cmd, &listOpts.output)
+	bindCLILoggingFlags(cmd, &listOpts.logging)
 	return cmd
 }
 
@@ -190,6 +197,9 @@ func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one conversation through /v1/rpc conversation.get.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viewOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := viewOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -197,6 +207,7 @@ func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	bindCLIOutputFlags(cmd, &viewOpts.output)
+	bindCLILoggingFlags(cmd, &viewOpts.logging)
 	return cmd
 }
 
@@ -207,6 +218,9 @@ func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one conversation turn through /v1/rpc conversation.get_turn.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := turnOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := turnOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -214,6 +228,7 @@ func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	bindCLIOutputFlags(cmd, &turnOpts.output)
+	bindCLILoggingFlags(cmd, &turnOpts.logging)
 	return cmd
 }
 

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -21,6 +21,7 @@ const (
 type diagnosticRunListOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 	status     string
 	since      string
 	until      string
@@ -43,6 +44,7 @@ type diagnosticTraceOptions struct {
 type diagnosticRunOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+	logging    cliLoggingOptions
 	noDiagnose bool
 }
 
@@ -137,6 +139,9 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
 				return fmt.Errorf("--limit must be between 1 and 500")
 			}
+			if err := runOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := runOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -145,6 +150,7 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	bindDiagnosticRunListFlags(cmd, &runOpts)
 	bindCLIOutputFlags(cmd, &runOpts.output)
+	bindCLILoggingFlags(cmd, &runOpts.logging)
 	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }
@@ -152,11 +158,15 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 	apiOpts := opts
 	outputOpts := cliOutputOptions{}
+	loggingOpts := cliLoggingOptions{}
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Print structured operator health through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := loggingOpts.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := outputOpts.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -164,6 +174,7 @@ func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	bindCLIOutputFlags(cmd, &outputOpts)
+	bindCLILoggingFlags(cmd, &loggingOpts)
 	bindCLIAPIConnectionFlags(cmd, &apiOpts)
 	return cmd
 }
@@ -179,6 +190,9 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 			if len(args) == 1 {
 				runID = args[0]
 			}
+			if err := runOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			if err := runOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -187,6 +201,7 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&runOpts.noDiagnose, "no-diagnose", false, "Use run.get and print only the canonical run header")
 	bindCLIOutputFlags(cmd, &runOpts.output)
+	bindCLILoggingFlags(cmd, &runOpts.logging)
 	bindCLIAPIConnectionFlags(cmd, &runOpts.apiOptions)
 	return cmd
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -390,7 +390,7 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string,
 		}
 		return 2
 	}
-	if err := loggingOpts.validate(); err != nil {
+	if err := applyCLILoggingFlagSetArgs(args, &loggingOpts); err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "verify failed: %v\n", err)
 		}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -381,8 +381,16 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string,
 	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	outputOpts := cliOutputOptions{}
+	loggingOpts := cliLoggingOptions{}
 	bindCLIOutputFlagSet(fs, &outputOpts)
+	bindCLILoggingFlagSet(fs, &loggingOpts)
 	if err := fs.Parse(args); err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: %v\n", err)
+		}
+		return 2
+	}
+	if err := loggingOpts.validate(); err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "verify failed: %v\n", err)
 		}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6042,15 +6042,15 @@ cli_specification:
       - no direct DB/store/runtime/EventBus reads for API-backed output rendering
     cli_logging_policy:
       promoted_by: '#936'
-      implementation_status: authority_promoted_behavior_pending
+      implementation_status: implemented for current shared-output first-slice consumers only
       canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.cli_logging_policy
       future_runtime_owner: cmd/swarm shared CLI diagnostic logging policy resolver
       scope: >
         Merge-bearing CLI v2 authority for CLI process diagnostic logging controls. This owner governs
         `--log-level` source disposition, allowed levels, command applicability, stdout/stderr separation, and
         boundaries with successful output rendering, serve boot observability, runtime log filters, and persisted
-        runtime log payloads. This contract is source-of-truth repair only until a later child implements a shared
-        `cmd/swarm` resolver that consumes it.
+        runtime log payloads. Behavior is implemented only for the current shared-output first-slice consumers
+        listed below; all other command rows remain pending or split until a later child consumes this owner.
       accepted_sources:
         flag: --log-level <debug|info|warn|error>
       source_precedence:
@@ -6105,6 +6105,27 @@ cli_specification:
         json: '`--json` controls successful stdout rendering only; diagnostics remain stderr-only.'
         quiet: '`--quiet` controls successful stdout rendering only; diagnostics remain stderr-only and may still be filtered by logging level.'
         no_color: '`--no-color` and `NO_COLOR` are color controls, not logging filters. They do not change diagnostic level selection.'
+      implemented_logging_policy_first_slice:
+        implemented_by: '#944'
+        failure_class: runtime.cli.v2.logging_resolver_for_current_shared_output_consumers
+        owner: cmd/swarm shared CLI diagnostic logging policy resolver
+        status: implemented
+        rule: >
+          These consumers accept `--log-level` through one shared CLI diagnostic logging policy resolver. The
+          resolver accepts only `debug`, `info`, `warn`, and `error`, defaults to `info`, rejects invalid levels
+          with CLI validation exit 2 before local/API/runtime side effects, and does not accept environment or
+          config-file logging sources. This first slice closes resolver parsing, validation, defaulting,
+          applicability, and stdout/stderr separation for the listed consumers only; it does not claim new
+          diagnostic emission content.
+        consumers:
+        - version
+        - verify
+        - health
+        - runs
+        - status
+        - conversations_list
+        - conversation_view
+        - conversation_turn
       split_siblings:
       - '#844 config-file log_level precedence'
       - '#844 universal/repeatable --verbose/-v outside serve boot observability'
@@ -6116,8 +6137,9 @@ cli_specification:
       - persisted runtime `log_level` payloads and runtime/daemon logging configuration
       implementation_boundaries:
       - 'This #936 first slice is source-of-truth repair only: no Cobra flags, config/env parsing, runtime logging, or command behavior change is implied.'
-      - 'Future implementation MUST introduce or consume one shared cmd/swarm diagnostic logging policy resolver before accepting `--log-level` anywhere.'
-      - 'Future implementation MUST prove stdout/stderr separation for JSON, quiet, default text, and diagnostics.'
+      - 'The #944 behavior slice implements only the current shared-output first-slice consumers listed above.'
+      - 'Future implementation MUST consume the shared cmd/swarm diagnostic logging policy resolver before accepting `--log-level` on any additional command row.'
+      - 'Implementation MUST prove stdout/stderr separation for JSON, quiet, default text, and diagnostics.'
       - 'Future implementation MUST keep runtime log filters and serve boot verbosity classified as separate owners unless a later spec PR deliberately changes that boundary.'
     auth_boundary: >
       Runtime-state commands use v1 bearer auth through token sources governed by


### PR DESCRIPTION
## Summary

Implements the approved #944 first slice for `runtime.cli.v2.logging_resolver_for_current_shared_output_consumers`.

Closes #944.

## Governing refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.cli_logging_policy`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.output_contract`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.error_channel_and_exit_code_contract`
- #944 Pre-Implementation Coverage Audit and independent gate outcome

## Semantic migration

New canonical code owner: shared `cmd/swarm` CLI diagnostic logging policy resolver in `cmd/swarm/cli_logging.go`, consuming `platform-spec.yaml#cli_specification.foundations.cli_logging_policy`.

Old producer / reader / writer path now invalid: command-local `--log-level` parsing remains invalid. Root/global `--log-level`, `SWARM_LOG_LEVEL`, config-file `log_level`, serve `--verbose/-v`, `logs/incidents --level`, and persisted runtime `log_level` are not promoted as this CLI process diagnostic source.

Production paths checked for surviving old behavior: supported first-slice consumers are `version`, `verify`, `health`, `runs`, `status`, `conversations list`, `conversation view`, and `conversation turn`. Unsupported/split paths checked include root placement, completion, serve, logs, incidents, trace, run, retired investigate, absent forkchat, `SWARM_LOG_LEVEL`, config `log_level`, and existing `--level` / `--verbose` owners.

Migration complete for this chosen first slice: yes. Parent #844/#794/#735 remains open for config/env logging sources, universal verbosity, serve/runtime logging, and wider command-family adoption.

## Proof

- `git diff --check HEAD~1..HEAD`
- `go test ./cmd/swarm -run 'TestCLILogging|TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- grep proof over production `cmd/swarm` for `log-level`, `bindCLILogging`, `cliLogging`, `SWARM_LOG_LEVEL`, `log_level`, `--level`, and `--verbose` boundaries