### PR TITLE
[agent-e][issue #997] Gate cli_test workspace CLI startup diagnostics

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1052,6 +1052,61 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 	}
 }
 
+func TestPlatformSpecLocalCLITestWorkspaceCLIAvailabilityPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				LocalCLITestWorkspaceCLIAvailability struct {
+					PromotedBy           string   `yaml:"promoted_by"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					CanonicalOwner       string   `yaml:"canonical_owner"`
+					Scope                string   `yaml:"scope"`
+					WorkspaceCLIRule     string   `yaml:"workspace_cli_rule"`
+					Consumers            []string `yaml:"consumers"`
+					SplitTail            []string `yaml:"split_tail"`
+				} `yaml:"local_cli_test_workspace_cli_availability"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	availability := spec.CLISpecification.Foundations.LocalCLITestWorkspaceCLIAvailability
+	if strings.TrimSpace(availability.PromotedBy) != "#997" {
+		t.Fatalf("local cli_test workspace cli availability promoted_by = %q, want #997", availability.PromotedBy)
+	}
+	if strings.TrimSpace(availability.ImplementationStatus) != "implemented" {
+		t.Fatalf("local cli_test workspace cli availability implementation_status = %q, want implemented", availability.ImplementationStatus)
+	}
+	if !strings.Contains(availability.CanonicalOwner, "cli_specification.foundations.local_cli_test_workspace_cli_availability") {
+		t.Fatalf("canonical owner does not point at local_cli_test_workspace_cli_availability: %s", availability.CanonicalOwner)
+	}
+	for _, want := range []string{"remaining #997", "workspace image/default-agent Claude CLI availability", "local `swarm serve`", "local foreground `swarm run`"} {
+		if !strings.Contains(availability.Scope, want) {
+			t.Fatalf("local cli_test workspace cli availability scope missing %q:\n%s", want, availability.Scope)
+		}
+	}
+	for _, want := range []string{"startup validation MUST prove", "before readiness or event delivery", "Docker image inspection", "existing container reuse", "SWARM_WORKSPACE_IMAGE"} {
+		if !strings.Contains(availability.WorkspaceCLIRule, want) {
+			t.Fatalf("workspace cli rule missing %q:\n%s", want, availability.WorkspaceCLIRule)
+		}
+	}
+	for _, want := range []string{"local `swarm serve`", "local foreground `swarm run`", "managed-agent startup validation", "Claude CLI startup probe", "configured workspace image/container targets"} {
+		if !stringSliceContains(availability.Consumers, want) {
+			t.Fatalf("local cli_test workspace cli availability consumers missing %q: %#v", want, availability.Consumers)
+		}
+	}
+	for _, want := range []string{"#996 Docker Compose", "#995 schema migration", "#979/#1012", "#1002 runtime workspace source-root image packaging is closed"} {
+		if !stringSliceContains(availability.SplitTail, want) {
+			t.Fatalf("local cli_test workspace cli availability split_tail missing %q: %#v", want, availability.SplitTail)
+		}
+	}
+}
+
 func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
 	spec := loadCLIContractPlatformSpecPathResolutionSpec(t)
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6213,10 +6213,45 @@ cli_specification:
         still additionally compare the provider-visible native tool list. Agent-free `cli_test`
         boot remains governed by #993 and MUST NOT require LLM/gateway startup credentials.
       split_tail:
-      - '#997 local cli_test workspace image contents/default-agent Claude CLI availability remains open.'
+      - '#997 local cli_test workspace image contents/default-agent Claude CLI availability is closed by cli_specification.foundations.local_cli_test_workspace_cli_availability.'
       - '#996 Docker Compose setup remains split.'
       - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not an open tail.'
