### PR TITLE
[agent-c][issue #1030] Align event receipt subscriber identity

### DIFF
--- a/docs/specs/swarm-platform/platform/CHANGELOG.md
+++ b/docs/specs/swarm-platform/platform/CHANGELOG.md
@@ -375,7 +375,7 @@ Legacy `workflow_state` section removed (superseded by `entity_state` table).
 
 ### event_receipts widened, mailbox finalized, diagnostics encoding defined
 
-**event_receipts** — `entity_id` nullable, `handler_node` replaced by generic `subscriber_type` + `subscriber_id`. Added `duration_ms`, `idempotency_key`. UNIQUE on (event_id, subscriber_id). Replaces both pipeline_receipts and system_node_ledger.
+**event_receipts** — `entity_id` nullable, `handler_node` replaced by generic `subscriber_type` + `subscriber_id`. Added `duration_ms`, `idempotency_key`. UNIQUE on (event_id, subscriber_type, subscriber_id). Replaces both pipeline_receipts and system_node_ledger.
 
 **mailbox** — payload-centric model confirmed. All human_tasks become `item_type='human_task'`. Added `from_agent`, `summary`, `decision_notes`, `notified`, `source_event_id`. Old columns (context, timeout_at, priority) replaced by payload, expires_at, severity.
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3653,7 +3653,7 @@ platform_tables:
         \     TEXT,\n    outcome           TEXT NOT NULL CHECK (outcome IN ('success', 'reject', 'discard', 'kill', 'escalate',\
         \ 'dead_letter', 'terminal_reject', 'waiting', 'fanned_out', 'no_op')),\n    reason_code       TEXT,\n    state_before      TEXT,\n    state_after       TEXT,\n    side_effects      JSONB\
         \ NOT NULL DEFAULT '{}',\n    duration_ms       INTEGER,\n    idempotency_key   TEXT,\n    processed_at      TIMESTAMPTZ\
-        \ NOT NULL DEFAULT NOW(),\n    UNIQUE (event_id, subscriber_id),\n    INDEX idx_receipts_entity (entity_id) WHERE\
+        \ NOT NULL DEFAULT NOW(),\n    UNIQUE (event_id, subscriber_type, subscriber_id),\n    INDEX idx_receipts_entity (entity_id) WHERE\
         \ entity_id IS NOT NULL,\n    INDEX idx_receipts_subscriber (subscriber_id, processed_at),\n    INDEX idx_receipts_idempotency\
         \ (idempotency_key) WHERE idempotency_key IS NOT NULL\n);"
     entity_state:

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1555,7 +1555,7 @@ CREATE TABLE event_receipts (
     duration_ms       INTEGER,
     idempotency_key   TEXT,
     processed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE (event_id, subscriber_id),
+    UNIQUE (event_id, subscriber_type, subscriber_id),
     INDEX idx_receipts_entity (entity_id) WHERE entity_id IS NOT NULL,
     INDEX idx_receipts_subscriber (subscriber_id, processed_at),
     INDEX idx_receipts_idempotency (idempotency_key) WHERE idempotency_key IS NOT NULL

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -252,6 +252,10 @@ active_issues:
     title: Aggressively retire legacy universal entity tools from agent catalogs
     maps_to:
       - transport_policy_and_surface_parity
+  - id: 1030
+    title: Reconcile event_receipts typed subscriber identity key
+    maps_to:
+      - delivery_and_replay_ownership
 nodes:
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
@@ -322,6 +326,7 @@ nodes:
       - selected-contract fork-local runtime container is owned by runtime.run_fork.selected_contract_execution.fork_local_runtime_container; it consumes selected recipient planning, authoritative agent delivery materialization, fork-local agent runtime materializer/executor proof, selected route recovery, EventBus recipient guards/descriptors, runtime/platform lineage policy, typed runtime lineage, activation lineage inputs, cleanup, and quiescence for the live selected-fork execution path, while keeping source rows/outcomes, live subscriptions, normal AgentManager current state, readiness/operator output, restart recovery, current-state snapshots, sessions/turns/audits, non-agent replay, retry/idempotency/follow-up policy, and operator consumers split or invalid
       - selected-contract fork-local typed runtime lineage is owned by runtime.run_fork.selected_contract_execution.fork_local_runtime_typed_lineage; selected-fork EventBus, AgentManager, RuntimeLogger, LLM/runtime diagnostic producers, selected-execution tool-executor diagnostics, and MCP turn-context bridges carry fork run ID, subject event ID/type, causal parent event ID, row category, selected-fork owner context, and source/fork/operator classification before persisting canonical ParentEventID/source_event_id truth, while action/reason strings, produced_by_type alone, descriptors, source platform facts, operator state, restart recovery, current-state snapshots, sessions/turns/audits, non-agent replay, and retry/follow-up policy remain invalid or split
       - selected-contract fork-local runtime/platform control event lineage is owned by runtime.run_fork.selected_contract_execution.fork_local_runtime_platform_event_lineage_policy; fresh fork-run platform/control outputs and platform.runtime_log diagnostics from the selected-fork runtime container are admissible only when causally parented to selected execution under the fork run_id, with runtime-log lineage persisted through source_event_id from an explicit parent_event_id or verified same-run subject event rather than action/reason strings, while unrelated fork platform events, source platform facts, produced_by_type alone, and operator surfaces remain invalid selected-fork truth
+      - event_receipts typed subscriber identity is owned by the platform DDL and store migration/capability boundary; platform, node, and agent receipt writers must conflict on event_id, subscriber_type, and subscriber_id together rather than preserving local subscriber-id namespacing
     representative_issues:
       - 112
       - 144
@@ -344,6 +349,7 @@ nodes:
       - 690
       - 709
       - 722
+      - 1030
     common_framing_mistakes:
       too_broad:
         - delivery is flaky

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -51,6 +51,10 @@ active_issues:
     title: Persist canonical normal run completion/quiescence owner
     maps_to:
       - persisted_normal_run_completion_quiescence_owner
+  - id: 1030
+    title: Reconcile event_receipts typed subscriber identity key
+    maps_to:
+      - event_receipts_typed_subscriber_identity_owner
   - id: 132
     title: Make CEL validation lifecycle-aware for entity-field availability
     maps_to:
@@ -165,6 +169,29 @@ nodes:
         - run.get read-side terminal inference
         - run.diagnose projection-only repair
     current_action_pressure: active first-slice closure under issue 994
+  - id: event_receipts_typed_subscriber_identity_owner
+    title: Event Receipts Typed Subscriber Identity Owner
+    parent_class: runtime delivery/receipt identity ownership drift across schema, writers, typed readers, replay/fork planning, and diagnostics
+    canonical_owners:
+      - docs/specs/swarm-platform/platform/contracts/platform-spec.yaml platform_tables.event_receipts DDL
+      - internal/store/postgres.go event_receipts typed identity migration and fail-closed capability binding
+      - internal/store/events.go, internal/store/event_receipt_store.go, internal/runtime/pipeline/node_system_runner.go, internal/runtime/pipeline/workflow_transitions.go, and internal/store/active_run_quiescence.go receipt writers
+    why_this_node_exists: event receipt readers already interpret subscriber identity as event_id plus subscriber_type plus subscriber_id, while the old physical key and writer conflict targets used only event_id plus subscriber_id and forced local string namespacing.
+    known_manifestations:
+      - a system node named pipeline can collide with the platform pipeline receipt unless subscriber_type participates in the physical identity key
+      - agent, node, and platform receipt writers can overwrite same-event same-subscriber_id rows across types under the old conflict target
+      - replay/fork planning, pending delivery reads, run completion, and diagnostics consume typed receipt identity and can drift if writers preserve untyped uniqueness or local namespacing
+      - existing node:pipeline rows from the local #1007 workaround require one-way normalization under the typed identity owner
+    representative_issues:
+      - 1030
+    common_framing_mistakes:
+      too_broad:
+        - all runtime delivery/replay lifecycle semantics
+      too_narrow:
+        - one node named pipeline workaround
+        - centralized subscriber-id namespacing without DDL and writer migration
+        - changing one ON CONFLICT target while leaving other receipt writers on the old key
+    current_action_pressure: active implementation under issue 1030
   - id: boot_check_definition_drift
     title: Boot Check Definition Drift
     parent_class: semantic correctness drift between authoritative boot-check definitions and enforcement/proof surfaces

--- a/internal/apiv1/operator_run_completion_system_node_test.go
+++ b/internal/apiv1/operator_run_completion_system_node_test.go
@@ -64,8 +64,8 @@ func TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces(t *testin
 
 	eventID := triggerEventIDForRun(t, db, runID)
 	assertPipelineReceiptSucceeded(t, db, eventID)
-	assertSystemNodeReceiptPersisted(t, db, eventID, "terminal-node")
-	assertSystemNodeDeliverySettled(t, db, eventID, "terminal-node")
+	assertSystemNodeReceiptPersisted(t, db, eventID, "pipeline")
+	assertSystemNodeDeliverySettled(t, db, eventID, "pipeline")
 	assertRunEntityTerminal(t, db, runID, "done")
 
 	diagnose := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"diagnose","method":"run.diagnose","params":{"run_id":%q}}`, runID))
@@ -300,8 +300,8 @@ flow.started:
     - entity_id
 `)
 	writeRunCompletionFixtureFile(t, filepath.Join(root, "flows", "discovery", "nodes.yaml"), `
-terminal-node:
-  id: terminal-node
+pipeline:
+  id: pipeline
   execution_type: system_node
   subscribes_to:
     - flow.started

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -312,7 +312,7 @@ func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bo
 			  AND subscriber_id = $1
 			  AND idempotency_key = $2
 		)
-	`, systemNodeReceiptSubscriberID(n.nodeID), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
+	`, strings.TrimSpace(n.nodeID), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
 	return err == nil && ok
 }
 
@@ -358,16 +358,6 @@ func systemNodeProcessedReceiptSideEffects(nodeID, eventID string) string {
 	return string(sideEffects)
 }
 
-func systemNodeReceiptSubscriberID(nodeID string) string {
-	nodeID = strings.TrimSpace(nodeID)
-	if nodeID == "pipeline" {
-		// event_receipts is unique on event_id + subscriber_id, so avoid colliding
-		// with the platform pipeline receipt for workflows that name a node "pipeline".
-		return "node:pipeline"
-	}
-	return nodeID
-}
-
 func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db *sql.DB, nodeID, eventID, sideEffects string) error {
 	if db == nil {
 		return nil
@@ -404,7 +394,6 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 	if tx == nil {
 		return nil
 	}
-	receiptSubscriberID := systemNodeReceiptSubscriberID(nodeID)
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
@@ -415,7 +404,7 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 			'no_op', 'idempotent_no_op', $3::jsonb, $4, now()
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			entity_id = EXCLUDED.entity_id,
 			flow_instance = EXCLUDED.flow_instance,
 			outcome = EXCLUDED.outcome,
@@ -423,7 +412,7 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 			side_effects = EXCLUDED.side_effects,
 			idempotency_key = EXCLUDED.idempotency_key,
 			processed_at = now()
-	`, eventID, receiptSubscriberID, sideEffects, SystemNodeReceiptIdempotencyKey(nodeID, eventID))
+	`, eventID, nodeID, sideEffects, SystemNodeReceiptIdempotencyKey(nodeID, eventID))
 	if err != nil {
 		return fmt.Errorf("upsert system node receipt: %w", err)
 	}

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -138,12 +138,12 @@ func TestSystemNodeRunner_PipelineNamedNodeDoesNotMaskPlatformReceipt(t *testing
 		FROM event_receipts
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
-		  AND subscriber_id = 'node:pipeline'
+		  AND subscriber_id = 'pipeline'
 	`, eventID).Scan(&nodeReceipts); err != nil {
 		t.Fatalf("count node receipt: %v", err)
 	}
 	if nodeReceipts != 1 {
-		t.Fatalf("node:pipeline receipts = %d, want 1", nodeReceipts)
+		t.Fatalf("node pipeline receipts = %d, want 1", nodeReceipts)
 	}
 	var deliveryStatus string
 	if err := db.QueryRowContext(ctx, `

--- a/internal/runtime/pipeline/workflow_transitions.go
+++ b/internal/runtime/pipeline/workflow_transitions.go
@@ -199,7 +199,7 @@ func recordPipelineTransitionReceipt(ctx context.Context, db *sql.DB, eventID, h
 			$3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), $7::jsonb, NULLIF($8,0), now()
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			outcome = EXCLUDED.outcome,
 			reason_code = EXCLUDED.reason_code,
 			state_before = EXCLUDED.state_before,

--- a/internal/runtime/pipeline/workflow_transitions_test.go
+++ b/internal/runtime/pipeline/workflow_transitions_test.go
@@ -18,6 +18,7 @@ func TestRecordPipelineTransition_PersistsViaCanonicalCapabilityOwner(t *testing
 	defer db.Close()
 
 	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(canonicalTransitionSchemaRows())
+	mock.ExpectQuery("FROM pg_index").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	eventID := uuid.NewString()
 	pipelineID := uuid.NewString()
 	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM events WHERE event_id = \$1::uuid\)`).
