### PR TITLE
[agent-c][issue #472] Clarify event admission validation ownership

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -355,6 +355,14 @@ contract_formats:
       Wave 1 type catalog. Runtime validators MUST NOT pass unresolved
       contract type names such as named types, scalar aliases, or enums
       to the primitive JSON schema validator as literal schema types.
+      Validation ownership is layered, not competing: supported emit
+      surfaces validate producer-authored payloads before publish, while
+      canonical event-store admission validates every event payload that
+      reaches persistence. Event-store admission is the primary owner for
+      ingress/direct/store append paths without a more specific producer
+      surface owner, and is only a final guard for supported emit surfaces
+      that already validated before publish. Event-store admission MUST NOT
+      interpret routing, delivery, source, target, or recipient semantics.
     format:
       event_name: |
         swarm:
@@ -1931,8 +1939,10 @@ engine:
         external API.'
     - step: 2
       name: validate_payload
-      action: Validate event payload against the schema in events.yaml. Reject if schema mismatch. Log and discard invalid
-        events.
+      action: Validate event payload against the schema in events.yaml before persistence. Supported producer emit surfaces
+        perform their own fail-closed validation before publish; this event-loop admission check remains the canonical final
+        guard for all events that reach the event store and the primary owner for ingress/direct/store append paths without
+        a more specific producer surface owner. Reject if schema mismatch. Log and discard invalid events.
     - step: 3
       name: persist_event
       action: 'Write event to the event store (write-ahead). The event is durable before any processing begins. Crash after

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -386,8 +386,11 @@ nodes:
         - dead contract/type residue for PayloadTransformSpec after retired authored surfaces stopped being accepted on supported handler/rule/fan_out paths
         - stale verify/report wording and dead-event audit text that still described payload_transform-era proof surfaces
         - supported proof-harness allowlists and active prose/reference surfaces that still described payload_transform, fan_out.emit_per_item, or implicit passthrough as current behavior
-      - adjacent split retained after this node:
-        - generic post-publish canonical-event validation cleanup remains outside this migration class unless later promoted
+      - adjacent split promoted by #472:
+        - canonical event-store admission validation remains intentionally separate from supported emit-surface validation;
+          emit surfaces own producer-authored payload proof before publish, while runtime/store admission validates all events
+          before persistence and residual ingress/store append paths; routing, delivery, source/target, and recipient semantics
+          stay split to #926
       - adjacent supporting migration tracked by #605:
         - canonical event-level swarm metadata now owns non-derivable external/lifecycle topology proof so flat event payload fields and verifier metadata no longer share ambiguous underscore ownership
     representative_issues:
@@ -399,6 +402,7 @@ nodes:
       - 466
       - 468
       - 470
+      - 472
       - 605
     common_framing_mistakes:
       too_broad:

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -21,6 +21,9 @@ type EventInterceptor interface {
 	Intercept(ctx context.Context, evt events.Event) (passthrough bool, deferred []events.Event, err error)
 }
 
+// PayloadValidator validates canonical event-store admission before an event is
+// persisted or direct-recipient eligibility is reported. It does not own
+// producer-surface shaping or routing/delivery/source-target semantics.
 type PayloadValidator func(eventType string, payload []byte) error
 
 type EventBus struct {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -548,6 +548,31 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 	}
 }
 
+func TestEventBusCheckDirectRecipients_PayloadValidatorFailureAbortsBeforeRecipientPlanning(t *testing.T) {
+	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+		PayloadValidator: func(string, []byte) error {
+			return context.DeadlineExceeded
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+
+	status, err := eb.CheckDirectRecipients(context.Background(), events.Event{
+		Type:    "task.completed",
+		Payload: []byte(`{}`),
+	}, []string{"agent-a"})
+	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
+		t.Fatalf("expected payload validator failure, got %v", err)
+	}
+	if !slices.Equal(status.Requested, []string{"agent-a"}) {
+		t.Fatalf("requested recipients = %#v, want agent-a", status.Requested)
+	}
+	if len(status.Recipients) != 0 || len(status.Filtered) != 0 || len(status.Missing) != 0 {
+		t.Fatalf("recipient status after validation failure = %#v, want no planning result", status)
+	}
+}
+
 func TestEventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut(t *testing.T) {
 	store := &descriptorAwareEventStore{
 		descriptors: []runtimebus.ActiveAgentDescriptor{

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -28,6 +28,10 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 	})
 }
 
