### PR TITLE
[agent-b][issue #953] Promote mailbox decision result effects

### DIFF
--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -13,10 +13,14 @@ import (
 )
 
 type mailboxDecisionResult struct {
-	OK                bool   `json:"ok"`
-	MailboxDecisionID string `json:"mailbox_decision_id"`
-	DownstreamEventID string `json:"downstream_event_id,omitempty"`
-	Status            string `json:"status"`
+	OK                         bool      `json:"ok"`
+	MailboxDecisionID          string    `json:"mailbox_decision_id"`
+	DownstreamEventID          string    `json:"downstream_event_id,omitempty"`
+	DownstreamEventName        string    `json:"downstream_event_name,omitempty"`
+	DownstreamSubscribers      *[]string `json:"downstream_subscribers,omitempty"`
+	DownstreamSubscriberSource string    `json:"downstream_subscriber_source,omitempty"`
+	Status                     string    `json:"status"`
+	IdempotencyReplayed        *bool     `json:"idempotency_replayed"`
 }
 
 type mailboxItem struct {
@@ -445,6 +449,9 @@ func validateMailboxDecisionResult(action string, result mailboxDecisionResult) 
 	if strings.TrimSpace(result.Status) == "" {
 		return fmt.Errorf("malformed mailbox decision result: status is required")
 	}
+	if result.IdempotencyReplayed == nil {
+		return fmt.Errorf("malformed mailbox decision result: idempotency_replayed is required")
+	}
 	expectedStatus, err := expectedMailboxDecisionStatus(action)
 	if err != nil {
 		return err
@@ -452,7 +459,29 @@ func validateMailboxDecisionResult(action string, result mailboxDecisionResult) 
 	if result.Status != expectedStatus {
 		return fmt.Errorf("malformed mailbox decision result: status=%q, want %q for mailbox %s", result.Status, expectedStatus, action)
 	}
+	if result.DownstreamEventID != "" {
+		if strings.TrimSpace(result.DownstreamEventName) == "" {
+			return fmt.Errorf("malformed mailbox decision result: downstream_event_name is required when downstream_event_id is present")
+		}
+		if result.DownstreamSubscribers == nil {
+			return fmt.Errorf("malformed mailbox decision result: downstream_subscribers is required when downstream_event_id is present")
+		}
+		if !validMailboxSubscriberSource(result.DownstreamSubscriberSource) {
+			return fmt.Errorf("malformed mailbox decision result: downstream_subscriber_source must be event_catalog, unavailable, or none")
+		}
+	} else if strings.TrimSpace(result.DownstreamEventName) != "" || result.DownstreamSubscribers != nil || strings.TrimSpace(result.DownstreamSubscriberSource) != "" {
+		return fmt.Errorf("malformed mailbox decision result: downstream_event_id is required when downstream detail is present")
+	}
 	return nil
+}
+
+func validMailboxSubscriberSource(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "event_catalog", "unavailable", "none":
+		return true
+	default:
+		return false
+	}
 }
 
 func expectedMailboxDecisionStatus(action string) (string, error) {
@@ -697,8 +726,14 @@ func writeMailboxDecisionResult(out io.Writer, action, mailboxID string, result 
 		return
 	}
 	fmt.Fprintf(out, "mailbox %s ok: mailbox_id=%s status=%s decision_id=%s", action, mailboxID, result.Status, result.MailboxDecisionID)
+	if result.IdempotencyReplayed != nil {
+		fmt.Fprintf(out, " idempotency_replayed=%t", *result.IdempotencyReplayed)
+	}
 	if result.DownstreamEventID != "" {
 		fmt.Fprintf(out, " downstream_event_id=%s", result.DownstreamEventID)
+		fmt.Fprintf(out, " downstream_event_name=%s", result.DownstreamEventName)
+		fmt.Fprintf(out, " downstream_subscribers=%s", mailboxStringList(*result.DownstreamSubscribers))
+		fmt.Fprintf(out, " downstream_subscriber_source=%s", result.DownstreamSubscriberSource)
 	}
 	fmt.Fprintln(out)
 }

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -31,7 +31,7 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 				"idempotency_key":  "idem-approve",
 				"decision_payload": map[string]any{"approved": true},
 			},
