### PR TITLE
[agent-b][issue #855] Add snapshot trace typed filters

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -30,15 +30,20 @@ type diagnosticRunListOptions struct {
 }
 
 type diagnosticTraceOptions struct {
-	apiOptions rootCommandOptions
-	follow     bool
-	noRetry    bool
-	since      string
-	limit      int
-	cursor     string
-	sinceSet   bool
-	limitSet   bool
-	cursorSet  bool
+	apiOptions       rootCommandOptions
+	follow           bool
+	noRetry          bool
+	since            string
+	limit            int
+	cursor           string
+	eventNames       []string
+	entityIDs        []string
+	deliveryStatuses []string
+	subscriberIDs    []string
+	subscriberTypes  []string
+	sinceSet         bool
+	limitSet         bool
+	cursorSet        bool
 }
 
 type diagnosticRunOptions struct {
@@ -228,6 +233,11 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
 	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
+	cmd.Flags().StringArrayVar(&traceOpts.eventNames, "event-name", nil, "Snapshot-only event name filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.entityIDs, "entity-id", nil, "Snapshot-only entity id filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.deliveryStatuses, "delivery-status", nil, "Snapshot-only delivery status filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.subscriberIDs, "subscriber-id", nil, "Snapshot-only subscriber id filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.subscriberTypes, "subscriber-type", nil, "Snapshot-only subscriber type filter: node or agent; repeat to match any")
 	bindCLIAPIConnectionFlags(cmd, &traceOpts.apiOptions)
 	return cmd
 }
@@ -457,6 +467,11 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 			{name: "--since", set: o.sinceSet},
 			{name: "--limit", set: o.limitSet},
 			{name: "--cursor", set: o.cursorSet},
+			{name: "--event-name", set: len(o.eventNames) > 0},
+			{name: "--entity-id", set: len(o.entityIDs) > 0},
+			{name: "--delivery-status", set: len(o.deliveryStatuses) > 0},
+			{name: "--subscriber-id", set: len(o.subscriberIDs) > 0},
+			{name: "--subscriber-type", set: len(o.subscriberTypes) > 0},
 		} {
 			if flag.set {
 				return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
@@ -488,7 +503,104 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 		}
 		params["since"] = since
 	}
+	filter, err := o.snapshotFilter()
+	if err != nil {
+		return nil, err
+	}
+	if len(filter) > 0 {
+		params["filter"] = filter
+	}
 	return params, nil
