### PR TITLE
[agent-c][issue #1008] Map preservation cleanup owner boundary

### DIFF
--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -55,6 +55,10 @@ active_issues:
     title: Reconcile event_receipts typed subscriber identity key
     maps_to:
       - event_receipts_typed_subscriber_identity_owner
+  - id: 1008
+    title: Define preservation-mode cleanup owner for multi-bundle orphan and force-delete cleanup
+    maps_to:
+      - multi_bundle_preservation_cleanup_owner
   - id: 132
     title: Make CEL validation lifecycle-aware for entity-field availability
     maps_to:
@@ -196,6 +200,40 @@ nodes:
         - centralized subscriber-id namespacing without DDL and writer migration
         - changing one ON CONFLICT target while leaving other receipt writers on the old key
     current_action_pressure: active implementation under issue 1030
+  - id: multi_bundle_preservation_cleanup_owner
+    title: Multi-Bundle Preservation Cleanup Owner
+    parent_class: multi-bundle source-authority and runtime lifecycle cleanup drift between destructive reset deletion and preservation-mode orphan/delete transitions
+    canonical_owners:
+      - issue #1012 / platform-spec.yaml multi-bundle source authority before runtime implementation
+      - future internal/runtime/preservationcleanup owner for preserve-and-transition cleanup
+      - internal/runtime/destructivereset remains the separate destructive reset owner for runtime.nuke only
+    why_this_node_exists: multi-bundle unavailable-bundle cleanup must preserve historical run, event, delivery, session, timer, audit, and entity rows while transitioning their terminal state; reusing the existing destructive reset delete catalog would erase the audit identity the bundle lifecycle requires.
+    known_manifestations:
+      - old #987 and #988 wording says to reuse destructivereset even though DefaultPlatformCleanupCatalog deletes run-scoped history rows
+      - current master has no preservationcleanup owner and no merge-bearing platform-spec authority for bundle_source, bundles, bundle.delete, or bundle unavailable error codes
+      - startup recovery auto-orphan (#1016) and bundle.delete --force Phase 3 (#1019) must consume one preservation cleanup owner rather than local per-consumer SQL
+      - bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner
+      - server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern
+    representative_issues:
+      - 1008
+      - 987
+      - 988
+      - 1009
+      - 1011
+      - 1012
+      - 1016
+      - 1019
+      - 1027
+    common_framing_mistakes:
+      too_broad:
+        - implement all multi-bundle persistence behavior from the cleanup owner issue
+        - absorb API, CLI, schema, OpenRPC, startup recovery, bundle.delete, and runtime.nuke include_bundles in one slice
+        - treat Phase 5 bundle row deletion and preservation cleanup as one owner
+      too_narrow:
+        - add a destructivereset mode flag while preserving delete-path ownership
+        - patch only startup auto-orphan or only bundle.delete --force instead of centralizing the shared preservation owner
+        - transition one table without accounting for runs, run_control_state, deliveries, sessions, timers, events, audits, turns, entity_state, and entity_mutations
+    current_action_pressure: source-authority and owner-boundary first slice under issue 1008; runtime implementation remains blocked until #1012 source authority lands or a later gate explicitly widens
   - id: boot_check_definition_drift
     title: Boot Check Definition Drift
     parent_class: semantic correctness drift between authoritative boot-check definitions and enforcement/proof surfaces

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -204,16 +204,16 @@ nodes:
     title: Multi-Bundle Preservation Cleanup Owner
     parent_class: multi-bundle source-authority and runtime lifecycle cleanup drift between destructive reset deletion and preservation-mode orphan/delete transitions
     canonical_owners:
-      - issue #1012 / platform-spec.yaml multi-bundle source authority before runtime implementation
+      - "issue #1012 / platform-spec.yaml multi-bundle source authority before runtime implementation"
       - future internal/runtime/preservationcleanup owner for preserve-and-transition cleanup
       - internal/runtime/destructivereset remains the separate destructive reset owner for runtime.nuke only
     why_this_node_exists: multi-bundle unavailable-bundle cleanup must preserve historical run, event, delivery, session, timer, audit, and entity rows while transitioning their terminal state; reusing the existing destructive reset delete catalog would erase the audit identity the bundle lifecycle requires.
     known_manifestations:
-      - old #987 and #988 wording says to reuse destructivereset even though DefaultPlatformCleanupCatalog deletes run-scoped history rows
+      - "old #987 and #988 wording says to reuse destructivereset even though DefaultPlatformCleanupCatalog deletes run-scoped history rows"
       - current master has no preservationcleanup owner and no merge-bearing platform-spec authority for bundle_source, bundles, bundle.delete, or bundle unavailable error codes
-      - startup recovery auto-orphan (#1016) and bundle.delete --force Phase 3 (#1019) must consume one preservation cleanup owner rather than local per-consumer SQL
-      - bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner
-      - server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern
+      - "startup recovery auto-orphan (#1016) and bundle.delete --force Phase 3 (#1019) must consume one preservation cleanup owner rather than local per-consumer SQL"
+      - "bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner"
+      - "server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern"
     representative_issues:
       - 1008
       - 987
@@ -233,7 +233,7 @@ nodes:
         - add a destructivereset mode flag while preserving delete-path ownership
         - patch only startup auto-orphan or only bundle.delete --force instead of centralizing the shared preservation owner
         - transition one table without accounting for runs, run_control_state, deliveries, sessions, timers, events, audits, turns, entity_state, and entity_mutations
-    current_action_pressure: source-authority and owner-boundary first slice under issue 1008; runtime implementation remains blocked until #1012 source authority lands or a later gate explicitly widens
+    current_action_pressure: "source-authority and owner-boundary first slice under issue 1008; runtime implementation remains blocked until #1012 source authority lands or a later gate explicitly widens"
   - id: boot_check_definition_drift
     title: Boot Check Definition Drift
     parent_class: semantic correctness drift between authoritative boot-check definitions and enforcement/proof surfaces


### PR DESCRIPTION
## Summary

Adds the source/owner-boundary watchlist mapping approved by the #1008 gate. This PR does not implement runtime cleanup behavior.

This PR:
- maps #1008 to a new `multi_bundle_preservation_cleanup_owner` semantic watchlist node;
- records the approved preservation cleanup owner boundary and known sibling splits;
- keeps #1012 source authority, #1009 Phase 5 atomicity, #1016 startup recovery, #1019 bundle.delete force behavior, and #1027 runtime.nuke bundle-catalog behavior explicitly separate.

Part of #1008
Related to #1011, #1012, #1009, #1016, #1019, #1027

## Governing refs / context

No exact merge-bearing platform-spec section exists on current `master` for the #1008 runtime behavior. The binding context for this source-boundary slice is:
- #1008 pre-audit and independent gate outcome;
- #1011 parent multi-bundle tracker;
- #1012 source-authority prerequisite, currently open;
- #987/#988 implementation-guidance updates replacing destructive-reset reuse with #1008 preservation cleanup;
- #998/#999/#1004 status, migration, and error-policy decisions;
- #1009 Phase 5 transaction-ordering split.

Adjacent current spec/code context:
- `platform_tables.destructive_reset_cleanup_policy` and `runtime.nuke` remain destructive reset authority only;
- `agent_sessions.session_termination_metadata`, `runs`, and `timers` define current table semantics consumed by the future preservation owner.

## Semantic migration accounting

New canonical map artifact:
- `docs/watchlists/semantic-correctness.yaml#multi_bundle_preservation_cleanup_owner` maps the #1008 failure class.

Old path now invalid as authority:
- old #987/#988 wording that suggested direct destructivereset reuse for preservation cleanup.

Production paths checked for surviving old behavior:
- no runtime/API/CLI/schema/OpenRPC/store code changed;
- destructive reset and `runtime.nuke` remain untouched;
- the watchlist node explicitly marks destructive reset as a separate owner.

Migration completeness:
- complete for this source/owner-boundary watchlist slice;
- runtime implementation remains blocked until #1012 source authority lands or a later gate explicitly widens.

## Tests

- `git diff --check`
- `go test ./...`

Note: a strict Ruby YAML parse also fails on the unmodified `HEAD` version of this watchlist because of existing nested-list syntax around the strict event-schema node; this PR does not repair that unrelated pre-existing format issue.
