### PR TITLE
[agent-c][issue #447] Fail closed gate schema validation

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -136,6 +136,10 @@ active_issues:
     title: Align runtime enforcement with primitive-only cross-flow model
     maps_to:
       - primitive_only_cross_flow_runtime_migration
+  - id: 447
+    title: Extract bootverify gate-schema validation check
+    maps_to:
+      - boot_check_definition_drift
   - id: 448
     title: Reconcile payload_field_coverage ownership across bootverify and catalog harness
     maps_to:
@@ -203,8 +207,10 @@ nodes:
       - one check id reused for event-payload source-field coverage and entity write-target compliance
       - catalog or legacy verifier surfaces interpreting a boot check id independently from Go bootverify
       - reference docs and fixture prose preserving stale check meanings after the supported surface moved
+      - gate schema validation treats missing or empty gate_state as an open schema for handler-level sets_gate
       - condition payload-reference validation treats existing empty event payload schemas as open schemas
     representative_issues:
+      - 447
       - 448
       - 974
     common_framing_mistakes:

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -291,7 +291,6 @@ func checkAgentPermissionValidation(c *checkerContext) []Finding {
 	return uniqueFindings(append(c.permissions(), c.permissionWarnings()...))
 }
 func checkPlatformMetadataValidation(c *checkerContext) []Finding  { return c.platformMetadata() }
-func checkGateSchemaValidation(c *checkerContext) []Finding        { return c.gateSchemaValidation() }
 func checkDeprecatedContractAlias(c *checkerContext) []Finding     { return c.deprecatedAliases() }
 func checkPromptSchemaGuardStructural(c *checkerContext) []Finding { return c.promptSchemaGuard() }
 func checkCrossSurfaceNamedTypeUse(c *checkerContext) []Finding {
@@ -384,34 +383,6 @@ func (c *checkerContext) platformMetadata() []Finding {
 		})
 	}
 	return c.platformMetaFindings