@@ -50,6 +51,7 @@ func TestRecordPipelineTransition_FailsClosedOnMixedSchemaCapability(t *testing.
 	defer db.Close()
 
 	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(mixedTransitionSchemaRows())
+	mock.ExpectQuery("FROM pg_index").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	pg := &store.PostgresStore{DB: db}
 	err = runtimepipeline.RecordPipelineTransition(context.Background(), db, pg.CanonicalEventReceiptsCapability, runtimepipeline.PipelineTransitionInput{
 		EventID:    uuid.NewString(),

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -348,7 +348,7 @@ func terminalizeActiveRunQuiescenceDeliveryTx(ctx context.Context, tx *sql.Tx, i
 			'dead_letter', $4, $5::jsonb, NULLIF($6, ''), $7
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			outcome = 'dead_letter',
 			reason_code = $4,
 			side_effects = $5::jsonb,
@@ -375,7 +375,7 @@ func upsertActiveRunQuiescencePipelineReceiptTx(ctx context.Context, tx *sql.Tx,
 			'dead_letter', $3, $4::jsonb, $5
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			outcome = 'dead_letter',
 			reason_code = $3,
 			side_effects = $4::jsonb,

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -337,7 +337,7 @@ func (s *PostgresStore) upsertAgentReceiptRowTx(ctx context.Context, tx *sql.Tx,
 			$3, NULLIF($4,''), $5::jsonb, now()
 		FROM events e
 		WHERE e.event_id = $1::uuid
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			entity_id = EXCLUDED.entity_id,
 			flow_instance = EXCLUDED.flow_instance,
 			outcome = EXCLUDED.outcome,

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1109,7 +1109,7 @@ func (s *PostgresStore) upsertPipelineReceiptSpec(ctx context.Context, tx *sql.T
 			  AND d.status = 'dead_letter'
 			  AND d.reason_code IN ($5, $6)
 		  )
-		ON CONFLICT (event_id, subscriber_id) DO UPDATE SET
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			outcome = EXCLUDED.outcome,
 			reason_code = EXCLUDED.reason_code,
 			side_effects = EXCLUDED.side_effects,

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -219,6 +219,11 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return fmt.Errorf("ensure event_deliveries.delivery_target_route column: %w", err)
 		}
 	}
+	if catalog.hasTable("event_receipts") && catalog.hasColumns("event_receipts", "event_id", "subscriber_type", "subscriber_id") {
+		if err := s.ensureEventReceiptsTypedSubscriberIdentity(ctx); err != nil {
+			return err
+		}
+	}
 	if catalog.hasTable("dead_letters") {
 		for _, stmt := range []struct {
 			column string
@@ -348,6 +353,142 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *PostgresStore) ensureEventReceiptsTypedSubscriberIdentity(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	var duplicateTypedRows int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT event_id, subscriber_type, subscriber_id
+			FROM event_receipts
+			GROUP BY event_id, subscriber_type, subscriber_id
+			HAVING COUNT(*) > 1
+		) dup
+	`).Scan(&duplicateTypedRows); err != nil {
+		return fmt.Errorf("inspect event_receipts typed identity duplicates: %w", err)
+	}
+	if duplicateTypedRows > 0 {
+		return fmt.Errorf("event_receipts typed subscriber identity migration found %d duplicate typed identities", duplicateTypedRows)
+	}
+
+	var nodePipelineConflicts int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts legacy
+		WHERE legacy.subscriber_type = 'node'
+		  AND legacy.subscriber_id = 'node:pipeline'
+		  AND EXISTS (
+			SELECT 1
+			FROM event_receipts canonical
+			WHERE canonical.event_id = legacy.event_id
+			  AND canonical.subscriber_type = 'node'
+			  AND canonical.subscriber_id = 'pipeline'
+		  )
+	`).Scan(&nodePipelineConflicts); err != nil {
+		return fmt.Errorf("inspect event_receipts node:pipeline migration conflicts: %w", err)
+	}
+	if nodePipelineConflicts > 0 {
+		return fmt.Errorf("event_receipts typed subscriber identity migration found %d node:pipeline rows colliding with canonical node pipeline receipts", nodePipelineConflicts)
+	}
+
+	for _, stmt := range []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "drop legacy event_receipts untyped unique constraints",
+			sql: `
+				DO $$
+				DECLARE rec RECORD;
+				BEGIN
+					FOR rec IN
+						SELECT c.conname
+						FROM pg_constraint c
+						JOIN pg_class tbl ON tbl.oid = c.conrelid
+						JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+						WHERE ns.nspname = 'public'
+						  AND tbl.relname = 'event_receipts'
+						  AND c.contype = 'u'
+						  AND replace(pg_get_constraintdef(c.oid), '"', '') = 'UNIQUE (event_id, subscriber_id)'
+					LOOP
+						EXECUTE format('ALTER TABLE %I.%I DROP CONSTRAINT %I', 'public', 'event_receipts', rec.conname);
+					END LOOP;
+				END
+				$$;
+			`,
+		},
+		{
+			name: "drop legacy event_receipts untyped unique indexes",
+			sql: `
+				DO $$
+				DECLARE rec RECORD;
+				BEGIN
+					FOR rec IN
+						SELECT idx.relname AS index_name
+						FROM pg_index i
+						JOIN pg_class tbl ON tbl.oid = i.indrelid
+						JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+						JOIN pg_class idx ON idx.oid = i.indexrelid
+						LEFT JOIN pg_constraint c ON c.conindid = i.indexrelid
+						WHERE ns.nspname = 'public'
+						  AND tbl.relname = 'event_receipts'
+						  AND i.indisunique
+						  AND c.oid IS NULL
+						  AND replace(pg_get_indexdef(i.indexrelid), '"', '') LIKE '% USING btree (event_id, subscriber_id)%'
+					LOOP
+						EXECUTE format('DROP INDEX IF EXISTS %I.%I', 'public', rec.index_name);
+					END LOOP;
+				END
+				$$;
+			`,
+		},
+		{
+			name: "normalize event_receipts node:pipeline subscriber ids",
+			sql: `
+				UPDATE event_receipts
+				SET subscriber_id = 'pipeline'
+				WHERE subscriber_type = 'node'
+				  AND subscriber_id = 'node:pipeline'
+			`,
+		},
+	} {
+		if _, err := s.DB.ExecContext(ctx, stmt.sql); err != nil {
+			return fmt.Errorf("%s: %w", stmt.name, err)
+		}
+	}
+
+	var postMigrationDuplicates int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT event_id, subscriber_type, subscriber_id
+			FROM event_receipts
+			GROUP BY event_id, subscriber_type, subscriber_id
+			HAVING COUNT(*) > 1
+		) dup
+	`).Scan(&postMigrationDuplicates); err != nil {
+		return fmt.Errorf("inspect event_receipts typed identity duplicates after migration: %w", err)
+	}
+	if postMigrationDuplicates > 0 {
+		return fmt.Errorf("event_receipts typed subscriber identity migration left %d duplicate typed identities", postMigrationDuplicates)
+	}
+	hasTypedIdentity, err := eventReceiptsTypedSubscriberIdentityKeyExists(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !hasTypedIdentity {
+		if _, err := s.DB.ExecContext(ctx, `
+			CREATE UNIQUE INDEX event_receipts_event_subscriber_identity_unique
+			ON event_receipts (event_id, subscriber_type, subscriber_id)
+		`); err != nil {
+			return fmt.Errorf("ensure event_receipts typed subscriber identity unique index: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *PostgresStore) ensureAgentSessionTerminationMetadata(ctx context.Context) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -381,6 +381,7 @@ func (s *PostgresStore) ensureEventReceiptsTypedSubscriberIdentity(ctx context.C
 		FROM event_receipts legacy
 		WHERE legacy.subscriber_type = 'node'
 		  AND legacy.subscriber_id = 'node:pipeline'
+		  AND COALESCE(legacy.idempotency_key, '') = 'pipeline:' || legacy.event_id::text
 		  AND EXISTS (
 			SELECT 1
 			FROM event_receipts canonical
@@ -393,6 +394,22 @@ func (s *PostgresStore) ensureEventReceiptsTypedSubscriberIdentity(ctx context.C
 	}
 	if nodePipelineConflicts > 0 {
 		return fmt.Errorf("event_receipts typed subscriber identity migration found %d node:pipeline rows colliding with canonical node pipeline receipts", nodePipelineConflicts)
+	}
+	var ambiguousNodePipelineRows int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE subscriber_type = 'node'
+		  AND subscriber_id = 'node:pipeline'
+		  AND COALESCE(idempotency_key, '') NOT IN (
+			'pipeline:' || event_id::text,
+			'node:pipeline:' || event_id::text
+		  )
+	`).Scan(&ambiguousNodePipelineRows); err != nil {
+		return fmt.Errorf("inspect ambiguous event_receipts node:pipeline rows: %w", err)
+	}
+	if ambiguousNodePipelineRows > 0 {
+		return fmt.Errorf("event_receipts typed subscriber identity migration found %d ambiguous node:pipeline rows without canonical system-node idempotency proof", ambiguousNodePipelineRows)
 	}
 
 	for _, stmt := range []struct {
@@ -453,6 +470,7 @@ func (s *PostgresStore) ensureEventReceiptsTypedSubscriberIdentity(ctx context.C
 				SET subscriber_id = 'pipeline'
 				WHERE subscriber_type = 'node'
 				  AND subscriber_id = 'node:pipeline'
+				  AND COALESCE(idempotency_key, '') = 'pipeline:' || event_id::text
 			`,
 		},
 	} {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1674,22 +1674,26 @@ func TestPostgresStore_EnsureSchemaTables_MigratesEventReceiptsTypedSubscriberId
 	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
 
 	eventID := uuid.NewString()
+	literalNodeEventID := uuid.NewString()
 	entityID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
-		) VALUES (
-			$1::uuid, 'test.receipts.migration', $2::uuid, 'flow-1', 'entity', '{}'::jsonb, 'test', 'platform', now()
-		)
-	`, eventID, entityID); err != nil {
+		) VALUES
+			($1::uuid, 'test.receipts.migration', $3::uuid, 'flow-1', 'entity', '{}'::jsonb, 'test', 'platform', now()),
+			($2::uuid, 'test.receipts.literal_node_pipeline', $3::uuid, 'flow-1', 'entity', '{}'::jsonb, 'test', 'platform', now())
+	`, eventID, literalNodeEventID, entityID); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects, idempotency_key)
 		VALUES
-			($1::uuid, 'platform', 'pipeline', 'success', '{}'::jsonb),
-			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb)
-	`, eventID); err != nil {
+			($1::uuid, 'platform', 'pipeline', 'success', '{}'::jsonb, NULL),
+			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb, $3),
+			($2::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb, $4)
+	`, eventID, literalNodeEventID,
+		runtimepipeline.SystemNodeReceiptIdempotencyKey("pipeline", eventID),
+		runtimepipeline.SystemNodeReceiptIdempotencyKey("node:pipeline", literalNodeEventID)); err != nil {
 		t.Fatalf("seed legacy receipts: %v", err)
 	}
 
@@ -1730,6 +1734,20 @@ func TestPostgresStore_EnsureSchemaTables_MigratesEventReceiptsTypedSubscriberId
 	if legacyRows != 0 {
 		t.Fatalf("legacy node:pipeline receipt rows = %d, want 0", legacyRows)
 	}
+	var literalRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node:pipeline'
+		  AND idempotency_key = $2
+	`, literalNodeEventID, runtimepipeline.SystemNodeReceiptIdempotencyKey("node:pipeline", literalNodeEventID)).Scan(&literalRows); err != nil {
+		t.Fatalf("count literal node:pipeline receipts: %v", err)
+	}
+	if literalRows != 1 {
+		t.Fatalf("literal node:pipeline receipt rows = %d, want 1", literalRows)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
 		VALUES ($1::uuid, 'node', 'pipeline', 'success', '{}'::jsonb)
@@ -1752,11 +1770,13 @@ func TestPostgresStore_EnsureSchemaTables_FailsClosedOnNodePipelineMigrationConf
 		t.Fatalf("seed event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects, idempotency_key)
 		VALUES
-			($1::uuid, 'node', 'pipeline', 'success', '{}'::jsonb),
-			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb)
-	`, eventID); err != nil {
+			($1::uuid, 'node', 'pipeline', 'success', '{}'::jsonb, $2),
+			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb, $3)
+	`, eventID,
+		runtimepipeline.SystemNodeReceiptIdempotencyKey("pipeline", eventID),
+		runtimepipeline.SystemNodeReceiptIdempotencyKey("pipeline", eventID)); err != nil {
 		t.Fatalf("seed conflicting legacy receipts: %v", err)
 	}
 
