### PR TITLE
[agent-a][issue #1002] Make swarm binary portable for no-asset commands

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -139,7 +139,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Output = cmd.OutOrStdout()
-			code := runServe(ctx, repo, opts)
+			code := runServe(ctx, assetCommandRepoRoot(repo), opts)
 			if code != 0 {
 				return commandExitError{code: code}
 			}
@@ -177,7 +177,7 @@ func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 			if len(args) > 0 {
 				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("unexpected argument %q", args[0]))
 			}
-			code := runVerifyCommandWithOutput(ctx, repo, opts, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			code := runVerifyCommandWithOutput(ctx, assetCommandRepoRoot(repo), opts, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			if code != 0 {
 				return commandExitError{code: code}
 			}

--- a/cmd/swarm/cli_paths.go
+++ b/cmd/swarm/cli_paths.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,10 @@ type cliContractPlatformSpecPaths struct {
 }
 
 func resolveCLIContractPlatformSpecPaths(repoRoot string, opts cliContractPlatformSpecPathOptions) (cliContractPlatformSpecPaths, error) {
+	repoRoot = strings.TrimSpace(repoRoot)
+	if repoRoot == "" {
+		repoRoot = discoverRepoRoot()
+	}
 	cfg, err := loadCLIAPIConfigFile()
 	if err != nil {
 		return cliContractPlatformSpecPaths{}, err
@@ -29,11 +34,18 @@ func resolveCLIContractPlatformSpecPaths(repoRoot string, opts cliContractPlatfo
 		cfg.ContractsPath,
 		discoverRepoContractsPath(repoRoot),
 	)
+	configPlatformSpecPath := strings.TrimSpace(cfg.PlatformSpecPath)
 	platformSpecPath := firstNonEmpty(
 		opts.PlatformSpecPath,
-		cfg.PlatformSpecPath,
-		defaultPlatformSpecPath,
+		configPlatformSpecPath,
 	)
+	if platformSpecPath == "" {
+		embedded, err := embeddedPlatformSpecPath()
+		if err != nil {
+			return cliContractPlatformSpecPaths{}, fmt.Errorf("resolve embedded platform spec: %w", err)
+		}
+		platformSpecPath = embedded
+	}
 	return cliContractPlatformSpecPaths{
 		ContractsPath:    resolvePath(repoRoot, contractsPath),
 		PlatformSpecPath: resolvePath(repoRoot, platformSpecPath),
@@ -41,6 +53,10 @@ func resolveCLIContractPlatformSpecPaths(repoRoot string, opts cliContractPlatfo
 }
 
 func discoverRepoContractsPath(repoRoot string) string {
+	repoRoot = strings.TrimSpace(repoRoot)
+	if repoRoot == "" {
+		return ""
+	}
 	candidate := filepath.Join(repoRoot, "contracts")
 	if regularFileExists(filepath.Join(candidate, "package.yaml")) {
 		return candidate

--- a/cmd/swarm/cli_paths_test.go
+++ b/cmd/swarm/cli_paths_test.go
@@ -82,7 +82,7 @@ func TestResolveCLIContractPlatformSpecPathsPrecedenceAndDiscovery(t *testing.T)
 		}
 	})
 
-	t.Run("discovers repo contracts and built in platform spec last", func(t *testing.T) {
+	t.Run("discovers repo contracts and embedded platform spec last", func(t *testing.T) {
 		isolateCLIAPIConfigEnv(t)
 
 		got, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{})
@@ -92,10 +92,46 @@ func TestResolveCLIContractPlatformSpecPathsPrecedenceAndDiscovery(t *testing.T)
 		if got.ContractsPath != discoveredContracts {
 			t.Fatalf("contracts path = %q, want %q", got.ContractsPath, discoveredContracts)
 		}
-		if want := filepath.Join(repo, defaultPlatformSpecPath); got.PlatformSpecPath != want {
+		want, err := embeddedPlatformSpecPath()
+		if err != nil {
+			t.Fatalf("embedded platform spec path: %v", err)
+		}
+		if got.PlatformSpecPath != want {
 			t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, want)
 		}
 	})
+}
+
+func TestResolveCLIContractPlatformSpecPathsEmbeddedDefaultDoesNotRequireRepoRoot(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	outsideRepo := t.TempDir()
+	contractsRoot := filepath.Join(t.TempDir(), "contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "package.yaml"), `name: external`)
+	t.Chdir(outsideRepo)
+
+	got, err := resolveCLIContractPlatformSpecPaths("", cliContractPlatformSpecPathOptions{
+		ContractsPath: contractsRoot,
+	})
+	if err != nil {
+		t.Fatalf("resolve paths: %v", err)
+	}
+	if got.ContractsPath != contractsRoot {
+		t.Fatalf("contracts path = %q, want %q", got.ContractsPath, contractsRoot)
+	}
+	want, err := embeddedPlatformSpecPath()
+	if err != nil {
+		t.Fatalf("embedded platform spec path: %v", err)
+	}
+	if got.PlatformSpecPath != want {
+		t.Fatalf("platform spec path = %q, want %q", got.PlatformSpecPath, want)
+	}
+	data, err := os.ReadFile(got.PlatformSpecPath)
+	if err != nil {
+		t.Fatalf("read embedded platform spec materialization: %v", err)
+	}
+	if !bytes.Contains(data, []byte("cli_specification:")) {
+		t.Fatalf("materialized platform spec missing cli_specification")
+	}
 }
 
 func TestCLIContractPathResolutionIgnoresLegacyContractsDir(t *testing.T) {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2132,6 +2132,13 @@ func discoverRepoRoot() string {
 	}
 }
 
+func assetCommandRepoRoot(repo string) string {
+	if repo = strings.TrimSpace(repo); repo != "" {
+		return repo
+	}
+	return discoverRepoRoot()
+}
+
 func embeddedPlatformSpecPath() (string, error) {
 	return platformcontracts.MaterializePlatformSpecFile()
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	platformcontracts "swarm/docs/specs/swarm-platform/platform/contracts"
 	apiv1 "swarm/internal/apiv1"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
@@ -102,7 +103,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	os.Exit(executeRootCommand(ctx, repoRoot(), os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(executeRootCommand(ctx, "", os.Args[1:], os.Stdout, os.Stderr))
 }
 
 type serveOptions struct {
@@ -2102,9 +2103,22 @@ func configuredWorkspaceLifecycle(db *sql.DB, repoRoot, contractsRoot string, so
 }
 
 func repoRoot() string {
+	root := discoverRepoRoot()
+	if root != "" {
+		return root
+	}
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("resolve cwd: %v", err)
+	}
+	log.Fatalf("locate repo root from %s", dir)
+	return ""
+}
+
+func discoverRepoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
 	}
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
@@ -2112,10 +2126,14 @@ func repoRoot() string {
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			log.Fatalf("locate repo root from %s", dir)
+			return ""
 		}
 		dir = parent
 	}
+}
+
+func embeddedPlatformSpecPath() (string, error) {
+	return platformcontracts.MaterializePlatformSpecFile()
 }
 
 func closeDB(db *sql.DB) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -752,6 +752,90 @@ func TestRootNoAssetCommandsDoNotRequireRepoRoot(t *testing.T) {
 	}
 }
 
+func TestAssetCommandsDiscoverRepoRootAtExecution(t *testing.T) {
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
+	t.Chdir(repo)
+
+	var capturedRepo string
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, repo string, _ serveOptions) int {
+		capturedRepo = repo
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), "", []string{"serve"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if capturedRepo != repo {
+		t.Fatalf("serve repo = %q, want discovered repo %q", capturedRepo, repo)
+	}
+}
+
+func TestVerifyCommandLoadsRepoDotEnvAfterLazyRepoDiscovery(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	_ = os.Unsetenv("SWARM_CONTRACTS_PATH")
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
+	contractsRoot := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "package.yaml"), `
+name: dot-env-contracts
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "schema.yaml"), "name: dot-env-contracts\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "agents.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "events.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_CONTRACTS_PATH="+contractsRoot+"\n")
+	t.Chdir(repo)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), "", []string{"verify"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("verify code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "verify ok: contracts="+contractsRoot) {
+		t.Fatalf("verify did not consume contracts path from repo .env:\n%s", stdout.String())
+	}
+}
+
+func TestLocalRunDiscoversRepoRootBeforeDotEnvAndServe(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	_ = os.Unsetenv("SWARM_API_TOKEN")
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_API_TOKEN=test-token\n")
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	writeWorkflowValidationFixtureFile(t, payloadPath, "{}\n")
+	t.Chdir(repo)
+
+	var capturedRepo string
+	opts := runCommandOptions{
+		apiOptions:   defaultRootCommandOptions(),
+		eventName:    "scan.requested",
+		payloadPath:  payloadPath,
+		changedFlags: map[string]bool{},
+	}
+	opts.apiOptions.runServe = func(ctx context.Context, repo string, _ serveOptions) int {
+		capturedRepo = repo
+		<-ctx.Done()
+		return 1
+	}
+	opts.apiOptions.runReadyTimeout = time.Millisecond
+	opts.apiOptions.runReadyPoll = time.Millisecond
+
+	var stdout, stderr bytes.Buffer
+	_ = runRunCommand(context.Background(), "", &stdout, &stderr, opts)
+	if capturedRepo != repo {
+		t.Fatalf("local run serve repo = %q, want discovered repo %q; stderr=%s stdout=%s", capturedRepo, repo, stderr.String(), stdout.String())
+	}
+}
+
 func TestRunVerifyCommandUsesEmbeddedPlatformSpecWithoutRepoRoot(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	t.Chdir(t.TempDir())

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -719,6 +719,118 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	}
 }
 
+func TestRootNoAssetCommandsDoNotRequireRepoRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "bare root help", args: nil, want: "Usage:"},
+		{name: "root help", args: []string{"--help"}, want: "Usage:"},
+		{name: "version", args: []string{"version"}, want: "Swarm dev"},
+		{name: "completion", args: []string{"completion", "bash"}, want: "swarm"},
+		{name: "serve help", args: []string{"serve", "--help"}, want: "Start the Swarm runtime"},
+		{name: "verify help", args: []string{"verify", "--help"}, want: "Validate local Swarm contract files"},
+		{name: "run help", args: []string{"run", "--help"}, want: "Start or reattach to a Swarm run"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Chdir(t.TempDir())
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommand(context.Background(), "", tc.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+			}
+			if !strings.Contains(stdout.String(), tc.want) {
+				t.Fatalf("stdout missing %q:\n%s", tc.want, stdout.String())
+			}
+			if strings.Contains(stderr.String(), "locate repo root") {
+				t.Fatalf("stderr leaked repo root discovery failure: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunVerifyCommandUsesEmbeddedPlatformSpecWithoutRepoRoot(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Chdir(t.TempDir())
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: embedded-platform-spec
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: embedded-platform-spec\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+
+	var buf bytes.Buffer
+	code := runVerifyCommandWithContractsForTest(context.Background(), "", root, &buf)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "verify ok: contracts=") {
+		t.Fatalf("verify output missing success marker:\n%s", buf.String())
+	}
+}
+
+func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				InstalledBinaryPortability struct {
+					PromotedBy           string            `yaml:"promoted_by"`
+					ImplementationStatus string            `yaml:"implementation_status"`
+					CanonicalOwner       string            `yaml:"canonical_owner"`
+					Scope                string            `yaml:"scope"`
+					Rule                 string            `yaml:"rule"`
+					EmbeddedAssets       map[string]string `yaml:"embedded_assets"`
+					SplitTail            []string          `yaml:"split_tail"`
+				} `yaml:"installed_binary_portability"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	portability := spec.CLISpecification.Foundations.InstalledBinaryPortability
+	if strings.TrimSpace(portability.PromotedBy) != "#1002" {
+		t.Fatalf("installed binary portability promoted_by = %q, want #1002", portability.PromotedBy)
+	}
+	if strings.TrimSpace(portability.ImplementationStatus) != "implemented" {
+		t.Fatalf("installed binary portability implementation_status = %q, want implemented", portability.ImplementationStatus)
+	}
+	if !strings.Contains(portability.CanonicalOwner, "cli_specification.foundations.installed_binary_portability") {
+		t.Fatalf("canonical owner does not point at installed_binary_portability: %s", portability.CanonicalOwner)
+	}
+	for _, want := range []string{"help", "completion", "local `swarm version`", "contract_platform_spec_path_resolution"} {
+		if !strings.Contains(portability.Scope, want) {
+			t.Fatalf("installed binary portability scope missing %q:\n%s", want, portability.Scope)
+		}
+	}
+	for _, want := range []string{"without a source checkout", "go.mod", "MUST NOT block help"} {
+		if !strings.Contains(portability.Rule, want) {
+			t.Fatalf("installed binary portability rule missing %q:\n%s", want, portability.Rule)
+		}
+	}
+	if !strings.Contains(portability.EmbeddedAssets["platform_spec"], defaultPlatformSpecPath) {
+		t.Fatalf("platform_spec embedded asset missing tracked path:\n%s", portability.EmbeddedAssets["platform_spec"])
+	}
+	for _, want := range []string{"Dockerfile.workspace", "#996 Docker Compose", "#997 local cli_test"} {
+		if !stringSliceContains(portability.SplitTail, want) {
+			t.Fatalf("installed binary portability split_tail missing %q: %#v", want, portability.SplitTail)
+		}
+	}
+}
+
 func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
 	spec := loadCLIContractPlatformSpecPathResolutionSpec(t)
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
@@ -761,7 +873,7 @@ func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
 	if !strings.Contains(spec.ContractsPath.RejectedSources["SWARM_CONTRACTS_DIR"], "Not a CLI source") {
 		t.Fatalf("SWARM_CONTRACTS_DIR rejection missing CLI-source rule:\n%s", spec.ContractsPath.RejectedSources["SWARM_CONTRACTS_DIR"])
 	}
-	wantPlatformOrder := []string{"--platform-spec", "config platform_spec_path", "built-in tracked platform spec"}
+	wantPlatformOrder := []string{"--platform-spec", "config platform_spec_path", "embedded tracked platform spec"}
 	if len(spec.PlatformSpecPath.SourceOrder) != len(wantPlatformOrder) {
 		t.Fatalf("platform source order = %#v, want %#v", spec.PlatformSpecPath.SourceOrder, wantPlatformOrder)
 	}
@@ -781,6 +893,9 @@ func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
 	}
 	if !strings.Contains(spec.PlatformSpecPath.RejectedSources["SWARM_PLATFORM_SPEC_PATH"], "Not promoted") {
 		t.Fatalf("SWARM_PLATFORM_SPEC_PATH rejection missing not-promoted rule:\n%s", spec.PlatformSpecPath.RejectedSources["SWARM_PLATFORM_SPEC_PATH"])
+	}
+	if !strings.Contains(spec.PlatformSpecPath.DefaultRule, "embedded") || !strings.Contains(spec.PlatformSpecPath.DefaultRule, "MUST NOT require source checkout") {
+		t.Fatalf("platform default rule missing embedded portability semantics:\n%s", spec.PlatformSpecPath.DefaultRule)
 	}
 	for _, want := range []string{"verify", "serve", "local foreground run", "API auth/config", "connected run"} {
 		if !stringSliceContains(spec.ImplementationBoundaries, want) {
@@ -3940,6 +4055,7 @@ type cliContractPlatformSpecPathResolutionSpec struct {
 		} `yaml:"accepted_sources"`
 		SourceOrder     []string          `yaml:"source_order"`
 		RejectedSources map[string]string `yaml:"rejected_sources"`
+		DefaultRule     string            `yaml:"default_rule"`
 	} `yaml:"platform_spec_path"`
 	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
 }

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -137,6 +137,7 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 
 	var stopLocal func()
 	if strings.TrimSpace(opts.connectURL) == "" {
+		repo = assetCommandRepoRoot(repo)
 		if err := loadRepoDotEnv(repo); err != nil {
 			fmt.Fprintf(errOut, "load .env: %v\n", err)
 			return commandExitError{code: 3}

--- a/docs/specs/swarm-platform/platform/contracts/embed.go
+++ b/docs/specs/swarm-platform/platform/contracts/embed.go
@@ -1,0 +1,80 @@
+package platformcontracts
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed platform-spec.yaml
+var platformSpecYAML []byte
+
+const PlatformSpecDisplayPath = "embedded://swarm/platform-spec.yaml"
+
+func PlatformSpecYAML() []byte {
+	out := make([]byte, len(platformSpecYAML))
+	copy(out, platformSpecYAML)
+	return out
+}
+
+func MaterializePlatformSpecFile() (string, error) {
+	digest := sha256.Sum256(platformSpecYAML)
+	name := "platform-spec-" + hex.EncodeToString(digest[:8]) + ".yaml"
+	var attempts []string
+	for _, base := range platformSpecCacheBases() {
+		path, err := materializePlatformSpecFile(base, name)
+		if err == nil {
+			return path, nil
+		}
+		attempts = append(attempts, fmt.Sprintf("%s: %v", base, err))
+	}
+	return "", fmt.Errorf("materialize embedded platform spec: %s", strings.Join(attempts, "; "))
+}
+
+func platformSpecCacheBases() []string {
+	var bases []string
+	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
+		bases = append(bases, filepath.Join(cache, "swarm", "embedded-assets"))
+	}
+	bases = append(bases, filepath.Join(os.TempDir(), "swarm-embedded-assets"))
+	return bases
+}
+
+func materializePlatformSpecFile(dir, name string) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, platformSpecYAML) {
+		return path, nil
+	}
+	tmp, err := os.CreateTemp(dir, name+".tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(platformSpecYAML); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, platformSpecYAML) {
+			return path, nil
+		}
+		return "", err
+	}
+	return path, nil
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6137,6 +6137,31 @@ cli_specification:
       canonical_owner: cmd/swarm Cobra command tree
       implementation_framework: github.com/spf13/cobra
       rule: 'Cobra is the only semantic command router. Bare os.Args routing or parallel flag dispatch for operator commands is not authoritative.'
