### PR TITLE
[agent-c][issue #949] Gate runtime-log recorder persistence

### DIFF
--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -85,24 +85,6 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 		action = "unknown"
 	}
 	e.NormalizeEntityID()
-	if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && recorder != nil {
-		recorder.AppendRuntimeLog(diaglog.RunEntry{
-			Level:       e.Level,
-			Message:     e.Message,
-			Component:   e.Component,
-			Action:      e.Action,
-			EventID:     e.EventID,
-			EventType:   e.EventType,
-			AgentID:     e.AgentID,
-			EntityID:    e.EntityID,
-			SessionID:   e.SessionID,
-			Correlation: e.Correlation,
-			Detail:      e.Detail,
-			Error:       e.Error,
-			StackTrace:  e.StackTrace,
-			DurationUS:  e.DurationUS,
-		})
-	}
 	if l.db == nil {
 		return nil
 	}
@@ -115,8 +97,12 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 	}
 
 	detail := marshalJSONOrEmpty(e.Detail)
-	if err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level.String(), component, action, e, detail); err != nil {
+	payload, err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level.String(), component, action, e, detail)
+	if err != nil {
 		return err
+	}
+	if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && recorder != nil {
+		recorder.AppendRuntimeLog(runtimeLogRecorderEntry(payload))
 	}
 	return nil
 }
@@ -215,9 +201,9 @@ func sanitizeStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) error {
+func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) (CanonicalRuntimeLogPayload, error) {
 	if db == nil {
-		return nil
+		return CanonicalRuntimeLogPayload{}, nil
 	}
 	detailMap := map[string]any{}
 	_ = json.Unmarshal(detail, &detailMap)
@@ -244,7 +230,7 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 	}
 	parentEventID, err := runtimeLogLineageParentEventID(ctx, db, lineageRunID, explicitParentEventID, subjectEventID)
 	if err != nil {
-		return err
+		return CanonicalRuntimeLogPayload{}, err
 	}
 	handlerID := strings.TrimSpace(runtimecorrelation.HandlerIDFromContext(ctx))
 	if handlerID == "" {
@@ -253,29 +239,17 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 	payload := runtimeLogPayload(level, component, action, e, detailMap, runID, parentEventID, handlerID)
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return CanonicalRuntimeLogPayload{}, err
 	}
