### PR TITLE
[agent-e][issue #955] Stabilize cataloge2e publish budget

### DIFF
--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -24,7 +24,10 @@ import (
 	"swarm/internal/testutil"
 )
 
-const catalogRuntimeRunID = "88888888-8888-8888-8888-888888888888"
+const (
+	catalogRuntimeRunID          = "88888888-8888-8888-8888-888888888888"
+	catalogRuntimePublishTimeout = 5 * time.Second
+)
 
 type catalogTriggerStep struct {
 	Event                         string         `yaml:"event"`

--- a/internal/runtime/cataloge2e/tier10_policy_patterns_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier10_policy_patterns_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier10PolicyPatternFixtures = []string{
@@ -30,7 +29,7 @@ func TestTier10PolicyPatternCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier11FlowCompositionFixtures = []string{
@@ -55,7 +54,7 @@ func TestTier11FlowCompositionCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 5*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier11_probe_test.go
+++ b/internal/runtime/cataloge2e/tier11_probe_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -44,7 +43,7 @@ func TestTier11Probe(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, true)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 5*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			rows, err := workflowStateDebugRows(h.db)
 			if err != nil {

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -395,7 +395,7 @@ func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot stri
 	h := newRuntimeHarness(t, fixtureRoot, true)
 	pauseCatalogRun(t, h)
 	h.seedEntityFields(expected)
-	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], 5*time.Second)
+	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], catalogRuntimePublishTimeout)
 	plan, err := h.pg.PlanRunFork(h.ctx, store.RunForkPlanRequest{
 		SourceRunID: catalogRuntimeRunID,
 		At:          sourceEventID,

--- a/internal/runtime/cataloge2e/tier1_primitives_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier1_primitives_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier1PrimitiveFixtures = []string{
@@ -57,7 +56,7 @@ func TestTier1PrimitiveCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier2AccumulationFixtures = []string{
@@ -36,7 +35,7 @@ func TestTier2AccumulationCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier3_list_processing_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier3_list_processing_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier3ListProcessingFixtures = []string{
@@ -39,7 +38,7 @@ func TestTier3ListProcessingCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier4CrossEntityFixtures = []string{
@@ -31,7 +30,7 @@ func TestTier4CrossEntityCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 type catalogExcludedFixture struct {
@@ -48,9 +47,9 @@ func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
 				return
 			}
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
-			h.waitForExpectedEmittedEvents(expected, 2*time.Second)
+			h.waitForExpectedEmittedEvents(expected, catalogRuntimePublishTimeout)
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})
 	}

--- a/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier6EventLoopFixtures = []string{
@@ -36,10 +35,10 @@ func TestTier6EventLoopCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			if len(expected.Trigger.Concurrent) > 0 {
-				h.publishConcurrentAndWait(expected.Trigger.Concurrent, 2*time.Second)
+				h.publishConcurrentAndWait(expected.Trigger.Concurrent, catalogRuntimePublishTimeout)
 			} else {
 				for _, step := range expected.triggerSequence() {
-					h.publishAndWait(step, 2*time.Second)
+					h.publishAndWait(step, catalogRuntimePublishTimeout)
 				}
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)

--- a/internal/runtime/cataloge2e/tier7_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier7_composition_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier7CompositionFixtures = []string{
@@ -37,7 +36,7 @@ func TestTier7CompositionCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})

--- a/internal/runtime/cataloge2e/tier9_composition_patterns_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier9_composition_patterns_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 )
 
 var tier9CompositionPatternFixtures = []string{
@@ -38,7 +37,7 @@ func TestTier9CompositionPatternCatalogFixtures_RealRuntime(t *testing.T) {
 			h := newRuntimeHarness(t, fixtureRoot, false)
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
-				h.publishAndWait(step, 2*time.Second)
+				h.publishAndWait(step, catalogRuntimePublishTimeout)
 			}
 			assertCatalogRuntimeOutcome(t, h, expected)
 		})


### PR DESCRIPTION
## Summary

- add one shared `catalogRuntimePublishTimeout` for cataloge2e real-runtime publish/wait proof
- move Tier 1/2/3/4/5/6/7/9/10 callers off hard-coded 2s publish windows
- route the existing Tier 11 and relevant Tier 12 5s publish windows through the same owner

Closes #955

## Governing refs / context

- #955 issue body, Pre-Implementation Coverage Audit, and independent `approved as first slice` gate
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `event_receipts`: one handler completion acknowledgement per event/subscriber
- `platform-spec.yaml` `pipeline_transition_encoding`: handler execution produces event_receipts with outcome/state/side-effect proof
- `platform-spec.yaml` run lifecycle: completion is checked after event receipts and requires no in-flight events
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`

## Semantic migration

- New canonical test-harness owner: `internal/runtime/cataloge2e/runtime_harness_test.go` `catalogRuntimePublishTimeout`
- Old non-authoritative paths invalidated for this class: scattered 2s/5s per-suite cataloge2e publish/wait literals
- Production paths checked for surviving old behavior: `EventBus.Publish`, `PostgresStore.UpsertPipelineReceipt`, and pipeline receipt schema/spec were inspected during the audit and are unchanged
- Migration completeness: complete for cataloge2e real-runtime `publishAndWait` / `publishConcurrentAndWait` consumers in the approved #955 owner cluster; unrelated boot-only and selected-fork longer timeouts remain distinct concepts

No production EventBus, store receipt SQL, runtime pipeline semantics, or platform spec behavior changed.

## Tests

- `git diff --check`
- `go test ./internal/runtime/cataloge2e -run 'TestTier9CompositionPatternCatalogFixtures_RealRuntime/test-compose-gate-data-advance-emit' -count=10`
- `go test ./internal/runtime/cataloge2e -run TestTier9CompositionPatternCatalogFixtures_RealRuntime -count=3`
- `go test ./internal/runtime/bus -run 'TestEventBusWaitForQuiescenceWaitsForPublishCompletion|Test.*PipelineReceipt|Test.*Publish' -count=3`
- `go test ./internal/store -run 'TestPostgresStore_PipelineReceipts_MissingEventsQuery|TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCapability|Test.*PipelineReceipt|Test.*Receipt' -count=3`
- `go test ./... -count=1`