+}
+
+func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
+	filter := map[string]any{}
+	addStringList := func(name, flag string, values []string) error {
+		values, err := snapshotTraceStringList(flag, values)
+		if err != nil {
+			return err
+		}
+		if len(values) > 0 {
+			filter[name] = values
+		}
+		return nil
+	}
+	if err := addStringList("event_name", "--event-name", o.eventNames); err != nil {
+		return nil, err
+	}
+	entityIDs, err := snapshotTraceStringList("--entity-id", o.entityIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, entityID := range entityIDs {
+		if err := validateEntityOpaqueIDArg("--entity-id", entityID); err != nil {
+			return nil, err
+		}
+	}
+	if len(entityIDs) > 0 {
+		filter["entity_id"] = entityIDs
+	}
+	deliveryStatuses, err := snapshotTraceEnumList("--delivery-status", o.deliveryStatuses, eventObservationValidDeliveryStatuses, "pending, in_progress, delivered, failed, dead_letter")
+	if err != nil {
+		return nil, err
+	}
+	if len(deliveryStatuses) > 0 {
+		filter["delivery_status"] = deliveryStatuses
+	}
+	if err := addStringList("subscriber_id", "--subscriber-id", o.subscriberIDs); err != nil {
+		return nil, err
+	}
+	subscriberTypes, err := snapshotTraceEnumList("--subscriber-type", o.subscriberTypes, eventObservationValidSubscriberTypes, "node, agent")
+	if err != nil {
+		return nil, err
+	}
+	if len(subscriberTypes) > 0 {
+		filter["subscriber_type"] = subscriberTypes
+	}
+	return filter, nil
+}
+
+func snapshotTraceStringList(flag string, values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("%s must not be empty", flag)
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func snapshotTraceEnumList(flag string, values []string, valid map[string]struct{}, allowed string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			return nil, fmt.Errorf("%s must not be empty", flag)
+		}
+		if _, ok := valid[normalized]; !ok {
+			return nil, fmt.Errorf("%s must be one of %s", flag, allowed)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out, nil
 }
 
 func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string, opts diagnosticTraceOptions) error {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -362,6 +362,13 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 			"limit":  float64(2),
 			"cursor": "trace-cur",
 			"since":  "2026-05-13T10:00:00Z",
+			"filter": map[string]any{
+				"event_name":      []any{"scan.requested", "scan.completed"},
+				"entity_id":       []any{"entity-1", "entity-2"},
+				"delivery_status": []any{"delivered", "failed"},
+				"subscriber_id":   []any{"agent-1", "node-2"},
+				"subscriber_type": []any{"agent", "node"},
+			},
 		}
 		if !reflect.DeepEqual(req.Params, wantParams) {
 			t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
@@ -383,7 +390,22 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-1", "--limit", "2", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"trace", "run-1",
+		"--limit", "2",
+		"--cursor", "trace-cur",
+		"--since", "2026-05-13T10:00:00Z",
+		"--event-name", "scan.requested",
+		"--event-name", "scan.completed",
+		"--entity-id", "entity-1",
+		"--entity-id", "entity-2",
+		"--delivery-status", "delivered",
+		"--delivery-status", "FAILED",
+		"--subscriber-id", "agent-1",
+		"--subscriber-id", "node-2",
+		"--subscriber-type", "agent",
+		"--subscriber-type", "NODE",
+	}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -422,6 +444,7 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 				"limit":  float64(3),
 				"cursor": "trace-cur",
 				"since":  "2026-05-13T10:00:00Z",
+				"filter": map[string]any{"event_name": []any{"scan.requested"}},
 			}
 			if !reflect.DeepEqual(req.Params, wantParams) {
 				t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, wantParams)
@@ -439,7 +462,7 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--limit", "3", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--limit", "3", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z", "--event-name", "scan.requested"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -924,8 +947,17 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace follow rejects typed filters", args: []string{"trace", "run-1", "--follow", "--event-name", "scan.requested"}, wantStderr: "--event-name is not supported with --follow"},
+		{name: "trace follow rejects entity filter", args: []string{"trace", "run-1", "--follow", "--entity-id", "entity-1"}, wantStderr: "--entity-id is not supported with --follow"},
+		{name: "trace follow rejects delivery status filter", args: []string{"trace", "run-1", "--follow", "--delivery-status", "delivered"}, wantStderr: "--delivery-status is not supported with --follow"},
+		{name: "trace follow rejects subscriber id filter", args: []string{"trace", "run-1", "--follow", "--subscriber-id", "agent-1"}, wantStderr: "--subscriber-id is not supported with --follow"},
+		{name: "trace follow rejects subscriber type filter", args: []string{"trace", "run-1", "--follow", "--subscriber-type", "agent"}, wantStderr: "--subscriber-type is not supported with --follow"},
 		{name: "trace follow direct replay since remains unpromoted", args: []string{"trace", "run-1", "--follow", "--replay-since", "2026-05-13T10:00:00Z"}, wantStderr: "unknown flag"},
