### PR TITLE
[agent-b][issue #1039] Add agent diagnose CLI consumer

### DIFF
--- a/cmd/swarm/agent_diagnose_test.go
+++ b/cmd/swarm/agent_diagnose_test.go
@@ -211,6 +211,26 @@ func TestAgentDiagnoseFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantStderr: "malformed agent.diagnose result: last_tool_outcome.ok is required",
 		},
 		{
+			name: "healthy watchdog missing last output",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDiagnosisResult()
+				result["runtime_state"] = map[string]any{
+					"watchdog": map[string]any{
+						"state":          "healthy_long_running",
+						"blocking_layer": "session_execution",
+						"action":         "turn_long_running",
+						"outcome":        "observed",
+						"recorded_at":    "2026-05-18T03:02:00Z",
+					},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.diagnose result: runtime_state.watchdog.last_output_at is required for healthy_long_running state",
+		},
+		{
 			name: "malformed last tool result",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest

--- a/cmd/swarm/agent_diagnose_test.go
+++ b/cmd/swarm/agent_diagnose_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentDiagnoseUsesAgentDiagnoseAndRendersOwnedFields(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validAgentDiagnosisResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "diagnose", " agent-1 ", "--queue-limit", "2", "--queue-cursor", "cursor-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "agent.diagnose" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/agent.diagnose", captured.JSONRPC, captured.Method)
+	}
+	wantParams := map[string]any{"agent_id": "agent-1", "queue_limit": float64(2), "queue_cursor": "cursor-1"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	for _, want := range []string{
+		"Agent agent-1",
+		"status=running",
+		"current_session_ref: session_id=session-1 started_at=2026-05-18T03:00:00Z",
+		"last_turn_ref: turn_id=turn-1 completed_at=2026-05-18T03:05:00Z parse_ok=true error=-",
+		"queue: pending_count=2 oldest_pending_age_seconds=30 next_cursor=cursor-2",
+		"pending_delivery: event_id=event-1 event_name=platform.agent_directive enqueued_at=2026-05-18T03:01:00Z attempts=1",
+		"delivery_lifecycle: state=retrying blocking_layer=agent_delivery",
+		"runtime_state.watchdog: state=no_output blocking_layer=session_execution action=session_no_output outcome=warning_emitted last_output_at=- recorded_at=2026-05-18T03:02:00Z",
+		"active: turn_id=turn-1 task_id=task-1 entity_id=entity-1",
+		`last_tool_outcome: turn_id=turn-1 tool_name=read_file tool_use_id=toolu-1 ok=true result={"summary":"ok"}`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"token_usage", "recent_failures", "dead_letters", "full runtime_state", "agent.get", "agent.list", "conversation.", "run.diagnose", "trace"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("stdout contains split concept %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDiagnoseJSONPreservesAPIResultShape(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validAgentDiagnosisResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "diagnose", "agent-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "agent.diagnose" {
+		t.Fatalf("method = %q, want agent.diagnose", captured.Method)
+	}
+	if !reflect.DeepEqual(captured.Params, map[string]any{"agent_id": "agent-1"}) {
+		t.Fatalf("params = %#v, want agent_id only", captured.Params)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode stdout JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded["agent_id"] != "agent-1" || decoded["status"] != "running" {
+		t.Fatalf("json identity/status = %#v", decoded)
+	}
+	if _, ok := decoded["queue"].(map[string]any); !ok {
+		t.Fatalf("json queue = %#v, want object", decoded["queue"])
+	}
+	if _, ok := decoded["last_tool_outcome"].(map[string]any); !ok {
+		t.Fatalf("json last_tool_outcome = %#v, want object", decoded["last_tool_outcome"])
+	}
+	for _, wrapper := range []string{"agent", "diagnosis"} {
+		if _, ok := decoded[wrapper]; ok {
+			t.Fatalf("json output contains CLI wrapper %q: %#v", wrapper, decoded)
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDiagnoseRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validAgentDiagnosisResult())
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing id", args: []string{"agent", "diagnose"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank id", args: []string{"agent", "diagnose", "  "}, wantStderr: "agent id is required"},
+		{name: "extra arg", args: []string{"agent", "diagnose", "agent-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "unsupported flag", args: []string{"agent", "diagnose", "agent-1", "--unknown"}, wantStderr: "unknown flag"},
+		{name: "queue limit too small", args: []string{"agent", "diagnose", "agent-1", "--queue-limit", "0"}, wantStderr: "--queue-limit must be between 1 and 200"},
+		{name: "queue limit too large", args: []string{"agent", "diagnose", "agent-1", "--queue-limit", "201"}, wantStderr: "--queue-limit must be between 1 and 200"},
+		{name: "blank queue cursor", args: []string{"agent", "diagnose", "agent-1", "--queue-cursor", ""}, wantStderr: "--queue-cursor is required when provided"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentDiagnoseFailClosedOnRPCAndMalformedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   cliExitAuth,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "agent not found",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantCode:   cliExitNotFound,
+			wantStderr: "AGENT_NOT_FOUND: Application error: AGENT_NOT_FOUND",
+		},
+		{
+			name: "api invalid params",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentInvalidParamsJSONRPCError(t, w, req.ID, "Invalid params: queue_limit")
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "Invalid params: queue_limit",
+		},
+		{
+			name: "missing queue deliveries",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDiagnosisResult()
+				result["queue"] = map[string]any{"pending_count": 1, "oldest_pending_age_seconds": 30}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.diagnose result: queue.pending_deliveries is required",
+		},
+		{
+			name: "missing last tool ok",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDiagnosisResult()
+				result["last_tool_outcome"] = map[string]any{"turn_id": "turn-1", "tool_name": "read_file"}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.diagnose result: last_tool_outcome.ok is required",
+		},
+		{
+			name: "malformed last tool result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDiagnosisResult()
+				result["last_tool_outcome"] = map[string]any{"turn_id": "turn-1", "tool_name": "read_file", "ok": true, "result": "not-object"}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.diagnose result: last_tool_outcome.result must be a JSON object",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "diagnose", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func validAgentDiagnosisResult() map[string]any {
+	return map[string]any{
+		"agent_id":            "agent-1",
+		"status":              "running",
+		"current_session_ref": map[string]any{"session_id": "session-1", "started_at": "2026-05-18T03:00:00Z"},
+		"last_turn_ref":       map[string]any{"turn_id": "turn-1", "completed_at": "2026-05-18T03:05:00Z", "parse_ok": true},
+		"queue": map[string]any{
+			"pending_count":              2,
+			"oldest_pending_age_seconds": 30,
+			"pending_deliveries": []map[string]any{
+				{"event_id": "event-1", "event_name": "platform.agent_directive", "enqueued_at": "2026-05-18T03:01:00Z", "attempts": 1},
+			},
+			"next_cursor": "cursor-2",
+		},
+		"delivery_lifecycle": map[string]any{"state": "retrying", "blocking_layer": "agent_delivery"},
+		"runtime_state": map[string]any{
+			"watchdog": map[string]any{
+				"state":          "no_output",
+				"blocking_layer": "session_execution",
+				"action":         "session_no_output",
+				"outcome":        "warning_emitted",
+				"recorded_at":    "2026-05-18T03:02:00Z",
+			},
+		},
+		"active":            map[string]any{"turn_id": "turn-1", "task_id": "task-1", "entity_id": "entity-1"},
+		"last_tool_outcome": map[string]any{"turn_id": "turn-1", "tool_name": "read_file", "tool_use_id": "toolu-1", "ok": true, "result": map[string]any{"summary": "ok"}},
+	}
+}
+
+func writeAgentInvalidParamsJSONRPCError(t *testing.T, w http.ResponseWriter, id string, message string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32602,
+			"message": message,
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +18,16 @@ type agentListCommandOptions struct {
 	role       string
 }
 
+type agentDiagnoseCommandOptions struct {
+	apiOptions  rootCommandOptions
+	queueLimit  int
+	queueCursor string
+	asJSON      bool
+
+	queueLimitSet  bool
+	queueCursorSet bool
+}
+
 type agentListResult struct {
 	Agents []agentSummary `json:"agents"`
 }
@@ -24,6 +36,64 @@ type agentDetailResult struct {
 	Agent             agentSummary     `json:"agent"`
 	CurrentSessionRef *agentSessionRef `json:"current_session_ref,omitempty"`
 	LastTurnRef       *agentTurnRef    `json:"last_turn_ref,omitempty"`
+}
+
+type agentDiagnosisResult struct {
+	AgentID           string                           `json:"agent_id"`
+	Status            string                           `json:"status"`
+	CurrentSessionRef *agentSessionRef                 `json:"current_session_ref,omitempty"`
+	LastTurnRef       *agentTurnRef                    `json:"last_turn_ref,omitempty"`
+	Queue             agentDiagnosisQueue              `json:"queue"`
+	DeliveryLifecycle *agentDiagnosisDeliveryLifecycle `json:"delivery_lifecycle,omitempty"`
+	RuntimeState      *agentDiagnosisRuntimeState      `json:"runtime_state,omitempty"`
+	Active            *agentDiagnosisActive            `json:"active,omitempty"`
+	LastToolOutcome   *agentDiagnosisLastToolOutcome   `json:"last_tool_outcome,omitempty"`
+}
+
+type agentDiagnosisQueue struct {
+	PendingCount            int                             `json:"pending_count"`
+	OldestPendingAgeSeconds int                             `json:"oldest_pending_age_seconds"`
+	PendingDeliveries       []agentDiagnosisPendingDelivery `json:"pending_deliveries"`
+	NextCursor              *string                         `json:"next_cursor,omitempty"`
+}
+
+type agentDiagnosisPendingDelivery struct {
+	EventID    string `json:"event_id"`
+	EventName  string `json:"event_name"`
+	EnqueuedAt string `json:"enqueued_at"`
+	Attempts   int    `json:"attempts"`
+}
+
+type agentDiagnosisDeliveryLifecycle struct {
+	State         string `json:"state"`
+	BlockingLayer string `json:"blocking_layer"`
+}
+
+type agentDiagnosisRuntimeState struct {
+	Watchdog *agentDiagnosisWatchdog `json:"watchdog"`
+}
+
+type agentDiagnosisWatchdog struct {
+	State         string  `json:"state"`
+	BlockingLayer string  `json:"blocking_layer"`
+	Action        string  `json:"action"`
+	Outcome       string  `json:"outcome"`
+	LastOutputAt  *string `json:"last_output_at,omitempty"`
+	RecordedAt    string  `json:"recorded_at"`
+}
+
+type agentDiagnosisActive struct {
+	TurnID   string  `json:"turn_id"`
+	TaskID   *string `json:"task_id,omitempty"`
+	EntityID *string `json:"entity_id,omitempty"`
+}
+
+type agentDiagnosisLastToolOutcome struct {
+	TurnID    string          `json:"turn_id"`
+	ToolName  string          `json:"tool_name"`
+	ToolUseID *string         `json:"tool_use_id,omitempty"`
+	OK        *bool           `json:"ok"`
+	Result    json.RawMessage `json:"result,omitempty"`
 }
 
 type agentSummary struct {
@@ -92,11 +162,31 @@ func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newAgentViewCommand(opts),
+		newAgentDiagnoseCommand(opts),
 		newAgentRestartCommand(opts),
 		newAgentReplayCommand(opts),
 		newAgentReplayBacklogCommand(opts),
 		newAgentDirectiveCommand(opts),
 	)
+	return cmd
+}
+
+func newAgentDiagnoseCommand(opts rootCommandOptions) *cobra.Command {
+	diagnoseOpts := agentDiagnoseCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "diagnose <agent-id>",
+		Short: "Diagnose one agent through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			diagnoseOpts.queueLimitSet = cmd.Flags().Changed("queue-limit")
+			diagnoseOpts.queueCursorSet = cmd.Flags().Changed("queue-cursor")
+			return runAgentDiagnoseCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), diagnoseOpts, args[0])
+		},
+	}
+	cmd.Flags().IntVar(&diagnoseOpts.queueLimit, "queue-limit", 0, "Max pending-delivery detail rows to return (1-200)")
+	cmd.Flags().StringVar(&diagnoseOpts.queueCursor, "queue-cursor", "", "Opaque queue cursor returned by the previous diagnosis result")
+	cmd.Flags().BoolVar(&diagnoseOpts.asJSON, "json", false, cliOutputJSONFlagHelp)
+	bindCLIAPIConnectionFlags(cmd, &diagnoseOpts.apiOptions)
 	return cmd
 }
 
@@ -167,11 +257,41 @@ func runAgentViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCo
 	return nil
 }
 
+func runAgentDiagnoseCommand(ctx context.Context, out, errOut io.Writer, opts agentDiagnoseCommandOptions, agentID string) error {
+	params, err := opts.params(agentID)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, agentDiagnoseAPIErrorClassifier())
+	}
+	var result agentDiagnosisResult
+	if err := client.call(ctx, "agent.diagnose", params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, agentDiagnoseAPIErrorClassifier())
+	}
+	if err := validateAgentDiagnosisResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, agentDiagnoseAPIErrorClassifier())
+	}
+	if opts.asJSON {
+		if err := json.NewEncoder(out).Encode(result); err != nil {
+			return returnCLIValidationError(errOut, fmt.Errorf("render json output: %w", err))
+		}
+		return nil
+	}
+	writeAgentDiagnosisResult(out, result)
+	return nil
+}
+
 func agentListAPIErrorClassifier() cliAPIErrorClassifier {
 	return cliAPIErrorClassifier{}
 }
 
 func agentViewAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"AGENT_NOT_FOUND"}}