-			wantOutput: []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "downstream_event_id=event-1"},
+			wantOutput: []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "idempotency_replayed=false", "downstream_event_id=event-1", "downstream_event_name=mailbox.item_decided", "downstream_subscribers=approval-agent,review-agent", "downstream_subscriber_source=event_catalog"},
 		},
 		{
 			name:       "reject",
@@ -42,7 +42,7 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 				"reason":          "not enough evidence",
 				"idempotency_key": "idem-reject",
 			},
-			wantOutput: []string{"mailbox reject ok:", "mailbox_id=mailbox-2", "status=decided", "decision_id=decision-1"},
+			wantOutput: []string{"mailbox reject ok:", "mailbox_id=mailbox-2", "status=decided", "decision_id=decision-1", "idempotency_replayed=false"},
 		},
 		{
 			name:       "defer",
@@ -53,7 +53,7 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 				"until":           "2026-05-13T12:30:00Z",
 				"idempotency_key": "idem-defer",
 			},
-			wantOutput: []string{"mailbox defer ok:", "mailbox_id=mailbox-3", "status=deferred", "decision_id=decision-1"},
+			wantOutput: []string{"mailbox defer ok:", "mailbox_id=mailbox-3", "status=deferred", "decision_id=decision-1", "idempotency_replayed=false"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -77,12 +77,19 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 				if tc.name == "approve" {
 					downstream = "event-1"
 				}
-				writeJSONRPCResult(t, w, captured.ID, map[string]any{
-					"ok":                  true,
-					"mailbox_decision_id": "decision-1",
-					"downstream_event_id": downstream,
-					"status":              status,
-				})
+				result := map[string]any{
+					"ok":                   true,
+					"mailbox_decision_id":  "decision-1",
+					"downstream_event_id":  downstream,
+					"status":               status,
+					"idempotency_replayed": false,
+				}
+				if tc.name == "approve" {
+					result["downstream_event_name"] = "mailbox.item_decided"
+					result["downstream_subscribers"] = []string{"approval-agent", "review-agent"}
+					result["downstream_subscriber_source"] = "event_catalog"
+				}
+				writeJSONRPCResult(t, w, captured.ID, result)
 			}))
 			defer server.Close()
 
@@ -128,10 +135,14 @@ func TestMailboxApproveDecisionPayloadFileSendsV1RPCRequest(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 		}
 		writeJSONRPCResult(t, w, captured.ID, map[string]any{
-			"ok":                  true,
-			"mailbox_decision_id": "decision-1",
-			"downstream_event_id": "event-1",
-			"status":              "decided",
+			"ok":                           true,
+			"mailbox_decision_id":          "decision-1",
+			"downstream_event_id":          "event-1",
+			"downstream_event_name":        "mailbox.item_decided",
+			"downstream_subscribers":       []string{"approval-agent", "review-agent"},
+			"downstream_subscriber_source": "event_catalog",
+			"status":                       "decided",
+			"idempotency_replayed":         false,
 		})
 	}))
 	defer server.Close()
@@ -153,7 +164,7 @@ func TestMailboxApproveDecisionPayloadFileSendsV1RPCRequest(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "downstream_event_id=event-1"} {
+	for _, want := range []string{"mailbox approve ok:", "mailbox_id=mailbox-1", "status=decided", "decision_id=decision-1", "idempotency_replayed=false", "downstream_event_id=event-1", "downstream_event_name=mailbox.item_decided", "downstream_subscribers=approval-agent,review-agent", "downstream_subscriber_source=event_catalog"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -714,6 +725,60 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantCode:   5,
 			wantStderr: "MAILBOX_NOT_FOUND",
 		},
+		{
+			name: "approve malformed missing idempotency replayed",
+			args: []string{"mailbox", "approve", "mailbox-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"ok":                  true,
+					"mailbox_decision_id": "decision-1",
+					"status":              "decided",
+				})
+			},
+			wantCode:   3,
+			wantStderr: "malformed mailbox decision result: idempotency_replayed is required",
+		},
+		{
+			name: "approve malformed missing downstream subscribers",
+			args: []string{"mailbox", "approve", "mailbox-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"ok":                           true,
+					"mailbox_decision_id":          "decision-1",
+					"status":                       "decided",
+					"idempotency_replayed":         false,
+					"downstream_event_id":          "event-1",
+					"downstream_event_name":        "mailbox.item_decided",
+					"downstream_subscriber_source": "event_catalog",
+				})
+			},
+			wantCode:   3,
+			wantStderr: "malformed mailbox decision result: downstream_subscribers is required when downstream_event_id is present",
+		},
+		{
+			name: "approve malformed invalid downstream source",
+			args: []string{"mailbox", "approve", "mailbox-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"ok":                           true,
+					"mailbox_decision_id":          "decision-1",
+					"status":                       "decided",
+					"idempotency_replayed":         false,
+					"downstream_event_id":          "event-1",
+					"downstream_event_name":        "mailbox.item_decided",
+					"downstream_subscribers":       []string{"approval-agent"},
+					"downstream_subscriber_source": "local_guess",
+				})
+			},
+			wantCode:   3,
+			wantStderr: "malformed mailbox decision result: downstream_subscriber_source must be event_catalog, unavailable, or none",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -767,9 +832,10 @@ func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				writeJSONRPCResult(t, w, req.ID, map[string]any{
-					"ok":                  true,
-					"mailbox_decision_id": "decision-1",
-					"status":              tc.status,
+					"ok":                   true,
+					"mailbox_decision_id":  "decision-1",
+					"status":               tc.status,
+					"idempotency_replayed": false,
 				})
 			}))
 			defer server.Close()

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -6498,6 +6498,30 @@
             "$ref": "#/components/schemas/OpaqueId",
             "description": "Present only when the decision triggered an event emission (typically on approve)."
           },