@@ -1766,6 +1786,35 @@ func TestPostgresStore_EnsureSchemaTables_FailsClosedOnNodePipelineMigrationConf
 	}
 	if !strings.Contains(err.Error(), "node:pipeline") {
 		t.Fatalf("EnsureSchemaTables error = %v, want node:pipeline conflict", err)
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_FailsClosedOnAmbiguousNodePipelineRows(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
+
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, 'test.receipts.ambiguous_node_pipeline', 'global', '{}'::jsonb, 'test', 'platform', now())
+	`, eventID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects, idempotency_key)
+		VALUES ($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb, NULL)
+	`, eventID); err != nil {
+		t.Fatalf("seed ambiguous legacy receipt: %v", err)
+	}
+
+	err := pg.EnsureSchemaTables(ctx, eventReceiptsTypedIdentityPlans(t))
+	if err == nil {
+		t.Fatal("EnsureSchemaTables error = nil, want ambiguous node:pipeline fail-closed migration error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous node:pipeline") {
+		t.Fatalf("EnsureSchemaTables error = %v, want ambiguous node:pipeline", err)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1562,6 +1562,260 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 	}
 }
 
+func TestPostgresStore_EventReceiptsTypedIdentitySeparatesReceiptWriters(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope,
+			payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'test.receipts.typed_identity', $3::uuid, 'flow-1', 'entity',
+			'{}'::jsonb, 'test', 'platform', now()
+		)
+	`, eventID, runID, entityID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'pipeline', 'in_progress', now()
+		)
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed agent delivery: %v", err)
+	}
+	var nodeDeliveryID string
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', 'pipeline', 'in_progress', now()
+		)
+		RETURNING delivery_id::text
+	`, runID, eventID).Scan(&nodeDeliveryID); err != nil {
+		t.Fatalf("seed node delivery: %v", err)
+	}
+
+	if err := pg.UpsertPipelineReceipt(ctx, eventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := pg.UpsertEventReceipt(ctx, eventID, "pipeline", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("UpsertEventReceipt: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin active quiescence tx: %v", err)
+	}
+	if err := terminalizeActiveRunQuiescenceDeliveryTx(ctx, tx, activeRunQuiescenceDeliveryTarget{
+		DeliveryID:     nodeDeliveryID,
+		RunID:          runID,
+		EventID:        eventID,
+		SubscriberType: "node",
+		SubscriberID:   "pipeline",
+		Status:         "in_progress",
+	}, "serve_abandon", "operator shutdown", time.Now().UTC()); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("terminalizeActiveRunQuiescenceDeliveryTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit active quiescence tx: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT subscriber_type, subscriber_id, outcome
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = 'pipeline'
+		ORDER BY subscriber_type
+	`, eventID)
+	if err != nil {
+		t.Fatalf("query typed receipts: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]string{}
+	for rows.Next() {
+		var subscriberType, subscriberID, outcome string
+		if err := rows.Scan(&subscriberType, &subscriberID, &outcome); err != nil {
+			t.Fatalf("scan typed receipt: %v", err)
+		}
+		got[subscriberType+"|"+subscriberID] = outcome
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read typed receipts: %v", err)
+	}
+	want := map[string]string{
+		"agent|pipeline":    "success",
+		"node|pipeline":     "dead_letter",
+		"platform|pipeline": "success",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("typed receipt rows = %#v, want %#v", got, want)
+	}
+	for key, wantOutcome := range want {
+		if got[key] != wantOutcome {
+			t.Fatalf("receipt %s outcome = %q, want %q (all rows %#v)", key, got[key], wantOutcome, got)
+		}
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_MigratesEventReceiptsTypedSubscriberIdentity(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
+
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, 'test.receipts.migration', $2::uuid, 'flow-1', 'entity', '{}'::jsonb, 'test', 'platform', now()
+		)
+	`, eventID, entityID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
+		VALUES
+			($1::uuid, 'platform', 'pipeline', 'success', '{}'::jsonb),
+			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb)
+	`, eventID); err != nil {
+		t.Fatalf("seed legacy receipts: %v", err)
+	}
+
+	if err := pg.EnsureSchemaTables(ctx, eventReceiptsTypedIdentityPlans(t)); err != nil {
+		t.Fatalf("EnsureSchemaTables(event_receipts typed identity): %v", err)
+	}
+
+	hasTypedKey, err := eventReceiptsTypedSubscriberIdentityKeyExists(ctx, db)
+	if err != nil {
+		t.Fatalf("eventReceiptsTypedSubscriberIdentityKeyExists: %v", err)
+	}
+	if !hasTypedKey {
+		t.Fatal("typed event_receipts subscriber identity key missing after migration")
+	}
+	var rowsForPipeline int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = 'pipeline'
+		  AND subscriber_type IN ('platform', 'node')
+	`, eventID).Scan(&rowsForPipeline); err != nil {
+		t.Fatalf("count migrated pipeline receipts: %v", err)
+	}
+	if rowsForPipeline != 2 {
+		t.Fatalf("pipeline typed receipt rows = %d, want 2", rowsForPipeline)
+	}
+	var legacyRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node:pipeline'
+	`, eventID).Scan(&legacyRows); err != nil {
+		t.Fatalf("count legacy node:pipeline receipts: %v", err)
+	}
+	if legacyRows != 0 {
+		t.Fatalf("legacy node:pipeline receipt rows = %d, want 0", legacyRows)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
+		VALUES ($1::uuid, 'node', 'pipeline', 'success', '{}'::jsonb)
+	`, eventID); err == nil {
+		t.Fatal("duplicate typed event_receipts identity insert succeeded, want unique violation")
+	}
+}
+
+func TestPostgresStore_EnsureSchemaTables_FailsClosedOnNodePipelineMigrationConflict(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
+
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, 'test.receipts.migration_conflict', 'global', '{}'::jsonb, 'test', 'platform', now())
+	`, eventID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, side_effects)
+		VALUES
+			($1::uuid, 'node', 'pipeline', 'success', '{}'::jsonb),
+			($1::uuid, 'node', 'node:pipeline', 'no_op', '{}'::jsonb)
+	`, eventID); err != nil {
+		t.Fatalf("seed conflicting legacy receipts: %v", err)
+	}
+
+	err := pg.EnsureSchemaTables(ctx, eventReceiptsTypedIdentityPlans(t))
+	if err == nil {
+		t.Fatal("EnsureSchemaTables error = nil, want node:pipeline fail-closed migration error")
+	}
+	if !strings.Contains(err.Error(), "node:pipeline") {
+		t.Fatalf("EnsureSchemaTables error = %v, want node:pipeline conflict", err)
+	}
+}
+
+func downgradeEventReceiptsToUntypedSubscriberIdentity(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		DO $$
+		DECLARE rec RECORD;
+		BEGIN
+			FOR rec IN
+				SELECT c.conname
+				FROM pg_constraint c
+				WHERE c.conrelid = 'event_receipts'::regclass
+				  AND c.contype = 'u'
+			LOOP
+				EXECUTE format('ALTER TABLE event_receipts DROP CONSTRAINT %I', rec.conname);
+			END LOOP;
+		END
+		$$;
+		DROP INDEX IF EXISTS event_receipts_event_subscriber_identity_unique;
+		ALTER TABLE event_receipts
+			ADD CONSTRAINT event_receipts_event_id_subscriber_id_key UNIQUE (event_id, subscriber_id);
+	`); err != nil {
+		t.Fatalf("downgrade event_receipts identity: %v", err)
+	}
+	pg := &PostgresStore{DB: db}
+	_, err := pg.BindSchemaCapabilities(ctx)
+	if err != nil {
+		t.Fatalf("bind downgraded schema capabilities: %v", err)
+	}
+}
+
+func eventReceiptsTypedIdentityPlans(t *testing.T) []SchemaTableDDL {
+	t.Helper()
+	var spec runtimecontracts.PlatformSpecDocument
+	spec.PlatformTables.Tables = map[string]struct {
+		Description string `yaml:"description"`
+		DDL         string `yaml:"ddl"`
+	}{
+		"event_receipts": {
+			DDL: "CREATE TABLE event_receipts (\n    receipt_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    event_id UUID NOT NULL REFERENCES events(event_id),\n    subscriber_type TEXT NOT NULL CHECK (subscriber_type IN ('node', 'agent', 'platform')),\n    subscriber_id TEXT NOT NULL,\n    entity_id UUID,\n    flow_instance TEXT,\n    outcome TEXT NOT NULL CHECK (outcome IN ('success', 'reject', 'discard', 'kill', 'escalate', 'dead_letter', 'terminal_reject', 'waiting', 'fanned_out', 'no_op')),\n    reason_code TEXT,\n    state_before TEXT,\n    state_after TEXT,\n    side_effects JSONB NOT NULL DEFAULT '{}',\n    duration_ms INTEGER,\n    idempotency_key TEXT,\n    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (event_id, subscriber_type, subscriber_id)\n);",
+		},
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs(event_receipts): %v", err)
+	}
+	return plans
+}
+
 func TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -31,6 +31,7 @@ type EventSchemaCapabilities struct {
 	LogIdempotencyKey    bool
 	LogRouteIdentity     bool
 	DeliveryTargetRoute  bool
+	ReceiptTypedIdentity bool
 }
 
 type ConversationSchemaCapabilities struct {
@@ -109,6 +110,28 @@ func loadSchemaColumnCatalog(ctx context.Context, db *sql.DB) (schemaColumnCatal
 		return schemaColumnCatalog{}, fmt.Errorf("read store schema columns: %w", err)
 	}
 	return catalog, nil
+}
+
+func eventReceiptsTypedSubscriberIdentityKeyExists(ctx context.Context, db *sql.DB) (bool, error) {
+	if db == nil {
+		return false, fmt.Errorf("postgres store is required")
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_index i
+			JOIN pg_class tbl ON tbl.oid = i.indrelid
+			JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+			WHERE ns.nspname = 'public'
+			  AND tbl.relname = 'event_receipts'
+			  AND i.indisunique
+			  AND replace(pg_get_indexdef(i.indexrelid), '"', '') LIKE '% USING btree (event_id, subscriber_type, subscriber_id)%'
+		)
+	`).Scan(&exists); err != nil {
+		return false, fmt.Errorf("inspect event_receipts typed subscriber identity key: %w", err)
+	}
+	return exists, nil
 }
 
 func detectSchemaFlavor(catalog schemaColumnCatalog, tableName string, canonicalColumns, legacyColumns []string) SchemaFlavor {
@@ -265,6 +288,16 @@ func (s *PostgresStore) BindSchemaCapabilities(ctx context.Context) (StoreSchema
 		return StoreSchemaCapabilities{}, err
 	}
 	caps := detectStoreSchemaCapabilities(catalog)
+	if caps.Events.Receipts == SchemaFlavorCanonical {
+		hasTypedIdentity, err := eventReceiptsTypedSubscriberIdentityKeyExists(ctx, s.DB)
+		if err != nil {
+			return StoreSchemaCapabilities{}, err
+		}
+		caps.Events.ReceiptTypedIdentity = hasTypedIdentity
+		if !hasTypedIdentity {
+			caps.Events.Receipts = SchemaFlavorUnsupported
+		}
+	}
 	s.schemaCapsMu.Lock()
 	s.schemaCaps = caps
 	s.schemaCapsBound = true

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -75,6 +75,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	)
 
 	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+	expectEventReceiptsTypedIdentityKey(mock, true)
 
 	pg := &PostgresStore{DB: db}
 	caps, err := pg.BindSchemaCapabilities(context.Background())