+}
+
+func agentDiagnoseAPIErrorClassifier() cliAPIErrorClassifier {
 	return cliAPIErrorClassifier{notFoundCodes: []string{"AGENT_NOT_FOUND"}}
 }
 
@@ -184,6 +304,28 @@ func (opts agentListCommandOptions) params() map[string]any {
 		params["role"] = role
 	}
 	return params
+}
+
+func (opts agentDiagnoseCommandOptions) params(agentID string) (map[string]any, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	params := map[string]any{"agent_id": agentID}
+	if opts.queueLimitSet {
+		if opts.queueLimit < 1 || opts.queueLimit > 200 {
+			return nil, fmt.Errorf("--queue-limit must be between 1 and 200")
+		}
+		params["queue_limit"] = opts.queueLimit
+	}
+	if opts.queueCursorSet {
+		cursor := strings.TrimSpace(opts.queueCursor)
+		if cursor == "" {
+			return nil, fmt.Errorf("--queue-cursor is required when provided")
+		}
+		params["queue_cursor"] = cursor
+	}
+	return params, nil
 }
 
 func validateAgentListResult(result agentListResult) error {
@@ -224,6 +366,182 @@ func validateAgentDetailResult(result agentDetailResult) error {
 	return nil
 }
 
+func validateAgentDiagnosisResult(result agentDiagnosisResult) error {
+	if strings.TrimSpace(result.AgentID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: agent_id is required")
+	}
+	if _, ok := agentValidStatuses[strings.TrimSpace(result.Status)]; !ok {
+		return fmt.Errorf("malformed agent.diagnose result: status=%q is not a valid AgentStatus", result.Status)
+	}
+	if ref := result.CurrentSessionRef; ref != nil {
+		if strings.TrimSpace(ref.SessionID) == "" {
+			return fmt.Errorf("malformed agent.diagnose result: current_session_ref.session_id is required")
+		}
+		if err := validateAgentDiagnosisTimestamp("current_session_ref.started_at", ref.StartedAt); err != nil {
+			return err
+		}
+	}
+	if ref := result.LastTurnRef; ref != nil {
+		if strings.TrimSpace(ref.TurnID) == "" {
+			return fmt.Errorf("malformed agent.diagnose result: last_turn_ref.turn_id is required")
+		}
+		if err := validateAgentDiagnosisTimestamp("last_turn_ref.completed_at", ref.CompletedAt); err != nil {
+			return err
+		}
+		if ref.ParseOK == nil {
+			return fmt.Errorf("malformed agent.diagnose result: last_turn_ref.parse_ok is required")
+		}
+	}
+	if result.Queue.PendingCount < 0 {
+		return fmt.Errorf("malformed agent.diagnose result: queue.pending_count must be non-negative")
+	}
+	if result.Queue.OldestPendingAgeSeconds < 0 {
+		return fmt.Errorf("malformed agent.diagnose result: queue.oldest_pending_age_seconds must be non-negative")
+	}
+	if result.Queue.PendingDeliveries == nil {
+		return fmt.Errorf("malformed agent.diagnose result: queue.pending_deliveries is required")
+	}
+	if result.Queue.NextCursor != nil && strings.TrimSpace(*result.Queue.NextCursor) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: queue.next_cursor is empty")
+	}
+	for i, delivery := range result.Queue.PendingDeliveries {
+		if strings.TrimSpace(delivery.EventID) == "" {
+			return fmt.Errorf("malformed agent.diagnose result: queue.pending_deliveries[%d].event_id is required", i)
+		}
+		if strings.TrimSpace(delivery.EventName) == "" {
+			return fmt.Errorf("malformed agent.diagnose result: queue.pending_deliveries[%d].event_name is required", i)
+		}
+		if err := validateAgentDiagnosisTimestamp(fmt.Sprintf("queue.pending_deliveries[%d].enqueued_at", i), delivery.EnqueuedAt); err != nil {
+			return err
+		}
+		if delivery.Attempts < 0 {
+			return fmt.Errorf("malformed agent.diagnose result: queue.pending_deliveries[%d].attempts must be non-negative", i)
+		}
+	}
+	if lifecycle := result.DeliveryLifecycle; lifecycle != nil {
+		if _, ok := agentDiagnosisLifecycleStates[strings.TrimSpace(lifecycle.State)]; !ok {
+			return fmt.Errorf("malformed agent.diagnose result: delivery_lifecycle.state=%q is not valid", lifecycle.State)
+		}
+		if strings.TrimSpace(lifecycle.BlockingLayer) == "" {
+			return fmt.Errorf("malformed agent.diagnose result: delivery_lifecycle.blocking_layer is required")
+		}
+	}
+	if state := result.RuntimeState; state != nil {
+		if err := validateAgentDiagnosisRuntimeState(state); err != nil {
+			return err
+		}
+	}
+	if active := result.Active; active != nil {
+		if err := validateAgentDiagnosisActive(active); err != nil {
+			return err
+		}
+	}
+	if outcome := result.LastToolOutcome; outcome != nil {
+		if err := validateAgentDiagnosisLastToolOutcome(outcome); err != nil {
+			return err
+		}
+		if result.Active == nil {
+			return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome requires active selected-turn evidence")
+		}
+		if strings.TrimSpace(outcome.TurnID) != strings.TrimSpace(result.Active.TurnID) {
+			return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.turn_id %q must match active.turn_id %q", outcome.TurnID, result.Active.TurnID)
+		}
+	}
+	return nil
+}
+
+var agentDiagnosisLifecycleStates = map[string]struct{}{
+	"queued":    {},
+	"launching": {},
+	"active":    {},
+	"retrying":  {},
+	"exhausted": {},
+}
+
+var agentDiagnosisWatchdogStates = map[string]struct{}{
+	"healthy_long_running": {},
+	"no_output":            {},
+}
+
+var agentDiagnosisWatchdogBlockingLayers = map[string]struct{}{
+	"session_execution": {},
+}
+
+var agentDiagnosisWatchdogActions = map[string]struct{}{
+	"turn_long_running": {},
+	"session_no_output": {},
+}
+
+var agentDiagnosisWatchdogOutcomes = map[string]struct{}{
+	"observed":        {},
+	"warning_emitted": {},
+}
+
+func validateAgentDiagnosisRuntimeState(state *agentDiagnosisRuntimeState) error {
+	if state.Watchdog == nil {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog is required")
+	}
+	watchdog := state.Watchdog
+	if _, ok := agentDiagnosisWatchdogStates[strings.TrimSpace(watchdog.State)]; !ok {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.state=%q is not valid", watchdog.State)
+	}
+	if _, ok := agentDiagnosisWatchdogBlockingLayers[strings.TrimSpace(watchdog.BlockingLayer)]; !ok {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.blocking_layer=%q is not valid", watchdog.BlockingLayer)
+	}
+	if _, ok := agentDiagnosisWatchdogActions[strings.TrimSpace(watchdog.Action)]; !ok {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.action=%q is not valid", watchdog.Action)
+	}
+	if _, ok := agentDiagnosisWatchdogOutcomes[strings.TrimSpace(watchdog.Outcome)]; !ok {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.outcome=%q is not valid", watchdog.Outcome)
+	}
+	if watchdog.LastOutputAt != nil {
+		if err := validateAgentDiagnosisTimestamp("runtime_state.watchdog.last_output_at", *watchdog.LastOutputAt); err != nil {
+			return err
+		}
+	}
+	if err := validateAgentDiagnosisTimestamp("runtime_state.watchdog.recorded_at", watchdog.RecordedAt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAgentDiagnosisActive(active *agentDiagnosisActive) error {
+	if strings.TrimSpace(active.TurnID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: active.turn_id is required")
+	}
+	if active.TaskID != nil && strings.TrimSpace(*active.TaskID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: active.task_id is empty")
+	}
+	if active.EntityID != nil && strings.TrimSpace(*active.EntityID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: active.entity_id is empty")
+	}
+	return nil
+}
+
+func validateAgentDiagnosisLastToolOutcome(outcome *agentDiagnosisLastToolOutcome) error {
+	if strings.TrimSpace(outcome.TurnID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.turn_id is required")
+	}
+	if strings.TrimSpace(outcome.ToolName) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.tool_name is required")
+	}
+	if outcome.ToolUseID != nil && strings.TrimSpace(*outcome.ToolUseID) == "" {
+		return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.tool_use_id is empty")
+	}
+	if outcome.OK == nil {
+		return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.ok is required")
+	}
+	if len(outcome.Result) > 0 && !jsonRawMessageIsObject(outcome.Result) {
+		return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.result must be a JSON object")
+	}
+	return nil
+}
+
+func jsonRawMessageIsObject(raw json.RawMessage) bool {
+	var decoded map[string]any
+	return json.Unmarshal(raw, &decoded) == nil && decoded != nil
+}
+
 func validateAgentSummary(agent agentSummary) error {
 	for _, field := range []struct {
 		name  string
@@ -249,6 +567,17 @@ func validateAgentSummary(agent agentSummary) error {
 	}
 	if _, ok := agentValidSessionScopes[strings.TrimSpace(agent.SessionScope)]; !ok {
 		return fmt.Errorf("session_scope=%q is not a valid SessionScope", agent.SessionScope)
+	}
+	return nil
+}
+
+func validateAgentDiagnosisTimestamp(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("malformed agent.diagnose result: %s is required", field)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("malformed agent.diagnose result: %s must be an RFC3339 timestamp: %w", field, err)
 	}
 	return nil
 }
@@ -286,6 +615,69 @@ func writeAgentListResult(out io.Writer, result agentListResult) {
 	}
 }
 
