### PR TITLE
[agent-b][issue #855] Add trace follow shorthand

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -223,7 +223,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 			return runDiagnosticTraceCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), traceOpts, runID)
 		},
 	}
-	cmd.Flags().BoolVar(&traceOpts.follow, "follow", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -455,25 +455,35 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 }
 
 func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
-	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
-		wsRows:           []map[string]any{validRunCommandTraceRow("evt-follow")},
-		wsCloseAfterRows: true,
-	})
-	defer server.Close()
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "long follow", args: []string{"trace", "run-follow", "--follow", "--no-retry"}},
+		{name: "shorthand follow", args: []string{"trace", "run-follow", "-f", "--no-retry"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+				wsRows:           []map[string]any{validRunCommandTraceRow("evt-follow")},
+				wsCloseAfterRows: true,
+			})
+			defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-follow", "--follow", "--no-retry"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 0 {
-		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	assertRunCommandMethods(t, calls, nil)
-	assertRunCommandTraceSubscription(t, wsRequests, "run-follow", false)
-	if !strings.Contains(stdout.String(), "trace event_id=evt-follow") {
-		t.Fatalf("stdout = %q, want trace row", stdout.String())
-	}
-	if strings.TrimSpace(stderr.String()) != "" {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			assertRunCommandMethods(t, calls, nil)
+			assertRunCommandTraceSubscription(t, wsRequests, "run-follow", false)
+			if !strings.Contains(stdout.String(), "trace event_id=evt-follow") {
+				t.Fatalf("stdout = %q, want trace row", stdout.String())
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
 	}
 }
 
