### PR TITLE
[agent-a][issue #1044] Align mailbox approval payload shape

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8944,6 +8944,42 @@ api_specification:
         event_name: mailbox.item_decided
       - item_type: operational_decision
         event_name: mailbox.item_decided
+      approval_event_payload_contract:
+        event_name: mailbox.item_decided
+        producer: /v1/rpc mailbox.approve
+        rule: >
+          Mailbox approval events are platform-produced flat event payloads and
+          MUST satisfy the active event schema before persistence. The original
+          public mailbox row payload MUST be emitted under the declared
+          `mailbox_payload` field. The operator approval context remains under
+          `decision_payload`.
+        required_fields:
+        - mailbox_id
+        - mailbox_decision_id
+        - decision
+        - decision_payload
+        - item_type
+        - mailbox_payload
+        - source_event_id
+        - source_flow
+        - source_entity_id
+        - decided_by
+        - decided_at
+        field_semantics:
+          mailbox_payload: >
+            Original public mailbox row payload produced by the mailbox row
+            materialization owner, exposed as a declared business payload field
+            for consumers of `mailbox.item_decided`.
+          decision_payload: >
+            Operator-supplied approval context from the `mailbox.approve`
+            request. It is separate from `mailbox_payload` and MUST NOT be
+            merged with the row payload.
+        forbidden_fields:
+        - payload
+        validation: >
+          The producer MUST NOT emit the retired top-level `payload` member and
+          validators MUST NOT add a special allowlist for it. Contracts that need
+          the mailbox row payload must declare and consume `mailbox_payload`.
     scopes:
       vocabulary: action-resource (read:<resource>, write:<resource>, control:<resource>, admin:<resource>, approve:<resource>,
         verify:<resource>)

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -24,9 +24,11 @@ import (
 func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
-	bus, err := runtimebus.NewEventBus(pg)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(true)),
+	})
 	if err != nil {
-		t.Fatalf("NewEventBus: %v", err)
+		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -213,6 +215,8 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 1 {
 		t.Fatalf("mailbox.item_decided event count = %d, want 1", count)
 	}
+	approvalPayload := loadEventPayload(t, db, downstreamID)
+	assertMailboxItemDecidedPayloadShape(t, approvalPayload, "review this", true)
 
 	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"conflict","method":"mailbox.approve","params":{"mailbox_id":"`+mailboxID+`","decision_payload":{"approved":false},"idempotency_key":"idem-approve"}}`)
 	if conflict.Error == nil {
@@ -350,24 +354,100 @@ func TestOperatorMailboxGetDegradesEntityContextReadFailure(t *testing.T) {
 	}
 }
 
-func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(false)),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
 	if err := pg.AppendEvent(ctx, events.Event{
 		ID:      sourceEventID,
 		Type:    "review.requested",
 		RunID:   uuid.NewString(),
 		Payload: json.RawMessage(`{"request":true}`),
-	}); err != nil {
+	}.WithEntityID(entityID)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
-		EventID: sourceEventID,
-		Type:    "review_request",
-		Summary: "needs approval",
-		Context: []byte(`{"title":"review this"}`),
+		EventID:  sourceEventID,
+		EntityID: entityID,
+		Type:     "review_request",
+		Summary:  "needs approval",
+		Context:  []byte(`{"title":"review this"}`),
+	})
+	if err != nil {
+		t.Fatalf("insert mailbox: %v", err)
+	}
+
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:         func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready:       func() bool { return true },
+			Database:    fakePinger{},
+			Mailbox:     pg,
+			Idempotency: pg,
+			Events:      bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+		}),
+	})
+
+	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-schema-reject"}}`
+	rejected := rpcCall(t, handler, approveBody)
+	if rejected.Error == nil {
+		t.Fatal("mailbox.approve schema rejection error = nil")
+	}
+	detail, err := pg.GetV1MailboxItem(ctx, mailboxID)
+	if err != nil {
+		t.Fatalf("get mailbox after schema rejection: %v", err)
+	}
+	if detail.Item.Status != "pending" {
+		t.Fatalf("mailbox status after schema rejection = %s, want pending", detail.Item.Status)
+	}
+	if count := countEventsByName(t, db, "mailbox.item_decided"); count != 0 {
+		t.Fatalf("mailbox.item_decided event count after schema rejection = %d, want 0", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 0 {
+		t.Fatalf("api_idempotency rows after schema rejection = %d, want 0", count)
+	}
+
+	oldShape := validMailboxItemDecidedPayload()
+	oldShape["payload"] = map[string]any{"title": "review this"}
+	if err := runtimetools.ValidatePayloadAgainstSchema(mailboxItemDecidedStrictPayloadSchema(true), oldShape); err == nil {
+		t.Fatal("old mailbox.item_decided payload field unexpectedly passed strict schema")
+	}
+}
+
+func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   uuid.NewString(),
+		Payload: json.RawMessage(`{"request":true}`),
+	}.WithEntityID(entityID)); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:  sourceEventID,
+		EntityID: entityID,
+		Type:     "review_request",
+		Summary:  "needs approval",
+		Context:  []byte(`{"title":"review this"}`),
 	})
 	if err != nil {
 		t.Fatalf("insert mailbox: %v", err)
@@ -405,9 +485,11 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 		t.Fatalf("api_idempotency rows after failed publish = %d, want 0", count)
 	}
 
