### PR TITLE
[agent-e][issue #997] Gate local cli_test gateway startup defaults

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -53,6 +55,7 @@ const (
 	serveAPIRoutes          = "/healthz /readyz /v1/rpc /v1/ws"
 	serveMCPRoutes          = "/mcp /tools/"
 	serveReadinessRoutes    = "/healthz /readyz"
+	serveGatewayTokenBytes  = 32
 )
 
 var (
@@ -1942,10 +1945,26 @@ func configureServeMCPGatewayEnv(mcpAddr net.Addr) (func(), error) {
 	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_CONTAINER_URL", os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), mcpAddr); err != nil {
 		return func() {}, err
 	}
+	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
+	if gatewayToken == "" {
+		gatewayToken, err = generateServeMCPGatewayToken()
+		if err != nil {
+			return func() {}, err
+		}
+	}
 	return setServeGatewayEnv(map[string]string{
 		"SWARM_TOOL_GATEWAY_URL":           mcpHostURL,
 		"SWARM_TOOL_GATEWAY_CONTAINER_URL": mcpContainerURL,
+		"SWARM_TOOL_GATEWAY_TOKEN":         gatewayToken,
 	})
+}
+
+func generateServeMCPGatewayToken() (string, error) {
+	raw := make([]byte, serveGatewayTokenBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate mcp gateway token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
 func validateExistingServeGatewayURL(name, raw string, mcpAddr net.Addr) error {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -986,6 +987,67 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 	for _, want := range []string{"#996", "#997"} {
 		if !strings.Contains(packaging.SplitScope, want) {
 			t.Fatalf("runtime image packaging split scope missing %q:\n%s", want, packaging.SplitScope)
+		}
+	}
+}
+
+func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				LocalCLITestGatewayStartup struct {
+					PromotedBy            string   `yaml:"promoted_by"`
+					ImplementationStatus  string   `yaml:"implementation_status"`
+					CanonicalOwner        string   `yaml:"canonical_owner"`
+					Scope                 string   `yaml:"scope"`
+					GatewayTokenRule      string   `yaml:"gateway_token_rule"`
+					GatewayTokenConsumers []string `yaml:"gateway_token_consumers"`
+					StartupProbeRule      string   `yaml:"startup_probe_rule"`
+					SplitTail             []string `yaml:"split_tail"`
+				} `yaml:"local_cli_test_gateway_startup"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	startup := spec.CLISpecification.Foundations.LocalCLITestGatewayStartup
+	if strings.TrimSpace(startup.PromotedBy) != "#997" {
+		t.Fatalf("local cli_test gateway startup promoted_by = %q, want #997", startup.PromotedBy)
+	}
+	if strings.TrimSpace(startup.ImplementationStatus) != "implemented_first_slice" {
+		t.Fatalf("local cli_test gateway startup implementation_status = %q, want implemented_first_slice", startup.ImplementationStatus)
+	}
+	if !strings.Contains(startup.CanonicalOwner, "cli_specification.foundations.local_cli_test_gateway_startup") {
+		t.Fatalf("canonical owner does not point at local_cli_test_gateway_startup: %s", startup.CanonicalOwner)
+	}
+	for _, want := range []string{"narrowed #997", "MCP gateway token derivation", "MCP-only managed-agent startup proof", "does not close full #997"} {
+		if !strings.Contains(startup.Scope, want) {
+			t.Fatalf("local cli_test gateway startup scope missing %q:\n%s", want, startup.Scope)
+		}
+	}
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "per-boot", "operator-provided", "Local foreground `swarm run`"} {
+		if !strings.Contains(startup.GatewayTokenRule, want) {
+			t.Fatalf("gateway token rule missing %q:\n%s", want, startup.GatewayTokenRule)
+		}
+	}
+	for _, want := range []string{"RuntimeOptions.ToolGatewayToken", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "docker exec", "MCP HTTP binding"} {
+		if !stringSliceContains(startup.GatewayTokenConsumers, want) {
+			t.Fatalf("gateway token consumers missing %q: %#v", want, startup.GatewayTokenConsumers)
+		}
+	}
+	for _, want := range []string{"startup validation MUST execute", "every managed agent", "MCP-only", "Agent-free `cli_test`"} {
+		if !strings.Contains(startup.StartupProbeRule, want) {
+			t.Fatalf("startup probe rule missing %q:\n%s", want, startup.StartupProbeRule)
+		}
+	}
+	for _, want := range []string{"#997 local cli_test workspace image contents", "#996 Docker Compose", "#979/#1012", "#1002 runtime workspace source-root image packaging is closed"} {
+		if !stringSliceContains(startup.SplitTail, want) {
+			t.Fatalf("local cli_test gateway startup split_tail missing %q: %#v", want, startup.SplitTail)
 		}
 	}
 }
@@ -3875,6 +3937,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 func TestConfigureServeMCPGatewayEnvAlignsToMCPListener(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen mcp: %v", err)
@@ -3895,12 +3958,45 @@ func TestConfigureServeMCPGatewayEnvAlignsToMCPListener(t *testing.T) {
 	if got, want := os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), "http://host.docker.internal:"+port; got != want {
 		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want %q", got, want)
 	}
+	gatewayToken := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")
+	if strings.TrimSpace(gatewayToken) == "" {
+		t.Fatal("SWARM_TOOL_GATEWAY_TOKEN was not generated")
+	}
+	if got, want := len(gatewayToken), base64.RawURLEncoding.EncodedLen(serveGatewayTokenBytes); got != want {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN length = %d, want %d", got, want)
+	}
 	restore()
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_URL"); got != "" {
 		t.Fatalf("SWARM_TOOL_GATEWAY_URL after restore = %q, want empty", got)
 	}
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"); got != "" {
 		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL after restore = %q, want empty", got)
+	}
+	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN after restore = %q, want empty", got)
+	}
+}
+
+func TestConfigureServeMCPGatewayEnvPreservesExplicitGatewayToken(t *testing.T) {
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen mcp: %v", err)
+	}
+	defer listener.Close()
+
+	restore, err := configureServeMCPGatewayEnv(listener.Addr())
+	if err != nil {
+		t.Fatalf("configure gateway env: %v", err)
+	}
+	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "operator-token" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want explicit operator token", got)
+	}
+	restore()
+	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "operator-token" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN after restore = %q, want explicit operator token", got)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6183,6 +6183,40 @@ cli_specification:
           workspace mount defaults.
       split_tail:
       - '#996 Docker Compose setup, #997 local cli_test defaults/image contents, #992 serve listener behavior, multi-bundle work, and README/public-doc polish remain split.'
+    local_cli_test_gateway_startup:
+      promoted_by: '#997'
+      implementation_status: implemented_first_slice
+      canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup
+      scope: >
+        Merge-bearing CLI/runtime authority for the narrowed #997 local `cli_test` first slice:
+        local serve/run MCP gateway token derivation and MCP-only managed-agent startup proof.
+        This owner does not close full #997, local workspace image contents/default-agent CLI
+        availability, Docker Compose setup, selected-contract/multi-bundle gateway materialization,
+        or public one-secret quickstart polish.
+      gateway_token_rule: >
+        `swarm serve` MUST derive `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL`
+        from the bound MCP listener and MUST derive a per-boot `SWARM_TOOL_GATEWAY_TOKEN` when
+        the operator did not provide one. An explicit non-empty operator-provided
+        `SWARM_TOOL_GATEWAY_TOKEN` remains authoritative for that process. Local foreground
+        `swarm run` consumes the same serve startup owner and MUST NOT fork an independent
+        gateway-token owner.
+      gateway_token_consumers:
+      - 'runtime `RuntimeOptions.ToolGatewayToken`'
+      - runtime MCP gateway auth
+      - '`llm.ValidateClaudeCLIRuntimeConfig`'
+      - Claude CLI docker exec environment
+      - MCP HTTP binding for startup/runtime tool calls
+      startup_probe_rule: >
+        For agent-present `cli_test` managed agents, startup validation MUST execute the Claude
+        CLI/container startup probe for every managed agent before accepting MCP-only
+        `tools/list` or optional `tools/call` gateway proof. Provider-native builtin surfaces
+        still additionally compare the provider-visible native tool list. Agent-free `cli_test`
+        boot remains governed by #993 and MUST NOT require LLM/gateway startup credentials.
+      split_tail:
+      - '#997 local cli_test workspace image contents/default-agent Claude CLI availability remains open.'
+      - '#996 Docker Compose setup remains split.'
+      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not an open tail.'
     no_args_behavior: '`swarm` with no arguments prints root help and exits 0. Bare `swarm` MUST NOT start the runtime.'
     daemon_startup: '`swarm serve` owns runtime/API/health/MCP startup. `swarm run` may consume the serve startup owner for local foreground start, but MUST NOT fork a second runtime boot owner.'
     cli_consumes_api_rule: 'All CLI commands that read or mutate runtime state consume the canonical API at /v1/rpc or /v1/ws. The only local file-contract carve-out is `swarm verify`, which validates contract files on disk and does not require runtime DB/API state.'

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -79,6 +79,9 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8081/mcp") {
 		t.Fatalf("docker args = %q, want explicit container MCP gateway URL", got)
 	}
+	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=gateway-token") {
+		t.Fatalf("docker args = %q, want MCP gateway token propagated into cli_test container exec", got)
+	}
 }
 
 func TestClaudeCLIRuntimePersistOversizedToolResultRelay_WritesWorkspaceVisibleFile(t *testing.T) {

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -163,15 +163,15 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 		if len(sessionTools) == 0 {
 			return fmt.Errorf("managed-agent startup probe found no declared tools for agent %s", agentID)
 		}
+		if startupProbe == nil {
+			return fmt.Errorf("claude cli startup probe is required for agent %s", agentID)
+		}
+		probeResp, err := startupProbe.ProbeStartupVisibleToolSurface(ctx, agentCfg, runtimemanager.ExtractSystemPromptFromConfig(agentCfg.Config), sessionTools)
+		if err != nil {
+			return fmt.Errorf("claude cli startup probe failed for agent %s: %w", agentID, err)
+		}
 		surface := llm.AgentVisibleToolSurfaceForActor(agentCfg, sessionTools)
 		if len(surface.NativeBuiltinTools) > 0 {
-			if startupProbe == nil {
-				return fmt.Errorf("provider-native startup probe is required for agent %s", agentID)
-			}
-			probeResp, err := startupProbe.ProbeStartupVisibleToolSurface(ctx, agentCfg, runtimemanager.ExtractSystemPromptFromConfig(agentCfg.Config), sessionTools)
-			if err != nil {
-				return fmt.Errorf("provider-native startup probe failed for agent %s: %w", agentID, err)
-			}
 			expectedVisible := llm.PlannedProviderNativeVisibleToolsForActor(agentCfg, sessionTools)
 			actualVisible := llm.ObservedProviderNativeVisibleToolsForActor(agentCfg, sessionTools, probeResp)
 			if !equalSortedStrings(actualVisible, expectedVisible) {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -413,12 +413,72 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 		caps: startupProbeCaps(),
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before MCP runtime proof", probe.calls)
 	}
 	if !slices.Equal(exec.executed, []string{"health_check"}) {
 		t.Fatalf("executed = %#v, want health_check tools/call smoke", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_RequiresCLIStartupProbeForMCPOnlySurface(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "campaign-coordinator",
+		Role:   "campaign_coordinator",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "claude cli startup probe is required") {
+		t.Fatalf("expected required CLI startup probe error, got %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no MCP tools/call before CLI startup proof", exec.executed)
+	}
+}
+
+func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenMCPOnlyCLIStartupProbeFails(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.RuntimeMode = "cli_test"
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ID:     "campaign-coordinator",
+		Role:   "campaign_coordinator",
+		Config: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	exec := &startupProbeToolExecutor{
+		defs: startupProbeDefs(),
+		caps: startupProbeCaps(),
+	}
+	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{err: errors.New("claude: command not found")}
+
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "claude cli startup probe failed") || !strings.Contains(err.Error(), "claude: command not found") {
+		t.Fatalf("expected CLI startup probe failure, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup probe for MCP-only surface", probe.calls)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("executed = %#v, want no MCP tools/call after CLI startup proof failure", exec.executed)
 	}
 }
 
@@ -454,9 +514,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_SeparatesStaticInventoryFromNoCu
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"analysis-agent"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before MCP visibility proof", probe.calls)
 	}
 	if exec.contextDefCalls == 0 || exec.contextCapsCalls == 0 {
 		t.Fatalf("expected startup MCP proof to consume context-aware surface, defCalls=%d capCalls=%d", exec.contextDefCalls, exec.contextCapsCalls)
@@ -491,9 +555,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_AllowsEmptyConcreteSurfaceWhenSt
 		contextCaps: map[string]toolcapabilities.Capability{},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"validation-agent"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof for empty concrete MCP surface", probe.calls)
 	}
 	if len(exec.executed) != 0 {
 		t.Fatalf("executed = %#v, want no callable startup probe for empty concrete surface", exec.executed)
@@ -519,9 +587,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_AcceptsExplicitValidationOnlyPro
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before validation-only MCP call", probe.calls)
 	}
 	if !slices.Equal(exec.executed, []string{"health_check"}) {
 		t.Fatalf("executed = %#v, want health_check tools/call smoke", exec.executed)
@@ -544,10 +616,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTo
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "wrong-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "invalid token") {
 		t.Fatalf("expected invalid token error, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"market-research-agent"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before MCP auth proof", probe.calls)
 	}
 }
 
@@ -573,10 +649,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "found no visible tools") {
 		t.Fatalf("expected empty visible tools error, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before empty visible-surface failure", probe.calls)
 	}
 }
 
@@ -784,9 +864,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenNoExplicit
 				},
 			}
 			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+			probe := &startupVisibleSurfaceProbeStub{}
 
-			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+			}
+			if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+				t.Fatalf("probe calls = %#v, want CLI startup proof before MCP visibility-only proof", probe.calls)
 			}
 			if len(exec.executed) != 0 {
 				t.Fatalf("executed = %#v, want visibility-only startup proof for required-input-only surface", exec.executed)
@@ -820,9 +904,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_DoesNotCallSchemaOnlyEmptyObject
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"lifecycle-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before schema-only MCP proof", probe.calls)
 	}
 	if len(exec.executed) != 0 {
 		t.Fatalf("executed = %#v, want query_entities visibility-only despite empty-object schema", exec.executed)
@@ -852,9 +940,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenVisibleToo
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before emit-only MCP proof", probe.calls)
 	}
 	if len(exec.executed) != 0 {
 		t.Fatalf("executed = %#v, want visibility-only startup proof for emit-only surface", exec.executed)
@@ -883,10 +975,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenExplicitProbeSafe
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "call_empty_object") {
 		t.Fatalf("expected explicit probe-safe schema mismatch error, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before explicit startup probe policy failure", probe.calls)
 	}
 	if len(exec.executed) != 0 {
 		t.Fatalf("executed = %#v, want no tools/call smoke for invalid explicit startup probe policy", exec.executed)
@@ -908,10 +1004,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableP
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected tool failure") {
 		t.Fatalf("expected unexpected callable probe error, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before callable probe failure", probe.calls)
 	}
 }
 
@@ -930,9 +1030,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonVal
 		},
 	}
 	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "execution path must be enabled before use") {
 		t.Fatalf("expected generic phrase non-validation probe error, got %v", err)
+	}
+	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
+		t.Fatalf("probe calls = %#v, want CLI startup proof before generic callable probe failure", probe.calls)
 	}
 }


### PR DESCRIPTION
Part of #997

## Summary
- Promotes `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup` for the narrowed #997 first slice.
- Derives a per-boot local MCP gateway token in `swarm serve` when `SWARM_TOOL_GATEWAY_TOKEN` is absent, while preserving explicit operator-provided tokens.
- Requires managed `cli_test` agents, including MCP-only agents, to pass the Claude CLI/container startup probe before MCP gateway visibility/call proof can satisfy startup validation.

## Governing Refs / Context
- Exact spec authority: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`.
- Binding issue/gate context: #997 repaired pre-audit and Gate E re-review approval.
- Adjacent split context: #993/#1010 agent-free boot stays closed; #996 Docker Compose stays split; #979/#1012 selected-contract/multi-bundle gateway materialization stays split; #997 still owns local `cli_test` image contents/default-agent Claude CLI availability residuals.

## Semantic Migration
- New canonical owner: `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`.
- Old non-authoritative paths now invalid for this narrowed class: env-only local `SWARM_TOOL_GATEWAY_TOKEN` as the only serve/run token source, and MCP `tools/list` / optional `tools/call` as sufficient startup proof for MCP-only managed `cli_test` agents.
- Production paths checked: `swarm serve` gateway env setup, local foreground `swarm run` serve-owner consumption, `RuntimeOptions.ToolGatewayToken`, runtime MCP gateway auth, `llm.ValidateClaudeCLIRuntimeConfig`, Claude CLI docker exec env, MCP HTTP binding, and #993 agent-free bypass.
- Migration completeness: complete for `runtime.local_cli_test.gateway_token_derivation_and_mcp_only_startup_probe`; not complete for full #997 or the local image/default-agent residuals.

## Tests
- `go test ./cmd/swarm -run 'TestConfigureServeMCPGatewayEnv|TestPlatformSpecLocalCLITestGatewayStartupPromoted|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API' -count=1`
- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents_(UsesRealFilteredTransport|RequiresCLIStartupProbeForMCPOnlySurface|FailsClosedWhenMCPOnlyCLIStartupProbeFails|UsesVisibilityOnlyWhenNoExplicitSafeStartupCallExists|DoesNotCallSchemaOnlyEmptyObjectTool|UsesVisibilityOnlyWhenVisibleToolsAreEmitOnly|UsesLiveVisibleSurfaceForNativeBuiltinOnlySurface)|TestRuntimeStart_AgentFreeCLITestDoesNotRequireClaudeStartupEnv|TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv' -count=1`
- `go test ./internal/runtime/llm -run 'TestValidateClaudeCLIRuntimeConfig|TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL|TestBuildMCPHTTPBinding' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime ./internal/runtime/llm -count=1`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