-	if _, err := DecodeCanonicalRuntimeLogPayload(encoded); err != nil {
-		return err
+	canonicalPayload, err := DecodeCanonicalRuntimeLogPayload(encoded)
+	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
 	}
 	if hasRunID {
-		if err := ensureRuntimeLogRunRow(ctx, db, runID); err != nil {
-			return err
+		if err := persistRunScopedRuntimeLog(ctx, db, runID, string(encoded), parentEventID); err != nil {
+			return CanonicalRuntimeLogPayload{}, err
 		}
-		_, err = db.ExecContext(ctx, `
-			INSERT INTO events (
-				run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
-				chain_depth, produced_by, produced_by_type, source_event_id, created_at
-			)
-			VALUES (
-				NULLIF($1,'')::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
-				0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
-			)
-		`, runID, string(encoded), parentEventID)
-		if err != nil {
-			return err
-		}
-		return storerunlifecycle.SyncCounts(ctx, db, runID)
+		return canonicalPayload, nil
 	}
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO events (
@@ -288,9 +262,64 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 		)
 	`, string(encoded), parentEventID)
 	if err != nil {
+		return CanonicalRuntimeLogPayload{}, err
+	}
+	return canonicalPayload, nil
+}
+
+func persistRunScopedRuntimeLog(ctx context.Context, db *sql.DB, runID, encodedPayload, parentEventID string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
 		return err
 	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := ensureRuntimeLogRunRow(ctx, tx, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			NULLIF($1,'')::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
+			0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
+		)
+	`, runID, encodedPayload, parentEventID); err != nil {
+		return err
+	}
+	if err := storerunlifecycle.SyncCounts(ctx, tx, runID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
 	return nil
+}
+
+func runtimeLogRecorderEntry(payload CanonicalRuntimeLogPayload) diaglog.RunEntry {
+	return diaglog.RunEntry{
+		Level:       diaglog.NormalizeLevel(payload.LogLevel),
+		Message:     payload.Message,
+		Component:   payload.Component,
+		Action:      payload.Action,
+		EventID:     payload.EventID,
+		EventType:   payload.EventType,
+		AgentID:     payload.AgentID,
+		EntityID:    payload.EntityID,
+		SessionID:   payload.SessionID,
+		Correlation: payload.Correlation,
+		Detail:      payload.Detail,
+		Error:       payload.Error,
+		StackTrace:  payload.StackTrace,
+		DurationUS:  payload.DurationUS,
+	}
 }
 
 func runtimeLogLineageForEntry(lineage runtimecorrelation.RuntimeLineage, e RuntimeLogEntry) runtimecorrelation.RuntimeLineage {
@@ -377,7 +406,7 @@ func runtimeLogLineageParentEventID(ctx context.Context, db *sql.DB, runID, expl
 	return subjectEventID, nil
 }
 
-func ensureRuntimeLogRunRow(ctx context.Context, db *sql.DB, runID string) error {
+func ensureRuntimeLogRunRow(ctx context.Context, db storerunlifecycle.DBTX, runID string) error {
 	if db == nil {
 		return nil
 	}

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -27,7 +27,34 @@ func (s runtimeLogCapabilityStub) CanonicalRuntimeLogCapability(context.Context)
 }
 
 func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
-	logger := NewRuntimeLogger(nil, nil)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(runtimeLogPayloadArg{
+			level:      "warn",
+			message:    "Tool execution was denied for save_entity_field",
+			component:  "tool-executor",
+			action:     "tool_execution_denied",
+			eventID:    "evt-1",
+			eventType:  "validation/requested",
+			agentID:    "agent-1",
+			entityID:   "entity-1",
+			sessionID:  "session-1",
+			errorText:  "runtime_error code=cross_flow_write_forbidden",
+			durationUS: 1200,
+			detail: map[string]any{
+				"tool_name":     "save_entity_field",
+				"denial_layer":  "executor",
+				"denial_reason": "cross_flow_write_forbidden",
+			},
+		}, "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 
@@ -85,10 +112,29 @@ func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
 	if details["error"] != "runtime_error code=cross_flow_write_forbidden" {
 		t.Fatalf("details.error = %#v", details["error"])
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
 }
 
 func TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults(t *testing.T) {
-	logger := NewRuntimeLogger(nil, nil)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(runtimeLogPayloadArg{
+			level:     "warn",
+			message:   "runtime warning",
+			component: "runtime",
+			action:    "unknown",
+			eventType: "diagnostic/actual",
+		}, "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 
@@ -135,6 +181,9 @@ func TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults(t *testing.T) 
 	if details["event_type"] != "diagnostic/actual" {
 		t.Fatalf("details.event_type = %#v, want diagnostic/actual", details["event_type"])
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
 }
 
 func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testing.T) {
@@ -145,7 +194,7 @@ func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testin
 	defer db.Close()
 
 	mock.ExpectExec(`INSERT INTO events`).
-		WithArgs("", runtimeLogPayloadArg{
+		WithArgs(runtimeLogPayloadArg{
 			level:      "warn",
 			message:    "Tool execution was denied for save_entity_field",
 			component:  "tool-executor",
@@ -165,7 +214,7 @@ func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testin
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	if err := logger.Log(context.Background(), RuntimeLogEntry{
 		Level:      "warn",
 		Message:    "Tool execution was denied for save_entity_field",
@@ -199,8 +248,11 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	defer db.Close()
 
 	const runID = "8d4891f8-0f8e-4c85-b34b-9e0e7f4327dd"
-	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
+	mock.ExpectBegin()
 	mock.ExpectExec(`INSERT INTO runs`).
 		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -210,6 +262,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	mock.ExpectExec(`UPDATE runs`).
 		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	if err := logger.Log(ctx, RuntimeLogEntry{
@@ -223,6 +276,17 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
 	}
+	entries := recorder.SnapshotFlightRecorder()
+	if len(entries) != 1 {
+		t.Fatalf("flight recorder count = %d, want 1", len(entries))
+	}
+	details, ok := entries[0].Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details type = %T, want map[string]any", entries[0].Details)
+	}
+	if got := strings.TrimSpace(asString(details["run_id"])); got != runID {
+		t.Fatalf("details.run_id = %q, want %q", got, runID)
+	}
 }
 
 func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
@@ -234,11 +298,13 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 
 	writeErr := errors.New("insert failed")
 	mock.ExpectExec(`INSERT INTO events`).
-		WithArgs("", sqlmock.AnyArg(), "").
+		WithArgs(sqlmock.AnyArg(), "").
 		WillReturnError(writeErr)
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
-	err = logger.Log(context.Background(), RuntimeLogEntry{
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
 		Message:   "Persisting the pipeline receipt failed",
 		Component: "eventbus",
@@ -250,6 +316,9 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet() error = %v", err)
 	}
+	if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+		t.Fatalf("flight recorder count = %d, want 0", len(entries))
+	}
 }
 
 func TestRuntimeLogger_Log_AllowsEmptyCanonicalMessageWhenDetailsExist(t *testing.T) {
@@ -260,7 +329,7 @@ func TestRuntimeLogger_Log_AllowsEmptyCanonicalMessageWhenDetailsExist(t *testin
 	defer db.Close()
 
 	mock.ExpectExec(`INSERT INTO events`).
-		WithArgs("", runtimeLogPayloadArg{
+		WithArgs(runtimeLogPayloadArg{
 			level:     "info",
 			message:   "",
 			component: "agent-manager",
@@ -278,7 +347,7 @@ func TestRuntimeLogger_Log_AllowsEmptyCanonicalMessageWhenDetailsExist(t *testin
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	if err := logger.Log(context.Background(), RuntimeLogEntry{
 		Level:     "debug",
 		Message:   "",
@@ -313,20 +382,194 @@ func TestDecodeCanonicalRuntimeLogPayload_FailsClosedOnMissingMessageField(t *te
 }
 
 func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
+	capabilityErr := errors.New("capability unavailable")
+	tests := []struct {
+		name         string
+		db           bool
+		capabilities runtimeLogCapabilityResolver
+	}{
+		{name: "missing database", capabilities: runtimeLogCapabilityStub{enabled: true}},
+		{name: "missing resolver", db: true},
+		{name: "disabled", db: true, capabilities: runtimeLogCapabilityStub{}},
+		{name: "resolver error", db: true, capabilities: runtimeLogCapabilityStub{err: capabilityErr}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				db   *sql.DB
+				mock sqlmock.Sqlmock
+				err  error
+			)
+			if tt.db {
+				db, mock, err = sqlmock.New()
+				if err != nil {
+					t.Fatalf("sqlmock: %v", err)
+				}
+				defer db.Close()
+			}
+
+			recorder := runtimebus.NewEmittedEventsRecorder()
+			ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+			logger := NewRuntimeLogger(db, tt.capabilities)
+			if err := logger.Log(ctx, RuntimeLogEntry{
+				Level:   "info",
+				Message: "runtime log",
+			}); err != nil {
+				t.Fatalf("logger.Log() error = %v", err)
+			}
+
+			if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+				t.Fatalf("flight recorder count = %d, want 0", len(entries))
+			}
+			if mock != nil {
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Fatalf("expectations: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnPayloadValidationFailure(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	defer db.Close()
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{})
-	if err := logger.Log(context.Background(), RuntimeLogEntry{
-		Level:   "info",
-		Message: "runtime log",
-	}); err != nil {
-		t.Fatalf("logger.Log() error = %v", err)
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	err = logger.Log(ctx, RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "runtime log",
+		Component: "diagnostics",
+		Action:    "payload_validation",
+		Detail: map[string]any{
+			"correlation": []any{"not-a-string-map"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "details.correlation") {
+		t.Fatalf("logger.Log() error = %v, want correlation validation failure", err)
 	}
+	if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+		t.Fatalf("flight recorder count = %d, want 0", len(entries))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
 
+func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnLineageLookupFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	runID := uuid.NewString()
+	subjectEventID := uuid.NewString()
+	lineageErr := errors.New("lineage lookup failed")
+	mock.ExpectQuery(`SELECT EXISTS`).
+		WithArgs(runID, subjectEventID).
+		WillReturnError(lineageErr)
+
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	err = logger.Log(ctx, RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "runtime log",
+		Component: "eventbus",
+		Action:    "lineage_lookup",
+		EventID:   subjectEventID,
+	})
+	if !errors.Is(err, lineageErr) {
+		t.Fatalf("logger.Log() error = %v, want %v", err, lineageErr)
+	}
+	if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+		t.Fatalf("flight recorder count = %d, want 0", len(entries))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnRunRowFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	runID := uuid.NewString()
+	runRowErr := errors.New("run row failed")
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO runs`).
+		WithArgs(runID).
+		WillReturnError(runRowErr)
+	mock.ExpectRollback()
+
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	err = logger.Log(ctx, RuntimeLogEntry{
+		Level:     "error",
+		Message:   "runtime log",
+		Component: "workflow-runtime",
+		Action:    "handler_error",
+	})
+	if !errors.Is(err, runRowErr) {
+		t.Fatalf("logger.Log() error = %v, want %v", err, runRowErr)
+	}
+	if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+		t.Fatalf("flight recorder count = %d, want 0", len(entries))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnSyncCountsFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	runID := uuid.NewString()
+	syncErr := errors.New("sync failed")
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO runs`).
+		WithArgs(runID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO events`).
+		WithArgs(runID, sqlmock.AnyArg(), "").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE runs`).
+		WithArgs(runID).
+		WillReturnError(syncErr)
+	mock.ExpectRollback()
+
+	recorder := runtimebus.NewEmittedEventsRecorder()
+	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	err = logger.Log(ctx, RuntimeLogEntry{
+		Level:     "error",
+		Message:   "runtime log",
+		Component: "workflow-runtime",
+		Action:    "handler_error",
+	})
+	if !errors.Is(err, syncErr) {
+		t.Fatalf("logger.Log() error = %v, want %v", err, syncErr)
+	}
+	if entries := recorder.SnapshotFlightRecorder(); len(entries) != 0 {
+		t.Fatalf("flight recorder count = %d, want 0", len(entries))
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Gates turn-local `runtime_log` flight-recorder append behind successful canonical `platform.runtime_log` persistence.
- Returns the decoded canonical runtime-log payload from the write owner and materializes recorder entries from that same payload.
- Makes run-scoped runtime-log write success include one transaction over run-row setup, event insert, and `storerunlifecycle.SyncCounts`.

Closes #949
Part of #363
Part of #101

## Governing Refs / Context

Exact spec refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.agent_turns`: `turn_blocks` is populated from canonical `platform.runtime_log` plus turn-local publish/tool transcript context.
- `diagnostics_encoding.runtime_log_encoding`: `platform.runtime_log` is persisted in `events`; `details` is the machine-readable source of truth.
- `flight_recorder`: flight recorder is a persisted query pattern over platform tables, not a separate runtime-log truth source.
- `conversation.get_turn`: composes the canonical turn owner with the canonical persisted runtime-log owner.
- `runtime.logs` / `runtime.subscribe_logs`: supported runtime-log read surfaces consume persisted runtime-log rows.

Gate refs:
- #949 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/949#issuecomment-4520960521
- Independent gate: https://github.com/yazzaoui/Swarm/issues/949#issuecomment-4521036263

## Semantic Migration

- New canonical owner: `RuntimeLogger.Log` / `logRuntimeEventSpec` is the write owner for both persisted `platform.runtime_log` and any turn-local runtime-log recorder materialization.
- Old invalid path: pre-persist `EmittedEventsRecorder.AppendRuntimeLog` inside `RuntimeLogger.Log` before capability, payload validation, run-row setup, insert, and `SyncCounts` completed.
- Production paths checked for surviving old behavior: `rg -n "AppendRuntimeLog\(" --glob '!**/*_test.go' .` finds only the post-persist `RuntimeLogger.Log` call and the recorder method definition.
- Migration complete for #949: no production runtime-log recorder append remains outside the canonical post-persist owner. #363 remains open for split run/debug, terminal-state, #852, OpenRPC/conformance, and CLI lanes.

## Proof

- `go test ./internal/runtime -run 'TestRuntimeLogger_Log_(AppendsSpecShapedFlightRecorderEntry|AppendsCanonicalFlightRecorderDefaults|PersistsRuntimeLogPayloadViaCapabilityOwner|ReturnsPersistenceFailure|AllowsEmptyCanonicalMessageWhenDetailsExist|FailsClosedWithoutCanonicalCapability|DoesNotAppendFlightRecorderOnPayloadValidationFailure|DoesNotAppendFlightRecorderOnLineageLookupFailure|DoesNotAppendFlightRecorderOnRunRowFailure|DoesNotAppendFlightRecorderOnSyncCountsFailure|EnsuresRunRowBeforePersistingRunScopedEntry|PersistsCanonicalRunOwnershipFromContext|DoesNotInferRunOwnershipFromDetailPayload|DerivesLineageFromPersistedSubjectEvent|DoesNotDeriveLineageFromUnpersistedSubjectEvent|PersistsTypedRuntimeLineage)$' -count=1`
- `go test ./internal/runtime/llm -run 'TestBuildTurnBlocks_DefaultsRuntimeLogMessageForCanonicalValidation|TestBuildTurnBlocks_IncludesSpecShapedRuntimeLogFlightRecorderEntries|TestDecodeCanonicalRuntimeLogTurnBlocks' -count=1`
- `go test ./internal/store -run 'TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlock|TestManagerStore_AppendAgentTurn_FailsOnNonStringCanonicalRuntimeLogTurnBlockField|TestOperatorConversationReadSurface.*Turn|Test.*Canonical.*RuntimeLog.*TurnBlock' -count=1`
- `go test ./internal/builder -run 'TestProjectCanonicalRunDebugReplay_PreservesCanonicalRuntimeLogDetailAndTimestamp' -count=1`
- `go test ./...`