### PR TITLE
[agent-b][issue #947] Add mailbox decision payload files

### DIFF
--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -92,6 +93,7 @@ type mailboxDecisionCommandOptions struct {
 	until               string
 	idempotencyKey      string
 	decisionPayloadJSON string
+	decisionPayloadFile string
 }
 
 func newControlCommand(opts rootCommandOptions) *cobra.Command {
@@ -210,6 +212,7 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&actionOpts.decisionPayloadFile, "decision-payload", "", "Read optional approval event JSON object from file")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadJSON, "decision-payload-json", "", "Optional JSON object attached to the approval event")
 	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
 	return cmd
@@ -522,7 +525,7 @@ func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any,
 	}
 	switch o.action {
 	case "approve":
-		payload, ok, err := parseOptionalDecisionPayload(o.decisionPayloadJSON)
+		payload, ok, err := parseOptionalDecisionPayload(o.decisionPayloadJSON, o.decisionPayloadFile)
 		if err != nil {
 			return nil, err
 		}
@@ -551,19 +554,42 @@ func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any,
 	return params, nil
 }
 
-func parseOptionalDecisionPayload(raw string) (map[string]any, bool, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+func parseOptionalDecisionPayload(inlineJSON, filePath string) (map[string]any, bool, error) {
+	inlineJSON = strings.TrimSpace(inlineJSON)
+	filePath = strings.TrimSpace(filePath)
+	if inlineJSON != "" && filePath != "" {
+		return nil, false, fmt.Errorf("--decision-payload and --decision-payload-json are mutually exclusive")
+	}
+	if filePath != "" {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, false, fmt.Errorf("--decision-payload could not be read: %w", err)
+		}
+		payload, err := parseDecisionPayloadObject("--decision-payload", string(content))
+		if err != nil {
+			return nil, false, err
+		}
+		return payload, true, nil
+	}
+	if inlineJSON == "" {
 		return nil, false, nil
 	}
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return nil, false, fmt.Errorf("--decision-payload-json must be a JSON object: %w", err)
-	}
-	if payload == nil {
-		return nil, false, fmt.Errorf("--decision-payload-json must be a JSON object")
+	payload, err := parseDecisionPayloadObject("--decision-payload-json", inlineJSON)
+	if err != nil {
+		return nil, false, err
 	}
 	return payload, true, nil
+}
+
+func parseDecisionPayloadObject(flagName, raw string) (map[string]any, error) {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("%s must be a JSON object: %w", flagName, err)
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("%s must be a JSON object", flagName)
+	}
+	return payload, nil
 }
 
 func writeMailboxListResult(out io.Writer, result mailboxListResult) {

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -86,14 +86,16 @@ type mailboxListCommandOptions struct {
 }
 
 type mailboxDecisionCommandOptions struct {
-	apiOptions          rootCommandOptions
-	action              string
-	method              string
-	reason              string
-	until               string
-	idempotencyKey      string
-	decisionPayloadJSON string
-	decisionPayloadFile string
+	apiOptions             rootCommandOptions
+	action                 string
+	method                 string
+	reason                 string
+	until                  string
+	idempotencyKey         string
+	decisionPayloadJSON    string
+	decisionPayloadJSONSet bool
+	decisionPayloadFile    string
+	decisionPayloadFileSet bool
 }
 
 func newControlCommand(opts rootCommandOptions) *cobra.Command {
@@ -208,7 +210,10 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Approve a pending mailbox item through v1 RPC.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
+			runOpts := actionOpts
+			runOpts.decisionPayloadFileSet = cmd.Flags().Changed("decision-payload")
+			runOpts.decisionPayloadJSONSet = cmd.Flags().Changed("decision-payload-json")
+			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
@@ -525,7 +530,7 @@ func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any,
 	}
 	switch o.action {
 	case "approve":
-		payload, ok, err := parseOptionalDecisionPayload(o.decisionPayloadJSON, o.decisionPayloadFile)
+		payload, ok, err := parseOptionalDecisionPayload(o.decisionPayloadJSON, o.decisionPayloadJSONSet, o.decisionPayloadFile, o.decisionPayloadFileSet)
 		if err != nil {
 			return nil, err
 		}
@@ -554,13 +559,16 @@ func (o mailboxDecisionCommandOptions) params(mailboxID string) (map[string]any,
 	return params, nil
 }
 
-func parseOptionalDecisionPayload(inlineJSON, filePath string) (map[string]any, bool, error) {
+func parseOptionalDecisionPayload(inlineJSON string, inlineSet bool, filePath string, fileSet bool) (map[string]any, bool, error) {
 	inlineJSON = strings.TrimSpace(inlineJSON)
 	filePath = strings.TrimSpace(filePath)
-	if inlineJSON != "" && filePath != "" {
+	if inlineSet && fileSet {
 		return nil, false, fmt.Errorf("--decision-payload and --decision-payload-json are mutually exclusive")
 	}
-	if filePath != "" {
+	if fileSet {
+		if filePath == "" {
+			return nil, false, fmt.Errorf("--decision-payload requires a file path")
+		}
 		content, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, false, fmt.Errorf("--decision-payload could not be read: %w", err)
@@ -571,7 +579,7 @@ func parseOptionalDecisionPayload(inlineJSON, filePath string) (map[string]any, 
 		}
 		return payload, true, nil
 	}
-	if inlineJSON == "" {
+	if !inlineSet {
 		return nil, false, nil
 	}
 	payload, err := parseDecisionPayloadObject("--decision-payload-json", inlineJSON)

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -345,6 +345,8 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 		{name: "approve unsupported flag", args: []string{"mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
 		{name: "approve malformed payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "{"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
 		{name: "approve non-object payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "[]"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "approve blank inline payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", ""}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "approve blank payload file path", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload", ""}, wantStderr: "--decision-payload requires a file path", wantNoCalls: true},
 		{name: "approve missing payload file", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload", filepath.Join(t.TempDir(), "missing.json")}, wantStderr: "--decision-payload could not be read", wantNoCalls: true},
 		{
 			name: "approve malformed payload file",
@@ -390,6 +392,18 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 					t.Fatalf("write payload file: %v", err)
 				}
 				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path, "--decision-payload-json", `{"approved":true}`}
+			},
+			wantStderr:  "--decision-payload and --decision-payload-json are mutually exclusive",
+			wantNoCalls: true,
+		},
+		{
+			name: "approve conflicting payload flags with blank inline",
+			prepare: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "payload.json")
+				if err := os.WriteFile(path, []byte(`{"approved":true}`), 0o600); err != nil {
+					t.Fatalf("write payload file: %v", err)
+				}
+				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path, "--decision-payload-json", ""}
 			},
 			wantStderr:  "--decision-payload and --decision-payload-json are mutually exclusive",
 			wantNoCalls: true,

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -104,6 +106,60 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 				t.Fatalf("stderr = %q, want empty", stderr.String())
 			}
 		})
+	}
+}
+
+func TestMailboxApproveDecisionPayloadFileSendsV1RPCRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	payloadPath := filepath.Join(t.TempDir(), "decision-payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"approved":true,"source":"file"}`), 0o600); err != nil {
+		t.Fatalf("write payload file: %v", err)
+	}
+
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"ok":                  true,
+			"mailbox_decision_id": "decision-1",
+			"downstream_event_id": "event-1",
+			"status":              "decided",
+		})
+	}))
+	defer server.Close()
+
+	args := []string{"mailbox", "approve", "mailbox-1", "--idempotency-key", "idem-file", "--decision-payload", payloadPath}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	wantParams := map[string]any{
+		"mailbox_id":       "mailbox-1",
+		"idempotency_key":  "idem-file",
+		"decision_payload": map[string]any{"approved": true, "source": "file"},
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "mailbox.approve" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/mailbox.approve", captured.JSONRPC, captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "downstream_event_id=event-1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -271,6 +327,7 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		args        []string
+		prepare     func(t *testing.T) []string
 		wantStderr  string
 		wantNoCalls bool
 	}{
@@ -288,15 +345,68 @@ func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
 		{name: "approve unsupported flag", args: []string{"mailbox", "approve", "mailbox-1", "--unknown"}, wantStderr: "unknown flag", wantNoCalls: true},
 		{name: "approve malformed payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "{"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
 		{name: "approve non-object payload", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload-json", "[]"}, wantStderr: "--decision-payload-json must be a JSON object", wantNoCalls: true},
+		{name: "approve missing payload file", args: []string{"mailbox", "approve", "mailbox-1", "--decision-payload", filepath.Join(t.TempDir(), "missing.json")}, wantStderr: "--decision-payload could not be read", wantNoCalls: true},
+		{
+			name: "approve malformed payload file",
+			prepare: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "payload.json")
+				if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+					t.Fatalf("write payload file: %v", err)
+				}
+				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path}
+			},
+			wantStderr:  "--decision-payload must be a JSON object",
+			wantNoCalls: true,
+		},
+		{
+			name: "approve non-object payload file",
+			prepare: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "payload.json")
+				if err := os.WriteFile(path, []byte("[]"), 0o600); err != nil {
+					t.Fatalf("write payload file: %v", err)
+				}
+				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path}
+			},
+			wantStderr:  "--decision-payload must be a JSON object",
+			wantNoCalls: true,
+		},
+		{
+			name: "approve null payload file",
+			prepare: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "payload.json")
+				if err := os.WriteFile(path, []byte("null"), 0o600); err != nil {
+					t.Fatalf("write payload file: %v", err)
+				}
+				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path}
+			},
+			wantStderr:  "--decision-payload must be a JSON object",
+			wantNoCalls: true,
+		},
+		{
+			name: "approve conflicting payload flags",
+			prepare: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), "payload.json")
+				if err := os.WriteFile(path, []byte(`{"approved":true}`), 0o600); err != nil {
+					t.Fatalf("write payload file: %v", err)
+				}
+				return []string{"mailbox", "approve", "mailbox-1", "--decision-payload", path, "--decision-payload-json", `{"approved":true}`}
+			},
+			wantStderr:  "--decision-payload and --decision-payload-json are mutually exclusive",
+			wantNoCalls: true,
+		},
 		{name: "reject missing reason", args: []string{"mailbox", "reject", "mailbox-1"}, wantStderr: "--reason is required", wantNoCalls: true},
 		{name: "reject blank reason", args: []string{"mailbox", "reject", "mailbox-1", "--reason", "  "}, wantStderr: "--reason is required", wantNoCalls: true},
 		{name: "defer missing until", args: []string{"mailbox", "defer", "mailbox-1"}, wantStderr: "--until is required", wantNoCalls: true},
 		{name: "defer invalid until", args: []string{"mailbox", "defer", "mailbox-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp", wantNoCalls: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			args := tc.args
+			if tc.prepare != nil {
+				args = tc.prepare(t)
+			}
 			before := calls.Load()
 			var stdout, stderr bytes.Buffer
-			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
 			if code != 2 {
 				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
@@ -320,11 +430,16 @@ func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 		writeJSONRPCResult(t, w, "unexpected", map[string]any{"ok": true})
 	}))
 	defer server.Close()