-		{name: "trace richer filter still unpromoted", args: []string{"trace", "run-1", "--event-name", "scan.requested"}, wantStderr: "unknown flag"},
+		{name: "trace blank event name", args: []string{"trace", "run-1", "--event-name", " "}, wantStderr: "--event-name must not be empty"},
+		{name: "trace blank subscriber id", args: []string{"trace", "run-1", "--subscriber-id", " "}, wantStderr: "--subscriber-id must not be empty"},
+		{name: "trace invalid entity id", args: []string{"trace", "run-1", "--entity-id", "bad id!"}, wantStderr: "--entity-id must match OpaqueId pattern"},
+		{name: "trace invalid delivery status", args: []string{"trace", "run-1", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
+		{name: "trace invalid subscriber type", args: []string{"trace", "run-1", "--subscriber-type", "platform"}, wantStderr: "--subscriber-type must be one of"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -953,6 +985,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"runs"},
 		{"trace", "run-1"},
 		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z"},
+		{"trace", "run-1", "--event-name", "scan.requested", "--entity-id", "entity-1", "--delivery-status", "delivered", "--subscriber-id", "agent-1", "--subscriber-type", "agent"},
 		{"trace", "run-1", "--follow"},
 		{"trace", "run-1", "-f"},
 		{"trace", "run-1", "--follow", "--no-retry"},

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -4643,6 +4643,14 @@
           "schema": {
             "$ref": "#/components/schemas/Timestamp"
           }
+        },
+        {
+          "name": "filter",
+          "required": false,
+          "description": "Snapshot-only typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",
+          "schema": {
+            "$ref": "#/components/schemas/RunTraceFilter"
+          }
         }
       ],
       "result": {
@@ -6919,6 +6927,55 @@
           "forked"
         ],
         "type": "string"