+    installed_binary_portability:
+      promoted_by: '#1002'
+      implementation_status: implemented
+      canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.installed_binary_portability
+      scope: >
+        Merge-bearing CLI v2 authority for source-checkout-independent startup and embedded platform-spec defaults.
+        This owner covers root command construction, no-asset command surfaces (`swarm`, help, completion, local
+        `swarm version`, and `swarm version --server` command construction), and the built-in platform spec default
+        consumed by `cli_specification.foundations.contract_platform_spec_path_resolution`. It does not close runtime
+        workspace image packaging, `Dockerfile.workspace` distribution, Docker Compose setup, local `cli_test` defaults,
+        multi-bundle work, or README/public-doc polish.
+      rule: >
+        An installed `swarm` binary MUST construct the Cobra command tree and run no-asset command surfaces without a
+        source checkout, repo-root discovery, or `go.mod` walk. Source checkout discovery may occur only after command
+        selection inside local asset-consuming commands, and failure to discover a checkout MUST NOT block help,
+        completion, or local version output.
+      embedded_assets:
+        platform_spec: >
+          The built-in platform spec default is compiled into the binary from the tracked
+          `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`. Implementations may materialize these
+          embedded bytes to an internal cache path for existing path-based readers, but that path is not a user-facing
+          configuration source and MUST NOT require a source checkout.
+      split_tail:
+      - 'Runtime workspace image packaging and `Dockerfile.workspace` source-root coupling remain #1002 parent tail unless separately gated.'
+      - '#996 Docker Compose setup, #997 local cli_test defaults, #992 serve listener behavior, multi-bundle work, and README/public-doc polish remain split.'
     no_args_behavior: '`swarm` with no arguments prints root help and exits 0. Bare `swarm` MUST NOT start the runtime.'
     daemon_startup: '`swarm serve` owns runtime/API/health/MCP startup. `swarm run` may consume the serve startup owner for local foreground start, but MUST NOT fork a second runtime boot owner.'
     cli_consumes_api_rule: 'All CLI commands that read or mutate runtime state consume the canonical API at /v1/rpc or /v1/ws. The only local file-contract carve-out is `swarm verify`, which validates contract files on disk and does not require runtime DB/API state.'