+	payloadPath := filepath.Join(t.TempDir(), "decision-payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"approved":true}`), 0o600); err != nil {
+		t.Fatalf("write payload file: %v", err)
+	}
 
 	for _, args := range [][]string{
 		{"mailbox", "list"},
 		{"mailbox", "view", "mailbox-1"},
 		{"mailbox", "approve", "mailbox-1"},
+		{"mailbox", "approve", "mailbox-1", "--decision-payload", payloadPath},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "")

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7235,11 +7235,46 @@ cli_specification:
         rendering, priority enum/prose repair, and shared output/payload policy remain
         split under #856/#735/#794.
     mailbox_approve:
-      command: swarm mailbox approve <mailbox-item-id>
+      command: swarm mailbox approve <mailbox-item-id> [--decision-payload <file> | --decision-payload-json <json-object>] [--idempotency-key <key>]
       tier: must_have
       implementation_status: implemented
       owner: /v1/rpc mailbox.approve
-      behavior: Mailbox approval action through canonical API owner; no direct DB/store/mailbox writes.
+      behavior: >-
+        Mailbox approval action through canonical API owner. The CLI may adapt either a file-backed JSON object
+        from `--decision-payload <file>` or an inline JSON object from `--decision-payload-json` into the
+        canonical `decision_payload` param, but the server/API remains the mailbox decision semantics owner.
+        The CLI must not derive downstream events or perform direct DB/store/mailbox/runtime/EventBus writes.
+      flags:
+      - name: --decision-payload <file>
+        maps_to: decision_payload
+        behavior: Optional path to a file containing a JSON object attached to the approval event.
+      - name: --decision-payload-json <json-object>
+        maps_to: decision_payload
+        behavior: Optional inline JSON object attached to the approval event.
+      - name: --idempotency-key <key>
+        maps_to: idempotency_key
+        behavior: Optional v1 API idempotency key for this mutating approval request.
+      validation:
+      - '`--decision-payload` and `--decision-payload-json` are mutually exclusive.'
+      - '`--decision-payload` file content and `--decision-payload-json` values MUST parse as JSON objects; malformed, null, and non-object values fail before any API call.'
+      - 'Missing/unreadable `--decision-payload` files fail before any API call.'
+      output:
+        success_detail: Existing `MailboxDecisionResult` summary rendering remains authoritative; richer mutation-result rendering is split under #856/#794.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        mailbox_not_found: 5
+        decision_conflict_or_rejected: 6
+      proof_expectations:
+      - exact /v1/rpc mailbox.approve call with mailbox_id, optional decision_payload, and optional idempotency_key params only
+      - invalid args, conflicting payload flags, missing/unreadable payload files, malformed/null/non-object payload JSON, and missing SWARM_API_TOKEN make zero API calls
+      - file-backed and inline payload inputs share the same canonical object validation and param construction
+      - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or retired swarm control mailbox path usage
+      split_tail: >
+        Richer approve/reject/defer mutation-result rendering, priority enum/prose repair,
+        shared output/payload policy, trace/run work, and forkchat remain split under #856/#735/#794.
     mailbox_reject:
       command: swarm mailbox reject <mailbox-item-id>
       tier: must_have

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7256,8 +7256,9 @@ cli_specification:
         behavior: Optional v1 API idempotency key for this mutating approval request.
       validation:
       - '`--decision-payload` and `--decision-payload-json` are mutually exclusive.'