+func writeAgentDiagnosisResult(out io.Writer, result agentDiagnosisResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Agent %s\n", result.AgentID)
+	fmt.Fprintf(out, "status=%s\n", result.Status)
+	if ref := result.CurrentSessionRef; ref != nil {
+		fmt.Fprintf(out, "current_session_ref: session_id=%s started_at=%s\n", ref.SessionID, ref.StartedAt)
+	}
+	if ref := result.LastTurnRef; ref != nil {
+		fmt.Fprintf(out, "last_turn_ref: turn_id=%s completed_at=%s parse_ok=%t error=%s\n",
+			ref.TurnID,
+			ref.CompletedAt,
+			*ref.ParseOK,
+			agentDash(ref.Error),
+		)
+	}
+	queue := result.Queue
+	fmt.Fprintf(out, "queue: pending_count=%d oldest_pending_age_seconds=%d next_cursor=%s\n",
+		queue.PendingCount,
+		queue.OldestPendingAgeSeconds,
+		agentOptionalStringDash(queue.NextCursor),
+	)
+	for _, delivery := range queue.PendingDeliveries {
+		fmt.Fprintf(out, "pending_delivery: event_id=%s event_name=%s enqueued_at=%s attempts=%d\n",
+			delivery.EventID,
+			delivery.EventName,
+			delivery.EnqueuedAt,
+			delivery.Attempts,
+		)
+	}
+	if lifecycle := result.DeliveryLifecycle; lifecycle != nil {
+		fmt.Fprintf(out, "delivery_lifecycle: state=%s blocking_layer=%s\n", lifecycle.State, lifecycle.BlockingLayer)
+	}
+	if state := result.RuntimeState; state != nil && state.Watchdog != nil {
+		watchdog := state.Watchdog
+		fmt.Fprintf(out, "runtime_state.watchdog: state=%s blocking_layer=%s action=%s outcome=%s last_output_at=%s recorded_at=%s\n",
+			watchdog.State,
+			watchdog.BlockingLayer,
+			watchdog.Action,
+			watchdog.Outcome,
+			agentOptionalStringDash(watchdog.LastOutputAt),
+			watchdog.RecordedAt,
+		)
+	}
+	if active := result.Active; active != nil {
+		fmt.Fprintf(out, "active: turn_id=%s task_id=%s entity_id=%s\n",
+			active.TurnID,
+			agentOptionalStringDash(active.TaskID),
+			agentOptionalStringDash(active.EntityID),
+		)
+	}
+	if outcome := result.LastToolOutcome; outcome != nil {
+		fmt.Fprintf(out, "last_tool_outcome: turn_id=%s tool_name=%s tool_use_id=%s ok=%t result=%s\n",
+			outcome.TurnID,
+			outcome.ToolName,
+			agentOptionalStringDash(outcome.ToolUseID),
+			*outcome.OK,
+			agentJSONRawMessageDash(outcome.Result),
+		)
+	}
+}
+
 func writeAgentDetailResult(out io.Writer, result agentDetailResult) {
 	if out == nil {
 		return
@@ -311,6 +703,24 @@ func writeAgentDetailResult(out io.Writer, result agentDetailResult) {
 			agentDash(ref.Error),
 		)
 	}
+}
+
+func agentOptionalStringDash(value *string) string {
+	if value == nil {
+		return "-"
+	}
+	return agentDash(*value)
+}
+
+func agentJSONRawMessageDash(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "-"
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return string(raw)
+	}
+	return compact.String()
 }
 
 func agentDash(value string) string {

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -494,6 +494,9 @@ func validateAgentDiagnosisRuntimeState(state *agentDiagnosisRuntimeState) error
 	if _, ok := agentDiagnosisWatchdogOutcomes[strings.TrimSpace(watchdog.Outcome)]; !ok {
 		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.outcome=%q is not valid", watchdog.Outcome)
 	}
+	if strings.TrimSpace(watchdog.State) == "healthy_long_running" && watchdog.LastOutputAt == nil {
+		return fmt.Errorf("malformed agent.diagnose result: runtime_state.watchdog.last_output_at is required for healthy_long_running state")
+	}
 	if watchdog.LastOutputAt != nil {
 		if err := validateAgentDiagnosisTimestamp("runtime_state.watchdog.last_output_at", *watchdog.LastOutputAt); err != nil {
 			return err

--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -131,6 +131,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "incidents", args: []string{"incidents"}},
 		{name: "agents list", args: []string{"agents", "list"}},
 		{name: "agent view", args: []string{"agent", "view", "agent-1"}},
+		{name: "agent diagnose", args: []string{"agent", "diagnose", "agent-1"}},
 		{name: "agent restart", args: []string{"agent", "restart", "agent-1"}},
 		{name: "agent replay", args: []string{"agent", "replay", "agent-1", "--event-id", "event-1"}},
 		{name: "agent replay backlog", args: []string{"agent", "replay-backlog", "agent-1"}},

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -326,7 +326,7 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 	withFlags := []string{
 		"runs", "status", "trace", "health", "logs", "incidents",
 		"events list", "events follow", "event view", "event publish", "event replay",
-		"agents list", "agent view", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
+		"agents list", "agent view", "agent diagnose", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
 		"entities list", "entity view", "entity aggregate",
 		"mailbox list", "mailbox view", "mailbox approve", "mailbox reject", "mailbox defer",
 		"control pause", "control continue", "control stop", "control nuke",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7815,6 +7815,33 @@ cli_specification:
       - AGENT_NOT_FOUND and malformed AgentDetail responses fail closed
       - invalid args/flags make zero API calls
       - output remains refs-only; no conversation.current_for_agent, conversation.get, transcript, direct DB/store/runtime/EventBus/agentcontrol, or legacy endpoint usage
+    agent_diagnose:
+      command: swarm agent diagnose <agent-id> [--queue-limit <n>] [--queue-cursor <cursor>] [--json]
+      tier: should_have
+      implementation_status: implemented
+      owner: /v1/rpc agent.diagnose
+      behavior: Read-only single-agent diagnosis CLI consumer. The CLI sends only agent_id and explicitly provided queue_limit/queue_cursor to /v1/rpc agent.diagnose, renders only owner-backed AgentDiagnosis fields, and MUST NOT synthesize diagnosis from agent.get/list, conversation, run, trace, token, dashboard/Builder REST, DB/store, runtime, EventBus, or agentcontrol owners.
+      output:
+        header: Agent <agent-id>
+        summary_line: status=<status>
+        queue_line: pending_count=<pending_count> oldest_pending_age_seconds=<seconds> next_cursor=<cursor-or-dash>
+        optional_refs: optional current_session_ref, last_turn_ref, delivery_lifecycle, runtime_state.watchdog, active, and last_tool_outcome lines when present
+        json: --json emits the AgentDiagnosis result shape exactly, with no CLI wrapper
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        not_found_errors:
+        - AGENT_NOT_FOUND
+      proof_expectations:
+      - exact /v1/rpc agent.diagnose call with agent_id plus queue_limit/queue_cursor only when explicitly provided
+      - --queue-limit fails before API request unless it is in the API-owned 1..200 range
+      - --queue-cursor fails before API request when explicitly blank
+      - --json preserves the AgentDiagnosis result shape without adding token usage, failures, dead letters, full runtime_state enum, top-level watchdog, run_id, bundle_version, dashboard state, or richer per-tool diagnostics
+      - AGENT_NOT_FOUND, invalid params, HTTP failures, and malformed AgentDiagnosis responses fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/agentcontrol/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation, run, trace, agent.get, or agent.list method usage
     agent_restart:
       command: swarm agent restart <agent-id> [--idempotency-key <key>]
       tier: should_have


### PR DESCRIPTION
## Summary

Adds the supported `swarm agent diagnose <agent-id>` CLI consumer over the already-promoted `/v1/rpc agent.diagnose` API owner.

Closes #1039
Part of #852
Related to #735 and #794

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.agent.diagnose`
- `docs/specs/swarm-platform/platform/contracts/openrpc.json` generated `agent.diagnose` method
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.agent_diagnose`
- #1039 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice with same-PR command-row promotion.

## Semantic Boundary

New canonical CLI command authority: `platform-spec.yaml` command catalog row for `swarm agent diagnose <agent-id> [--queue-limit <n>] [--queue-cursor <cursor>] [--json]`.

API/read owner consumed: `/v1/rpc agent.diagnose`. The CLI sends only `agent_id`, `queue_limit`, and `queue_cursor`, and omits unset optional params.

Old producer / reader / writer path now invalid: none existed for `swarm agent diagnose`; this PR prevents a local CLI diagnosis interpreter from being introduced. Checked production paths for surviving old behavior: `cmd/swarm` agent commands, API boundary tests, generated OpenRPC, `internal/apiv1` `agent.diagnose`, and `internal/store` diagnosis owner tests. Migration is complete for this CLI child; #852 remains open for dashboard and future diagnosis-field residuals.

## Proof

- `go test ./cmd/swarm -run 'TestAgentDiagnose|TestAgentRead|TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest|TestCLIAPIConnectionFlagsSurfaceAndIsolation'`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -run 'AgentDiagnose|AgentDiagnosis|OpenRPC'`
- `go run ./cmd/swarm agent diagnose --help`
- `go test ./...`
- `git diff --check`