@@ -6712,14 +6737,18 @@ cli_specification:
         source_order:
         - --platform-spec
         - config platform_spec_path
-        - built-in tracked platform spec
+        - embedded tracked platform spec
         rejected_sources:
           SWARM_PLATFORM_SPEC_PATH: >
             Not promoted. Platform spec path selection is intentionally flag/config/default only; adding an env
             source would create untracked source precedence and must be separately gated.
         default_rule: >
-          The built-in default is the tracked platform spec path relative to the current repo root. Relative
-          explicit/config values are resolved against the repo root; absolute values are preserved.
+          The built-in default is the tracked platform spec embedded into the installed `swarm` binary at compile time
+          from `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`; it MUST NOT require source checkout,
+          repo-root discovery, or a `go.mod` walk. Implementations may materialize the embedded bytes to an internal
+          cache path for path-based readers, but that materialized path is not a user-facing config source. Relative
+          explicit/config values are resolved against the repo root when one is available; without a repo root they use
+          normal filesystem semantics from the current working directory. Absolute values are preserved.
       cli_config_file:
         shared_parser: >
           `SWARM_CONFIG` and the XDG default config path are shared with


### PR DESCRIPTION
## Summary

Part of #1002.

This PR closes the approved first slice `runtime.cli.installed_binary_no_asset_commands_and_embedded_platform_spec_default`:

