### PR TITLE
[agent-a][issue #844] Promote CLI contract path resolver

### DIFF
--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -80,8 +80,10 @@ type cliAPISettings struct {
 }
 
 type cliAPIConfigFile struct {
-	APIServer    string `yaml:"api_server"`
-	APITokenFile string `yaml:"api_token_file"`
+	APIServer        string `yaml:"api_server"`
+	APITokenFile     string `yaml:"api_token_file"`
+	ContractsPath    string `yaml:"contracts_path"`
+	PlatformSpecPath string `yaml:"platform_spec_path"`
 }
 
 type cliAPIValidationError struct {
@@ -203,7 +205,7 @@ func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, err
 	}
 	for key, value := range decoded {
 		switch key {
-		case "api_server", "api_token_file":
+		case "api_server", "api_token_file", "contracts_path", "platform_spec_path":
 			if value == nil {
 				continue
 			}

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -127,6 +127,28 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 	})
 }
 
+func TestCLIAPIResolverToleratesContractPathConfigKeys(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "config-token")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"api_server":         "http://127.0.0.1:4444",
+		"api_token_file":     tokenFile,
+		"contracts_path":     "contracts-from-config",
+		"platform_spec_path": "platform-from-config.yaml",
+	}))
+
+	client, err := newCLIAPIClient(rootCommandOptions{})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient: %v", err)
+	}
+	if client.endpoint != "http://127.0.0.1:4444/v1/rpc" {
+		t.Fatalf("endpoint = %q", client.endpoint)
+	}
+	if client.token != "config-token" {
+		t.Fatalf("token = %q", client.token)
+	}
+}
+
 func TestCLIAPISettingsFailClosed(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -550,6 +572,8 @@ func isolateCLIAPIConfigEnv(t *testing.T) {
 	t.Setenv("SWARM_API_SERVER", "")
 	t.Setenv("SWARM_API_TOKEN", "")
 	t.Setenv("SWARM_API_TOKEN_FILE", "")
+	t.Setenv("SWARM_CONTRACTS_PATH", "")
+	t.Setenv("SWARM_CONTRACTS_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 }
 
@@ -565,7 +589,7 @@ func writeCLIAPITokenFile(t *testing.T, token string) string {
 func writeCLIAPIConfigFile(t *testing.T, values map[string]string) string {
 	t.Helper()
 	var body strings.Builder
-	for _, key := range []string{"api_server", "api_token_file"} {
+	for _, key := range []string{"api_server", "api_token_file", "contracts_path", "platform_spec_path"} {
 		if value, ok := values[key]; ok {
 			body.WriteString(key)
 			body.WriteString(": ")

--- a/cmd/swarm/cli_paths.go
+++ b/cmd/swarm/cli_paths.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const cliContractsPathEnv = "SWARM_CONTRACTS_PATH"
+
+type cliContractPlatformSpecPathOptions struct {
+	ContractsPath    string
+	PlatformSpecPath string
+}
+
+type cliContractPlatformSpecPaths struct {
+	ContractsPath    string
+	PlatformSpecPath string
+}
+
+func resolveCLIContractPlatformSpecPaths(repoRoot string, opts cliContractPlatformSpecPathOptions) (cliContractPlatformSpecPaths, error) {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return cliContractPlatformSpecPaths{}, err
+	}
+	contractsPath := firstNonEmpty(
+		opts.ContractsPath,
+		os.Getenv(cliContractsPathEnv),
+		cfg.ContractsPath,
+		discoverRepoContractsPath(repoRoot),
+	)
+	platformSpecPath := firstNonEmpty(
+		opts.PlatformSpecPath,
+		cfg.PlatformSpecPath,
+		defaultPlatformSpecPath,
+	)
+	return cliContractPlatformSpecPaths{
+		ContractsPath:    resolvePath(repoRoot, contractsPath),
+		PlatformSpecPath: resolvePath(repoRoot, platformSpecPath),
+	}, nil
+}
+
+func discoverRepoContractsPath(repoRoot string) string {
+	candidate := filepath.Join(repoRoot, "contracts")
+	if regularFileExists(filepath.Join(candidate, "package.yaml")) {
+		return candidate
+	}
+	return ""
+}
+
+func regularFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func resolveContractsPath(repoRoot, raw string) string {
+	if resolved := resolvePath(repoRoot, raw); strings.TrimSpace(resolved) != "" {
+		return resolved
+	}
+	return discoverRepoContractsPath(repoRoot)
+}

--- a/cmd/swarm/cli_paths_test.go
+++ b/cmd/swarm/cli_paths_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	"swarm/internal/runtime"
+)
+
+func TestResolveCLIContractPlatformSpecPathsPrecedenceAndDiscovery(t *testing.T) {
+	repo := t.TempDir()
+	discoveredContracts := filepath.Join(repo, "contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(discoveredContracts, "package.yaml"), `name: discovered`)
+	configContracts := filepath.Join(t.TempDir(), "config-contracts")
+	configPlatform := filepath.Join(t.TempDir(), "config-platform.yaml")
+	envContracts := filepath.Join(t.TempDir(), "env-contracts")
+
+	t.Run("flags beat env config and discovery", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		t.Setenv("SWARM_CONTRACTS_PATH", envContracts)
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"contracts_path":     configContracts,
+			"platform_spec_path": configPlatform,
+		}))
+
+		got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+			ContractsPath:    "flag-contracts",
+			PlatformSpecPath: "flag-platform.yaml",
+		})
+		if err != nil {
+			t.Fatalf("resolve paths: %v", err)
+		}
+		if want := filepath.Join(repo, "flag-contracts"); got.ContractsPath != want {
+			t.Fatalf("contracts path = %q, want %q", got.ContractsPath, want)
+		}
+		if want := filepath.Join(repo, "flag-platform.yaml"); got.PlatformSpecPath != want {
+			t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, want)
+		}
+	})
+
+	t.Run("environment beats config and discovery for contracts only", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		t.Setenv("SWARM_CONTRACTS_PATH", envContracts)
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"contracts_path":     configContracts,
+			"platform_spec_path": configPlatform,
+		}))
+
+		got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{})
+		if err != nil {
+			t.Fatalf("resolve paths: %v", err)
+		}
+		if got.ContractsPath != envContracts {
+			t.Fatalf("contracts path = %q, want %q", got.ContractsPath, envContracts)
+		}
+		if got.PlatformSpecPath != configPlatform {
+			t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, configPlatform)
+		}
+	})
+
+	t.Run("config beats discovery and built in default", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"contracts_path":     configContracts,
+			"platform_spec_path": configPlatform,
+		}))
+
+		got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{})
+		if err != nil {
+			t.Fatalf("resolve paths: %v", err)
+		}
+		if got.ContractsPath != configContracts {
+			t.Fatalf("contracts path = %q, want %q", got.ContractsPath, configContracts)
+		}
+		if got.PlatformSpecPath != configPlatform {
+			t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, configPlatform)
+		}
+	})
+
+	t.Run("discovers repo contracts and built in platform spec last", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+
+		got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{})
+		if err != nil {
+			t.Fatalf("resolve paths: %v", err)
+		}
+		if got.ContractsPath != discoveredContracts {
+			t.Fatalf("contracts path = %q, want %q", got.ContractsPath, discoveredContracts)
+		}
+		if want := filepath.Join(repo, defaultPlatformSpecPath); got.PlatformSpecPath != want {
+			t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, want)
+		}
+	})
+}
+
+func TestCLIContractPathResolutionIgnoresLegacyContractsDir(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := t.TempDir()
+	legacyContracts := filepath.Join(t.TempDir(), "legacy-contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(legacyContracts, "package.yaml"), `name: legacy`)
+	t.Setenv("SWARM_CONTRACTS_DIR", legacyContracts)
+
+	got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{})
+	if err != nil {
+		t.Fatalf("resolve paths: %v", err)
+	}
+	if got.ContractsPath != "" {
+		t.Fatalf("contracts path = %q, want empty; SWARM_CONTRACTS_DIR must not be a CLI source", got.ContractsPath)
+	}
+}
+
+func TestResolveCLIContractPlatformSpecPathsFailClosedOnUnsupportedConfigKey(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("retry: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("SWARM_CONFIG", configPath)
+
+	_, err := resolveCLIContractPlatformSpecPaths(t.TempDir(), cliContractPlatformSpecPathOptions{})
+	if err == nil {
+		t.Fatal("resolve paths returned nil error")
+	}
+	if !strings.Contains(err.Error(), `unsupported CLI config key "retry"`) {
+		t.Fatalf("err = %q", err.Error())
+	}
+}
+
+func TestRunVerifyCommandConsumesContractPathResolver(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := repoRoot()
+	configContracts := filepath.Join(t.TempDir(), "config-contracts")
+	envContracts := filepath.Join(t.TempDir(), "env-contracts")
+	legacyContracts := filepath.Join(t.TempDir(), "legacy-contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(legacyContracts, "package.yaml"), `name: legacy`)
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"contracts_path": configContracts,
+	}))
+	t.Setenv("SWARM_CONTRACTS_PATH", envContracts)
+	t.Setenv("SWARM_CONTRACTS_DIR", legacyContracts)
+
+	var out bytes.Buffer
+	code := runVerifyCommandWithOutput(context.Background(), repo, defaultVerifyCommandOptions(), &out, &out)
+	if code == 0 {
+		t.Fatalf("verify unexpectedly succeeded: %s", out.String())
+	}
+	if !strings.Contains(out.String(), envContracts) {
+		t.Fatalf("verify did not use SWARM_CONTRACTS_PATH path %q:\n%s", envContracts, out.String())
+	}
+	if strings.Contains(out.String(), configContracts) || strings.Contains(out.String(), legacyContracts) {
+		t.Fatalf("verify used lower-priority or legacy path:\n%s", out.String())
+	}
+}
+
+func TestRunServeRuntimeConsumesContractPathResolverBeforeBundleLoad(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := t.TempDir()
+	configContracts := filepath.Join(t.TempDir(), "config-contracts")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"contracts_path": configContracts,
+	}))
+	originalBuildStores := buildStoresForServe
+	buildStoresForServe = func(context.Context, string, *config.Config) (storeBundle, error) {
+		return storeBundle{}, nil
+	}
+	t.Cleanup(func() {
+		buildStoresForServe = originalBuildStores
+	})
+
+	var out bytes.Buffer
+	code := runServeRuntime(context.Background(), repo, serveOptions{
+		StoreMode:          "postgres",
+		HealthAddr:         defaultHealthAddr,
+		ShutdownGrace:      runtime.DefaultShutdownGrace,
+		SelfCheck:          true,
+		RequireBundleMatch: true,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code == 0 {
+		t.Fatalf("serve unexpectedly succeeded: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "contracts="+configContracts) {
+		t.Fatalf("serve boot output did not use config contracts_path %q:\n%s", configContracts, out.String())
+	}
+	if !strings.Contains(out.String(), "bundle_load") || !strings.Contains(out.String(), "FAILED") {
+		t.Fatalf("serve did not reach bundle_load failure proof:\n%s", out.String())
+	}
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -115,7 +115,6 @@ type serveOptions struct {
 
 func defaultServeOptions() serveOptions {
 	return serveOptions{
-		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
 		HealthAddr:         defaultHealthAddr,
 		ShutdownGrace:      runtime.DefaultShutdownGrace,
@@ -129,13 +128,22 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	reporter := newServeBootReporter(opts.Verbose, opts.Output)
 	reporter.emit(1, "process_start", "ok", "")
 	resolvedConfigPath := resolvePath(repo, opts.ConfigPath)
-	resolvedContractsPath := resolveContractsPath(repo, opts.ContractsPath)
-	resolvedPlatformSpecPath := resolvePath(repo, opts.PlatformSpecPath)
 	if err := loadRepoDotEnv(repo); err != nil {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("load .env: %v", err)
 		return 1
 	}
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.ContractsPath,
+		PlatformSpecPath: opts.PlatformSpecPath,
+	})
+	if err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
+		log.Printf("resolve CLI path config: %v", err)
+		return 1
+	}
+	resolvedContractsPath := resolvedPaths.ContractsPath
+	resolvedPlatformSpecPath := resolvedPaths.PlatformSpecPath
 
 	cfg, err := loadRuntimeConfig(resolvedConfigPath)
 	if err != nil {
@@ -380,8 +388,7 @@ type verifyCommandOptions struct {
 
 func defaultVerifyCommandOptions() verifyCommandOptions {
 	return verifyCommandOptions{
-		platformSpecPath: defaultPlatformSpecPath,
-		logging:          defaultCLILoggingOptions(),
+		logging: defaultCLILoggingOptions(),
 	}
 }
 
@@ -408,8 +415,18 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		}
 		return 1
 	}
-	resolvedContractsPath := resolveContractsPath(repo, opts.contractsPath)
-	resolvedPlatformSpecPath := resolvePath(repo, opts.platformSpecPath)
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.contractsPath,
+		PlatformSpecPath: opts.platformSpecPath,
+	})
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "verify failed: resolve path config: %v\n", err)
+		}
+		return cliAPIErrorExitCode(err, cliAPIErrorClassifier{})
+	}
+	resolvedContractsPath := resolvedPaths.ContractsPath
+	resolvedPlatformSpecPath := resolvedPaths.PlatformSpecPath
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
 		if errOut != nil {
@@ -1478,16 +1495,6 @@ func asString(v any) string {
 	default:
 		return ""
 	}
-}
-
-func resolveContractsPath(repoRoot, raw string) string {
-	if resolved := resolvePath(repoRoot, raw); strings.TrimSpace(resolved) != "" {
-		return resolved
-	}
-	if discovered := strings.TrimSpace(runtimecontracts.DefaultWorkflowContractsDir(repoRoot)); discovered != "" {
-		return discovered
-	}
-	return ""
 }
 
 func resolvePath(repoRoot, path string) string {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -567,9 +567,14 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("cli config accepted key %q missing: %#v", key, spec.CLIConfigFile.AcceptedKeys)
 		}
 	}
