### PR TITLE
[agent-b][issue #855] Add trace until filtering

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -34,6 +34,7 @@ type diagnosticTraceOptions struct {
 	follow           bool
 	noRetry          bool
 	since            string
+	until            string
 	limit            int
 	cursor           string
 	eventNames       []string
@@ -42,6 +43,7 @@ type diagnosticTraceOptions struct {
 	subscriberIDs    []string
 	subscriberTypes  []string
 	sinceSet         bool
+	untilSet         bool
 	limitSet         bool
 	cursorSet        bool
 }
@@ -219,6 +221,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			traceOpts.sinceSet = cmd.Flags().Changed("since")
+			traceOpts.untilSet = cmd.Flags().Changed("until")
 			traceOpts.limitSet = cmd.Flags().Changed("limit")
 			traceOpts.cursorSet = cmd.Flags().Changed("cursor")
 			runID := ""
@@ -231,6 +234,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
+	cmd.Flags().StringVar(&traceOpts.until, "until", "", "Snapshot-only inclusive RFC3339 trace materialization upper bound")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
 	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
 	cmd.Flags().StringArrayVar(&traceOpts.eventNames, "event-name", nil, "Event name filter; repeat to match any")
@@ -483,12 +487,28 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 		}
 		params["cursor"] = cursor
 	}