+      },
+      "RunTraceFilter": {
+        "additionalProperties": false,
+        "description": "Snapshot-only typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace only. /v1/ws run.subscribe_trace does not accept it until a separate follow-filter contract is promoted.",
+        "properties": {
+          "delivery_status": {
+            "items": {
+              "$ref": "#/components/schemas/DeliveryStatus"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "entity_id": {
+            "items": {
+              "$ref": "#/components/schemas/OpaqueId"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "event_name": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subscriber_id": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subscriber_type": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriberType"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
       },
       "RunTraceListResult": {
         "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5968,10 +5968,11 @@ cli_specification:
           used by the run-debug trace owner. Trace-specific `swarm trace --follow` subscription recovery and
           `--no-retry` are promoted in
           cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract by #928. Review-artifact
-          `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Review-artifact
-          `until`, event-name, subscriber, entity-id, delivery-status, `--include-payload`, shared `swarm run`
-          recovery, and multi-run `--all` remain explicitly unpromoted split tails until later gated children promote
-          their own canonical owners.
+          `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Snapshot-only typed
+          RunTraceFilter fields for event-name, subscriber identity, entity-id, and delivery-status are promoted on
+          `/v1/rpc run.trace` and consumed by `swarm trace`. Review-artifact `until`, follow-capable typed filters,
+          `--include-payload`, shared `swarm run` recovery, and multi-run `--all` remain explicitly unpromoted split
+          tails until later gated children promote their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: promoted_first_slice
         tracker: '#856'
@@ -7180,7 +7181,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--follow|-f] [--no-retry]
+      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow/-f
@@ -7194,18 +7195,28 @@ cli_specification:
         - limit
         - cursor
         - since
+        - filter
+        filter_schema: RunTraceFilter
+        filter_fields:
+          event_name: Snapshot-only repeatable event-name predicate. The CLI sends an array of non-empty names as `filter.event_name` and the server matches any value against RunTraceRow.event_name.
+          entity_id: Snapshot-only repeatable entity-id predicate. The CLI sends an array of OpaqueId values as `filter.entity_id` and the server matches any value against RunTraceRow.entity_id.
+          delivery_status: Snapshot-only repeatable delivery-status predicate. The CLI sends an array of DeliveryStatus enum values as `filter.delivery_status` and the server matches any value against RunTraceRow.delivery_status.
+          subscriber_id: Snapshot-only repeatable subscriber identity predicate. The CLI sends an array of non-empty subscriber ids as `filter.subscriber_id` and the server matches any value against RunTraceRow.subscriber_id.
+          subscriber_type: Snapshot-only repeatable subscriber type predicate. The CLI sends an array of SubscriberType enum values as `filter.subscriber_type` and the server matches any value against RunTraceRow.subscriber_type.
         since_semantics: >
           `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
           materialization watermark is strictly after `since`, where that watermark is the greatest available
           timestamp across the joined event, delivery, session, and turn fields owned by RunTraceRow.
-        current_cli_consumer_status: implemented_by_918
+        current_cli_consumer_status: implemented_by_918_and_855
         cli_consumer_behavior: >
-          Snapshot `swarm trace` consumes `--since`, `--limit`, and `--cursor` by sending the exact promoted params
-          to `/v1/rpc run.trace`. These snapshot flags are invalid with `--follow` and must fail before any API or
+          Snapshot `swarm trace` consumes `--since`, `--limit`, `--cursor`, `--event-name`, `--entity-id`,
+          `--delivery-status`, `--subscriber-id`, and `--subscriber-type` by sending the exact promoted params to
+          `/v1/rpc run.trace`. These snapshot flags are invalid with `--follow`/`-f` and must fail before any API or
           WebSocket request; follow mode remains the base `/v1/ws run.subscribe_trace` consumer.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
-        - invalid --since, out-of-range --limit, blank --cursor, and --follow plus snapshot filters fail before API/WS calls
+        - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/limit/cursor
+        - invalid --since, out-of-range --limit, blank --cursor, blank/invalid typed filters, and --follow plus snapshot filters fail before API/WS calls
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:
@@ -7268,10 +7279,7 @@ cli_specification:
         - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
         split_tail:
           until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
-          event_name: Not promoted; event-name filtering requires a typed RunTraceFilter owner before CLI use.
-          subscriber: Not promoted; subscriber filtering requires a typed RunTraceFilter owner before CLI use.
-          entity_id: Not promoted; entity filtering requires a typed RunTraceFilter owner before CLI use.
-          delivery_status: Not promoted; delivery-status filtering requires a typed RunTraceFilter owner before CLI use.
+          follow_capable_typed_filters: Not promoted; /v1/ws run.subscribe_trace currently has no RunTraceFilter param and remains split because it has distinct recovery semantics and shared `swarm run` coupling.
           include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
           shared_run_follow_recovery: Not promoted; `swarm run` follow and reattach have distinct lifecycle semantics and remain split.
           all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
@@ -10056,6 +10064,43 @@ api_specification:
               $ref: '#/components/schemas/RunTraceRow'
           next_cursor:
             $ref: '#/components/schemas/Cursor'
+      RunTraceFilter:
+        description: Snapshot-only typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace only. /v1/ws run.subscribe_trace does not accept it until a separate follow-filter contract is promoted.
+        type: object
+        additionalProperties: false
+        properties:
+          event_name:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              type: string
+              minLength: 1
+          entity_id:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              $ref: '#/components/schemas/OpaqueId'
+          delivery_status:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              $ref: '#/components/schemas/DeliveryStatus'
+          subscriber_id:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              type: string
+              minLength: 1
+          subscriber_type:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              $ref: '#/components/schemas/SubscriberType'
       VerifyError:
         type: object
         additionalProperties: false
@@ -11023,6 +11068,11 @@ api_specification:
           materialization watermark is strictly after this timestamp.
         schema:
           $ref: '#/components/schemas/Timestamp'
+      - name: filter
+        required: false
+        description: Snapshot-only typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
+        schema:
+          $ref: '#/components/schemas/RunTraceFilter'
       result:
         name: result
         required: true

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 70 {
-		t.Fatalf("schema count = %d, want 70", report.SchemaCount)
+	if report.SchemaCount != 71 {
+		t.Fatalf("schema count = %d, want 71", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 70 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 70", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 71 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 71", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -15,7 +15,11 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 			"run-1": {{
 				EventID:        "evt-1",
 				EventName:      "scan.requested",
+				EntityID:       "entity-1",
 				EventCreatedAt: now,
+				SubscriberType: "agent",
+				SubscriberID:   "agent-1",
+				DeliveryStatus: "delivered",
 			}},
 		},
 		events: map[string]store.OperatorEventFull{
@@ -66,7 +70,7 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		}),
 	})
 
-	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1,"since":"2023-11-14T22:12:00Z"}}`)
+	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1,"since":"2023-11-14T22:12:00Z","filter":{"event_name":["scan.requested"],"entity_id":["entity-1"],"delivery_status":["delivered"],"subscriber_id":["agent-1"],"subscriber_type":["agent"]}}}`)
 	if trace.Error != nil {
 		t.Fatalf("run.trace error = %#v", trace.Error)
 	}
@@ -76,10 +80,17 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 	if observability.lastTrace.Since == nil || observability.lastTrace.Limit != 1 {
 		t.Fatalf("run.trace options = %#v", observability.lastTrace)
 	}
+	if got := observability.lastTrace.Filter; len(got.EventNames) != 1 || got.EventNames[0] != "scan.requested" || len(got.EntityIDs) != 1 || got.EntityIDs[0] != "entity-1" || len(got.DeliveryStatuses) != 1 || got.DeliveryStatuses[0] != "delivered" || len(got.SubscriberIDs) != 1 || got.SubscriberIDs[0] != "agent-1" || len(got.SubscriberTypes) != 1 || got.SubscriberTypes[0] != "agent" {
+		t.Fatalf("run.trace filter = %#v", got)
+	}
 
 	invalidTraceSince := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-since","method":"run.trace","params":{"run_id":"run-1","since":"not-a-time"}}`)
 	if invalidTraceSince.Error == nil || invalidTraceSince.Error.Code != codeInvalidParams {
 		t.Fatalf("run.trace invalid since error = %#v, want invalid params", invalidTraceSince.Error)
+	}
+	invalidTraceFilter := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-filter","method":"run.trace","params":{"run_id":"run-1","filter":{"delivery_status":["done"]}}}`)
+	if invalidTraceFilter.Error == nil || invalidTraceFilter.Error.Code != codeInvalidParams {
+		t.Fatalf("run.trace invalid filter error = %#v, want invalid params", invalidTraceFilter.Error)
 	}
 
 	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"filter":{"run_id":"run-1","event_name":"scan.requested","has_dead_letter":false},"limit":10}}`)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -637,7 +637,11 @@ func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHa
 			if err != nil {
 				return nil, err
 			}
-			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since})
+			filter, err := runTraceFilterParam(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since, Filter: filter})
 			if errors.Is(err, store.ErrRunNotFound) {
 				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 			}
@@ -901,6 +905,66 @@ func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter,
 	return out, nil
 }
 
+func runTraceFilterParam(params map[string]any) (store.RunDebugTraceFilter, error) {
+	raw, ok := params["filter"]
+	if !ok || isEmptyParam(raw) {
+		return store.RunDebugTraceFilter{}, nil
+	}
+	filter, ok := raw.(map[string]any)
+	if !ok {
+		return store.RunDebugTraceFilter{}, NewInvalidParamsError(map[string]any{"field": "filter", "reason": "must be an object"})
+	}
+	for name := range filter {
+		if _, ok := runTraceFilterFields[name]; !ok {
+			return store.RunDebugTraceFilter{}, NewInvalidParamsError(map[string]any{"field": "filter." + name, "reason": "unknown parameter"})
+		}
+	}
+	out := store.RunDebugTraceFilter{}
+	var err error
+	if out.EventNames, err = requiredRunTraceStringListFilter(filter, "event_name"); err != nil {
+		return store.RunDebugTraceFilter{}, err
+	}
+	if out.EntityIDs, err = requiredRunTraceStringListFilter(filter, "entity_id"); err != nil {
+		return store.RunDebugTraceFilter{}, err
+	}
+	for _, entityID := range out.EntityIDs {
+		if !opaqueIDPattern.MatchString(entityID) {
+			return store.RunDebugTraceFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.entity_id", "reason": "must contain only OpaqueId values"})
+		}
+	}
+	if out.DeliveryStatuses, err = requiredRunTraceStringListFilter(filter, "delivery_status"); err != nil {
+		return store.RunDebugTraceFilter{}, err
+	}
+	for _, status := range out.DeliveryStatuses {
+		if _, ok := eventListDeliveryStatuses[status]; !ok {
+			return store.RunDebugTraceFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.delivery_status", "reason": "must contain only valid DeliveryStatus values"})
+		}
+	}
+	if out.SubscriberIDs, err = requiredRunTraceStringListFilter(filter, "subscriber_id"); err != nil {
+		return store.RunDebugTraceFilter{}, err
+	}
+	if out.SubscriberTypes, err = requiredRunTraceStringListFilter(filter, "subscriber_type"); err != nil {
+		return store.RunDebugTraceFilter{}, err
+	}
+	for _, subscriberType := range out.SubscriberTypes {
+		if _, ok := eventListSubscriberTypes[subscriberType]; !ok {
+			return store.RunDebugTraceFilter{}, NewInvalidParamsError(map[string]any{"field": "filter.subscriber_type", "reason": "must contain only valid SubscriberType values"})
+		}
+	}
+	return out, nil
+}
+
+func requiredRunTraceStringListFilter(filter map[string]any, name string) ([]string, error) {
+	values, present, err := optionalStringListParam(filter, name)
+	if err != nil {
+		return nil, NewInvalidParamsError(map[string]any{"field": "filter." + name, "reason": "must be a non-empty array of strings"})
+	}
+	if present && len(values) == 0 {
+		return nil, NewInvalidParamsError(map[string]any{"field": "filter." + name, "reason": "must be a non-empty array of strings"})
+	}
+	return values, nil
+}
+
 var eventListFilterFields = map[string]struct{}{
 	"run_id":          {},
 	"entity_id":       {},
@@ -910,6 +974,14 @@ var eventListFilterFields = map[string]struct{}{
 	"subscriber_type": {},
 	"reason_code":     {},
 	"has_dead_letter": {},
+}
+
+var runTraceFilterFields = map[string]struct{}{
+	"event_name":      {},
+	"entity_id":       {},
+	"delivery_status": {},
+	"subscriber_id":   {},
+	"subscriber_type": {},
 }
 
 var eventListDeliveryStatuses = map[string]struct{}{

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -419,3 +419,79 @@ func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 		t.Fatalf("missing run error = %v, want ErrRunNotFound", err)
 	}
 }
+
+func TestRunDebugTracePageTypedFilters(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	entityOne := uuid.NewString()
+	entityTwo := uuid.NewString()
+	firstEvent := uuid.NewString()
+	secondEvent := uuid.NewString()
+	firstDelivery := uuid.NewString()
+	secondDelivery := uuid.NewString()
+	base := time.Unix(1700000400, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			($1::uuid, $2::uuid, 'first.event', $3::uuid, 'entity', '{}'::jsonb, 'runtime', 'platform', $4),
+			($5::uuid, $2::uuid, 'second.event', $6::uuid, 'entity', '{}'::jsonb, 'runtime', 'platform', $7)
+	`, firstEvent, runID, entityOne, base, secondEvent, entityTwo, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed trace events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at)
+		VALUES
+			($1::uuid, $2::uuid, $3::uuid, 'node', 'node-1', 'pending', '', $4),
+			($5::uuid, $2::uuid, $6::uuid, 'agent', 'agent-2', 'dead_letter', 'handler_error', $7)
+	`, firstDelivery, runID, firstEvent, base, secondDelivery, secondEvent, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed trace deliveries: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts RunDebugTraceQueryOptions
+		want string
+	}{
+		{
+			name: "event name multi-value",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{EventNames: []string{"missing.event", "second.event"}}},
+			want: secondEvent,
+		},
+		{
+			name: "entity id",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{EntityIDs: []string{entityOne}}},
+			want: firstEvent,
+		},
+		{
+			name: "delivery status",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{DeliveryStatuses: []string{"dead_letter"}}},
+			want: secondEvent,
+		},
+		{
+			name: "subscriber identity",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{SubscriberIDs: []string{"agent-2"}, SubscriberTypes: []string{"agent"}}},
+			want: secondEvent,
+		},
+		{
+			name: "and composition",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{EventNames: []string{"first.event", "second.event"}, EntityIDs: []string{entityTwo}, DeliveryStatuses: []string{"dead_letter"}, SubscriberIDs: []string{"agent-2"}, SubscriberTypes: []string{"agent"}}},
+			want: secondEvent,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, _, err := pg.LoadRunDebugTracePage(ctx, runID, tc.opts)
+			if err != nil {
+				t.Fatalf("LoadRunDebugTracePage: %v", err)
+			}
+			if len(rows) != 1 || rows[0].EventID != tc.want {
+				t.Fatalf("trace rows = %#v, want only %s", rows, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -131,6 +131,15 @@ type RunDebugTraceQueryOptions struct {
 	Limit  int
 	Cursor string
 	Since  *time.Time
+	Filter RunDebugTraceFilter
+}
+
+type RunDebugTraceFilter struct {
+	EventNames       []string
+	EntityIDs        []string
+	DeliveryStatuses []string
+	SubscriberIDs    []string
+	SubscriberTypes  []string
 }
 
 type RunDebugTraceRow struct {
@@ -193,7 +202,32 @@ func defaultRunDebugTraceQueryOptions(opts RunDebugTraceQueryOptions) RunDebugTr
 	if opts.Limit > 2000 {
 		opts.Limit = 2000
 	}
+	opts.Filter.EventNames = normalizedUniqueStrings(opts.Filter.EventNames)
+	opts.Filter.EntityIDs = normalizedUniqueStrings(opts.Filter.EntityIDs)
+	opts.Filter.DeliveryStatuses = normalizedUniqueStrings(opts.Filter.DeliveryStatuses)
+	opts.Filter.SubscriberIDs = normalizedUniqueStrings(opts.Filter.SubscriberIDs)
+	opts.Filter.SubscriberTypes = normalizedUniqueStrings(opts.Filter.SubscriberTypes)
 	return opts
+}
+
+func normalizedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
@@ -654,15 +688,29 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
 		sinceWhere = fmt.Sprintf(`
