### PR TITLE
[agent-b][issue #855] Add follow trace typed filters

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -233,11 +233,11 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
 	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
-	cmd.Flags().StringArrayVar(&traceOpts.eventNames, "event-name", nil, "Snapshot-only event name filter; repeat to match any")
-	cmd.Flags().StringArrayVar(&traceOpts.entityIDs, "entity-id", nil, "Snapshot-only entity id filter; repeat to match any")
-	cmd.Flags().StringArrayVar(&traceOpts.deliveryStatuses, "delivery-status", nil, "Snapshot-only delivery status filter; repeat to match any")
-	cmd.Flags().StringArrayVar(&traceOpts.subscriberIDs, "subscriber-id", nil, "Snapshot-only subscriber id filter; repeat to match any")
-	cmd.Flags().StringArrayVar(&traceOpts.subscriberTypes, "subscriber-type", nil, "Snapshot-only subscriber type filter: node or agent; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.eventNames, "event-name", nil, "Event name filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.entityIDs, "entity-id", nil, "Entity id filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.deliveryStatuses, "delivery-status", nil, "Delivery status filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.subscriberIDs, "subscriber-id", nil, "Subscriber id filter; repeat to match any")
+	cmd.Flags().StringArrayVar(&traceOpts.subscriberTypes, "subscriber-type", nil, "Subscriber type filter: node or agent; repeat to match any")
 	bindCLIAPIConnectionFlags(cmd, &traceOpts.apiOptions)
 	return cmd
 }
@@ -428,7 +428,7 @@ func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts di
 }
 
 func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
-	snapshotParams, err := opts.snapshotParams()
+	traceParams, err := opts.traceParams()
 	if err != nil {
 		return err
 	}
@@ -444,11 +444,11 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 		}
 	}
 	if opts.follow {
-		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID, opts)
+		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID, opts, traceParams)
 	}
-	snapshotParams["run_id"] = runID
+	traceParams["run_id"] = runID
 	var result diagnosticRunTraceResult
-	if err := client.call(ctx, "run.trace", snapshotParams, &result); err != nil {
+	if err := client.call(ctx, "run.trace", traceParams, &result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
 	if err := validateDiagnosticRunTraceResult(result); err != nil {
@@ -458,27 +458,14 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	return nil
 }
 
-func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
+func (o diagnosticTraceOptions) traceParams() (map[string]any, error) {
 	if o.follow {
-		for _, flag := range []struct {
-			name string
-			set  bool
-		}{
-			{name: "--since", set: o.sinceSet},
-			{name: "--limit", set: o.limitSet},
-			{name: "--cursor", set: o.cursorSet},
-			{name: "--event-name", set: len(o.eventNames) > 0},
-			{name: "--entity-id", set: len(o.entityIDs) > 0},
-			{name: "--delivery-status", set: len(o.deliveryStatuses) > 0},
-			{name: "--subscriber-id", set: len(o.subscriberIDs) > 0},
-			{name: "--subscriber-type", set: len(o.subscriberTypes) > 0},
-		} {
-			if flag.set {
-				return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
-			}
-		}
-		return map[string]any{}, nil
+		return o.followParams()
 	}
+	return o.snapshotParams()
+}
+
+func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 	if o.noRetry {
 		return nil, fmt.Errorf("--no-retry requires --follow")
 	}
@@ -503,7 +490,7 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 		}
 		params["since"] = since
 	}
-	filter, err := o.snapshotFilter()
+	filter, err := o.traceFilter()
 	if err != nil {
 		return nil, err
 	}
@@ -513,10 +500,34 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 	return params, nil
 }
 