+          "downstream_event_name": {
+            "description": "Present with downstream_event_id when the decision triggered an event emission.",
+            "type": "string"
+          },
+          "downstream_subscriber_source": {
+            "description": "Present with downstream_event_id and uses the same vocabulary as MailboxDownstreamPreview.subscriber_source.",
+            "enum": [
+              "event_catalog",
+              "unavailable",
+              "none"
+            ],
+            "type": "string"
+          },
+          "downstream_subscribers": {
+            "description": "Present with downstream_event_id; empty array is valid when no subscribers are known.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "idempotency_replayed": {
+            "description": "False for first execution; true when returned from the API idempotency replay path.",
+            "type": "boolean"
+          },
           "mailbox_decision_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
@@ -6512,7 +6536,8 @@
         "required": [
           "ok",
           "mailbox_decision_id",
-          "status"
+          "status",
+          "idempotency_replayed"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7282,7 +7282,11 @@ cli_specification:
       - '`--decision-payload` file content and `--decision-payload-json` values MUST parse as JSON objects; blank, malformed, null, and non-object values fail before any API call.'
       - 'Blank, missing, or unreadable `--decision-payload` file paths fail before any API call.'
       output:
-        success_detail: Existing `MailboxDecisionResult` summary rendering remains authoritative; richer mutation-result rendering is split under #856/#794.
+        success_detail: >
+          Renders the API-owned `MailboxDecisionResult` summary, including required
+          `idempotency_replayed`. When `downstream_event_id` is present, the result
+          also renders the server-owned downstream event name, subscriber list, and
+          subscriber source from the same `MailboxDecisionResult` owner.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -7292,11 +7296,13 @@ cli_specification:
         decision_conflict_or_rejected: 6
       proof_expectations:
       - exact /v1/rpc mailbox.approve call with mailbox_id, optional decision_payload, and optional idempotency_key params only
+      - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.approve, including idempotency_replayed and downstream event detail
+      - malformed response proof for missing idempotency_replayed and incomplete or invalid downstream detail
       - invalid args, conflicting payload flags including explicitly blank conflicting values, blank/missing/unreadable payload files, blank/malformed/null/non-object payload JSON, and missing SWARM_API_TOKEN make zero API calls
       - file-backed and inline payload inputs share the same canonical object validation and param construction
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or retired swarm control mailbox path usage
       split_tail: >
-        Richer approve/reject/defer mutation-result rendering, priority enum/prose repair,
+        Reject reason echo, defer-until echo, run impact/status, priority enum/prose repair,
         shared output/payload policy, trace/run work, and forkchat remain split under #856/#735/#794.
     mailbox_reject:
       command: swarm mailbox reject <mailbox-item-id>
@@ -7304,12 +7310,24 @@ cli_specification:
       implementation_status: implemented
       owner: /v1/rpc mailbox.reject
       behavior: Mailbox rejection action through canonical API owner; no direct DB/store/mailbox writes.
+      output:
+        success_detail: Renders API-owned `MailboxDecisionResult` common fields including required `idempotency_replayed`; reject reason echo remains split.
+      proof_expectations:
+      - exact /v1/rpc mailbox.reject call with mailbox_id, reason, and optional idempotency_key params only
+      - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.reject
+      - invalid args and missing SWARM_API_TOKEN make zero API calls
     mailbox_defer:
       command: swarm mailbox defer <mailbox-item-id>
       tier: must_have
       implementation_status: implemented
       owner: /v1/rpc mailbox.defer
       behavior: Mailbox defer action through canonical API owner; no direct DB/store/mailbox writes.
+      output:
+        success_detail: Renders API-owned `MailboxDecisionResult` common fields including required `idempotency_replayed`; defer-until echo remains split.
+      proof_expectations:
+      - exact /v1/rpc mailbox.defer call with mailbox_id, until, and optional idempotency_key params only
+      - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.defer
+      - invalid args and missing SWARM_API_TOKEN make zero API calls
     health:
       command: swarm health
       tier: must_have
@@ -9292,6 +9310,7 @@ api_specification:
         - ok
         - mailbox_decision_id
         - status
+        - idempotency_replayed
         properties:
           ok:
             type: boolean
@@ -9301,8 +9320,26 @@ api_specification:
           downstream_event_id:
             $ref: '#/components/schemas/OpaqueId'
             description: Present only when the decision triggered an event emission (typically on approve).
+          downstream_event_name:
+            type: string
+            description: Present with downstream_event_id when the decision triggered an event emission.
+          downstream_subscribers:
+            type: array
+            items:
+              type: string
+            description: Present with downstream_event_id; empty array is valid when no subscribers are known.
+          downstream_subscriber_source:
+            type: string
+            enum:
+            - event_catalog
+            - unavailable
+            - none
+            description: Present with downstream_event_id and uses the same vocabulary as MailboxDownstreamPreview.subscriber_source.
           status:
             $ref: '#/components/schemas/MailboxStatus'
+          idempotency_replayed:
+            type: boolean
+            description: False for first execution; true when returned from the API idempotency replay path.
       ConversationMode:
         type: string
         enum:

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -285,19 +285,19 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 		"mailbox.approve": {
 			Params:         map[string]any{"mailbox_id": "mailbox-1", "decision_payload": map[string]any{"approved": true}},
 			ConflictParams: map[string]any{"mailbox_id": "mailbox-1", "decision_payload": map[string]any{"approved": false}},
-			ResultKeys:     []string{"ok", "mailbox_decision_id", "status", "downstream_event_id"},
+			ResultKeys:     []string{"ok", "mailbox_decision_id", "status", "idempotency_replayed", "downstream_event_id", "downstream_event_name", "downstream_subscribers", "downstream_subscriber_source"},
 			SuccessEffects: 2,
 		},
 		"mailbox.defer": {
 			Params:         map[string]any{"mailbox_id": "mailbox-1", "until": until},
 			ConflictParams: map[string]any{"mailbox_id": "mailbox-1", "until": later},
-			ResultKeys:     []string{"ok", "mailbox_decision_id", "status"},
+			ResultKeys:     []string{"ok", "mailbox_decision_id", "status", "idempotency_replayed"},
 			SuccessEffects: 1,
 		},
 		"mailbox.reject": {
 			Params:         map[string]any{"mailbox_id": "mailbox-1", "reason": "not enough evidence"},
 			ConflictParams: map[string]any{"mailbox_id": "mailbox-1", "reason": "duplicate request"},
-			ResultKeys:     []string{"ok", "mailbox_decision_id", "status"},
+			ResultKeys:     []string{"ok", "mailbox_decision_id", "status", "idempotency_replayed"},
 			SuccessEffects: 1,
 		},
 		"run.continue": {
@@ -919,6 +919,13 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 		if decision.Action == "approved" && strings.TrimSpace(decision.ApprovalEventType) != "" && decision.ApprovalEventTx != nil {
 			eventID := "mailbox-event-1"
 			result.DownstreamEventID = eventID
+			result.DownstreamEventName = strings.TrimSpace(decision.ApprovalEventType)
+			subscribers := append([]string(nil), decision.ApprovalEventSubscribers...)
+			if subscribers == nil {
+				subscribers = []string{}
+			}
+			result.DownstreamSubscribers = &subscribers
+			result.DownstreamSubscriberSource = strings.TrimSpace(decision.ApprovalEventSubscriberSource)
 			if err := decision.ApprovalEventTx(ctx, nil, events.Event{
 				ID:          eventID,
 				Type:        events.EventType(decision.ApprovalEventType),

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -82,13 +82,16 @@ func OperatorMailboxHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 			if err != nil {
 				return nil, err
 			}
+			eventName, subscribers, subscriberSource := mailboxApprovalEventEffect(opts.MailboxApprovalRoutes, stringParam(req.Params, "mailbox_id"), opts.Mailbox, ctx, opts)
 			return executeMailboxDecision(ctx, req, opts, store.MailboxV1DecisionRequest{
-				MailboxID:         stringParam(req.Params, "mailbox_id"),
-				Action:            "approved",
-				ActorTokenID:      req.ActorTokenID,
-				DecisionPayload:   payload,
-				Now:               now().UTC(),
-				ApprovalEventType: mailboxApprovalEventType(opts.MailboxApprovalRoutes, stringParam(req.Params, "mailbox_id"), opts.Mailbox, ctx),
+				MailboxID:                     stringParam(req.Params, "mailbox_id"),
+				Action:                        "approved",
+				ActorTokenID:                  req.ActorTokenID,
+				DecisionPayload:               payload,
+				Now:                           now().UTC(),
+				ApprovalEventType:             eventName,
+				ApprovalEventSubscribers:      subscribers,
+				ApprovalEventSubscriberSource: subscriberSource,
 			})
 		},
 		"mailbox.reject": func(ctx context.Context, req Request) (any, error) {
@@ -235,6 +238,7 @@ func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadO
 		}
 		return nil, mailboxDecisionError(decision.MailboxID, err)
 	}
+	outcome.Result.IdempotencyReplayed = outcome.Replayed
 	return outcome.Result, nil
 }
 
@@ -340,13 +344,18 @@ func requiredTimestampParam(params map[string]any, name string) (time.Time, erro
 	return parsed.UTC(), nil
 }
 
-func mailboxApprovalEventType(routes map[string]string, mailboxID string, mailbox MailboxAPIStore, ctx context.Context) string {
+func mailboxApprovalEventEffect(routes map[string]string, mailboxID string, mailbox MailboxAPIStore, ctx context.Context, opts OperatorReadOptions) (string, []string, string) {
 	if len(routes) == 0 || mailbox == nil {
-		return ""
+		return "", nil, ""
 	}
 	detail, err := mailbox.GetV1MailboxItem(ctx, mailboxID)
 	if err != nil {
-		return ""
+		return "", nil, ""
 	}
-	return strings.TrimSpace(routes[detail.Item.Type])
+	eventName := strings.TrimSpace(routes[detail.Item.Type])
+	if eventName == "" {
+		return "", nil, ""
+	}
+	subscribers, subscriberSource := mailboxDownstreamSubscribers(eventName, opts)
+	return eventName, subscribers, subscriberSource
 }

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -156,12 +156,27 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if downstreamID == "" || approvedResult["status"] != "decided" {
 		t.Fatalf("mailbox.approve result = %#v", approvedResult)
 	}
+	if approvedResult["idempotency_replayed"] != false || approvedResult["downstream_event_name"] != "mailbox.item_decided" || approvedResult["downstream_subscriber_source"] != "event_catalog" {
+		t.Fatalf("mailbox.approve promoted result fields = %#v", approvedResult)
+	}
+	approvedSubscribers := approvedResult["downstream_subscribers"].([]any)
+	if len(approvedSubscribers) != 2 || approvedSubscribers[0] != "approval-agent" || approvedSubscribers[1] != "review-agent" {
+		t.Fatalf("mailbox.approve downstream_subscribers = %#v", approvedSubscribers)
+	}
 	replay := rpcCall(t, handler, approveBody)
 	if replay.Error != nil {
 		t.Fatalf("mailbox.approve replay error = %#v", replay.Error)
 	}
-	if got := asMap(t, replay.Result)["downstream_event_id"]; got != downstreamID {
+	replayResult := asMap(t, replay.Result)
+	if got := replayResult["downstream_event_id"]; got != downstreamID {
 		t.Fatalf("idempotency replay downstream_event_id = %v, want %s", got, downstreamID)
+	}
+	if replayResult["idempotency_replayed"] != true || replayResult["downstream_event_name"] != "mailbox.item_decided" || replayResult["downstream_subscriber_source"] != "event_catalog" {
+		t.Fatalf("mailbox.approve replay promoted result fields = %#v", replayResult)
+	}
+	replaySubscribers := replayResult["downstream_subscribers"].([]any)
+	if len(replaySubscribers) != 2 || replaySubscribers[0] != "approval-agent" || replaySubscribers[1] != "review-agent" {
+		t.Fatalf("mailbox.approve replay downstream_subscribers = %#v", replaySubscribers)
 	}
 	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
 		t.Fatalf("mailbox.item_decided event count = %d, want 1", count)
@@ -202,8 +217,12 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if deferred.Error != nil {
 		t.Fatalf("mailbox.defer error = %#v", deferred.Error)
 	}
-	if status := asMap(t, deferred.Result)["status"]; status != "deferred" {
+	deferredResult := asMap(t, deferred.Result)
+	if status := deferredResult["status"]; status != "deferred" {
 		t.Fatalf("mailbox.defer status = %v, want deferred", status)
+	}
+	if deferredResult["idempotency_replayed"] != false {
+		t.Fatalf("mailbox.defer idempotency_replayed = %v, want false", deferredResult["idempotency_replayed"])
 	}
 	laterHandler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -230,8 +249,38 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if deferReplay.Error != nil {
 		t.Fatalf("mailbox.defer replay after until passed error = %#v", deferReplay.Error)
 	}
-	if status := asMap(t, deferReplay.Result)["status"]; status != "deferred" {
+	deferReplayResult := asMap(t, deferReplay.Result)
+	if status := deferReplayResult["status"]; status != "deferred" {
 		t.Fatalf("mailbox.defer replay status = %v, want deferred", status)
+	}
+	if deferReplayResult["idempotency_replayed"] != true {
+		t.Fatalf("mailbox.defer replay idempotency_replayed = %v, want true", deferReplayResult["idempotency_replayed"])
+	}
+
+	rejectID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		Type:    "approval",
+		Summary: "reject me",
+		Context: []byte(`{"title":"reject"}`),
+	})
+	if err != nil {
+		t.Fatalf("insert reject mailbox: %v", err)
+	}
+	rejectBody := `{"jsonrpc":"2.0","id":"reject-fresh","method":"mailbox.reject","params":{"mailbox_id":"` + rejectID + `","reason":"not enough evidence","idempotency_key":"idem-reject"}}`
+	rejected := rpcCall(t, handler, rejectBody)
+	if rejected.Error != nil {
+		t.Fatalf("mailbox.reject error = %#v", rejected.Error)
+	}
+	rejectedResult := asMap(t, rejected.Result)
+	if rejectedResult["status"] != "decided" || rejectedResult["idempotency_replayed"] != false {
+		t.Fatalf("mailbox.reject result = %#v", rejectedResult)
+	}
+	rejectReplay := rpcCall(t, handler, rejectBody)
+	if rejectReplay.Error != nil {
+		t.Fatalf("mailbox.reject replay error = %#v", rejectReplay.Error)
+	}
+	rejectReplayResult := asMap(t, rejectReplay.Result)
+	if rejectReplayResult["status"] != "decided" || rejectReplayResult["idempotency_replayed"] != true {
+		t.Fatalf("mailbox.reject replay result = %#v", rejectReplayResult)
 	}
 
 	empty := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"empty","method":"mailbox.list","params":{"status":"pending","type":"review_request"}}`)

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -178,6 +178,38 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if len(replaySubscribers) != 2 || replaySubscribers[0] != "approval-agent" || replaySubscribers[1] != "review-agent" {
 		t.Fatalf("mailbox.approve replay downstream_subscribers = %#v", replaySubscribers)
 	}
+	legacyReplayResponse, err := json.Marshal(map[string]any{
+		"ok":                  true,
+		"mailbox_decision_id": approvedResult["mailbox_decision_id"],
+		"downstream_event_id": downstreamID,
+		"status":              "decided",
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy replay response: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE api_idempotency
+		SET response = $1::jsonb
+		WHERE method = 'mailbox.approve'
+		  AND idempotency_key = 'idem-approve'
+	`, string(legacyReplayResponse)); err != nil {
+		t.Fatalf("rewrite legacy idempotency response: %v", err)
+	}
+	legacyReplay := rpcCall(t, handler, approveBody)
+	if legacyReplay.Error != nil {
+		t.Fatalf("mailbox.approve legacy replay error = %#v", legacyReplay.Error)
+	}
+	legacyReplayResult := asMap(t, legacyReplay.Result)
+	if legacyReplayResult["idempotency_replayed"] != true ||
+		legacyReplayResult["downstream_event_id"] != downstreamID ||
+		legacyReplayResult["downstream_event_name"] != "mailbox.item_decided" ||
+		legacyReplayResult["downstream_subscriber_source"] != "unavailable" {
+		t.Fatalf("mailbox.approve legacy replay result = %#v", legacyReplayResult)
+	}
+	legacyReplaySubscribers := legacyReplayResult["downstream_subscribers"].([]any)
+	if len(legacyReplaySubscribers) != 0 {
+		t.Fatalf("mailbox.approve legacy replay downstream_subscribers = %#v, want empty", legacyReplaySubscribers)
+	}
 	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
 		t.Fatalf("mailbox.item_decided event count = %d, want 1", count)
 	}

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -79,23 +79,29 @@ type MailboxV1DownstreamPreview struct {
 }
 
 type MailboxV1DecisionRequest struct {
-	MailboxID         string
-	Action            string
-	ActorTokenID      string
-	Reason            string
-	DecisionPayload   json.RawMessage
-	DeferUntil        time.Time
-	Now               time.Time
-	ApprovalEventType string
-	ApprovalEventTx   func(context.Context, *sql.Tx, events.Event) error
-	Idempotency       *APIIdempotencyRequest
+	MailboxID                     string
+	Action                        string
+	ActorTokenID                  string
+	Reason                        string
+	DecisionPayload               json.RawMessage
+	DeferUntil                    time.Time
+	Now                           time.Time
+	ApprovalEventType             string
+	ApprovalEventSubscribers      []string
+	ApprovalEventSubscriberSource string
+	ApprovalEventTx               func(context.Context, *sql.Tx, events.Event) error
+	Idempotency                   *APIIdempotencyRequest
 }
 
 type MailboxV1DecisionResult struct {
-	OK                bool   `json:"ok"`
-	MailboxDecisionID string `json:"mailbox_decision_id"`
-	DownstreamEventID string `json:"downstream_event_id,omitempty"`
-	Status            string `json:"status"`
+	OK                         bool      `json:"ok"`
+	MailboxDecisionID          string    `json:"mailbox_decision_id"`
+	DownstreamEventID          string    `json:"downstream_event_id,omitempty"`
+	DownstreamEventName        string    `json:"downstream_event_name,omitempty"`
+	DownstreamSubscribers      *[]string `json:"downstream_subscribers,omitempty"`
+	DownstreamSubscriberSource string    `json:"downstream_subscriber_source,omitempty"`
+	Status                     string    `json:"status"`
+	IdempotencyReplayed        bool      `json:"idempotency_replayed"`
 }
 
 type MailboxV1DecisionOutcome struct {
@@ -348,7 +354,18 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		if err != nil {
 			return MailboxV1DecisionOutcome{}, err
 		}
+		subscribers := append([]string(nil), input.ApprovalEventSubscribers...)
+		if subscribers == nil {
+			subscribers = []string{}
+		}
+		subscriberSource := strings.TrimSpace(input.ApprovalEventSubscriberSource)
+		if subscriberSource == "" {
+			subscriberSource = "unavailable"
+		}
 		outcome.Result.DownstreamEventID = eventID
+		outcome.Result.DownstreamEventName = strings.TrimSpace(input.ApprovalEventType)
+		outcome.Result.DownstreamSubscribers = &subscribers
+		outcome.Result.DownstreamSubscriberSource = subscriberSource
 		outcome.ApprovalEvent = &evt
 	}
 	res, err := tx.ExecContext(ctx, `

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -306,6 +306,9 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 			if err := json.Unmarshal(existing.Response, &result); err != nil {
 				return MailboxV1DecisionOutcome{}, fmt.Errorf("decode api idempotency mailbox response: %w", err)
 			}
+			if err := normalizeMailboxV1DecisionReplayResult(ctx, tx, &result); err != nil {
+				return MailboxV1DecisionOutcome{}, err
+			}
 			if err := tx.Commit(); err != nil {
 				return MailboxV1DecisionOutcome{}, fmt.Errorf("commit v1 mailbox idempotency replay tx: %w", err)
 			}
@@ -448,6 +451,47 @@ func prepareMailboxV1IdempotencyRequest(input MailboxV1DecisionRequest) (APIIdem
 	}
 	req.Now = req.Now.UTC()
 	return req, true, nil
+}
+
+func normalizeMailboxV1DecisionReplayResult(ctx context.Context, q execQueryer, result *MailboxV1DecisionResult) error {
+	if result == nil || strings.TrimSpace(result.DownstreamEventID) == "" {
+		return nil
+	}
+	if strings.TrimSpace(result.DownstreamEventName) == "" {
+		eventName, err := loadMailboxV1DecisionReplayEventName(ctx, q, result.DownstreamEventID)
+		if err != nil {
+			return err
+		}
+		result.DownstreamEventName = eventName
+	}
+	if result.DownstreamSubscribers == nil {
+		subscribers := []string{}
+		result.DownstreamSubscribers = &subscribers
+	}
+	if strings.TrimSpace(result.DownstreamSubscriberSource) == "" {
+		result.DownstreamSubscriberSource = "unavailable"
+	}
+	return nil
+}
+
+func loadMailboxV1DecisionReplayEventName(ctx context.Context, q execQueryer, eventID string) (string, error) {
+	var eventName string
+	err := q.QueryRowContext(ctx, `
+		SELECT event_name
+		FROM events
+		WHERE event_id = $1::uuid
+	`, strings.TrimSpace(eventID)).Scan(&eventName)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", fmt.Errorf("load mailbox idempotency replay event name: event %s not found", strings.TrimSpace(eventID))
+	case err != nil:
+		return "", fmt.Errorf("load mailbox idempotency replay event name: %w", err)
+	}
+	eventName = strings.TrimSpace(eventName)
+	if eventName == "" {
+		return "", fmt.Errorf("load mailbox idempotency replay event name: event %s has empty event_name", strings.TrimSpace(eventID))
+	}
+	return eventName, nil
 }
 
 func (s *PostgresStore) appendMailboxV1ApprovalEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {


### PR DESCRIPTION
## Summary

Promotes mailbox decision mutation-result effects into the canonical `/v1/rpc mailbox.approve|reject|defer` result owner and updates the CLI to consume only that owner.

Closes #953
Part of #856
Part of #735
Part of #794

## Governing Refs / Context

Exact governing spec references updated in this PR:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.mailbox_approve`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.mailbox_reject`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `cli_specification.command_catalog.mailbox_defer`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `api_specification.components.schemas.MailboxDecisionResult`
- Generated OpenRPC: `docs/specs/swarm-platform/platform/contracts/openrpc.json` `MailboxDecisionResult`

Binding issue/gate context:

- #953 Pre-Implementation Coverage Audit
- #953 Gate Repair: Widened Result Contract Proposal
- #953 Independent Gate Re-Review: `approved as first slice`

## Semantic Migration

New canonical owner:

- Expanded `MailboxDecisionResult` returned by `/v1/rpc mailbox.approve`, `/v1/rpc mailbox.reject`, and `/v1/rpc mailbox.defer`.

Old producer / reader / writer path now invalid:

- CLI-side enrichment or inference of downstream event name, downstream subscribers, subscriber source, or idempotency replay state remains invalid.
- `mailbox.get` decision-sheet downstream preview remains a read/detail owner and is not used as a mutation-result owner.
- Direct DB/store/runtime/EventBus/dashboard/Builder/legacy reads from CLI remain invalid.

Production paths checked for surviving old behavior:

- `cmd/swarm/control_mailbox.go` consumes only `/v1/rpc mailbox.approve|reject|defer` result fields for mutation output.
- `internal/apiv1/operator_mailbox.go` returns API-owned `idempotency_replayed` and passes server-owned downstream detail into the store result owner.
- `internal/store/mailbox_v1.go` persists downstream effect fields in idempotency responses and replays them without creating new downstream events.
- Static no-bypass grep over `cmd/swarm/control_mailbox.go` found no prohibited direct DB/store/runtime/EventBus/dashboard/Builder/legacy/API transport references.

Migration complete for the approved #953 first slice. Reject reason echo, defer-until echo, run impact/status, priority enum/prose repair, shared output/payload policy, trace/run residuals, and forkchat/#749 remain split/backlog per the gate.

## Proof

- `go test ./cmd/swarm -run Mailbox -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorMailbox|TestOpenRPCMutatingHTTPRuntimeProbes|TestRegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./...`
- Static no-bypass grep over `cmd/swarm/control_mailbox.go`