-		  AND GREATEST(
-			e.created_at,
+			  AND GREATEST(
+				e.created_at,
 			COALESCE(d.created_at, '-infinity'::timestamptz),
 			COALESCE(d.started_at, '-infinity'::timestamptz),
 			COALESCE(d.delivered_at, '-infinity'::timestamptz),
 			COALESCE(sess.updated_at, '-infinity'::timestamptz),
-			COALESCE(t.created_at, '-infinity'::timestamptz)
-		  ) > $%d::timestamptz`, len(args))
+				COALESCE(t.created_at, '-infinity'::timestamptz)
+			  ) > $%d::timestamptz`, len(args))
 	}
+	filterWhere := ""
+	addTextArrayFilter := func(values []string, expression string) {
+		if len(values) == 0 {
+			return
+		}
+		args = append(args, pq.Array(values))
+		filterWhere += fmt.Sprintf(`
+			  AND %s = ANY($%d::text[])`, expression, len(args))
+	}
+	addTextArrayFilter(opts.Filter.EventNames, "e.event_name")
+	addTextArrayFilter(opts.Filter.EntityIDs, "e.entity_id::text")
+	addTextArrayFilter(opts.Filter.DeliveryStatuses, "d.status")
+	addTextArrayFilter(opts.Filter.SubscriberIDs, "d.subscriber_id")
+	addTextArrayFilter(opts.Filter.SubscriberTypes, "d.subscriber_type")
 	args = append(args, opts.Limit+1)
 	limitArg := len(args)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