+	var sinceTime *time.Time
 	if o.sinceSet {
 		since := strings.TrimSpace(o.since)
-		if err := validateRFC3339Flag("--since", since); err != nil {
+		parsed, err := parseRFC3339Flag("--since", since)
+		if err != nil {
 			return nil, err
 		}
+		sinceTime = &parsed
 		params["since"] = since
+	}
+	var untilTime *time.Time
+	if o.untilSet {
+		until := strings.TrimSpace(o.until)
+		parsed, err := parseRFC3339Flag("--until", until)
+		if err != nil {
+			return nil, err
+		}
+		untilTime = &parsed
+		params["until"] = until
+	}
+	if sinceTime != nil && untilTime != nil && sinceTime.After(*untilTime) {
+		return nil, fmt.Errorf("--until must be at or after --since")
 	}
 	filter, err := o.traceFilter()
 	if err != nil {
@@ -506,6 +526,7 @@ func (o diagnosticTraceOptions) followParams() (map[string]any, error) {
 		set  bool
 	}{
 		{name: "--since", set: o.sinceSet},
+		{name: "--until", set: o.untilSet},
 		{name: "--limit", set: o.limitSet},
 		{name: "--cursor", set: o.cursorSet},
 	} {
@@ -897,10 +918,16 @@ func (o diagnosticRunListOptions) params() (map[string]any, error) {
 }
 
 func validateRFC3339Flag(name, value string) error {
-	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
-		return fmt.Errorf("%s must be an RFC3339 timestamp: %w", name, err)
+	_, err := parseRFC3339Flag(name, value)
+	return err
+}
+
+func parseRFC3339Flag(name, value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s must be an RFC3339 timestamp: %w", name, err)
 	}
-	return nil
+	return parsed, nil
 }
 
 func validateDiagnosticRunListResult(result diagnosticRunListResult) error {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -362,6 +362,7 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 			"limit":  float64(2),
 			"cursor": "trace-cur",
 			"since":  "2026-05-13T10:00:00Z",
+			"until":  "2026-05-13T10:05:00Z",
 			"filter": map[string]any{
 				"event_name":      []any{"scan.requested", "scan.completed"},
 				"entity_id":       []any{"entity-1", "entity-2"},
@@ -395,6 +396,7 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 		"--limit", "2",
 		"--cursor", "trace-cur",
 		"--since", "2026-05-13T10:00:00Z",
+		"--until", "2026-05-13T10:05:00Z",
 		"--event-name", "scan.requested",
 		"--event-name", "scan.completed",
 		"--entity-id", "entity-1",
@@ -454,6 +456,7 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 				"limit":  float64(3),
 				"cursor": "trace-cur",
 				"since":  "2026-05-13T10:00:00Z",
+				"until":  "2026-05-13T10:05:00Z",
 				"filter": map[string]any{"event_name": []any{"scan.requested"}},
 			}
 			if !reflect.DeepEqual(req.Params, wantParams) {
@@ -472,7 +475,7 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--limit", "3", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z", "--event-name", "scan.requested"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--limit", "3", "--cursor", "trace-cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T10:05:00Z", "--event-name", "scan.requested"}, &stdout, &stderr, testRootCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -573,6 +576,9 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "-f, --follow") {
 		t.Fatalf("help missing -f shorthand:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--until") {
+		t.Fatalf("help missing --until:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--replay-since") {
 		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
@@ -969,14 +975,18 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace invalid limit low", args: []string{"trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
 		{name: "trace invalid limit high", args: []string{"trace", "run-1", "--limit", "2001"}, wantStderr: "--limit must be between 1 and 2000"},
 		{name: "trace invalid since", args: []string{"trace", "run-1", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "trace invalid until", args: []string{"trace", "run-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp"},
+		{name: "trace since after until", args: []string{"trace", "run-1", "--since", "2026-05-13T10:05:00Z", "--until", "2026-05-13T10:00:00Z"}, wantStderr: "--until must be at or after --since"},
 		{name: "trace blank cursor", args: []string{"trace", "run-1", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
 		{name: "trace no retry requires follow", args: []string{"trace", "run-1", "--no-retry"}, wantStderr: "--no-retry requires --follow"},
 		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace follow rejects until", args: []string{"trace", "run-1", "--follow", "--until", "2026-05-13T10:05:00Z"}, wantStderr: "--until is not supported with --follow"},
 		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
+		{name: "trace shorthand follow rejects until", args: []string{"trace", "run-1", "-f", "--until", "2026-05-13T10:05:00Z"}, wantStderr: "--until is not supported with --follow"},
 		{name: "trace follow direct replay since remains unpromoted", args: []string{"trace", "run-1", "--follow", "--replay-since", "2026-05-13T10:00:00Z"}, wantStderr: "unknown flag"},
 		{name: "trace blank event name", args: []string{"trace", "run-1", "--event-name", " "}, wantStderr: "--event-name must not be empty"},
 		{name: "trace blank subscriber id", args: []string{"trace", "run-1", "--subscriber-id", " "}, wantStderr: "--subscriber-id must not be empty"},
@@ -1014,7 +1024,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 	for _, args := range [][]string{
 		{"runs"},
 		{"trace", "run-1"},
-		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z"},
+		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T10:05:00Z"},
 		{"trace", "run-1", "--event-name", "scan.requested", "--entity-id", "entity-1", "--delivery-status", "delivered", "--subscriber-id", "agent-1", "--subscriber-type", "agent"},
 		{"trace", "run-1", "--follow"},
 		{"trace", "run-1", "-f"},

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -4653,6 +4653,14 @@
           }
         },
         {
+          "name": "until",
+          "required": false,
+          "description": "Optional snapshot-only RFC3339/RFC3339Nano materialization watermark upper bound. Returns rows whose canonical trace materialization watermark is less than or equal to this timestamp. When combined with since, the server applies the half-open window `(since, until]`; since after until is invalid.\n",
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        {
           "name": "filter",
           "required": false,
           "description": "Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5970,15 +5970,16 @@ cli_specification:
           The bounded snapshot trace filter contract is promoted in
           api_specification.method_catalog.run.trace and
           cli_specification.command_catalog.trace.promoted_trace_filter_contract. The promoted API owner accepts
-          `limit`, `cursor`, and `since`; `since` filters by the canonical RunTraceRow materialization watermark
+          `limit`, `cursor`, `since`, and `until`; `since` and `until` filter by the canonical RunTraceRow materialization watermark
           used by the run-debug trace owner. Trace-specific `swarm trace --follow` subscription recovery and
           `--no-retry` are promoted in
           cli_specification.command_catalog.trace.promoted_trace_follow_recovery_contract by #928. Review-artifact
           `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Typed
           RunTraceFilter fields for event-name, subscriber identity, entity-id, and delivery-status are promoted on
           `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace` and consumed by `swarm trace` snapshot and follow
-          modes. Review-artifact `until`, `--include-payload`, shared `swarm run` recovery, and multi-run `--all`
-          remain explicitly unpromoted split tails until later gated children promote their own canonical owners.
+          modes. Snapshot `until` is promoted on `/v1/rpc run.trace` only as an inclusive upper bound. Review-artifact
+          `--include-payload`, shared `swarm run` recovery, and multi-run `--all` remain explicitly unpromoted split
+          tails until later gated children promote their own canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: promoted_first_slice
         tracker: '#856'
@@ -7275,7 +7276,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--since <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
+      command: swarm trace [<run-id>] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow/-f
@@ -7290,6 +7291,7 @@ cli_specification:
         - limit
         - cursor
         - since
+        - until
         - filter
         filter_schema: RunTraceFilter
         filter_fields:
@@ -7302,18 +7304,24 @@ cli_specification:
           `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
           materialization watermark is strictly after `since`, where that watermark is the greatest available
           timestamp across the joined event, delivery, session, and turn fields owned by RunTraceRow.
+        until_semantics: >
+          `until` is a snapshot-only RFC3339/RFC3339Nano timestamp upper bound. The server returns trace rows whose
+          canonical materialization watermark is less than or equal to `until`, using the same greatest-available
+          event, delivery, session, and turn timestamp owner as `since`. Combined `since` and `until` define the
+          half-open window `(since, until]`; `since` after `until` is invalid, while equal timestamps are allowed and
+          naturally produce an empty exclusive/inclusive window.
         current_cli_consumer_status: implemented_by_918_and_855
         cli_consumer_behavior: >
-          Snapshot `swarm trace` consumes `--since`, `--limit`, `--cursor`, `--event-name`, `--entity-id`,
+          Snapshot `swarm trace` consumes `--since`, `--until`, `--limit`, `--cursor`, `--event-name`, `--entity-id`,
           `--delivery-status`, `--subscriber-id`, and `--subscriber-type` by sending the exact promoted params to
           `/v1/rpc run.trace`. Follow `swarm trace --follow` / `swarm trace -f` consumes the same typed filter flags
-          by sending `filter` to `/v1/ws run.subscribe_trace`; fixed-window snapshot controls `--since`, `--limit`,
-          and `--cursor` remain invalid with follow and must fail before any API or WebSocket request.
+          by sending `filter` to `/v1/ws run.subscribe_trace`; fixed-window snapshot controls `--since`, `--until`,
+          `--limit`, and `--cursor` remain invalid with follow and must fail before any API or WebSocket request.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
-        - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/limit/cursor
+        - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/until/limit/cursor
         - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
-        - invalid --since, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
+        - invalid --since, invalid --until, since-after-until, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:
@@ -7362,6 +7370,7 @@ cli_specification:
           0 on a clean close, and fails closed on the first subscription or notification error.
         invalid_combinations:
         - --since with --follow/-f
+        - --until with --follow/-f
         - --limit with --follow/-f
         - --cursor with --follow/-f
         - --no-retry without --follow/-f
@@ -7377,7 +7386,6 @@ cli_specification:
         - '`swarm run` foreground/follow and reattach regression proof remains unchanged'
         - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
         split_tail:
-          until: Not promoted; the current run-debug trace owner has no upper-bound watermark contract.
           include_payload: Not promoted; RunTraceRow has no payload field and output/schema ownership is split.
           shared_run_follow_recovery: Not promoted; `swarm run` follow and reattach have distinct lifecycle semantics and remain split.
           all_runs: Not promoted; multi-run trace needs a canonical multi-run owner or explicit run.list + run.trace composition contract.
@@ -11217,6 +11225,14 @@ api_specification:
         description: >
           Optional RFC3339/RFC3339Nano materialization watermark. Returns rows whose canonical trace
           materialization watermark is strictly after this timestamp.
+        schema:
+          $ref: '#/components/schemas/Timestamp'
+      - name: until
+        required: false
+        description: >
+          Optional snapshot-only RFC3339/RFC3339Nano materialization watermark upper bound. Returns rows whose
+          canonical trace materialization watermark is less than or equal to this timestamp. When combined with
+          since, the server applies the half-open window `(since, until]`; since after until is invalid.
         schema:
           $ref: '#/components/schemas/Timestamp'
       - name: filter

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 71 {
-		t.Fatalf("schema count = %d, want 71", report.SchemaCount)
+	if report.SchemaCount != 72 {
+		t.Fatalf("schema count = %d, want 72", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 71 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 71", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 72 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 72", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -70,14 +70,14 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		}),
 	})
 
-	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1,"since":"2023-11-14T22:12:00Z","filter":{"event_name":["scan.requested"],"entity_id":["entity-1"],"delivery_status":["delivered"],"subscriber_id":["agent-1"],"subscriber_type":["agent"]}}}`)
+	trace := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":"run-1","limit":1,"since":"2023-11-14T22:12:00Z","until":"2023-11-14T22:14:00Z","filter":{"event_name":["scan.requested"],"entity_id":["entity-1"],"delivery_status":["delivered"],"subscriber_id":["agent-1"],"subscriber_type":["agent"]}}}`)
 	if trace.Error != nil {
 		t.Fatalf("run.trace error = %#v", trace.Error)
 	}
 	if rows, _ := asMap(t, trace.Result)["trace"].([]any); len(rows) != 1 {
 		t.Fatalf("run.trace rows = %#v", asMap(t, trace.Result)["trace"])
 	}
-	if observability.lastTrace.Since == nil || observability.lastTrace.Limit != 1 {
+	if observability.lastTrace.Since == nil || observability.lastTrace.Until == nil || observability.lastTrace.Limit != 1 {
 		t.Fatalf("run.trace options = %#v", observability.lastTrace)
 	}
 	if got := observability.lastTrace.Filter; len(got.EventNames) != 1 || got.EventNames[0] != "scan.requested" || len(got.EntityIDs) != 1 || got.EntityIDs[0] != "entity-1" || len(got.DeliveryStatuses) != 1 || got.DeliveryStatuses[0] != "delivered" || len(got.SubscriberIDs) != 1 || got.SubscriberIDs[0] != "agent-1" || len(got.SubscriberTypes) != 1 || got.SubscriberTypes[0] != "agent" {
@@ -87,6 +87,17 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 	invalidTraceSince := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-since","method":"run.trace","params":{"run_id":"run-1","since":"not-a-time"}}`)
 	if invalidTraceSince.Error == nil || invalidTraceSince.Error.Code != codeInvalidParams {
 		t.Fatalf("run.trace invalid since error = %#v, want invalid params", invalidTraceSince.Error)
+	}
+	invalidTraceUntil := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-until","method":"run.trace","params":{"run_id":"run-1","until":"not-a-time"}}`)
+	if invalidTraceUntil.Error == nil || invalidTraceUntil.Error.Code != codeInvalidParams {
+		t.Fatalf("run.trace invalid until error = %#v, want invalid params", invalidTraceUntil.Error)
+	}
+	invalidTraceWindow := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-window","method":"run.trace","params":{"run_id":"run-1","since":"2023-11-14T22:14:00Z","until":"2023-11-14T22:12:00Z"}}`)
+	if invalidTraceWindow.Error == nil || invalidTraceWindow.Error.Code != codeInvalidParams {
+		t.Fatalf("run.trace invalid window error = %#v, want invalid params", invalidTraceWindow.Error)
+	}
+	if details := asMap(t, asMap(t, invalidTraceWindow.Error.Data)["details"]); details["field"] != "until" {
+		t.Fatalf("run.trace invalid window details = %#v, want until field", details)
 	}
 	invalidTraceFilter := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-filter","method":"run.trace","params":{"run_id":"run-1","filter":{"delivery_status":["done"]}}}`)
 	if invalidTraceFilter.Error == nil || invalidTraceFilter.Error.Code != codeInvalidParams {
@@ -264,6 +275,9 @@ func (s *fakeObservabilityReadStore) LoadRunDebugTracePage(_ context.Context, ru
 	rows := []store.RunDebugTraceRow{}
 	for _, row := range s.traceRows[runID] {
 		if opts.Since != nil && !row.EventCreatedAt.After(opts.Since.UTC()) {
+			continue
+		}
+		if opts.Until != nil && row.EventCreatedAt.After(opts.Until.UTC()) {
 			continue
 		}
 		rows = append(rows, row)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -678,11 +678,18 @@ func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHa
 			if err != nil {
 				return nil, err
 			}
+			until, err := timestampParam(req.Params, "until")
+			if err != nil {
+				return nil, err
+			}
+			if since != nil && until != nil && since.After(*until) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "until", "reason": "must be at or after since"})
+			}
 			filter, err := runTraceFilterParam(req.Params)
 			if err != nil {
 				return nil, err
 			}
-			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since, Filter: filter})
+			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since, Until: until, Filter: filter})
 			if errors.Is(err, store.ErrRunNotFound) {
 				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 			}

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -397,6 +397,7 @@ func TestRunSubscribeTraceFilterValidation(t *testing.T) {
 		wantField string
 	}{
 		{name: "unknown top-level limit", params: map[string]any{"run_id": "run-1", "limit": 1}, wantField: "limit"},
+		{name: "unknown top-level until", params: map[string]any{"run_id": "run-1", "until": "2026-05-13T10:05:00Z"}, wantField: "until"},
 		{name: "unknown filter field", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"event_nmae": []any{"scan.requested"}}}, wantField: "filter.event_nmae"},
 		{name: "invalid delivery status", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"delivery_status": []any{"done"}}}, wantField: "filter.delivery_status"},
 		{name: "invalid subscriber type", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"subscriber_type": []any{"system"}}}, wantField: "filter.subscriber_type"},

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -408,12 +408,48 @@ func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	if len(page2) != 1 || page2[0].EventID != secondEvent {
 		t.Fatalf("trace page2 = %#v", page2)
 	}
