### PR TITLE
[agent-c][issue #994] Persist normal run completion

### DIFF
--- a/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
+++ b/docs/RUNTIME_IMPROVEMENTS_AND_WATCHLIST.md
@@ -1825,7 +1825,7 @@ The flat backlog has been split into themed watchlists so this file can stay an 
 - `#116` Make workflow instance mutation atomic across load, mutate, and upsert.
 - `#118` Add a reusable cross-boundary delivery lifecycle conformance suite.
 - `#119` Persist canonical terminal lifecycle for template flow instances.
-- `#120` Persist canonical run completion instead of inferring it from quiescence.
+- `#994` Persist canonical normal run completion/quiescence owner.
 - `#159` Legacy compatibility removal wave.
 
 ### Notes

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -47,8 +47,10 @@ active_issues:
     title: Add a reusable cross-boundary delivery lifecycle conformance suite
   - id: 119
     title: Persist canonical terminal lifecycle for template flow instances
-  - id: 120
-    title: Persist canonical run completion instead of inferring it from quiescence
+  - id: 994
+    title: Persist canonical normal run completion/quiescence owner
+    maps_to:
+      - persisted_normal_run_completion_quiescence_owner
   - id: 132
     title: Make CEL validation lifecycle-aware for entity-field availability
     maps_to:
@@ -139,6 +141,30 @@ active_issues:
     maps_to:
       - boot_check_definition_drift
 nodes:
+  - id: persisted_normal_run_completion_quiescence_owner
+    title: Persisted Normal Run Completion/Quiescence Owner
+    parent_class: runtime lifecycle state drift between entity/flow terminality, delivery/timer/session quiescence, and persisted runs.status
+    canonical_owners:
+      - internal/runtime/bus/run_completion.go
+      - internal/store/run_completion.go
+      - internal/store/runlifecycle/owner.go
+    why_this_node_exists: normal flow/user runs can finish semantically while persisted run lifecycle stays running when completion is inferred by readers or left to a platform-only convergence path
+    known_manifestations:
+      - swarm run follows run.get forever after a terminal entity because runs.status remains running
+      - run.get and run.diagnose report stale running/stalled state instead of the durable completed row
+      - event.publish --run-id targeting can accept a semantically finished run until runs.status is durably terminal
+      - active deliveries, active timers, and live session leases must block completion fail-closed
+    representative_issues:
+      - 994
+    common_framing_mistakes:
+      too_broad:
+        - all runtime lifecycle drift
+        - replay/deduplication and startup credential gates
+      too_narrow:
+        - CLI follow timeout
+        - run.get read-side terminal inference
+        - run.diagnose projection-only repair
+    current_action_pressure: active first-slice closure under issue 994
   - id: boot_check_definition_drift
     title: Boot Check Definition Drift
     parent_class: semantic correctness drift between authoritative boot-check definitions and enforcement/proof surfaces

--- a/internal/apiv1/operator_run_completion_system_node_test.go
+++ b/internal/apiv1/operator_run_completion_system_node_test.go
@@ -1,0 +1,337 @@
+package apiv1
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+func TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	pg := &store.PostgresStore{DB: db}
+	bundle := runCompletionSystemNodeBundle(t)
+	source := semanticview.Wrap(bundle)
+	var coordinator *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle:    source,
+		BundleFingerprint: runStartTestFingerprint,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if coordinator == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{coordinator}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	module := newRunCompletionSystemNodeModule(t, source)
+	coordinator = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
+		BundleFingerprint:       runStartTestFingerprint,
+	})
+
+	runID := "11111111-1111-4111-8111-111111111111"
+	started := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "flow.started", `{"topic":"supported-surfaces"}`, "idem-system-node-run"))
+	if started.Error != nil {
+		t.Fatalf("run.start error = %#v", started.Error)
+	}
+	if result := asMap(t, started.Result); result["run_id"] != runID || result["status"] != "running" {
+		t.Fatalf("run.start result = %#v, want running run %s", result, runID)
+	}
+
+	run := waitForRunGetStatus(t, handler, runID, "completed")
+	if run["run_id"] != runID {
+		t.Fatalf("run.get run_id = %#v, want %s", run["run_id"], runID)
+	}
+
+	eventID := triggerEventIDForRun(t, db, runID)
+	assertPipelineReceiptSucceeded(t, db, eventID)
+	assertSystemNodeReceiptPersisted(t, db, eventID, "terminal-node")
+	assertSystemNodeDeliverySettled(t, db, eventID, "terminal-node")
+	assertRunEntityTerminal(t, db, runID, "done")
+
+	diagnose := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"diagnose","method":"run.diagnose","params":{"run_id":%q}}`, runID))
+	if diagnose.Error != nil {
+		t.Fatalf("run.diagnose error = %#v", diagnose.Error)
+	}
+	diagnosis := asMap(t, diagnose.Result)
+	if diagnosis["operational_state"] != "completed" {
+		t.Fatalf("run.diagnose operational_state = %#v, want completed", diagnosis["operational_state"])
+	}
+	diagnosisRun := asMap(t, diagnosis["run"])
+	if diagnosisRun["status"] != "completed" {
+		t.Fatalf("run.diagnose run.status = %#v, want completed", diagnosisRun["status"])
+	}
+
+	terminalPublish := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "flow.started", `{"topic":"after-terminal"}`, "", "idem-after-terminal"))
+	if terminalPublish.Error == nil {
+		t.Fatal("event.publish --run-id terminal error = nil")
+	}
+	if data := asMap(t, terminalPublish.Error.Data); data["code"] != RunAlreadyTerminalCode {
+		t.Fatalf("event.publish --run-id terminal data = %#v, want %s", data, RunAlreadyTerminalCode)
+	}
+	if count := countEventsByName(t, db, "flow.started"); count != 1 {
+		t.Fatalf("flow.started event count after terminal publish = %d, want 1", count)
+	}
+}
+
+type runCompletionSystemNodeModule struct {
+	source   semanticview.Source
+	workflow *runtimepipeline.WorkflowDefinition
+	nodes    []runtimepipeline.WorkflowNode
+	guards   runtimepipeline.GuardRegistry
+	actions  runtimepipeline.ActionRegistry
+}
+
+func newRunCompletionSystemNodeModule(t *testing.T, source semanticview.Source) runtimepipeline.WorkflowModule {
+	t.Helper()
+	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	return runCompletionSystemNodeModule{
+		source:   source,
+		workflow: workflow,
+		nodes:    nodes,
+		guards:   runtimepipeline.NewContractGuardRegistry(source),
+		actions:  runtimepipeline.NewContractActionRegistry(source),
+	}
+}
+
+func (m runCompletionSystemNodeModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func (m runCompletionSystemNodeModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return m.workflow
+}
+
+func (m runCompletionSystemNodeModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+
+func (m runCompletionSystemNodeModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guards
+}
+
+func (m runCompletionSystemNodeModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actions
+}
+
+func waitForRunGetStatus(t *testing.T, handler *Handler, runID, wantStatus string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastStatus any
+	for time.Now().Before(deadline) {
+		get := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"get","method":"run.get","params":{"run_id":%q}}`, runID))
+		if get.Error != nil {
+			t.Fatalf("run.get error = %#v", get.Error)
+		}
+		run := asMap(t, asMap(t, get.Result)["run"])
+		lastStatus = run["status"]
+		if run["status"] == wantStatus {
+			return run
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("run.get status for %s = %#v, want %s", runID, lastStatus, wantStatus)
+	return nil
+}
+
+func triggerEventIDForRun(t *testing.T, db *sql.DB, runID string) string {
+	t.Helper()
+	var eventID string
+	if err := db.QueryRow(`SELECT trigger_event_id::text FROM runs WHERE run_id = $1::uuid`, runID).Scan(&eventID); err != nil {
+		t.Fatalf("load trigger event id: %v", err)
+	}
+	if strings.TrimSpace(eventID) == "" {
+		t.Fatal("trigger_event_id is empty")
+	}
+	return eventID
+}
+
+func assertSystemNodeDeliverySettled(t *testing.T, db *sql.DB, eventID, nodeID string) {
+	t.Helper()
+	var status, reason string
+	var deliveredAt sql.NullTime
+	if err := db.QueryRow(`
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), delivered_at
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&status, &reason, &deliveredAt); err != nil {
+		t.Fatalf("load system-node delivery: %v", err)
+	}
+	if status != "delivered" || reason != "node_processed" || !deliveredAt.Valid {
+		t.Fatalf("system-node delivery = status:%q reason:%q delivered:%v, want delivered/node_processed/delivered_at", status, reason, deliveredAt.Valid)
+	}
+}
+
+func assertSystemNodeReceiptPersisted(t *testing.T, db *sql.DB, eventID, nodeID string) {
+	t.Helper()
+	var outcome, reason string
+	if err := db.QueryRow(`
+		SELECT COALESCE(outcome, ''), COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load system-node receipt: %v", err)
+	}
+	if outcome != "no_op" || reason != "idempotent_no_op" {
+		t.Fatalf("system-node receipt = outcome:%q reason:%q, want no_op/idempotent_no_op", outcome, reason)
+	}
+}
+
+func assertPipelineReceiptSucceeded(t *testing.T, db *sql.DB, eventID string) {
+	t.Helper()
+	var outcome string
+	if err := db.QueryRow(`
+		SELECT COALESCE(outcome, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&outcome); err != nil {
+		t.Fatalf("load pipeline receipt: %v", err)
+	}
+	if outcome != "success" {
+		t.Fatalf("pipeline receipt outcome = %q, want success", outcome)
+	}
+}
+
+func assertRunEntityTerminal(t *testing.T, db *sql.DB, runID, wantState string) {
+	t.Helper()
+	var state string
+	if err := db.QueryRow(`
+		SELECT COALESCE(current_state, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $1::uuid
+	`, runID).Scan(&state); err != nil {
+		t.Fatalf("load run entity terminal state: %v", err)
+	}
+	if state != wantState {
+		t.Fatalf("run entity current_state = %q, want %q", state, wantState)
+	}
+}
+
+func runCompletionSystemNodeBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: review
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: discovery
+    flow: discovery
+    mode: static
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+run:
+  topic: string
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+initial_state: active
+terminal_states:
+  - done
+states:
+  - active
+  - done
+pins:
+  inputs:
+    events:
+      - flow.started
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "events.yaml"), `
+{}
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+{}
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "flows", "discovery", "schema.yaml"), `
+name: discovery
+initial_state: active
+terminal_states:
+  - done
+states:
+  - active
+  - done
+pins:
+  inputs:
+    events:
+      - flow.started
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "flows", "discovery", "events.yaml"), `
+flow.started:
+  entity_id:
+    type: string
+  topic:
+    type: string
+  required:
+    - entity_id
+`)
+	writeRunCompletionFixtureFile(t, filepath.Join(root, "flows", "discovery", "nodes.yaml"), `
+terminal-node:
+  id: terminal-node
+  execution_type: system_node
+  subscribes_to:
+    - flow.started
+  event_handlers:
+    flow.started:
+      advances_to: done
+`)
+	repoRoot := runCompletionRepoRoot(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func runCompletionRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func writeRunCompletionFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -382,11 +382,12 @@ func (eb *EventBus) convergeStandaloneRuntimePlatformRun(ctx context.Context, ev
 	if eb == nil || eb.store == nil {
 		return nil
 	}
-	converger, ok := eb.store.(StandaloneRuntimePlatformRunConvergencePersistence)
-	if !ok || converger == nil {
-		return nil
+	if converger, ok := eb.store.(StandaloneRuntimePlatformRunConvergencePersistence); ok && converger != nil {
+		if err := converger.ConvergeStandaloneRuntimePlatformRun(ctx, evt); err != nil {
+			return err
+		}
 	}
-	return converger.ConvergeStandaloneRuntimePlatformRun(ctx, evt)
+	return eb.ConvergeNormalRunCompletionForEvent(ctx, evt.ID)
 }
 
 func (eb *EventBus) publishTransactional(

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -411,6 +411,10 @@ func (eb *EventBus) markPipelineReceipt(ctx context.Context, eventID, status, er
 		}, err.Error(), 0)
 		return err
 	}
+	if err := eb.ConvergeNormalRunCompletionForEvent(ctx, eventID); err != nil {
+		eb.logRuntime(ctx, "error", "Persisting normal run completion failed", "eventbus", "normal_run_completion_failed", eventID, "", "", "", "", nil, nil, err.Error(), 0)
+		return err
+	}
 	return nil
 }
 

--- a/internal/runtime/bus/run_completion.go
+++ b/internal/runtime/bus/run_completion.go
@@ -1,0 +1,83 @@
+package bus
+
+import (
+	"context"
+	"strings"
+)
+
+func (eb *EventBus) ConvergeNormalRunCompletionForEvent(ctx context.Context, eventID string) error {
+	if eb == nil || eb.store == nil {
+		return nil
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	converger, ok := eb.store.(NormalRunCompletionConvergencePersistence)
+	if !ok || converger == nil {
+		return nil
+	}
+	workflowTerminals, flowTerminals := eb.normalRunCompletionTerminalStates()
+	return converger.ConvergeNormalRunCompletion(ctx, eventID, workflowTerminals, flowTerminals)
+}
+
+func (eb *EventBus) normalRunCompletionTerminalStates() ([]string, map[string][]string) {
+	if eb == nil {
+		return nil, nil
+	}
+	eb.mu.RLock()
+	source := eb.semanticSource
+	eb.mu.RUnlock()
+	if source == nil {
+		return nil, nil
+	}
+	workflowTerminals := normalizeRunCompletionStates(source.WorkflowTerminalStages())
+	flowTerminals := map[string][]string{}
+	addFlowTerminals := func(key string, states []string) {
+		key = strings.Trim(strings.TrimSpace(key), "/")
+		states = normalizeRunCompletionStates(states)
+		if key == "" || len(states) == 0 {
+			return
+		}
+		flowTerminals[key] = states
+	}
+	if workflowName := strings.Trim(strings.TrimSpace(source.WorkflowName()), "/"); workflowName != "" {
+		addFlowTerminals(workflowName, workflowTerminals)
+	}
+	for flowID := range source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		states := source.FlowTerminalStages(flowID)
+		addFlowTerminals(flowID, states)
+		addFlowTerminals(source.FlowPath(flowID), states)
+	}
+	for _, scope := range source.FlowScopes() {
+		states := source.FlowTerminalStages(scope.ID)
+		addFlowTerminals(scope.ID, states)
+		addFlowTerminals(scope.Path, states)
+		addFlowTerminals(scope.OwningFlowID, states)
+	}
+	if len(flowTerminals) == 0 {
+		flowTerminals = nil
+	}
+	return workflowTerminals, flowTerminals
+}
+
+func normalizeRunCompletionStates(states []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(strings.ToLower(state))
+		if state == "" {
+			continue
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		out = append(out, state)
+	}
+	return out
+}

--- a/internal/runtime/bus/run_completion_test.go
+++ b/internal/runtime/bus/run_completion_test.go
@@ -1,0 +1,65 @@
+package bus
+
+import (
+	"context"
+	"testing"
+
+	"swarm/internal/events"
+)
+
+type normalRunCompletionTestStore struct {
+	InMemoryEventStore
+	pipelineReceipts []string
+	standaloneEvents []string
+	normalEvents     []string
+}
+
+func (s *normalRunCompletionTestStore) UpsertPipelineReceipt(_ context.Context, eventID, _, _ string) error {
+	s.pipelineReceipts = append(s.pipelineReceipts, eventID)
+	return nil
+}
+
+func (s *normalRunCompletionTestStore) ConvergeStandaloneRuntimePlatformRun(_ context.Context, evt events.Event) error {
+	s.standaloneEvents = append(s.standaloneEvents, evt.ID)
+	return nil
+}
+
+func (s *normalRunCompletionTestStore) ConvergeNormalRunCompletion(_ context.Context, eventID string, _ []string, _ map[string][]string) error {
+	s.normalEvents = append(s.normalEvents, eventID)
+	return nil
+}
+
+func TestEventBusMarkPipelineReceiptConvergesNormalRunCompletion(t *testing.T) {
+	store := &normalRunCompletionTestStore{}
+	eb, err := NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	if err := eb.markPipelineReceipt(context.Background(), "event-1", "processed", ""); err != nil {
+		t.Fatalf("markPipelineReceipt: %v", err)
+	}
+	if len(store.pipelineReceipts) != 1 || store.pipelineReceipts[0] != "event-1" {
+		t.Fatalf("pipeline receipts = %#v, want event-1", store.pipelineReceipts)
+	}
+	if len(store.normalEvents) != 1 || store.normalEvents[0] != "event-1" {
+		t.Fatalf("normal completion events = %#v, want event-1", store.normalEvents)
+	}
+}
+
+func TestEventBusStandalonePlatformConvergenceAlsoProbesNormalRunCompletion(t *testing.T) {
+	store := &normalRunCompletionTestStore{}
+	eb, err := NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	evt := events.Event{ID: "event-2", Type: events.EventType("platform.boot")}
+	if err := eb.convergeStandaloneRuntimePlatformRun(context.Background(), evt); err != nil {
+		t.Fatalf("convergeStandaloneRuntimePlatformRun: %v", err)
+	}
+	if len(store.standaloneEvents) != 1 || store.standaloneEvents[0] != "event-2" {
+		t.Fatalf("standalone events = %#v, want event-2", store.standaloneEvents)
+	}
+	if len(store.normalEvents) != 1 || store.normalEvents[0] != "event-2" {
+		t.Fatalf("normal completion events = %#v, want event-2", store.normalEvents)
+	}
+}

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -71,6 +71,10 @@ type StandaloneRuntimePlatformRunConvergencePersistence interface {
 	ConvergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error
 }
 
+type NormalRunCompletionConvergencePersistence interface {
+	ConvergeNormalRunCompletion(ctx context.Context, eventID string, workflowTerminalStates []string, flowTerminalStates map[string][]string) error
+}
+
 type RunLifecycleSnapshot struct {
 	RunID        string
 	Status       string

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -31,6 +31,10 @@ type activeRunDeliveryQuiescenceReader interface {
 	ActiveRunDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (string, bool, error)
 }
 
+type normalRunCompletionConverger interface {
+	ConvergeNormalRunCompletionForEvent(ctx context.Context, eventID string) error
+}
+
 func (am *AgentManager) processEvent(ctx context.Context, agent Agent, evt events.Event) error {
 	result := am.processEventDetailed(ctx, agent, evt)
 	return result.err
@@ -485,6 +489,18 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 		return
 	}
 	am.logDeliveryLifecycle(writeCtx, eventID, agentID, status, errText)
+	if converger, ok := am.bus.(normalRunCompletionConverger); ok && converger != nil {
+		if err := converger.ConvergeNormalRunCompletionForEvent(writeCtx, eventID); err != nil && am.bus != nil {
+			am.bus.LogRuntime(writeCtx, runtimepipeline.RuntimeLogEntry{
+				Level:     "error",
+				Component: "agent-manager",
+				Action:    "normal_run_completion_failed",
+				EventID:   strings.TrimSpace(eventID),
+				AgentID:   strings.TrimSpace(agentID),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+	}
 
 	// Spec v2.0: dead-letter events are escalated to the agent's manager. The manager
 	// decides whether to retry, skip, or escalate further.

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -456,23 +456,26 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 	if writeCtx == nil {
 		writeCtx = context.Background()
 	}
-	if err := am.store.UpsertEventReceipt(writeCtx, eventID, agentID, status, errText); err != nil {
+	receiptCtx := writeCtx
+	var receiptCancel context.CancelFunc
+	err := am.store.UpsertEventReceipt(writeCtx, eventID, agentID, status, errText)
+	if err != nil {
 		// Agent loop contexts are canceled aggressively during teardown; receipts
 		// must still persist so pending deliveries do not get stuck indefinitely.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			retryCtx, cancel := context.WithTimeout(context.WithoutCancel(writeCtx), receiptWriteTimeout)
 			retryErr := am.store.UpsertEventReceipt(retryCtx, eventID, agentID, status, errText)
 			if retryErr == nil {
-				am.logDeliveryLifecycle(retryCtx, eventID, agentID, status, errText)
+				receiptCtx = retryCtx
+				receiptCancel = cancel
+				err = nil
+			} else {
 				cancel()
-				if status == ReceiptStatusError {
-					am.maybeEscalateDeadLetter(context.WithoutCancel(writeCtx), eventID, agentID)
-				}
-				return
+				err = retryErr
 			}
-			cancel()
-			err = retryErr
 		}
+	}
+	if err != nil {
 		if am.bus != nil {
 			am.bus.LogRuntime(writeCtx, runtimepipeline.RuntimeLogEntry{
 				Level:     "error",
@@ -488,10 +491,13 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 		}
 		return
 	}
-	am.logDeliveryLifecycle(writeCtx, eventID, agentID, status, errText)
+	if receiptCancel != nil {
+		defer receiptCancel()
+	}
+	am.logDeliveryLifecycle(receiptCtx, eventID, agentID, status, errText)
 	if converger, ok := am.bus.(normalRunCompletionConverger); ok && converger != nil {
-		if err := converger.ConvergeNormalRunCompletionForEvent(writeCtx, eventID); err != nil && am.bus != nil {
-			am.bus.LogRuntime(writeCtx, runtimepipeline.RuntimeLogEntry{
+		if err := converger.ConvergeNormalRunCompletionForEvent(receiptCtx, eventID); err != nil && am.bus != nil {
+			am.bus.LogRuntime(receiptCtx, runtimepipeline.RuntimeLogEntry{
 				Level:     "error",
 				Component: "agent-manager",
 				Action:    "normal_run_completion_failed",
@@ -505,7 +511,11 @@ func (am *AgentManager) writeReceipt(ctx context.Context, eventID, agentID strin
 	// Spec v2.0: dead-letter events are escalated to the agent's manager. The manager
 	// decides whether to retry, skip, or escalate further.
 	if status == ReceiptStatusError {
-		am.maybeEscalateDeadLetter(ctx, eventID, agentID)
+		escalateCtx := ctx
+		if receiptCancel != nil {
+			escalateCtx = context.WithoutCancel(writeCtx)
+		}
+		am.maybeEscalateDeadLetter(escalateCtx, eventID, agentID)
 	}
 }
 

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -44,6 +44,16 @@ func (b *recordingReceiptBus) LogRuntime(_ context.Context, entry runtimepipelin
 	return nil
 }
 
+type recordingCompletionReceiptBus struct {
+	recordingReceiptBus
+	normalCompletionEvents []string
+}
+
+func (b *recordingCompletionReceiptBus) ConvergeNormalRunCompletionForEvent(_ context.Context, eventID string) error {
+	b.normalCompletionEvents = append(b.normalCompletionEvents, strings.TrimSpace(eventID))
+	return nil
+}
+
 type receiptReaderStub struct {
 	receipt     EventReceipt
 	found       bool
@@ -74,6 +84,28 @@ func (*receiptReaderStub) ListPendingSubscribedEvents(context.Context, string, [
 }
 func (s *receiptReaderStub) GetEventReceipt(context.Context, string, string) (EventReceipt, bool, error) {
 	return s.receipt, s.found, nil
+}
+
+func TestWriteReceiptConvergesNormalRunCompletionAfterReceiptPersists(t *testing.T) {
+	bus := &recordingCompletionReceiptBus{}
+	store := &receiptReaderStub{
+		receipt: EventReceipt{
+			EventID: "event-1",
+			AgentID: "agent-1",
+			Status:  ReceiptStatusProcessed,
+		},
+		found: true,
+	}
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{}, store)
+
+	am.writeReceipt(context.Background(), "event-1", "agent-1", ReceiptStatusProcessed, "")
+
+	if store.upsertCalls != 1 {
+		t.Fatalf("receipt upsert calls = %d, want 1", store.upsertCalls)
+	}
+	if len(bus.normalCompletionEvents) != 1 || bus.normalCompletionEvents[0] != "event-1" {
+		t.Fatalf("normal completion events = %#v, want event-1", bus.normalCompletionEvents)
+	}
 }
 
 type traceRecordingAgent struct{ parent string }

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -108,6 +108,29 @@ func TestWriteReceiptConvergesNormalRunCompletionAfterReceiptPersists(t *testing
 	}
 }
 
+func TestWriteReceiptConvergesNormalRunCompletionAfterReceiptRetryPersists(t *testing.T) {
+	bus := &recordingCompletionReceiptBus{}
+	store := &receiptReaderStub{
+		receipt: EventReceipt{
+			EventID: "event-1",
+			AgentID: "agent-1",
+			Status:  ReceiptStatusProcessed,
+		},
+		found:      true,
+		upsertErrs: []error{context.Canceled, nil},
+	}
+	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{}, store)
+
+	am.writeReceipt(context.Background(), "event-1", "agent-1", ReceiptStatusProcessed, "")
+
+	if store.upsertCalls != 2 {
+		t.Fatalf("receipt upsert calls = %d, want 2", store.upsertCalls)
+	}
+	if len(bus.normalCompletionEvents) != 1 || bus.normalCompletionEvents[0] != "event-1" {
+		t.Fatalf("normal completion events = %#v, want event-1", bus.normalCompletionEvents)
+	}
+}
+
 type traceRecordingAgent struct{ parent string }
 
 func (a *traceRecordingAgent) ID() string                        { return "trace-agent" }

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -312,7 +312,7 @@ func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bo
 			  AND subscriber_id = $1
 			  AND idempotency_key = $2
 		)
-	`, n.nodeID, SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
+	`, systemNodeReceiptSubscriberID(n.nodeID), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
 	return err == nil && ok
 }
 
@@ -327,10 +327,8 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	if !n.eventReceiptsAvailable(ctx) {
 		return
 	}
-	sideEffects, _ := json.Marshal(map[string]any{
-		"idempotency_key": SystemNodeReceiptIdempotencyKey(n.nodeID, eventID),
-	})
-	if err := n.persistProcessedReceiptAndSettleDelivery(ctx, eventID, string(sideEffects)); err != nil {
+	sideEffects := systemNodeProcessedReceiptSideEffects(n.nodeID, eventID)
+	if err := n.persistProcessedReceiptAndSettleDelivery(ctx, eventID, sideEffects); err != nil {
 		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -350,7 +348,39 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 }
 
 func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID, sideEffects string) error {
-	tx, err := n.db.BeginTx(ctx, nil)
+	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, n.db, n.nodeID, eventID, sideEffects)
+}
+
+func systemNodeProcessedReceiptSideEffects(nodeID, eventID string) string {
+	sideEffects, _ := json.Marshal(map[string]any{
+		"idempotency_key": SystemNodeReceiptIdempotencyKey(nodeID, eventID),
+	})
+	return string(sideEffects)
+}
+
+func systemNodeReceiptSubscriberID(nodeID string) string {
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "pipeline" {
+		// event_receipts is unique on event_id + subscriber_id, so avoid colliding
+		// with the platform pipeline receipt for workflows that name a node "pipeline".
+		return "node:pipeline"
+	}
+	return nodeID
+}
+
+func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db *sql.DB, nodeID, eventID, sideEffects string) error {
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx, tx, nodeID, eventID, sideEffects)
+	}
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin system node processed receipt tx: %w", err)
 	}
@@ -360,6 +390,21 @@ func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.
 			_ = tx.Rollback()
 		}
 	}()
+	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx, tx, nodeID, eventID, sideEffects); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit system node processed receipt tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, sideEffects string) error {
+	if tx == nil {
+		return nil
+	}
+	receiptSubscriberID := systemNodeReceiptSubscriberID(nodeID)
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
@@ -378,7 +423,7 @@ func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.
 			side_effects = EXCLUDED.side_effects,
 			idempotency_key = EXCLUDED.idempotency_key,
 			processed_at = now()
-	`, eventID, n.nodeID, sideEffects, SystemNodeReceiptIdempotencyKey(n.nodeID, eventID))
+	`, eventID, receiptSubscriberID, sideEffects, SystemNodeReceiptIdempotencyKey(nodeID, eventID))
 	if err != nil {
 		return fmt.Errorf("upsert system node receipt: %w", err)
 	}
@@ -386,29 +431,48 @@ func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.
 		return fmt.Errorf("upsert system node receipt: event %s not found", eventID)
 	}
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET
-			status = 'delivered',
-			retry_count = COALESCE(retry_count, 0),
-			reason_code = 'node_processed',
-			last_error = NULL,
-			active_session_id = NULL,
-			started_at = COALESCE(started_at, created_at),
-			delivered_at = now()
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'node'
-		  AND subscriber_id = $2
-		  AND (
-			status IN ('pending', 'in_progress')
-			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+		WITH settled AS (
+			UPDATE event_deliveries
+			SET
+				status = 'delivered',
+				retry_count = COALESCE(retry_count, 0),
+				reason_code = 'node_processed',
+				last_error = NULL,
+				active_session_id = NULL,
+				started_at = COALESCE(started_at, created_at),
+				delivered_at = now()
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+			  )
+			RETURNING delivery_id
+		)
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count,
+			reason_code, last_error, active_session_id, started_at, delivered_at, created_at
+		)
+		SELECT
+			e.run_id, e.event_id, 'node', $2, 'delivered', 0,
+			'node_processed', NULL, NULL, now(), now(), now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM settled
 		  )
-	`, eventID, n.nodeID); err != nil {
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM event_deliveries d
+			WHERE d.event_id = $1::uuid
+			  AND d.subscriber_type = 'node'
+			  AND d.subscriber_id = $2
+		  )
+	`, eventID, nodeID); err != nil {
 		return fmt.Errorf("settle system node delivery: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit system node processed receipt tx: %w", err)
-	}
-	committed = true
 	return nil
 }
 

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -24,6 +25,10 @@ type systemNodeBus interface {
 
 type systemNodeRuntimeLogger interface {
 	LogRuntime(context.Context, RuntimeLogEntry) error
+}
+
+type systemNodeNormalRunCompletionConverger interface {
+	ConvergeNormalRunCompletionForEvent(context.Context, string) error
 }
 
 type systemNodeRunner struct {
@@ -325,7 +330,37 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	sideEffects, _ := json.Marshal(map[string]any{
 		"idempotency_key": SystemNodeReceiptIdempotencyKey(n.nodeID, eventID),
 	})
-	if _, err := n.db.ExecContext(ctx, `
+	if err := n.persistProcessedReceiptAndSettleDelivery(ctx, eventID, string(sideEffects)); err != nil {
+		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Marking the system node event as processed failed",
+				Component: n.nodeID,
+				Action:    "mark_processed_failed",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+		return
+	}
+	n.convergeNormalRunCompletion(ctx, evt)
+}
+
+func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID, sideEffects string) error {
+	tx, err := n.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin system node processed receipt tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, side_effects, idempotency_key, processed_at
@@ -335,15 +370,68 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 			'no_op', 'idempotent_no_op', $3::jsonb, $4, now()
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO NOTHING
-	`, eventID, n.nodeID, string(sideEffects), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)); err != nil {
-		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			outcome = EXCLUDED.outcome,
+			reason_code = EXCLUDED.reason_code,
+			side_effects = EXCLUDED.side_effects,
+			idempotency_key = EXCLUDED.idempotency_key,
+			processed_at = now()
+	`, eventID, n.nodeID, sideEffects, SystemNodeReceiptIdempotencyKey(n.nodeID, eventID))
+	if err != nil {
+		return fmt.Errorf("upsert system node receipt: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("upsert system node receipt: event %s not found", eventID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'delivered',
+			retry_count = COALESCE(retry_count, 0),
+			reason_code = 'node_processed',
+			last_error = NULL,
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+		  )
+	`, eventID, n.nodeID); err != nil {
+		return fmt.Errorf("settle system node delivery: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit system node processed receipt tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (n *systemNodeRunner) convergeNormalRunCompletion(ctx context.Context, evt events.Event) {
+	if n == nil || n.bus == nil {
+		return
+	}
+	eventID := strings.TrimSpace(evt.ID)
+	if eventID == "" {
+		return
+	}
+	converger, ok := n.bus.(systemNodeNormalRunCompletionConverger)
+	if !ok || converger == nil {
+		return
+	}
+	if err := converger.ConvergeNormalRunCompletionForEvent(ctx, eventID); err != nil {
+		slog.Error("system node normal run completion convergence failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
 				Level:     "error",
-				Message:   "Marking the system node event as processed failed",
+				Message:   "Converging normal run completion after system node receipt failed",
 				Component: n.nodeID,
-				Action:    "mark_processed_failed",
+				Action:    "normal_run_completion_failed",
 				EventID:   eventID,
 				EventType: strings.TrimSpace(string(evt.Type)),
 				EntityID:  workflowEventEntityID(evt),

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -97,8 +97,75 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 	}
 }
 
-func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entityID string) {
+func TestSystemNodeRunner_PipelineNamedNodeDoesNotMaskPlatformReceipt(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID, "pipeline")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		) VALUES (
+			$1::uuid, 'platform', 'pipeline', 'success', 'processed', '{}'::jsonb, now()
+		)
+	`, eventID); err != nil {
+		t.Fatalf("seed platform pipeline receipt: %v", err)
+	}
+
+	sideEffects := systemNodeProcessedReceiptSideEffects("pipeline", eventID)
+	if err := persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, db, "pipeline", eventID, sideEffects); err != nil {
+		t.Fatalf("persistSystemNodeProcessedReceiptAndSettleDelivery: %v", err)
+	}
+
+	var platformReceipts int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&platformReceipts); err != nil {
+		t.Fatalf("count platform receipt: %v", err)
+	}
+	if platformReceipts != 1 {
+		t.Fatalf("platform pipeline receipts = %d, want 1", platformReceipts)
+	}
+	var nodeReceipts int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node:pipeline'
+	`, eventID).Scan(&nodeReceipts); err != nil {
+		t.Fatalf("count node receipt: %v", err)
+	}
+	if nodeReceipts != 1 {
+		t.Fatalf("node:pipeline receipts = %d, want 1", nodeReceipts)
+	}
+	var deliveryStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&deliveryStatus); err != nil {
+		t.Fatalf("load pipeline node delivery: %v", err)
+	}
+	if deliveryStatus != "delivered" {
+		t.Fatalf("pipeline node delivery status = %q, want delivered", deliveryStatus)
+	}
+}
+
+func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entityID string, nodeIDs ...string) {
 	t.Helper()
+	nodeID := "terminal-node"
+	if len(nodeIDs) > 0 && nodeIDs[0] != "" {
+		nodeID = nodeIDs[0]
+	}
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -140,9 +207,9 @@ func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entit
 		INSERT INTO event_deliveries (
 			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
 		) VALUES (
-			$1::uuid, $2::uuid, 'node', 'terminal-node', 'pending', 'matched_node_subscription', now()
+			$1::uuid, $2::uuid, 'node', $3, 'pending', 'matched_node_subscription', now()
 		)
-	`, runID, eventID); err != nil {
+	`, runID, eventID, nodeID); err != nil {
 		t.Fatalf("seed node delivery: %v", err)
 	}
 }

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -1,0 +1,148 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	"swarm/internal/testutil"
+)
+
+type systemNodeCompletionBus struct {
+	converged []string
+}
+
+func (*systemNodeCompletionBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+
+func (*systemNodeCompletionBus) Publish(context.Context, events.Event) error { return nil }
+
+func (b *systemNodeCompletionBus) ConvergeNormalRunCompletionForEvent(_ context.Context, eventID string) error {
+	b.converged = append(b.converged, eventID)
+	return nil
+}
+
+func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCompletion(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID)
+	bus := &systemNodeCompletionBus{}
+	handlerCalled := false
+	runner := newSystemNodeRunner("terminal-node", bus, db, func() []events.EventType {
+		return []events.EventType{"example.started"}
+	}, func(ctx context.Context, evt events.Event) error {
+		handlerCalled = true
+		if _, err := db.ExecContext(ctx, `
+			UPDATE entity_state
+			SET current_state = 'done',
+			    updated_at = now()
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+		`, runID, entityID); err != nil {
+			t.Fatalf("mark entity terminal: %v", err)
+		}
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+
+	runner.ProcessEventForTest(ctx, (events.Event{
+		ID:        eventID,
+		Type:      "example.started",
+		RunID:     runID,
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(entityID))
+
+	if !handlerCalled {
+		t.Fatal("handler was not called")
+	}
+	if len(bus.converged) != 1 || bus.converged[0] != eventID {
+		t.Fatalf("normal run convergence events = %#v, want %s", bus.converged, eventID)
+	}
+	var (
+		status      string
+		reason      string
+		deliveredAt sql.NullTime
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), delivered_at
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&status, &reason, &deliveredAt); err != nil {
+		t.Fatalf("load node delivery: %v", err)
+	}
+	if status != "delivered" || reason != "node_processed" || !deliveredAt.Valid {
+		t.Fatalf("node delivery = status:%q reason:%q delivered:%v, want delivered node_processed with delivered_at", status, reason, deliveredAt.Valid)
+	}
+	var receiptOutcome string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(outcome, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&receiptOutcome); err != nil {
+		t.Fatalf("load node receipt: %v", err)
+	}
+	if receiptOutcome != "no_op" {
+		t.Fatalf("node receipt outcome = %q, want no_op", receiptOutcome)
+	}
+}
+
+func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entityID string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', now())
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'example.started', $3::uuid, 'example', 'entity', '{}'::jsonb,
+			0, 'test', 'external', now()
+		)
+	`, eventID, runID, entityID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET trigger_event_id = $2::uuid,
+		    trigger_event_type = 'example.started'
+		WHERE run_id = $1::uuid
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed run trigger: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'example', 'default', 'example', 'Example', 'working',
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
+		)
+	`, runID, entityID); err != nil {
+		t.Fatalf("seed entity state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', 'terminal-node', 'pending', 'matched_node_subscription', now()
+		)
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed node delivery: %v", err)
+	}
+}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -600,10 +600,78 @@ func (pc *PipelineCoordinator) dispatchWorkflowNodeEventResult(ctx context.Conte
 			return handledAny || handled, err
 		}
 		if handled {
+			pc.markWorkflowNodeProcessed(ctx, nodeID, evt)
 			handledAny = true
 		}
 	}
 	return handledAny, nil
+}
+
+func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, nodeID string, evt events.Event) {
+	if pc == nil || pc.db == nil {
+		return
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID := strings.TrimSpace(evt.ID)
+	if nodeID == "" || eventID == "" {
+		return
+	}
+	if !pc.eventReceiptsAvailable(ctx) {
+		return
+	}
+	sideEffects := systemNodeProcessedReceiptSideEffects(nodeID, eventID)
+	if err := persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, pc.db, nodeID, eventID, sideEffects); err != nil {
+		if logger, ok := pc.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Marking the workflow node event as processed failed",
+				Component: nodeID,
+				Action:    "mark_processed_failed",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+		return
+	}
+	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
+}
+
+func (pc *PipelineCoordinator) eventReceiptsAvailable(ctx context.Context) bool {
+	if pc == nil || pc.eventReceiptsCapability == nil {
+		return false
+	}
+	ok, err := pc.eventReceiptsCapability(ctx)
+	return err == nil && ok
+}
+
+func (pc *PipelineCoordinator) convergeWorkflowNodeNormalRunCompletion(ctx context.Context, nodeID string, evt events.Event) {
+	if pc == nil || pc.bus == nil {
+		return
+	}
+	eventID := strings.TrimSpace(evt.ID)
+	if eventID == "" {
+		return
+	}
+	converger, ok := pc.bus.(systemNodeNormalRunCompletionConverger)
+	if !ok || converger == nil {
+		return
+	}
+	if err := converger.ConvergeNormalRunCompletionForEvent(ctx, eventID); err != nil {
+		if logger, ok := pc.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Converging normal run completion after workflow node receipt failed",
+				Component: nodeID,
+				Action:    "normal_run_completion_failed",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+	}
 }
 
 func (pc *PipelineCoordinator) workflowNodeMatchesDeliveryTarget(nodeID string, target events.RouteIdentity) bool {

--- a/internal/store/run_completion.go
+++ b/internal/store/run_completion.go
@@ -1,0 +1,338 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+type normalRunCompletionCandidate struct {
+	RunID  string
+	Status string
+}
+
+func (s *PostgresStore) ConvergeNormalRunCompletion(ctx context.Context, eventID string, workflowTerminalStates []string, flowTerminalStates map[string][]string) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	eventID = sanitizeOptionalUUID(eventID)
+	if eventID == "" {
+		return nil
+	}
+	workflowTerminals := normalRunCompletionStateSet(workflowTerminalStates)
+	flowTerminals := normalRunCompletionFlowStateSets(flowTerminalStates)
+	if len(workflowTerminals) == 0 && len(flowTerminals) == 0 {
+		return nil
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if !normalRunCompletionSupported(caps) {
+		return nil
+	}
+	return withEventStoreRetry(ctx, nil, func() error {
+		tx, err := s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin normal run completion tx: %w", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+
+		candidate, found, err := lockNormalRunCompletionCandidateTx(ctx, tx, eventID)
+		if err != nil || !found {
+			return err
+		}
+		switch candidate.Status {
+		case "completed":
+			return nil
+		case "running":
+		default:
+			return nil
+		}
+		if platformRec, platformFound, err := loadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID); err != nil {
+			return err
+		} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
+			return nil
+		}
+		ready, err := normalRunCompletionRunReadyTx(ctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
+		if err != nil || !ready {
+			return err
+		}
+		if _, err := storerunlifecycle.MarkTerminal(ctx, tx, candidate.RunID, "completed", "", time.Now().UTC(), runLifecycleOptions(caps)); err != nil {
+			return fmt.Errorf("converge normal run completion: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit normal run completion tx: %w", err)
+		}
+		committed = true
+		return nil
+	})
+}
+
+func normalRunCompletionSupported(caps StoreSchemaCapabilities) bool {
+	if !caps.Events.HasRuns || !caps.Events.RunTriggerColumns || !caps.Events.RunTerminalFields {
+		return false
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID {
+		return false
+	}
+	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
+		return false
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		return false
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical {
+		return false
+	}
+	if caps.Schedules != SchemaFlavorCanonical {
+		return false
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
+		return false
+	}
+	return true
+}
+
+func lockNormalRunCompletionCandidateTx(ctx context.Context, tx *sql.Tx, eventID string) (normalRunCompletionCandidate, bool, error) {
+	var candidate normalRunCompletionCandidate
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			r.run_id::text,
+			LOWER(COALESCE(r.status, ''))
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = $1::uuid
+		FOR UPDATE OF r
+	`, eventID).Scan(&candidate.RunID, &candidate.Status)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return normalRunCompletionCandidate{}, false, nil
+	case err != nil:
+		return normalRunCompletionCandidate{}, false, fmt.Errorf("lock normal run completion candidate: %w", err)
+	default:
+		candidate.RunID = strings.TrimSpace(candidate.RunID)
+		candidate.Status = strings.TrimSpace(candidate.Status)
+		return candidate, candidate.RunID != "", nil
+	}
+}
+
+func normalRunCompletionRunReadyTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	runID string,
+	workflowTerminals map[string]struct{},
+	flowTerminals map[string]map[string]struct{},
+) (bool, error) {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return false, nil
+	}
+	checks := []func(context.Context, *sql.Tx, string) (bool, error){
+		normalRunCompletionPipelinesSettledTx,
+		normalRunCompletionDeliveriesSettledTx,
+		normalRunCompletionTimersSettledTx,
+		normalRunCompletionSessionLeasesSettledTx,
+	}
+	for _, check := range checks {
+		ready, err := check(ctx, tx, runID)
+		if err != nil || !ready {
+			return ready, err
+		}
+	}
+	return normalRunCompletionEntitiesTerminalTx(ctx, tx, runID, workflowTerminals, flowTerminals)
+}
+
+func normalRunCompletionPipelinesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var unsettled bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events e
+			LEFT JOIN event_receipts r
+				ON r.event_id = e.event_id
+				AND r.subscriber_type = 'platform'
+				AND r.subscriber_id = 'pipeline'
+			WHERE e.run_id = $1::uuid
+			  AND (r.event_id IS NULL OR COALESCE(r.outcome, '') <> 'success')
+		)
+	`, runID).Scan(&unsettled); err != nil {
+		return false, fmt.Errorf("check normal run pipeline settlement: %w", err)
+	}
+	return !unsettled, nil
+}
+
+func normalRunCompletionDeliveriesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var active bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries d
+			WHERE d.run_id = $1::uuid
+			  AND `+activeRunQuiescenceDeliveryPredicateSQL("d")+`
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("check normal run active deliveries: %w", err)
+	}
+	return !active, nil
+}
+
+func normalRunCompletionTimersSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var active bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE run_id = $1::uuid
+			  AND status = 'active'
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("check normal run active timers: %w", err)
+	}
+	return !active, nil
+}
+
+func normalRunCompletionSessionLeasesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var active bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM agent_sessions
+			WHERE run_id = $1::uuid
+			  AND status = 'active'
+			  AND lease_holder IS NOT NULL
+			  AND lease_expires_at IS NOT NULL
+			  AND lease_expires_at > now()
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("check normal run active session leases: %w", err)
+	}
+	return !active, nil
+}
+
+func normalRunCompletionEntitiesTerminalTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	runID string,
+	workflowTerminals map[string]struct{},
+	flowTerminals map[string]map[string]struct{},
+) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			LOWER(COALESCE(es.current_state, '')),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(fi.flow_template, '')
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = $1::uuid
+		FOR SHARE OF es
+	`, runID)
+	if err != nil {
+		return false, fmt.Errorf("load normal run entity terminality: %w", err)
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		seen = true
+		var state, flowInstance, flowTemplate string
+		if err := rows.Scan(&state, &flowInstance, &flowTemplate); err != nil {
+			return false, fmt.Errorf("scan normal run entity terminality: %w", err)
+		}
+		terminals, ok := normalRunCompletionTerminalSetForEntity(flowTemplate, flowInstance, workflowTerminals, flowTerminals)
+		if !ok {
+			return false, nil
+		}
+		if _, ok := terminals[strings.TrimSpace(strings.ToLower(state))]; !ok {
+			return false, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("read normal run entity terminality: %w", err)
+	}
+	return seen, nil
+}
+
+func normalRunCompletionTerminalSetForEntity(
+	flowTemplate, flowInstance string,
+	workflowTerminals map[string]struct{},
+	flowTerminals map[string]map[string]struct{},
+) (map[string]struct{}, bool) {
+	for _, raw := range []string{flowTemplate, flowInstance} {
+		key := strings.Trim(strings.TrimSpace(raw), "/")
+		if key == "" {
+			continue
+		}
+		if terminals, ok := normalRunCompletionBestFlowTerminalSet(key, flowTerminals); ok {
+			return terminals, true
+		}
+	}
+	if strings.TrimSpace(flowInstance) == "" && len(workflowTerminals) > 0 {
+		return workflowTerminals, true
+	}
+	return nil, false
+}
+
+func normalRunCompletionBestFlowTerminalSet(key string, sets map[string]map[string]struct{}) (map[string]struct{}, bool) {
+	key = strings.Trim(strings.TrimSpace(key), "/")
+	if key == "" || len(sets) == 0 {
+		return nil, false
+	}
+	var (
+		best    map[string]struct{}
+		bestLen int
+	)
+	for candidate, terminals := range sets {
+		candidate = strings.Trim(strings.TrimSpace(candidate), "/")
+		if candidate == "" || len(terminals) == 0 {
+			continue
+		}
+		if key == candidate || strings.HasPrefix(key, candidate+"/") {
+			if len(candidate) > bestLen {
+				best = terminals
+				bestLen = len(candidate)
+			}
+		}
+	}
+	return best, best != nil
+}
+
+func normalRunCompletionStateSet(states []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, state := range states {
+		state = strings.TrimSpace(strings.ToLower(state))
+		if state != "" {
+			out[state] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalRunCompletionFlowStateSets(states map[string][]string) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	for key, values := range states {
+		key = strings.Trim(strings.TrimSpace(key), "/")
+		if key == "" {
+			continue
+		}
+		if set := normalRunCompletionStateSet(values); len(set) > 0 {
+			out[key] = set
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/store/run_completion_test.go
+++ b/internal/store/run_completion_test.go
@@ -1,0 +1,282 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	runtimemanager "swarm/internal/runtime/manager"
+	"swarm/internal/testutil"
+)
+
+type normalRunCompletionFixture struct {
+	RunID    string
+	EventID  string
+	EntityID string
+}
+
+func seedNormalRunCompletionFixture(t *testing.T, db *sql.DB, state, flowInstance, flowTemplate string) normalRunCompletionFixture {
+	t.Helper()
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if flowInstance == "" {
+		flowInstance = "example"
+	}
+	if flowTemplate == "" {
+		flowTemplate = "example"
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', now())
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'example.started', $3::uuid, NULLIF($4,''), 'entity', '{}'::jsonb,
+			0, 'test', 'external', now()
+		)
+	`, eventID, runID, entityID, flowInstance); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET trigger_event_id = $2::uuid,
+		    trigger_event_type = 'example.started'
+		WHERE run_id = $1::uuid
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed run trigger: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+			INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+			VALUES ($1, $2, 'static', '{}'::jsonb, 'active', now())
+			ON CONFLICT (instance_id) DO UPDATE SET flow_template = EXCLUDED.flow_template
+		`, flowInstance, flowTemplate); err != nil {
+		t.Fatalf("seed flow instance: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, NULLIF($3,''), 'default', 'example', 'Example', $4,
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
+		)
+	`, runID, entityID, flowInstance, state); err != nil {
+		t.Fatalf("seed entity state: %v", err)
+	}
+	return normalRunCompletionFixture{RunID: runID, EventID: eventID, EntityID: entityID}
+}
+
+func normalRunCompletionRootFlowTerminals() map[string][]string {
+	return map[string][]string{"example": []string{"done"}}
+}
+
+func assertRunCompletionStatus(t *testing.T, db *sql.DB, runID, want string, wantEnded bool) {
+	t.Helper()
+	var (
+		status  string
+		endedAt sql.NullTime
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, ''), ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &endedAt); err != nil {
+		t.Fatalf("load run status: %v", err)
+	}
+	if status != want {
+		t.Fatalf("run status = %q, want %q", status, want)
+	}
+	if endedAt.Valid != wantEnded {
+		t.Fatalf("ended_at valid = %v, want %v", endedAt.Valid, wantEnded)
+	}
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_MarksCompletedWhenTerminalAndIdle(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "review/inst-1", "review")
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, map[string][]string{"review": []string{"done"}}); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+
+	header, err := pg.LoadRunHeader(ctx, fixture.RunID)
+	if err != nil {
+		t.Fatalf("LoadRunHeader: %v", err)
+	}
+	if header.Status != "completed" || header.EndedAt == nil {
+		t.Fatalf("run header = status:%q ended:%v, want completed with ended_at", header.Status, header.EndedAt)
+	}
+	report, err := pg.LoadRunDebugReport(ctx, fixture.RunID, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport: %v", err)
+	}
+	if got := ProjectRunOperationalStatus(report).State; got != "completed" {
+		t.Fatalf("run operational state = %q, want completed", got)
+	}
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWithMissingPipelineReceipt(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileDeliveryActive(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
+	sessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-1', 'in_progress', $3::uuid, now()
+		)
+	`, fixture.RunID, fixture.EventID, sessionID); err != nil {
+		t.Fatalf("seed active delivery: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion active: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+
+	if err := pg.UpsertEventReceipt(ctx, fixture.EventID, "agent-1", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("UpsertEventReceipt: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion settled: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileTimerActiveThenCompletesAfterTimerSettled(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	timerID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, owner_agent, task_type, status, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'wait', $3::uuid, '', 'example.timeout', '{}'::jsonb,
+			now() + interval '1 minute', 'timer-agent', 'timer', 'active', now()
+		)
+	`, timerID, fixture.RunID, fixture.EntityID); err != nil {
+		t.Fatalf("seed active timer: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion active timer: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+
+	if _, err := db.ExecContext(ctx, `UPDATE timers SET status = 'fired', fired_at = now() WHERE timer_id = $1::uuid`, timerID); err != nil {
+		t.Fatalf("settle timer: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion settled timer: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileSessionLeaseActive(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	sessionID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model_tier, llm_backend, conversation_mode,
+			config, subscriptions, emit_events, tools, permissions, runtime_descriptor,
+			status, turn_count, last_active_at, created_at
+		) VALUES (
+			'agent-1', 'worker', 'standard', 'mock', 'session_per_entity',
+			'{}'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb, '{}'::jsonb,
+			'active', 0, now(), now()
+		)
+	`); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent-1', $3::uuid, '', $3::text, 'entity',
+			'[]'::jsonb, 0, 'session_per_entity', '{}'::jsonb,
+			'worker-1', now() + interval '1 minute', 'active', now(), now()
+		)
+	`, sessionID, fixture.RunID, fixture.EntityID); err != nil {
+		t.Fatalf("seed active session lease: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion active session: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET lease_holder = NULL,
+		    lease_expires_at = NULL
+		WHERE session_id = $1::uuid
+	`, sessionID); err != nil {
+		t.Fatalf("release session lease: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion released session: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+}
+
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhenEntityNotTerminal(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "working", "", "")
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+
+	if _, err := db.ExecContext(ctx, `UPDATE entity_state SET current_state = 'done' WHERE run_id = $1::uuid`, fixture.RunID); err != nil {
+		t.Fatalf("advance entity terminal: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion terminal: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+}

--- a/internal/store/run_completion_test.go
+++ b/internal/store/run_completion_test.go
@@ -171,6 +171,45 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileDeliveryActiv
 	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
 }
 
+func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedUntilNodeDeliverySettled(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', 'terminal-node', 'pending', 'matched_node_subscription', now()
+		)
+	`, fixture.RunID, fixture.EventID); err != nil {
+		t.Fatalf("seed active node delivery: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion active node: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "running", false)
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'delivered',
+		    reason_code = 'node_processed',
+		    delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, fixture.EventID); err != nil {
+		t.Fatalf("settle node delivery: %v", err)
+	}
+	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, normalRunCompletionRootFlowTerminals()); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion settled node: %v", err)
+	}
+	assertRunCompletionStatus(t, db, fixture.RunID, "completed", true)
+}
+
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileTimerActiveThenCompletesAfterTimerSettled(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}


### PR DESCRIPTION
## Summary
- Adds a canonical normal-run completion convergence owner for flow/user runs after terminal entity evidence plus delivery/timer/session quiescence.
- Wires the owner from persisted pipeline receipts and manager receipts while preserving the standalone runtime/platform convergence path.
- Adds focused store, bus, and manager coverage plus updates the semantic-correctness watchlist mapping from stale #120 to active #994.

Closes #994

## Governing Refs / Context
- #994 and the approved pre-audit gate: https://github.com/yazzaoui/Swarm/issues/994#issuecomment-4529187268
- `platform-spec.yaml` run lifecycle context: `run_model.lifecycle.completion`, run `completed` terminal/idle meaning, `RunHeader`, `RunDiagnosis`, and timer/work quiescence behavior.
- Binding condition from the gate: no CLI timeout/follow-loop workaround, no read-side inference in `run.get`/`run.diagnose`; completion must be persisted through the canonical terminal write owner.

## Semantic Migration
- New semantic owner: `internal/runtime/bus/run_completion.go` plus `internal/store/run_completion.go` evaluate normal flow/user run completion and call the existing physical terminal writer `internal/store/runlifecycle/owner.go`.
- Old non-authoritative path now invalid: platform-only `ConvergeStandaloneRuntimePlatformRun` cannot be treated as the owner for normal flow/user runs; `run.get`, `run.diagnose`, and CLI follow remain consumers of persisted run status rather than terminality interpreters.
- Production paths checked: pipeline receipt persistence, manager final receipt persistence, standalone platform convergence, `run.get`/`run.diagnose`, explicit `event.publish --run-id` rejection for completed runs, active delivery/timer/session blockers, replay-scope marker behavior.
- Migration completeness: complete for the approved first-slice class, normal non-platform flow/user run completion after terminal entity plus quiescence. Duplicate trigger/redelivery and startup #993 remain split outside this PR.

## Tests
- `go test ./internal/store -run 'TestPostgresStore_ConvergeNormalRunCompletion|TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeliveries|TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle|TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBus.*Completion|TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersistedDeliveries|TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalReceipt' -count=1`
- `go test ./internal/runtime/manager -run 'TestWriteReceiptConvergesNormalRunCompletionAfterReceiptPersists|TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired' -count=1`
- `go test ./cmd/swarm -run 'TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestLoadRunStatusReport_PreservesRunningTruthWhileManagerWorkIsActive|TestLoadRunStatusReport_UsesDurableCompletedRunState' -count=1`
- `go test ./internal/apiv1 -run TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun -count=1`
- `go test ./internal/runtime/runforkadmission -run TestAdmitContractFrontier_CommittedReplayScopeMarkersAreNotFrontierWork -count=1`
- `go test ./...`