+// newRuntimePayloadValidator owns canonical event-store admission validation.
+// Supported emit surfaces validate producer-authored payloads before publish;
+// this validator is the final pre-persistence guard for every event and the
+// primary guard for ingress/direct/store paths without a producer-surface owner.
 func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtimecontracts.EventSchema) runtimebus.PayloadValidator {
 	return func(eventType string, payload []byte) error {
 		eventType = strings.TrimSpace(eventType)
@@ -62,6 +66,9 @@ func newRuntimePayloadValidator(logger *RuntimeLogger, schemas map[string]runtim
 	}
 }
 
+// payloadForCanonicalEventValidation validates only the event payload contract.
+// Runtime-owned canonical context is envelope/admission metadata unless the
+// target event schema explicitly declares the same field as payload.
 func payloadForCanonicalEventValidation(payload map[string]any, schema map[string]any) map[string]any {
 	if len(payload) == 0 || schema == nil {
 		return payload

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -43,6 +43,9 @@ func (s *PostgresStore) SetEventPayloadValidator(validator func(eventType string
 	s.eventPayloadValidator = EventPayloadValidator(validator)
 }
 
+// validateEventPayload is the store-side canonical admission guard for append
+// paths that may not pass through an emit-surface owner immediately before
+// persistence.
 func (s *PostgresStore) validateEventPayload(eventType string, payload []byte) error {
 	if s == nil || s.eventPayloadValidator == nil {
 		return nil


### PR DESCRIPTION
## Summary

Closes #472.

This PR keeps the generic validator intentionally and closes the ownership ambiguity around it:

- documents supported emit surfaces as the producer-owned fail-closed validation layer before publish
- documents canonical event-store admission as the final pre-persistence guard and the primary owner for ingress/direct/store append paths without a producer-surface owner
- adds the missing `CheckDirectRecipients` proof that admission validation fails before recipient planning is reported
- updates the semantic watchlist to promote the #472 adjacent split and keep #926 routing/delivery/source-target semantics out of scope

## Governing Refs / Context

Exact governing spec sections updated or relied on:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#contract_formats.event_schema`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#engine.event_loop.lifecycle.validate_payload`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#engine.agent_session_management.event_emission`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.declarative_system_node_emit_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.action_originated_emit_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#observation_model.emitted_events.payload_rules.auto_emit_on_create_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#compliance.runtime_enforcement.required_checks`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#handler_specification.retired_fields`

Binding issue/gate context:

- #472 Pre-Implementation Coverage Audit
- #472 independent gate outcome: `approved`
- #455 parent closeout and child stream #457/#458, #459/#460, #461/#462, #464/#465, #466/#467, #468/#469, #470/#471
- #926 remains the explicit split for source/target pin-routing, delivery planning, replay/retry, and persisted-recipient semantics

## Semantic Ownership

Canonical owner after this PR:

- event schema definition and lowered runtime schema: `platform-spec.yaml`, `internal/runtime/contracts/schema_registry.go`, `internal/runtime/semanticview/event_schema.go`
- shared schema primitive: `internal/runtime/eventschema/validate.go`
- runtime-owned canonical context projection: `internal/runtime/eventpayload/context.go`
- canonical event-store admission validator: `internal/runtime/eventbus_logger.go` `newRuntimePayloadValidator`
- EventBus/store admission consumers: `internal/runtime/bus`, `internal/store/events.go`, `internal/store/inbound.go`

Old invalid interpretation:

- treating the generic validator as the primary owner for supported #455 emit surfaces
- treating #455 producer-surface validation as enough to remove canonical admission for public/operator ingress or direct store append paths
- describing the current seam as literal post-publish validation without noting current normal paths validate before persistence

Production paths checked for surviving old behavior:

- declarative handler/rules/on_complete/accumulate/fan_out emits
- agent emit tools
- action-originated emits and artifact result events
- auto_emit_on_create immediate and queued publish paths
- event.publish and run.start API ingress
- EventBus Publish, PublishTx, PublishDirect, CheckDirectRecipients
- Postgres AppendEvent, PersistEventWithDeliveries, RecordInboundEvent

Migration completeness: complete for the approved #472 ownership-boundary class. No routing/delivery/source-target behavior was changed.

## Validation

Focused proof run:

```sh
go test ./internal/runtime -run 'TestRuntimePayloadValidator_' -count=1
go test ./internal/runtime/bus -run 'TestEventBusPublish_(UsesPayloadValidator|PayloadValidatorFailureAbortsPublish)|TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish|TestEventBusCheckDirectRecipients_PayloadValidatorFailureAbortsBeforeRecipientPlanning' -count=1
go test ./internal/runtime/eventschema ./internal/runtime/eventpayload -count=1
go test ./internal/store -run 'TestPostgresStore_(AppendEvent|RecordInboundEvent)_RejectsPayloadValidatorFailureBeforePersistence' -count=1
go test ./internal/runtime/tools -run 'TestHandleEmitTool_(FailsClosedOnUndeclaredPayloadField|AllowsValidWave1EventPayloadTypes|FailsClosedOnNamedTypeViolation)|TestExecutorTelemetry_EmitToolLogs(StructuredPublishedOutcome|SchemaValidationFailureSeparatelyFromPublishFailure|UndeclaredFieldSchemaValidationFailure)' -count=1
go test ./internal/runtime/pipeline -run 'TestPipelineEnginePayloadShaper|Test.*EmitPayload|Test.*Action.*Emit|Test.*Payload.*Schema|Test.*ContractViolation' -count=1
go test ./internal/runtime/manager -run 'Test.*AutoEmit|Test.*validateAutoEmitPayload|Test.*FlowActivation.*Emit' -count=1
go test ./internal/apiv1 -run 'TestOperatorEventPublishHandlersFailClosedBeforePersistence|TestOperatorRunStartHandlersFailClosedBeforePersistence|TestMutatingRuntimeProbe|TestOpenRPCMutatingRuntime' -count=1
go test ./...
```

All passed.