### PR TITLE
[agent-a][issue #844] Serve listener source precedence

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -129,6 +129,17 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if opts.ShutdownGrace <= 0 {
 				return fmt.Errorf("--shutdown-grace must be a positive duration")
 			}
+			apiListenAddr, mcpListenAddr, err := resolveCLIServeListenerAddresses(cliServeListenerAddressOptions{
+				APIListenAddr:        opts.APIListenAddr,
+				MCPListenAddr:        opts.MCPListenAddr,
+				APIListenAddrFlagSet: cmd.Flags().Changed("api-listen-addr"),
+				MCPListenAddrFlagSet: cmd.Flags().Changed("mcp-listen-addr"),
+			})
+			if err != nil {
+				return err
+			}
+			opts.APIListenAddr = apiListenAddr
+			opts.MCPListenAddr = mcpListenAddr
 			if err := validateServeListenAddr("--api-listen-addr", opts.APIListenAddr); err != nil {
 				return err
 			}

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -22,6 +22,9 @@ const (
 	defaultCLIAPIServer = "http://127.0.0.1:8081"
 	cliAPIRPCPath       = "/v1/rpc"
 	cliAPIWSPath        = "/v1/ws"
+
+	cliServeAPIListenAddrEnv = "SWARM_API_LISTEN_ADDR"
+	cliServeMCPListenAddrEnv = "SWARM_MCP_LISTEN_ADDR"
 )
 
 type rootCommandOptions struct {
@@ -80,10 +83,12 @@ type cliAPISettings struct {
 }
 
 type cliAPIConfigFile struct {
-	APIServer        string `yaml:"api_server"`
-	APITokenFile     string `yaml:"api_token_file"`
-	ContractsPath    string `yaml:"contracts_path"`
-	PlatformSpecPath string `yaml:"platform_spec_path"`
+	APIServer          string `yaml:"api_server"`
+	APITokenFile       string `yaml:"api_token_file"`
+	ContractsPath      string `yaml:"contracts_path"`
+	PlatformSpecPath   string `yaml:"platform_spec_path"`
+	ServeAPIListenAddr string `yaml:"serve_api_listen_addr"`
+	ServeMCPListenAddr string `yaml:"serve_mcp_listen_addr"`
 }
 
 type cliAPIValidationError struct {
@@ -153,6 +158,37 @@ func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile) (string, 
 	return "", errCLIAPITokenRequired
 }
 
+type cliServeListenerAddressOptions struct {
+	APIListenAddr        string
+	MCPListenAddr        string
+	APIListenAddrFlagSet bool
+	MCPListenAddrFlagSet bool
+}
+
+func resolveCLIServeListenerAddresses(opts cliServeListenerAddressOptions) (string, string, error) {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return "", "", err
+	}
+	apiAddr := defaultAPIListenAddr
+	if opts.APIListenAddrFlagSet {
+		apiAddr = opts.APIListenAddr
+	} else if env := strings.TrimSpace(os.Getenv(cliServeAPIListenAddrEnv)); env != "" {
+		apiAddr = env
+	} else if config := strings.TrimSpace(cfg.ServeAPIListenAddr); config != "" {
+		apiAddr = config
+	}
+	mcpAddr := defaultMCPListenAddr
+	if opts.MCPListenAddrFlagSet {
+		mcpAddr = opts.MCPListenAddr
+	} else if env := strings.TrimSpace(os.Getenv(cliServeMCPListenAddrEnv)); env != "" {
+		mcpAddr = env
+	} else if config := strings.TrimSpace(cfg.ServeMCPListenAddr); config != "" {
+		mcpAddr = config
+	}
+	return apiAddr, mcpAddr, nil
+}
+
 func readCLIAPITokenFile(tokenFile, source string) (string, error) {
 	raw, err := os.ReadFile(tokenFile)
 	if err != nil {
@@ -205,7 +241,7 @@ func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, err
 	}
 	for key, value := range decoded {
 		switch key {
-		case "api_server", "api_token_file", "contracts_path", "platform_spec_path":
+		case "api_server", "api_token_file", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr":
 			if value == nil {
 				continue
 			}

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -166,27 +166,46 @@ type cliServeListenerAddressOptions struct {
 }
 
 func resolveCLIServeListenerAddresses(opts cliServeListenerAddressOptions) (string, string, error) {
+	apiAddr, apiResolved := resolveCLIServeListenerAddressHighPriority(
+		opts.APIListenAddr,
+		opts.APIListenAddrFlagSet,
+		cliServeAPIListenAddrEnv,
+	)
+	mcpAddr, mcpResolved := resolveCLIServeListenerAddressHighPriority(
+		opts.MCPListenAddr,
+		opts.MCPListenAddrFlagSet,
+		cliServeMCPListenAddrEnv,
+	)
+	if apiResolved && mcpResolved {
+		return apiAddr, mcpAddr, nil
+	}
 	cfg, err := loadCLIAPIConfigFile()
 	if err != nil {
 		return "", "", err
 	}
-	apiAddr := defaultAPIListenAddr
-	if opts.APIListenAddrFlagSet {
-		apiAddr = opts.APIListenAddr
-	} else if env := strings.TrimSpace(os.Getenv(cliServeAPIListenAddrEnv)); env != "" {
-		apiAddr = env
-	} else if config := strings.TrimSpace(cfg.ServeAPIListenAddr); config != "" {
-		apiAddr = config
+	if !apiResolved {
+		apiAddr = defaultAPIListenAddr
+		if config := strings.TrimSpace(cfg.ServeAPIListenAddr); config != "" {
+			apiAddr = config
+		}
 	}
-	mcpAddr := defaultMCPListenAddr
-	if opts.MCPListenAddrFlagSet {
-		mcpAddr = opts.MCPListenAddr
-	} else if env := strings.TrimSpace(os.Getenv(cliServeMCPListenAddrEnv)); env != "" {
-		mcpAddr = env
-	} else if config := strings.TrimSpace(cfg.ServeMCPListenAddr); config != "" {
-		mcpAddr = config
+	if !mcpResolved {
+		mcpAddr = defaultMCPListenAddr
+		if config := strings.TrimSpace(cfg.ServeMCPListenAddr); config != "" {
+			mcpAddr = config
+		}
 	}
 	return apiAddr, mcpAddr, nil
+}
+
+func resolveCLIServeListenerAddressHighPriority(flagValue string, flagSet bool, envName string) (string, bool) {
+	if flagSet {
+		return flagValue, true
+	}
+	if env := strings.TrimSpace(os.Getenv(envName)); env != "" {
+		return env, true
+	}
+	return "", false
 }
 
 func readCLIAPITokenFile(tokenFile, source string) (string, error) {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -149,6 +149,28 @@ func TestCLIAPIResolverToleratesContractPathConfigKeys(t *testing.T) {
 	}
 }
 
+func TestCLIAPIResolverIgnoresServeListenerConfigKeys(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "config-token")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"api_server":            "http://127.0.0.1:4444",
+		"api_token_file":        tokenFile,
+		"serve_api_listen_addr": "not-a-listen-address",
+		"serve_mcp_listen_addr": "http://127.0.0.1:9002",
+	}))
+
+	client, err := newCLIAPIClient(rootCommandOptions{})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient: %v", err)
+	}
+	if client.endpoint != "http://127.0.0.1:4444/v1/rpc" {
+		t.Fatalf("endpoint = %q", client.endpoint)
+	}
+	if client.token != "config-token" {
+		t.Fatalf("token = %q", client.token)
+	}
+}
+
 func TestCLIAPISettingsFailClosed(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -572,6 +594,8 @@ func isolateCLIAPIConfigEnv(t *testing.T) {
 	t.Setenv("SWARM_API_SERVER", "")
 	t.Setenv("SWARM_API_TOKEN", "")
 	t.Setenv("SWARM_API_TOKEN_FILE", "")
+	t.Setenv("SWARM_API_LISTEN_ADDR", "")
+	t.Setenv("SWARM_MCP_LISTEN_ADDR", "")
 	t.Setenv("SWARM_CONTRACTS_PATH", "")
 	t.Setenv("SWARM_CONTRACTS_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -589,7 +613,7 @@ func writeCLIAPITokenFile(t *testing.T, token string) string {
 func writeCLIAPIConfigFile(t *testing.T, values map[string]string) string {
 	t.Helper()
 	var body strings.Builder
-	for _, key := range []string{"api_server", "api_token_file", "contracts_path", "platform_spec_path"} {
+	for _, key := range []string{"api_server", "api_token_file", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
 		if value, ok := values[key]; ok {
 			body.WriteString(key)
 			body.WriteString(": ")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -540,6 +540,97 @@ func TestCLI_ServeRuntimeConfigDoesNotFeedListenerConfig(t *testing.T) {
 	}
 }
 
+func TestCLI_ServeListenAddrHigherPrecedenceSourcesSkipCLIConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		setup     func(t *testing.T)
+		wantAPI   string
+		wantMCP   string
+		wantRan   bool
+		wantError string
+	}{
+		{
+			name: "both flags skip missing explicit cli config",
+			args: []string{"serve", "--api-listen-addr", "127.0.0.1:9401", "--mcp-listen-addr", "127.0.0.1:9402"},
+			setup: func(t *testing.T) {
+				t.Setenv("SWARM_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+				t.Setenv("SWARM_API_LISTEN_ADDR", "8081")
+				t.Setenv("SWARM_MCP_LISTEN_ADDR", "http://127.0.0.1:8082")
+			},
+			wantAPI: "127.0.0.1:9401",
+			wantMCP: "127.0.0.1:9402",
+			wantRan: true,
+		},
+		{
+			name: "both env vars skip malformed cli config",
+			args: []string{"serve"},
+			setup: func(t *testing.T) {
+				configPath := filepath.Join(t.TempDir(), "config.yaml")
+				if err := os.WriteFile(configPath, []byte("serve_api_listen_addr: [\n"), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+				t.Setenv("SWARM_CONFIG", configPath)
+				t.Setenv("SWARM_API_LISTEN_ADDR", "127.0.0.1:9501")
+				t.Setenv("SWARM_MCP_LISTEN_ADDR", "127.0.0.1:9502")
+			},
+			wantAPI: "127.0.0.1:9501",
+			wantMCP: "127.0.0.1:9502",
+			wantRan: true,
+		},
+		{
+			name: "partial env still loads cli config for unresolved listener",
+			args: []string{"serve"},
+			setup: func(t *testing.T) {
+				t.Setenv("SWARM_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+				t.Setenv("SWARM_API_LISTEN_ADDR", "127.0.0.1:9601")
+			},
+			wantError: "read SWARM_CONFIG",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			tc.setup(t)
+			var captured serveOptions
+			ran := false
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+				captured = serveOpts
+				ran = true
+				return 0
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if tc.wantError != "" {
+				if code != 2 {
+					t.Fatalf("serve code = %d, want 2\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+				}
+				if !strings.Contains(stderr.String(), tc.wantError) {
+					t.Fatalf("serve stderr missing %q:\n%s", tc.wantError, stderr.String())
+				}
+				if ran {
+					t.Fatal("serve runtime started after required CLI config load failed")
+				}
+				return
+			}
+			if code != 0 {
+				t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if ran != tc.wantRan {
+				t.Fatalf("runtime ran = %v, want %v", ran, tc.wantRan)
+			}
+			if captured.APIListenAddr != tc.wantAPI {
+				t.Fatalf("api listen addr = %q, want %q", captured.APIListenAddr, tc.wantAPI)
+			}
+			if captured.MCPListenAddr != tc.wantMCP {
+				t.Fatalf("mcp listen addr = %q, want %q", captured.MCPListenAddr, tc.wantMCP)
+			}
+		})
+	}
+}
+
 func TestCLI_ServeDevFlagComposesClosedServeOwners(t *testing.T) {
 	var captured serveOptions
 	opts := defaultRootCommandOptions()

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -335,6 +335,8 @@ func TestCLI_ServeRetiresHealthAddrAndValidatesListenAddresses(t *testing.T) {
 }
 
 func TestCLI_ServeListenAddrFlagsConsumeIndependentOwners(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+
 	var captured serveOptions
 	opts := defaultRootCommandOptions()
 	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
@@ -366,6 +368,175 @@ func TestCLI_ServeListenAddrFlagsConsumeIndependentOwners(t *testing.T) {
 	}
 	if captured.MCPListenAddr != "127.0.0.1:9002" {
 		t.Fatalf("mcp listen addr = %q, want override", captured.MCPListenAddr)
+	}
+}
+
+func TestCLI_ServeListenAddrSourcePrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		config  map[string]string
+		env     map[string]string
+		wantAPI string
+		wantMCP string
+	}{
+		{
+			name: "config beats defaults",
+			config: map[string]string{
+				"serve_api_listen_addr": "127.0.0.1:9101",
+				"serve_mcp_listen_addr": "127.0.0.1:9102",
+			},
+			wantAPI: "127.0.0.1:9101",
+			wantMCP: "127.0.0.1:9102",
+		},
+		{
+			name: "environment beats config",
+			config: map[string]string{
+				"serve_api_listen_addr": "127.0.0.1:9101",
+				"serve_mcp_listen_addr": "127.0.0.1:9102",
+			},
+			env: map[string]string{
+				"SWARM_API_LISTEN_ADDR": "0.0.0.0:9201",
+				"SWARM_MCP_LISTEN_ADDR": "0.0.0.0:9202",
+			},
+			wantAPI: "0.0.0.0:9201",
+			wantMCP: "0.0.0.0:9202",
+		},
+		{
+			name: "flag beats environment for that listener only",
+			args: []string{"--api-listen-addr", "127.0.0.1:9301"},
+			config: map[string]string{
+				"serve_api_listen_addr": "127.0.0.1:9101",
+				"serve_mcp_listen_addr": "127.0.0.1:9102",
+			},
+			env: map[string]string{
+				"SWARM_API_LISTEN_ADDR": "0.0.0.0:9201",
+				"SWARM_MCP_LISTEN_ADDR": "0.0.0.0:9202",
+			},
+			wantAPI: "127.0.0.1:9301",
+			wantMCP: "0.0.0.0:9202",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			if len(tc.config) > 0 {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, tc.config))
+			}
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+
+			var captured serveOptions
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+				captured = serveOpts
+				return 0
+			}
+
+			var stdout, stderr bytes.Buffer
+			args := append([]string{"serve"}, tc.args...)
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, opts)
+			if code != 0 {
+				t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.APIListenAddr != tc.wantAPI {
+				t.Fatalf("api listen addr = %q, want %q", captured.APIListenAddr, tc.wantAPI)
+			}
+			if captured.MCPListenAddr != tc.wantMCP {
+				t.Fatalf("mcp listen addr = %q, want %q", captured.MCPListenAddr, tc.wantMCP)
+			}
+		})
+	}
+}
+
+func TestCLI_ServeListenAddrEnvConfigValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T)
+		wantStderr string
+	}{
+		{
+			name: "invalid api environment address",
+			setup: func(t *testing.T) {
+				t.Setenv("SWARM_API_LISTEN_ADDR", "8081")
+			},
+			wantStderr: "--api-listen-addr must be a host:port listen address",
+		},
+		{
+			name: "invalid mcp config address",
+			setup: func(t *testing.T) {
+				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+					"serve_mcp_listen_addr": "http://127.0.0.1:8082",
+				}))
+			},
+			wantStderr: "--mcp-listen-addr must be a host:port listen address, not a URL",
+		},
+		{
+			name: "bare listener config key stays unsupported",
+			setup: func(t *testing.T) {
+				configPath := filepath.Join(t.TempDir(), "config.yaml")
+				if err := os.WriteFile(configPath, []byte("api_listen_addr: \"127.0.0.1:9101\"\n"), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+				t.Setenv("SWARM_CONFIG", configPath)
+			},
+			wantStderr: `unsupported CLI config key "api_listen_addr"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			tc.setup(t)
+			ran := false
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(context.Context, string, serveOptions) int {
+				ran = true
+				return 0
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve"}, &stdout, &stderr, opts)
+			if code != 2 {
+				t.Fatalf("serve code = %d, want 2\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("serve stderr missing %q:\n%s", tc.wantStderr, stderr.String())
+			}
+			if ran {
+				t.Fatal("serve runtime started after invalid listener source")
+			}
+		})
+	}
+}
+
+func TestCLI_ServeRuntimeConfigDoesNotFeedListenerConfig(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	runtimeConfig := filepath.Join(t.TempDir(), "runtime.yaml")
+	if err := os.WriteFile(runtimeConfig, []byte("serve_api_listen_addr: \"0.0.0.0:9999\"\nserve_mcp_listen_addr: \"0.0.0.0:9998\"\n"), 0o600); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
+
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--config", runtimeConfig}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.ConfigPath != runtimeConfig {
+		t.Fatalf("runtime config path = %q, want %q", captured.ConfigPath, runtimeConfig)
+	}
+	if captured.APIListenAddr != defaultAPIListenAddr {
+		t.Fatalf("api listen addr = %q, want default %q", captured.APIListenAddr, defaultAPIListenAddr)
+	}
+	if captured.MCPListenAddr != defaultMCPListenAddr {
+		t.Fatalf("mcp listen addr = %q, want default %q", captured.MCPListenAddr, defaultMCPListenAddr)
 	}
 }
 
@@ -548,7 +719,10 @@ func TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted(t *testing.T) {
 	if strings.TrimSpace(spec.RuntimeBindImplementedBy) != "#992" {
 		t.Fatalf("listener topology runtime_bind_implemented_by = %q, want #992", spec.RuntimeBindImplementedBy)
 	}
-	if strings.TrimSpace(spec.ImplementationStatus) != "runtime_bind_implemented_enable_disable_env_pending" {
+	if strings.TrimSpace(spec.EnvConfigPrecedenceImplementedBy) != "#844" {
+		t.Fatalf("listener topology env_config_precedence_implemented_by = %q, want #844", spec.EnvConfigPrecedenceImplementedBy)
+	}
+	if strings.TrimSpace(spec.ImplementationStatus) != "runtime_bind_and_env_config_precedence_implemented_enable_disable_pending" {
 		t.Fatalf("listener topology status = %q", spec.ImplementationStatus)
 	}
 	if spec.Listeners.API.BindFlag != "--api-listen-addr <host:port>" {
@@ -563,6 +737,26 @@ func TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted(t *testing.T) {
 	if spec.Defaults.MCPListenAddr != defaultMCPListenAddr || spec.Listeners.MCP.DefaultListenAddr != defaultMCPListenAddr {
 		t.Fatalf("mcp default = defaults:%q listener:%q want %q", spec.Defaults.MCPListenAddr, spec.Listeners.MCP.DefaultListenAddr, defaultMCPListenAddr)
 	}
+	wantSourceOrder := []string{"flag", "environment", "cli_config_file", "built_in_default"}
+	if len(spec.SourcePrecedence.SourceOrder) != len(wantSourceOrder) {
+		t.Fatalf("listener source order = %#v, want %#v", spec.SourcePrecedence.SourceOrder, wantSourceOrder)
+	}
+	for i, want := range wantSourceOrder {
+		if spec.SourcePrecedence.SourceOrder[i] != want {
+			t.Fatalf("listener source order[%d] = %q, want %q", i, spec.SourcePrecedence.SourceOrder[i], want)
+		}
+	}
+	if spec.SourcePrecedence.APIListenAddr.Environment != "SWARM_API_LISTEN_ADDR" || spec.SourcePrecedence.APIListenAddr.ConfigKey != "serve_api_listen_addr" {
+		t.Fatalf("api listener source precedence = %#v", spec.SourcePrecedence.APIListenAddr)
+	}
+	if spec.SourcePrecedence.MCPListenAddr.Environment != "SWARM_MCP_LISTEN_ADDR" || spec.SourcePrecedence.MCPListenAddr.ConfigKey != "serve_mcp_listen_addr" {
+		t.Fatalf("mcp listener source precedence = %#v", spec.SourcePrecedence.MCPListenAddr)
+	}
+	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT", "api_listen_addr", "mcp_listen_addr"} {
+		if strings.TrimSpace(spec.SourcePrecedence.RejectedSources[key]) == "" {
+			t.Fatalf("listener source precedence rejected source %q missing: %#v", key, spec.SourcePrecedence.RejectedSources)
+		}
+	}
 	for _, want := range []string{"/healthz", "/readyz", "/v1/rpc", "/v1/ws"} {
 		if !stringSliceContains(spec.Listeners.API.Routes, want) {
 			t.Fatalf("api routes missing %q: %#v", want, spec.Listeners.API.Routes)
@@ -573,7 +767,7 @@ func TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted(t *testing.T) {
 			t.Fatalf("mcp routes missing %q: %#v", want, spec.Listeners.MCP.Routes)
 		}
 	}
-	for _, want := range []string{"#992 implements", "`--health-addr` retirement", "`swarm run --mcp-port` remains fail-closed", "Environment/config precedence remains #844"} {
+	for _, want := range []string{"#992 implements", "`--health-addr` retirement", "`swarm run --mcp-port` remains fail-closed", "#844 implements `swarm serve` listener source precedence"} {
 		if !stringSliceContains(spec.ImplementationBoundaries, want) {
 			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
 		}
@@ -688,7 +882,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("cli config accepted key %q missing: %#v", key, spec.CLIConfigFile.AcceptedKeys)
 		}
 	}
-	for _, key := range []string{"api_token", "output_format", "no_color", "log_level", "retry", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
+	for _, key := range []string{"api_token", "output_format", "no_color", "log_level", "retry"} {
 		if strings.TrimSpace(spec.CLIConfigFile.RejectedKeys[key]) == "" {
 			t.Fatalf("cli config rejected key %q missing: %#v", key, spec.CLIConfigFile.RejectedKeys)
 		}
@@ -698,14 +892,19 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("cli config shared non-API key %q missing contract path owner: %#v", key, spec.CLIConfigFile.SharedNonAPIKeys)
 		}
 	}
+	for _, key := range []string{"serve_api_listen_addr", "serve_mcp_listen_addr"} {
+		if !strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys[key], "listener_topology_v2_1.source_precedence") {
+			t.Fatalf("cli config shared non-API key %q missing listener source owner: %#v", key, spec.CLIConfigFile.SharedNonAPIKeys)
+		}
+	}
 	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT"} {
 		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.RejectedPorts[key], "Not promoted") {
 			t.Fatalf("serve listener rejected port %q missing not-promoted rule:\n%s", key, spec.ServeListenerEnvConfigBoundary.RejectedPorts[key])
 		}
 	}
 	for _, key := range []string{"SWARM_API_LISTEN_ADDR", "SWARM_MCP_LISTEN_ADDR"} {
-		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.ReservedCandidates[key], "later #884/#750") {
-			t.Fatalf("serve listener reserved candidate %q missing split rule:\n%s", key, spec.ServeListenerEnvConfigBoundary.ReservedCandidates[key])
+		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.AcceptedListenerEnvironment[key], "listener_topology_v2_1") {
+			t.Fatalf("serve listener accepted env %q missing listener owner:\n%s", key, spec.ServeListenerEnvConfigBoundary.AcceptedListenerEnvironment[key])
 		}
 	}
 	for _, want := range []string{"#848", "#884/#750", "#743", "`--no-retry`"} {
@@ -4220,12 +4419,13 @@ type serveUnifiedListenerSpec struct {
 }
 
 type serveListenerTopologySpec struct {
-	PromotedBy               string `yaml:"promoted_by"`
-	RuntimeBindImplementedBy string `yaml:"runtime_bind_implemented_by"`
-	ImplementationStatus     string `yaml:"implementation_status"`
-	CanonicalOwner           string `yaml:"canonical_owner"`
-	Summary                  string `yaml:"summary"`
-	Listeners                struct {
+	PromotedBy                       string `yaml:"promoted_by"`
+	RuntimeBindImplementedBy         string `yaml:"runtime_bind_implemented_by"`
+	EnvConfigPrecedenceImplementedBy string `yaml:"env_config_precedence_implemented_by"`
+	ImplementationStatus             string `yaml:"implementation_status"`
+	CanonicalOwner                   string `yaml:"canonical_owner"`
+	Summary                          string `yaml:"summary"`
+	Listeners                        struct {
 		API struct {
 			BindFlag          string   `yaml:"bind_flag"`
 			DefaultListenAddr string   `yaml:"default_listen_addr"`
@@ -4241,6 +4441,22 @@ type serveListenerTopologySpec struct {
 		APIListenAddr string `yaml:"api_listen_addr"`
 		MCPListenAddr string `yaml:"mcp_listen_addr"`
 	} `yaml:"defaults"`
+	SourcePrecedence struct {
+		SourceOrder   []string `yaml:"source_order"`
+		APIListenAddr struct {
+			Flag           string `yaml:"flag"`
+			Environment    string `yaml:"environment"`
+			ConfigKey      string `yaml:"config_key"`
+			BuiltInDefault string `yaml:"built_in_default"`
+		} `yaml:"api_listen_addr"`
+		MCPListenAddr struct {
+			Flag           string `yaml:"flag"`
+			Environment    string `yaml:"environment"`
+			ConfigKey      string `yaml:"config_key"`
+			BuiltInDefault string `yaml:"built_in_default"`
+		} `yaml:"mcp_listen_addr"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+	} `yaml:"source_precedence"`
 	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
 }
 
@@ -4276,9 +4492,9 @@ type cliAPIConnectionAuthConfigSpec struct {
 		RejectedKeys     map[string]string `yaml:"rejected_keys"`
 	} `yaml:"cli_config_file"`
 	ServeListenerEnvConfigBoundary struct {
-		RejectedPorts      map[string]string `yaml:"rejected_ports"`
-		ReservedCandidates map[string]string `yaml:"reserved_candidates"`
-		Rule               string            `yaml:"rule"`
+		RejectedPorts               map[string]string `yaml:"rejected_ports"`
+		AcceptedListenerEnvironment map[string]string `yaml:"accepted_listener_environment"`
+		Rule                        string            `yaml:"rule"`
 	} `yaml:"serve_listener_env_config_boundary"`
 	SplitSiblings            []string `yaml:"split_siblings"`
 	ImplementationBoundaries []string `yaml:"implementation_boundaries"`

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5933,9 +5933,10 @@ cli_specification:
           API connection/auth/config authority is promoted in
           cli_specification.foundations.api_connection_auth_config_precedence. Diagnostic logging authority is
           promoted in cli_specification.foundations.cli_logging_policy. Contract/platform-spec path resolution is
-          promoted in cli_specification.foundations.contract_platform_spec_path_resolution. Retry, output-renderer
-          implementation tails, and serve listener environment/config behavior remain split until later children
-          promote their own merge-bearing owners.
+          promoted in cli_specification.foundations.contract_platform_spec_path_resolution. Serve listener
+          environment/config precedence is promoted and implemented under
+          cli_specification.command_catalog.serve.listener_topology_v2_1. Retry and output-renderer implementation
+          tails remain split until later children promote their own merge-bearing owners.
       exit_code_and_error_channel_normalization:
         disposition: promoted_first_slice
         tracker: '#846'
@@ -5976,8 +5977,9 @@ cli_specification:
           cli_specification.command_catalog.serve.listener_topology_v2_1. The final contract uses separate API
           and MCP listen-address socket owners, superseding the CLI UX v2 draft's port-only serve flags and the
           historical `--health-addr` implementation name. #992 consumes this owner for Cobra/runtime listener bind
-          wiring and `swarm run --api-port` as an API listener consumer. OpenRPC remains unchanged; #844 env/config
-          precedence, enable-disable controls, and `swarm run --mcp-port` support remain follow-up work.
+          wiring and `swarm run --api-port` as an API listener consumer. #844 consumes this owner for `swarm
+          serve` listener env/config precedence. OpenRPC remains unchanged; enable-disable controls and `swarm
+          run --mcp-port` support remain follow-up work.
       trace_filters_and_subscription_recovery:
         disposition: promoted_first_slice
         tracker: '#855'
@@ -6708,6 +6710,14 @@ cli_specification:
             Accepted by the shared CLI config parser for
             cli_specification.foundations.contract_platform_spec_path_resolution; ignored by the API connection
             and auth resolver.
+          serve_api_listen_addr: >
+            Accepted by the shared CLI config parser for
+            cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence; ignored by the API
+            connection and auth resolver.
+          serve_mcp_listen_addr: >
+            Accepted by the shared CLI config parser for
+            cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence; ignored by the API
+            connection and auth resolver.
         rejected_keys:
           api_token: Inline bearer tokens in config files are not promoted.
           output_format: Split to #848 output renderer implementation.
@@ -6719,24 +6729,22 @@ cli_specification:
             cli_specification.foundations.cli_logging_policy, but config-file `log_level` precedence remains a
             later #844 child.
           retry: Split to retry policy work.
-          serve_api_listen_addr: Split to #884/#750 serve listener implementation.
-          serve_mcp_listen_addr: Split to #884/#750 serve listener implementation.
       serve_listener_env_config_boundary:
         rejected_ports:
           SWARM_API_PORT: 'Not promoted; final v2.1 listener topology uses full listen addresses.'
           SWARM_MCP_PORT: 'Not promoted; final v2.1 listener topology uses full listen addresses.'
-        reserved_candidates:
-          SWARM_API_LISTEN_ADDR: 'Candidate environment name for a later #884/#750 listener implementation child; not accepted by this first-slice API client resolver.'
-          SWARM_MCP_LISTEN_ADDR: 'Candidate environment name for a later #884/#750 listener implementation child; not accepted by this first-slice API client resolver.'
+        accepted_listener_environment:
+          SWARM_API_LISTEN_ADDR: 'Accepted by `swarm serve` API listener source precedence in listener_topology_v2_1; ignored by the API client resolver.'
+          SWARM_MCP_LISTEN_ADDR: 'Accepted by `swarm serve` MCP listener source precedence in listener_topology_v2_1; ignored by the API client resolver.'
         rule: >
           API client connection settings and serve listener bind settings are different concepts. This owner
-          governs where CLI clients connect; listener bind flags/env/config remain under the serve topology owner
-          until a later child promotes and implements them.
+          governs where CLI clients connect; the shared config parser accepts listener keys for the serve topology
+          owner, but the API connection/auth resolver MUST ignore listener env/config keys.
       split_siblings:
       - '#848 output modes/shared renderer; spec promoted, implementation pending'
       - '#846 error-channel and exit-code classification; closed first slice'
       - '#844 later behavior child for API config/auth resolver implementation'
-      - '#884/#750 serve listener runtime implementation and listener env/config keys'
+      - '#884/#750 serve listener enable-disable controls and runtime topology siblings'
       - '#743 swarm run behavior and follow semantics'
       - '`--no-retry` retry policy'
       implementation_boundaries:
@@ -6963,19 +6971,21 @@ cli_specification:
         - --log-level
         sibling_boundaries: >
           Output modes remain governed by `cli_specification.foundations.output_contract`; universal config/env
-          precedence remains #844; `swarm run` foreground/follow behavior remains #743; explicit split API/MCP
-          listener implementation remains split under #884/#750/#794/#735 until follow-up children consume the
-          final v2.1 listener_topology_v2_1 owner.
+          precedence remains #844; `swarm run` foreground/follow behavior remains #743; final split API/MCP
+          listener runtime binding is consumed by `listener_topology_v2_1`, while enable-disable controls remain
+          future work outside this historical unified-listener evidence row.
       listener_topology_v2_1:
         promoted_by: '#884'
         runtime_bind_implemented_by: '#992'
-        implementation_status: runtime_bind_implemented_enable_disable_env_pending
+        env_config_precedence_implemented_by: '#844'
+        implementation_status: runtime_bind_and_env_config_precedence_implemented_enable_disable_pending
         canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1
         summary: >
           Final CLI v2.1 `swarm serve` topology uses two independently configurable HTTP listeners: one API
-          listener and one MCP listener. This is the merge-bearing final topology decision. Runtime binding now
-          consumes `--api-listen-addr <host:port>` and `--mcp-listen-addr <host:port>`; historical `--health-addr`
-          remains migration evidence only.
+          listener and one MCP listener. This is the merge-bearing final topology decision. Runtime binding and
+          listener source precedence now consume `--api-listen-addr <host:port>`, `--mcp-listen-addr <host:port>`,
+          `SWARM_API_LISTEN_ADDR`, `SWARM_MCP_LISTEN_ADDR`, `serve_api_listen_addr`, and
+          `serve_mcp_listen_addr`; historical `--health-addr` remains migration evidence only.
         listeners:
           api:
             enabled_by_default: true
@@ -7024,6 +7034,46 @@ cli_specification:
           rationale: >
             Loopback defaults prevent accidental public exposure. Operators must explicitly bind to `0.0.0.0`
             or another routable interface for remote access.
+        source_precedence:
+          applies_to:
+          - '`swarm serve` API listener bind address.'
+          - '`swarm serve` MCP listener bind address.'
+          not_applies_to:
+          - '`swarm run` local foreground listener startup.'
+          - API client connection/auth configuration such as `--api-server`, `SWARM_API_SERVER`, and `api_server`.
+          - '`swarm serve --config`, which remains command-local runtime configuration.'
+          source_order:
+          - flag
+          - environment
+          - cli_config_file
+          - built_in_default
+          api_listen_addr:
+            flag: --api-listen-addr <host:port>
+            environment: SWARM_API_LISTEN_ADDR
+            config_key: serve_api_listen_addr
+            built_in_default: 127.0.0.1:8081
+          mcp_listen_addr:
+            flag: --mcp-listen-addr <host:port>
+            environment: SWARM_MCP_LISTEN_ADDR
+            config_key: serve_mcp_listen_addr
+            built_in_default: 127.0.0.1:8082
+          cli_config_file:
+            accepted_sources:
+            - SWARM_CONFIG
+            - '${XDG_CONFIG_HOME:-$HOME/.config}/swarm/config.yaml'
+            rejected_sources:
+            - '`swarm serve --config` runtime-config path'
+          independence_rule: >
+            API and MCP source resolution is per-listener. A source for one listener MUST NOT infer, mutate,
+            or default the other listener.
+          validation_rule: >
+            Values from flags, environment, and CLI config MUST use the host:port address_format above and
+            fail before runtime startup if invalid.
+          rejected_sources:
+            SWARM_API_PORT: 'Not promoted; port-only configuration cannot express bind interface/IP.'
+            SWARM_MCP_PORT: 'Not promoted; port-only configuration cannot express bind interface/IP.'
+            api_listen_addr: 'Not promoted as a CLI config key; use serve_api_listen_addr.'
+            mcp_listen_addr: 'Not promoted as a CLI config key; use serve_mcp_listen_addr.'
         interaction_rules:
           independent_bind_addresses: >
             API and MCP listener addresses are independent. Supplying one listener address never mutates or
@@ -7096,9 +7146,9 @@ cli_specification:
         implementation_boundaries:
         - '#884 promoted the source-of-truth repair only.'
         - '#992 implements Cobra/runtime binding for `--api-listen-addr` and `--mcp-listen-addr`, route partitioning, listener address validation, listener bind failure exit 3 before readiness, `--health-addr` retirement, MCP gateway URL alignment, and `swarm run --api-port` as an API listener consumer.'
+        - '#844 implements `swarm serve` listener source precedence for `SWARM_API_LISTEN_ADDR`, `SWARM_MCP_LISTEN_ADDR`, `serve_api_listen_addr`, and `serve_mcp_listen_addr`.'
         - '`swarm run --mcp-port` remains fail-closed until a later child explicitly promotes local foreground MCP listener control.'
         - 'API/MCP enable-disable implementation may be a later child if not absorbed with listener implementation.'
-        - 'Environment/config precedence remains #844.'
         - '`--log-level` is governed by cli_specification.foundations.cli_logging_policy, not listener topology.'
       boot_observability:
         implemented_by: '#802'
@@ -8432,8 +8482,9 @@ cli_specification:
         #884 promotes final CLI v2.1 separate API/MCP listen-address topology as source-of-truth repair only. #992
         implements the runtime bind slice for `swarm serve --api-listen-addr` and `--mcp-listen-addr`, route
         partitioning, listener bind failures, `--health-addr` retirement, MCP gateway URL alignment, and
-        `swarm run --api-port` as an API listener consumer. Remaining listener topology tail is API/MCP
-        enable-disable controls, #844 env/config precedence, and any future `swarm run` MCP listener consumer.
+        `swarm run --api-port` as an API listener consumer. #844 implements `swarm serve` listener env/config
+        precedence. Remaining listener topology tail is API/MCP enable-disable controls and any future `swarm run`
+        MCP listener consumer.
       remaining_tail: 'No promoted serve lifecycle tail remains after #830. `platform.shutdown` and persisted `interrupted_by_shutdown`
         remain unpromoted unless a later runtime lifecycle child makes them authoritative; not a direct blocker for #743 API owners.'
   parent_tail:


### PR DESCRIPTION
Part of #844.

## Summary

Implements the approved #844 first slice for `runtime.cli.v2.serve_listener_env_config_precedence` on `swarm serve`.

- Adds `SWARM_API_LISTEN_ADDR` and `SWARM_MCP_LISTEN_ADDR` as listener environment sources.
- Adds shared CLI config keys `serve_api_listen_addr` and `serve_mcp_listen_addr`.
- Applies source order `flag > environment > CLI config > built-in default` independently for API and MCP listeners.
- Keeps `SWARM_API_PORT`, `SWARM_MCP_PORT`, bare `api_listen_addr`/`mcp_listen_addr`, `serve --config`, local `swarm run`, API client config, output/logging/retry, and enable-disable controls out of scope.

## Governing refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file`
- #844 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/844#issuecomment-4530862057
- #844 independent gate: https://github.com/yazzaoui/Swarm/issues/844#issuecomment-4530896796

## Semantic migration

- New canonical owner: `listener_topology_v2_1.source_precedence` for `swarm serve` API/MCP listener address sources.
- Old invalid/non-authoritative paths: candidate env names routed to #884/#750, rejected `serve_*_listen_addr` config keys, port-only listener env names, and `serve --config` as a CLI config source.
- Production paths checked: `swarm serve` Cobra PreRun, shared CLI config parser, API client resolver, contract/platform-spec path resolver boundary, local `swarm run` split boundary.
- Migration status: complete for the approved `swarm serve` listener env/config precedence child; #844 umbrella may still need tracker closeout decision.

## Proof

- `go test ./cmd/swarm -run 'TestCLI_ServeListenAddr(SourcePrecedence|EnvConfigValidation|FlagsConsumeIndependentOwners|RuntimeConfigDoesNotFeedListenerConfig)|TestCLIAPIResolverIgnoresServeListenerConfigKeys|TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted|TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- Static no-bypass grep for listener env/config names in production `cmd/swarm`.
- Static stale-spec grep for old #884/#750 listener env/config candidate routing.
