### PR TITLE
[agent-a][issue #840] Align Cobra discoverability and verify flags

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -156,18 +156,32 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 }
 
 func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
-	return &cobra.Command{
-		Use:                "verify",
-		Short:              "Validate local Swarm contract files.",
-		DisableFlagParsing: true,
+	opts := defaultVerifyCommandOptions()
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Validate local Swarm contract files.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			code := runVerifyCommandWithOutput(ctx, repo, args, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if err := opts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := opts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if len(args) > 0 {
+				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("unexpected argument %q", args[0]))
+			}
+			code := runVerifyCommandWithOutput(ctx, repo, opts, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			if code != 0 {
 				return commandExitError{code: code}
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&opts.contractsPath, "contracts", opts.contractsPath, "Path to Swarm contract bundle root")
+	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
+	bindCLIOutputFlags(cmd, &opts.output)
+	bindCLILoggingFlags(cmd, &opts.logging)
+	return cmd
 }
 
 type versionCommandOptions struct {
@@ -287,6 +301,7 @@ func newRetiredForkCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:                "fork",
 		Short:              "Removed v1 command; use future swarm control run fork.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeForkRetiredMessage(cmd.ErrOrStderr())

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -140,6 +140,7 @@ func newRetiredControlMailboxCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:                "mailbox",
 		Short:              "Removed v2 command; use swarm mailbox.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeControlMailboxRetiredMessage(cmd.ErrOrStderr())

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -234,9 +234,10 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 
 func newInvestigateCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "investigate",
-		Short: "Retired legacy namespace; use swarm runs/status/trace/health.",
-		Args:  cobra.NoArgs,
+		Use:                "investigate",
+		Short:              "Retired legacy namespace; use swarm runs/status/trace/health.",
+		Hidden:             true,
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeInvestigateRetiredMessage(cmd.ErrOrStderr())
 			return commandExitError{code: 2}
@@ -255,6 +256,7 @@ func newInvestigateRunsCommand(opts rootCommandOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:                "runs",
 		Short:              "Retired legacy command; use swarm runs.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeInvestigateRunsRetiredMessage(cmd.ErrOrStderr())
@@ -267,6 +269,7 @@ func newInvestigateRunCommand(opts rootCommandOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:                "run [run-id]",
 		Short:              "Retired legacy command; use swarm status.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeInvestigateRunRetiredMessage(cmd.ErrOrStderr())
@@ -279,6 +282,7 @@ func newInvestigateTraceCommand(opts rootCommandOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:                "trace [run-id]",
 		Short:              "Retired legacy command; use swarm trace.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeInvestigateTraceRetiredMessage(cmd.ErrOrStderr())
@@ -291,6 +295,7 @@ func newInvestigateHealthCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:                "health",
 		Short:              "Retired legacy command; use swarm health.",
+		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writeInvestigateHealthRetiredMessage(cmd.ErrOrStderr())

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -371,32 +371,32 @@ type verifyFindingOutput struct {
 	Message  string `json:"message"`
 }
 
-func runVerifyCommand(ctx context.Context, repo string, args []string, out io.Writer) int {
-	return runVerifyCommandWithOutput(ctx, repo, args, out, out)
+type verifyCommandOptions struct {
+	contractsPath    string
+	platformSpecPath string
+	output           cliOutputOptions
+	logging          cliLoggingOptions
 }
 
-func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string, out, errOut io.Writer) int {
-	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	contractsPath := fs.String("contracts", "", "Path to Swarm contract bundle root")
-	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
-	outputOpts := cliOutputOptions{}
-	loggingOpts := cliLoggingOptions{}
-	bindCLIOutputFlagSet(fs, &outputOpts)
-	bindCLILoggingFlagSet(fs, &loggingOpts)
-	if err := fs.Parse(args); err != nil {
+func defaultVerifyCommandOptions() verifyCommandOptions {
+	return verifyCommandOptions{
+		platformSpecPath: defaultPlatformSpecPath,
+		logging:          defaultCLILoggingOptions(),
+	}
+}
+
+func runVerifyCommand(ctx context.Context, repo string, opts verifyCommandOptions, out io.Writer) int {
+	return runVerifyCommandWithOutput(ctx, repo, opts, out, out)
+}
+
+func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCommandOptions, out, errOut io.Writer) int {
+	if err := opts.logging.validate(); err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "verify failed: %v\n", err)
 		}
 		return 2
 	}
-	if err := applyCLILoggingFlagSetArgs(args, &loggingOpts); err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "verify failed: %v\n", err)
-		}
-		return 2
-	}
-	if err := outputOpts.validate(); err != nil {
+	if err := opts.output.validate(); err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "verify failed: %v\n", err)
 		}
@@ -408,8 +408,8 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string,
 		}
 		return 1
 	}
