### PR TITLE
[agent-e][issue #859] Pass control idempotency keys

### DIFF
--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -149,6 +149,28 @@ func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
 	}
 }
 
+func TestControlNukeRejectsIdempotencyKeyBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", runtimeNukeTestResult(runtimeNukeStatusDone))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--idempotency-key", "idem-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+	if !strings.Contains(stderr.String(), "unknown flag: --idempotency-key") {
+		t.Fatalf("stderr = %q, want unknown flag", stderr.String())
+	}
+}
+
 func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -27,11 +27,13 @@ const (
 )
 
 type controlRunCommandOptions struct {
-	apiOptions rootCommandOptions
-	action     string
-	runMethod  string
-	allMethod  string
-	all        bool
+	apiOptions        rootCommandOptions
+	action            string
+	runMethod         string
+	allMethod         string
+	all               bool
+	idempotencyKey    string
+	idempotencyKeySet bool
 }
 
 type controlCommandOKResult struct {
@@ -77,10 +79,12 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runOpts := cmdOpts
+			runOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
 			return runControlRunCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, runOpts)
 		},
 	}
 	cmd.Flags().BoolVar(&cmdOpts.all, "all", false, "Apply the supported all-runs scope for this action")
+	cmd.Flags().StringVar(&cmdOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIAPIConnectionFlags(cmd, &cmdOpts.apiOptions)
 	return cmd
 }
@@ -98,6 +102,15 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 		fmt.Fprintln(errOut, err)
 		return commandExitError{code: controlCommandExitCodeValidation}
 	}
+	idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	if opts.all && opts.action == "stop" && idempotencyKey != "" {
+		fmt.Fprintln(errOut, "--idempotency-key is not supported with control stop --all")
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
 		fmt.Fprintln(errOut, err)
@@ -112,7 +125,7 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 			fmt.Fprintf(errOut, "unsupported all-runs control action %q\n", opts.action)
 			return commandExitError{code: controlCommandExitCodeRuntimeError}
 		}
-		if err := callControlOK(ctx, client, opts.allMethod, map[string]any{}); err != nil {
+		if err := callControlOK(ctx, client, opts.allMethod, controlRunParams("", idempotencyKey)); err != nil {
 			fmt.Fprintln(errOut, err)
 			return commandExitError{code: controlCommandErrorExitCode(err)}
 		}
@@ -120,7 +133,7 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 		return nil
 	}
 
-	if err := callControlOK(ctx, client, opts.runMethod, map[string]any{"run_id": runID}); err != nil {
+	if err := callControlOK(ctx, client, opts.runMethod, controlRunParams(runID, idempotencyKey)); err != nil {
 		fmt.Fprintln(errOut, err)
 		return commandExitError{code: controlCommandErrorExitCode(err)}
 	}
@@ -143,6 +156,17 @@ func validateControlRunTarget(args []string, all bool) (string, error) {
 		return "", fmt.Errorf("run id is required")
 	}
 	return runID, nil
+}
+
+func controlRunParams(runID, idempotencyKey string) map[string]any {
+	params := map[string]any{}
+	if runID != "" {
+		params["run_id"] = runID
+	}
+	if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params
 }
 
 func callControlOK(ctx context.Context, client *cliAPIClient, method string, params map[string]any) error {

--- a/cmd/swarm/control_run_test.go
+++ b/cmd/swarm/control_run_test.go
@@ -60,6 +60,39 @@ func TestControlRunSingleCommandsSendV1RPCRequests(t *testing.T) {
 	}
 }
 