+	until := base.Add(time.Second)
+	boundedPage1, boundedNext, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 1, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage bounded page1: %v", err)
+	}
+	if len(boundedPage1) != 1 || boundedPage1[0].EventID != firstEvent || boundedNext == "" {
+		t.Fatalf("bounded trace page1 rows=%#v next=%q", boundedPage1, boundedNext)
+	}
+	boundedPage2, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 1, Cursor: boundedNext, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage bounded page2: %v", err)
+	}
+	if len(boundedPage2) != 1 || boundedPage2[0].EventID != secondEvent {
+		t.Fatalf("bounded trace page2 = %#v", boundedPage2)
+	}
 	sinceRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &base})
 	if err != nil {
 		t.Fatalf("LoadRunDebugTracePage since: %v", err)
 	}
 	if len(sinceRows) != 1 || sinceRows[0].EventID != secondEvent {
 		t.Fatalf("trace since rows = %#v, want only second event", sinceRows)
+	}
+	untilRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Until: &base})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage until: %v", err)
+	}
+	if len(untilRows) != 1 || untilRows[0].EventID != firstEvent {
+		t.Fatalf("trace until rows = %#v, want only first event", untilRows)
+	}
+	emptyWindowRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &base, Until: &base})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage empty window: %v", err)
+	}
+	if len(emptyWindowRows) != 0 {
+		t.Fatalf("trace equal since/until rows = %#v, want empty exclusive/inclusive window", emptyWindowRows)
+	}
+	windowRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &base, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage bounded window: %v", err)
+	}
+	if len(windowRows) != 1 || windowRows[0].EventID != secondEvent {
+		t.Fatalf("trace bounded window rows = %#v, want only second event", windowRows)
 	}
 	if _, _, err := pg.LoadRunDebugTracePage(ctx, uuid.NewString(), RunDebugTraceQueryOptions{}); !errors.Is(err, ErrRunNotFound) {
 		t.Fatalf("missing run error = %v, want ErrRunNotFound", err)
@@ -433,6 +469,7 @@ func TestRunDebugTracePageTypedFilters(t *testing.T) {
 	firstDelivery := uuid.NewString()
 	secondDelivery := uuid.NewString()
 	base := time.Unix(1700000400, 0).UTC()
+	until := base
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
@@ -482,6 +519,11 @@ func TestRunDebugTracePageTypedFilters(t *testing.T) {
 			name: "and composition",
 			opts: RunDebugTraceQueryOptions{Limit: 10, Filter: RunDebugTraceFilter{EventNames: []string{"first.event", "second.event"}, EntityIDs: []string{entityTwo}, DeliveryStatuses: []string{"dead_letter"}, SubscriberIDs: []string{"agent-2"}, SubscriberTypes: []string{"agent"}}},
 			want: secondEvent,
+		},
+		{
+			name: "filter and until composition",
+			opts: RunDebugTraceQueryOptions{Limit: 10, Until: &until, Filter: RunDebugTraceFilter{EventNames: []string{"first.event", "second.event"}}},
+			want: firstEvent,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -131,6 +131,7 @@ type RunDebugTraceQueryOptions struct {
 	Limit  int
 	Cursor string
 	Since  *time.Time
+	Until  *time.Time
 	Filter RunDebugTraceFilter
 }
 
@@ -625,6 +626,18 @@ func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opt
 	return rows, err
 }
 
+func runDebugTraceWatermarkWhere(operator string, argIndex int) string {
+	return fmt.Sprintf(`
+			  AND GREATEST(
+				e.created_at,
+				COALESCE(d.created_at, '-infinity'::timestamptz),
+				COALESCE(d.started_at, '-infinity'::timestamptz),
+				COALESCE(d.delivered_at, '-infinity'::timestamptz),
+				COALESCE(sess.updated_at, '-infinity'::timestamptz),
+				COALESCE(t.created_at, '-infinity'::timestamptz)
+			  ) %s $%d::timestamptz`, operator, argIndex)
+}
+
 func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, string, error) {
 	if s == nil || s.DB == nil {
 		return nil, "", fmt.Errorf("postgres store is required")
@@ -687,15 +700,12 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 	sinceWhere := ""
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
-		sinceWhere = fmt.Sprintf(`
-			  AND GREATEST(
-				e.created_at,
-			COALESCE(d.created_at, '-infinity'::timestamptz),
-			COALESCE(d.started_at, '-infinity'::timestamptz),
-			COALESCE(d.delivered_at, '-infinity'::timestamptz),
-			COALESCE(sess.updated_at, '-infinity'::timestamptz),
-				COALESCE(t.created_at, '-infinity'::timestamptz)
-			  ) > $%d::timestamptz`, len(args))
+		sinceWhere = runDebugTraceWatermarkWhere(">", len(args))
+	}
+	untilWhere := ""
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		untilWhere = runDebugTraceWatermarkWhere("<=", len(args))
 	}
 	filterWhere := ""
 	addTextArrayFilter := func(values []string, expression string) {
@@ -774,6 +784,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			%s
 			%s
 			%s
+			%s
 			ORDER BY
 				e.created_at ASC,
 				e.event_id ASC,
@@ -782,7 +793,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			t.created_at ASC NULLS FIRST,
 			t.turn_id ASC NULLS FIRST
 		LIMIT $%d
-		`, sessionSources, cursorWhere, sinceWhere, filterWhere, limitArg), args...)
+		`, sessionSources, cursorWhere, sinceWhere, untilWhere, filterWhere, limitArg), args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("load run debug trace: %w", err)
 	}


