### PR TITLE
[agent-a][issue #1002] Close runtime workspace asset source-root coupling

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2091,8 +2091,8 @@ func buildCredentialStore() (runtimecredentials.Store, error) {
 func configuredWorkspaceLifecycle(db *sql.DB, repoRoot, contractsRoot string, source semanticview.Source) *workspace.DockerManager {
 	manager := workspace.NewDockerManager(db)
 	cfg := workspace.DefaultDockerConfig()
-	if dataDir := strings.TrimSpace(filepath.Join(repoRoot, "data")); dataDir != "" {
-		cfg.SharedDataSource = dataDir
+	if root := strings.TrimSpace(repoRoot); root != "" {
+		cfg.SharedDataSource = filepath.Join(root, "data")
 	}
 	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {
 		cfg.ContractsSource = contractsDir

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -862,21 +862,65 @@ platform: ">=1.6.0"
 	}
 }
 
+func TestConfiguredWorkspaceLifecycleDoesNotInventSourceRootDataSource(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
+	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+
+	manager := configuredWorkspaceLifecycle(nil, "", contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	if err == nil || !strings.Contains(err.Error(), "/data source is not configured") {
+		t.Fatalf("ValidateSource error = %v, want explicit /data source requirement", err)
+	}
+}
+
+func TestConfiguredWorkspaceLifecycleUsesExplicitRepoAndContractsSources(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
+	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
+	repoRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repoRoot, "data"), 0o755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+
+	manager := configuredWorkspaceLifecycle(nil, repoRoot, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	if err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+}
+
 func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 	var spec struct {
 		CLISpecification struct {
 			Foundations struct {
 				InstalledBinaryPortability struct {
-					PromotedBy           string            `yaml:"promoted_by"`
-					ImplementationStatus string            `yaml:"implementation_status"`
-					CanonicalOwner       string            `yaml:"canonical_owner"`
-					Scope                string            `yaml:"scope"`
-					Rule                 string            `yaml:"rule"`
-					EmbeddedAssets       map[string]string `yaml:"embedded_assets"`
-					SplitTail            []string          `yaml:"split_tail"`
+					PromotedBy             string            `yaml:"promoted_by"`
+					ImplementationStatus   string            `yaml:"implementation_status"`
+					CanonicalOwner         string            `yaml:"canonical_owner"`
+					Scope                  string            `yaml:"scope"`
+					Rule                   string            `yaml:"rule"`
+					EmbeddedAssets         map[string]string `yaml:"embedded_assets"`
+					RuntimeWorkspaceAssets map[string]string `yaml:"runtime_workspace_assets"`
+					SplitTail              []string          `yaml:"split_tail"`
 				} `yaml:"installed_binary_portability"`
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
+		WorkspaceModel struct {
+			RuntimeImagePackaging struct {
+				PromotedBy           string `yaml:"promoted_by"`
+				ImplementationStatus string `yaml:"implementation_status"`
+				CanonicalOwner       string `yaml:"canonical_owner"`
+				Rule                 string `yaml:"rule"`
+				MountSourceRule      string `yaml:"mount_source_rule"`
+				SplitScope           string `yaml:"split_scope"`
+			} `yaml:"runtime_image_packaging"`
+		} `yaml:"workspace_model"`
 	}
 	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
 	if err != nil {
@@ -895,7 +939,7 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 	if !strings.Contains(portability.CanonicalOwner, "cli_specification.foundations.installed_binary_portability") {
 		t.Fatalf("canonical owner does not point at installed_binary_portability: %s", portability.CanonicalOwner)
 	}
-	for _, want := range []string{"help", "completion", "local `swarm version`", "contract_platform_spec_path_resolution"} {
+	for _, want := range []string{"help", "completion", "local `swarm version`", "contract_platform_spec_path_resolution", "workspace_model.runtime_image_packaging"} {
 		if !strings.Contains(portability.Scope, want) {
 			t.Fatalf("installed binary portability scope missing %q:\n%s", want, portability.Scope)
 		}
@@ -908,9 +952,40 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 	if !strings.Contains(portability.EmbeddedAssets["platform_spec"], defaultPlatformSpecPath) {
 		t.Fatalf("platform_spec embedded asset missing tracked path:\n%s", portability.EmbeddedAssets["platform_spec"])
 	}
-	for _, want := range []string{"Dockerfile.workspace", "#996 Docker Compose", "#997 local cli_test"} {
+	if !strings.Contains(portability.RuntimeWorkspaceAssets["workspace_image"], "MUST NOT use") || !strings.Contains(portability.RuntimeWorkspaceAssets["workspace_image"], "Dockerfile.workspace") {
+		t.Fatalf("workspace_image embedded portability rule missing source-root prohibition:\n%s", portability.RuntimeWorkspaceAssets["workspace_image"])
+	}
+	if stringSliceContains(portability.SplitTail, "Dockerfile.workspace") {
+		t.Fatalf("installed binary portability still lists Dockerfile.workspace as split tail: %#v", portability.SplitTail)
+	}
+	for _, want := range []string{"#996 Docker Compose", "#997 local cli_test"} {
 		if !stringSliceContains(portability.SplitTail, want) {
 			t.Fatalf("installed binary portability split_tail missing %q: %#v", want, portability.SplitTail)
+		}
+	}
+	packaging := spec.WorkspaceModel.RuntimeImagePackaging
+	if strings.TrimSpace(packaging.PromotedBy) != "#1002" {
+		t.Fatalf("runtime image packaging promoted_by = %q, want #1002", packaging.PromotedBy)
+	}
+	if strings.TrimSpace(packaging.ImplementationStatus) != "implemented" {
+		t.Fatalf("runtime image packaging implementation_status = %q, want implemented", packaging.ImplementationStatus)
+	}
+	if !strings.Contains(packaging.CanonicalOwner, "workspace_model.runtime_image_packaging") {
+		t.Fatalf("runtime image packaging canonical owner = %q, want workspace_model.runtime_image_packaging", packaging.CanonicalOwner)
+	}
+	for _, want := range []string{"prebuilt runtime dependency", "fail closed", "MUST NOT build", "Dockerfile.workspace", "runtime.Caller"} {
+		if !strings.Contains(packaging.Rule, want) {
+			t.Fatalf("runtime image packaging rule missing %q:\n%s", want, packaging.Rule)
+		}
+	}
+	for _, want := range []string{"/data", "/opt/swarm/contracts", "MUST NOT derive"} {
+		if !strings.Contains(packaging.MountSourceRule, want) {
+			t.Fatalf("runtime image packaging mount source rule missing %q:\n%s", want, packaging.MountSourceRule)
+		}
+	}
+	for _, want := range []string{"#996", "#997"} {
+		if !strings.Contains(packaging.SplitScope, want) {
+			t.Fatalf("runtime image packaging split scope missing %q:\n%s", want, packaging.SplitScope)
 		}
 	}
 }

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5251,6 +5251,22 @@ workspace_model:
   description: Defines the filesystem contract for agent sessions. The platform provides three standard mount points and a
     scoping model. Products define workspace classes that map agent roles to specific scope configurations. If a product declares
     a workspace_class on an agent, the platform MUST provide all mounts at the declared scopes.
+  runtime_image_packaging:
+    promoted_by: '#1002'
+    implementation_status: implemented
+    canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#workspace_model.runtime_image_packaging
+    rule: >
+      Runtime workspace startup treats the configured workspace image as a prebuilt runtime dependency. The runtime MUST inspect
+      the resolved workspace image before creating workspaces and fail closed with an actionable diagnostic when the image is
+      absent. Production runtime code MUST NOT build a missing workspace image from source-checkout `Dockerfile.workspace`, use
+      `runtime.Caller` / Go source paths as a runtime asset root, or walk for `go.mod` to recover build material.
+    mount_source_rule: >
+      Host sources for `/data` and `/opt/swarm/contracts` MUST come from explicit deployment configuration, environment,
+      config/CLI path resolution, or an already selected workflow/project root passed by the command owner. Default workspace
+      runtime configuration MUST NOT derive those mount sources from the Swarm source checkout.
+    split_scope: >
+      Docker Compose setup and workspace image contents/default agent CLI availability remain tracked separately by #996 and
+      #997 unless a future gate explicitly widens them.
   standard_mounts:
     description: Three mount points are available to every agent session. Products cannot add new mount points — they configure
       access and scope for these three via workspace class definitions.
@@ -6145,9 +6161,10 @@ cli_specification:
         Merge-bearing CLI v2 authority for source-checkout-independent startup and embedded platform-spec defaults.
         This owner covers root command construction, no-asset command surfaces (`swarm`, help, completion, local
         `swarm version`, and `swarm version --server` command construction), and the built-in platform spec default
-        consumed by `cli_specification.foundations.contract_platform_spec_path_resolution`. It does not close runtime
-        workspace image packaging, `Dockerfile.workspace` distribution, Docker Compose setup, local `cli_test` defaults,
-        multi-bundle work, or README/public-doc polish.
+        consumed by `cli_specification.foundations.contract_platform_spec_path_resolution`. It also records that
+        installed-binary runtime workspace startup consumes `workspace_model.runtime_image_packaging` instead of
+        source-checkout `Dockerfile.workspace` lookup. It does not close Docker Compose setup, local `cli_test`
+        defaults, multi-bundle work, or README/public-doc polish.
       rule: >
         An installed `swarm` binary MUST construct the Cobra command tree and run no-asset command surfaces without a
         source checkout, repo-root discovery, or `go.mod` walk. Source checkout discovery may occur only after command
@@ -6159,9 +6176,13 @@ cli_specification:
           `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`. Implementations may materialize these
           embedded bytes to an internal cache path for existing path-based readers, but that path is not a user-facing
           configuration source and MUST NOT require a source checkout.
+      runtime_workspace_assets:
+        workspace_image: >
+          Runtime workspace startup consumes `workspace_model.runtime_image_packaging`. An installed binary MUST NOT use
+          source-checkout discovery, Go caller file paths, or a `go.mod` walk to locate `Dockerfile.workspace` or derive
+          workspace mount defaults.
       split_tail:
-      - 'Runtime workspace image packaging and `Dockerfile.workspace` source-root coupling remain #1002 parent tail unless separately gated.'
-      - '#996 Docker Compose setup, #997 local cli_test defaults, #992 serve listener behavior, multi-bundle work, and README/public-doc polish remain split.'
+      - '#996 Docker Compose setup, #997 local cli_test defaults/image contents, #992 serve listener behavior, multi-bundle work, and README/public-doc polish remain split.'
     no_args_behavior: '`swarm` with no arguments prints root help and exits 0. Bare `swarm` MUST NOT start the runtime.'
     daemon_startup: '`swarm serve` owns runtime/API/health/MCP startup. `swarm run` may consume the serve startup owner for local foreground start, but MUST NOT fork a second runtime boot owner.'
     cli_consumes_api_rule: 'All CLI commands that read or mutate runtime state consume the canonical API at /v1/rpc or /v1/ws. The only local file-contract carve-out is `swarm verify`, which validates contract files on disk and does not require runtime DB/API state.'

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -18,7 +18,6 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
-	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -76,15 +75,14 @@ type DockerConfig struct {
 }
 
 func DefaultDockerConfig() DockerConfig {
-	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	return DockerConfig{
 		DockerBin:             EnvOrDefault("SWARM_DOCKER_BIN", "docker"),
 		WorkspaceImage:        EnvOrDefault("SWARM_WORKSPACE_IMAGE", "swarm-workspace:latest"),
 		WorkspaceNetwork:      EnvOrDefault("SWARM_WORKSPACE_NETWORK", "mas_default"),
 		WorkspaceVolumesFrom:  EnvOrDefault("SWARM_WORKSPACE_VOLUMES_FROM", ""),
-		SharedDataSource:      EnvOrDefault("SWARM_WORKSPACE_DATA_SOURCE", filepath.Join(repoRoot, "data")),
+		SharedDataSource:      EnvOrDefault("SWARM_WORKSPACE_DATA_SOURCE", ""),
 		DataMountPoint:        EnvOrDefault("SWARM_WORKSPACE_DATA_MOUNT", "/data"),
-		ContractsSource:       EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", runtimecontracts.DefaultWorkflowContractsDir(repoRoot)),
+		ContractsSource:       EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", ""),
 		ContractsMountPoint:   EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_MOUNT", "/opt/swarm/contracts"),
 		ScaffoldContainer:     EnvOrDefault("SWARM_SCAFFOLD_CONTAINER", "swarm-scaffold"),
 		ScaffoldWorkdir:       EnvOrDefault("SWARM_SCAFFOLD_WORKDIR", "/opt/swarm/scaffold"),
@@ -671,16 +669,8 @@ func (m *DockerManager) ensureWorkspaceImage(ctx context.Context) error {
 	if image == "" {
 		return fmt.Errorf("workspace prerequisite failed: workspace image is required")
 	}
-	if _, err := m.RunDocker(ctx, "image", "inspect", image); err == nil {
-		return nil
-	}
-	repoRoot := runtimepipeline.WorkflowRepoRoot()
-	dockerfile := filepath.Join(repoRoot, "Dockerfile.workspace")
-	if _, statErr := os.Stat(dockerfile); statErr != nil {
-		return fmt.Errorf("workspace prerequisite failed: inspect image %s and Dockerfile.workspace is unavailable: %w", image, statErr)
-	}
-	if _, err := m.RunDocker(ctx, "build", "-t", image, "-f", dockerfile, repoRoot); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: build image %s: %w", image, err)
+	if _, err := m.RunDocker(ctx, "image", "inspect", image); err != nil {
+		return fmt.Errorf("workspace prerequisite failed: workspace image %s is not available; build or pull the image before startup, or set SWARM_WORKSPACE_IMAGE to an available image: %w", image, err)
 	}
 	return nil
 }

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -290,7 +290,35 @@ func TestResolveWorkspace_FailsClosedWithoutInjectedSourceForWorkspaceClassScope
 	}
 }
 
-func TestEnsurePrereqs_CreatesMissingNetworkAndBuildsMissingImage(t *testing.T) {
+func TestDefaultDockerConfigDoesNotDeriveSourceRootMounts(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
+	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
+
+	cfg := DefaultDockerConfig()
+	if cfg.SharedDataSource != "" {
+		t.Fatalf("SharedDataSource = %q, want no source-root default", cfg.SharedDataSource)
+	}
+	if cfg.ContractsSource != "" {
+		t.Fatalf("ContractsSource = %q, want no source-root default", cfg.ContractsSource)
+	}
+}
+
+func TestDefaultDockerConfigConsumesExplicitWorkspaceMountEnv(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", dataDir)
+	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", contractsDir)
+
+	cfg := DefaultDockerConfig()
+	if cfg.SharedDataSource != dataDir {
+		t.Fatalf("SharedDataSource = %q, want %q", cfg.SharedDataSource, dataDir)
+	}
+	if cfg.ContractsSource != contractsDir {
+		t.Fatalf("ContractsSource = %q, want %q", cfg.ContractsSource, contractsDir)
+	}
+}
+
+func TestEnsurePrereqs_CreatesMissingNetworkAndFailsClosedForMissingImage(t *testing.T) {
 	manager := NewDockerManager(nil)
 	cfg := DefaultDockerConfig()
 	cfg.WorkspaceNetwork = "test-network"
@@ -316,8 +344,15 @@ func TestEnsurePrereqs_CreatesMissingNetworkAndBuildsMissingImage(t *testing.T) 
 		}
 	})
 
-	if err := manager.EnsurePrereqs(context.Background()); err != nil {
-		t.Fatalf("EnsurePrereqs: %v", err)
+	err := manager.EnsurePrereqs(context.Background())
+	if err == nil {
+		t.Fatal("EnsurePrereqs unexpectedly succeeded with missing workspace image")
+	}
+	if !strings.Contains(err.Error(), "workspace image test-image:latest is not available") {
+		t.Fatalf("EnsurePrereqs error = %v, want missing image diagnostic", err)
+	}
+	if !strings.Contains(err.Error(), "set SWARM_WORKSPACE_IMAGE") {
+		t.Fatalf("EnsurePrereqs error = %v, want configured image remediation", err)
 	}
 
 	joined := flattenDockerCalls(calls)
@@ -326,12 +361,13 @@ func TestEnsurePrereqs_CreatesMissingNetworkAndBuildsMissingImage(t *testing.T) 
 		"network inspect test-network",
 		"network create test-network",
 		"image inspect test-image:latest",
-		"build -t test-image:latest",
-		"Dockerfile.workspace",
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("EnsurePrereqs calls missing %q: %s", expected, joined)
 		}
+	}
+	if strings.Contains(joined, "build ") || strings.Contains(joined, "Dockerfile.workspace") {
+		t.Fatalf("EnsurePrereqs still attempted source-root image build:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1002.

This PR closes the remaining installed-binary runtime workspace asset tail after PR #1029:

- promotes `platform-spec.yaml#workspace_model.runtime_image_packaging` as the runtime workspace image packaging owner
- removes production `WorkflowRepoRoot()` consumption from `internal/runtime/workspace.DefaultDockerConfig()`
- stops building a missing workspace image from source-checkout `Dockerfile.workspace`
- fails closed with an actionable prebuilt-image diagnostic when the configured workspace image is absent
- fixes `configuredWorkspaceLifecycle()` so `/data` comes only from an explicit selected repo root, not `filepath.Join("", "data")`

## Governing refs / context

- #1002 refreshed pre-audit and gate outcome: approved first slice for `runtime.workspace.installed_binary_workspace_image_asset_packaging` with a tightened boundary.
- `platform-spec.yaml#cli_specification.foundations.installed_binary_portability`
- `platform-spec.yaml#workspace_model.runtime_image_packaging`
- Adjacent split trackers kept out of scope: #996 Docker Compose setup and #997 local `cli_test` runtime defaults/image contents.

## Semantic migration

New canonical owner: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#workspace_model.runtime_image_packaging`.

Old invalid paths:

- `internal/runtime/workspace.DefaultDockerConfig()` deriving `/data` and contracts sources from `WorkflowRepoRoot()`
- `internal/runtime/workspace.ensureWorkspaceImage()` deriving source-checkout `Dockerfile.workspace` from `WorkflowRepoRoot()` and running `docker build`
- `configuredWorkspaceLifecycle()` inventing relative `data` when no repo root is selected

Production paths checked for surviving old behavior:

- `swarm serve` uses `configuredWorkspaceLifecycleForServe -> configuredWorkspaceLifecycle -> workspace.DockerManager`
- local foreground `swarm run` starts local serve and consumes the same path
- builder supervisor startup uses `configuredWorkspaceLifecycle` and `EnsurePrereqs()`
- run-fork selected-contract harness uses `configuredWorkspaceLifecycle`
- static grep shows no production `cmd/swarm` or `internal/runtime/workspace` `WorkflowRepoRoot()` / source `Dockerfile.workspace` build path remains

Migration complete for #1002. Remaining Docker Compose and local `cli_test` image-content/default-agent work remains split under #996/#997.

## Proof

- `go test ./internal/runtime/workspace -count=1`
- `go test ./cmd/swarm -run 'TestConfiguredWorkspaceLifecycleDoesNotInventSourceRootDataSource|TestConfiguredWorkspaceLifecycleUsesExplicitRepoAndContractsSources|TestPlatformSpecInstalledBinaryPortabilityPromoted|TestRootNoAssetCommandsDoNotRequireRepoRoot|TestAssetCommandsDiscoverRepoRootAtExecution|TestLocalRunDiscoversRepoRootBeforeDotEnvAndServe' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- installed-binary smoke from `/tmp`: `--help`, `version`, `completion bash`, `serve --help`, `run --help`, `verify --help`
- `git diff --check`
- static grep proof for removed production `WorkflowRepoRoot()` / `Dockerfile.workspace` workspace build paths