-	bus, err := runtimebus.NewEventBus(pg)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(true)),
+	})
 	if err != nil {
-		t.Fatalf("NewEventBus: %v", err)
+		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	successHandler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -441,9 +523,11 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
-	bus, err := runtimebus.NewEventBus(pg)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(true)),
+	})
 	if err != nil {
-		t.Fatalf("NewEventBus: %v", err)
+		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
 	t.Cleanup(runtimebus.ResumeRuntimeIngress)
@@ -580,6 +664,8 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	if got := countPipelineReceiptsForEvent(t, ctx, db, downstreamID); got != 1 {
 		t.Fatalf("mailbox approval pipeline receipts after resume = %d, want 1", got)
 	}
+	approvalPayload := loadEventPayload(t, db, downstreamID)
+	assertMailboxItemDecidedPayloadShape(t, approvalPayload, "review this", true)
 }
 
 func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
@@ -589,6 +675,19 @@ func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {
 		t.Fatalf("count events %s: %v", eventName, err)
 	}
 	return count
+}
+
+func loadEventPayload(t *testing.T, db *sql.DB, eventID string) map[string]any {
+	t.Helper()
+	var raw []byte
+	if err := db.QueryRow(`SELECT payload FROM events WHERE event_id = $1::uuid`, eventID).Scan(&raw); err != nil {
+		t.Fatalf("load event payload %s: %v", eventID, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode event payload %s: %v", eventID, err)
+	}
+	return payload
 }
 
 func countEventDeliveriesForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
@@ -627,6 +726,133 @@ func countAPIIdempotencyRows(t *testing.T, db *sql.DB) int {
 		t.Fatalf("count api_idempotency rows: %v", err)
 	}
 	return count
+}
+
+func mailboxItemDecidedPayloadValidator(t *testing.T, schema map[string]any) runtimebus.PayloadValidator {
+	t.Helper()
+	return func(eventType string, payload []byte) error {
+		if eventType != "mailbox.item_decided" {
+			return nil
+		}
+		if len(payload) == 0 {
+			payload = []byte("{}")
+		}
+		decoded := map[string]any{}
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			return err
+		}
+		return runtimetools.ValidatePayloadAgainstSchema(schema, decoded)
+	}
+}
+
+func mailboxItemDecidedStrictPayloadSchema(includeMailboxPayload bool) map[string]any {
+	properties := map[string]any{
+		"mailbox_id": map[string]any{
+			"type":   "string",
+			"format": "uuid",
+		},
+		"mailbox_decision_id": map[string]any{
+			"type":   "string",
+			"format": "uuid",
+		},
+		"decision": map[string]any{
+			"type": "string",
+		},
+		"decision_payload": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"approved": map[string]any{"type": "boolean"},
+			},
+			"required":             []any{"approved"},
+			"additionalProperties": false,
+		},
+		"item_type": map[string]any{
+			"type": "string",
+		},
+		"source_event_id": map[string]any{
+			"type":   "string",
+			"format": "uuid",
+		},
+		"source_flow": map[string]any{
+			"type": "string",
+		},
+		"source_entity_id": map[string]any{
+			"type":   "string",
+			"format": "uuid",
+		},
+		"decided_by": map[string]any{
+			"type": "string",
+		},
+		"decided_at": map[string]any{
+			"type": "string",
+		},
+	}
+	required := []any{
+		"mailbox_id",
+		"mailbox_decision_id",
+		"decision",
+		"decision_payload",
+		"item_type",
+		"source_event_id",
+		"source_flow",
+		"source_entity_id",
+		"decided_by",
+		"decided_at",
+	}
+	if includeMailboxPayload {
+		properties["mailbox_payload"] = map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title": map[string]any{"type": "string"},
+			},
+			"required":             []any{"title"},
+			"additionalProperties": false,
+		}
+		required = append(required, "mailbox_payload")
+	}
+	return map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func validMailboxItemDecidedPayload() map[string]any {
+	return map[string]any{
+		"mailbox_id":          uuid.NewString(),
+		"mailbox_decision_id": uuid.NewString(),
+		"decision":            "approved",
+		"decision_payload":    map[string]any{"approved": true},
+		"item_type":           "review_request",
+		"mailbox_payload":     map[string]any{"title": "review this"},
+		"source_event_id":     uuid.NewString(),
+		"source_flow":         "empire/review",
+		"source_entity_id":    uuid.NewString(),
+		"decided_by":          "agent-d-run-token",
+		"decided_at":          "2026-05-10T12:00:00Z",
+	}
+}
+
+func assertMailboxItemDecidedPayloadShape(t *testing.T, payload map[string]any, wantTitle string, wantApproved bool) {
+	t.Helper()
+	if _, ok := payload["payload"]; ok {
+		t.Fatalf("mailbox.item_decided retained retired payload field: %#v", payload)
+	}
+	mailboxPayload, ok := payload["mailbox_payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("mailbox_payload = %#v, want object", payload["mailbox_payload"])
+	}
+	if mailboxPayload["title"] != wantTitle {
+		t.Fatalf("mailbox_payload.title = %#v, want %q", mailboxPayload["title"], wantTitle)
+	}
+	decisionPayload, ok := payload["decision_payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("decision_payload = %#v, want object", payload["decision_payload"])
+	}
+	if decisionPayload["approved"] != wantApproved {
+		t.Fatalf("decision_payload.approved = %#v, want %v", decisionPayload["approved"], wantApproved)
+	}
 }
 
 type failingTxPublisher struct{}

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -765,7 +765,7 @@ func (r mailboxV1Row) approvalEvent(eventID, decisionID, eventType, actorTokenID
 		"decision":            "approved",
 		"decision_payload":    payloadMap,
 		"item_type":           strings.TrimSpace(r.Type),
-		"payload":             cloneMailboxV1Payload(r.Payload),
+		"mailbox_payload":     cloneMailboxV1Payload(r.Payload),
 		"source_event_id":     strings.TrimSpace(r.SourceEventID),
 		"source_flow":         mailboxV1SourceFlow(r.FlowInstance),
 		"source_entity_id":    strings.TrimSpace(r.EntityID),

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -123,6 +123,21 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	if !outcome.Result.OK || outcome.Result.Status != "decided" || outcome.Result.DownstreamEventID == "" || outcome.ApprovalEvent == nil {
 		t.Fatalf("unexpected approve outcome=%#v", outcome)
 	}
+	var approvalPayload map[string]any
+	if err := json.Unmarshal(outcome.ApprovalEvent.Payload, &approvalPayload); err != nil {
+		t.Fatalf("decode approval event payload: %v", err)
+	}
+	if _, ok := approvalPayload["payload"]; ok {
+		t.Fatalf("approval event retained retired payload field: %#v", approvalPayload)
+	}
+	mailboxPayload := approvalPayload["mailbox_payload"].(map[string]any)
+	if mailboxPayload["title"] != "check" {
+		t.Fatalf("approval event mailbox_payload = %#v, want title check", mailboxPayload)
+	}
+	decisionPayload := approvalPayload["decision_payload"].(map[string]any)
+	if decisionPayload["ok"] != true {
+		t.Fatalf("approval event decision_payload = %#v, want ok true", decisionPayload)
+	}
 	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
 		MailboxID:         firstID,
 		Action:            "approved",


### PR DESCRIPTION
Closes #1044

## Summary

Promotes the platform-owned `mailbox.item_decided` approval event row-payload shape to `mailbox_payload` and removes the retired top-level `payload` producer field from the Swarm mailbox approval producer.

## Governing refs / context

- `platform-spec.yaml` `contract_formats.event_schema.strict_payload_contract`
- `platform-spec.yaml` `event_payload_migration.rules`
- `platform-spec.yaml` `runtime_enforcement.event_loop.validate_payload`
- `platform-spec.yaml` `api_specification.methods.mailbox.approve`
- `platform-spec.yaml` `api_specification.conventions.mailbox.approval_event_routes`
- Gate: #1044 independent gate approved `platform.mailbox_item_decided_payload_shape_drift`

## Semantic migration

- New canonical owner: `platform-spec.yaml` `api_specification.conventions.mailbox.approval_event_payload_contract`, consumed by `internal/store/mailbox_v1.go` `mailboxV1Row.approvalEvent`.
- Old producer path now invalid: top-level `payload` on `mailbox.item_decided`.
- New producer path: top-level `mailbox_payload` for the original mailbox row payload.
- `decision_payload` remains separate and is not merged with the row payload.
- Production paths checked: `mailboxV1Row.approvalEvent`, `/v1/rpc mailbox.approve`, strict EventBus validation, paused-runtime transactional publish, publish-failure rollback, and CLI-backed corrected contract verification.
- Migration complete for the Swarm producer class; external/proof consumers must use `payload.mailbox_payload.*`, not `payload.payload.*`.

## Proof

- `go test ./internal/store -run 'TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners|TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersistence|TestPostgresStore_RecordInboundEvent_RejectsPayloadValidatorFailureBeforePersistence' -count=1`
- `go test ./internal/runtime -run 'TestRuntimePayloadValidator_(RejectsUndeclaredCallerPayloadFieldWhenAdditionalPropertiesFalse|AllowsUndeclaredCanonicalContextFields|AllowsValidSchemaPayload)' -count=1`
- `go test ./internal/runtime/eventschema -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorMailboxHandlersSupportedRPCPath|TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack|TestOperatorMailboxApprovePublishFailureLeavesItemRetryable|TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused' -count=1`
- `go run ./cmd/swarm verify --contracts /tmp/empire-1044-proof-contracts --platform-spec docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`
- `go test ./...`
