### PR TITLE
[agent-e][issue #859] Add stop-all confirmation gate

### DIFF
--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -133,7 +133,7 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 
 func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runtimeNukeCommandOptions) error {
 	if !opts.dryRun && !opts.yes {
-		if !runtimeNukeStdinIsTerminal(opts.apiOptions) {
+		if !controlStdinIsTerminal(opts.apiOptions) {
 			fmt.Fprintln(errOut, "ERROR: `swarm control nuke` is destructive; pass --yes for non-TTY invocations.")
 			return commandExitError{code: 2}
 		}
@@ -169,13 +169,6 @@ func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runt
 		return commandExitError{code: 3}
 	}
 	return nil
-}
-
-func runtimeNukeStdinIsTerminal(opts rootCommandOptions) bool {
-	if opts.stdinIsTerminal == nil {
-		return false
-	}
-	return opts.stdinIsTerminal()
 }
 
 func confirmRuntimeNuke(input io.Reader, errOut io.Writer) (bool, error) {

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -32,6 +34,7 @@ type controlRunCommandOptions struct {
 	runMethod         string
 	allMethod         string
 	all               bool
+	yes               bool
 	idempotencyKey    string
 	idempotencyKeySet bool
 }
@@ -84,6 +87,9 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&cmdOpts.all, "all", false, "Apply the supported all-runs scope for this action")
+	if opts.action == "stop" {
+		cmd.Flags().BoolVar(&cmdOpts.yes, "yes", false, "Skip the stop-all confirmation prompt")
+	}
 	cmd.Flags().StringVar(&cmdOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIAPIConnectionFlags(cmd, &cmdOpts.apiOptions)
 	return cmd
@@ -110,6 +116,15 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 	if opts.all && opts.action == "stop" && idempotencyKey != "" {
 		fmt.Fprintln(errOut, "--idempotency-key is not supported with control stop --all")
 		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	if opts.action == "stop" && opts.yes && !opts.all {
+		fmt.Fprintln(errOut, "--yes is only supported with control stop --all")
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	if opts.all && opts.action == "stop" {
+		if err := requireControlStopAllConfirmation(opts.apiOptions, opts.yes, errOut); err != nil {
+			return err
+		}
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
@@ -202,6 +217,47 @@ func runControlStopAllCommand(ctx context.Context, out, errOut io.Writer, client
 		return commandExitError{code: controlStopAllExitCode(failures)}
 	}
 	return nil
+}
+
+func requireControlStopAllConfirmation(opts rootCommandOptions, yes bool, errOut io.Writer) error {
+	if yes {
+		return nil
+	}
+	if !controlStdinIsTerminal(opts) {
+		fmt.Fprintln(errOut, "ERROR: `swarm control stop --all` stops every running or paused run; pass --yes for non-TTY invocations.")
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	confirmed, err := confirmControlStopAll(opts.input, errOut)
+	if err != nil {
+		fmt.Fprintf(errOut, "read confirmation: %v\n", err)
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	if !confirmed {
+		fmt.Fprintln(errOut, "Aborted; no runs stopped.")
+		return commandExitError{code: controlCommandExitCodeValidation}
+	}
+	return nil
+}
+
+func controlStdinIsTerminal(opts rootCommandOptions) bool {
+	if opts.stdinIsTerminal == nil {
+		return false
+	}
+	return opts.stdinIsTerminal()
+}
+
+func confirmControlStopAll(input io.Reader, errOut io.Writer) (bool, error) {
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	fmt.Fprintln(errOut, "WARNING: `swarm control stop --all` will stop every running or paused run.")
+	fmt.Fprint(errOut, "Continue? [y/N] ")
+	line, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }
 
 func listControlStopAllRunIDs(ctx context.Context, client *cliAPIClient) ([]string, error) {

--- a/cmd/swarm/control_run_test.go
+++ b/cmd/swarm/control_run_test.go
@@ -204,7 +204,7 @@ func TestControlStopAllListsActiveRunsAndStopsUniqueTargets(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -250,6 +250,8 @@ func TestControlRunRejectsInvalidTargetsBeforeRequest(t *testing.T) {
 		{name: "blank idempotency key continue all", args: []string{"control", "continue", "--all", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "blank idempotency key stop run", args: []string{"control", "stop", "run-1", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "stop all rejects idempotency key", args: []string{"control", "stop", "--all", "--idempotency-key", "idem-1"}, wantStderr: "--idempotency-key is not supported with control stop --all"},
+		{name: "stop all rejects idempotency key with yes", args: []string{"control", "stop", "--all", "--yes", "--idempotency-key", "idem-1"}, wantStderr: "--idempotency-key is not supported with control stop --all"},
+		{name: "yes without all", args: []string{"control", "stop", "run-1", "--yes"}, wantStderr: "--yes is only supported with control stop --all"},
 		{name: "unsupported flag", args: []string{"control", "stop", "run-1", "--unknown"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -283,7 +285,7 @@ func TestControlRunRequiresAPITokenBeforeRequest(t *testing.T) {
 	for _, args := range [][]string{
 		{"control", "pause", "run-1"},
 		{"control", "continue", "--all"},
-		{"control", "stop", "--all"},
+		{"control", "stop", "--all", "--yes"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "")
@@ -375,6 +377,159 @@ func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) 
 	}
 }
 
+func TestControlStopAllConfirmationAndNoCallPaths(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		input         string
+		stdinTerminal bool
+		wantCode      int
+		wantCalls     int
+		wantStderr    []string
+	}{
+		{
+			name:          "tty confirmation proceeds with y",
+			args:          []string{"control", "stop", "--all"},
+			input:         "y\n",
+			stdinTerminal: true,
+			wantCalls:     2,
+			wantStderr:    []string{"WARNING: `swarm control stop --all` will stop every running or paused run.", "Continue? [y/N]"},
+		},
+		{
+			name:          "tty confirmation proceeds with yes case insensitive",
+			args:          []string{"control", "stop", "--all"},
+			input:         "YES\n",
+			stdinTerminal: true,
+			wantCalls:     2,
+			wantStderr:    []string{"Continue? [y/N]"},
+		},
+		{
+			name:          "tty abort makes no request",
+			args:          []string{"control", "stop", "--all"},
+			input:         "n\n",
+			stdinTerminal: true,
+			wantCode:      2,
+			wantStderr:    []string{"Aborted; no runs stopped."},
+		},
+		{
+			name:          "tty empty answer makes no request",
+			args:          []string{"control", "stop", "--all"},
+			input:         "\n",
+			stdinTerminal: true,
+			wantCode:      2,
+			wantStderr:    []string{"Aborted; no runs stopped."},
+		},
+		{
+			name:       "non tty without yes makes no request",
+			args:       []string{"control", "stop", "--all"},
+			wantCode:   2,
+			wantStderr: []string{"ERROR: `swarm control stop --all` stops every running or paused run; pass --yes for non-TTY invocations."},
+		},
+		{
+			name:      "yes bypasses prompt",
+			args:      []string{"control", "stop", "--all", "--yes"},
+			wantCalls: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				captured = append(captured, req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			opts := testRootCommandOptions(server)
+			opts.input = strings.NewReader(tc.input)
+			opts.stdinIsTerminal = func() bool { return tc.stdinTerminal }
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if len(captured) != tc.wantCalls {
+				t.Fatalf("server calls = %d, want %d", len(captured), tc.wantCalls)
+			}
+			for _, want := range tc.wantStderr {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+			if tc.wantCalls > 0 {
+				assertControlRequest(t, captured[0], controlCommandRunListMethod, map[string]any{"status": "running", "limit": float64(controlCommandStopAllPageLimit)})
+				assertControlRequest(t, captured[1], controlCommandRunListMethod, map[string]any{"status": "paused", "limit": float64(controlCommandStopAllPageLimit)})
+				if !strings.Contains(stdout.String(), "control stop ok: scope=all matched=0 stopped=0 failed=0") {
+					t.Fatalf("stdout = %q, want empty stop-all success", stdout.String())
+				}
+			}
+			if tc.name == "yes bypasses prompt" && strings.Contains(stderr.String(), "Continue?") {
+				t.Fatalf("stderr = %q, want no prompt", stderr.String())
+			}
+		})
+	}
+}
+
+func TestControlStopAllConfirmationPrecedesAPIClientConstruction(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		input         string
+		stdinTerminal bool
+		wantCode      int
+		wantStderr    string
+	}{
+		{
+			name:       "non tty without yes fails before missing token",
+			wantCode:   2,
+			wantStderr: "pass --yes for non-TTY",
+		},
+		{
+			name:          "tty abort fails before missing token",
+			input:         "n\n",
+			stdinTerminal: true,
+			wantCode:      2,
+			wantStderr:    "Aborted; no runs stopped.",
+		},
+		{
+			name:          "tty confirmation then checks token",
+			input:         "y\n",
+			stdinTerminal: true,
+			wantCode:      4,
+			wantStderr:    "SWARM_API_TOKEN is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "")
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				writeJSONRPCResult(t, w, "unexpected", map[string]any{"runs": []any{}})
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			opts := testRootCommandOptions(server)
+			opts.input = strings.NewReader(tc.input)
+			opts.stdinIsTerminal = func() bool { return tc.stdinTerminal }
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all"}, &stdout, &stderr, opts)
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0", calls.Load())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
 func TestControlStopAllReportsPartialFailures(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var captured []jsonRPCRequest
@@ -403,7 +558,7 @@ func TestControlStopAllReportsPartialFailures(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 3 {
 		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5991,8 +5991,9 @@ cli_specification:
           `swarm control pause|continue` and single-run `swarm control stop` idempotency-key pass-through are
           promoted as the first #859 slice. `swarm control stop --all --idempotency-key` fails before any API
           request because no per-target key derivation policy is promoted. `stop --all --yes` confirmation/non-TTY
-          behavior and `swarm control nuke --idempotency-key` remain split tails under #859 unless later gates
-          promote them.
+          behavior is promoted as the second #859 slice: stop-all requires TTY confirmation before API client
+          construction/request unless --yes is supplied, and --yes is valid only with stop --all. `swarm control
+          nuke --idempotency-key` remains a split tail under #859 unless a later gate promotes it.
       rich_agent_operator_ux:
         disposition: tracked_child
         tracker: '#860'
@@ -7533,7 +7534,7 @@ cli_specification:
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_stop:
-      command: swarm control stop <run-id> [--idempotency-key <key>] | --all
+      command: swarm control stop <run-id> [--idempotency-key <key>] | --all [--yes]
       tier: should_have
       implementation_status: implemented
       owners:
@@ -7541,7 +7542,7 @@ cli_specification:
         all_discovery: /v1/rpc run.list
         all_stop: /v1/rpc run.stop
       targeting:
-        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, unsupported flags, explicitly blank idempotency keys, or --all with --idempotency-key fails before any API request with exit 2.'
+        rule: 'Exactly one target is required: either one <run-id> or --all. Supplying both, supplying neither, blank run IDs, extra args, unsupported flags, explicitly blank idempotency keys, --yes without --all, or --all with --idempotency-key fails before any API request with exit 2.'
         all_scope_semantics: >
           `--all` is an API-only CLI composite, not an atomic runtime-wide stop owner. The CLI lists active runs with status=running
           and status=paused, follows next_cursor pagination to exhaustion with limit=500, deduplicates run IDs, and calls run.stop once
@@ -7550,6 +7551,18 @@ cli_specification:
       idempotency:
         single_run: '`--idempotency-key <key>` is optional for `swarm control stop <run-id>`. When supplied, the CLI trims and passes the value as `idempotency_key` to run.stop; an explicitly blank key fails before any API request with exit 2.'
         all_scope_split: '`swarm control stop --all --idempotency-key <key>` fails before any API request because no promoted per-target idempotency-key derivation policy exists. The CLI MUST NOT generate or derive keys for the composite stop-all flow.'
+      confirmation:
+        rule: >
+          `swarm control stop --all` is a bulk destructive control action. Unless --yes is supplied, the CLI MUST
+          complete confirmation before constructing the API client or sending any API request. Non-TTY invocation
+          without --yes fails before any API request with exit 2. TTY invocation prompts on stderr before any API
+          request and proceeds only when the trimmed, case-insensitive answer is `y` or `yes`; empty input and every
+          other answer abort before any API request with exit 2. `--yes` bypasses the prompt and is valid only with
+          `swarm control stop --all`.
+        non_tty_error: 'ERROR: `swarm control stop --all` stops every running or paused run; pass --yes for non-TTY invocations.'
+        warning: 'WARNING: `swarm control stop --all` will stop every running or paused run.'
+        prompt: 'Continue? [y/N] '
+        abort: 'Aborted; no runs stopped.'
       output:
         single_run_success: 'control stop ok: scope=run run_id=<run-id>'
         all_success: 'control stop ok: scope=all matched=<n> stopped=<n> failed=0'
@@ -7568,6 +7581,10 @@ cli_specification:
       - exact /v1/rpc run.list status=running/status=paused paginated discovery for --all
       - exact /v1/rpc run.stop calls for unique discovered run IDs and explicit partial-failure reporting
       - explicit blank --idempotency-key and --all with --idempotency-key fail before any API request with exit 2
+      - stop --all without --yes prompts on TTY before API client construction/request and accepts only y/yes confirmation
+      - stop --all without --yes fails in non-TTY before API client construction/request with the promoted non_tty_error text
+      - stop --all --yes bypasses the prompt and preserves the existing run.list plus per-run run.stop behavior
+      - --yes without --all fails before any API request with exit 2
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_nuke:


### PR DESCRIPTION
## Summary

Implements the approved #859 stop-all confirmation slice:

- promotes exact `swarm control stop --all [--yes]` confirmation/non-TTY behavior into `platform-spec.yaml`
- adds `--yes` for `swarm control stop --all` only
- fails non-TTY `stop --all` without `--yes` before API client construction/request
- prompts TTY `stop --all` before API client construction/request and accepts only `y`/`yes`
- preserves #966 idempotency behavior and existing stop-all partial-result behavior

Part of #859.

## Governing Refs / Context

- #859 refreshed Pre-Implementation Coverage Audit: `#859#issuecomment-4523934008`
- #859 independent gate outcome: `approved as first slice` for `cli.control.stop_all_confirmation_non_tty_gate_drift`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.review_artifact_reconciliation.under_promoted_review_features.control_idempotency_and_stop_all_confirmation`
  - `cli_specification.command_catalog.control_stop`
- #812/#815: base `stop --all` composite over `/v1/rpc run.list` plus per-target `/v1/rpc run.stop`
- #966: closed control idempotency pass-through and stop-all idempotency fail-closed behavior

## Semantic Migration / Owner Boundary

- New canonical owner for this CLI behavior: promoted `platform-spec.yaml` `control_stop` command row.
- Old invalid behavior: `swarm control stop --all` could proceed without explicit confirmation and had no `--yes` bypass contract.
- Production paths checked for surviving old behavior: `cmd/swarm/control_run.go`, `cmd/swarm/control_nuke.go`, focused control tests, and grep proof for no direct runtime/store/EventBus/legacy/destructive path.
- Migration completeness: complete for `cli.control.stop_all_confirmation_non_tty_gate_drift`; #859 remains open for the split `swarm control nuke --idempotency-key` tail unless lead later closes or backlogs it.

## Proof

- `go test ./cmd/swarm -run 'TestControlStopAll|TestControlRunRejectsInvalidTargetsBeforeRequest|TestControlRunRequiresAPITokenBeforeRequest|TestControlNukeConfirmationAndNoCallPaths' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go build -o /tmp/swarm-issue-859-stop-all ./cmd/swarm`
- `go test ./...`
- `git diff --check`
- `go run ./cmd/swarm control stop --help`
- `rg -n 'runtime\.stop|runtime\.nuke|internal/store|internal/runtime|EventBus|/api/|/rpc|/ws' cmd/swarm/control_run.go cmd/swarm/control_run_test.go` returned only `/v1/rpc` test path assertions.