-      - '`--decision-payload` file content and `--decision-payload-json` values MUST parse as JSON objects; malformed, null, and non-object values fail before any API call.'
-      - 'Missing/unreadable `--decision-payload` files fail before any API call.'
+      - 'Flag presence is semantic: explicitly supplied blank payload flags are invalid rather than treated as absent.'
+      - '`--decision-payload` file content and `--decision-payload-json` values MUST parse as JSON objects; blank, malformed, null, and non-object values fail before any API call.'
+      - 'Blank, missing, or unreadable `--decision-payload` file paths fail before any API call.'
       output:
         success_detail: Existing `MailboxDecisionResult` summary rendering remains authoritative; richer mutation-result rendering is split under #856/#794.
       exit_codes:
@@ -7269,7 +7270,7 @@ cli_specification:
         decision_conflict_or_rejected: 6
       proof_expectations:
       - exact /v1/rpc mailbox.approve call with mailbox_id, optional decision_payload, and optional idempotency_key params only
-      - invalid args, conflicting payload flags, missing/unreadable payload files, malformed/null/non-object payload JSON, and missing SWARM_API_TOKEN make zero API calls
+      - invalid args, conflicting payload flags including explicitly blank conflicting values, blank/missing/unreadable payload files, blank/malformed/null/non-object payload JSON, and missing SWARM_API_TOKEN make zero API calls
       - file-backed and inline payload inputs share the same canonical object validation and param construction
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or retired swarm control mailbox path usage
       split_tail: >