+func TestControlRunSingleCommandsSendIdempotencyKeys(t *testing.T) {
+	for _, tc := range []struct {
+		action     string
+		wantMethod string
+	}{
+		{action: "pause", wantMethod: controlCommandRunPauseMethod},
+		{action: "continue", wantMethod: controlCommandRunContinueMethod},
+		{action: "stop", wantMethod: controlCommandRunStopMethod},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", tc.action, "run-1", "--idempotency-key", "idem-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			assertControlRequest(t, captured, tc.wantMethod, map[string]any{"run_id": "run-1", "idempotency_key": "idem-1"})
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
 func TestControlRunAllPauseContinueSendRuntimeRPCRequests(t *testing.T) {
 	for _, tc := range []struct {
 		action     string
@@ -94,6 +127,38 @@ func TestControlRunAllPauseContinueSendRuntimeRPCRequests(t *testing.T) {
 			if !strings.Contains(stdout.String(), tc.wantOutput) {
 				t.Fatalf("stdout = %q, want substring %q", stdout.String(), tc.wantOutput)
 			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestControlRunAllPauseContinueSendIdempotencyKeys(t *testing.T) {
+	for _, tc := range []struct {
+		action     string
+		wantMethod string
+	}{
+		{action: "pause", wantMethod: controlCommandRuntimePauseMethod},
+		{action: "continue", wantMethod: controlCommandRuntimeResumeMethod},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, map[string]any{"ok": true})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", tc.action, "--all", "--idempotency-key", "idem-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			assertControlRequest(t, captured, tc.wantMethod, map[string]any{"idempotency_key": "idem-1"})
 			if strings.TrimSpace(stderr.String()) != "" {
 				t.Fatalf("stderr = %q, want empty", stderr.String())
 			}
@@ -179,6 +244,12 @@ func TestControlRunRejectsInvalidTargetsBeforeRequest(t *testing.T) {
 		{name: "all with run id", args: []string{"control", "pause", "run-1", "--all"}, wantStderr: "--all cannot be combined with a run id"},
 		{name: "extra target", args: []string{"control", "continue", "run-1", "run-2"}, wantStderr: "accepts at most 1 arg"},
 		{name: "blank run id", args: []string{"control", "stop", "  "}, wantStderr: "run id is required"},
+		{name: "blank idempotency key pause run", args: []string{"control", "pause", "run-1", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "blank idempotency key pause all", args: []string{"control", "pause", "--all", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "blank idempotency key continue run", args: []string{"control", "continue", "run-1", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "blank idempotency key continue all", args: []string{"control", "continue", "--all", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "blank idempotency key stop run", args: []string{"control", "stop", "run-1", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "stop all rejects idempotency key", args: []string{"control", "stop", "--all", "--idempotency-key", "idem-1"}, wantStderr: "--idempotency-key is not supported with control stop --all"},
 		{name: "unsupported flag", args: []string{"control", "stop", "run-1", "--unknown"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5986,7 +5986,12 @@ cli_specification:
       control_idempotency_and_stop_all_confirmation:
         disposition: tracked_child
         tracker: '#859'
-        action: Promote idempotency-key and stop-all confirmation/non-TTY rules before implementation.
+        action: >
+          `swarm control pause|continue` and single-run `swarm control stop` idempotency-key pass-through are
+          promoted as the first #859 slice. `swarm control stop --all --idempotency-key` fails before any API
+          request because no per-target key derivation policy is promoted. `stop --all --yes` confirmation/non-TTY
+          behavior and `swarm control nuke --idempotency-key` remain split tails under #859 unless later gates
+          promote them.
       rich_agent_operator_ux:
         disposition: tracked_child
         tracker: '#860'
@@ -7464,7 +7469,7 @@ cli_specification:
       owner: /v1/rpc health.check
       behavior: Structured authenticated operator health; separate from lightweight /healthz and /readyz process probes.
     control_pause:
-      command: swarm control pause <run-id> | --all
+      command: swarm control pause <run-id> [--idempotency-key <key>] | --all [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented
       owners:
@@ -7473,6 +7478,8 @@ cli_specification:
       targeting:
         rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
         all_scope_semantics: '`--all` pauses runtime ingress through runtime.pause. It does not claim to pause every existing run-control state individually.'
+      idempotency:
+        rule: '`--idempotency-key <key>` is optional. When supplied, the CLI trims and passes the value as `idempotency_key` to the selected RPC owner; an explicitly blank key fails before any API request with exit 2. The CLI MUST NOT generate, persist, derive, hash, or locally interpret idempotency keys.'
       output:
         single_run_success: 'control pause ok: scope=run run_id=<run-id>'
         all_success: 'control pause ok: scope=runtime'
@@ -7484,12 +7491,13 @@ cli_specification:
         run_not_found: 5
         idempotency_conflict: 6
       proof_expectations:
-      - exact /v1/rpc run.pause call with run_id for single-run mode
-      - exact /v1/rpc runtime.pause call with empty params for --all
+      - exact /v1/rpc run.pause call with run_id and idempotency_key when supplied for single-run mode
+      - exact /v1/rpc runtime.pause call with idempotency_key when supplied and empty params when omitted for --all
+      - explicit blank --idempotency-key fails before any API request with exit 2
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_continue:
-      command: swarm control continue <run-id> | --all
+      command: swarm control continue <run-id> [--idempotency-key <key>] | --all [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented
       owners:
@@ -7498,6 +7506,8 @@ cli_specification:
       targeting:
         rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
         all_scope_semantics: '`--all` resumes runtime ingress through runtime.resume. It does not claim to continue every existing run-control state individually.'
+      idempotency:
+        rule: '`--idempotency-key <key>` is optional. When supplied, the CLI trims and passes the value as `idempotency_key` to the selected RPC owner; an explicitly blank key fails before any API request with exit 2. The CLI MUST NOT generate, persist, derive, hash, or locally interpret idempotency keys.'
       output:
         single_run_success: 'control continue ok: scope=run run_id=<run-id>'
         all_success: 'control continue ok: scope=runtime'
@@ -7509,12 +7519,13 @@ cli_specification:
         run_not_found: 5
         idempotency_conflict: 6
       proof_expectations:
-      - exact /v1/rpc run.continue call with run_id for single-run mode
-      - exact /v1/rpc runtime.resume call with empty params for --all
+      - exact /v1/rpc run.continue call with run_id and idempotency_key when supplied for single-run mode
+      - exact /v1/rpc runtime.resume call with idempotency_key when supplied and empty params when omitted for --all
+      - explicit blank --idempotency-key fails before any API request with exit 2
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_stop:
-      command: swarm control stop <run-id> | --all
+      command: swarm control stop <run-id> [--idempotency-key <key>] | --all
       tier: should_have
       implementation_status: implemented
       owners:
@@ -7522,12 +7533,15 @@ cli_specification:
         all_discovery: /v1/rpc run.list
         all_stop: /v1/rpc run.stop
       targeting:
-        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, or unsupported flags fails before any API request with exit 2.'
+        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, unsupported flags, explicitly blank idempotency keys, or --all with --idempotency-key fails before any API request with exit 2.'
         all_scope_semantics: >
           `--all` is an API-only CLI composite, not an atomic runtime-wide stop owner. The CLI lists active runs with status=running
           and status=paused, follows next_cursor pagination to exhaustion with limit=500, deduplicates run IDs, and calls run.stop once
           for each discovered target. It MUST NOT call runtime.nuke, introduce runtime.stop, inspect local DB/store/runtime state, or
           infer targets from logs/EventBus.
+      idempotency:
+        single_run: '`--idempotency-key <key>` is optional for `swarm control stop <run-id>`. When supplied, the CLI trims and passes the value as `idempotency_key` to run.stop; an explicitly blank key fails before any API request with exit 2.'
+        all_scope_split: '`swarm control stop --all --idempotency-key <key>` fails before any API request because no promoted per-target idempotency-key derivation policy exists. The CLI MUST NOT generate or derive keys for the composite stop-all flow.'
       output:
         single_run_success: 'control stop ok: scope=run run_id=<run-id>'
         all_success: 'control stop ok: scope=all matched=<n> stopped=<n> failed=0'
@@ -7542,9 +7556,10 @@ cli_specification:
         idempotency_conflict: 6
         stop_all_partial_failure: 3
       proof_expectations:
-      - exact /v1/rpc run.stop call with run_id for single-run mode
+      - exact /v1/rpc run.stop call with run_id and idempotency_key when supplied for single-run mode
       - exact /v1/rpc run.list status=running/status=paused paginated discovery for --all
       - exact /v1/rpc run.stop calls for unique discovered run IDs and explicit partial-failure reporting
+      - explicit blank --idempotency-key and --all with --idempotency-key fail before any API request with exit 2
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_nuke:


### PR DESCRIPTION
## Summary

- Add `--idempotency-key` pass-through for `swarm control pause`, `swarm control continue`, and single-run `swarm control stop`.
- Fail closed before any API request for explicit blank keys and for `swarm control stop --all --idempotency-key` because no per-target derivation policy is promoted.
- Update promoted `platform-spec.yaml` control command rows and the #859 reconciliation entry for this first slice.

Part of #859.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.review_artifact_reconciliation.under_promoted_review_features.control_idempotency_and_stop_all_confirmation`
  - `cli_specification.command_catalog.control_pause`
  - `cli_specification.command_catalog.control_continue`
  - `cli_specification.command_catalog.control_stop`
  - `api_specification.conventions.idempotency`
  - `api_specification.method_catalog.run.pause`, `run.continue`, `run.stop`, `runtime.pause`, `runtime.resume`
- Generated `openrpc.json` already declares optional `idempotency_key` for the touched RPC owners.
- #859 pre-audit and independent gate comment approved first slice `cli.control.run_state_idempotency_key_pass_through_drift`.

## Semantic Migration

- New canonical owner for accepted CLI behavior: promoted `platform-spec.yaml` control command rows consuming existing API/OpenRPC idempotency ownership.
- Old invalid producer/reader path: `cmd/swarm/control_run.go` treated control mutations as no-key request bodies and command rows expected empty params for runtime pause/resume.
- Production paths checked: `control_run.go`, `control_nuke.go`, `run` Ctrl-C `run.stop`, mailbox/event/agent mutation idempotency patterns, `internal/apispec`, `internal/apiv1`, and the compliance matrix.
- Migration complete for this approved first slice only. `stop --all --yes`, `control nuke --idempotency-key`, and runtime/API idempotency behavior remain split under #859.

## Tests

- `go test ./cmd/swarm -run 'TestControlRunSingleCommandsSendV1RPCRequests|TestControlRunSingleCommandsSendIdempotencyKeys|TestControlRunAllPauseContinueSendRuntimeRPCRequests|TestControlRunAllPauseContinueSendIdempotencyKeys|TestControlStopAllListsActiveRunsAndStopsUniqueTargets|TestControlRunRejectsInvalidTargetsBeforeRequest|TestControlNukeRejectsIdempotencyKeyBeforeRequest|TestControlNukeDryRunSendsV1RPCRequest|TestControlNukeYesAppliesThroughV1RPC|TestControlNukeConfirmationAndNoCallPaths|TestControlNukeMapsFailureExitCodes' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -run 'TestMutatingMethodsDeclareIdempotencyKey|TestValidateRejectsRequiredMutatingIdempotencyKey|TestOpenRPCMutatingHTTPRuntimeProbes|TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency|TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency|TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go build -o /tmp/swarm-issue-859 ./cmd/swarm`
- `go test ./...`