-	for _, key := range []string{"api_token", "output_format", "no_color", "contracts_path", "platform_spec_path", "log_level", "retry", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
+	for _, key := range []string{"api_token", "output_format", "no_color", "log_level", "retry", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
 		if strings.TrimSpace(spec.CLIConfigFile.RejectedKeys[key]) == "" {
 			t.Fatalf("cli config rejected key %q missing: %#v", key, spec.CLIConfigFile.RejectedKeys)
+		}
+	}
+	for _, key := range []string{"contracts_path", "platform_spec_path"} {
+		if !strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys[key], "contract_platform_spec_path_resolution") {
+			t.Fatalf("cli config shared non-API key %q missing contract path owner: %#v", key, spec.CLIConfigFile.SharedNonAPIKeys)
 		}
 	}
 	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT"} {
@@ -588,6 +593,76 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 		}
 	}
 	for _, want := range []string{"API-backed command leaves consume", "OpenRPC", "Future API-backed CLI commands MUST consume this owner"} {
+		if !stringSliceContains(spec.ImplementationBoundaries, want) {
+			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
+		}
+	}
+}
+
+func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
+	spec := loadCLIContractPlatformSpecPathResolutionSpec(t)
+	if strings.TrimSpace(spec.PromotedBy) != "#844" {
+		t.Fatalf("contract path promoted_by = %q, want #844", spec.PromotedBy)
+	}
+	if strings.TrimSpace(spec.ImplementationStatus) != "implemented" {
+		t.Fatalf("contract path implementation_status = %q, want implemented", spec.ImplementationStatus)
+	}
+	if !strings.Contains(spec.CanonicalOwner, "cli_specification.foundations.contract_platform_spec_path_resolution") {
+		t.Fatalf("canonical owner does not point at promoted section: %s", spec.CanonicalOwner)
+	}
+	for _, want := range []string{"swarm verify", "swarm serve", "local foreground `swarm run`"} {
+		if !stringSliceContains(spec.AppliesTo, want) {
+			t.Fatalf("applies_to missing %q: %#v", want, spec.AppliesTo)
+		}
+	}
+	for _, want := range []string{"swarm run --connect", "swarm run --reattach", "root/global `--config`"} {
+		if !stringSliceContains(spec.NotAppliesTo, want) {
+			t.Fatalf("not_applies_to missing %q: %#v", want, spec.NotAppliesTo)
+		}
+	}
+	wantContractsOrder := []string{"--contracts", "SWARM_CONTRACTS_PATH", "config contracts_path", "repo contracts/package.yaml"}
+	if len(spec.ContractsPath.SourceOrder) != len(wantContractsOrder) {
+		t.Fatalf("contracts source order = %#v, want %#v", spec.ContractsPath.SourceOrder, wantContractsOrder)
+	}
+	for i, want := range wantContractsOrder {
+		if spec.ContractsPath.SourceOrder[i] != want {
+			t.Fatalf("contracts source order[%d] = %q, want %q", i, spec.ContractsPath.SourceOrder[i], want)
+		}
+	}
+	if spec.ContractsPath.AcceptedSources.Flag != "--contracts <path>" {
+		t.Fatalf("contracts flag = %q", spec.ContractsPath.AcceptedSources.Flag)
+	}
+	if spec.ContractsPath.AcceptedSources.Environment != "SWARM_CONTRACTS_PATH" {
+		t.Fatalf("contracts env = %q", spec.ContractsPath.AcceptedSources.Environment)
+	}
+	if spec.ContractsPath.AcceptedSources.ConfigKey != "contracts_path" {
+		t.Fatalf("contracts config key = %q", spec.ContractsPath.AcceptedSources.ConfigKey)
+	}
+	if !strings.Contains(spec.ContractsPath.RejectedSources["SWARM_CONTRACTS_DIR"], "Not a CLI source") {
+		t.Fatalf("SWARM_CONTRACTS_DIR rejection missing CLI-source rule:\n%s", spec.ContractsPath.RejectedSources["SWARM_CONTRACTS_DIR"])
+	}
+	wantPlatformOrder := []string{"--platform-spec", "config platform_spec_path", "built-in tracked platform spec"}
+	if len(spec.PlatformSpecPath.SourceOrder) != len(wantPlatformOrder) {
+		t.Fatalf("platform source order = %#v, want %#v", spec.PlatformSpecPath.SourceOrder, wantPlatformOrder)
+	}
+	for i, want := range wantPlatformOrder {
+		if spec.PlatformSpecPath.SourceOrder[i] != want {
+			t.Fatalf("platform source order[%d] = %q, want %q", i, spec.PlatformSpecPath.SourceOrder[i], want)
+		}
+	}
+	if spec.PlatformSpecPath.AcceptedSources.Flag != "--platform-spec <path>" {
+		t.Fatalf("platform flag = %q", spec.PlatformSpecPath.AcceptedSources.Flag)
+	}
+	if spec.PlatformSpecPath.AcceptedSources.ConfigKey != "platform_spec_path" {
+		t.Fatalf("platform config key = %q", spec.PlatformSpecPath.AcceptedSources.ConfigKey)
+	}
+	if spec.PlatformSpecPath.AcceptedSources.BuiltInDefault != defaultPlatformSpecPath {
+		t.Fatalf("platform default = %q, want %q", spec.PlatformSpecPath.AcceptedSources.BuiltInDefault, defaultPlatformSpecPath)
+	}
+	if !strings.Contains(spec.PlatformSpecPath.RejectedSources["SWARM_PLATFORM_SPEC_PATH"], "Not promoted") {
+		t.Fatalf("SWARM_PLATFORM_SPEC_PATH rejection missing not-promoted rule:\n%s", spec.PlatformSpecPath.RejectedSources["SWARM_PLATFORM_SPEC_PATH"])
+	}
+	for _, want := range []string{"verify", "serve", "local foreground run", "API auth/config", "connected run"} {
 		if !stringSliceContains(spec.ImplementationBoundaries, want) {
 			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
 		}
@@ -3517,10 +3592,11 @@ type cliAPIConnectionAuthConfigSpec struct {
 		TokenFileRule   string            `yaml:"token_file_rule"`
 	} `yaml:"api_token"`
 	CLIConfigFile struct {
-		AcceptedSources map[string]string `yaml:"accepted_sources"`
-		RejectedSources map[string]string `yaml:"rejected_sources"`
-		AcceptedKeys    map[string]string `yaml:"accepted_keys"`
-		RejectedKeys    map[string]string `yaml:"rejected_keys"`
+		AcceptedSources  map[string]string `yaml:"accepted_sources"`
+		RejectedSources  map[string]string `yaml:"rejected_sources"`
+		AcceptedKeys     map[string]string `yaml:"accepted_keys"`
+		SharedNonAPIKeys map[string]string `yaml:"shared_non_api_keys"`
+		RejectedKeys     map[string]string `yaml:"rejected_keys"`
 	} `yaml:"cli_config_file"`
 	ServeListenerEnvConfigBoundary struct {
 		RejectedPorts      map[string]string `yaml:"rejected_ports"`
@@ -3528,6 +3604,36 @@ type cliAPIConnectionAuthConfigSpec struct {
 		Rule               string            `yaml:"rule"`
 	} `yaml:"serve_listener_env_config_boundary"`
 	SplitSiblings            []string `yaml:"split_siblings"`
+	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
+}
+
+type cliContractPlatformSpecPathResolutionSpec struct {
+	PromotedBy           string   `yaml:"promoted_by"`
+	ImplementationStatus string   `yaml:"implementation_status"`
+	CanonicalOwner       string   `yaml:"canonical_owner"`
+	Scope                string   `yaml:"scope"`
+	AppliesTo            []string `yaml:"applies_to"`
+	NotAppliesTo         []string `yaml:"not_applies_to"`
+	ContractsPath        struct {
+		AcceptedSources struct {
+			Flag              string `yaml:"flag"`
+			Environment       string `yaml:"environment"`
+			ConfigKey         string `yaml:"config_key"`
+			DiscoveredDefault string `yaml:"discovered_default"`
+		} `yaml:"accepted_sources"`
+		SourceOrder     []string          `yaml:"source_order"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+		MissingSource   string            `yaml:"missing_source_rule"`
+	} `yaml:"contracts_path"`
+	PlatformSpecPath struct {
+		AcceptedSources struct {
+			Flag           string `yaml:"flag"`
+			ConfigKey      string `yaml:"config_key"`
+			BuiltInDefault string `yaml:"built_in_default"`
+		} `yaml:"accepted_sources"`
+		SourceOrder     []string          `yaml:"source_order"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+	} `yaml:"platform_spec_path"`
 	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
 }
 
@@ -3640,6 +3746,28 @@ func loadCLIAPIConnectionAuthConfigSpec(t *testing.T) cliAPIConnectionAuthConfig
 		t.Fatal("platform spec missing api_connection_auth_config_precedence")
 	}
 	return spec.CLISpecification.Foundations.APIConnectionAuthConfig
