### PR TITLE
[agent-e][issue #859] Pass control nuke idempotency key

### DIFF
--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -19,9 +19,11 @@ const (
 )
 
 type runtimeNukeCommandOptions struct {
-	apiOptions rootCommandOptions
-	yes        bool
-	dryRun     bool
+	apiOptions        rootCommandOptions
+	yes               bool
+	dryRun            bool
+	idempotencyKey    string
+	idempotencyKeySet bool
 }
 
 type runtimeNukeResult struct {
@@ -122,16 +124,24 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "Destructively reset Swarm runtime state through v1 RPC.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runControlNukeCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), nukeOpts)
+			opts := nukeOpts
+			opts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			return runControlNukeCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
 	cmd.Flags().BoolVarP(&nukeOpts.yes, "yes", "y", false, "Skip the destructive confirmation prompt")
 	cmd.Flags().BoolVar(&nukeOpts.dryRun, "dry-run", false, "Preview the destructive reset without applying it")
+	cmd.Flags().StringVar(&nukeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIAPIConnectionFlags(cmd, &nukeOpts.apiOptions)
 	return cmd
 }
 
 func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runtimeNukeCommandOptions) error {
+	idempotencyKey, err := optionalNonBlankNukeFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: 2}
+	}
 	if !opts.dryRun && !opts.yes {
 		if !controlStdinIsTerminal(opts.apiOptions) {
 			fmt.Fprintln(errOut, "ERROR: `swarm control nuke` is destructive; pass --yes for non-TTY invocations.")
@@ -154,6 +164,9 @@ func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runt
 		return commandExitError{code: runtimeNukeErrorExitCode(err)}
 	}
 	params := map[string]any{"dry_run": opts.dryRun}
+	if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
 	var result runtimeNukeResult
 	if err := client.call(ctx, runtimeNukeMethod, params, &result); err != nil {
 		fmt.Fprintln(errOut, err)
@@ -169,6 +182,13 @@ func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runt
 		return commandExitError{code: 3}
 	}
 	return nil
+}
+
+func optionalNonBlankNukeFlag(name, value string, changed bool) (string, error) {
+	if changed && strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("%s must be non-empty", name)
+	}
+	return value, nil
 }
 
 func confirmRuntimeNuke(input io.Reader, errOut io.Writer) (bool, error) {

--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -83,6 +83,75 @@ func TestControlNukeYesAppliesThroughV1RPC(t *testing.T) {
 	}
 }
 
+func TestControlNukeSendsIdempotencyKey(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		input         string
+		stdinTerminal bool
+		wantParams    map[string]any
+		wantPrompt    bool
+	}{
+		{
+			name:       "dry run",
+			args:       []string{"control", "nuke", "--dry-run", "--idempotency-key", "idem-dry"},
+			wantParams: map[string]any{"dry_run": true, "idempotency_key": "idem-dry"},
+		},
+		{
+			name:       "yes apply",
+			args:       []string{"control", "nuke", "--yes", "--idempotency-key", "idem-apply"},
+			wantParams: map[string]any{"dry_run": false, "idempotency_key": "idem-apply"},
+		},
+		{
+			name:       "yes apply preserves caller key",
+			args:       []string{"control", "nuke", "--yes", "--idempotency-key", "  idem-spaced  "},
+			wantParams: map[string]any{"dry_run": false, "idempotency_key": "  idem-spaced  "},
+		},
+		{
+			name:          "tty confirmed apply",
+			args:          []string{"control", "nuke", "--idempotency-key", "idem-tty"},
+			input:         "y\n",
+			stdinTerminal: true,
+			wantParams:    map[string]any{"dry_run": false, "idempotency_key": "idem-tty"},
+			wantPrompt:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				status := runtimeNukeStatusDone
+				if tc.wantParams["dry_run"] == true {
+					status = runtimeNukeStatusDryRun
+				}
+				writeJSONRPCResult(t, w, captured.ID, runtimeNukeTestResult(status))
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			opts := testRootCommandOptions(server)
+			opts.input = strings.NewReader(tc.input)
+			opts.stdinIsTerminal = func() bool { return tc.stdinTerminal }
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.Method != "runtime.nuke" {
+				t.Fatalf("method = %q, want runtime.nuke", captured.Method)
+			}
+			if !reflect.DeepEqual(captured.Params, tc.wantParams) {
+				t.Fatalf("params = %#v, want %#v", captured.Params, tc.wantParams)
+			}
+			if gotPrompt := strings.Contains(stderr.String(), "Continue? [y/N]"); gotPrompt != tc.wantPrompt {
+				t.Fatalf("prompt present = %v, want %v stderr=%q", gotPrompt, tc.wantPrompt, stderr.String())
+			}
+		})
+	}
+}
+
 func TestControlNukeNoOpResultExitsZero(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -128,6 +197,8 @@ func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
 		{name: "tty confirmation proceeds", args: []string{"control", "nuke"}, input: "y\n", stdinTerminal: true, wantCode: 0, wantCalls: 1, wantStderr: "Continue? [y/N]"},
 		{name: "tty abort makes no request", args: []string{"control", "nuke"}, input: "n\n", stdinTerminal: true, wantCode: 2, wantCalls: 0, wantStderr: "Aborted; no destruction performed."},
 		{name: "non tty apply without yes makes no request", args: []string{"control", "nuke"}, stdinTerminal: false, wantCode: 2, wantCalls: 0, wantStderr: "pass --yes for non-TTY"},
+		{name: "tty abort with key makes no request", args: []string{"control", "nuke", "--idempotency-key", "idem-abort"}, input: "n\n", stdinTerminal: true, wantCode: 2, wantCalls: 0, wantStderr: "Aborted; no destruction performed."},
+		{name: "non tty apply with key without yes makes no request", args: []string{"control", "nuke", "--idempotency-key", "idem-ntty"}, stdinTerminal: false, wantCode: 2, wantCalls: 0, wantStderr: "pass --yes for non-TTY"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			calls.Store(0)
@@ -149,7 +220,7 @@ func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
 	}
 }
 