-}
-
-func (c *checkerContext) gateSchemaValidation() []Finding {
-	if c.gateSchemaLoaded {
-		return c.gateSchemaFindings
-	}
-	c.gateSchemaLoaded = true
-	nodes := c.source.NodeEntries()
-	for _, transition := range c.source.DerivedHandlerTransitions() {
-		if gate := gateNameLocal(transition.SetsGate); gate != "" {
-			node, ok := nodes[strings.TrimSpace(transition.NodeID)]
-			if !ok {
-				continue
-			}
-			validGates := stateSchemaGateNamesLocal(node.GateState)
-			if len(validGates) > 0 {
-				if _, ok := validGates[gate]; !ok {
-					c.gateSchemaFindings = append(c.gateSchemaFindings, Finding{
-						CheckID:  "gate_schema_validation",
-						Severity: "error",
-						Message:  fmt.Sprintf("handler transition %s sets_gate %s not recognized in node %s gate_state schema", transition.ID, gate, transition.NodeID),
-						Location: strings.TrimSpace(transition.ID),
-					})
-				}
-			}
-		}
-	}
-	return c.gateSchemaFindings
 }
 
 func platformVersionAtLeast(raw string, major, minor, patch int) bool {
@@ -2150,16 +2121,6 @@ func handlerPatternMatchesLocal(pattern, eventType string) bool {
 
 func routeMatchesLocal(pattern, eventType string) bool {
 	return eventidentity.MatchPattern(pattern, eventType)
-}
-
-func stateSchemaGateNamesLocal(schema runtimecontracts.NodeGateStateSchema) map[string]struct{} {
-	gates := map[string]struct{}{}
-	for _, f := range schema.Gates {
-		if strings.TrimSpace(f.Name) != "" {
-			gates[strings.TrimSpace(f.Name)] = struct{}{}
-		}
-	}
-	return gates
 }
 
 func stringValueLocal(v any) string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1238,6 +1238,75 @@ func TestRun_MapsConditionPayloadMismatchToNamedError(t *testing.T) {
 	}
 }
 
+func TestRun_MapsUnknownSetsGateToGateSchemaValidationError(t *testing.T) {
+	bundle := gateSchemaValidationBundle(runtimecontracts.NodeGateStateSchema{
+		Gates: []runtimecontracts.NodeGateField{{Name: "approved"}},
+	}, runtimecontracts.SystemNodeEventHandler{
+		SetsGate: &runtimecontracts.GateSpec{Name: "rejected", Value: true},
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "gate_schema_validation", "sets_gate rejected") {
+		t.Fatalf("expected gate_schema_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_MapsMissingOrEmptyGateStateToGateSchemaValidationError(t *testing.T) {
+	cases := []struct {
+		name      string
+		gateState runtimecontracts.NodeGateStateSchema
+	}{
+		{name: "missing gate_state"},
+		{name: "empty gate_state", gateState: runtimecontracts.NodeGateStateSchema{Gates: []runtimecontracts.NodeGateField{}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := gateSchemaValidationBundle(tc.gateState, runtimecontracts.SystemNodeEventHandler{
+				SetsGate: &runtimecontracts.GateSpec{Name: "approved", Value: true},
+			})
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "gate_schema_validation", "sets_gate approved") {
+				t.Fatalf("expected gate_schema_validation error, got %#v", report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_AllowsDeclaredSetsGateFromScalarAndStructuredForms(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "scalar",
+			yaml: "sets_gate: approved\n",
+		},
+		{
+			name: "structured",
+			yaml: "sets_gate:\n  name: approved\n  value: true\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := decodeGateSchemaHandler(t, tc.yaml)
+			bundle := gateSchemaValidationBundle(runtimecontracts.NodeGateStateSchema{
+				Gates: []runtimecontracts.NodeGateField{{Name: "approved"}},
+			}, handler)
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Errors(), "gate_schema_validation", "sets_gate approved") {
+				t.Fatalf("unexpected gate_schema_validation error, got %#v", report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_MapsEmptyEventPayloadSchemaConditionRefsToNamedError(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -5264,6 +5333,48 @@ func defaultFixtureYAML(contents string) string {
 		return contents
 	}
 	return contents + "\n"
+}
+
+func gateSchemaValidationBundle(gateState runtimecontracts.NodeGateStateSchema, handler runtimecontracts.SystemNodeEventHandler) *runtimecontracts.WorkflowContractBundle {
+	const (
+		nodeID    = "validate-task"
+		eventType = "task.requested"
+	)
+	node := runtimecontracts.SystemNodeContract{
+		ID:            nodeID,
+		ExecutionType: "system_node",
+		SubscribesTo:  []string{eventType},
+		GateState:     gateState,
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			eventType: handler,
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			eventType: {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			nodeID: node,
+		},
+	}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	bundle.Semantics.HandlerTransitions = []runtimecontracts.HandlerTransitionSemantic{{
+		ID:        nodeID + ":" + eventType,
+		NodeID:    nodeID,
+		EventType: eventType,
+		SetsGate:  handler.SetsGate,
+	}}
+	return bundle
+}
+
+func decodeGateSchemaHandler(t *testing.T, raw string) runtimecontracts.SystemNodeEventHandler {
+	t.Helper()
+	var handler runtimecontracts.SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(raw), &handler); err != nil {
+		t.Fatalf("decode gate schema handler: %v", err)
+	}
+	return handler
 }
 
 func reportContains(items []Finding, checkID, contains string) bool {

--- a/internal/runtime/bootverify/workflow_gate_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_gate_schema_checks.go
@@ -1,0 +1,49 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func checkGateSchemaValidation(c *checkerContext) []Finding { return c.gateSchemaValidation() }
+
+func (c *checkerContext) gateSchemaValidation() []Finding {
+	if c.gateSchemaLoaded {
+		return c.gateSchemaFindings
+	}
+	c.gateSchemaLoaded = true
+	nodes := c.source.NodeEntries()
+	for _, transition := range c.source.DerivedHandlerTransitions() {
+		gate := gateNameLocal(transition.SetsGate)
+		if gate == "" {
+			continue
+		}
+		node, ok := nodes[strings.TrimSpace(transition.NodeID)]
+		if !ok {
+			continue
+		}
+		validGates := stateSchemaGateNamesLocal(node.GateState)
+		if _, ok := validGates[gate]; ok {
+			continue
+		}
+		c.gateSchemaFindings = append(c.gateSchemaFindings, Finding{
+			CheckID:  "gate_schema_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("handler transition %s sets_gate %s not recognized in node %s gate_state schema", transition.ID, gate, transition.NodeID),
+			Location: strings.TrimSpace(transition.ID),
+		})
+	}
+	return c.gateSchemaFindings
+}
+
+func stateSchemaGateNamesLocal(schema runtimecontracts.NodeGateStateSchema) map[string]struct{} {
+	gates := map[string]struct{}{}
+	for _, f := range schema.Gates {
+		if strings.TrimSpace(f.Name) != "" {
+			gates[strings.TrimSpace(f.Name)] = struct{}{}
+		}
+	}
+	return gates
+}

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
@@ -8,6 +8,8 @@ delivery-node:
     - timer.item.timeout
   produces:
     - item.completed
+  gate_state:
+    delivery_ready: gate set when delivery is ready
   timers:
     - id: item_timeout
       event: timer.item.timeout

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -9,6 +9,8 @@ intake-router:
   produces:
     - item.processed
     - item.review_requested
+  gate_state:
+    intake_ready: gate set when intake is ready
   event_handlers:
     item.created:
       guard:

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
@@ -9,6 +9,8 @@ processing-node:
   produces:
     - item.completed
     - item.rejected
+  gate_state:
+    score_ready: gate set when score is ready
   event_handlers:
     item.review_requested:
       guard:

--- a/tests/tier1-primitives/test-sets-gate/nodes.yaml
+++ b/tests/tier1-primitives/test-sets-gate/nodes.yaml
@@ -3,6 +3,8 @@ test-node:
   execution_type: system_node
   subscribes_to: [gate.requested]
   produces: [gate.set]
+  gate_state:
+    g1_check: gate set by the handler
   event_handlers:
     gate.requested:
       sets_gate: g1_check

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/nodes.yaml
@@ -4,6 +4,8 @@ validator:
     - validate.start
   produces:
     - validation.done
+  gate_state:
+    g_validated: gate set when validation completes
   event_handlers:
     validate.start:
       create_entity: true

--- a/tests/tier6-event-loop/test-atomicity-commit/nodes.yaml
+++ b/tests/tier6-event-loop/test-atomicity-commit/nodes.yaml
@@ -3,6 +3,8 @@ test-node:
   execution_type: system_node
   subscribes_to: [task.submitted]
   produces: [task.accepted]
+  gate_state:
+    approval_gate: gate set when task is accepted
   event_handlers:
     task.submitted:
       advances_to: done

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/nodes.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/nodes.yaml
@@ -3,6 +3,8 @@ processor:
   execution_type: system_node
   subscribes_to: [process.requested]
   produces: [process.done]
+  gate_state:
+    g_processed: gate set when processing succeeds
   event_handlers:
     process.requested:
       guard:

--- a/tests/tier6-event-loop/test-atomicity-rollback/nodes.yaml
+++ b/tests/tier6-event-loop/test-atomicity-rollback/nodes.yaml
@@ -3,6 +3,8 @@ test-node:
   execution_type: system_node
   subscribes_to: [task.submitted]
   produces: [task.accepted]
+  gate_state:
+    approval_gate: gate set when task is accepted
   event_handlers:
     task.submitted:
       guard:

--- a/tests/tier7-composition/test-full-lifecycle/nodes.yaml
+++ b/tests/tier7-composition/test-full-lifecycle/nodes.yaml
@@ -3,6 +3,8 @@ validation-node:
   execution_type: system_node
   subscribes_to: [order.submitted]
   produces: [order.validated]
+  gate_state:
+    validation_passed: gate set when validation succeeds
   event_handlers:
     order.submitted:
       guard:

--- a/tests/tier7-composition/test-multi-gate-pipeline/nodes.yaml
+++ b/tests/tier7-composition/test-multi-gate-pipeline/nodes.yaml
@@ -3,6 +3,8 @@ gate-setter-1:
   execution_type: system_node
   subscribes_to: [gate.g1_set]
   produces: [gate.set]
+  gate_state:
+    g1: first gate in the approval pipeline
   event_handlers:
     gate.g1_set:
       sets_gate: g1
@@ -15,6 +17,8 @@ gate-setter-2:
   execution_type: system_node
   subscribes_to: [gate.g2_set]
   produces: [gate.set]
+  gate_state:
+    g2: second gate in the approval pipeline
   event_handlers:
     gate.g2_set:
       sets_gate: g2
@@ -27,6 +31,8 @@ gate-setter-3:
   execution_type: system_node
   subscribes_to: [gate.g3_set]
   produces: [gate.set]
+  gate_state:
+    g3: third gate in the approval pipeline
   event_handlers:
     gate.g3_set:
       sets_gate: g3

--- a/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/nodes.yaml
@@ -3,6 +3,8 @@ reviewer:
   execution_type: system_node
   subscribes_to: [review.done, review.insufficient]
   produces: [review.approved, review.restarted]
+  gate_state:
+    g_reviewed: gate set when review is approved
   event_handlers:
     review.done:
       sets_gate: g_reviewed

--- a/tests/tier9-composition-patterns/test-compose-gate-chain-three/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-chain-three/nodes.yaml
@@ -3,6 +3,10 @@ pipeline:
   execution_type: system_node
   subscribes_to: [step.a_done, step.b_done, step.c_done]
   produces: [release.ready]
+  gate_state:
+    g_a: first gate in the release chain
+    g_b: second gate in the release chain
+    g_c: third gate in the release chain
   event_handlers:
     step.a_done:
       sets_gate: g_a

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/nodes.yaml
@@ -3,6 +3,9 @@ pipeline:
   execution_type: system_node
   subscribes_to: [stage.one_done, stage.two_done]
   produces: [stage.two_start, stage.complete]
+  gate_state:
+    g_stage_one: gate set when stage one completes
+    g_stage_two: gate set when stage two completes
   event_handlers:
     stage.one_done:
       sets_gate: g_stage_one


### PR DESCRIPTION
## Summary

- Extract `gate_schema_validation` into `internal/runtime/bootverify/workflow_gate_schema_checks.go` as the boundary-owned bootverify check module.
- Remove the old empty-schema bypass so handler-level `sets_gate` fails closed unless the gate is declared in the same node's `gate_state` schema.
- Add direct `Run(...)` proof for unknown gates, missing/empty `gate_state`, and declared scalar/structured `sets_gate` forms.
- Align existing catalog/testdata fixtures that intentionally set gates by declaring their authored `gate_state` names.
- Map #447 to the `boot_check_definition_drift` semantic watchlist node.

Closes #447

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `handler_fields.sets_gate`: handler-level `sets_gate` mutates `entity.gates.{name} = true`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `runtime_state.gate_state`: gate state is declared node state and mutated by `sets_gate`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `boot_verification.checks.gate_schema_validation`: handler `sets_gate` references must name gates declared in the node `gate_state` schema.
- #447 pre-audit and gate: approved as first slice for handler-level `sets_gate` / node `gate_state` fail-closed bootverify ownership only.

## Semantic migration notes

- New canonical owner: `internal/runtime/bootverify/workflow_gate_schema_checks.go` for Go bootverify `gate_schema_validation`.
- Old invalid path: inline `checks.go` gate validation with `len(validGates) > 0`, which treated missing/empty `gate_state` as an open schema.
- Production paths checked: bootverify registry `gate_schema_validation`, `Run(...)` reporting, affected catalog runtime fixtures, `cmd/swarm` verify package tests, and repo-wide authored YAML `sets_gate` fixture/testdata declarations.
- Migration completeness: complete for the approved handler-level bootverify class; rule-level `sets_gate`, catalog gate mutation, runtime gate execution, and `verify.py` gate-info remain outside this gate per #447.

## Validation

- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsUnknownSetsGateToGateSchemaValidationError|MapsMissingOrEmptyGateStateToGateSchemaValidationError|AllowsDeclaredSetsGateFromScalarAndStructuredForms)$|TestHandlerEntityFieldWriters_TracksSetsGateAndClearTargets' -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier(1Primitive|6EventLoop|7Composition|9CompositionPattern|11FlowComposition)CatalogFixtures_RealRuntime' -count=1`
- `go test ./internal/runtime/swarmflowtest -count=1`
- `go test ./cmd/swarm -run TestVerify -count=1`
- `go test ./...`
