### PR TITLE
[agent-e][issue #993] Gate Claude boot validation on agent presence

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1544,8 +1544,8 @@ engine:
       always_required:
       - package.yaml
       - schema.yaml
-      at_least_one: agents.yaml OR flows/ with at least one child
-      boot_error: A flow with no agents.yaml and no child flows is an error.
+      at_least_one: No agent file is required for an agent-free flow; flows/ remains optional composition.
+      boot_error: Missing agents.yaml is not a boot error by itself. It is invalid only when the flow declares or depends on agents without corresponding agent entries.
     optional_files:
       nodes.yaml: System node handlers. Omit if flow only composes children via agents.
       events.yaml: Event payload schemas. Omit if flow uses only events declared by children or root.

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -687,8 +687,8 @@ Specification for the platform engine — how it loads, validates, and executes 
 - `package.yaml`
 - `schema.yaml`
 
-- `at_least_one`: agents.yaml OR flows/ with at least one child
-- `boot_error`: A flow with no agents.yaml and no child flows is an error.
+- `at_least_one`: No agent file is required for an agent-free flow; flows/ remains optional composition.
+- `boot_error`: Missing agents.yaml is not a boot error by itself. It is invalid only when the flow declares or depends on agents without corresponding agent entries.
 - `optional_files`:
   - `nodes.yaml`: System node handlers. Omit if flow only composes children via agents.
   - `events.yaml`: Event payload schemas. Omit if flow uses only events declared by children or root.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -256,13 +256,13 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 	if err := cfg.ValidateExtensions(); err != nil {
 		return nil, fmt.Errorf("runtime config validation failed: %w", err)
 	}
-	if err := validateClaudeStartupConfig(cfg, opts); err != nil {
-		return nil, fmt.Errorf("claude runtime startup validation failed: %w", err)
-	}
 	if err := ensureWorkflowBootWiring(opts); err != nil {
 		return nil, fmt.Errorf("workflow contract validation failed: %w", err)
 	}
 	source := opts.WorkflowModule.SemanticSource()
+	if err := validateClaudeStartupConfig(cfg, opts, source); err != nil {
+		return nil, fmt.Errorf("claude runtime startup validation failed: %w", err)
+	}
 	promptResolver, err := newRuntimePromptResolver(source)
 	if err != nil {
 		return nil, fmt.Errorf("build prompt resolver: %w", err)
@@ -812,13 +812,18 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	} else {
 		rt.emitBootProgress(14, "flow_required_agents", "skipped", "manager unavailable")
 	}
-	if err := validateClaudeManagedAgentWorkspaces(ctx, rt.Config, rt.Workspace, rt.Manager); err != nil {
+	source := rt.Options.WorkflowModule.SemanticSource()
+	if err := validateClaudeStartupConfigForActiveAgents(rt.Config, rt.Options, source, rt.Manager); err != nil {
+		rt.emitBootProgress(15, "workspace_validation_and_system_containers", "FAILED", err.Error())
+		return fmt.Errorf("claude runtime startup validation failed: %w", err)
+	}
+	if err := validateClaudeManagedAgentWorkspaces(ctx, rt.Config, source, rt.Workspace, rt.Manager); err != nil {
 		rt.emitBootProgress(15, "workspace_validation_and_system_containers", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime workspace validation failed: %w", err)
 	}
 	rt.emitBootProgress(15, "workspace_validation_and_system_containers", "ok", fmt.Sprintf("%d system containers", len(rt.Options.SystemContainers)))
 	startupProbe, _ := rt.LLM.(llm.StartupVisibleToolSurfaceProber)
-	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, source, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
 		rt.emitBootProgress(16, "mcp_tool_validation", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)
 	}

--- a/internal/runtime/runtime_agent_free_claude_boot_test.go
+++ b/internal/runtime/runtime_agent_free_claude_boot_test.go
@@ -1,0 +1,144 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	workspace "swarm/internal/runtime/workspace"
+)
+
+func TestRuntimeStart_AgentFreeCLITestDoesNotRequireClaudeStartupEnv(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	module := loadAgentFreeRuntimeWorkflowModule(t)
+	if got := len(module.SemanticSource().AgentEntries()); got != 0 {
+		t.Fatalf("agent-free fixture has %d semantic agents", got)
+	}
+
+	rt, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Shutdown() })
+
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+}
+
+func TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	module := semanticOnlyWorkflowRuntime{source: loadPackageBackedRuntimeSessionScopeSource(t)}
+	if got := len(module.SemanticSource().AgentEntries()); got == 0 {
+		t.Fatal("agent-present fixture unexpectedly has zero semantic agents")
+	}
+
+	_, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	})
+	if err == nil {
+		t.Fatal("expected agent-present cli_test runtime to require Claude startup env")
+	}
+	if !strings.Contains(err.Error(), "claude runtime startup validation failed") {
+		t.Fatalf("NewRuntime error = %v, want claude startup validation failure", err)
+	}
+}
+
+func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	rt, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+		SelfCheck:      false,
+		WorkflowModule: loadAgentFreeRuntimeWorkflowModule(t),
+		LLMRuntime:     noopLLMRuntime{},
+		WorkspaceLifecycle: claudeStartupWorkspaceStub{
+			target: &workspace.Target{Container: "swarm-agent-recovered-agent", Workdir: "/workspace"},
+		},
+		EnableToolGateway: true,
+		ToolGatewayToken:  "gateway-token",
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Shutdown() })
+	if err := rt.Manager.SpawnAgent(runtimeactors.AgentConfig{ID: "recovered-agent", Role: "recovered", Config: json.RawMessage(`{"system_prompt":"Recovered agent"}`)}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+
+	err = rt.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "claude runtime startup validation failed") || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_CONTAINER_URL") {
+		t.Fatalf("Start error = %v, want startup validation failure for missing container gateway URL", err)
+	}
+}
+
+func loadAgentFreeRuntimeWorkflowModule(t *testing.T) semanticOnlyWorkflowRuntime {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: agent-free-runtime
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: agent-free-runtime
+initial_state: idle
+states:
+  - idle
+terminal_states:
+  - idle
+`)
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeAgentFreeRuntimeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)}
+}
+
+func writeAgentFreeRuntimeFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -17,15 +17,41 @@ import (
 	llm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
+	"swarm/internal/runtime/semanticview"
 	workspace "swarm/internal/runtime/workspace"
 )
 
-func validateClaudeStartupConfig(cfg *config.Config, opts RuntimeOptions) error {
-	if err := llm.ValidateClaudeCLIRuntimeConfig(cfg); err != nil {
-		return err
-	}
+func validateClaudeStartupConfig(cfg *config.Config, opts RuntimeOptions, source semanticview.Source) error {
 	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
 		return nil
+	}
+	hasAgents, err := workflowSourceDeclaresAgents(source)
+	if err != nil {
+		return err
+	}
+	if !hasAgents {
+		return nil
+	}
+	return validateClaudeStartupRequirements(cfg, opts)
+}
+
+func validateClaudeStartupConfigForActiveAgents(cfg *config.Config, opts RuntimeOptions, source semanticview.Source, manager *runtimemanager.AgentManager) error {
+	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
+		return nil
+	}
+	hasAgents, err := workflowSourceOrManagerDeclaresAgents(source, manager)
+	if err != nil {
+		return err
+	}
+	if !hasAgents {
+		return nil
+	}
+	return validateClaudeStartupRequirements(cfg, opts)
+}
+
+func validateClaudeStartupRequirements(cfg *config.Config, opts RuntimeOptions) error {
+	if err := llm.ValidateClaudeCLIRuntimeConfig(cfg); err != nil {
+		return err
 	}
 	if opts.WorkspaceLifecycle == nil {
 		return fmt.Errorf("workspace lifecycle is required for claude cli runtime")
@@ -39,8 +65,36 @@ func validateClaudeStartupConfig(cfg *config.Config, opts RuntimeOptions) error 
 	return nil
 }
 
-func validateClaudeManagedAgentWorkspaces(ctx context.Context, cfg *config.Config, workspaces workspace.Lifecycle, manager *runtimemanager.AgentManager) error {
+func workflowSourceDeclaresAgents(source semanticview.Source) (bool, error) {
+	if source == nil {
+		return false, fmt.Errorf("semantic source is required for claude cli runtime")
+	}
+	return len(source.AgentEntries()) > 0, nil
+}
+
+func workflowSourceOrManagerDeclaresAgents(source semanticview.Source, manager *runtimemanager.AgentManager) (bool, error) {
+	hasAgents, err := workflowSourceDeclaresAgents(source)
+	if err != nil {
+		return false, err
+	}
+	if hasAgents {
+		return true, nil
+	}
+	if manager == nil {
+		return false, nil
+	}
+	return len(manager.ListAgentConfigs()) > 0, nil
+}
+
+func validateClaudeManagedAgentWorkspaces(ctx context.Context, cfg *config.Config, source semanticview.Source, workspaces workspace.Lifecycle, manager *runtimemanager.AgentManager) error {
 	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
+		return nil
+	}
+	hasAgents, err := workflowSourceOrManagerDeclaresAgents(source, manager)
+	if err != nil {
+		return err
+	}
+	if !hasAgents {
 		return nil
 	}
 	if workspaces == nil {
@@ -71,8 +125,15 @@ type claudeStartupContextAwareToolSource interface {
 	ToolCapabilitiesForActorInContext(context.Context, runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
 }
 
-func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, startupProbe llm.StartupVisibleToolSurfaceProber, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
+func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, source semanticview.Source, startupProbe llm.StartupVisibleToolSurfaceProber, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
 	if cfg == nil || strings.TrimSpace(cfg.LLM.RuntimeMode) != "cli_test" {
+		return nil
+	}
+	hasAgents, err := workflowSourceOrManagerDeclaresAgents(source, manager)
+	if err != nil {
+		return err
+	}
+	if !hasAgents {
 		return nil
 	}
 	if turnStore == nil {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"swarm/internal/config"
+	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/toolcapabilities"
 	llm "swarm/internal/runtime/llm"
@@ -39,6 +40,25 @@ func (s claudeStartupWorkspaceStub) EnsureSystemWorkspaces(context.Context) erro
 func (s claudeStartupWorkspaceStub) EnsureEntityWorkspace(context.Context, string) error { return nil }
 func (s claudeStartupWorkspaceStub) StopEntityWorkspace(context.Context, string) error   { return nil }
 
+func claudeStartupAgentFreeSource() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+}
+
+func claudeStartupAgentSource(ids ...string) semanticview.Source {
+	if len(ids) == 0 {
+		ids = []string{"campaign-coordinator"}
+	}
+	agents := make(map[string]runtimecontracts.AgentRegistryEntry, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		agents[id] = runtimecontracts.AgentRegistryEntry{ID: id, Role: id}
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Agents: agents})
+}
+
 func TestValidateClaudeStartupConfig_RequiresWorkspaceAndGateway(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
@@ -48,9 +68,55 @@ func TestValidateClaudeStartupConfig_RequiresWorkspaceAndGateway(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := validateClaudeStartupConfig(cfg, RuntimeOptions{})
+	err := validateClaudeStartupConfig(cfg, RuntimeOptions{}, claudeStartupAgentSource())
 	if err == nil || !strings.Contains(err.Error(), "workspace lifecycle") {
 		t.Fatalf("expected workspace lifecycle error, got %v", err)
+	}
+}
+
+func TestValidateClaudeStartupConfig_SkipsClaudeEnvForAgentFreeSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	if err := validateClaudeStartupConfig(cfg, RuntimeOptions{}, claudeStartupAgentFreeSource()); err != nil {
+		t.Fatalf("validateClaudeStartupConfig: %v", err)
+	}
+}
+
+func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIEnvForRecoveredManagerAgent(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "recovered-agent", Role: "recovered"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	opts := RuntimeOptions{
+		WorkspaceLifecycle: claudeStartupWorkspaceStub{
+			target: &workspace.Target{Container: "swarm-agent-recovered-agent", Workdir: "/workspace"},
+		},
+		EnableToolGateway: true,
+		ToolGatewayToken:  "gateway-token",
+	}
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	err := validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
+	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_CONTAINER_URL") {
+		t.Fatalf("expected container gateway URL error, got %v", err)
+	}
+
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
+	err = validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
+	if err == nil || !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
+		t.Fatalf("expected oauth token error, got %v", err)
 	}
 }
 
@@ -62,7 +128,7 @@ func TestValidateClaudeManagedAgentWorkspaces_RequiresResolvedContainerTargets(t
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 
-	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupWorkspaceStub{}, manager)
+	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), claudeStartupWorkspaceStub{}, manager)
 	if err == nil || !strings.Contains(err.Error(), "resolved no container workspace target") {
 		t.Fatalf("expected workspace target error, got %v", err)
 	}
@@ -76,7 +142,7 @@ func TestValidateClaudeManagedAgentWorkspaces_PropagatesResolverErrors(t *testin
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 
-	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupWorkspaceStub{err: errors.New("docker unavailable")}, manager)
+	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), claudeStartupWorkspaceStub{err: errors.New("docker unavailable")}, manager)
 	if err == nil || !strings.Contains(err.Error(), "docker unavailable") {
 		t.Fatalf("expected resolver error, got %v", err)
 	}
@@ -90,11 +156,34 @@ func TestValidateClaudeManagedAgentWorkspaces_AcceptsContainerTargets(t *testing
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 
-	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupWorkspaceStub{
+	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), claudeStartupWorkspaceStub{
 		target: &workspace.Target{Container: "swarm-agent-campaign-coordinator", Workdir: "/workspace"},
 	}, manager)
 	if err != nil {
 		t.Fatalf("validateClaudeManagedAgentWorkspaces: %v", err)
+	}
+}
+
+func TestValidateClaudeManagedAgentWorkspaces_SkipsWorkspaceForAgentFreeSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+
+	if err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, nil); err != nil {
+		t.Fatalf("validateClaudeManagedAgentWorkspaces: %v", err)
+	}
+}
+
+func TestValidateClaudeManagedAgentWorkspaces_RequiresWorkspaceForRecoveredManagerAgent(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: "recovered-agent", Role: "recovered"}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+
+	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, manager)
+	if err == nil || !strings.Contains(err.Error(), "workspace lifecycle") {
+		t.Fatalf("expected workspace lifecycle error, got %v", err)
 	}
 }
 
@@ -247,6 +336,67 @@ func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManag
 	return turns
 }
 
+func TestValidateClaudeMCPToolsForManagedAgents_SkipsGatewayEnvForAgentFreeSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, nil, nil, nil); err != nil {
+		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForAgentSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "campaign-coordinator",
+		Role:   "campaign_coordinator",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_URL") {
+		t.Fatalf("expected gateway URL error, got %v", err)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForRecoveredManagerAgent(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "recovered-agent",
+		Role:   "recovered",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_URL") {
+		t.Fatalf("expected gateway URL error, got %v", err)
+	}
+}
+
 func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
@@ -264,7 +414,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(exec.executed, []string{"health_check"}) {
@@ -305,7 +455,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_SeparatesStaticInventoryFromNoCu
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if exec.contextDefCalls == 0 || exec.contextCapsCalls == 0 {
@@ -342,7 +492,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_AllowsEmptyConcreteSurfaceWhenSt
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if len(exec.executed) != 0 {
@@ -370,7 +520,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_AcceptsExplicitValidationOnlyPro
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(exec.executed, []string{"health_check"}) {
@@ -395,7 +545,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTo
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "wrong-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "invalid token") {
 		t.Fatalf("expected invalid token error, got %v", err)
 	}
@@ -424,7 +574,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "found no visible tools") {
 		t.Fatalf("expected empty visible tools error, got %v", err)
 	}
@@ -466,7 +616,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesLiveVisibleSurfaceForNativeB
 		},
 	}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -508,7 +658,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_ComparesProviderNativeSurfaceOnl
 		},
 	}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"trend-research-agent"}) {
@@ -550,7 +700,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedProviderN
 		},
 	}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected visible tool surface") {
 		t.Fatalf("expected provider-native visible-surface mismatch, got %v", err)
 	}
@@ -592,7 +742,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenNativeBuiltinVisi
 		},
 	}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected visible tool surface") {
 		t.Fatalf("expected visible tool surface mismatch, got %v", err)
 	}
@@ -635,7 +785,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenNoExplicit
 			}
 			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 			}
 			if len(exec.executed) != 0 {
@@ -671,7 +821,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_DoesNotCallSchemaOnlyEmptyObject
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if len(exec.executed) != 0 {
@@ -703,7 +853,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenVisibleToo
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if len(exec.executed) != 0 {
@@ -734,7 +884,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenExplicitProbeSafe
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "call_empty_object") {
 		t.Fatalf("expected explicit probe-safe schema mismatch error, got %v", err)
 	}
@@ -759,7 +909,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableP
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected tool failure") {
 		t.Fatalf("expected unexpected callable probe error, got %v", err)
 	}
@@ -781,7 +931,7 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonVal
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "execution path must be enabled before use") {
 		t.Fatalf("expected generic phrase non-validation probe error, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- Gates `cli_test` Claude startup env, workspace, and MCP startup validation on source-backed semantic agent presence.
- Keeps agent-present `cli_test` bundles fail-closed on missing Claude/tool-gateway startup env.
- Updates the authoritative platform spec and generated markdown surface to allow agent-free flows without `agents.yaml`.

Closes #993

## Governing refs / context

- #993 body/thread and approved gate comment.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `package_layout.minimum_flow_package`
  - `flow_tree_walker.minimum_required_files`
- `internal/runtime/runtime.go` runtime constructor/start path.
- `semanticview.Source.AgentEntries()` / `WorkflowContractBundle.AgentEntries()` as the canonical agent-presence owner.

## Semantic migration

- New canonical owner consumed by boot validation: `semanticview.Source.AgentEntries()` backed by `WorkflowContractBundle.AgentEntries()`.
- Old invalid path: unconditional `llm.ValidateClaudeCLIRuntimeConfig(cfg)` before source-aware workflow boot wiring, plus `Runtime.Start` MCP validation requiring gateway env before proving semantic agents exist.
- Production paths checked: `cmd/swarm/main.go` `runServeRuntime`, `cmd/swarm/run_command.go` local foreground `startLocalRunServe`, `cmd/swarm/builder_project_supervisor.go` reload/create runtime path, and `swarm verify` validation path.
- Migration completeness: complete for the approved child class. Broader lazy LLM init / one-secret local onboarding remains split to existing trackers.

## Tests

```bash
go test ./internal/runtime -run 'TestValidateClaude|TestRuntimeStart_AgentFreeCLITestDoesNotRequireClaudeStartupEnv' -count=1
go test ./internal/runtime ./cmd/swarm -count=1
go run ./cmd/swarm-openrpc-gen --check
go test ./internal/apispec ./internal/apiv1 ./internal/runtime/contracts -count=1
go test ./...
```