### PR TITLE
[agent-a][issue #843] Guard CLI API boundary

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
+	sources := readProductionCommandSources(t)
+	wantAPIConsumers := map[string]struct{}{
+		"agent_directive.go":      {},
+		"agent_replay.go":         {},
+		"agent_replay_backlog.go": {},
+		"agent_restart.go":        {},
+		"agents.go":               {},
+		"control_mailbox.go":      {},
+		"control_nuke.go":         {},
+		"control_run.go":          {},
+		"conversations.go":        {},
+		"diagnostics.go":          {},
+		"entities.go":             {},
+		"event_publish.go":        {},
+		"events.go":               {},
+		"incidents.go":            {},
+		"logs.go":                 {},
+		"run_command.go":          {},
+	}
+
+	gotAPIConsumers := map[string]struct{}{}
+	for name, source := range sources {
+		if name == "cli_api.go" {
+			continue
+		}
+		if strings.Contains(source, "newCLIAPIClient(") {
+			gotAPIConsumers[name] = struct{}{}
+		}
+	}
+	if diff := missingKeys(wantAPIConsumers, gotAPIConsumers); len(diff) > 0 {
+		t.Fatalf("API-backed command files missing newCLIAPIClient use: %v", diff)
+	}
+	if diff := missingKeys(gotAPIConsumers, wantAPIConsumers); len(diff) > 0 {
+		t.Fatalf("new API-backed command files must be classified in this guard: %v", diff)
+	}
+
+	localBypassNeedles := []string{
+		"runForkRuntimeOwnerHarness",
+		"loadRunStatusReport",
+		"runStatusReportFromStore",
+		"printRunStatusReport",
+		"buildStores(",
+		"LoadRunDebugReport",
+		"MaterializeRunFork",
+		"PlanRunFork",
+		"ActivateSelectedContractRunFork",
+		"runtime.NewRuntime",
+		"store.NewPostgresStore",
+		"SWARM_BUILDER_AUTH_TOKEN",
+		"SWARM_OPERATOR_AUTH_TOKEN",
+	}
+	for name := range wantAPIConsumers {
+		source := sources[name]
+		for _, needle := range localBypassNeedles {
+			if strings.Contains(source, needle) {
+				t.Fatalf("%s contains local/runtime bypass %q; runtime-state CLI commands must consume newCLIAPIClient", name, needle)
+			}
+		}
+	}
+}
+
+func TestCLILocalRuntimeHelpersRemainNonOperatorQuarantined(t *testing.T) {
+	sources := readProductionCommandSources(t)
+	all := strings.Join(sortedSourceValues(sources), "\n")
+
+	wantCounts := map[string]int{
+		"runForkRuntimeOwnerHarness(": 1,
+		"loadRunStatusReport(":        1,
+		"printRunStatusReport(":       1,
+		"runStatusReportFromStore(":   2, // one private helper call plus its definition
+	}
+	for needle, want := range wantCounts {
+		if got := strings.Count(all, needle); got != want {
+			t.Fatalf("%q occurrences = %d, want %d; local helper must remain non-operator/quarantined", needle, got, want)
+		}
+	}
+
+	retiredRoutes := [][]string{
+		{"fork"},
+		{"fork", "--help"},
+		{"investigate", "runs"},
+		{"control", "mailbox", "list"},
+	}
+	for _, args := range retiredRoutes {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommand(context.Background(), t.TempDir(), args, &stdout, &stderr)
+			if code == cliExitOK {
+				t.Fatalf("%v code = 0, want fail-closed retired route", args)
+			}
+			if strings.Contains(stdout.String(), "Fork Run:") || strings.Contains(stderr.String(), "Fork Run:") {
+				t.Fatalf("%v reached fork runtime owner output; stdout=%q stderr=%q", args, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T) {
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"topic":"sample"}`), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "runs", args: []string{"runs"}},
+		{name: "status", args: []string{"status", "run-1"}},
+		{name: "trace", args: []string{"trace", "run-1"}},
+		{name: "trace follow", args: []string{"trace", "run-1", "--follow"}},
+		{name: "health", args: []string{"health"}},
+		{name: "logs", args: []string{"logs"}},
+		{name: "logs follow", args: []string{"logs", "--follow"}},
+		{name: "incidents", args: []string{"incidents"}},
+		{name: "agents list", args: []string{"agents", "list"}},
+		{name: "agent view", args: []string{"agent", "view", "agent-1"}},
+		{name: "agent restart", args: []string{"agent", "restart", "agent-1"}},
+		{name: "agent replay", args: []string{"agent", "replay", "agent-1", "--event-id", "event-1"}},
+		{name: "agent replay backlog", args: []string{"agent", "replay-backlog", "agent-1"}},
+		{name: "agent directive", args: []string{"agent", "directive", "agent-1", "continue"}},
+		{name: "mailbox list", args: []string{"mailbox", "list"}},
+		{name: "mailbox view", args: []string{"mailbox", "view", "mailbox-1"}},
+		{name: "mailbox approve", args: []string{"mailbox", "approve", "mailbox-1"}},
+		{name: "mailbox reject", args: []string{"mailbox", "reject", "mailbox-1", "--reason", "not approved"}},
+		{name: "mailbox defer", args: []string{"mailbox", "defer", "mailbox-1", "--until", "2026-05-23T00:00:00Z"}},
+		{name: "control pause", args: []string{"control", "pause", "run-1"}},
+		{name: "control continue", args: []string{"control", "continue", "run-1"}},
+		{name: "control stop", args: []string{"control", "stop", "run-1"}},
+		{name: "control nuke", args: []string{"control", "nuke", "--dry-run"}},
+		{name: "events list", args: []string{"events", "list"}},
+		{name: "events follow", args: []string{"events", "follow"}},
+		{name: "event view", args: []string{"event", "view", "event-1"}},
+		{name: "event replay", args: []string{"event", "replay", "event-1"}},
+		{name: "event publish", args: []string{"event", "publish", "scan.requested", "--payload-json", `{"topic":"sample"}`}},
+		{name: "conversations list", args: []string{"conversations", "list"}},
+		{name: "conversation view", args: []string{"conversation", "view", "session-1"}},
+		{name: "conversation turn", args: []string{"conversation", "turn", "session-1", "1"}},
+		{name: "entities list", args: []string{"entities", "list"}},
+		{name: "entity view", args: []string{"entity", "view", "entity-1"}},
+		{name: "entity aggregate", args: []string{"entity", "aggregate"}},
+		{name: "run connect start", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--no-follow"}},
+		{name: "run connect reattach", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1"}},
+		{name: "version server", args: []string{"version", "--server"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Setenv("SWARM_BUILDER_AUTH_TOKEN", "builder-token")
+			t.Setenv("SWARM_OPERATOR_AUTH_TOKEN", "operator-token")
+
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitAuth {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitAuth, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+				t.Fatalf("stderr = %q, want shared missing-token error", stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0 before auth", calls.Load())
+			}
+		})
+	}
+}
+
+func readProductionCommandSources(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read cmd/swarm: %v", err)
+	}
+	sources := make(map[string]string)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		raw, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		sources[name] = string(raw)
+	}
+	return sources
+}
+
+func sortedSourceValues(sources map[string]string) []string {
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	values := make([]string, 0, len(names))
+	for _, name := range names {
+		values = append(values, sources[name])
+	}
+	return values
+}
+
+func missingKeys(want, got map[string]struct{}) []string {
+	var missing []string
+	for key := range want {
+		if _, ok := got[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}


### PR DESCRIPTION
## Summary
- Adds a focused `cmd/swarm` conformance guard for the CLI v2 API-consumption boundary.
- Accounts for every current API-backed command source file and fails if a new `newCLIAPIClient` consumer is added without classification.
- Proves local helper seams (`runForkRuntimeOwnerHarness`, `loadRunStatusReport`, `runStatusReportFromStore`, `printRunStatusReport`) remain non-operator/quarantined and that representative runtime-state commands fail through the shared API-token resolver before any request when legacy builder/operator tokens are set.

Closes #843

## Governing refs/context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.cli_consumes_api_rule`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.auth_boundary`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.cli_consumption_rule`
- Approved pre-audit: https://github.com/yazzaoui/Swarm/issues/843#issuecomment-4523822038
- Independent gate: https://github.com/yazzaoui/Swarm/issues/843#issuecomment-4523834584

## Semantic migration
- New canonical owner: unchanged spec owner, with `cmd/swarm/api_consumption_boundary_test.go` as the closure-bearing guard/proof for current implemented CLI consumers.
- Old producer/reader path now invalid: any supported runtime-state Cobra command routing to `runForkRuntimeOwnerHarness`, `loadRunStatusReport`, `runStatusReportFromStore`, `printRunStatusReport`, direct store/runtime construction, or builder/operator auth fallback.
- Production paths checked: all current non-test `newCLIAPIClient` consumers, representative read and mutation command routes, retired `fork`/`investigate`/`control mailbox` routes, and the approved local carveouts (`verify`, `serve`, local foreground `run` startup) as split adjacent owners.
- Migration complete for the approved first-slice class: API-consumption boundary proof/helper quarantine. Runtime/API behavior, serve listener/runtime semantics, retry/follow, output/logging, and command-family behavior remain out of scope.

## Proof
- `go test ./cmd/swarm -run 'TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted|TestCLILocalRuntimeHelpersRemainNonOperatorQuarantined|TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --cached --check`