+}
+
+func loadCLIContractPlatformSpecPathResolutionSpec(t *testing.T) cliContractPlatformSpecPathResolutionSpec {
+	t.Helper()
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				ContractPlatformSpecPathResolution cliContractPlatformSpecPathResolutionSpec `yaml:"contract_platform_spec_path_resolution"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	if strings.TrimSpace(spec.CLISpecification.Foundations.ContractPlatformSpecPathResolution.CanonicalOwner) == "" {
+		t.Fatal("platform spec missing contract_platform_spec_path_resolution")
+	}
+	return spec.CLISpecification.Foundations.ContractPlatformSpecPathResolution
 }
 
 func stringSliceContains(values []string, want string) bool {

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -95,7 +95,7 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.reattachRunID, "reattach", "", "Existing run id to reattach to")
 	cmd.Flags().StringVar(&opts.bundleFingerprint, "bundle-fingerprint", "", "Expected server bundle fingerprint")
 	cmd.Flags().StringVar(&opts.contractsPath, "contracts", "", "Path to Swarm contract bundle root for local foreground startup")
-	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml for local foreground startup")
+	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", "", "Path to platform spec yaml for local foreground startup")
 	cmd.Flags().StringVar(&opts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for run.start")
 	cmd.Flags().StringVar(&opts.runID, "run-id", "", "Optional caller-provided run id for run.start")
 	cmd.Flags().IntVar(&opts.apiPort, "api-port", 0, "Local API/health port for local foreground startup")
@@ -312,9 +312,16 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	if runServe == nil {
 		runServe = runServeRuntime
 	}
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.contractsPath,
+		PlatformSpecPath: opts.platformSpecPath,
+	})
+	if err != nil {
+		return nil, err
+	}
 	serveOpts := defaultServeOptions()
-	serveOpts.ContractsPath = opts.contractsPath
-	serveOpts.PlatformSpecPath = opts.platformSpecPath
+	serveOpts.ContractsPath = resolvedPaths.ContractsPath
+	serveOpts.PlatformSpecPath = resolvedPaths.PlatformSpecPath
 	if opts.apiPort > 0 {
 		serveOpts.HealthAddr = ":" + strconv.Itoa(opts.apiPort)
 	}

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -50,9 +51,10 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	var serveCalled atomic.Int32
 	serveCanceled := make(chan struct{})
 	opts := testRunCommandOptions(server)
+	repo := t.TempDir()
 	opts.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
 		serveCalled.Add(1)
-		if serveOpts.ContractsPath != "contracts" || serveOpts.PlatformSpecPath != "platform.yaml" {
+		if serveOpts.ContractsPath != filepath.Join(repo, "contracts") || serveOpts.PlatformSpecPath != filepath.Join(repo, "platform.yaml") {
 			t.Errorf("serve opts = %#v", serveOpts)
 		}
 		<-ctx.Done()
@@ -61,7 +63,7 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--contracts", "contracts", "--platform-spec", "platform.yaml"}, &stdout, &stderr, opts)
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--contracts", "contracts", "--platform-spec", "platform.yaml"}, &stdout, &stderr, opts)
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -82,6 +84,48 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	repo := t.TempDir()
+	configContracts := filepath.Join(t.TempDir(), "config-contracts")
+	configPlatform := filepath.Join(t.TempDir(), "config-platform.yaml")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"contracts_path":     configContracts,
+		"platform_spec_path": configPlatform,
+	}))
+	server, _, _ := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			if req.Method != "health.check" {
+				t.Fatalf("unexpected method = %q", req.Method)
+			}
+			return runCommandHealthResult()
+		},
+	})
+	defer server.Close()
+
+	opts := runCommandOptions{apiOptions: testRunCommandOptions(server)}
+	serveStarted := make(chan serveOptions, 1)
+	opts.apiOptions.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
+		serveStarted <- serveOpts
+		<-ctx.Done()
+		return 0
+	}
+
+	stop, err := startLocalRunServe(context.Background(), repo, opts)
+	if err != nil {
+		t.Fatalf("startLocalRunServe: %v", err)
+	}
+	stop()
+	serveOpts := <-serveStarted
+	if serveOpts.ContractsPath != configContracts {
+		t.Fatalf("contracts path = %q, want %q", serveOpts.ContractsPath, configContracts)
+	}
+	if serveOpts.PlatformSpecPath != configPlatform {
+		t.Fatalf("platform spec path = %q, want %q", serveOpts.PlatformSpecPath, configPlatform)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5911,7 +5911,8 @@ cli_specification:
         action: >
           API connection/auth/config authority is promoted in
           cli_specification.foundations.api_connection_auth_config_precedence. Diagnostic logging authority is
-          promoted in cli_specification.foundations.cli_logging_policy. Retry, contract-path, output-renderer
+          promoted in cli_specification.foundations.cli_logging_policy. Contract/platform-spec path resolution is
+          promoted in cli_specification.foundations.contract_platform_spec_path_resolution. Retry, output-renderer
           implementation tails, and serve listener environment/config behavior remain split until later children
           promote their own merge-bearing owners.
       exit_code_and_error_channel_normalization:
@@ -6545,8 +6546,9 @@ cli_specification:
       - '`swarm run --connect` only for shared API client/auth error categories; run mode and follow semantics remain #743.'
       not_applies_to:
       - '`swarm serve` runtime configuration such as the existing command-local `--config` runtime-config path.'
-      - '`swarm verify` contract-file validation, except for future separately promoted contract-path defaults.'
-      - Output mode, logging verbosity, retry, color, contract path, and platform-spec path resolution.
+      - '`swarm verify` contract-file validation, except for contract/platform-spec path resolution governed by
+        cli_specification.foundations.contract_platform_spec_path_resolution.'
+      - Output mode, logging verbosity, retry, and color.
       precedence_order:
       - flag
       - environment
@@ -6602,14 +6604,21 @@ cli_specification:
         accepted_keys:
           api_server: API server base URL consumed by API-backed commands.
           api_token_file: Path to a file containing the bearer token.
+        shared_non_api_keys:
+          contracts_path: >
+            Accepted by the shared CLI config parser for
+            cli_specification.foundations.contract_platform_spec_path_resolution; ignored by the API connection
+            and auth resolver.
+          platform_spec_path: >
+            Accepted by the shared CLI config parser for
+            cli_specification.foundations.contract_platform_spec_path_resolution; ignored by the API connection
+            and auth resolver.
         rejected_keys:
           api_token: Inline bearer tokens in config files are not promoted.
           output_format: Split to #848 output renderer implementation.
           no_color: >
             Not promoted as a config-file key by #931. #931 accepts only `--no-color` and non-empty `NO_COLOR`
             through the shared output owner for current first-slice consumers.
-          contracts_path: Split to contract-path resolution.
-          platform_spec_path: Split to contract-path resolution.
           log_level: >
             Not promoted as a config-file key by #936. `--log-level` flag authority is promoted in
             cli_specification.foundations.cli_logging_policy, but config-file `log_level` precedence remains a
@@ -6634,12 +6643,87 @@ cli_specification:
       - '#844 later behavior child for API config/auth resolver implementation'
       - '#884/#750 serve listener runtime implementation and listener env/config keys'
       - '#743 swarm run behavior and follow semantics'
-      - 'contract path/platform spec path defaults'
       - '`--no-retry` retry policy'
       implementation_boundaries:
       - 'API-backed command leaves consume one cmd/swarm resolver for this owner.'
       - 'No root/global --config, inline --api-token, OpenRPC, output renderer, retry, or listener behavior changes are implied by this owner.'
       - 'Future API-backed CLI commands MUST consume this owner rather than the ignored review artifact.'
+    contract_platform_spec_path_resolution:
+      promoted_by: '#844'
+      implementation_status: implemented
+      canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution
+      scope: >
+        Merge-bearing CLI v2 authority for selecting the local workflow contract bundle path and the platform
+        spec YAML path. This owner covers the currently implemented local file-contract surfaces only: `swarm
+        verify`, `swarm serve`, and local foreground `swarm run` before it starts the serve owner. It does not add
+        API connection behavior, OpenRPC methods, root/global config flags, serve listener binding, retry/follow
+        policy, output rendering, or absent command families.
+      applies_to:
+      - '`swarm verify` local contract-file validation.'
+      - '`swarm serve` runtime boot bundle loading.'
+      - 'local foreground `swarm run` as a consumer of serve startup.'
+      not_applies_to:
+      - '`swarm run --connect` because connected run consumes an existing server and MUST NOT accept local
+        contract/platform-spec path overrides.'
+      - '`swarm run --reattach` because reattach consumes existing run/server state and MUST NOT accept local
+        contract/platform-spec path overrides.'
+      - 'root/global `--config`; the shared CLI config file remains discovered through `SWARM_CONFIG` or XDG only.'
+      - 'inline `--api-token`, API auth/config resolver behavior, output/color/logging, retry/follow, and serve
+        listener/runtime binding.'
+      contracts_path:
+        accepted_sources:
+          flag: --contracts <path>
+          environment: SWARM_CONTRACTS_PATH
+          config_key: contracts_path
+          discovered_default: repo-local contracts/package.yaml when present
+        source_order:
+        - --contracts
+        - SWARM_CONTRACTS_PATH
+        - config contracts_path
+        - repo contracts/package.yaml
+        rejected_sources:
+          SWARM_CONTRACTS_DIR: >
+            Not a CLI source. This legacy internal runtime contracts helper environment name MUST NOT compete with
+            the promoted CLI resolver. If it remains for non-CLI internals, supported CLI surfaces must bypass it.
+        missing_source_rule: >
+          If no source yields a contracts root and repo discovery does not find `contracts/package.yaml`, the
+          command fails closed during local contract resolution with the promoted missing-contracts-source error.
+          There is no implicit contracts root default without a discovered package file.
+      platform_spec_path:
+        accepted_sources:
+          flag: --platform-spec <path>
+          config_key: platform_spec_path
+          built_in_default: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+        source_order:
+        - --platform-spec
+        - config platform_spec_path
+        - built-in tracked platform spec
+        rejected_sources:
+          SWARM_PLATFORM_SPEC_PATH: >
+            Not promoted. Platform spec path selection is intentionally flag/config/default only; adding an env
+            source would create untracked source precedence and must be separately gated.
+        default_rule: >
+          The built-in default is the tracked platform spec path relative to the current repo root. Relative
+          explicit/config values are resolved against the repo root; absolute values are preserved.
+      cli_config_file:
+        shared_parser: >
+          `SWARM_CONFIG` and the XDG default config path are shared with
+          cli_specification.foundations.api_connection_auth_config_precedence. The parser accepts this owner's
+          path keys plus API connection/auth keys, while each semantic resolver consumes only its own keys.
+        accepted_keys:
+          contracts_path: Consumed only by this contract path resolver.
+          platform_spec_path: Consumed only by this platform spec path resolver.
+        rejected_keys:
+          SWARM_CONTRACTS_DIR: Environment variable, not config-file key, and not a CLI source.
+          SWARM_PLATFORM_SPEC_PATH: Environment variable, not config-file key, and not promoted.
+      implementation_boundaries:
+      - 'verify consumes this resolver before local contract bundle loading.'
+      - 'serve consumes this resolver before runtime boot bundle loading.'
+      - 'local foreground run consumes this resolver before starting the serve owner.'
+      - 'connected run and run --reattach reject local contract/platform-spec path flags and do not consume this owner.'
+      - 'The API auth/config resolver may share config parsing but must ignore contracts_path and platform_spec_path.'
+      - 'Unsupported config keys still fail closed; accepting this owner’s path keys must not silently accept output, logging, retry, serve listener, or inline token keys.'
+      - 'SWARM_CONTRACTS_DIR may remain only for non-CLI internals and must not affect supported CLI surfaces.'
     error_channel_and_exit_code_contract:
       implemented_by: '#846'
       scope: >


### PR DESCRIPTION
Part of #844

## Governing refs
- Approved pre-audit: https://github.com/yazzaoui/Swarm/issues/844#issuecomment-4523639479
- Gate outcome: https://github.com/yazzaoui/Swarm/issues/844#issuecomment-4523661472
- Merge-bearing authority added here: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- Adjacent retained authority: `cli_specification.foundations.api_connection_auth_config_precedence`

## Scope
- Promotes and implements contract/platform-spec path resolution for the approved surfaces: `swarm verify`, `swarm serve`, and local foreground `swarm run`.
- Contracts path precedence: `--contracts` > `SWARM_CONTRACTS_PATH` > config `contracts_path` > discovered repo `contracts/package.yaml`.
- Platform spec path precedence: `--platform-spec` > config `platform_spec_path` > built-in tracked platform spec path.
- `SWARM_CONTRACTS_DIR` remains non-authoritative for supported CLI surfaces; if retained, it is internal runtime-contract helper behavior only.

## Semantic migration
- New canonical owner: `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution` plus `cmd/swarm` shared resolver.
- Old producer/reader path invalidated for CLI: `runtimecontracts.DefaultWorkflowContractsDir` / `SWARM_CONTRACTS_DIR` is no longer consumed by supported CLI path resolution.
- Shared config parser now accepts `contracts_path` and `platform_spec_path`, while API auth/config resolution still ignores those keys and continues rejecting unsupported keys.
- Migration complete for the chosen first-slice class: `verify`, `serve`, and local foreground `run` consume the shared resolver; connected `run` and `run --reattach` remain rejected/out of scope.

## Proof
- `go test ./cmd/swarm -run 'TestResolveCLIContractPlatformSpecPaths|TestCLIContractPathResolution|TestRunVerifyCommandConsumesContractPathResolver|TestRunServeRuntimeConsumesContractPathResolver|TestStartLocalRunServeConsumesContractPathConfigResolver|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestRunCommandValidationAndAuthNoCallPaths|TestCLIAPIResolverToleratesContractPathConfigKeys|TestCLIAPISettingsFailClosed|TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted|TestPlatformSpecContractPlatformSpecPathResolutionPromoted' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `git diff --check`