### PR TITLE
[agent-f][issue #963] Promote agent.diagnose last-tool outcome

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -14,7 +14,7 @@
   "methods": [
     {
       "name": "agent.diagnose",
-      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor,\nand active as selected active-session latest-turn refs. active is\nomitted when no active live session is selected or the selected session\nhas no latest turn. active.turn_id is required when active is present;\nactive.task_id and active.entity_id are omitted when empty or absent.\nactive.entity_id is the latest selected agent_turns.entity_id dispatch\nentity and must not fall back to the agent configured/effective entity,\ntask target entity, role-scoped current-entity tool context, dashboard\nprojection, conversation API response, or stale session evidence.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner and selected-turn active\nsub-owner. It must not join conversation, run, trace, token, CLI, or\ndashboard owners locally, and it must not expose the full runtime_state\nenum, top-level watchdog, run_id, bundle_version, actual in-flight\nactive work, configured/effective current entity, task target entity,\nrole-scoped current entity, last tool outcome, token usage, recent\nfailures, or dead letters.\n",
+      "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor,\nactive as selected active-session latest-turn refs, and\nlast_tool_outcome as compact selected active-session latest-turn\ncanonical tool-result evidence. active is omitted when no active live\nsession is selected or the selected session has no latest turn.\nactive.turn_id is required when active is present; active.task_id and\nactive.entity_id are omitted when empty or absent. active.entity_id is\nthe latest selected agent_turns.entity_id dispatch entity and must not\nfall back to the agent configured/effective entity, task target entity,\nrole-scoped current-entity tool context, dashboard projection,\nconversation API response, or stale session evidence.\nlast_tool_outcome is omitted when no active live session is selected,\nno latest turn exists, no canonical turn summary exists, or the\ncanonical summary has no tool result. last_tool_outcome.ok is the\nselected turn parse_ok value and is not a per-tool execution status;\nricher per-tool status, latency, completed_at, and error diagnostics\nremain split.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner, selected-turn active sub-owner,\nand selected-turn last_tool_outcome sub-owner. It must not locally join\nconversation, run, trace, token, CLI, or dashboard owners, and it must\nnot expose the full runtime_state\nenum, top-level watchdog, run_id, bundle_version, actual in-flight\nactive work, configured/effective current entity, task target entity,\nrole-scoped current entity, token usage, recent failures, or dead\nletters.\n",
       "params": [
         {
           "name": "agent_id",
@@ -5376,6 +5376,9 @@
           "delivery_lifecycle": {
             "$ref": "#/components/schemas/AgentDeliveryLifecycle"
           },
+          "last_tool_outcome": {
+            "$ref": "#/components/schemas/AgentDiagnosisLastToolOutcome"
+          },
           "last_turn_ref": {
             "$ref": "#/components/schemas/TurnRef"
           },
@@ -5413,6 +5416,38 @@
         },
         "required": [
           "turn_id"
+        ],
+        "type": "object"
+      },
+      "AgentDiagnosisLastToolOutcome": {
+        "additionalProperties": false,
+        "description": "Compact selected-turn last-tool evidence for agent.diagnose. This\nobject is present only when the diagnosis owner selects an active\nlive agent_sessions row for session/session_per_entity modes, that\nselected session has a latest agent_turns row, and that turn has a\ncanonical turn_summary.tool_results entry. turn_id is the same\nselected latest turn used by AgentDiagnosisActive. tool_name,\noptional tool_use_id, and optional result come from the last\ncanonical tool_results entry. ok is the selected latest\nagent_turns.parse_ok value; it is not a per-tool execution status.\nThe owner must omit last_tool_outcome when no selected active live\nsession, latest turn, canonical summary, or canonical tool result\nexists, and must fail closed on malformed canonical summary or tool\nresult data. It must not fall back to raw response_payload, raw\ntranscript text, dashboard projections, conversation API composition,\nruntime executor telemetry, event/dead-letter data, stale/inactive\nsessions, or richer per-tool status/latency/completion/error\ndiagnostics.\n",
+        "properties": {
+          "ok": {
+            "description": "Selected latest agent_turns.parse_ok; not a per-tool execution status.",
+            "type": "boolean"
+          },
+          "result": {
+            "additionalProperties": true,
+            "description": "Optional validated JSON object from the selected canonical tool_results entry.",
+            "type": "object"
+          },
+          "tool_name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "tool_use_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "turn_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        "required": [
+          "turn_id",
+          "tool_name",
+          "ok"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -9716,6 +9716,47 @@ api_specification:
             minLength: 1
           entity_id:
             $ref: '#/components/schemas/OpaqueId'
+      AgentDiagnosisLastToolOutcome:
+        type: object
+        additionalProperties: false
+        description: |
+          Compact selected-turn last-tool evidence for agent.diagnose. This
+          object is present only when the diagnosis owner selects an active
+          live agent_sessions row for session/session_per_entity modes, that
+          selected session has a latest agent_turns row, and that turn has a
+          canonical turn_summary.tool_results entry. turn_id is the same
+          selected latest turn used by AgentDiagnosisActive. tool_name,
+          optional tool_use_id, and optional result come from the last
+          canonical tool_results entry. ok is the selected latest
+          agent_turns.parse_ok value; it is not a per-tool execution status.
+          The owner must omit last_tool_outcome when no selected active live
+          session, latest turn, canonical summary, or canonical tool result
+          exists, and must fail closed on malformed canonical summary or tool
+          result data. It must not fall back to raw response_payload, raw
+          transcript text, dashboard projections, conversation API composition,
+          runtime executor telemetry, event/dead-letter data, stale/inactive
+          sessions, or richer per-tool status/latency/completion/error
+          diagnostics.
+        required:
+        - turn_id
+        - tool_name
+        - ok
+        properties:
+          turn_id:
+            $ref: '#/components/schemas/OpaqueId'
+          tool_name:
+            type: string
+            minLength: 1
+          tool_use_id:
+            type: string
+            minLength: 1
+          ok:
+            type: boolean
+            description: Selected latest agent_turns.parse_ok; not a per-tool execution status.
+          result:
+            type: object
+            additionalProperties: true
+            description: Optional validated JSON object from the selected canonical tool_results entry.
       AgentDiagnosis:
         type: object
         additionalProperties: false
@@ -9740,6 +9781,8 @@ api_specification:
             $ref: '#/components/schemas/AgentDiagnosisRuntimeState'
           active:
             $ref: '#/components/schemas/AgentDiagnosisActive'
+          last_tool_outcome:
+            $ref: '#/components/schemas/AgentDiagnosisLastToolOutcome'
       ConversationSummary:
         type: object
         additionalProperties: false
@@ -11597,14 +11640,22 @@ api_specification:
         pending-delivery queue summary/detail evidence, and optional delivery
         lifecycle evidence. It may also return runtime_state.watchdog as a
         narrow projection of the canonical active session watchdog descriptor,
-        and active as selected active-session latest-turn refs. active is
-        omitted when no active live session is selected or the selected session
-        has no latest turn. active.turn_id is required when active is present;
-        active.task_id and active.entity_id are omitted when empty or absent.
-        active.entity_id is the latest selected agent_turns.entity_id dispatch
-        entity and must not fall back to the agent configured/effective entity,
-        task target entity, role-scoped current-entity tool context, dashboard
-        projection, conversation API response, or stale session evidence.
+        active as selected active-session latest-turn refs, and
+        last_tool_outcome as compact selected active-session latest-turn
+        canonical tool-result evidence. active is omitted when no active live
+        session is selected or the selected session has no latest turn.
+        active.turn_id is required when active is present; active.task_id and
+        active.entity_id are omitted when empty or absent. active.entity_id is
+        the latest selected agent_turns.entity_id dispatch entity and must not
+        fall back to the agent configured/effective entity, task target entity,
+        role-scoped current-entity tool context, dashboard projection,
+        conversation API response, or stale session evidence.
+        last_tool_outcome is omitted when no active live session is selected,
+        no latest turn exists, no canonical turn summary exists, or the
+        canonical summary has no tool result. last_tool_outcome.ok is the
+        selected turn parse_ok value and is not a per-tool execution status;
+        richer per-tool status, latency, completed_at, and error diagnostics
+        remain split.
         runtime_state.watchdog is omitted when no active live session or no
         active-session watchdog evidence exists, and malformed watchdog data
         fails closed. Queue details are paged with queue_limit and
@@ -11614,13 +11665,14 @@ api_specification:
         canonical recorded retry counter from event_deliveries.retry_count, with
         no API-layer +1 or status arithmetic. The API handler consumes the
         canonical agent diagnosis read owner directly, including its
-        watchdog-backed runtime_state sub-owner and selected-turn active
-        sub-owner. It must not join conversation, run, trace, token, CLI, or
-        dashboard owners locally, and it must not expose the full runtime_state
+        watchdog-backed runtime_state sub-owner, selected-turn active sub-owner,
+        and selected-turn last_tool_outcome sub-owner. It must not locally join
+        conversation, run, trace, token, CLI, or dashboard owners, and it must
+        not expose the full runtime_state
         enum, top-level watchdog, run_id, bundle_version, actual in-flight
         active work, configured/effective current entity, task target entity,
-        role-scoped current entity, last tool outcome, token usage, recent
-        failures, or dead letters.
+        role-scoped current entity, token usage, recent failures, or dead
+        letters.
       scope:
         required:
         - read:agents

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 70 {
-		t.Fatalf("schema count = %d, want 70", report.SchemaCount)
+	if report.SchemaCount != 71 {
+		t.Fatalf("schema count = %d, want 71", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 70 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 70", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 71 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 71", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
@@ -105,6 +105,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := doc.Components.Schemas["AgentDiagnosisActive"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisActive")
 	}
+	if _, ok := doc.Components.Schemas["AgentDiagnosisLastToolOutcome"]; !ok {
+		t.Fatal("generated OpenRPC missing AgentDiagnosisLastToolOutcome")
+	}
 	for _, schemaName := range []string{"MailboxDecisionSheet", "MailboxEntityContext", "MailboxDownstreamPreview"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
@@ -131,6 +134,13 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if got, want := activeSchema["$ref"], "#/components/schemas/AgentDiagnosisActive"; got != want {
 		t.Fatalf("generated AgentDiagnosis.active ref = %#v, want %q", got, want)
+	}
+	lastToolOutcomeSchema, ok := agentDiagnosisProperties["last_tool_outcome"].(map[string]any)
+	if !ok {
+		t.Fatalf("generated AgentDiagnosis.last_tool_outcome = %#v, want object", agentDiagnosisProperties["last_tool_outcome"])
+	}
+	if got, want := lastToolOutcomeSchema["$ref"], "#/components/schemas/AgentDiagnosisLastToolOutcome"; got != want {
+		t.Fatalf("generated AgentDiagnosis.last_tool_outcome ref = %#v, want %q", got, want)
 	}
 	if _, ok := methods["runtime.subscribe_logs"]; !ok {
 		t.Fatal("generated OpenRPC missing runtime.subscribe_logs")

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -264,7 +264,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 
 func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 	return map[string]readOnlyHTTPRuntimeFixture{
-		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active"}},
+		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active", "last_tool_outcome"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
@@ -546,6 +546,13 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 					TaskID:   "task-1",
 					EntityID: "33333333-3333-3333-3333-333333333333",
 				},
+				LastToolOutcome: &store.OperatorAgentLastToolOutcome{
+					TurnID:    "22222222-2222-2222-2222-222222222222",
+					ToolName:  "selected_tool",
+					ToolUseID: "toolu-selected",
+					OK:        true,
+					Result:    []byte(`{"status":"selected"}`),
+				},
 				RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
 					Watchdog: &store.OperatorAgentDiagnosisWatchdog{
 						State:         "no_output",
@@ -705,7 +712,15 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
 			t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
 		}
-		for _, splitField := range []string{"bundle_version", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+		lastTool := asMap(t, result["last_tool_outcome"])
+		if lastTool["turn_id"] != "22222222-2222-2222-2222-222222222222" || lastTool["tool_name"] != "selected_tool" || lastTool["tool_use_id"] != "toolu-selected" || lastTool["ok"] != true {
+			t.Fatalf("agent.diagnose last_tool_outcome = %#v", lastTool)
+		}
+		lastToolResult := asMap(t, lastTool["result"])
+		if lastToolResult["status"] != "selected" {
+			t.Fatalf("agent.diagnose last_tool_outcome.result = %#v", lastToolResult)
+		}
+		for _, splitField := range []string{"bundle_version", "watchdog", "token_usage", "failures_recent", "dead_letters_recent"} {
 			if _, ok := result[splitField]; ok {
 				t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, result)
 			}

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -131,6 +131,13 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 				TaskID:   "task-1",
 				EntityID: "33333333-3333-3333-3333-333333333333",
 			},
+			LastToolOutcome: &store.OperatorAgentLastToolOutcome{
+				TurnID:    "22222222-2222-2222-2222-222222222222",
+				ToolName:  "selected_tool",
+				ToolUseID: "toolu-selected",
+				OK:        true,
+				Result:    []byte(`{"status":"selected"}`),
+			},
 			RuntimeState: &store.OperatorAgentDiagnosisRuntimeState{
 				Watchdog: &store.OperatorAgentDiagnosisWatchdog{
 					State:         "no_output",
@@ -260,7 +267,15 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	if watchdog["recorded_at"] != "2026-05-21T10:01:00Z" {
 		t.Fatalf("agent.diagnose runtime_state.watchdog.recorded_at = %#v", watchdog["recorded_at"])
 	}
-	for _, splitField := range []string{"bundle_version", "watchdog", "last_tool_outcome", "token_usage", "failures_recent", "dead_letters_recent"} {
+	lastTool := asMap(t, diagnosis["last_tool_outcome"])
+	if lastTool["turn_id"] != "22222222-2222-2222-2222-222222222222" || lastTool["tool_name"] != "selected_tool" || lastTool["tool_use_id"] != "toolu-selected" || lastTool["ok"] != true {
+		t.Fatalf("agent.diagnose last_tool_outcome = %#v", lastTool)
+	}
+	lastToolResult := asMap(t, lastTool["result"])
+	if lastToolResult["status"] != "selected" {
+		t.Fatalf("agent.diagnose last_tool_outcome.result = %#v", lastToolResult)
+	}
+	for _, splitField := range []string{"bundle_version", "watchdog", "token_usage", "failures_recent", "dead_letters_recent"} {
 		if _, ok := diagnosis[splitField]; ok {
 			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
 		}
@@ -697,6 +712,79 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedActiveOwnerData(t *testing.T
 	errorText := fmt.Sprint(resp.Error.Message, resp.Error.Data)
 	if !strings.Contains(errorText, "agent.diagnose owner returned malformed result") || !strings.Contains(errorText, "active.turn_id") {
 		t.Fatalf("error = %#v, want malformed active owner result", resp.Error)
+	}
+}
+
+func TestOperatorAgentDiagnoseFailsClosedOnMalformedLastToolOutcomeOwnerData(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		active *store.OperatorAgentDiagnosisActive
+		item   *store.OperatorAgentLastToolOutcome
+		want   string
+	}{
+		{
+			name: "missing turn id",
+			item: &store.OperatorAgentLastToolOutcome{ToolName: "read_file", OK: true},
+			want: "last_tool_outcome.turn_id",
+		},
+		{
+			name: "missing tool name",
+			item: &store.OperatorAgentLastToolOutcome{TurnID: "turn-1", OK: true},
+			want: "last_tool_outcome.tool_name",
+		},
+		{
+			name: "non object result",
+			item: &store.OperatorAgentLastToolOutcome{TurnID: "turn-1", ToolName: "read_file", OK: true, Result: []byte(`"ok"`)},
+			want: "last_tool_outcome.result must be a JSON object",
+		},
+		{
+			name: "null result",
+			item: &store.OperatorAgentLastToolOutcome{TurnID: "turn-1", ToolName: "read_file", OK: true, Result: []byte(`null`)},
+			want: "last_tool_outcome.result must be a JSON object",
+		},
+		{
+			name: "without active selected turn",
+			item: &store.OperatorAgentLastToolOutcome{TurnID: "turn-1", ToolName: "read_file", OK: true},
+			want: "last_tool_outcome requires active",
+		},
+		{
+			name:   "turn id does not match active turn id",
+			active: &store.OperatorAgentDiagnosisActive{TurnID: "turn-2"},
+			item:   &store.OperatorAgentLastToolOutcome{TurnID: "turn-1", ToolName: "read_file", OK: true},
+			want:   "last_tool_outcome.turn_id",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reads := &fakeAgentConversationReadStore{
+				agentDiagnosisResult: store.OperatorAgentDiagnosis{
+					AgentID: "agent-1",
+					Status:  "running",
+					Queue: store.OperatorAgentDiagnosisQueue{
+						PendingDeliveries: []store.OperatorAgentPendingDelivery{},
+					},
+					Active:          tc.active,
+					LastToolOutcome: tc.item,
+				},
+			}
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					AgentConversations: reads,
+				}),
+			})
+
+			resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"agent.diagnose","params":{"agent_id":"agent-1"}}`)
+			if resp.Error == nil {
+				t.Fatal("agent.diagnose returned success for malformed last_tool_outcome owner result")
+			}
+			if resp.Error.Code != codeInternalError {
+				t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+			}
+			errorText := fmt.Sprint(resp.Error.Message, resp.Error.Data)
+			if !strings.Contains(errorText, "agent.diagnose owner returned malformed result") || !strings.Contains(errorText, tc.want) {
+				t.Fatalf("error = %#v, want malformed last_tool_outcome owner result containing %q", resp.Error, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -1,7 +1,9 @@
 package apiv1
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -490,6 +492,19 @@ func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
 	if err := validateAgentDiagnosisRuntimeStateResult(item.RuntimeState); err != nil {
 		return err
 	}
+	if err := validateAgentDiagnosisLastToolOutcomeResult(item.LastToolOutcome); err != nil {
+		return err
+	}
+	if item.LastToolOutcome != nil {
+		if item.Active == nil {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome requires active selected-turn evidence")
+		}
+		activeTurnID := strings.TrimSpace(item.Active.TurnID)
+		lastToolTurnID := strings.TrimSpace(item.LastToolOutcome.TurnID)
+		if activeTurnID != lastToolTurnID {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.turn_id %q must match active.turn_id %q", lastToolTurnID, activeTurnID)
+		}
+	}
 	return nil
 }
 
@@ -520,6 +535,32 @@ func validateAgentDiagnosisRuntimeStateResult(item *store.OperatorAgentDiagnosis
 	}
 	if err := store.ValidateConversationRuntimeWatchdogDescriptor(watchdog); err != nil {
 		return fmt.Errorf("agent.diagnose owner returned malformed result: runtime_state.watchdog is invalid: %w", err)
+	}
+	return nil
+}
+
+func validateAgentDiagnosisLastToolOutcomeResult(item *store.OperatorAgentLastToolOutcome) error {
+	if item == nil {
+		return nil
+	}
+	if strings.TrimSpace(item.TurnID) == "" {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.turn_id is required")
+	}
+	if strings.TrimSpace(item.ToolName) == "" {
+		return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.tool_name is required")
+	}
+	if item.Result != nil {
+		trimmed := bytes.TrimSpace(item.Result)
+		if len(trimmed) == 0 {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.result is empty")
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.result must be a JSON object: %w", err)
+		}
+		if obj == nil {
+			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.result must be a JSON object")
+		}
 	}
 	return nil
 }

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -131,12 +131,21 @@ type OperatorAgentDiagnosis struct {
 	DeliveryLifecycle *OperatorAgentDeliveryLifecycle     `json:"delivery_lifecycle,omitempty"`
 	RuntimeState      *OperatorAgentDiagnosisRuntimeState `json:"runtime_state,omitempty"`
 	Active            *OperatorAgentDiagnosisActive       `json:"active,omitempty"`
+	LastToolOutcome   *OperatorAgentLastToolOutcome       `json:"last_tool_outcome,omitempty"`
 }
 
 type OperatorAgentDiagnosisActive struct {
 	TurnID   string `json:"turn_id"`
 	TaskID   string `json:"task_id,omitempty"`
 	EntityID string `json:"entity_id,omitempty"`
+}
+
+type OperatorAgentLastToolOutcome struct {
+	TurnID    string          `json:"turn_id"`
+	ToolName  string          `json:"tool_name"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	OK        bool            `json:"ok"`
+	Result    json.RawMessage `json:"result,omitempty"`
 }
 
 type OperatorAgentDiagnosisRuntimeState struct {
@@ -1295,6 +1304,11 @@ func operatorAgentDiagnosisFromDetail(detail OperatorAgentDetail) (OperatorAgent
 		RuntimeState: agent.DiagnosisRuntimeState,
 		Active:       cloneOperatorAgentDiagnosisActive(agent.DiagnosisActive),
 	}
+	lastToolOutcome, err := operatorAgentDiagnosisLastToolOutcomeFromAgent(agent)
+	if err != nil {
+		return OperatorAgentDiagnosis{}, err
+	}
+	out.LastToolOutcome = lastToolOutcome
 	if state := strings.TrimSpace(agent.DeliveryLifecycle); state != "" {
 		out.DeliveryLifecycle = &OperatorAgentDeliveryLifecycle{
 			State:         state,
@@ -1369,6 +1383,19 @@ func validateOperatorAgentDiagnosis(item OperatorAgentDiagnosis) error {
 	if err := validateOperatorAgentDiagnosisRuntimeState(item.RuntimeState); err != nil {
 		return err
 	}
+	if err := validateOperatorAgentDiagnosisLastToolOutcome(item.LastToolOutcome); err != nil {
+		return err
+	}
+	if item.LastToolOutcome != nil {
+		if item.Active == nil {
+			return fmt.Errorf("agent diagnosis last_tool_outcome requires active selected-turn evidence")
+		}
+		activeTurnID := strings.TrimSpace(item.Active.TurnID)
+		lastToolTurnID := strings.TrimSpace(item.LastToolOutcome.TurnID)
+		if activeTurnID != lastToolTurnID {
+			return fmt.Errorf("agent diagnosis last_tool_outcome.turn_id %q must match active.turn_id %q", lastToolTurnID, activeTurnID)
+		}
+	}
 	return nil
 }
 
@@ -1413,6 +1440,73 @@ func cloneOperatorAgentDiagnosisActive(in *OperatorAgentDiagnosisActive) *Operat
 	}
 	out := *in
 	return &out
+}
+
+func operatorAgentDiagnosisLastToolOutcomeFromAgent(agent OperatorAgentSummary) (*OperatorAgentLastToolOutcome, error) {
+	if agent.DiagnosisActive == nil {
+		return nil, nil
+	}
+	turnID := strings.TrimSpace(agent.DiagnosisActive.TurnID)
+	if turnID == "" {
+		return nil, nil
+	}
+	if agent.LiveTurn == nil || agent.LiveTurn.LastTool == nil {
+		return nil, nil
+	}
+	if liveTurnID := strings.TrimSpace(agent.LiveTurn.TurnID); liveTurnID != "" && liveTurnID != turnID {
+		return nil, fmt.Errorf("agent diagnosis last_tool_outcome turn_id %q does not match active turn_id %q", liveTurnID, turnID)
+	}
+	last := agent.LiveTurn.LastTool
+	out := &OperatorAgentLastToolOutcome{
+		TurnID:    turnID,
+		ToolName:  strings.TrimSpace(last.Name),
+		ToolUseID: strings.TrimSpace(last.ToolUseID),
+		OK:        last.OK,
+	}
+	if last.Result != nil {
+		trimmed := bytes.TrimSpace(last.Result)
+		if len(trimmed) == 0 {
+			return nil, fmt.Errorf("agent diagnosis last_tool_outcome.result is empty")
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return nil, fmt.Errorf("agent diagnosis last_tool_outcome.result must be a JSON object: %w", err)
+		}
+		if obj == nil {
+			return nil, fmt.Errorf("agent diagnosis last_tool_outcome.result must be a JSON object")
+		}
+		out.Result = append(json.RawMessage(nil), trimmed...)
+	}
+	if err := validateOperatorAgentDiagnosisLastToolOutcome(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func validateOperatorAgentDiagnosisLastToolOutcome(item *OperatorAgentLastToolOutcome) error {
+	if item == nil {
+		return nil
+	}
+	if strings.TrimSpace(item.TurnID) == "" {
+		return fmt.Errorf("agent diagnosis last_tool_outcome.turn_id is required")
+	}
+	if strings.TrimSpace(item.ToolName) == "" {
+		return fmt.Errorf("agent diagnosis last_tool_outcome.tool_name is required")
+	}
+	if item.Result != nil {
+		trimmed := bytes.TrimSpace(item.Result)
+		if len(trimmed) == 0 {
+			return fmt.Errorf("agent diagnosis last_tool_outcome.result is empty")
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return fmt.Errorf("agent diagnosis last_tool_outcome.result must be a JSON object: %w", err)
+		}
+		if obj == nil {
+			return fmt.Errorf("agent diagnosis last_tool_outcome.result must be a JSON object")
+		}
+	}
+	return nil
 }
 
 func validOperatorAgentDiagnosisStatus(status string) bool {

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -388,6 +389,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	turnCompletedAt := time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
 	eventTime := time.Date(2026, 5, 12, 8, 55, 0, 0, time.UTC)
 	runtimeState := []byte(`{"provider_session_id":"provider-sess-1","watchdog":{"state":"healthy_long_running","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","last_output_at":"2026-05-12T09:04:00Z","recorded_at":"2026-05-12T09:05:00Z"}}`)
+	turnBlocks := []byte(`[{"kind":"turn_summary","data":{"assistant_visible_output":"working","tool_results":[{"tool_name":"older_tool","tool_use_id":"toolu-old","output":{"status":"old"}},{"tool_name":"selected_tool","tool_use_id":"toolu-selected","output":{"status":"selected"}}]}}]`)
 	agent := testOperatorAgent("agent-1")
 	agent.Config.EntityID = configuredEntityID
 	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
@@ -417,7 +419,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", turnEntityID, true, "", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", turnEntityID, true, "", turnCompletedAt, turnBlocks))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
@@ -460,6 +462,20 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	if watchdog.LastOutputAt != "2026-05-12T09:04:00Z" || watchdog.RecordedAt != "2026-05-12T09:05:00Z" {
 		t.Fatalf("runtime_state.watchdog timestamps = %#v", watchdog)
 	}
+	if diagnosis.LastToolOutcome == nil {
+		t.Fatalf("last_tool_outcome = nil, want selected latest tool")
+	}
+	lastTool := diagnosis.LastToolOutcome
+	if lastTool.TurnID != turnID || lastTool.ToolName != "selected_tool" || lastTool.ToolUseID != "toolu-selected" || !lastTool.OK {
+		t.Fatalf("last_tool_outcome = %#v", lastTool)
+	}
+	var lastToolResult map[string]any
+	if err := json.Unmarshal(lastTool.Result, &lastToolResult); err != nil {
+		t.Fatalf("decode last_tool_outcome.result: %v", err)
+	}
+	if lastToolResult["status"] != "selected" {
+		t.Fatalf("last_tool_outcome.result = %#v", lastToolResult)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
@@ -501,8 +517,99 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	if diagnosis.Active != nil {
 		t.Fatalf("active = %#v, want nil without selected active-session latest turn", diagnosis.Active)
 	}
+	if diagnosis.LastToolOutcome != nil {
+		t.Fatalf("last_tool_outcome = %#v, want nil without selected active-session latest turn", diagnosis.LastToolOutcome)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisLastToolOutcomeUsesParseOK(t *testing.T) {
+	turnID := "22222222-2222-2222-2222-222222222222"
+	diagnosis, err := loadAgentDiagnosisWithLatestTurn(t, turnID, "task-1", "", false, []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"read_file","tool_use_id":"toolu-1","output":{"ok":true}}]}}]`))
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+	}
+	if diagnosis.LastToolOutcome == nil {
+		t.Fatalf("last_tool_outcome = nil")
+	}
+	if diagnosis.LastToolOutcome.TurnID != turnID || diagnosis.LastToolOutcome.ToolName != "read_file" || diagnosis.LastToolOutcome.OK {
+		t.Fatalf("last_tool_outcome = %#v, want parse_ok=false reflected as ok=false", diagnosis.LastToolOutcome)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsLastToolOutcomeWithoutToolResult(t *testing.T) {
+	turnID := "22222222-2222-2222-2222-222222222222"
+	for _, tc := range []struct {
+		name       string
+		turnBlocks []byte
+	}{
+		{name: "no summary", turnBlocks: []byte(`[]`)},
+		{name: "summary without tool results", turnBlocks: []byte(`[{"kind":"turn_summary","data":{"assistant_visible_output":"done"}}]`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			diagnosis, err := loadAgentDiagnosisWithLatestTurn(t, turnID, "task-1", "", true, tc.turnBlocks)
+			if err != nil {
+				t.Fatalf("LoadOperatorAgentDiagnosis: %v", err)
+			}
+			if diagnosis.Active == nil || diagnosis.Active.TurnID != turnID {
+				t.Fatalf("active = %#v, want selected turn", diagnosis.Active)
+			}
+			if diagnosis.LastToolOutcome != nil {
+				t.Fatalf("last_tool_outcome = %#v, want nil", diagnosis.LastToolOutcome)
+			}
+		})
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLastToolOutcome(t *testing.T) {
+	turnID := "22222222-2222-2222-2222-222222222222"
+	for _, tc := range []struct {
+		name       string
+		turnBlocks []byte
+		want       string
+	}{
+		{
+			name:       "missing tool name",
+			turnBlocks: []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_use_id":"toolu-1","output":{"status":"ok"}}]}}]`),
+			want:       "latest canonical tool_result is missing tool_name",
+		},
+		{
+			name:       "non object result",
+			turnBlocks: []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"read_file","tool_use_id":"toolu-1","output":"ok"}]}}]`),
+			want:       "last_tool_outcome.result must be a JSON object",
+		},
+		{
+			name:       "null result",
+			turnBlocks: []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"read_file","tool_use_id":"toolu-1","output":null}]}}]`),
+			want:       "last_tool_outcome.result must be a JSON object",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadAgentDiagnosisWithLatestTurn(t, turnID, "task-1", "", true, tc.turnBlocks)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadOperatorAgentDiagnosis err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestOperatorAgentDiagnosisValidationFailsClosedOnLastToolOutcomeWithoutActive(t *testing.T) {
+	err := validateOperatorAgentDiagnosis(OperatorAgentDiagnosis{
+		AgentID: "agent-1",
+		Status:  "running",
+		Queue: OperatorAgentDiagnosisQueue{
+			PendingDeliveries: []OperatorAgentPendingDelivery{},
+		},
+		LastToolOutcome: &OperatorAgentLastToolOutcome{
+			TurnID:   "turn-1",
+			ToolName: "read_file",
+			OK:       true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "last_tool_outcome requires active") {
+		t.Fatalf("validateOperatorAgentDiagnosis err = %v, want last_tool_outcome active requirement", err)
 	}
 }
 
@@ -564,6 +671,9 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsActiveWithoutLatestTurn(
 	}
 	if diagnosis.Active != nil {
 		t.Fatalf("active = %#v, want nil for active session without latest turn", diagnosis.Active)
+	}
+	if diagnosis.LastToolOutcome != nil {
+		t.Fatalf("last_tool_outcome = %#v, want nil for active session without latest turn", diagnosis.LastToolOutcome)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -702,6 +812,35 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedWithoutCanonicalTu
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
+}
+
+func loadAgentDiagnosisWithLatestTurn(t *testing.T, turnID, taskID, entityID string, parseOK bool, turnBlocks []byte) (OperatorAgentDiagnosis, error) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps:   canonicalAgentConversationReadCaps(),
+		agents: []runtimemanager.PersistedAgent{testOperatorAgent("agent-1")},
+	}, 0)
+
+	var turnCompletedAt any
+	if strings.TrimSpace(turnID) != "" {
+		turnCompletedAt = time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC)
+	}
+	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
+		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
+		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
+			AddRow("agent-1", "active", "11111111-1111-1111-1111-111111111111", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 1, "", nil, []byte(`{}`), 0, 0, 0, 0, turnID, taskID, entityID, parseOK, "", turnCompletedAt, turnBlocks))
+
+	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("expectations: %v", expectationsErr)
+	}
+	return diagnosis, err
 }
 
 func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessionOnly(t *testing.T) {


### PR DESCRIPTION
## Summary

- Promotes `AgentDiagnosis.last_tool_outcome` into tracked `platform-spec.yaml` and regenerates OpenRPC.
- Routes the field through `LoadOperatorAgentDiagnosis` using the selected active-session latest turn and canonical `turn_summary.tool_results` evidence.
- Adds API/read-owner validation and tests for selected last tool, parse_ok semantics, omission cases, and malformed owner data.

Closes #963
Part of #852

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification`
- Generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apispec` OpenRPC/schema proof
- `internal/apiv1` `agent.diagnose` handler validation
- `internal/store` `LoadOperatorAgentDiagnosis` / `OperatorAgentDiagnosis`
- #963 pre-audit and independent gate outcome

## Semantic Migration

New canonical owner: tracked `AgentDiagnosis.last_tool_outcome` plus the `LoadOperatorAgentDiagnosis` read owner, consuming the selected active live session/latest turn and canonical `turn_summary.tool_results` projection.

Old non-authoritative paths now invalid for this API field: handler-local conversation joins, dashboard projections, raw `response_payload`, raw transcript text, runtime executor telemetry, event/dead-letter data, stale/inactive sessions, and richer per-tool status/latency/completion/error diagnostics.

Production paths checked for surviving old behavior: platform spec/OpenRPC, `internal/apispec`, `internal/apiv1`, `internal/store`, and dashboard last-tool tests as a split consumer. The migration is complete for the approved child class only; #852 remains open for token usage, failures/dead letters, CLI/dashboard rebinding, and richer execution diagnostics.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/store -run 'TestOperatorAgent.*Diagnosis|TestOperatorAgent.*LastTool|Test.*ToolResults|Test.*TurnSummary|Test.*Active' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader.*LastTool|Test.*ToolResults|Test.*TurnSummary' -count=1`
- `go test ./...`