-	resolvedContractsPath := resolveContractsPath(repo, *contractsPath)
-	resolvedPlatformSpecPath := resolvePath(repo, *platformSpecPath)
+	resolvedContractsPath := resolveContractsPath(repo, opts.contractsPath)
+	resolvedPlatformSpecPath := resolvePath(repo, opts.platformSpecPath)
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
 		if errOut != nil {
@@ -436,7 +436,7 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, args []string,
 			Warnings:     verifyFindingOutputs(result.BootReport.Warnings()),
 			LintEvidence: verifyFindingOutputs(result.BootReport.LintEvidence()),
 		}
-		if err := renderCLIOutput(out, errOut, outputOpts, output, func(w io.Writer) {
+		if err := renderCLIOutput(out, errOut, opts.output, output, func(w io.Writer) {
 			writeVerifyFindings(w, "warning", result.BootReport.Warnings())
 			writeVerifyFindings(w, "lint_evidence", result.BootReport.LintEvidence())
 			if w != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -104,6 +104,11 @@ func TestCLI_RootNoArgsPrintsHelpAndDoesNotStartRuntime(t *testing.T) {
 			t.Fatalf("root help missing %q:\n%s", want, stdout.String())
 		}
 	}
+	for _, retired := range []string{"fork", "investigate"} {
+		if strings.Contains(stdout.String(), "\n  "+retired) {
+			t.Fatalf("root help advertises retired command %q:\n%s", retired, stdout.String())
+		}
+	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("root stderr = %q, want empty", stderr.String())
 	}
@@ -132,6 +137,126 @@ func TestCLI_CompletionCommandSupportsCobraShells(t *testing.T) {
 				t.Fatalf("completion %s output missing swarm command:\n%s", shell, got)
 			}
 		})
+	}
+}
+
+func TestCLI_VerifyHelpAndCompletionOwnedByCobra(t *testing.T) {
+	for _, args := range [][]string{
+		{"verify", "--help"},
+		{"verify", "-h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommand(context.Background(), t.TempDir(), args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("%s code = %d stderr=%s stdout=%s", strings.Join(args, " "), code, stderr.String(), stdout.String())
+			}
+			for _, want := range []string{"Usage:", "--contracts", "--platform-spec", "--json", "--quiet", "--no-color", "--log-level"} {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("%s help missing %q:\n%s", strings.Join(args, " "), want, stdout.String())
+				}
+			}
+			if strings.Contains(stdout.String(), "flag_parsing_disabled") || strings.Contains(stderr.String(), "flag: help requested") {
+				t.Fatalf("%s leaked old flag parser state stdout=%q stderr=%q", strings.Join(args, " "), stdout.String(), stderr.String())
+			}
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), t.TempDir(), []string{"completion", "bash"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("completion bash code = %d stderr=%s", code, stderr.String())
+	}
+	verifySectionStart := strings.Index(stdout.String(), "_swarm_verify()")
+	if verifySectionStart < 0 {
+		t.Fatalf("completion output missing _swarm_verify section")
+	}
+	verifySection := stdout.String()[verifySectionStart:]
+	if verifySectionEnd := strings.Index(verifySection[len("_swarm_verify()"):], "\n_swarm_"); verifySectionEnd >= 0 {
+		verifySection = verifySection[:len("_swarm_verify()")+verifySectionEnd]
+	}
+	for _, want := range []string{"--contracts", "--platform-spec", "--json", "--quiet", "--no-color", "--log-level"} {
+		if !strings.Contains(verifySection, want) {
+			t.Fatalf("_swarm_verify completion missing %q:\n%s", want, verifySection)
+		}
+	}
+	if strings.Contains(verifySection, "flag_parsing_disabled") {
+		t.Fatalf("_swarm_verify completion still disables Cobra flag parsing:\n%s", verifySection)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), t.TempDir(), []string{"__complete", "verify", "--"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("__complete verify -- code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"--contracts", "--platform-spec", "--json", "--quiet", "--no-color", "--log-level"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("__complete verify -- missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestCLI_RetiredCommandsHiddenFromHelpAndCompletion(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"help"},
+	} {
+		t.Run("root "+strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommand(context.Background(), t.TempDir(), args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("root help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			for _, retired := range []string{"fork", "investigate"} {
+				if strings.Contains(stdout.String(), "\n  "+retired) {
+					t.Fatalf("root help advertises retired command %q:\n%s", retired, stdout.String())
+				}
+			}
+		})
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), t.TempDir(), []string{"__complete", ""}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("__complete root code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, retired := range []string{"fork\t", "investigate\t"} {
+		if strings.Contains(stdout.String(), retired) {
+			t.Fatalf("__complete root advertises retired command %q:\n%s", retired, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), t.TempDir(), []string{"control", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("control help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\n  mailbox") {
+		t.Fatalf("control help advertises retired mailbox command:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), t.TempDir(), []string{"__complete", "control", ""}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("__complete control code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "mailbox\t") {
+		t.Fatalf("__complete control advertises retired mailbox command:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), t.TempDir(), []string{"__complete", "investigate", ""}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("__complete investigate code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, retired := range []string{"runs\t", "run\t", "trace\t", "health\t"} {
+		if strings.Contains(stdout.String(), retired) {
+			t.Fatalf("__complete investigate advertises retired subcommand %q:\n%s", retired, stdout.String())
+		}
 	}
 }
 
@@ -2540,11 +2665,15 @@ func TestLoadDotEnvFileRejectsMalformedLine(t *testing.T) {
 	}
 }
 
+func runVerifyCommandWithContractsForTest(ctx context.Context, repo, contractsPath string, out *bytes.Buffer) int {
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = contractsPath
+	return runVerifyCommand(ctx, repo, opts, out)
+}
+
 func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", filepath.Join(t.TempDir(), "missing"),
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), filepath.Join(t.TempDir(), "missing"), &buf)
 	if code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
@@ -2613,9 +2742,7 @@ reader:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", root,
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -2682,9 +2809,7 @@ Use save_entity_field for `+"`business_brief`"+`.
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", root,
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
 	}
@@ -2719,9 +2844,7 @@ accumulator:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", root,
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
 	}
@@ -2776,9 +2899,7 @@ accumulator:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", root,
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -2861,9 +2982,7 @@ scorer:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommand(context.Background(), repoRoot(), []string{
-		"-contracts", root,
-	}, &buf)
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}