### PR DESCRIPTION
## Summary

Adds file-backed mailbox approval payload input:

- `swarm mailbox approve <mailbox-item-id> --decision-payload <file>` now reads a JSON object file and sends it as canonical `decision_payload` to `/v1/rpc mailbox.approve`.
- Inline `--decision-payload-json` remains the same semantic input source for the same canonical param; simultaneous inline/file usage fails closed before any API call.
- Repairs `platform-spec.yaml` `cli_specification.command_catalog.mailbox_approve` with command shape, flags, validation, output/exit-code/proof expectations, and split tails.

Closes #947.
Part of #856, #735, and #794.

## Governing refs/context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.mailbox_approve`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.mailbox.approve`
- `mailbox.approve` param `decision_payload` and result `MailboxDecisionResult`
- #947 pre-audit: https://github.com/yazzaoui/Swarm/issues/947#issuecomment-4520646391
- #947 independent gate: https://github.com/yazzaoui/Swarm/issues/947#issuecomment-4520700077

## Semantic migration accounting

- Canonical owner: `/v1/rpc mailbox.approve` remains the server/API owner for mailbox approval decision semantics and `decision_payload` object semantics.
- Old producer / reader / writer path now invalid: any file-backed CLI path that treats payload files as a separate semantic owner, bypasses `/v1/rpc mailbox.approve`, or uses direct DB/store/runtime/EventBus/dashboard/Builder/legacy transports.
- Production paths checked for surviving old behavior: `cmd/swarm/control_mailbox.go`, `cmd/swarm/control_mailbox_test.go`, `internal/apiv1/operator_mailbox.go`, `internal/store/mailbox_v1.go`, OpenRPC generated catalog, and `platform-spec.yaml` mailbox approve rows.
- Migration complete for this child: yes. `--decision-payload <file>` and `--decision-payload-json` share object validation and canonical param construction; broader #856 residuals remain split.

## Proof

- `go test ./cmd/swarm -run Mailbox -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `rg -n "EventBus|store|runtime|dashboard|Builder|/api/|/rpc|/ws|agentcontrol|http\." cmd/swarm/control_mailbox.go` returned no matches
- `go run ./cmd/swarm mailbox approve --help`
- `go test ./...`
