### PR TITLE
[agent-f][issue #1012] Promote multi-bundle source authority

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -97,7 +97,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newEntityCommand(opts),
 		newMailboxCommand(opts),
 		newControlCommand(opts),
-		newRetiredForkCommand(),
+		newPendingForkCommand(),
 	)
 	return cmd
 }
@@ -304,25 +304,25 @@ func newCompletionCommand() *cobra.Command {
 	}
 }
 
-func newRetiredForkCommand() *cobra.Command {
+func newPendingForkCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:                "fork",
-		Short:              "Removed v1 command; use future swarm control run fork.",
+		Short:              "Planned run-fork command; implementation pending.",
 		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			writeForkRetiredMessage(cmd.ErrOrStderr())
+			writeForkPendingMessage(cmd.ErrOrStderr())
 			return commandExitError{code: 2}
 		},
 	}
 }
 
-func writeForkRetiredMessage(w io.Writer) {
+func writeForkPendingMessage(w io.Writer) {
 	if w == nil {
 		return
 	}
-	fmt.Fprintln(w, "ERROR: `swarm fork` was removed in v1.")
-	fmt.Fprintln(w, "  Forking is a mutating control action; use")
-	fmt.Fprintln(w, "  `swarm control run fork <run-id>` once that command ships.")
-	fmt.Fprintln(w, "  For v1, manual run forking goes through the API owner; see `run.start` and the API spec.")
+	fmt.Fprintln(w, "ERROR: `swarm fork` is specified but not implemented yet.")
+	fmt.Fprintln(w, "  Planned command:")
+	fmt.Fprintln(w, "  `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]`")
+	fmt.Fprintln(w, "  It will consume `/v1/rpc run.fork`; legacy harness flags such as --dry-run, --materialize-only, --activate, and --contracts are not supported operator commands.")
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1367,14 +1367,15 @@ func TestCLI_VerifyPreservesLocalContractCarveOut(t *testing.T) {
 	}
 }
 
-func TestCLI_ForkIsHardRetired(t *testing.T) {
+func TestCLI_ForkIsSpecifiedButNotImplemented(t *testing.T) {
+	const expectedForkCommand = "swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]"
 	for _, tc := range []struct {
 		name string
 		args []string
 		want string
 	}{
-		{name: "fork", args: []string{"fork"}, want: "ERROR: `swarm fork` was removed in v1."},
-		{name: "fork-help", args: []string{"fork", "--help"}, want: "ERROR: `swarm fork` was removed in v1."},
+		{name: "fork", args: []string{"fork"}, want: "ERROR: `swarm fork` is specified but not implemented yet."},
+		{name: "fork-help", args: []string{"fork", "--help"}, want: expectedForkCommand},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
@@ -1387,6 +1388,12 @@ func TestCLI_ForkIsHardRetired(t *testing.T) {
 			}
 			if !strings.Contains(stderr.String(), tc.want) {
 				t.Fatalf("%s stderr = %q, want %q", tc.name, stderr.String(), tc.want)
+			}
+			if !strings.Contains(stderr.String(), expectedForkCommand) {
+				t.Fatalf("%s stderr = %q, want promoted fork command %q", tc.name, stderr.String(), expectedForkCommand)
+			}
+			if strings.Contains(stderr.String(), "swarm control run fork") || strings.Contains(stderr.String(), "was removed in v1") {
+				t.Fatalf("%s stderr preserves stale fork authority: %q", tc.name, stderr.String())
 			}
 		})
 	}

--- a/docs/SWARM_INVESTIGATE_COMMAND_DRAFT.md
+++ b/docs/SWARM_INVESTIGATE_COMMAND_DRAFT.md
@@ -4,7 +4,9 @@ Supersession note: this draft is historical design input. The authoritative v1
 CLI contract now lives in
 `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
 `cli_specification`. Runtime-state CLI commands must consume the v1 API, and
-top-level `swarm status` / `swarm fork` are retired.
+this draft's older top-level retirement claim is stale: top-level `swarm
+status` is restored and top-level `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]` is the planned run-fork command
+authority under the multi-bundle spec.
 
 API authority note: retired `/api/*`, `/rpc`, and `/api/rpc` references in this
 document are historical only. They are not supported operator API surfaces and

--- a/docs/specs/swarm-platform/platform/CHANGELOG.md
+++ b/docs/specs/swarm-platform/platform/CHANGELOG.md
@@ -56,7 +56,7 @@ Platform-level execution context. Every event, delivery, session, turn, and enti
 
 **Run lifecycle:** creation (system.started, external event, fork), causal chain propagation, completion detection, pause/resume.
 
-**Fork:** timestamp-based system fork with optional contract swap. Historical drafts used `swarm fork --run <id> --at <event_id|timestamp> [--contracts <path>]`; v1 retires top-level `swarm fork` in favor of a future separately gated control/API owner. System auto-detects pending work at fork point. Reconstructs all entity states via mutation log reverse-apply.
+**Fork:** timestamp-based system fork with optional contract swap. Historical drafts used `swarm fork --run <id> --at <event_id|timestamp> [--contracts <path>]`; those harness-style flags are historical records only. Current platform-spec authority promotes future public `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]` over `/v1/rpc run.fork`, with implementation still separately gated. System auto-detects pending work at fork point. Reconstructs all entity states via mutation log reverse-apply.
 
 **Flight recorder:** query pattern over events + entity_mutations + agent_turns + event_deliveries. Run reconstruction, entity timeline, drift detection.
 
@@ -69,7 +69,7 @@ Platform-level execution context. Every event, delivery, session, turn, and enti
 - [ ] run_id propagation in bus publish path (child inherits from parent)
 - [ ] Mutation logging in save_entity_field tool executor
 - [ ] Mutation logging in system node handler executor (data_accumulation, compute, sets_gate, advances_to, clear)
-- [ ] Future separately gated fork control/API surface (top-level `swarm fork` is retired in v1)
+- [ ] Future separately gated `run.fork` API/runtime/CLI implementation consuming the promoted top-level `swarm fork <source-run-id> ...` command authority
 
 ### New: Lineage Model (replaces trace_id)
 

--- a/docs/specs/swarm-platform/platform/FLIGHT-RECORDER.md
+++ b/docs/specs/swarm-platform/platform/FLIGHT-RECORDER.md
@@ -21,11 +21,13 @@ reverse-engineering it from the current state.
 
 ## Fork Semantics — Approach Comparison
 
-> Historical note: this document predates the v1 CLI contract. Top-level
-> `swarm fork` examples below are historical design records, not supported v1
-> CLI commands. `platform-spec.yaml` `cli_specification` retires top-level
-> `swarm fork`; any future fork control surface requires a separate gated
-> `swarm control run fork` / API owner.
+> Historical note: this document predates the promoted multi-bundle CLI/API
+> authority. Examples below using `swarm fork --run`, `--at`, or `--contracts`
+> are historical design records, not current public CLI authority. Current
+> authority lives in `platform-spec.yaml#multi_bundle_persistence` and promotes
+> the future public command `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]` over the future
+> `/v1/rpc run.fork` owner. Legacy harness flags remain rejected unless a later
+> source-authority PR promotes them.
 
 We evaluated three approaches to fork. This comparison captures the
 trade-offs that led to the chosen design.
@@ -314,7 +316,7 @@ the reconstructed state; only mutations after it are undone.
 | Turn creation | Stamp run_id |
 | `runs` table | New table, created at boot |
 | `entity_mutations` table | New table, created at boot |
-| `swarm fork` command | New CLI command |
+| `swarm fork` command | Historical design row; current public command authority is `platform-spec.yaml#multi_bundle_persistence.cli_surface.run_fork` |
 
 #### No changes
 
@@ -338,8 +340,8 @@ the reconstructed state; only mutations after it are undone.
 3. **Ship flight recorder queries** — immediate debugging value from
    run reconstruction and entity timeline queries.
 
-4. **Ship `swarm fork`** — state reconstruction + pending detection +
-   re-delivery under new run.
+4. **Ship fork execution** — consume the promoted `run.fork` API/CLI authority,
+   state reconstruction, pending detection, and re-delivery under a new run.
 
 5. **Ship drift detection** — `swarm verify --run <id>` validates
    entity_state against mutation log.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5128,6 +5128,36 @@ multi_bundle_persistence:
         - The CLI must not call internal runtime/store/fork harnesses directly.
         - Historical harness flags --dry-run, --materialize-only, --activate, and --contracts remain rejected unless a later source-authority PR promotes them.
   explicit_splits:
+    schema_foundation:
+      tracker: '#1013'
+      reason: Live bundles table, runs.bundle_hash, runs.bundle_source, indexes, and no-FK migration are database/schema implementation.
+    reader_migration:
+      tracker: '#1014'
+      reason: Production readers must migrate from bundle_fingerprint/null-collapse behavior to bundle_source availability semantics.
+    bundle_ingest_and_run_stamping:
+      tracker: '#1015'
+      reason: serve --contracts / --dev ingest, canonical hashing, bundle row writes, and persisted/ephemeral run stamping are runtime boot implementation.
+    startup_recovery_unavailable_bundle:
+      tracker: '#1016'
+      reason: Restart recovery for active persisted/ephemeral/deleted/legacy bundle-source runs is lifecycle implementation.
+    bundle_api_catalog:
+      tracker: '#1017'
+      reason: bundle.list/get/agents/register method publication, store owners, OpenRPC artifacts, and handler tests are API implementation.
+    bundle_delete_non_force:
+      tracker: '#1018'
+      reason: Non-force bundle.delete active-run refusal and non-active deleted marking are API/store lifecycle implementation.
+    bundle_delete_force:
+      tracker: '#1019'
+      reason: Forced bundle.delete preservation cleanup, mutex, quiescence, delivery/session/timer/container cleanup, and result projection are destructive-runtime implementation.
+    serve_db_loaded_bundle:
+      tracker: '#1020'
+      reason: swarm serve --bundle-hash DB-loaded YAML/data runtime boot mode is serve/runtime implementation and may depend on #981.
+    bundle_safe_list_read_scoping:
+      tracker: '#1021'
+      reason: agent/event/run/log/incident read/list method scoping and generated OpenRPC shape are API read-model implementation.
+    create_new_work_bundle_hash:
+      tracker: '#1022'
+      reason: event.publish/run.start create-new-work admission with required bundle_hash when run_id is absent is API/runtime routing implementation.
     cross_bundle_fork:
       tracker: '#976'
       reason: Different target bundle_hash selected for run.fork requires selected-contract routing and admission work beyond source authority.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3935,7 +3935,9 @@ platform_tables:
         New v1 run.start-created rows persist the orchestrator boot fingerprint after bundle_ref
         validation. UPSERT/reopen paths must not overwrite an existing non-NULL fingerprint, but may
         fill an unknown NULL fingerprint when a canonical boot-owned writer supplies one. Legacy NULL
-        values mean unknown bundle and are allowed by serve bundle-match admission.'
+        values mean unknown bundle and are allowed by serve bundle-match admission. This current live DDL
+        is superseded for multi-bundle source authority by multi_bundle_persistence.persistence_model,
+        but remains in platform_tables until #1001 and the database migration child replace the live runtime schema.'
     entity_mutations:
       description: 'Append-only mutation log for entity_state changes. Every write to entity_state.fields,
         entity_state.current_state, entity_state.gates, or entity_state.accumulator produces a row.
@@ -4117,8 +4119,9 @@ run_model:
   lifecycle:
     creation: 'A run is created when: (1) system.started fires (cold start), (2) an external event arrives with
       no active run (warm start), or (3) the runtime fork owner creates a forked run. The platform inserts a row
-      in the runs table with status=running and returns the run_id. Top-level `swarm fork` is retired by cli_specification
-      and is not a supported v1 command.'
+      in the runs table with status=running and returns the run_id. Public run forking is governed by
+      multi_bundle_persistence.api_surface.run_fork and the intended CLI command
+      `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]`.'
     propagation: 'run_id propagates through the causal chain. When a handler or agent emits an event, the child
       event inherits run_id from the parent. This is set at event creation time in the bus publish path — no
       handler or agent code needs to pass run_id explicitly.'
@@ -4136,7 +4139,7 @@ run_model:
     description: 'Fork creates a new run by reconstructing full system state at a point in time, optionally
       loading new contracts, and resuming execution. The system automatically determines which events need
       to be re-delivered. The original run is frozen. The forked run gets independent execution.'
-    command: 'retired in v1 CLI; future run-fork control surface requires its own gated `swarm control run fork` / API owner'
+    command: 'planned public CLI: `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]`, consuming /v1/rpc run.fork once #989 implements the API/runtime/CLI owner'
     dry_run_command: 'retired in v1 CLI; historical `swarm fork --dry-run` is not a supported operator command'
     materialize_only_command: 'retired in v1 CLI; historical `swarm fork --materialize-only` is not a supported operator command'
     activation_command: 'retired in v1 CLI; historical `swarm fork --activate` is not a supported operator command'
@@ -4454,9 +4457,11 @@ run_model:
       source rows, suppress fork-local execution with source outcomes, own current-state/entity
       materialization, reconstruct sessions/turns/audits, replay timers/routes/non-agent work, or claim restart
       recovery.'
-    selected_contract_supported_execution: 'The historical selected-contract timestamp-fork execution surface was
-      swarm fork --contracts; top-level swarm fork is now retired by cli_specification and any future operator command
-      requires a separate gated control/API surface. The runtime behavior is owned by runtime.run_fork.selected_contract_execution, not by CLI, route helpers,
+    selected_contract_supported_execution: 'The historical selected-contract timestamp-fork execution harness was
+      swarm fork --contracts; that legacy harness flag remains rejected unless a later source-authority PR promotes it.
+      The intended public command is now the top-level `swarm fork <source-run-id> ...` command defined by
+      multi_bundle_persistence.cli_surface.run_fork and blocked on #989 API/runtime/CLI implementation. The runtime
+      behavior is owned by runtime.run_fork.selected_contract_execution, not by CLI, route helpers,
       delivery-row helpers, or source-row replay. The owner consumes store.run_fork.selected_contract_binding,
       selected_contract_execution_admission, selected_contract_route_topology, selected_contract_dynamic_route_topology,
       runtime.run_fork.selected_contract_recipient_planning, and
@@ -4899,6 +4904,256 @@ run_model:
     run_pause: 'POST /runs/:run_id/pause — pause a running run.'
     run_resume: 'POST /runs/:run_id/resume — resume a paused run.'
     run_cancel: 'POST /runs/:run_id/cancel — cancel a running run. Drains in-flight events.'
+multi_bundle_persistence:
+  status: promoted_source_authority_no_runtime_behavior
+  promoted_by: '#1012'
+  source_evidence:
+    draft: docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md
+    canonical_hash_first_slice: '#979 / PR #1033'
+    bundle_hash_naming: '#1001'
+    run_fork_cli_authority_absorbed_from: '#1038'
+  authority_rule: >
+    This section is the merge-bearing source authority for multi-bundle persistence, bundle identity, bundle-aware
+    resume/delete/fork semantics, planned bundle API methods, and planned CLI command shape. The draft is now evidence
+    only. Runtime, API handler, CLI implementation, database migration, and generated OpenRPC publication remain separately
+    gated implementation work unless a later PR explicitly promotes and proves them.
+  generated_artifact_policy:
+    current_openrpc_status: unchanged
+    rule: >
+      Generated openrpc.json is derived from api_specification.method_catalog and must continue to match the currently
+      registered /v1/rpc handler set. Multi-bundle methods described here are source authority but are not added to
+      method_catalog/OpenRPC until their API/runtime handlers are implemented and registered in the same gated PR.
+    proof_expectation: >
+      Source-authority promotion proof must verify that run.fork and bundle.* are not silently published in generated
+      OpenRPC without implementation, and that future implementation PRs promote matching method_catalog entries and
+      generated artifacts together.
+  bundle_identity:
+    canonical_name: bundle_hash
+    format: 'bundle-v1:sha256:<64 lowercase hex>'
+    hash_rule_owner: '#979 / PR #1033 canonical bundle hash v1 design-doc authority'
+    rename_policy:
+      bundle_hash: promoted_name
+      bundle_fingerprint: legacy_pre_multi_bundle_name
+      bundle_ref: legacy_pre_multi_bundle_api_wrapper
+      dual_accept_transition: '#1001 only; old and new names must fail closed if both are supplied and disagree'
+    canonical_inputs_required_for_hash_rule:
+      - exact contract file byte inputs after the canonical bundle hash v1 path and YAML normalization rules
+      - deterministic path ordering and cross-platform separator handling
+      - explicit YAML scalar/key normalization and duplicate-key rejection
+      - explicit schema $ref expansion/non-expansion policy
+      - deterministic data/ blob inclusion and exclusion rules
+      - fail-closed symlink, ignored-file, and out-of-tree path policy
+      - hash namespace/version prefix
+  persistence_model:
+    live_schema_boundary: >
+      platform_tables.tables remains the current runtime DDL source. #1012 does not change live generated tables because
+      that would be runtime/schema implementation. The bundles table and runs.bundle_hash/runs.bundle_source fields below
+      are promoted source authority for the database migration child, which must update platform_tables, migrations, store
+      readers/writers, generated artifacts, and proof together.
+    bundles_table:
+      planned_live_owner_after_migration: platform_tables.tables.bundles
+      primary_key: bundle_hash
+      required_columns:
+        - bundle_hash
+        - content_yaml
+        - parsed_json
+        - ingested_at
+      optional_columns:
+        - data_blob
+        - metadata
+      stores:
+        - uploaded or registered contract YAML bytes
+        - data/ bundle blob bytes when included by the canonical hash rule
+        - parsed JSON projection for safe server-side inspection
+      does_not_store:
+        - external code
+        - host filesystem dependencies
+        - credentials
+        - generated runtime state
+    runs_table:
+      planned_live_owner_after_migration: platform_tables.tables.runs
+      promoted_fields:
+        bundle_hash: nullable canonical bundle identity for the run
+        bundle_source: "persisted | ephemeral | deleted | legacy"
+      foreign_key_policy: >
+        runs.bundle_hash intentionally has no database foreign key to bundles.bundle_hash. Deleting a bundle row must not
+        cascade into historical run rows; resume/fork admission consumes bundle_source and current bundle row presence.
+      migration_policy: >
+        Existing rows start as bundle_source=legacy with bundle_hash NULL unless a separately gated migration can prove a
+        persisted bundle hash. Migration must be aggressive and fail closed for unknown owners rather than inventing hashes
+        from stale filesystem paths.
+  resume_and_recovery:
+    resume_eligibility:
+      persisted_bundle_present:
+        condition: 'runs.bundle_source=persisted and bundles row exists for runs.bundle_hash'
+        result: resume_allowed
+      persisted_bundle_missing:
+        condition: 'runs.bundle_source=persisted and no bundles row exists for runs.bundle_hash'
+        result_error: BUNDLE_DATA_INTEGRITY_ERROR
+        rationale: A persisted source promised durable bytes; a missing row is data corruption, not normal unavailability.
+      ephemeral_deleted_or_legacy:
+        condition: 'runs.bundle_source in (ephemeral, deleted, legacy)'
+        result_error: BUNDLE_UNAVAILABLE
+        rationale: The server lacks authoritative bundle bytes for resume/fork after restart or deletion.
+    active_restart_recovery:
+      persisted_bundle_present: restart_may_resume_or_recover_the_run_under_runtime_recovery_owners
+      persisted_bundle_missing: fail_serve_with_BUNDLE_DATA_INTEGRITY_ERROR_until_operator_repairs_data
+      ephemeral_deleted_or_legacy: >
+        Active mid-flight runs cannot be resumed after process restart. Runtime recovery must orphan/terminalize them
+        through the active-run and delivery cleanup owner chain instead of pretending their filesystem bundle is still
+        authoritative.
+    completed_run_fork_after_bundle_delete:
+      rule: >
+        Completed runs whose source bundle row has been deleted are not forkable from bundle bytes. Same-bundle fork
+        admission returns BUNDLE_UNAVAILABLE unless another promoted owner proves an authoritative source bundle.
+  bundle_delete:
+    api_method: bundle.delete
+    cli_command: swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
+    non_force_rule: >
+      Without --force, deleting a bundle with any active run using that bundle fails closed with BUNDLE_HAS_ACTIVE_RUNS.
+    force_owner_chain:
+      - acquire shared destructive-operation mutex/idempotency owner
+      - plan affected runs and deliveries for the bundle_hash
+      - quiesce and terminalize active runs under run-control/runtime recovery owners
+      - cancel or drain retryable deliveries and pending queues under delivery owners
+      - stop/clean runtime containers and process-owned resources for the affected runs
+      - delete or mark bundle rows only after cleanup succeeds
+    errors:
+      - BUNDLE_NOT_FOUND
+      - BUNDLE_HAS_ACTIVE_RUNS
+      - BUNDLE_DELETE_IN_PROGRESS
+      - RUNTIME_NUKE_IN_PROGRESS
+      - IDEMPOTENCY_CONFLICT
+    result_shape:
+      name: BundleDeleteResult
+      required_fields:
+        - bundle_hash
+        - deleted
+        - active_runs_stopped
+        - deliveries_cancelled
+        - containers_stopped
+        - dry_run
+  api_surface:
+    publication_status: source_authority_not_generated_openrpc_until_runtime_api_implementation
+    command_transport_owner: api_specification
+    bundle_methods_planned:
+      bundle.list:
+        kind: read
+        result: BundleSummary page, optionally cursor-paginated
+      bundle.get:
+        kind: read
+        params: bundle_hash
+        result: BundleDetail
+      bundle.agents:
+        kind: read
+        params: bundle_hash
+        result: Agent definitions from the persisted bundle bytes
+      bundle.register:
+        kind: mutate
+        params: content_yaml, data_blob?, idempotency_key?
+        result: BundleRegistrationResult with bundle_hash
+      bundle.delete:
+        kind: destructive_mutate
+        params: bundle_hash, force?, dry_run?, idempotency_key?
+        result: BundleDeleteResult
+    bundle_aware_existing_methods_planned:
+      event.publish:
+        rule: >
+          New-run publication uses bundle_hash after #1001. Existing-run publication validates against the run's
+          canonical bundle identity. Legacy bundle_ref/bundle_fingerprint wrappers are transition-only and must not remain
+          authoritative after the rename migration.
+      run.start:
+        rule: Deprecated wrapper follows event.publish bundle_hash semantics while it remains present.
+      run.list:
+        rule: May accept optional bundle_hash filter.
+      runtime.logs:
+        rule: May accept optional bundle_hash filter.
+      runtime.incidents:
+        rule: May accept optional bundle_hash filter.
+      agent.list:
+        rule: Future bundle-aware listing must disambiguate run-scoped loaded agents from persisted bundle agent catalog.
+      event.list:
+        rule: Future multi-bundle event listing must avoid ambient bundle assumptions; run_id remains the primary run-scoped owner.
+      event.subscribe:
+        rule: Future multi-bundle subscription filters must avoid ambient bundle assumptions; run_id remains the primary run-scoped owner.
+    run_fork:
+      method: run.fork
+      params:
+        source_run_id:
+          required: true
+          meaning: Run to fork from.
+        fork_event_id:
+          required: false
+          cli_flag: --at-event <event-id>
+          meaning: Explicit event selector for the fork point; no ambient current-event heuristic is allowed.
+        bundle_hash:
+          required: false
+          cli_flag: --bundle-hash <bundle_hash>
+          meaning: Optional target/source bundle selector under the promoted bundle_hash naming rule.
+        idempotency_key:
+          required: false
+          cli_flag: --idempotency-key <key>
+      same_bundle_rule: >
+        If bundle_hash is omitted or equals the source run bundle_hash, same-bundle fork admission consumes the source
+        bundle row when available. Disk-loaded selected_contracts execution remains existing runtime ownership; DB-loaded
+        same-bundle source bytes remain blocked by #1024.
+      cross_bundle_rule: >
+        If bundle_hash differs from the source run bundle_hash, admission returns UNSUPPORTED_BUNDLE_HASH_FORK until #976
+        promotes and implements cross-bundle selected-contract routing.
+      unavailable_rule: >
+        Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
+        the server lacks authoritative persisted bundle bytes.
+  cli_surface:
+    publication_status: source_authority_not_implemented_until_cli_api_runtime_children
+    bundle_commands_planned:
+      - swarm bundle list
+      - swarm bundle show <bundle-hash>
+      - swarm bundle agents <bundle-hash>
+      - swarm bundle register <path-or-archive>
+      - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
+    modified_commands_planned:
+      - swarm serve --bundle-hash <bundle_hash>
+      - swarm serve --dev
+      - swarm agents list --run-id <run-id>
+      - swarm event publish <event-name> --bundle-hash <bundle_hash>
+      - swarm run --bundle-hash <bundle_hash>
+    run_fork:
+      command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
+      public_status: intended_public_command
+      api_owner: /v1/rpc run.fork
+      rules:
+        - Top-level swarm fork is the intended public command for run.fork and is no longer classified as a retired namespace.
+        - The bundle selector flag is --bundle-hash, not draft --bundle.
+        - --at-event selects the fork event only and never means ambient current-run or current-event.
+        - The CLI must not call internal runtime/store/fork harnesses directly.
+        - Historical harness flags --dry-run, --materialize-only, --activate, and --contracts remain rejected unless a later source-authority PR promotes them.
+  explicit_splits:
+    cross_bundle_fork:
+      tracker: '#976'
+      reason: Different target bundle_hash selected for run.fork requires selected-contract routing and admission work beyond source authority.
+    db_loaded_same_bundle_source:
+      tracker: '#1024'
+      reason: Same-bundle fork from persisted DB bundle bytes needs a sibling source loader separate from current disk-rooted selected_contracts execution.
+    run_fork_api_runtime_cli:
+      tracker: '#989'
+      reason: run.fork method publication, handler behavior, runtime execution, and CLI command implementation remain blocked until source authority lands.
+    multi_bundle_cli_inventory:
+      tracker: '#1023'
+      reason: Bundle CLI inventory and command implementation remain blocked until source authority and API owners land.
+    bundle_hash_dual_accept_migration:
+      tracker: '#1001'
+      reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
+    runtime_context_isolation:
+      tracker: '#981'
+      reason: Hosting multiple bundles in one runtime process requires explicit per-run/bundle context isolation and dispatcher/store filtering proof.
+    lifecycle_cleanup:
+      trackers:
+        - '#987'
+        - '#988'
+        - '#998'
+        - '#1008'
+        - '#1009'
+      reason: Delete/restart/ephemeral-run cleanup must consume existing lifecycle owners rather than invent bundle-local shortcuts.
 platform_events:
   description: Events emitted by the platform engine itself. These are NOT product events — they are operational signals from
     the engine. All platform events use the platform.* namespace. Products MUST NOT define events with reserved prefixes.
@@ -6054,7 +6309,9 @@ cli_specification:
           Retired namespace migration authority is reconciled by
           cli_specification.retired_namespaces and cli_specification.parent_tail.retired_or_fail_closed.
           Promoted fail-closed migration surfaces are `swarm investigate *`, `swarm control mailbox`,
-          and `swarm fork`. Review-artifact-only `swarm runtime pause|resume` and
+          and legacy `swarm fork --dry-run|--materialize-only|--activate|--contracts` harness forms only.
+          #1012 restores top-level `swarm fork <source-run-id> ...` as planned public source authority.
+          Review-artifact-only `swarm runtime pause|resume` and
           `swarm control run pause|continue|stop` are explicitly unpromoted candidate/backlog
           spellings; their current generic Cobra unknown-command behavior is intentional unless a
           later tracked spec row promotes hidden fail-closed stubs.
@@ -6135,10 +6392,12 @@ cli_specification:
           `swarm control mailbox approve|reject|defer` is retired in favor of `swarm mailbox
           approve|reject|defer`.
       fork_fail_closed_stub:
-        classification: legacy_migration_behavior
+        classification: superseded_by_multi_bundle_source_authority
         reason: >
-          Top-level `swarm fork` is retired and remains fail-closed only to prevent old mutating operator
-          behavior from bypassing a future gated run-fork API/control surface.
+          Previous tracked prose treated top-level `swarm fork` as retired. #1012 promotes the multi-bundle
+          source authority and restores top-level `swarm fork <source-run-id> ...` as the intended future public command
+          over /v1/rpc run.fork. Historical harness flags remain rejected; the bare public command remains absent until
+          #989 implements API/runtime/CLI behavior.
       runtime_and_control_run_legacy_spellings:
         classification: unpromoted_candidate_backlog
         reason: >
@@ -8153,6 +8412,51 @@ cli_specification:
       - success output renders only ConversationTurnDetail fields returned by the server; runtime logs are consumed from the API result, not independently queried
       - SESSION_NOT_FOUND, TURN_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, runtime.logs, run.trace, or forkchat usage
+    bundle:
+      command: swarm bundle list|show|agents|register|delete
+      tier: should_have
+      implementation_status: absent
+      blocker_state: '#1023; bundle CLI inventory and mutation commands require API/OpenRPC/runtime owners from #1012 follow-on implementation children.'
+      owners:
+      - multi_bundle_persistence.cli_surface.bundle_commands_planned
+      - multi_bundle_persistence.api_surface.bundle_methods_planned
+      behavior: >
+        Planned public CLI family for persisted bundle inventory, registration, agent catalog inspection, and deletion.
+        The command family must consume /v1/rpc bundle.* methods once they are promoted into method_catalog/OpenRPC and
+        implemented. Until then it must not call internal store/runtime helpers or infer bundle state from local files.
+      proof_expectations:
+      - no generated OpenRPC bundle.* publication without registered API handlers
+      - no direct DB/store/runtime bundle reads or writes from CLI
+      - bundle.delete consumes the bundle-delete owner chain, not a raw row delete
+    run_fork:
+      command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
+      tier: should_have
+      implementation_status: absent
+      blocker_state: '#989; run.fork API/OpenRPC/runtime/CLI implementation remains blocked until this source authority lands.'
+      owner: multi_bundle_persistence.cli_surface.run_fork
+      api_owner: /v1/rpc run.fork
+      behavior: >
+        Planned public run-fork CLI. Top-level `swarm fork` is the intended public command. The bundle selector flag is
+        `--bundle-hash`; draft `--bundle` is superseded by #1001. `--at-event` is an explicit fork-event selector only.
+        The CLI must validate arguments locally, call /v1/rpc run.fork exactly once, and render only server-owned fork
+        results after the API/runtime owner exists.
+      split_blockers:
+        cross_bundle_fork: '#976'
+        db_loaded_same_bundle_source: '#1024'
+        api_runtime_cli_owner: '#989'
+        cli_inventory_gate: '#1023'
+      rejected_legacy_flags:
+      - --dry-run
+      - --materialize-only
+      - --activate
+      - --contracts
+      proof_expectations:
+      - top-level swarm fork is no longer classified as a retired namespace
+      - no `swarm control run fork` command shape is promoted
+      - no draft `--bundle` flag is promoted
+      - no direct DB/store/runtime/fork harness access from CLI
+      - cross-bundle targets fail closed as #976 until that child lands
+      - DB-loaded same-bundle source loading remains #1024 until that child lands
     forkchat:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
@@ -8393,11 +8697,11 @@ cli_specification:
     status_v1_retirement_message:
       status: superseded
       rule: 'The old v1 retirement of top-level `swarm status` is no longer authoritative; v2 restores top-level `swarm status`.'
-    fork:
-      command: swarm fork
-      status: retired
+    fork_legacy_harness_forms:
+      command: swarm fork --dry-run|--materialize-only|--activate|--contracts
+      status: retired_legacy_harness_forms
       exit_code: 2
-      message: "ERROR: `swarm fork` was removed in v1. Forking is a mutating control action; use a future gated run-fork API/control surface. Historical `swarm fork` remains a runtime-owner test harness only, not a supported operator command."
+      message: "ERROR: legacy `swarm fork` harness flags are not supported operator commands. The intended public command is `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]` after #989 implements /v1/rpc run.fork."
     unpromoted_review_only_legacy_spellings:
       status: unpromoted_candidate_backlog
       commands:
@@ -8486,9 +8790,10 @@ cli_specification:
     - swarm investigate run
     - swarm investigate trace
     - swarm control mailbox
-    - swarm fork
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
+    - swarm bundle list|show|agents|register|delete
+    - swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
     - swarm forkchat new|resume|list|view|delete
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
@@ -8523,6 +8828,20 @@ api_specification:
       is candidate intent. It must be promoted into this section with matching
       generated/implementation proof, split to a tracked child, or explicitly
       downgraded to backlog before it can be used as implementation authority.
+  multi_bundle_publication_boundary:
+    owner: multi_bundle_persistence.api_surface
+    status: source_authority_not_method_catalog
+    rule: >
+      #1012 promotes the multi-bundle API contract as source authority, including bundle.* methods, run.fork, bundle_hash
+      filters, and bundle_hash create-new-work params. These methods and shapes are not in method_catalog/OpenRPC until
+      a later gated API/runtime implementation PR registers handlers and regenerates openrpc.json/proof artifacts in the
+      same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or #1038 prose as API authority after #1012.
+    blocked_children:
+      run_fork_api_runtime_cli: '#989'
+      multi_bundle_cli_inventory: '#1023'
+      cross_bundle_fork: '#976'
+      db_loaded_same_bundle_source: '#1024'
+      bundle_hash_dual_accept_migration: '#1001'
   foundations:
     transport:
       json_rpc_over_http:
@@ -12539,11 +12858,12 @@ api_specification:
       - bundle.open
       - bundle.reload
       - bundle.close
-      rationale: "Per-run dynamic bundle loading is deferred. v1 runtime uses\nboot-time bundle configuration; event.publish\
-        \ and deprecated run.start may\ncarry a bundle_ref whose fingerprint must match the boot-time fingerprint,\nor the\
-        \ bundle_ref may be omitted entirely.\
-        \ When dynamic loading lands,\nBundleRef likely gains content-addressable forms (registry\ncoordinate, uploaded content\
-        \ hash) \u2014 additive change to the\nBundleRef schema, not a breaking one.\n"
+      rationale: >
+        Legacy dynamic bundle.open/reload/close remains deferred and is not the multi-bundle public API. #1012 promotes the
+        authoritative multi-bundle source model under multi_bundle_persistence, with planned bundle.list/get/agents/register/delete,
+        run.fork, and bundle_hash create-new-work semantics. Those planned methods are intentionally not added to
+        method_catalog/OpenRPC until their gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
+        language is migration evidence only after the #1001 bundle_hash decision.
     verify:
       methods:
       - verify.full

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -221,11 +221,21 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 
 	splits := mustMappingValue(t, multi, "explicit_splits")
 	for split, tracker := range map[string]string{
-		"cross_bundle_fork":                 "#976",
-		"db_loaded_same_bundle_source":      "#1024",
-		"run_fork_api_runtime_cli":          "#989",
-		"multi_bundle_cli_inventory":        "#1023",
-		"bundle_hash_dual_accept_migration": "#1001",
+		"schema_foundation":                   "#1013",
+		"reader_migration":                    "#1014",
+		"bundle_ingest_and_run_stamping":      "#1015",
+		"startup_recovery_unavailable_bundle": "#1016",
+		"bundle_api_catalog":                  "#1017",
+		"bundle_delete_non_force":             "#1018",
+		"bundle_delete_force":                 "#1019",
+		"serve_db_loaded_bundle":              "#1020",
+		"bundle_safe_list_read_scoping":       "#1021",
+		"create_new_work_bundle_hash":         "#1022",
+		"cross_bundle_fork":                   "#976",
+		"db_loaded_same_bundle_source":        "#1024",
+		"run_fork_api_runtime_cli":            "#989",
+		"multi_bundle_cli_inventory":          "#1023",
+		"bundle_hash_dual_accept_migration":   "#1001",
 	} {
 		assertScalarValue(t, mustMappingValue(t, mustMappingValue(t, splits, split), "tracker"), tracker)
 	}
@@ -257,6 +267,26 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
 	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "source_authority_not_method_catalog")
+
+	for _, relPath := range []string{
+		filepath.Join("docs", "specs", "swarm-platform", "platform", "FLIGHT-RECORDER.md"),
+		filepath.Join("docs", "specs", "swarm-platform", "platform", "CHANGELOG.md"),
+	} {
+		raw, err := os.ReadFile(filepath.Join(repoRoot(t), relPath))
+		if err != nil {
+			t.Fatalf("read %s: %v", relPath, err)
+		}
+		content := string(raw)
+		if strings.Contains(content, "swarm control run fork") {
+			t.Fatalf("%s still promotes stale swarm control run fork authority", relPath)
+		}
+		if strings.Contains(content, "retires top-level `swarm fork`") || strings.Contains(content, "top-level `swarm fork` is retired") {
+			t.Fatalf("%s still says top-level swarm fork is retired", relPath)
+		}
+		if !strings.Contains(content, runForkCommand) {
+			t.Fatalf("%s missing promoted run fork command shape", relPath)
+		}
+	}
 
 	api := loadRepoAPISpec(t)
 	for _, methodName := range []string{"run.fork", "bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete"} {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -172,6 +172,114 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 }
 
+func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	multi := mustMappingValue(t, root, "multi_bundle_persistence")
+	assertScalarValue(t, mustMappingValue(t, multi, "status"), "promoted_source_authority_no_runtime_behavior")
+
+	sourceEvidence := mustMappingValue(t, multi, "source_evidence")
+	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
+
+	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
+	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "unchanged")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "not added to")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "until their API/runtime handlers are implemented")
+
+	identity := mustMappingValue(t, multi, "bundle_identity")
+	assertScalarValue(t, mustMappingValue(t, identity, "canonical_name"), "bundle_hash")
+	renamePolicy := mustMappingValue(t, identity, "rename_policy")
+	assertScalarValue(t, mustMappingValue(t, renamePolicy, "bundle_hash"), "promoted_name")
+	assertScalarContains(t, mustMappingValue(t, renamePolicy, "dual_accept_transition"), "#1001")
+
+	persistence := mustMappingValue(t, multi, "persistence_model")
+	assertScalarContains(t, mustMappingValue(t, persistence, "live_schema_boundary"), "does not change live generated tables")
+	platformTables := mustMappingValue(t, mustMappingValue(t, root, "platform_tables"), "tables")
+	if mappingValue(platformTables, "bundles") != nil {
+		t.Fatal("bundles table must not enter live platform_tables before the DB migration child lands")
+	}
+	runsDDL := mustMappingValue(t, mustMappingValue(t, platformTables, "runs"), "ddl")
+	assertScalarContains(t, runsDDL, "bundle_fingerprint TEXT")
+
+	cliSurface := mustMappingValue(t, multi, "cli_surface")
+	runFork := mustMappingValue(t, cliSurface, "run_fork")
+	const runForkCommand = "swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]"
+	assertScalarValue(t, mustMappingValue(t, runFork, "command"), runForkCommand)
+	if strings.Contains(runForkCommand, "--bundle ") {
+		t.Fatal("run fork command promoted legacy --bundle spelling")
+	}
+	if strings.Contains(runForkCommand, "swarm control run fork") {
+		t.Fatal("run fork command promoted control-run fork spelling")
+	}
+
+	apiSurface := mustMappingValue(t, multi, "api_surface")
+	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "source_authority_not_generated_openrpc_until_runtime_api_implementation")
+	apiRunFork := mustMappingValue(t, apiSurface, "run_fork")
+	assertScalarValue(t, mustMappingValue(t, apiRunFork, "method"), "run.fork")
+	apiRunForkParams := mustMappingValue(t, apiRunFork, "params")
+	bundleHashParam := mustMappingValue(t, apiRunForkParams, "bundle_hash")
+	assertScalarValue(t, mustMappingValue(t, bundleHashParam, "cli_flag"), "--bundle-hash <bundle_hash>")
+
+	splits := mustMappingValue(t, multi, "explicit_splits")
+	for split, tracker := range map[string]string{
+		"cross_bundle_fork":                 "#976",
+		"db_loaded_same_bundle_source":      "#1024",
+		"run_fork_api_runtime_cli":          "#989",
+		"multi_bundle_cli_inventory":        "#1023",
+		"bundle_hash_dual_accept_migration": "#1001",
+	} {
+		assertScalarValue(t, mustMappingValue(t, mustMappingValue(t, splits, split), "tracker"), tracker)
+	}
+
+	cli := mustMappingValue(t, root, "cli_specification")
+	commandCatalog := mustMappingValue(t, cli, "command_catalog")
+	assertScalarValue(t, mustMappingValue(t, mustMappingValue(t, commandCatalog, "run_fork"), "command"), runForkCommand)
+	retired := mustMappingValue(t, cli, "retired_namespaces")
+	if mappingValue(retired, "fork") != nil {
+		t.Fatal("bare top-level swarm fork must not remain classified as a retired namespace")
+	}
+	legacyHarness := mustMappingValue(t, retired, "fork_legacy_harness_forms")
+	assertScalarContains(t, mustMappingValue(t, legacyHarness, "command"), "--contracts")
+
+	parentTail := mustMappingValue(t, cli, "parent_tail")
+	retiredOrFailClosed := mustMappingValue(t, parentTail, "retired_or_fail_closed")
+	for _, item := range retiredOrFailClosed.Content {
+		if scalarValue(item) == "swarm fork" {
+			t.Fatal("bare top-level swarm fork must not remain in retired_or_fail_closed")
+		}
+	}
+	remaining := mustMappingValue(t, parentTail, "remaining_should_have_not_implemented")
+	if !sequenceContainsScalar(remaining, runForkCommand) {
+		t.Fatalf("remaining_should_have_not_implemented missing %q", runForkCommand)
+	}
+	if !sequenceContainsScalar(remaining, "swarm bundle list|show|agents|register|delete") {
+		t.Fatal("remaining_should_have_not_implemented missing swarm bundle command family")
+	}
+
+	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
+	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "source_authority_not_method_catalog")
+
+	api := loadRepoAPISpec(t)
+	for _, methodName := range []string{"run.fork", "bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete"} {
+		if _, ok := api.MethodCatalog[methodName]; ok {
+			t.Fatalf("%s must not be in live method_catalog until handler implementation lands", methodName)
+		}
+	}
+	generated, err := GenerateOpenRPC(api)
+	if err != nil {
+		t.Fatalf("GenerateOpenRPC() error = %v", err)
+	}
+	var doc OpenRPCDocument
+	if err := json.Unmarshal(generated, &doc); err != nil {
+		t.Fatalf("unmarshal generated openrpc: %v", err)
+	}
+	for _, method := range doc.Methods {
+		switch method.Name {
+		case "run.fork", "bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete":
+			t.Fatalf("%s must not be published in generated OpenRPC until implementation lands", method.Name)
+		}
+	}
+}
+
 func TestEntityFullAccumulatedSchemaPublishesRuntimeAccumulatorState(t *testing.T) {
 	api := loadRepoAPISpec(t)
 	entityFull, ok := api.Components.Schemas["EntityFull"].(map[string]any)
@@ -653,6 +761,18 @@ func mappingValue(node *yaml.Node, key string) *yaml.Node {
 
 func hasMappingKey(node *yaml.Node, key string) bool {
 	return mappingValue(node, key) != nil
+}
+
+func sequenceContainsScalar(node *yaml.Node, want string) bool {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, item := range node.Content {
+		if scalarValue(item) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func scalarValue(node *yaml.Node) string {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -269,6 +269,8 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "source_authority_not_method_catalog")
 
 	for _, relPath := range []string{
+		filepath.Join("cmd", "swarm", "cli.go"),
+		filepath.Join("docs", "SWARM_INVESTIGATE_COMMAND_DRAFT.md"),
 		filepath.Join("docs", "specs", "swarm-platform", "platform", "FLIGHT-RECORDER.md"),
 		filepath.Join("docs", "specs", "swarm-platform", "platform", "CHANGELOG.md"),
 	} {


### PR DESCRIPTION
## Summary

Promotes the multi-bundle persistence draft into merge-bearing `platform-spec.yaml` source authority without implementing runtime, API handler, database migration, or live OpenRPC behavior.

This PR:
- Adds `multi_bundle_persistence` as the source authority for bundle identity, persistence target model, resume/error policy, bundle.delete owner chain, planned API surfaces, and planned CLI surfaces.
- Absorbs #1038 by promoting top-level `swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]` as the intended public command.
- Resolves draft `--bundle` in favor of #1001 `--bundle-hash`.
- Keeps #976 cross-bundle fork and #1024 DB-loaded same-bundle source explicitly split.
- Repairs stale retired `swarm fork` authority so only legacy harness flags remain retired.
- Updates the live hidden `swarm fork` CLI fail-closed guidance/test: `swarm fork` is specified but not implemented yet, and the message names the promoted top-level command rather than `swarm control run fork`.
- Adds explicit split rows for known #1011 implementation children: #1013, #1014, #1015, #1016, #1017, #1018, #1019, #1020, #1021, and #1022.
- Repairs tracked `FLIGHT-RECORDER.md`, `CHANGELOG.md`, and `SWARM_INVESTIGATE_COMMAND_DRAFT.md` text that still described bare top-level `swarm fork` as retired.
- Adds proof that planned `bundle.*` / `run.fork` are not silently published in live OpenRPC and that live runtime DDL is not changed by this source-only PR.

Closes #1012
Absorbs #1038
Related to #1011, #1001, #976, #989, #1023, #1024

## Governing refs / context

Authoritative refs after this PR:
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.multi_bundle_publication_boundary`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.run_fork`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.bundle`

Input evidence promoted or reconciled:
- Root draft: `docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md` is design evidence only after this PR.
- #979 / PR #1033: canonical bundle hash v1 design-doc source authority only.
- #1001: final public naming is `bundle_hash` / `--bundle-hash`.
- #1038 gate correction: top-level `swarm fork` is the intended public command, not `swarm control run fork`.

## Semantic migration accounting

New canonical owner:
- `platform-spec.yaml#multi_bundle_persistence` for multi-bundle Phase 1 source authority.

Old producer / reader / writer paths now invalid as authority:
- Root `docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md` draft prose.
- Draft `--bundle` spelling.
- Stale platform-spec text treating bare top-level `swarm fork` as retired.
- Stale tracked docs treating bare top-level `swarm fork` as retired or pointing to `swarm control run fork`.
- Live hidden CLI guidance saying `swarm fork` was removed and pointing users to `swarm control run fork`.
- Any future CLI implementation that bypasses `/v1/rpc run.fork` and calls internal runtime/store fork harnesses directly.

Production paths checked for surviving old behavior:
- `api_specification.method_catalog` and generated `openrpc.json` still omit `bundle.*` and `run.fork` because no handlers are implemented in this PR.
- `platform_tables.tables` still retains current live DDL (`bundle_fingerprint`) because changing it here would be runtime/schema implementation.
- CLI command catalog records `bundle` and `run_fork` as absent/planned, not implemented behavior.
- The live hidden `swarm fork` command still exits 2, but its message now points at the promoted top-level command and rejects only unimplemented behavior/legacy harness flags.

Implementation child accounting:
- #1013 schema foundation for `bundles`, `runs.bundle_hash`, and `runs.bundle_source`.
- #1014 reader migration to `bundle_source` semantics.
- #1015 serve ingest and run stamping.
- #1016 startup recovery for unavailable-bundle active runs.
- #1017 bundle list/get/agents/register APIs.
- #1018 non-force bundle.delete semantics.
- #1019 force bundle.delete preservation cleanup.
- #1020 `swarm serve --bundle-hash` DB-loaded bundle mode.
- #1021 bundle-safe list/read scoping.
- #1022 create-new-work `bundle_hash` admission.
- #989/#1023 for run.fork API/runtime/CLI and bundle CLI inventory implementation.
- #976/#1024 for cross-bundle fork and DB-loaded same-bundle source.

Migration completeness:
- Complete for source-authority promotion and live fail-closed guidance alignment.
- Not complete for runtime/API/CLI/schema implementation; those remain in focused children.

## Tests

- `go test ./internal/apispec ./cmd/swarm`
- `go test ./internal/apiv1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