@@ -89,6 +90,9 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	}
 	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
 		t.Fatalf("delivery caps = %+v", caps.Events)
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical || !caps.Events.ReceiptTypedIdentity {
+		t.Fatalf("receipt caps = %+v", caps.Events)
 	}
 	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
 		t.Fatalf("entity_state caps = %+v run_id=%v", caps.EntityState, caps.EntityRunID)
@@ -267,6 +271,7 @@ func TestPostgresStore_CanonicalCapabilityReaders(t *testing.T) {
 		AddRow("event_receipts", "idempotency_key").
 		AddRow("event_receipts", "processed_at")
 	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+	expectEventReceiptsTypedIdentityKey(mock, true)
 
 	pg := &PostgresStore{DB: db}
 	logEnabled, logRunID, err := pg.CanonicalRuntimeLogCapability(context.Background())
@@ -318,6 +323,7 @@ func TestPostgresStore_CanonicalEventReceiptsCapability_FailsClosedWithoutCanoni
 		AddRow("event_receipts", "idempotency_key").
 		AddRow("event_receipts", "processed_at")
 	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+	expectEventReceiptsTypedIdentityKey(mock, true)
 
 	pg := &PostgresStore{DB: db}
 	receiptsEnabled, err := pg.CanonicalEventReceiptsCapability(context.Background())
@@ -330,4 +336,66 @@ func TestPostgresStore_CanonicalEventReceiptsCapability_FailsClosedWithoutCanoni
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
+}
+
+func TestPostgresStore_CanonicalEventReceiptsCapability_FailsClosedWithoutTypedIdentityKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"table_name", "column_name"}).
+		AddRow("events", "event_id").
+		AddRow("events", "run_id").
+		AddRow("events", "event_name").
+		AddRow("events", "entity_id").
+		AddRow("events", "flow_instance").
+		AddRow("events", "scope").
+		AddRow("events", "payload").
+		AddRow("events", "chain_depth").
+		AddRow("events", "produced_by").
+		AddRow("events", "produced_by_type").
+		AddRow("events", "source_event_id").
+		AddRow("events", "created_at").
+		AddRow("event_receipts", "receipt_id").
+		AddRow("event_receipts", "event_id").
+		AddRow("event_receipts", "subscriber_type").
+		AddRow("event_receipts", "subscriber_id").
+		AddRow("event_receipts", "entity_id").
+		AddRow("event_receipts", "flow_instance").
+		AddRow("event_receipts", "outcome").
+		AddRow("event_receipts", "reason_code").
+		AddRow("event_receipts", "state_before").
+		AddRow("event_receipts", "state_after").
+		AddRow("event_receipts", "side_effects").
+		AddRow("event_receipts", "duration_ms").
+		AddRow("event_receipts", "idempotency_key").
+		AddRow("event_receipts", "processed_at")
+	mock.ExpectQuery("FROM information_schema.columns").WillReturnRows(rows)
+	expectEventReceiptsTypedIdentityKey(mock, false)
+
+	pg := &PostgresStore{DB: db}
+	caps, err := pg.BindSchemaCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	if caps.Events.Receipts != SchemaFlavorUnsupported || caps.Events.ReceiptTypedIdentity {
+		t.Fatalf("event_receipts caps = %+v, want unsupported without typed identity key", caps.Events)
+	}
+	receiptsEnabled, err := pg.CanonicalEventReceiptsCapability(context.Background())
+	if err != nil {
+		t.Fatalf("CanonicalEventReceiptsCapability: %v", err)
+	}
+	if receiptsEnabled {
+		t.Fatal("CanonicalEventReceiptsCapability = true, want false without typed identity key")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func expectEventReceiptsTypedIdentityKey(mock sqlmock.Sqlmock, exists bool) {
+	mock.ExpectQuery("FROM pg_index").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(exists))
 }

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -208,6 +208,40 @@ func TestPlatformSpecRunsOwnsBundleFingerprint(t *testing.T) {
 	}
 }
 