@@ -722,18 +770,19 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 				sess.run_id = e.run_id
 				OR sess.run_id IS NULL
 		   )
-		WHERE e.run_id = $1::uuid
-		%s
-		%s
-		ORDER BY
-			e.created_at ASC,
-			e.event_id ASC,
+			WHERE e.run_id = $1::uuid
+			%s
+			%s
+			%s
+			ORDER BY
+				e.created_at ASC,
+				e.event_id ASC,
 			d.created_at ASC NULLS FIRST,
 			d.delivery_id ASC NULLS FIRST,
 			t.created_at ASC NULLS FIRST,
 			t.turn_id ASC NULLS FIRST
 		LIMIT $%d
-	`, sessionSources, cursorWhere, sinceWhere, limitArg), args...)
+		`, sessionSources, cursorWhere, sinceWhere, filterWhere, limitArg), args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("load run debug trace: %w", err)
 	}


### PR DESCRIPTION
Part of #855
Related to #735
Related to #794

## Summary
- Promotes snapshot-only typed `RunTraceFilter` ownership in `platform-spec.yaml` and regenerated OpenRPC for `/v1/rpc run.trace`.
- Adds repeatable `swarm trace` snapshot filters: `--event-name`, `--entity-id`, `--delivery-status`, `--subscriber-id`, and `--subscriber-type`.
- Wires the shared CLI API client, v1 `run.trace` handler validation, and store SQL predicates so filtering is server-side, not CLI post-filtering.
- Keeps typed filters invalid with `--follow`/`-f`; `/v1/ws run.subscribe_trace` remains split.