@@ -515,6 +525,9 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "--no-retry") {
 		t.Fatalf("help missing --no-retry:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "-f, --follow") {
+		t.Fatalf("help missing -f shorthand:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--replay-since") {
 		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
@@ -908,6 +921,9 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
+		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
+		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
 		{name: "trace follow direct replay since remains unpromoted", args: []string{"trace", "run-1", "--follow", "--replay-since", "2026-05-13T10:00:00Z"}, wantStderr: "unknown flag"},
 		{name: "trace richer filter still unpromoted", args: []string{"trace", "run-1", "--event-name", "scan.requested"}, wantStderr: "unknown flag"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
@@ -938,6 +954,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"trace", "run-1"},
 		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z"},
 		{"trace", "run-1", "--follow"},
+		{"trace", "run-1", "-f"},
 		{"trace", "run-1", "--follow", "--no-retry"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5953,7 +5953,8 @@ cli_specification:
           used by the run-debug trace owner. Trace-specific `swarm trace --follow` subscription recovery and
           `--no-retry` are promoted in
           cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract by #928. Review-artifact
-          `until`, event-name, subscriber, entity-id, delivery-status, `--include-payload`, `-f`, shared `swarm run`
+          `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Review-artifact
+          `until`, event-name, subscriber, entity-id, delivery-status, `--include-payload`, shared `swarm run`
           recovery, and multi-run `--all` remain explicitly unpromoted split tails until later gated children promote
           their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
@@ -7144,10 +7145,10 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow] [--no-retry]
+      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow|-f] [--no-retry]
       tier: must_have
       implementation_status: implemented
-      owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow
+      owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow/-f
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run trace rendering over API-owned RunTraceRow facts only; no CLI reconstruction from tables.
       promoted_trace_filter_contract:
@@ -7176,8 +7177,17 @@ cli_specification:
         status: api_owner_promoted_cli_implemented
         implemented_by: '#928'
         follow_owner: /v1/ws run.subscribe_trace
+        follow_shorthand:
+          implemented_by: '#855'
+          shorthand: -f
+          expands_to: --follow
+          behavior: >
+            `-f` is an exact CLI-only shorthand for `--follow`. It selects the same `/v1/ws run.subscribe_trace`
+            follow path, accepts the same `--no-retry` modifier, rejects the same snapshot-only flags before any
+            API or WebSocket call, and does not introduce new API params, runtime semantics, output behavior, or
+            `swarm run` follow behavior.
         scope: >
-          Applies only to `swarm trace --follow`. `swarm run` foreground follow, connected follow, and reattach keep their
+          Applies only to `swarm trace --follow` / `swarm trace -f`. `swarm run` foreground follow, connected follow, and reattach keep their
           existing lifecycle policy and may continue to use the shared one-shot `subscribeRunTrace` helper without inheriting
           this trace-specific reconnect policy.
         retry_policy: >
@@ -7203,17 +7213,18 @@ cli_specification:
           rendered, recovered requests also omit `replay_since`. The CLI does not deduplicate rows; recovery is at-least-once
           and the server/API owner remains responsible for trace ordering and retention semantics.
         no_retry_flag: >
-          `--no-retry` disables this recovery loop for `swarm trace --follow` only. With `--no-retry`, the command performs
+          `--no-retry` disables this recovery loop for `swarm trace --follow` / `swarm trace -f` only. With `--no-retry`, the command performs
           exactly one `run.subscribe_trace` request, never sends `replay_since`, exits 0 on a clean close, and fails closed on
           the first subscription or notification error.
         invalid_combinations:
-        - --since with --follow
-        - --limit with --follow
-        - --cursor with --follow
-        - --no-retry without --follow
+        - --since with --follow/-f
+        - --limit with --follow/-f
+        - --cursor with --follow/-f
+        - --no-retry without --follow/-f
         - direct --replay-since flag; replay_since is an internal recovery parameter, not a user-facing trace flag
         proof_expectations:
         - initial and recovered WebSocket request-shape tests prove exact run.subscribe_trace params and replay_since handling
+        - '`-f` help/discoverability and execution tests prove exact aliasing to --follow with no distinct API or runtime path'
         - omitted-run follow resolves through /v1/rpc run.list once before recovered subscriptions for the resolved run id
         - --no-retry proves one-shot close behavior and no replay_since
         - malformed subscription responses and notifications fail closed without retrying indefinitely
@@ -7227,7 +7238,6 @@ cli_specification:
           entity_id: Not promoted; entity filtering requires a typed RunTraceFilter owner before CLI use.
           delivery_status: Not promoted; delivery-status filtering requires a typed RunTraceFilter owner before CLI use.
           include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
-          shorthand_follow: Not promoted in this source-of-truth repair; `-f` is CLI UX only and must be gated separately.
           shared_run_follow_recovery: Not promoted; `swarm run` follow and reattach have distinct lifecycle semantics and remain split.
           all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
     mailbox_list:


### PR DESCRIPTION
## Summary

Implements the approved #855 first slice for `swarm trace -f` as an exact shorthand for `swarm trace --follow`.

This PR keeps the approved boundary:
- No API/runtime semantic changes.
- No new `/v1/ws run.subscribe_trace` params.
- No snapshot filter changes beyond regression proof.
- No payload/output, `--all`, richer typed filters, or shared `swarm run` follow recovery changes.

Part of #855.

## Governing Refs / Context

- Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/855#issuecomment-4522225247
- Independent gate outcome: https://github.com/yazzaoui/Swarm/issues/855#issuecomment-4522300248
- `platform-spec.yaml#cli_specification.command_catalog.trace`
- `platform-spec.yaml#cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract`
- `platform-spec.yaml#api_specification.method_catalog.run.subscribe_trace`
- `platform-spec.yaml#api_specification.method_catalog.run.trace`
- `platform-spec.yaml#components.schemas.RunTraceRow`

## Semantic Migration

- New canonical owner: `platform-spec.yaml#cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract.follow_shorthand`.
- Old non-authoritative state: `platform-spec.yaml` `split_tail.shorthand_follow` marked `-f` unpromoted; Cobra rejected `-f` as an unknown shorthand.
- Production paths checked for surviving old behavior: `cmd/swarm trace --help`, `cmd/swarm trace -f --no-retry`, invalid `-f` + snapshot flags, missing token no-call, static no-bypass grep, OpenRPC check.
- Migration complete for this child slice: `-f` now parses to the same `follow` bool and therefore the same `/v1/ws run.subscribe_trace` path as `--follow`.

## Proof

- `go test ./cmd/swarm -run 'TestTrace|TestDiagnosticsRejectInvalidInputBeforeRequest|TestDiagnosticsRequireAPITokenBeforeRequest' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./...`
- `go run ./cmd/swarm trace --help`
- Static no-bypass grep over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go` for direct store/runtime/EventBus/dashboard/Builder trace bypasses.