+func TestPlatformSpecEventReceiptsUsesTypedSubscriberIdentity(t *testing.T) {
+	_, file, _, _ := stdruntime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	var receipts SchemaTableDDL
+	for _, plan := range plans {
+		if plan.TableName == "event_receipts" {
+			receipts = plan
+			break
+		}
+	}
+	if receipts.TableName == "" {
+		t.Fatal("event_receipts ddl plan missing")
+	}
+	joined := strings.Join(receipts.Statements, "\n")
+	if !strings.Contains(joined, "UNIQUE (event_id, subscriber_type, subscriber_id)") {
+		t.Fatalf("event_receipts ddl missing typed subscriber identity:\n%s", joined)
+	}
+	if strings.Contains(joined, "UNIQUE (event_id, subscriber_id)") {
+		t.Fatalf("event_receipts ddl kept untyped subscriber identity:\n%s", joined)
+	}
+}
+
 func TestGeneratePlatformTableDDLs_StripsDeprecatedEntitySubjectDDL(t *testing.T) {
 	var spec runtimecontracts.PlatformSpecDocument
 	spec.PlatformTables.Tables = map[string]struct {


### PR DESCRIPTION
## Summary

- Align `event_receipts` with the typed subscriber identity contract: `(event_id, subscriber_type, subscriber_id)`.
- Move all production receipt writers to the typed conflict target and remove the `node:pipeline` writer workaround.
- Add schema migration/capability proof for the typed unique key, including selective one-way normalization of #1007 workaround rows, literal `node:pipeline` preservation, and fail-closed collision/ambiguity handling.
- Refine watchlist mapping for #1030.

Closes #1030

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.event_receipts`: prose says `subscriber_type + subscriber_id` identify the handler generically; this PR updates the authoritative DDL to match with `UNIQUE (event_id, subscriber_type, subscriber_id)`.
- Generated/derived spec text updated in `docs/specs/swarm-platform/platform/platform-spec.md` and the platform changelog entry.
- Approved gate: #1030 independent pre-implementation gate outcome approved the typed `event_receipts` subscriber identity owner and rejected centralized string namespacing/local workaround scope.

## Semantic migration

- New canonical owner: platform spec DDL plus `PostgresStore.ensureEventReceiptsTypedSubscriberIdentity` and `BindSchemaCapabilities` typed-key detection.
- Old invalid path: `ON CONFLICT (event_id, subscriber_id)` writers and the `node:pipeline` system-node subscriber-id workaround.
- Production paths checked/moved: platform pipeline receipts, agent receipts, system-node receipts/idempotency, workflow transition receipts, active-run quiescence delivery receipts, and active-run quiescence platform receipts.
- Migration completeness: existing #1007 workaround rows with `subscriber_type='node'`, `subscriber_id='node:pipeline'`, and idempotency key `pipeline:<event_id>` normalize to `subscriber_id='pipeline'`; legitimate literal node id `node:pipeline` rows with idempotency key `node:pipeline:<event_id>` are preserved; same-type collisions or ambiguous historical rows fail closed before migration instead of adding compatibility readers.

## Validation

- `go test ./internal/store -run 'TestPostgresStore_EnsureSchemaTables_(MigratesEventReceiptsTypedSubscriberIdentity|FailsClosedOnNodePipelineMigrationConflict|FailsClosedOnAmbiguousNodePipelineRows)'`
- `go test ./internal/store`
- `go test ./internal/runtime/pipeline`
- `go test ./internal/apiv1 -run TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces`
- `go test ./...`