### PR TITLE
[agent-a][issue #986] Add security reporting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The trajectory points at running whole company divisions as autonomous flows. Th
 | [`platform-spec.md`](docs/specs/swarm-platform/platform/platform-spec.md) | You need the authoritative specification. |
 | [`BUILDER-API.md`](docs/specs/swarm-platform/platform/BUILDER-API.md) | You're integrating with the Builder surface. |
 | [`FLIGHT-RECORDER.md`](docs/specs/swarm-platform/platform/FLIGHT-RECORDER.md) | You're debugging a run from its trace. |
+| [`SECURITY.md`](SECURITY.md) | You need to report a suspected vulnerability privately. |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+Division Swarm is pre-1.0. Until release branches are published, security
+reports are accepted for the current default branch and the latest public
+release, if one exists.
+
+| Version or branch | Security support |
+| --- | --- |
+| Current default branch | Supported |
+| Latest public release, if any | Supported |
+| Older commits, branches, or forks | Not supported unless maintainers explicitly say otherwise |
+
+## Reporting a Vulnerability
+
+Do not report suspected vulnerabilities in public GitHub issues, pull requests,
+or discussions.
+
+Send vulnerability reports privately to:
+
+```text
+security@division.sh
+```
+
+Include as much of the following information as you can:
+
+- A description of the suspected vulnerability and impact.
+- Affected version, branch, commit, or deployment surface.
+- Reproduction steps, proof-of-concept details, or relevant logs.
+- Any conditions that limit exploitability.
+- Your preferred contact information for follow-up.
+
+If you are unsure whether an issue is security-sensitive, report it privately.
+
+## Disclosure Expectations
+
+Please keep the report private while maintainers triage it and coordinate a
+fix or mitigation. Maintainers will use the private reporting thread to
+coordinate validation, remediation, and disclosure timing.
+
+After a fix or mitigation is available, maintainers may publish a security
+advisory, release note, or public issue with appropriate details. Do not publish
+exploit details before that coordination completes.
+
+## Non-Security Bugs
+
+For ordinary bugs, feature requests, or implementation questions that do not
+involve a suspected vulnerability, use the normal GitHub issue templates.


### PR DESCRIPTION
## Summary
- Add root `SECURITY.md` as the canonical vulnerability-reporting policy for the public repo.
- Define the private reporting channel as `security@division.sh`, supported-version scope for the current pre-1.0 state, and coordinated disclosure expectations.
- Add a minimal README discoverability link to the new policy.

Closes #986
Part of #814

## Governing Refs / Context
- No exact `platform-spec.yaml` section governs this repository-maintenance surface.
- Binding context: #986 issue body/thread and approved pre-audit gate, parent tracker #814, blocked license/SPDX tracker #823, root README setup closeout #971/#984, and current `origin/master` public-readiness state.

## Semantic Migration
- New canonical owner: root `SECURITY.md` owns vulnerability reporting, reporting channel, supported versions, and coordinated disclosure expectations.
- Old non-authoritative paths now invalid for this concept: #814 prose, README-only discoverability, public issue templates, runtime/API docs, and ad hoc tracker comments.
- Checked for surviving old behavior: README, `.github/ISSUE_TEMPLATE`, `docs`, and root public-readiness files. No competing vulnerability-reporting policy remains.
- Migration complete for #986. Broader #814 public repo readiness remains open for split siblings.

## Proof
- `dig +short MX division.sh`: Cloudflare MX records returned for the selected reporting domain.
- `git diff --check`: pass.
- `test -f SECURITY.md`: pass.
- Grep proof confirms `SECURITY.md` contains `security@division.sh`, supported-version language, no-public-issues guidance, and disclosure expectations.
- Grep proof confirms README links to `SECURITY.md`.
- Public issue-template scan found no contradictory vulnerability-reporting policy.
- `go test ./...`: pass.