- Builds the Cobra root without requiring source-checkout/repo-root discovery.
- Allows bare `swarm`, `swarm --help`, `swarm version`, completion, and command help to run from outside a checkout.
- Embeds the tracked `platform-spec.yaml` into the binary and uses a materialized embedded default for `verify`, `serve`, and local foreground `run` when no explicit/config `--platform-spec` is supplied.
- Keeps explicit/config filesystem `--platform-spec` overrides intact.

This does not claim full #1002 parent closure. Runtime workspace image / `Dockerfile.workspace` source-root coupling remains the tracked parent tail unless separately gated.

## Governing refs / context

- `platform-spec.yaml#cli_specification.foundations.installed_binary_portability`
- `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- `platform-spec.yaml#cli_specification.foundations.command_router`
- `platform-spec.yaml#cli_specification.command_catalog.version`
- #1002 pre-audit and gate outcome: approved as first slice

## Semantic migration

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.installed_binary_portability` plus repaired `contract_platform_spec_path_resolution.platform_spec_path.default_rule`.
- Old producer/reader path now invalid for this slice: `main() -> repoRoot()` before Cobra command construction and repo-root-relative platform spec default as the only built-in default.
- Production paths checked for surviving old behavior: root startup, Cobra help/completion/version path, `verify`, `serve`, local foreground `run`, `run --connect`, and `run --reattach` boundaries.
- Migration completeness: complete for the approved first slice; runtime workspace/Dockerfile asset packaging remains split and not closed here.

## Proof

- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `go build -o /tmp/swarm-portability-bin ./cmd/swarm`
- From `/tmp`: `/tmp/swarm-portability-bin`, `--help`, `version`, `completion bash`, `serve --help`, `verify --help`, `run --help`
- Static grep proof: no production root/help/version path calls `repoRoot()` or `WorkflowRepoRoot()` before command execution.