+    local_cli_test_workspace_cli_availability:
+      promoted_by: '#997'
+      implementation_status: implemented
+      canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_workspace_cli_availability
+      scope: >
+        Merge-bearing CLI/runtime authority for the remaining #997 local `cli_test`
+        workspace image/default-agent Claude CLI availability and early actionable
+        startup diagnostics class. This owner applies to agent-present local
+        `swarm serve` and local foreground `swarm run` flows that consume the serve
+        startup owner. It does not reopen #1002 source-root workspace image
+        packaging, #996 Docker Compose setup, #995 schema migration diagnostics,
+        API conformance, selected-contract/multi-bundle work, or public quickstart
+        docs polish.
+      workspace_cli_rule: >
+        For agent-present `cli_test` managed agents, startup validation MUST prove
+        the resolved workspace container can execute the configured Claude CLI
+        command before readiness or event delivery. Successful Docker image
+        inspection and existing container reuse are not sufficient proof of this
+        capability. Missing, stale, or incompatible workspace image/container
+        failures MUST fail closed with an actionable startup diagnostic naming the
+        configured Claude CLI command, the resolved container, the configured
+        workspace image, and remediation to build or pull an image containing the
+        Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE
+        to a compatible image.
+      consumers:
+      - 'local `swarm serve` runtime startup for agent-present `cli_test` bundles'
+      - 'local foreground `swarm run` that consumes the serve startup owner'
+      - '`internal/runtime/runtime_claude_startup.go` managed-agent startup validation'
+      - '`internal/runtime/llm` Claude CLI startup probe and per-turn fallback diagnostics'
+      - '`internal/runtime/workspace` configured workspace image/container targets'
+      split_tail:
+      - '#996 Docker Compose setup remains split.'
+      - '#995 schema migration startup diagnostics remain split.'
+      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not reopened.'
     no_args_behavior: '`swarm` with no arguments prints root help and exits 0. Bare `swarm` MUST NOT start the runtime.'
     daemon_startup: '`swarm serve` owns runtime/API/health/MCP startup. `swarm run` may consume the serve startup owner for local foreground start, but MUST NOT fork a second runtime boot owner.'
     cli_consumes_api_rule: 'All CLI commands that read or mutate runtime state consume the canonical API at /v1/rpc or /v1/ws. The only local file-contract carve-out is `swarm verify`, which validates contract files on disk and does not require runtime DB/API state.'

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -31,6 +31,7 @@ type ClaudeCLIRuntime struct {
 
 var ErrClaudeAuthRequired = errors.New("claude auth required")
 var ErrClaudeWorkspaceRequired = errors.New("claude workspace target required")
+var ErrClaudeWorkspaceCLIUnavailable = errors.New("claude workspace cli unavailable")
 
 type promptTransportFallback struct {
 	Attempted bool

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -36,7 +36,7 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 
 	cmd := r.buildCommand(runCtx, args, target)
 	if configuredCLIOutputFormat(r.cfg) == "stream-json" {
-		return r.runStreaming(runCtx, cmd, timeout, input, meta)
+		return r.runStreaming(runCtx, cmd, target, timeout, input, meta)
 	}
 
 	var stdout bytes.Buffer
@@ -74,6 +74,9 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 		if errOut == "" {
 			errOut = summarizeCLIErrorOutput(stdoutText)
 		}
+		if diag := workspaceCLIDiagnosticError(r.cfg, target, coalesce(errOut, stderrText, stdoutText)); diag != nil {
+			return nil, diag
+		}
 		if errOut == "" {
 			return nil, fmt.Errorf("claude cli run failed: %w", err)
 		}
@@ -86,7 +89,7 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 	return resp, nil
 }
 
-func (r *ClaudeCLIRuntime) runStreaming(ctx context.Context, cmd *exec.Cmd, timeout time.Duration, input string, meta MonitorTurnMeta) (*Response, error) {
+func (r *ClaudeCLIRuntime) runStreaming(ctx context.Context, cmd *exec.Cmd, target *workspace.Target, timeout time.Duration, input string, meta MonitorTurnMeta) (*Response, error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("create claude stdout pipe: %w", err)
@@ -148,6 +151,9 @@ func (r *ClaudeCLIRuntime) runStreaming(ctx context.Context, cmd *exec.Cmd, time
 		errOut := summarizeCLIErrorOutput(stderrText)
 		if errOut == "" {
 			errOut = summarizeCLIErrorOutput(stdoutText)
+		}
+		if diag := workspaceCLIDiagnosticError(r.cfg, target, coalesce(errOut, stderrText, stdoutText)); diag != nil {
+			return nil, diag
 		}
 		if errOut == "" {
 			return nil, fmt.Errorf("claude cli run failed: %w", waitErr)

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -3,6 +3,8 @@ package llm
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -81,6 +83,60 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 	}
 	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=gateway-token") {
 		t.Fatalf("docker args = %q, want MCP gateway token propagated into cli_test container exec", got)
+	}
+}
+
+func TestClaudeCLIRuntimeRunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
+	script := `#!/bin/sh
+set -eu
+cat >/dev/null
+printf '%s\n' 'OCI runtime exec failed: exec failed: unable to start container process: exec: "claude": executable file not found in $PATH: unknown' >&2
+exit 127
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker script: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+
+	cfg := &config.Config{}
+	cfg.LLM.ClaudeCLI.Command = "claude"
+	cfg.LLM.ClaudeCLI.OutputFormat = "json"
+	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+
+	_, err := runtime.runWithInput(context.Background(), nil, &workspace.Target{Container: "swarm-agent-market-research", Workdir: "/workspace"}, "hello", MonitorTurnMeta{})
+	if !errors.Is(err, ErrClaudeWorkspaceCLIUnavailable) {
+		t.Fatalf("runWithInput error = %v, want ErrClaudeWorkspaceCLIUnavailable", err)
+	}
+	for _, want := range []string{
+		"local cli_test workspace cannot execute configured Claude CLI command",
+		`"swarm-agent-market-research"`,
+		`"swarm-workspace:test"`,
+		"build or pull a workspace image",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("runWithInput error missing %q:\n%v", want, err)
+		}
+	}
+}
+
+func TestWorkspaceCLIDiagnosticError_MatchesAbsolutePathNoSuchFile(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:absolute")
+	cfg := &config.Config{}
+	cfg.LLM.ClaudeCLI.Command = "/usr/local/bin/claude"
+
+	err := workspaceCLIDiagnosticError(cfg, &workspace.Target{Container: "swarm-agent-market-research"}, `OCI runtime exec failed: exec failed: unable to start container process: exec: "/usr/local/bin/claude": stat /usr/local/bin/claude: no such file or directory: unknown`)
+	if !errors.Is(err, ErrClaudeWorkspaceCLIUnavailable) {
+		t.Fatalf("workspaceCLIDiagnosticError error = %v, want ErrClaudeWorkspaceCLIUnavailable", err)
+	}
+	for _, want := range []string{`"/usr/local/bin/claude"`, `"swarm-agent-market-research"`, `"swarm-workspace:absolute"`, "set SWARM_WORKSPACE_IMAGE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("workspaceCLIDiagnosticError error missing %q:\n%v", want, err)
+		}
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_startup_probe.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe.go
@@ -173,6 +173,9 @@ func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []st
 			if errOut == "" {
 				errOut = summarizeCLIErrorOutput(stdoutText)
 			}
+			if diag := workspaceCLIDiagnosticError(r.cfg, target, coalesce(errOut, stderrText, stdoutText)); diag != nil {
+				return nil, fmt.Errorf("claude cli startup probe failed: %w", diag)
+			}
 			if errOut != "" {
 				return nil, fmt.Errorf("claude cli startup probe failed: %w, stderr=%s", waitErr, errOut)
 			}
@@ -190,6 +193,9 @@ func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []st
 	}
 	if waitErr != nil {
 		errOut := summarizeCLIErrorOutput(stderrText)
+		if diag := workspaceCLIDiagnosticError(r.cfg, target, coalesce(errOut, stderrText)); diag != nil {
+			return nil, fmt.Errorf("claude cli startup probe failed: %w", diag)
+		}
 		if errOut == "" {
 			return nil, fmt.Errorf("claude cli startup probe failed: %w", waitErr)
 		}

--- a/internal/runtime/llm/cli_runtime_startup_probe_test.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe_test.go
@@ -2,10 +2,12 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,5 +172,65 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-startup-
 	sessionID := string(sessionIDBytes)
 	if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`).MatchString(sessionID) {
 		t.Fatalf("captured session id = %q, want UUID", sessionID)
+	}
+}
+
+func TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_MissingWorkspaceCLIIsActionable(t *testing.T) {
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
+	script := `#!/bin/sh
+set -eu
+cat >/dev/null
+printf '%s\n' 'OCI runtime exec failed: exec failed: unable to start container process: exec: "claude": executable file not found in $PATH: unknown' >&2
+exit 127
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker script: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+
+	cfg := &config.Config{}
+	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
+	cfg.LLM.ClaudeCLI.Command = "claude"
+
+	runtime := NewClaudeCLIRuntimeWithOptions(
+		cfg,
+		sessions.NewInMemoryRegistry(0),
+		"worker-1",
+		nil,
+		nil,
+		workspaceResolverStub{target: &workspace.Target{Container: "swarm-agent-market-research", Workdir: "/workspace"}},
+		nil,
+		nil,
+		ClaudeCLIRuntimeOptions{
+			MCPTurnContextStore: mcpTurnContextStoreStub{
+				register:   func(context.Context, time.Duration, []string) string { return "ctx-token-missing-cli" },
+				unregister: func(string) {},
+			},
+		},
+	)
+
+	actor := runtimeactors.AgentConfig{ID: "market-research-agent"}
+	_, err := runtime.ProbeStartupVisibleToolSurface(runtimeactors.WithActor(context.Background(), actor), actor, "system prompt", []ToolDefinition{{Name: "emit_event"}})
+	if !errors.Is(err, ErrClaudeWorkspaceCLIUnavailable) {
+		t.Fatalf("ProbeStartupVisibleToolSurface error = %v, want ErrClaudeWorkspaceCLIUnavailable", err)
+	}
+	for _, want := range []string{
+		"local cli_test workspace cannot execute configured Claude CLI command",
+		`"claude"`,
+		`"swarm-agent-market-research"`,
+		`"swarm-workspace:test"`,
+		"remove stale workspace containers",
+		"set SWARM_WORKSPACE_IMAGE",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ProbeStartupVisibleToolSurface error missing %q:\n%v", want, err)
+		}
 	}
 }

--- a/internal/runtime/llm/cli_runtime_workspace_diagnostics.go
+++ b/internal/runtime/llm/cli_runtime_workspace_diagnostics.go
@@ -1,0 +1,80 @@
+package llm
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"swarm/internal/config"
+	workspace "swarm/internal/runtime/workspace"
+)
+
+func workspaceCLIDiagnosticError(cfg *config.Config, target *workspace.Target, raw string) error {
+	summary := summarizeCLIErrorOutput(raw)
+	if summary == "" {
+		summary = strings.TrimSpace(raw)
+	}
+	command := configuredClaudeCLICommand(cfg)
+	if !looksLikeMissingWorkspaceCLI(command, summary) {
+		return nil
+	}
+
+	container := "unknown"
+	if target != nil && strings.TrimSpace(target.Container) != "" {
+		container = strings.TrimSpace(target.Container)
+	}
+	image := strings.TrimSpace(os.Getenv("SWARM_WORKSPACE_IMAGE"))
+	if image == "" {
+		image = workspace.ConfiguredWorkspaceImageFromEnv()
+	}
+	return fmt.Errorf("%w: local cli_test workspace cannot execute configured Claude CLI command %q in container %q (workspace image %q or an existing stale/incompatible workspace container is missing the CLI); build or pull a workspace image that includes the Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %s", ErrClaudeWorkspaceCLIUnavailable, command, container, image, summary)
+}
+
+func configuredClaudeCLICommand(cfg *config.Config) string {
+	if cfg != nil {
+		if command := strings.TrimSpace(cfg.LLM.ClaudeCLI.Command); command != "" {
+			return command
+		}
+	}
+	return "claude"
+}
+
+func looksLikeMissingWorkspaceCLI(command, raw string) bool {
+	command = strings.ToLower(strings.TrimSpace(command))
+	if command == "" {
+		command = "claude"
+	}
+	msg := strings.ToLower(strings.TrimSpace(raw))
+	if msg == "" {
+		return false
+	}
+
+	if strings.Contains(msg, "executable file not found") && messageMentionsCLICommand(msg, command) {
+		return true
+	}
+	if strings.Contains(msg, command+": command not found") || strings.Contains(msg, command+": not found") {
+		return true
+	}
+	if strings.Contains(msg, "exit status 127") && strings.Contains(msg, command) {
+		return true
+	}
+	if strings.Contains(msg, "no such file or directory") && messageMentionsCLICommand(msg, command) {
+		return true
+	}
+	return false
+}
+
+func messageMentionsCLICommand(msg, command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	if strings.Contains(msg, command) || strings.Contains(msg, `"`+command+`"`) {
+		return true
+	}
+	if idx := strings.LastIndex(command, "/"); idx >= 0 && idx+1 < len(command) {
+		base := strings.TrimSpace(command[idx+1:])
+		return base != "" && (strings.Contains(msg, base) || strings.Contains(msg, `"`+base+`"`))
+	}
+	return false
+}

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -52,6 +52,11 @@ type DevEntityContainerCleaner interface {
 }
 
 const DevEntityCleanupOperationName = "swarm.serve.dev.entity_container_cleanup"
+const defaultWorkspaceImage = "swarm-workspace:latest"
+
+func ConfiguredWorkspaceImageFromEnv() string {
+	return EnvOrDefault("SWARM_WORKSPACE_IMAGE", defaultWorkspaceImage)
+}
 
 type DockerConfig struct {
 	DockerBin             string
@@ -77,7 +82,7 @@ type DockerConfig struct {
 func DefaultDockerConfig() DockerConfig {
 	return DockerConfig{
 		DockerBin:             EnvOrDefault("SWARM_DOCKER_BIN", "docker"),
-		WorkspaceImage:        EnvOrDefault("SWARM_WORKSPACE_IMAGE", "swarm-workspace:latest"),
+		WorkspaceImage:        ConfiguredWorkspaceImageFromEnv(),
 		WorkspaceNetwork:      EnvOrDefault("SWARM_WORKSPACE_NETWORK", "mas_default"),
 		WorkspaceVolumesFrom:  EnvOrDefault("SWARM_WORKSPACE_VOLUMES_FROM", ""),
 		SharedDataSource:      EnvOrDefault("SWARM_WORKSPACE_DATA_SOURCE", ""),


### PR DESCRIPTION
## Summary

Closes #997.

This PR closes the approved final #997 slice: `runtime.local_cli_test.workspace_claude_cli_availability_and_actionable_startup_diagnostics`.

Changes:
- promotes `platform-spec.yaml#cli_specification.foundations.local_cli_test_workspace_cli_availability` as the merge-bearing owner for the remaining local `cli_test` workspace/default-agent Claude CLI availability class;
- turns missing/stale/incompatible workspace Claude CLI execution failures into an actionable startup diagnostic naming the configured command, container, workspace image, and remediation;
- applies the same diagnostic to the per-turn Claude CLI fallback so raw OCI `exit 127` is no longer the first useful message if a caller bypasses startup proof;
- adds focused tests for startup probe diagnostics, per-turn fallback diagnostics, and the promoted spec owner.

## Governing Refs / Context

Exact governing refs:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_workspace_cli_availability`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#workspace_model.runtime_image_packaging`
- #997 pre-audit: https://github.com/yazzaoui/Swarm/issues/997#issuecomment-4530949671
- #997 gate approval: https://github.com/yazzaoui/Swarm/issues/997#issuecomment-4530996354

## Semantic Migration

New canonical owner:
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_workspace_cli_availability`

Old non-authoritative paths now invalid:
- treating `docker image inspect` success as proof that local `cli_test` can execute the default Claude-backed agent;
- treating existing workspace container reuse as CLI capability proof;
- relying on raw OCI `exec: "claude": executable file not found` / per-turn `exit 127` as the user-facing diagnostic;
- treating `Dockerfile.workspace` defaults as the runtime image-content owner after #1002/#1034 closed runtime source-root image packaging.

Production paths checked:
- `internal/runtime/runtime_claude_startup.go` agent-present startup validation consumes `ProbeStartupVisibleToolSurface()` before MCP-only gateway proof;
- `internal/runtime/llm/cli_runtime_startup_probe.go` normalizes missing configured Claude CLI failures at startup;
- `internal/runtime/llm/cli_runtime_process.go` normalizes the same missing configured Claude CLI class for per-turn fallback diagnostics;
- `internal/runtime/workspace/manager.go` remains the image-presence owner and now exposes the default configured image name to the diagnostic without reopening image build behavior;
- `cmd/swarm` local foreground run remains proven to consume the serve owner via existing local foreground test coverage.

Migration completeness:
- Complete for the approved #997 class. Docker Compose setup (#996), schema migration diagnostics (#995), source-root runtime image packaging (#1002/#1034), API conformance, and selected-contract/multi-bundle work (#979/#1012) remain split and are not modified here.

## Tests

Focused:
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_MissingWorkspaceCLIIsActionable|TestClaudeCLIRuntimeRunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic' -count=1`
- `go test ./cmd/swarm -run 'TestPlatformSpecLocalCLITest(GatewayStartup|WorkspaceCLIAvailability)Promoted|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestConfigureServeMCPGatewayEnv(AlignsToMCPListener|PreservesExplicitGatewayToken)' -count=1`
- `go test ./internal/runtime -run 'TestValidateClaudeMCPToolsForManagedAgents_(RequiresCLIStartupProbeForMCPOnlySurface|FailsClosedWhenMCPOnlyCLIStartupProbeFails)|TestRuntimeStart_AgentFreeCLITestDoesNotRequireClaudeStartupEnv|TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv' -count=1`
- `go test ./internal/runtime/workspace -run 'TestEnsurePrereqs_CreatesMissingNetworkAndFailsClosedForMissingImage|TestEnsureSystemWorkspaces_CreatesScaffoldAndSystemContainers' -count=1`

Full:
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