-func TestControlNukeRejectsIdempotencyKeyBeforeRequest(t *testing.T) {
+func TestControlNukeRejectsBlankIdempotencyKeyBeforePromptOrRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -158,16 +229,35 @@ func TestControlNukeRejectsIdempotencyKeyBeforeRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "nuke", "--idempotency-key", "idem-1"}, &stdout, &stderr, testRootCommandOptions(server))
-	if code != 2 {
-		t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	if calls.Load() != 0 {
-		t.Fatalf("server calls = %d, want 0", calls.Load())
-	}
-	if !strings.Contains(stderr.String(), "unknown flag: --idempotency-key") {
-		t.Fatalf("stderr = %q, want unknown flag", stderr.String())
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		stdinTerminal bool
+	}{
+		{name: "dry run", args: []string{"control", "nuke", "--dry-run", "--idempotency-key", "   "}},
+		{name: "yes apply", args: []string{"control", "nuke", "--yes", "--idempotency-key", "   "}},
+		{name: "prompt path", args: []string{"control", "nuke", "--idempotency-key", "   "}, stdinTerminal: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			opts := testRootCommandOptions(server)
+			opts.input = strings.NewReader("y\n")
+			opts.stdinIsTerminal = func() bool { return tc.stdinTerminal }
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("server calls = %d, want 0", calls.Load())
+			}
+			if !strings.Contains(stderr.String(), "--idempotency-key must be non-empty") {
+				t.Fatalf("stderr = %q, want blank key validation", stderr.String())
+			}
+			if strings.Contains(stderr.String(), "Continue? [y/N]") {
+				t.Fatalf("stderr = %q, want no confirmation prompt", stderr.String())
+			}
+		})
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5998,7 +5998,10 @@ cli_specification:
           request because no per-target key derivation policy is promoted. `stop --all --yes` confirmation/non-TTY
           behavior is promoted as the second #859 slice: stop-all requires TTY confirmation before API client
           construction/request unless --yes is supplied, and --yes is valid only with stop --all. `swarm control
-          nuke --idempotency-key` remains a split tail under #859 unless a later gate promotes it.
+          nuke --idempotency-key` is promoted as the final #859 slice: the CLI accepts a caller-supplied key,
+          rejects explicit blank keys before prompt/client/request, and passes non-blank keys through unchanged to
+          `/v1/rpc runtime.nuke` for dry-run, --yes apply, and TTY-confirmed apply without generating,
+          deriving, hashing, persisting, or locally interpreting idempotency ownership.
       rich_agent_operator_ux:
         disposition: tracked_child
         tracker: '#860'
@@ -7597,11 +7600,32 @@ cli_specification:
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback, runtime.nuke, or runtime.stop
     control_nuke:
-      command: swarm control nuke [--yes|-y] [--dry-run]
+      command: swarm control nuke [--yes|-y] [--dry-run] [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented
       owner: /v1/rpc runtime.nuke
       behavior: Destructive reset CLI consumer over the public runtime.nuke owner. The CLI MUST NOT call raw Docker, SQL, store cleanup, runtime manager reset, or internal destructive-reset helpers directly.
+      idempotency:
+        rule: >
+          `--idempotency-key <key>` is optional. When supplied, the CLI passes the non-blank key through unchanged as
+          `idempotency_key` to runtime.nuke for dry-run, --yes apply, and TTY-confirmed apply. An explicitly
+          blank key fails before confirmation prompt, API client construction, or API request with exit 2. The
+          CLI MUST NOT generate, persist, derive, hash, or locally interpret idempotency keys.
+      confirmation:
+        rule: >
+          `swarm control nuke` apply remains destructive. `--dry-run` does not require confirmation. Apply
+          without --yes requires TTY confirmation before API client construction or request. Non-TTY apply
+          without --yes fails before API client construction or request. A supplied idempotency key does not
+          bypass confirmation; an explicitly blank idempotency key fails before prompt/client/request.
+      proof_expectations:
+      - exact /v1/rpc runtime.nuke call with dry_run=true and idempotency_key when supplied for --dry-run
+      - exact /v1/rpc runtime.nuke call with dry_run=false and idempotency_key when supplied for --yes or confirmed apply
+      - no-key dry-run/apply requests continue to send only dry_run
+      - explicit blank --idempotency-key fails before confirmation prompt, API client construction, or API request with exit 2
+      - non-TTY apply and user abort with idempotency key make no API request
+      - no direct DB/store/runtime/EventBus reads or writes
+      - no raw Docker, SQL, store cleanup, runtime manager reset, or internal destructive-reset helper calls
+      - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, Builder/operator token fallback
     agents_list:
       command: swarm agents list
       tier: should_have

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 43 {
 		t.Fatalf("method count = %d, want 43", report.MethodCount)
 	}
-	if report.SchemaCount != 71 {
-		t.Fatalf("schema count = %d, want 71", report.SchemaCount)
+	if report.SchemaCount != 72 {
+		t.Fatalf("schema count = %d, want 72", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 28 {
 		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 43 {
 		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 71 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 71", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 72 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 72", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 28 {
 		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))


### PR DESCRIPTION
## Summary
- Promotes the final #859 tail for `swarm control nuke --idempotency-key` in the platform spec ledger and `control_nuke` command row.
- Adds CLI pass-through for caller-supplied `--idempotency-key` to `/v1/rpc runtime.nuke` for dry-run, `--yes` apply, and TTY-confirmed apply.
- Rejects explicit blank/whitespace-only keys before confirmation prompt, API client construction, or API request, and preserves no-key behavior plus abort/non-TTY no-call behavior.
- Synchronizes the generated OpenRPC schema-count assertion with the current generated artifact count reported by `swarm-openrpc-gen`.

Closes #859

## Governing Refs / Context
- Pre-audit: #859 comment https://github.com/yazzaoui/Swarm/issues/859#issuecomment-4524044500
- Independent gate: #859 comment https://github.com/yazzaoui/Swarm/issues/859#issuecomment-4525793870
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `cli_specification.review_artifact_reconciliation.under_promoted_review_features.control_idempotency_and_stop_all_confirmation`
  - `cli_specification.command_catalog.control_nuke`
  - `api_specification.conventions.idempotency`
  - `api_specification.method_catalog.runtime.nuke`
- Generated `openrpc.json` already declares optional `runtime.nuke` `idempotency_key`; no runtime/API behavior change is included.

## Semantic Migration
- New canonical CLI behavior owner: `platform-spec.yaml` `control_nuke` command row for `--idempotency-key` prompt/no-call/pass-through behavior.
- Old invalid path: `swarm control nuke --idempotency-key` was rejected as an unknown flag while #859 still tracked it as a split tail.
- Checked production paths: `cmd/swarm/control_nuke.go`, focused `control_nuke` tests, `internal/apispec`, `internal/apiv1` runtime.nuke/OpenRPC proofs, generated OpenRPC check, and static sweep for direct runtime/store/destructive helper use.
- Migration complete for #859: this closes the final remaining #859 tail without introducing CLI-side key generation, derivation, hashing, persistence, replay ownership, or local interpretation.

## Tests
- `go test ./cmd/swarm -run 'TestControlNuke|TestControlRunRejectsInvalidTargetsBeforeRequest' -count=1`
- `go test ./internal/apispec ./internal/apiv1 -run 'TestMutatingMethodsDeclareIdempotencyKey|TestValidateRejectsRequiredMutatingIdempotencyKey|TestOperatorRuntimeNuke|TestOpenRPCMutatingHTTPRuntimeProbes' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go run ./cmd/swarm control nuke --help`
- static sweep for direct runtime/store/destructive helper or legacy endpoint use in `cmd/swarm/control_nuke.go` and tests
- `go test ./...`
- `git diff --check`