### PR DESCRIPTION
Part of #855
Related to #735
Related to #794

## Summary
- Promote snapshot `swarm trace --until` and `/v1/rpc run.trace.until` in `platform-spec.yaml` and regenerated OpenRPC.
- Add CLI RFC3339 validation, `since <= until` no-call validation, and `--follow/-f --until` rejection before API/WS setup.
- Add API/store support for inclusive `until` over the same canonical `RunTraceRow` materialization watermark as `since`, composing with cursor, limit, and `RunTraceFilter`.

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.trace.promoted_trace_filter_contract`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.run.trace`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` generated `run.trace` method
- #855 pre-audit and independent gate outcome: approved first slice for snapshot trace `--until` only

## Semantic Migration
- New canonical owner: `/v1/rpc run.trace` plus `store.RunDebugTraceQueryOptions` / `LoadRunDebugTracePage` for `(since, until]` bounded snapshot windows.
- Old invalid paths: CLI-side timestamp filtering, `run.subscribe_trace` `until`, direct DB/store/runtime/EventBus/dashboard/Builder reads, and legacy transport fallbacks remain invalid.
- Production paths checked: `cmd/swarm trace`, `internal/apiv1` `run.trace` and `run.subscribe_trace`, generated OpenRPC, store trace query owner, and static no-bypass grep over touched CLI files.
- Migration complete for the chosen snapshot `--until` class; parent #855 remains open for payload/output, multi-run `--all`, and shared `swarm run` recovery residuals.

## Proof
- `go test ./cmd/swarm -run 'Trace|DiagnosticTrace|DiagnosticsRejectInvalidInputBeforeRequest|DiagnosticsRequireAPITokenBeforeRequest' -count=1`
- `go test ./internal/apiv1 -run 'RunTrace|OpenRPC|RegistryMethodNamesMatchGeneratedOpenRPC|RunSubscribeTrace|WebSocketRunSubscribeTrace' -count=1`
- `go test ./internal/store -run 'RunDebugTrace|OperatorObservability.*Trace' -count=1`
- `go test ./internal/apispec -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- static no-bypass grep over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`
- `go test ./...`