-func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
+func (o diagnosticTraceOptions) followParams() (map[string]any, error) {
+	for _, flag := range []struct {
+		name string
+		set  bool
+	}{
+		{name: "--since", set: o.sinceSet},
+		{name: "--limit", set: o.limitSet},
+		{name: "--cursor", set: o.cursorSet},
+	} {
+		if flag.set {
+			return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
+		}
+	}
+	filter, err := o.traceFilter()
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{}
+	if len(filter) > 0 {
+		params["filter"] = filter
+	}
+	return params, nil
+}
+
+func (o diagnosticTraceOptions) traceFilter() (map[string]any, error) {
 	filter := map[string]any{}
 	addStringList := func(name, flag string, values []string) error {
-		values, err := snapshotTraceStringList(flag, values)
+		values, err := traceStringList(flag, values)
 		if err != nil {
 			return err
 		}
@@ -528,7 +539,7 @@ func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
 	if err := addStringList("event_name", "--event-name", o.eventNames); err != nil {
 		return nil, err
 	}
-	entityIDs, err := snapshotTraceStringList("--entity-id", o.entityIDs)
+	entityIDs, err := traceStringList("--entity-id", o.entityIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +551,7 @@ func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
 	if len(entityIDs) > 0 {
 		filter["entity_id"] = entityIDs
 	}
-	deliveryStatuses, err := snapshotTraceEnumList("--delivery-status", o.deliveryStatuses, eventObservationValidDeliveryStatuses, "pending, in_progress, delivered, failed, dead_letter")
+	deliveryStatuses, err := traceEnumList("--delivery-status", o.deliveryStatuses, eventObservationValidDeliveryStatuses, "pending, in_progress, delivered, failed, dead_letter")
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +561,7 @@ func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
 	if err := addStringList("subscriber_id", "--subscriber-id", o.subscriberIDs); err != nil {
 		return nil, err
 	}
-	subscriberTypes, err := snapshotTraceEnumList("--subscriber-type", o.subscriberTypes, eventObservationValidSubscriberTypes, "node, agent")
+	subscriberTypes, err := traceEnumList("--subscriber-type", o.subscriberTypes, eventObservationValidSubscriberTypes, "node, agent")
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +571,7 @@ func (o diagnosticTraceOptions) snapshotFilter() (map[string]any, error) {
 	return filter, nil
 }
 
-func snapshotTraceStringList(flag string, values []string) ([]string, error) {
+func traceStringList(flag string, values []string) ([]string, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -580,7 +591,7 @@ func snapshotTraceStringList(flag string, values []string) ([]string, error) {
 	return out, nil
 }
 
-func snapshotTraceEnumList(flag string, values []string, valid map[string]struct{}, allowed string) ([]string, error) {
+func traceEnumList(flag string, values []string, valid map[string]struct{}, allowed string) ([]string, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -603,7 +614,7 @@ func snapshotTraceEnumList(flag string, values []string, valid map[string]struct
 	return out, nil
 }
 
-func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string, opts diagnosticTraceOptions) error {
+func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, runID string, opts diagnosticTraceOptions, params map[string]any) error {
 	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
 	if err != nil {
 		if errOut != nil {
@@ -618,7 +629,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	retryAttempt := 0
 	var replaySince *time.Time
 	for {
-		sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince)
+		sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince, params)
 		if err != nil {
 			if ctx.Err() != nil {
 				return traceFollowDetached(errOut)

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -422,6 +422,16 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	}
 }
 
+func wantFullTraceFilterParams() map[string]any {
+	return map[string]any{
+		"event_name":      []any{"scan.requested", "scan.completed"},
+		"entity_id":       []any{"entity-1", "entity-2"},
+		"delivery_status": []any{"delivered", "failed"},
+		"subscriber_id":   []any{"agent-1", "node-2"},
+		"subscriber_type": []any{"agent", "node"},
+	}
+}
+
 func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
@@ -479,11 +489,20 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 
 func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		args []string
+		name       string
+		args       []string
+		wantFilter map[string]any
 	}{
-		{name: "long follow", args: []string{"trace", "run-follow", "--follow", "--no-retry"}},
-		{name: "shorthand follow", args: []string{"trace", "run-follow", "-f", "--no-retry"}},
+		{
+			name:       "long follow",
+			args:       []string{"trace", "run-follow", "--follow", "--no-retry", "--event-name", "scan.requested", "--event-name", "scan.completed", "--entity-id", "entity-1", "--entity-id", "entity-2", "--delivery-status", "delivered", "--delivery-status", "failed", "--subscriber-id", "agent-1", "--subscriber-id", "node-2", "--subscriber-type", "agent", "--subscriber-type", "node"},
+			wantFilter: wantFullTraceFilterParams(),
+		},
+		{
+			name:       "shorthand follow",
+			args:       []string{"trace", "run-follow", "-f", "--no-retry", "--event-name", "scan.requested"},
+			wantFilter: map[string]any{"event_name": []any{"scan.requested"}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -499,7 +518,7 @@ func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 				t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			assertRunCommandMethods(t, calls, nil)
-			assertRunCommandTraceSubscription(t, wsRequests, "run-follow", false)
+			assertRunCommandTraceSubscriptionWithFilter(t, wsRequests, "run-follow", false, tc.wantFilter)
 			if !strings.Contains(stdout.String(), "trace event_id=evt-follow") {
 				t.Fatalf("stdout = %q, want trace row", stdout.String())
 			}
@@ -528,12 +547,15 @@ func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--follow", "--no-retry"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--follow", "--no-retry", "--event-name", "scan.requested", "--subscriber-id", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	assertRunCommandMethods(t, calls, []string{"run.list"})
-	assertRunCommandTraceSubscription(t, wsRequests, "active-run", false)
+	assertRunCommandTraceSubscriptionWithFilter(t, wsRequests, "active-run", false, map[string]any{
+		"event_name":    []any{"scan.requested"},
+		"subscriber_id": []any{"agent-1"},
+	})
 	if !strings.Contains(stdout.String(), "trace event_id=evt-active") {
 		t.Fatalf("stdout = %q, want trace row", stdout.String())
 	}
@@ -646,7 +668,8 @@ func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
 		cancel()
 	}()
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	wantFilter := wantFullTraceFilterParams()
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "--follow", "--event-name", "scan.requested", "--event-name", "scan.completed", "--entity-id", "entity-1", "--entity-id", "entity-2", "--delivery-status", "delivered", "--delivery-status", "failed", "--subscriber-id", "agent-1", "--subscriber-id", "node-2", "--subscriber-type", "agent", "--subscriber-type", "node"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 130 {
 		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -660,6 +683,9 @@ func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
 		}
 		if got := req.Params["run_id"]; got != "active-run" {
 			t.Fatalf("ws run_id[%d] = %#v, want active-run", i, got)
+		}
+		if got := req.Params["filter"]; !reflect.DeepEqual(got, wantFilter) {
+			t.Fatalf("ws filter[%d] = %#v, want %#v", i, got, wantFilter)
 		}
 	}
 	if _, ok := wsRequests[0].Params["replay_since"]; ok {
@@ -747,7 +773,8 @@ func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
 		cancel()
 	}()
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "run-retry", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	wantFilter := map[string]any{"delivery_status": []any{"delivered"}, "subscriber_type": []any{"agent"}}
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"trace", "run-retry", "--follow", "--delivery-status", "delivered", "--subscriber-type", "agent"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 130 {
 		t.Fatalf("code = %d, want 130 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -760,6 +787,9 @@ func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
 		}
 		if _, ok := req.Params["replay_since"]; ok {
 			t.Fatalf("ws replay_since[%d] = %#v, want omitted because no row was rendered before retry", i, req.Params["replay_since"])
+		}
+		if got := req.Params["filter"]; !reflect.DeepEqual(got, wantFilter) {
+			t.Fatalf("ws filter[%d] = %#v, want %#v", i, got, wantFilter)
 		}
 	}
 	if !strings.Contains(stdout.String(), "trace event_id=evt-recovered") {
@@ -947,17 +977,17 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
-		{name: "trace follow rejects typed filters", args: []string{"trace", "run-1", "--follow", "--event-name", "scan.requested"}, wantStderr: "--event-name is not supported with --follow"},
-		{name: "trace follow rejects entity filter", args: []string{"trace", "run-1", "--follow", "--entity-id", "entity-1"}, wantStderr: "--entity-id is not supported with --follow"},
-		{name: "trace follow rejects delivery status filter", args: []string{"trace", "run-1", "--follow", "--delivery-status", "delivered"}, wantStderr: "--delivery-status is not supported with --follow"},
-		{name: "trace follow rejects subscriber id filter", args: []string{"trace", "run-1", "--follow", "--subscriber-id", "agent-1"}, wantStderr: "--subscriber-id is not supported with --follow"},
-		{name: "trace follow rejects subscriber type filter", args: []string{"trace", "run-1", "--follow", "--subscriber-type", "agent"}, wantStderr: "--subscriber-type is not supported with --follow"},
 		{name: "trace follow direct replay since remains unpromoted", args: []string{"trace", "run-1", "--follow", "--replay-since", "2026-05-13T10:00:00Z"}, wantStderr: "unknown flag"},
 		{name: "trace blank event name", args: []string{"trace", "run-1", "--event-name", " "}, wantStderr: "--event-name must not be empty"},
 		{name: "trace blank subscriber id", args: []string{"trace", "run-1", "--subscriber-id", " "}, wantStderr: "--subscriber-id must not be empty"},
 		{name: "trace invalid entity id", args: []string{"trace", "run-1", "--entity-id", "bad id!"}, wantStderr: "--entity-id must match OpaqueId pattern"},
 		{name: "trace invalid delivery status", args: []string{"trace", "run-1", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
 		{name: "trace invalid subscriber type", args: []string{"trace", "run-1", "--subscriber-type", "platform"}, wantStderr: "--subscriber-type must be one of"},
+		{name: "trace follow blank event name", args: []string{"trace", "run-1", "--follow", "--event-name", " "}, wantStderr: "--event-name must not be empty"},
+		{name: "trace follow invalid entity id", args: []string{"trace", "run-1", "--follow", "--entity-id", "bad id!"}, wantStderr: "--entity-id must match OpaqueId pattern"},
+		{name: "trace follow invalid delivery status", args: []string{"trace", "run-1", "--follow", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
+		{name: "trace follow blank subscriber id", args: []string{"trace", "run-1", "--follow", "--subscriber-id", " "}, wantStderr: "--subscriber-id must not be empty"},
+		{name: "trace follow invalid subscriber type", args: []string{"trace", "run-1", "--follow", "--subscriber-type", "platform"}, wantStderr: "--subscriber-type must be one of"},
 		{name: "status extra arg", args: []string{"status", "run-1", "extra"}, wantStderr: "accepts at most 1 arg(s)"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -989,6 +1019,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"trace", "run-1", "--follow"},
 		{"trace", "run-1", "-f"},
 		{"trace", "run-1", "--follow", "--no-retry"},
+		{"trace", "run-1", "--follow", "--event-name", "scan.requested", "--entity-id", "entity-1", "--delivery-status", "delivered", "--subscriber-id", "agent-1", "--subscriber-type", "agent"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "")

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -455,7 +455,7 @@ func runReattachCommand(ctx context.Context, out, errOut io.Writer, opts runComm
 }
 
 func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, opts runCommandOptions, wsEndpoint, runID string, replaySince *time.Time, stopOnInterrupt bool) error {
-	sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince)
+	sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince, nil)
 	if err != nil {
 		fmt.Fprintln(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
@@ -508,7 +508,7 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 	}
 }
 
-func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, replaySince *time.Time) (*runTraceSubscription, error) {
+func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, replaySince *time.Time, extraParams map[string]any) (*runTraceSubscription, error) {
 	header := http.Header{"Authorization": []string{"Bearer " + token}}
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
 	if err != nil {
@@ -516,6 +516,9 @@ func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, rep
 	}
 	requestID := "swarm-cli:" + runCommandMethodSubscribeTrace
 	params := map[string]any{"run_id": runID}
+	for name, value := range extraParams {
+		params[name] = value
+	}
 	if replaySince != nil {
 		params["replay_since"] = replaySince.UTC().Format(time.RFC3339Nano)
 	}

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -752,11 +752,29 @@ func assertRunCommandMethods(t *testing.T, calls *[]jsonRPCRequest, want []strin
 
 func assertRunCommandTraceSubscription(t *testing.T, requests *[]jsonRPCRequest, runID string, wantReplaySince bool) {
 	t.Helper()
+	assertRunCommandTraceSubscriptionParams(t, requests, runID, wantReplaySince, nil)
+}
+
+func assertRunCommandTraceSubscriptionWithFilter(t *testing.T, requests *[]jsonRPCRequest, runID string, wantReplaySince bool, wantFilter map[string]any) {
+	t.Helper()
+	assertRunCommandTraceSubscriptionParams(t, requests, runID, wantReplaySince, wantFilter)
+}
+
+func assertRunCommandTraceSubscriptionParams(t *testing.T, requests *[]jsonRPCRequest, runID string, wantReplaySince bool, wantFilter map[string]any) {
+	t.Helper()
 	if len(*requests) != 1 || (*requests)[0].Method != runCommandMethodSubscribeTrace {
 		t.Fatalf("ws requests = %#v, want %s", *requests, runCommandMethodSubscribeTrace)
 	}
 	if got := (*requests)[0].Params["run_id"]; got != runID {
 		t.Fatalf("ws run_id = %#v, want %s", got, runID)
+	}
+	rawFilter, hasFilter := (*requests)[0].Params["filter"]
+	if wantFilter == nil {
+		if hasFilter {
+			t.Fatalf("ws filter = %#v, want omitted", rawFilter)
+		}
+	} else if !reflect.DeepEqual(rawFilter, wantFilter) {
+		t.Fatalf("ws filter = %#v, want %#v", rawFilter, wantFilter)
 	}
 	rawReplaySince, ok := (*requests)[0].Params["replay_since"]
 	if !wantReplaySince {

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -4539,13 +4539,21 @@
     },
     {
       "name": "run.subscribe_trace",
-      "description": "Live composed trace stream for one run. Each notification carries one\njoined trace row (the same RunTraceRow shape returned by run.trace).\nDistinct from event.subscribe because trace is a composed view (event\n+ delivery + session + turn joined by the runtime), not raw events.\n",
+      "description": "Live composed trace stream for one run. Each notification carries one\njoined trace row (the same RunTraceRow shape returned by run.trace).\nDistinct from event.subscribe because trace is a composed view (event\n+ delivery + session + turn joined by the runtime), not raw events.\nSupports the same RunTraceFilter row predicates as run.trace, composed with\nreplay_since for catch-up/recovery.\n",
       "params": [
         {
           "name": "run_id",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "filter",
+          "required": false,
+          "description": "Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",
+          "schema": {
+            "$ref": "#/components/schemas/RunTraceFilter"
           }
         },
         {
@@ -4647,7 +4655,7 @@
         {
           "name": "filter",
           "required": false,
-          "description": "Snapshot-only typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",
+          "description": "Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",
           "schema": {
             "$ref": "#/components/schemas/RunTraceFilter"
           }
@@ -6930,7 +6938,7 @@
       },
       "RunTraceFilter": {
         "additionalProperties": false,
-        "description": "Snapshot-only typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace only. /v1/ws run.subscribe_trace does not accept it until a separate follow-filter contract is promoted.",
+        "description": "Typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace and /v1/ws run.subscribe_trace.",
         "properties": {
           "delivery_status": {
             "items": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5969,11 +5969,11 @@ cli_specification:
           used by the run-debug trace owner. Trace-specific `swarm trace --follow` subscription recovery and
           `--no-retry` are promoted in
           cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract by #928. Review-artifact
-          `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Snapshot-only typed
+          `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Typed
           RunTraceFilter fields for event-name, subscriber identity, entity-id, and delivery-status are promoted on
-          `/v1/rpc run.trace` and consumed by `swarm trace`. Review-artifact `until`, follow-capable typed filters,
-          `--include-payload`, shared `swarm run` recovery, and multi-run `--all` remain explicitly unpromoted split
-          tails until later gated children promote their own canonical owners.
+          `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace` and consumed by `swarm trace` snapshot and follow
+          modes. Review-artifact `until`, `--include-payload`, shared `swarm run` recovery, and multi-run `--all`
+          remain explicitly unpromoted split tails until later gated children promote their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: promoted_first_slice
         tracker: '#856'
@@ -7272,8 +7272,9 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run trace rendering over API-owned RunTraceRow facts only; no CLI reconstruction from tables.
       promoted_trace_filter_contract:
-        status: api_owner_promoted_cli_implemented
+        status: api_and_subscription_owner_promoted_cli_implemented
         snapshot_owner: /v1/rpc run.trace
+        subscription_owner: /v1/ws run.subscribe_trace
         promoted_params:
         - run_id
         - limit
@@ -7282,11 +7283,11 @@ cli_specification:
         - filter
         filter_schema: RunTraceFilter
         filter_fields:
-          event_name: Snapshot-only repeatable event-name predicate. The CLI sends an array of non-empty names as `filter.event_name` and the server matches any value against RunTraceRow.event_name.
-          entity_id: Snapshot-only repeatable entity-id predicate. The CLI sends an array of OpaqueId values as `filter.entity_id` and the server matches any value against RunTraceRow.entity_id.
-          delivery_status: Snapshot-only repeatable delivery-status predicate. The CLI sends an array of DeliveryStatus enum values as `filter.delivery_status` and the server matches any value against RunTraceRow.delivery_status.
-          subscriber_id: Snapshot-only repeatable subscriber identity predicate. The CLI sends an array of non-empty subscriber ids as `filter.subscriber_id` and the server matches any value against RunTraceRow.subscriber_id.
-          subscriber_type: Snapshot-only repeatable subscriber type predicate. The CLI sends an array of SubscriberType enum values as `filter.subscriber_type` and the server matches any value against RunTraceRow.subscriber_type.
+          event_name: Repeatable event-name predicate. The CLI sends an array of non-empty names as `filter.event_name` and the server matches any value against RunTraceRow.event_name.
+          entity_id: Repeatable entity-id predicate. The CLI sends an array of OpaqueId values as `filter.entity_id` and the server matches any value against RunTraceRow.entity_id.
+          delivery_status: Repeatable delivery-status predicate. The CLI sends an array of DeliveryStatus enum values as `filter.delivery_status` and the server matches any value against RunTraceRow.delivery_status.
+          subscriber_id: Repeatable subscriber identity predicate. The CLI sends an array of non-empty subscriber ids as `filter.subscriber_id` and the server matches any value against RunTraceRow.subscriber_id.
+          subscriber_type: Repeatable subscriber type predicate. The CLI sends an array of SubscriberType enum values as `filter.subscriber_type` and the server matches any value against RunTraceRow.subscriber_type.
         since_semantics: >
           `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
           materialization watermark is strictly after `since`, where that watermark is the greatest available
@@ -7295,12 +7296,14 @@ cli_specification:
         cli_consumer_behavior: >
           Snapshot `swarm trace` consumes `--since`, `--limit`, `--cursor`, `--event-name`, `--entity-id`,
           `--delivery-status`, `--subscriber-id`, and `--subscriber-type` by sending the exact promoted params to
-          `/v1/rpc run.trace`. These snapshot flags are invalid with `--follow`/`-f` and must fail before any API or
-          WebSocket request; follow mode remains the base `/v1/ws run.subscribe_trace` consumer.
+          `/v1/rpc run.trace`. Follow `swarm trace --follow` / `swarm trace -f` consumes the same typed filter flags
+          by sending `filter` to `/v1/ws run.subscribe_trace`; fixed-window snapshot controls `--since`, `--limit`,
+          and `--cursor` remain invalid with follow and must fail before any API or WebSocket request.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
         - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/limit/cursor
-        - invalid --since, out-of-range --limit, blank --cursor, blank/invalid typed filters, and --follow plus snapshot filters fail before API/WS calls
+        - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
+        - invalid --since, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:
@@ -7313,9 +7316,9 @@ cli_specification:
           expands_to: --follow
           behavior: >
             `-f` is an exact CLI-only shorthand for `--follow`. It selects the same `/v1/ws run.subscribe_trace`
-            follow path, accepts the same `--no-retry` modifier, rejects the same snapshot-only flags before any
-            API or WebSocket call, and does not introduce new API params, runtime semantics, output behavior, or
-            `swarm run` follow behavior.
+            follow path, accepts the same `--no-retry` modifier, rejects the same fixed-window snapshot flags before
+            any API or WebSocket call, and does not introduce distinct runtime semantics, output behavior, or
+            `swarm run` follow behavior. It may carry the promoted RunTraceFilter param when typed filter flags are present.
         scope: >
           Applies only to `swarm trace --follow` / `swarm trace -f`. `swarm run` foreground follow, connected follow, and reattach keep their
           existing lifecycle policy and may continue to use the shared one-shot `subscribeRunTrace` helper without inheriting
@@ -7340,12 +7343,13 @@ cli_specification:
         replay_watermark: >
           Initial `run.subscribe_trace` requests omit `replay_since`. Recovered subscriptions set `replay_since` to the
           RFC3339Nano `event_created_at` timestamp of the last successfully rendered RunTraceRow. If no row has been
-          rendered, recovered requests also omit `replay_since`. The CLI does not deduplicate rows; recovery is at-least-once
-          and the server/API owner remains responsible for trace ordering and retention semantics.
+          rendered, recovered requests also omit `replay_since`. Recovered requests preserve the same RunTraceFilter, if any,
+          that the initial follow request used. The CLI does not deduplicate rows; recovery is at-least-once and the server/API
+          owner remains responsible for trace ordering and retention semantics.
         no_retry_flag: >
           `--no-retry` disables this recovery loop for `swarm trace --follow` / `swarm trace -f` only. With `--no-retry`, the command performs
-          exactly one `run.subscribe_trace` request, never sends `replay_since`, exits 0 on a clean close, and fails closed on
-          the first subscription or notification error.
+          exactly one `run.subscribe_trace` request, may include the promoted RunTraceFilter, never sends `replay_since`, exits
+          0 on a clean close, and fails closed on the first subscription or notification error.
         invalid_combinations:
         - --since with --follow/-f
         - --limit with --follow/-f
@@ -7354,6 +7358,7 @@ cli_specification:
         - direct --replay-since flag; replay_since is an internal recovery parameter, not a user-facing trace flag
         proof_expectations:
         - initial and recovered WebSocket request-shape tests prove exact run.subscribe_trace params and replay_since handling
+        - follow-mode typed filter request-shape tests prove initial, recovered, and --no-retry subscriptions preserve the exact RunTraceFilter
         - '`-f` help/discoverability and execution tests prove exact aliasing to --follow with no distinct API or runtime path'
         - omitted-run follow resolves through /v1/rpc run.list once before recovered subscriptions for the resolved run id
         - --no-retry proves one-shot close behavior and no replay_since
@@ -7363,7 +7368,6 @@ cli_specification:
         - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
         split_tail:
           until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
-          follow_capable_typed_filters: Not promoted; /v1/ws run.subscribe_trace currently has no RunTraceFilter param and remains split because it has distinct recovery semantics and shared `swarm run` coupling.
           include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
           shared_run_follow_recovery: Not promoted; `swarm run` follow and reattach have distinct lifecycle semantics and remain split.
           all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
@@ -10149,7 +10153,7 @@ api_specification:
           next_cursor:
             $ref: '#/components/schemas/Cursor'
       RunTraceFilter:
-        description: Snapshot-only typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace only. /v1/ws run.subscribe_trace does not accept it until a separate follow-filter contract is promoted.
+        description: Typed predicates for the canonical composed RunTraceRow owner. Each present field is an OR-list for that field; different fields compose with AND. This schema is consumed by /v1/rpc run.trace and /v1/ws run.subscribe_trace.
         type: object
         additionalProperties: false
         properties:
@@ -11154,7 +11158,7 @@ api_specification:
           $ref: '#/components/schemas/Timestamp'
       - name: filter
         required: false
-        description: Snapshot-only typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
+        description: Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
         schema:
           $ref: '#/components/schemas/RunTraceFilter'
       result:
@@ -11198,6 +11202,10 @@ api_specification:
 
         + delivery + session + turn joined by the runtime), not raw events.
 
+        Supports the same RunTraceFilter row predicates as run.trace, composed with
+
+        replay_since for catch-up/recovery.
+
         '
       scope:
         required:
@@ -11210,6 +11218,11 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/OpaqueId'
+      - name: filter
+        required: false
+        description: Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
+        schema:
+          $ref: '#/components/schemas/RunTraceFilter'
       - name: replay_since
         required: false
         description: Optional catch-up window. If present, delivers trace rows from this time forward, then continues live.

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -175,8 +175,12 @@ func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSess
 	if err != nil {
 		return subscriptionPlan{}, err
 	}
+	filter, err := runTraceFilterParam(req.Params)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
 	baseSince := subscriptionBaseSince(replaySince, r.now())
-	if _, _, err := reads.LoadRunDebugTracePage(session.ctx, runID, store.RunDebugTraceQueryOptions{Limit: 1, Since: baseSince}); errors.Is(err, store.ErrRunNotFound) {
+	if _, _, err := reads.LoadRunDebugTracePage(session.ctx, runID, store.RunDebugTraceQueryOptions{Limit: 1, Since: baseSince, Filter: filter}); errors.Is(err, store.ErrRunNotFound) {
 		return subscriptionPlan{}, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 	} else if errors.Is(err, store.ErrInvalidObservabilityCursor) {
 		return subscriptionPlan{}, NewInvalidParamsError(map[string]any{"field": "replay_since", "reason": "invalid run trace replay watermark"})
@@ -187,7 +191,7 @@ func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSess
 	return subscriptionPlan{
 		Result: subscriptionIDResult{SubscriptionID: id},
 		Start: func() {
-			go r.runTraceSubscription(ctx, session, id, reads, runID, baseSince)
+			go r.runTraceSubscription(ctx, session, id, reads, runID, baseSince, filter)
 		},
 		Cancel: cancel,
 	}, nil
@@ -342,9 +346,9 @@ func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, sessio
 	return false
 }
 
-func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time) {
+func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter) {
 	seen := map[string]string{}
-	if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, seen) {
+	if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, seen) {
 		return
 	}
 	ticker := time.NewTicker(r.pollInterval)
@@ -354,20 +358,21 @@ func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, seen) {
+			if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, seen) {
 				return
 			}
 		}
 	}
 }
 
-func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, seen map[string]string) bool {
+func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter, seen map[string]string) bool {
 	cursor := ""
 	for page := 0; page < subscriptionMaxPages; page++ {
 		rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{
 			Limit:  subscriptionBatchLimit,
 			Cursor: cursor,
 			Since:  since,
+			Filter: filter,
 		})
 		if err != nil {
 			session.close()

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -356,6 +356,13 @@ func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testi
 		"params": map[string]any{
 			"run_id":       "run-1",
 			"replay_since": base.Format(time.RFC3339Nano),
+			"filter": map[string]any{
+				"event_name":      []any{"scan.requested"},
+				"entity_id":       []any{"entity-1"},
+				"delivery_status": []any{"delivered"},
+				"subscriber_id":   []any{"agent-1"},
+				"subscriber_type": []any{"agent"},
+			},
 		},
 	})
 	subscribe := readWSResponse(t, conn)
@@ -368,6 +375,50 @@ func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testi
 	}
 	if observability.lastTrace.Since == nil || !observability.lastTrace.Since.Equal(base) {
 		t.Fatalf("run.subscribe_trace since = %#v, want %s", observability.lastTrace.Since, base)
+	}
+	if got := observability.lastTrace.Filter; len(got.EventNames) != 1 || got.EventNames[0] != "scan.requested" || len(got.EntityIDs) != 1 || got.EntityIDs[0] != "entity-1" || len(got.DeliveryStatuses) != 1 || got.DeliveryStatuses[0] != "delivered" || len(got.SubscriberIDs) != 1 || got.SubscriberIDs[0] != "agent-1" || len(got.SubscriberTypes) != 1 || got.SubscriberTypes[0] != "agent" {
+		t.Fatalf("run.subscribe_trace filter = %#v", got)
+	}
+}
+
+func TestRunSubscribeTraceFilterValidation(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Subscriptions: OperatorSubscriptions(OperatorReadOptions{
+			Observability: &fakeObservabilityReadStore{},
+		}, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name      string
+		params    map[string]any
+		wantField string
+	}{
+		{name: "unknown top-level limit", params: map[string]any{"run_id": "run-1", "limit": 1}, wantField: "limit"},
+		{name: "unknown filter field", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"event_nmae": []any{"scan.requested"}}}, wantField: "filter.event_nmae"},
+		{name: "invalid delivery status", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"delivery_status": []any{"done"}}}, wantField: "filter.delivery_status"},
+		{name: "invalid subscriber type", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"subscriber_type": []any{"system"}}}, wantField: "filter.subscriber_type"},
+		{name: "invalid entity id", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"entity_id": []any{"bad id!"}}}, wantField: "filter.entity_id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := dialTestWS(t, server.URL)
+			defer conn.Close()
+			writeWSRequest(t, conn, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "bad-run-trace",
+				"method":  "run.subscribe_trace",
+				"params":  tc.params,
+			})
+			resp := readWSResponse(t, conn)
+			if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+				t.Fatalf("run.subscribe_trace response = %#v, want invalid params", resp)
+			}
+			if details := asMap(t, asMap(t, resp.Error.Data)["details"]); details["field"] != tc.wantField {
+				t.Fatalf("run.subscribe_trace details = %#v, want field %q", details, tc.wantField)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Part of #855
Related to #735
Related to #794

## Summary
- Promotes `RunTraceFilter` as the shared typed row-predicate owner for `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace` in `platform-spec.yaml`, then regenerates OpenRPC.
- Allows `swarm trace --follow/-f` to send repeatable typed filter flags under `filter`, preserving the exact filter on recovered subscriptions and with `--no-retry`.
- Wires `run.subscribe_trace` validation and store query consumption through `RunDebugTraceQueryOptions.Filter`; `swarm run` continues to pass no filter and preserves its request shape.

## Governing Refs / Context
- `platform-spec.yaml` `cli_specification.review_artifact_accounting.trace_filters_and_subscription_recovery`
- `platform-spec.yaml` `cli_specification.command_catalog.trace.promoted_trace_filter_contract`
- `platform-spec.yaml` `cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract`
- `platform-spec.yaml` `api_specification.components.schemas.RunTraceFilter`
- `platform-spec.yaml` `api_specification.method_catalog.run.trace`
- `platform-spec.yaml` `api_specification.method_catalog.run.subscribe_trace`
- #855 refreshed pre-audit and the independent gate outcome approving this follow-capable typed filter first slice.

## Semantic Migration
- New canonical owner: shared `RunTraceFilter` schema in `platform-spec.yaml`, generated OpenRPC, `/v1/rpc run.trace`, `/v1/ws run.subscribe_trace`, and `store.RunDebugTraceQueryOptions.Filter` / `LoadRunDebugTracePage` for execution.
- Old non-authoritative paths now invalid: CLI rejection of follow typed filters, unpromoted WS `filter` params, local CLI filtering, and direct DB/store/runtime/EventBus/dashboard/Builder reads from CLI.
- Production paths checked for surviving old behavior: `cmd/swarm trace`, `cmd/swarm run`, `internal/apiv1` `run.subscribe_trace`, `internal/store` trace query owner, generated OpenRPC, dashboard/runtime bypass references, event/log subscription precedents.
- Migration complete for follow-capable typed trace filters only. #855 remains open for `until`, payload/output, multi-run `--all`, and shared `swarm run` follow recovery.

## Proof
- `go test ./cmd/swarm -run 'TraceFollow|Trace|DiagnosticsRejectInvalidInputBeforeRequest|DiagnosticsRequireAPITokenBeforeRequest' -count=1`
- `go test ./cmd/swarm -run 'RunCommand' -count=1`
- `go test ./internal/apiv1 -run 'RunSubscribeTrace|WebSocketRunSubscribeTrace|OpenRPC|RegistryMethodNamesMatchGeneratedOpenRPC' -count=1`
- `go test ./internal/store -run 'RunDebugTrace|OperatorObservability.*Trace' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- static no-bypass grep over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`
- `go test ./...`