## Governing Refs / Context
- `platform-spec.yaml` `cli_specification.review_artifact_accounting.trace_filters_and_subscription_recovery`
- `platform-spec.yaml` `cli_specification.command_catalog.trace.promoted_trace_filter_contract`
- `platform-spec.yaml` `api_specification.components.schemas.RunTraceFilter`
- `platform-spec.yaml` `api_specification.method_catalog.run.trace`
- #855 pre-audit and the independent gate outcome approving snapshot-only typed `RunTraceFilter` as a first slice.

## Semantic Migration
- New canonical owner: authoritative `RunTraceFilter` schema in `platform-spec.yaml`, `/v1/rpc run.trace`, and `store.RunDebugTraceQueryOptions` / `LoadRunDebugTracePage`.
- Old non-authoritative paths now invalid: unknown/unowned local CLI filtering, scalar-only filter semantics, heuristic `--subscriber`, follow-mode typed filters, and CLI-side post-filtering.
- Production paths checked for surviving old behavior: `cmd/swarm trace`, `internal/apiv1` `run.trace`, `internal/store` trace query owner, generated OpenRPC, `/v1/ws run.subscribe_trace`, `swarm run`, event list/follow, and dashboard/runtime bypass references.
- Migration complete for the approved snapshot typed-filter slice only. #855 remains open for follow-capable typed filters, `until`, payload/output, multi-run `--all`, and shared `swarm run` follow recovery.

## Proof
- `go test ./cmd/swarm -run 'Trace|DiagnosticTrace|DiagnosticsRequireAPIToken|DiagnosticsRejectInvalidInput' -count=1`
- `go test ./internal/apiv1 -run 'RunTrace|OpenRPC|RegistryMethodNamesMatchGeneratedOpenRPC|WebSocketRunSubscribeTrace|OperatorObservability' -count=1`
- `go test ./internal/store -run 'RunDebugTrace|OperatorObservability.*Trace' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- Static no-bypass grep over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`
- `go test ./...`
