### PR TITLE
[agent-e][issue #995] Report outdated store schema diagnostics

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -102,6 +102,9 @@ func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTa
 				continue
 			}
 			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				if schemaErr := s.outdatedSchemaErrorForPlan(ctx, plan, err); schemaErr != nil {
+					return schemaErr
+				}
 				return fmt.Errorf("ensure %s table %s: %w", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName), err)
 			}
 		}
@@ -116,6 +119,39 @@ func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTa
 		}
 	}
 	return nil
+}
+
+func (s *PostgresStore) outdatedSchemaErrorForPlan(ctx context.Context, plan SchemaTableDDL, cause error) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	tableName := strings.TrimSpace(plan.TableName)
+	if tableName == "" {
+		return nil
+	}
+	expectedColumns := schemaDDLPlanColumnNames(plan)
+	if len(expectedColumns) == 0 {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil || !catalog.hasTable(tableName) {
+		return nil
+	}
+	missingColumns := make([]string, 0)
+	for _, columnName := range expectedColumns {
+		if !catalog.hasColumns(tableName, columnName) {
+			missingColumns = append(missingColumns, columnName)
+		}
+	}
+	if len(missingColumns) == 0 {
+		return nil
+	}
+	return &OutdatedSchemaError{
+		SchemaKind:     strings.TrimSpace(plan.SchemaKind),
+		TableName:      tableName,
+		MissingColumns: missingColumns,
+		Cause:          cause,
+	}
 }
 
 func schemaDDLIncludesPlatformTables(plans []SchemaTableDDL) bool {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -550,6 +551,106 @@ func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeD
 	}
 	if indexName != "idx_sessions_terminated_reason" {
 		t.Fatalf("idx_sessions_terminated_reason regclass = %q, want idx_sessions_terminated_reason", indexName)
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_ReportsOutdatedSchemaForLegacyTimers(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS timers CASCADE`); err != nil {
+		t.Fatalf("drop timers: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE timers (
+			timer_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			timer_name TEXT NOT NULL,
+			entity_id UUID,
+			flow_instance TEXT,
+			fire_event TEXT NOT NULL,
+			fire_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+			fire_at TIMESTAMPTZ NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("create legacy timers: %v", err)
+	}
+
+	err := pg.EnsureSchemaTables(ctx, []SchemaTableDDL{legacyTimerDiagnosticPlan()})
+	if err == nil {
+		t.Fatal("EnsureSchemaTables error = nil, want outdated schema diagnostic")
+	}
+	var outdated *OutdatedSchemaError
+	if !errors.As(err, &outdated) {
+		t.Fatalf("EnsureSchemaTables error = %T %[1]v, want OutdatedSchemaError", err)
+	}
+	if outdated.TableName != "timers" {
+		t.Fatalf("outdated table = %q, want timers", outdated.TableName)
+	}
+	if !containsString(outdated.MissingColumns, "run_id") {
+		t.Fatalf("missing columns = %#v, want run_id", outdated.MissingColumns)
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"database schema is out of date",
+		"platform_spec table timers",
+		"run_id",
+		"use a fresh database or run an approved schema migration",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want substring %q", got, want)
+		}
+	}
+	for _, disallowed := range []string{"pq:", "42703"} {
+		if strings.Contains(got, disallowed) {
+			t.Fatalf("error = %q, want no raw Postgres detail %q", got, disallowed)
+		}
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_AllowsCurrentTimerSchema(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if err := pg.EnsureSchemaTables(ctx, []SchemaTableDDL{legacyTimerDiagnosticPlan()}); err != nil {
+		t.Fatalf("EnsureSchemaTables current timers: %v", err)
+	}
+}
+
+func legacyTimerDiagnosticPlan() SchemaTableDDL {
+	return SchemaTableDDL{
+		TableName:   "timers",
+		SchemaKind:  "platform_spec",
+		ColumnCount: 21,
+		Statements: []string{
+			`CREATE TABLE IF NOT EXISTS timers (
+    timer_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timer_name TEXT NOT NULL,
+    run_id UUID REFERENCES runs(run_id),
+    source_timer_id UUID REFERENCES timers(timer_id),
+    forked_from_run_id UUID REFERENCES runs(run_id),
+    forked_from_event_id UUID REFERENCES events(event_id),
+    reconstruction_owner TEXT,
+    entity_id UUID,
+    flow_instance TEXT,
+    fire_event TEXT NOT NULL,
+    fire_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    fire_at TIMESTAMPTZ NOT NULL,
+    recurring BOOLEAN NOT NULL DEFAULT FALSE,
+    recurrence_cron TEXT,
+    recurrence_interval TEXT,
+    owner_node TEXT,
+    owner_agent TEXT,
+    task_type TEXT NOT NULL DEFAULT 'timer' CHECK (task_type IN ('timer', 'scheduled_task', 'deadline', 'global_recurring')),
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'fired', 'cancelled', 'expired')),
+    fired_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_timers_run ON timers(run_id, status, fire_at) WHERE run_id IS NOT NULL`,
+		},
 	}
 }
 

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -524,3 +524,56 @@ func schemaDDLColumnCount(statements []string) int {
 	}
 	return 0
 }
+
+func schemaDDLPlanColumnNames(plan SchemaTableDDL) []string {
+	for _, statement := range plan.Statements {
+		if schemaDDLExtractTableName(statement) == "" {
+			continue
+		}
+		return schemaDDLCreateTableColumnNames(statement)
+	}
+	return nil
+}
+
+func schemaDDLCreateTableColumnNames(statement string) []string {
+	start := strings.Index(statement, "(")
+	end := strings.LastIndex(statement, ")")
+	if start < 0 || end <= start {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, line := range strings.Split(statement[start+1:end], "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, ","))
+		if line == "" || schemaDDLCreateTableLineIsConstraint(line) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		columnName := strings.Trim(fields[0], `"`)
+		if columnName == "" {
+			continue
+		}
+		if _, exists := seen[columnName]; exists {
+			continue
+		}
+		seen[columnName] = struct{}{}
+		out = append(out, columnName)
+	}
+	return out
+}
+
+func schemaDDLCreateTableLineIsConstraint(line string) bool {
+	fields := strings.Fields(strings.ToUpper(strings.TrimSpace(line)))
+	if len(fields) == 0 {
+		return false
+	}
+	switch fields[0] {
+	case "PRIMARY", "FOREIGN", "UNIQUE", "CHECK", "CONSTRAINT", "EXCLUDE":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/store/schema_drift.go
+++ b/internal/store/schema_drift.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+type OutdatedSchemaError struct {
+	SchemaKind     string
+	TableName      string
+	MissingColumns []string
+	Cause          error
+}
+
+func (e *OutdatedSchemaError) Error() string {
+	tableName := strings.TrimSpace(e.TableName)
+	schemaKind := strings.TrimSpace(e.SchemaKind)
+	if schemaKind == "" {
+		schemaKind = "store"
+	}
+	missing := strings.Join(e.MissingColumns, ", ")
+	if missing == "" {
+		missing = "unknown"
+	}
+	if tableName == "" {
+		return fmt.Sprintf("database schema is out of date for %s schema: missing required column(s): %s; this Swarm build cannot migrate the existing database schema automatically; use a fresh database or run an approved schema migration before starting Swarm", schemaKind, missing)
+	}
+	return fmt.Sprintf("database schema is out of date for %s table %s: missing required column(s): %s; this Swarm build cannot migrate the existing database schema automatically; use a fresh database or run an approved schema migration before starting Swarm", schemaKind, tableName, missing)
+}
+
+func (e *OutdatedSchemaError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}


### PR DESCRIPTION
## Summary
- Adds a typed `OutdatedSchemaError` for generated schema DDL failures where an existing table is missing columns required by the current plan.
- Converts the known older-schema `timers`/`run_id` boot failure into an actionable stale database diagnostic instead of surfacing raw-only Postgres text.
- Preserves fresh/current schema behavior and existing compatibility shims; this PR does not implement managed migrations.

Part of #995

## Governing Refs / Context
- Pre-audit: #995 comment https://github.com/yazzaoui/Swarm/issues/995#issuecomment-4529157494
- Independent gate: #995 comment https://github.com/yazzaoui/Swarm/issues/995#issuecomment-4529189140
- Issue-thread boundary: friendly outdated-database error now; no migration for now.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `platform_tables.tables.schema_version`
  - `platform_tables.notes.migrations`
  - `migration_policy`
  - `platform_tables.tables.timers`

## Semantic Migration
- New canonical diagnostic owner: `internal/store.OutdatedSchemaError` plus `PostgresStore.EnsureSchemaTables` DDL-boundary classification.
- Old invalid path: generated schema DDL failures could expose raw driver details such as `pq: column "run_id" does not exist` as the only user-facing boot explanation.
- Production paths checked for surviving old behavior: `cmd/swarm` boot/store initialization path, `internal/store.EnsureSchemaTables`, schema capability binding, compatibility helpers, and current/fresh store schema tests.
- Migration completeness: diagnostic first slice complete; managed `schema_version`/`MigrationSpec`/`ApplyManagedMigrations` implementation remains open under #995 and is not claimed closed.

## Tests
- `go test ./internal/store -run 'TestPostgresStore_EnsureSchemaTables_ReportsOutdatedSchemaForLegacyTimers|TestPostgresStore_EnsureSchemaTables_AllowsCurrentTimerSchema|TestPostgresStore_EnsureSchemaTables_Phases|TestPostgresStore_EnsureSchemaTables_DropsDeprecatedEntitySubjectCompatibility|TestPostgresStore_BindSchemaCapabilities' -count=1`
- `go test ./internal/store -count=1`
- `go test ./...`
- `git diff --check`