### PR DESCRIPTION
## Summary
- Move `swarm verify` flags/help/completion onto the Cobra command owner while keeping local contract verification behavior in a typed execution helper.
- Hide retired `fork`, `investigate`, and `control mailbox` stubs from normal help/completion discovery while preserving explicit fail-closed migration messages.
- Add focused proof for root/help/completion visibility, verify Cobra flags, retired completion surfaces, and local verify execution behavior.

Closes #840

## Governing refs/context
- `platform-spec.yaml#cli_specification.source_of_truth`: tracked `cli_specification` is the sole merge-bearing CLI v2 authority; the local CLI UX v2 review artifact is reconciliation evidence only.
- `platform-spec.yaml#cli_specification.foundations.command_router`: Cobra is the only semantic operator command router; parallel operator flag dispatch is not authoritative.
- `platform-spec.yaml#cli_specification.foundations.no_args_behavior`: bare `swarm` prints root help and exits 0.
- `platform-spec.yaml#cli_specification.command_catalog.root/help/completion/verify`: implemented local surfaces in this class.
- `platform-spec.yaml#cli_specification.retired_namespaces`: `investigate`, `control_mailbox`, and `fork` remain retired fail-closed migration surfaces.

## Semantic migration
- New canonical implementation owner: `cmd/swarm` Cobra command tree for operator-visible `verify` flags/help/completion and retired command discoverability.
- Old path now invalid: `runVerifyCommandWithOutput` no longer reparses operator args with `flag.NewFlagSet("verify")`; it consumes typed `verifyCommandOptions` resolved by Cobra.
- Production paths checked for surviving old behavior: `newVerifyCommand`, generated bash `_swarm_verify`, `__complete verify --`, root `__complete`, `control --help`, `__complete control`, `__complete investigate`, explicit retired invocations, and grep for `flag.NewFlagSet("verify")` / `DisableFlagParsing` on `verify`.
- Migration complete for the approved first-slice class; broader #843/#912 local-helper quarantine, #844 universal config/env, #846 error classification, #848 renderer tails, #743 run, and #750/#884 serve work remain out of scope.

## Proof
- `go test ./cmd/swarm -run 'TestCLI_(RootNoArgs|HelpCommand|CompletionCommand|VerifyHelpAndCompletion|RetiredCommandsHidden|VerifyPreservesLocalContractCarveOut|ForkIsHardRetired)|TestRunVerifyCommand|TestControlMailboxRetiredAliases|TestInvestigate' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `go build -o /tmp/swarm-840-bin ./cmd/swarm`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check origin/master...HEAD`
- Smoke probes: `swarm`, `swarm help`, `swarm control --help`, `swarm verify --help`, `swarm verify -h`, `swarm completion bash` `_swarm_verify`, `swarm __complete ''`, `swarm __complete control ''`, `swarm __complete investigate ''`, `swarm __complete verify --`, `swarm fork --help`, `swarm investigate --help`, `swarm investigate runs --help`, `swarm control mailbox --help`, `swarm verify --contracts /tmp/missing-sw`, `swarm verify --contracts /tmp/missing-sw --log-level fatal`.