### PR TITLE
[agent-e][issue #1047] Define event publish source lineage

### DIFF
--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -26,11 +26,13 @@ type eventPublishCommandOptions struct {
 	apiOptions           rootCommandOptions
 	payloadJSON          string
 	runID                string
+	sourceEventID        string
 	bundleFingerprint    string
 	emitter              string
 	idempotencyKey       string
 	payloadJSONSet       bool
 	runIDSet             bool
+	sourceEventIDSet     bool
 	bundleFingerprintSet bool
 	emitterSet           bool
 	idempotencyKeySet    bool
@@ -39,6 +41,7 @@ type eventPublishCommandOptions struct {
 type eventPublishResult struct {
 	EventID       string                 `json:"event_id"`
 	RunID         string                 `json:"run_id"`
+	SourceEventID string                 `json:"source_event_id,omitempty"`
 	NewRunCreated *bool                  `json:"new_run_created"`
 	Deliveries    []eventPublishDelivery `json:"deliveries"`
 }
@@ -59,6 +62,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			publishOpts.payloadJSONSet = cmd.Flags().Changed("payload-json")
 			publishOpts.runIDSet = cmd.Flags().Changed("run-id")
+			publishOpts.sourceEventIDSet = cmd.Flags().Changed("source-event-id")
 			publishOpts.bundleFingerprintSet = cmd.Flags().Changed("bundle-fingerprint")
 			publishOpts.emitterSet = cmd.Flags().Changed("emitter")
 			publishOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
@@ -67,6 +71,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&publishOpts.payloadJSON, "payload-json", "", "Required JSON object payload")
 	cmd.Flags().StringVar(&publishOpts.runID, "run-id", "", "Optional existing nonterminal run id to inject into")
+	cmd.Flags().StringVar(&publishOpts.sourceEventID, "source-event-id", "", "Optional same-run parent event id for checkpoint lineage")
 	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
 	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
 	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
@@ -116,10 +121,22 @@ func (opts eventPublishCommandOptions) params(args []string) (string, map[string
 		"event_name": eventName,
 		"payload":    payload,
 	}
-	if runID, err := optionalNonEmptyFlag("--run-id", opts.runID, opts.runIDSet); err != nil {
+	runID, err := optionalNonEmptyFlag("--run-id", opts.runID, opts.runIDSet)
+	if err != nil {
 		return "", nil, err
-	} else if runID != "" {
+	}
+	if runID != "" {
 		params["run_id"] = runID
+	}
+	sourceEventID, err := optionalNonEmptyFlag("--source-event-id", opts.sourceEventID, opts.sourceEventIDSet)
+	if err != nil {
+		return "", nil, err
+	}
+	if sourceEventID != "" {
+		if runID == "" {
+			return "", nil, fmt.Errorf("--source-event-id requires --run-id")
+		}
+		params["source_event_id"] = sourceEventID
 	}
 	if fingerprint, err := optionalNonEmptyFlag("--bundle-fingerprint", opts.bundleFingerprint, opts.bundleFingerprintSet); err != nil {
 		return "", nil, err
@@ -236,6 +253,9 @@ func writeEventPublishResult(out io.Writer, eventName string, result eventPublis
 			delivery.Attempt,
 		)
 	}
+	if sourceEventID := strings.TrimSpace(result.SourceEventID); sourceEventID != "" {
+		fmt.Fprintf(out, "source_event_id=%s\n", sourceEventID)
+	}
 }
 
 func eventPublishErrorExitCode(err error) int {
@@ -244,7 +264,7 @@ func eventPublishErrorExitCode(err error) int {
 		authExit:      eventPublishExitAuth,
 		notFoundExit:  eventPublishExitNotFound,
 		conflictExit:  eventPublishExitRejected,
-		notFoundCodes: []string{"RUN_NOT_FOUND"},
+		notFoundCodes: []string{"RUN_NOT_FOUND", "EVENT_NOT_FOUND"},
 		conflictCodes: []string{
 			"BUNDLE_MISMATCH",
 			"UNSUPPORTED_BUNDLE_REF",

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -34,6 +34,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		"event", "publish", "scan.requested",
 		"--payload-json", `{"topic":"sample","count":2}`,
 		"--run-id", "run-1",
+		"--source-event-id", "event-parent-1",
 		"--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"--emitter", "cli:test",
 		"--idempotency-key", "idem-1",
@@ -50,7 +51,8 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 			"topic": "sample",
 			"count": float64(2),
 		},
-		"run_id": "run-1",
+		"run_id":          "run-1",
+		"source_event_id": "event-parent-1",
 		"bundle_ref": map[string]any{
 			"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
@@ -70,6 +72,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		"delivery subscriber_id=agent-1",
 		"session_id=session-1",
 		"attempt=2",
+		"source_event_id=event-parent-1",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
@@ -134,6 +137,8 @@ func TestEventPublishRejectsInvalidInputBeforeRequest(t *testing.T) {
 		{name: "null payload", args: []string{"event", "publish", "scan.requested", "--payload-json", "null"}, wantStderr: "JSON object"},
 		{name: "trailing json", args: []string{"event", "publish", "scan.requested", "--payload-json", `{} {}`}, wantStderr: "exactly one JSON object"},
 		{name: "blank run id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--run-id", "  "}, wantStderr: "--run-id must be non-empty"},
+		{name: "blank source event id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--source-event-id", "  "}, wantStderr: "--source-event-id must be non-empty"},
+		{name: "source event without run id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--source-event-id", "event-parent-1"}, wantStderr: "--source-event-id requires --run-id"},
 		{name: "blank bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "  "}, wantStderr: "--bundle-fingerprint must be non-empty"},
 		{name: "invalid bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "sha256:BAD"}, wantStderr: "--bundle-fingerprint must be sha256:<64 lowercase hex>"},
 		{name: "blank emitter", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--emitter", "  "}, wantStderr: "--emitter must be non-empty"},
@@ -197,6 +202,16 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 			},
 			wantCode:   5,
 			wantStderr: "RUN_NOT_FOUND",
+		},
+		{
+			name: "source event not found exits five",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "EVENT_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "EVENT_NOT_FOUND",
 		},
 		{
 			name: "bundle mismatch exits six",
@@ -396,6 +411,7 @@ func eventPublishTestResult(newRunCreated bool) map[string]any {
 	return map[string]any{
 		"event_id":        "event-1",
 		"run_id":          "run-1",
+		"source_event_id": "event-parent-1",
 		"new_run_created": newRunCreated,
 		"deliveries": []any{
 			map[string]any{

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -68,15 +68,16 @@ type eventListResult struct {
 }
 
 type eventFull struct {
-	EventID     string            `json:"event_id"`
-	EventName   string            `json:"event_name"`
-	CreatedAt   string            `json:"created_at"`
-	RunID       string            `json:"run_id,omitempty"`
-	EntityID    string            `json:"entity_id,omitempty"`
-	Source      string            `json:"source"`
-	Payload     map[string]any    `json:"payload"`
-	Deliveries  []eventDelivery   `json:"deliveries"`
-	DeadLetters []eventDeadLetter `json:"dead_letters"`
+	EventID       string            `json:"event_id"`
+	EventName     string            `json:"event_name"`
+	CreatedAt     string            `json:"created_at"`
+	RunID         string            `json:"run_id,omitempty"`
+	EntityID      string            `json:"entity_id,omitempty"`
+	SourceEventID string            `json:"source_event_id,omitempty"`
+	Source        string            `json:"source"`
+	Payload       map[string]any    `json:"payload"`
+	Deliveries    []eventDelivery   `json:"deliveries"`
+	DeadLetters   []eventDeadLetter `json:"dead_letters"`
 }
 
 type eventDelivery struct {
@@ -827,12 +828,13 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 		return
 	}
 	fmt.Fprintf(out, "Event %s\n", event.EventID)
-	fmt.Fprintf(out, "event_name=%s created_at=%s source=%s run_id=%s entity_id=%s\n",
+	fmt.Fprintf(out, "event_name=%s created_at=%s source=%s run_id=%s entity_id=%s source_event_id=%s\n",
 		event.EventName,
 		event.CreatedAt,
 		event.Source,
 		eventObservationDash(event.RunID),
 		eventObservationDash(event.EntityID),
+		eventObservationDash(event.SourceEventID),
 	)
 	fmt.Fprintf(out, "payload=%s\n", eventObservationCompactJSON(event.Payload))
 	if len(event.Deliveries) == 0 {
@@ -884,6 +886,9 @@ func writeEventFollowEvent(out io.Writer, event eventFull) {
 	}
 	if event.EntityID != "" {
 		fields = append(fields, "entity_id="+event.EntityID)
+	}
+	if event.SourceEventID != "" {
+		fields = append(fields, "source_event_id="+event.SourceEventID)
 	}
 	fields = append(fields,
 		fmt.Sprintf("deliveries=%d", len(event.Deliveries)),

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -111,6 +111,7 @@ func TestEventViewUsesEventGetV1RPC(t *testing.T) {
 	for _, want := range []string{
 		"Event event-1",
 		"event_name=scan.requested",
+		"source_event_id=source-event-1",
 		"payload={\"priority\":\"high\"}",
 		"delivery_id=delivery-1",
 		"dead_letter_id=dead-1",
@@ -717,12 +718,13 @@ func newEventObservationWSServer(t *testing.T, opts eventObservationWSServerOpti
 
 func validEventObservationEvent(eventID string) map[string]any {
 	return map[string]any{
-		"event_id":   eventID,
-		"event_name": "scan.requested",
-		"created_at": "2026-05-13T10:00:01Z",
-		"run_id":     "run-1",
-		"entity_id":  "entity-1",
-		"source":     "external",
+		"event_id":        eventID,
+		"event_name":      "scan.requested",
+		"created_at":      "2026-05-13T10:00:01Z",
+		"run_id":          "run-1",
+		"entity_id":       "entity-1",
+		"source_event_id": "source-event-1",
+		"source":          "external",
 		"payload": map[string]any{
 			"priority": "high",
 		},

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1828,7 +1828,7 @@
     },
     {
       "name": "event.publish",
-      "description": "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger, and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nThe method consumes the same canonical EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start remains only\nas a deprecated wrapper for older callers.\n",
+      "description": "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger, and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nCheckpoint/source-authority policy: callers that need causal proof\nMUST provide source_event_id together with run_id. The source event\nmust exist in the same run_id and the server persists it as\nevents.source_event_id / ParentEventID. Omitted source_event_id\nmeans the published event is unparented; it is valid low-level\ningress but MUST NOT be presented as proof that an internal\napproval/checkpoint path occurred. source_event_id without run_id,\nmalformed source_event_id, or a source event from another run fails\nclosed before event or idempotency completion persistence. A missing\nsource event fails closed with EVENT_NOT_FOUND.\n\nThe method consumes the same canonical EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start remains only\nas a deprecated wrapper for older callers.\n",
       "params": [
         {
           "name": "bundle_ref",
@@ -1857,6 +1857,14 @@
           "name": "run_id",
           "required": false,
           "description": "Existing nonterminal run to inject into; if omitted, runtime allocates and starts a new run.",
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "source_event_id",
+          "required": false,
+          "description": "Optional parent/source event id for explicit checkpoint lineage. Requires run_id and must identify an event in the same run.",
           "schema": {
             "$ref": "#/components/schemas/OpaqueId"
           }
@@ -2086,6 +2094,44 @@
                 },
                 "required": [
                   "run_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32006,
+          "message": "Application error: EVENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_id"
                 ],
                 "type": "object"
               },
@@ -6246,6 +6292,10 @@
           "source": {
             "description": "Producer identifier (node_id, agent_id, or \"external\").",
             "type": "string"
+          },
+          "source_event_id": {
+            "$ref": "#/components/schemas/OpaqueId",
+            "description": "Persisted causal parent/source event id. Omitted for root or unparented events."
           }
         },
         "required": [
@@ -6331,6 +6381,10 @@
           },
           "run_id": {
             "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_event_id": {
+            "$ref": "#/components/schemas/OpaqueId",
+            "description": "Verified parent/source event lineage for this publication when supplied. Omitted means the event is unparented and must not be treated as causal checkpoint proof."
           }
         },
         "required": [

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -8413,14 +8413,15 @@ cli_specification:
       - EVENT_NOT_FOUND, replay conflict errors, auth/HTTP/RPC failures, and malformed EventReplayResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.publish, agent.replay, or agent.replay_backlog usage
     event_publish:
-      command: swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]
+      command: swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--source-event-id <event-id>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented
       owner: /v1/rpc event.publish
       behavior: >-
         Mutating event publication CLI consumer. The CLI validates the event name, required JSON object payload, optional run
-        target, optional bundle fingerprint assertion, optional emitter, and optional idempotency key, then sends exactly those
-        params to /v1/rpc event.publish through the shared v1 API client. The server remains the event-publication owner:
+        target, optional same-run source event id, optional bundle fingerprint assertion, optional emitter, and optional
+        idempotency key, then sends exactly those params to /v1/rpc event.publish through the shared v1 API client. The server
+        remains the event-publication owner:
         it validates declared event/payload/run/bundle/idempotency semantics, publishes through the runtime EventBus/store
         owner, derives delivery rows, and returns EventPublishResult.
       flags:
@@ -8431,6 +8432,9 @@ cli_specification:
       - name: --run-id <run-id>
         maps_to: run_id
         behavior: Optional existing nonterminal run id to inject the event into. Omitted means the server allocates and starts a new run.
+      - name: --source-event-id <event-id>
+        maps_to: source_event_id
+        behavior: Optional parent/source event id for explicit checkpoint lineage. Must be used with --run-id and must name an event from the same run.
       - name: --bundle-fingerprint <sha256:...>
         maps_to: bundle_ref.fingerprint
         behavior: Optional assertion that the server is running the expected boot bundle fingerprint. v1 BundleRef supports fingerprint only.
@@ -8441,7 +8445,7 @@ cli_specification:
         maps_to: idempotency_key
         behavior: Optional v1 API idempotency key for this mutating publish request.
       output:
-        success_detail: One publish summary line with event_id, event_name, run_id, new_run_created, and delivery count, followed by persisted delivery rows containing subscriber_id, status, session_id, and attempt.
+        success_detail: One publish summary line with event_id, event_name, run_id, new_run_created, and delivery count, followed by persisted delivery rows containing subscriber_id, status, session_id, and attempt, and source_event_id when server-owned lineage was supplied.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -8451,6 +8455,7 @@ cli_specification:
         publish_rejected: 6
         not_found_errors:
         - RUN_NOT_FOUND
+        - EVENT_NOT_FOUND
         publish_rejected_errors:
         - BUNDLE_MISMATCH
         - UNSUPPORTED_BUNDLE_REF
@@ -8459,10 +8464,10 @@ cli_specification:
         - RUN_ALREADY_TERMINAL
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
-      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
+      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
       - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle fingerprint, invalid args, and missing SWARM_API_TOKEN make zero API calls
-      - success output renders only server-owned EventPublishResult event_id, run_id, new_run_created, and delivery rows
-      - RUN_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
+      - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
+      - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
       relation_to_run_start: '`run.start` remains usable for #743 until a separate migration changes the CLI internals to event.publish.'
     conversations_list:
@@ -9781,6 +9786,9 @@ api_specification:
             $ref: '#/components/schemas/OpaqueId'
           run_id:
             $ref: '#/components/schemas/OpaqueId'
+          source_event_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Verified parent/source event lineage for this publication when supplied. Omitted means the event is unparented and must not be treated as causal checkpoint proof.
           new_run_created:
             type: boolean
           deliveries:
@@ -9923,6 +9931,9 @@ api_specification:
             $ref: '#/components/schemas/OpaqueId'
           run_id:
             $ref: '#/components/schemas/OpaqueId'
+          source_event_id:
+            $ref: '#/components/schemas/OpaqueId'
+            description: Persisted causal parent/source event id. Omitted for root or unparented events.
           created_at:
             $ref: '#/components/schemas/Timestamp'
           source:
@@ -11505,10 +11516,16 @@ api_specification:
       description: "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into\
         \ the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger,\
         \ and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing\
-        \ or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nThe method consumes the same canonical\
-        \ EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted\
-        \ event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start\
-        \ remains only\nas a deprecated wrapper for older callers.\n"
+        \ or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nCheckpoint/source-authority policy:\
+        \ callers that need causal proof\nMUST provide source_event_id together with run_id. The source event\nmust exist\
+        \ in the same run_id and the server persists it as\nevents.source_event_id / ParentEventID. Omitted source_event_id\n\
+        means the published event is unparented; it is valid low-level\ningress but MUST NOT be presented as proof that an\
+        \ internal\napproval/checkpoint path occurred. source_event_id without run_id,\nmalformed source_event_id, or a source\
+        \ event from another run fails\nclosed before event or idempotency completion persistence. A missing\nsource event\
+        \ fails closed with EVENT_NOT_FOUND.\n\nThe method consumes the same canonical EventBus/store event-publication\n\
+        owner used by runtime dispatch. Delivery results are read back from the\npersisted event_deliveries owner; the API\
+        \ layer must not re-plan\nsubscribers. This is the canonical primitive; run.start remains only\nas a deprecated wrapper\
+        \ for older callers.\n"
       scope:
         required:
         - write:runs
@@ -11533,6 +11550,11 @@ api_specification:
         description: Existing nonterminal run to inject into; if omitted, runtime allocates and starts a new run.
         schema:
           $ref: '#/components/schemas/OpaqueId'
+      - name: source_event_id
+        required: false
+        description: Optional parent/source event id for explicit checkpoint lineage. Requires run_id and must identify an event in the same run.
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
       - name: emitter
         required: false
         description: Optional producer identifier. Defaults to cli-publish:<actor_token_id>.
@@ -11553,6 +11575,7 @@ api_specification:
       - EVENT_NOT_DECLARED
       - PAYLOAD_VALIDATION_FAILED
       - RUN_NOT_FOUND
+      - EVENT_NOT_FOUND
       - RUN_ALREADY_TERMINAL
       - IDEMPOTENCY_CONFLICT
     event.replay:

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -366,6 +366,7 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
 		{Method: "event.publish", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: RunAlreadyTerminalCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runs.headers[runID] = store.RunHeader{RunID: runID, Status: "completed"}
 		}}},
@@ -748,14 +749,15 @@ func (s *mutatingRuntimeProbeState) storeEvent(evt events.Event, deliveries []st
 		_ = json.Unmarshal(evt.Payload, &payload)
 	}
 	s.observability.events[evt.ID] = store.OperatorEventFull{
-		EventID:    evt.ID,
-		EventName:  strings.TrimSpace(string(evt.Type)),
-		EntityID:   evt.EntityID(),
-		RunID:      evt.RunID,
-		CreatedAt:  evt.CreatedAt.UTC(),
-		Source:     evt.SourceAgent,
-		Payload:    payload,
-		Deliveries: deliveries,
+		EventID:       evt.ID,
+		EventName:     strings.TrimSpace(string(evt.Type)),
+		EntityID:      evt.EntityID(),
+		RunID:         evt.RunID,
+		SourceEventID: strings.TrimSpace(evt.ParentEventID),
+		CreatedAt:     evt.CreatedAt.UTC(),
+		Source:        evt.SourceAgent,
+		Payload:       payload,
+		Deliveries:    deliveries,
 	}
 }
 

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -20,6 +20,7 @@ import (
 type eventPublishResult struct {
 	EventID       string                 `json:"event_id"`
 	RunID         string                 `json:"run_id"`
+	SourceEventID string                 `json:"source_event_id,omitempty"`
 	NewRunCreated bool                   `json:"new_run_created"`
 	Deliveries    []eventPublishDelivery `json:"deliveries"`
 }
@@ -38,6 +39,7 @@ type eventPublicationParams struct {
 	Payload           json.RawMessage
 	EntityID          string
 	RunID             string
+	SourceEventID     string
 	IdempotencyKey    string
 	Emitter           string
 	NewRunCreated     bool
@@ -83,6 +85,7 @@ func executeEventPublish(ctx context.Context, req Request, opts OperatorReadOpti
 			return eventPublishResult{
 				EventID:       params.EventID,
 				RunID:         params.RunID,
+				SourceEventID: params.SourceEventID,
 				NewRunCreated: params.NewRunCreated,
 				Deliveries:    []eventPublishDelivery{},
 			}, params.EventID, nil
@@ -133,6 +136,7 @@ func eventPublishResultFromStore(ctx context.Context, opts OperatorReadOptions, 
 	return eventPublishResult{
 		EventID:       strings.TrimSpace(event.EventID),
 		RunID:         runID,
+		SourceEventID: strings.TrimSpace(event.SourceEventID),
 		NewRunCreated: stored.NewRunCreated,
 		Deliveries:    eventPublishDeliveries(event.Deliveries),
 	}, nil
@@ -167,12 +171,13 @@ func executeOperatorEventPublication(
 			return store.APIIdempotencyCompletion{}, err
 		}
 		if err := opts.Events.Publish(ctx, events.Event{
-			ID:          params.EventID,
-			RunID:       params.RunID,
-			Type:        events.EventType(params.EventName),
-			SourceAgent: params.Emitter,
-			Payload:     params.Payload,
-			CreatedAt:   now,
+			ID:            params.EventID,
+			RunID:         params.RunID,
+			ParentEventID: params.SourceEventID,
+			Type:          events.EventType(params.EventName),
+			SourceAgent:   params.Emitter,
+			Payload:       params.Payload,
+			CreatedAt:     now,
 		}.WithEntityID(params.EntityID)); err != nil {
 			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
 		}
@@ -210,6 +215,23 @@ func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg 
 	if err != nil {
 		return eventPublicationParams{}, err
 	}
+	sourceEventID, sourceEventIDSet, err := optionalStringParam(req.Params, "source_event_id")
+	if err != nil {
+		return eventPublicationParams{}, err
+	}
+	if sourceEventIDSet {
+		if sourceEventID == "" {
+			return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
+		}
+		parsed, err := uuid.Parse(sourceEventID)
+		if err != nil {
+			return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
+		}
+		sourceEventID = parsed.String()
+	}
+	if sourceEventID != "" && runID == "" {
+		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "is required when source_event_id is provided"})
+	}
 	newRun := false
 	if runID == "" {
 		runID = uuid.NewString()
@@ -245,6 +267,7 @@ func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg 
 		Payload:           payload,
 		EntityID:          entityID,
 		RunID:             runID,
+		SourceEventID:     sourceEventID,
 		IdempotencyKey:    idempotencyKey,
 		Emitter:           emitter,
 		NewRunCreated:     newRun,
@@ -319,6 +342,24 @@ func validateEventPublication(ctx context.Context, opts OperatorReadOptions, par
 			return NewApplicationError(RunAlreadyTerminalCode, false, map[string]any{
 				"run_id":         params.RunID,
 				"current_status": status,
+			})
+		}
+	}
+	if params.SourceEventID != "" {
+		sourceEvent, err := opts.Observability.LoadOperatorEvent(ctx, params.SourceEventID)
+		if errors.Is(err, store.ErrEventNotFound) {
+			return NewApplicationError(EventNotFoundCode, false, map[string]any{"event_id": params.SourceEventID})
+		}
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(sourceEvent.RunID) != params.RunID {
+			return NewInvalidParamsError(map[string]any{
+				"field":           "source_event_id",
+				"reason":          "must belong to run_id",
+				"source_event_id": params.SourceEventID,
+				"run_id":          params.RunID,
+				"source_run_id":   strings.TrimSpace(sourceEvent.RunID),
 			})
 		}
 	}

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -206,6 +206,157 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 	}
 }
 
+func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	parent := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-source-parent"))
+	if parent.Error != nil {
+		t.Fatalf("parent event.publish error = %#v", parent.Error)
+	}
+	parentResult := asMap(t, parent.Result)
+	parentEventID := stringValue(t, parentResult["event_id"], "event_id")
+	parentRunID := stringValue(t, parentResult["run_id"], "run_id")
+
+	child := rpcCall(t, handler, eventPublishBodyWithSource(parentRunID, parentEventID, runStartTestFingerprint, "scan.requested", `{"topic":"checkpoint"}`, "operator-test", "idem-source-child"))
+	if child.Error != nil {
+		t.Fatalf("child event.publish error = %#v", child.Error)
+	}
+	childResult := asMap(t, child.Result)
+	childEventID := stringValue(t, childResult["event_id"], "event_id")
+	if childResult["run_id"] != parentRunID || childResult["new_run_created"] != false {
+		t.Fatalf("child result = %#v, want existing run", childResult)
+	}
+	if childResult["source_event_id"] != parentEventID {
+		t.Fatalf("child source_event_id = %#v, want %s", childResult["source_event_id"], parentEventID)
+	}
+	assertEventSourceEventID(t, db, childEventID, parentEventID)
+	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
+		t.Fatalf("scan.requested events after sourced publish = %d, want 2", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 2 {
+		t.Fatalf("api_idempotency rows after sourced publish = %d, want 2", count)
+	}
+}
+
+func TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	first := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"first"}`, "", "idem-source-first"))
+	if first.Error != nil {
+		t.Fatalf("first event.publish error = %#v", first.Error)
+	}
+	firstRunID := stringValue(t, asMap(t, first.Result)["run_id"], "run_id")
+	firstEventID := stringValue(t, asMap(t, first.Result)["event_id"], "event_id")
+
+	second := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"second"}`, "", "idem-source-second"))
+	if second.Error != nil {
+		t.Fatalf("second event.publish error = %#v", second.Error)
+	}
+	secondEventID := stringValue(t, asMap(t, second.Result)["event_id"], "event_id")
+
+	cases := []struct {
+		name          string
+		body          string
+		wantJSONCode  int
+		wantAppCode   string
+		wantField     string
+		mutateBefore  func()
+		wantEventRows int
+		wantIDEMRows  int
+	}{
+		{
+			name:          "source without explicit run",
+			body:          eventPublishBodyWithSource("", firstEventID, runStartTestFingerprint, "scan.requested", `{"topic":"no-run"}`, "", "idem-source-no-run"),
+			wantJSONCode:  codeInvalidParams,
+			wantField:     "run_id",
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+		{
+			name:          "invalid source uuid",
+			body:          eventPublishBodyWithSource(firstRunID, "not-a-uuid", runStartTestFingerprint, "scan.requested", `{"topic":"bad-source"}`, "", "idem-source-invalid"),
+			wantJSONCode:  codeInvalidParams,
+			wantField:     "source_event_id",
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+		{
+			name:          "missing source event",
+			body:          eventPublishBodyWithSource(firstRunID, uuid.NewString(), runStartTestFingerprint, "scan.requested", `{"topic":"missing-source"}`, "", "idem-source-missing"),
+			wantAppCode:   EventNotFoundCode,
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+		{
+			name:          "missing target run with source event",
+			body:          eventPublishBodyWithSource(uuid.NewString(), firstEventID, runStartTestFingerprint, "scan.requested", `{"topic":"missing-run-source"}`, "", "idem-source-missing-run"),
+			wantAppCode:   RunNotFoundCode,
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+		{
+			name:          "cross run source event",
+			body:          eventPublishBodyWithSource(firstRunID, secondEventID, runStartTestFingerprint, "scan.requested", `{"topic":"cross-run"}`, "", "idem-source-cross-run"),
+			wantJSONCode:  codeInvalidParams,
+			wantField:     "source_event_id",
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+		{
+			name: "terminal run with source",
+			body: eventPublishBodyWithSource(firstRunID, firstEventID, runStartTestFingerprint, "scan.requested", `{"topic":"terminal"}`, "", "idem-source-terminal"),
+			mutateBefore: func() {
+				if _, err := db.Exec(`UPDATE runs SET status = 'completed', ended_at = now() WHERE run_id = $1::uuid`, firstRunID); err != nil {
+					t.Fatalf("mark run terminal: %v", err)
+				}
+			},
+			wantAppCode:   RunAlreadyTerminalCode,
+			wantEventRows: 2,
+			wantIDEMRows:  2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mutateBefore != nil {
+				tc.mutateBefore()
+			}
+			resp := rpcCall(t, handler, tc.body)
+			if resp.Error == nil {
+				t.Fatal("event.publish source_event_id error = nil")
+			}
+			if tc.wantAppCode != "" {
+				if data := asMap(t, resp.Error.Data); data["code"] != tc.wantAppCode {
+					t.Fatalf("application error data = %#v, want %s", data, tc.wantAppCode)
+				}
+			} else if resp.Error.Code != tc.wantJSONCode {
+				t.Fatalf("json-rpc error code = %d, want %d", resp.Error.Code, tc.wantJSONCode)
+			} else if details := asMap(t, asMap(t, resp.Error.Data)["details"]); details["field"] != tc.wantField {
+				t.Fatalf("invalid params details = %#v, want field %s", details, tc.wantField)
+			}
+			if count := countEventsByName(t, db, "scan.requested"); count != tc.wantEventRows {
+				t.Fatalf("scan.requested event rows = %d, want %d", count, tc.wantEventRows)
+			}
+			if count := countAPIIdempotencyRows(t, db); count != tc.wantIDEMRows {
+				t.Fatalf("api_idempotency rows = %d, want %d", count, tc.wantIDEMRows)
+			}
+		})
+	}
+}
+
 func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	t.Run("bundle mismatch", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
@@ -407,6 +558,10 @@ func (s *failOnceEventReadStore) LoadOperatorEvent(ctx context.Context, eventID 
 }
 
 func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
+	return eventPublishBodyWithSource(runID, "", fingerprint, eventName, payload, emitter, idempotencyKey)
+}
+
+func eventPublishBodyWithSource(runID, sourceEventID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
 	parts := []string{
 		fmt.Sprintf(`"bundle_ref":{"fingerprint":%q}`, fingerprint),
 		fmt.Sprintf(`"event_name":%q`, eventName),
@@ -415,6 +570,9 @@ func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempoten
 	}
 	if strings.TrimSpace(runID) != "" {
 		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
+	}
+	if strings.TrimSpace(sourceEventID) != "" {
+		parts = append(parts, fmt.Sprintf(`"source_event_id":%q`, sourceEventID))
 	}
 	if strings.TrimSpace(emitter) != "" {
 		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
@@ -455,6 +613,17 @@ func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eve
 	}
 	if decoded["entity_id"] != runID || decoded["topic"] != "medicine" {
 		t.Fatalf("event.publish payload = %#v", decoded)
+	}
+}
+
+func assertEventSourceEventID(t *testing.T, db *sql.DB, eventID, wantSourceEventID string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow(`SELECT COALESCE(source_event_id::text, '') FROM events WHERE event_id = $1::uuid`, eventID).Scan(&got); err != nil {
+		t.Fatalf("load event source_event_id: %v", err)
+	}
+	if got != wantSourceEventID {
+		t.Fatalf("event source_event_id = %q, want %q", got, wantSourceEventID)
 	}
 }
 

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -261,12 +261,12 @@ methods:
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
-    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersFailClosedBeforePersistence}, {kind: go_test, name: TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun}]}
+    declared_error_tests: {status: spot_checked, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersFailClosedBeforePersistence}, {kind: go_test, name: TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun}, {kind: go_test, name: TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence}]}
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     notification_schema: {status: not_applicable}

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -43,15 +43,16 @@ type OperatorEventListResult struct {
 }
 
 type OperatorEventFull struct {
-	EventID     string                     `json:"event_id"`
-	EventName   string                     `json:"event_name"`
-	EntityID    string                     `json:"entity_id,omitempty"`
-	RunID       string                     `json:"run_id,omitempty"`
-	CreatedAt   time.Time                  `json:"created_at"`
-	Source      string                     `json:"source"`
-	Payload     map[string]any             `json:"payload"`
-	Deliveries  []OperatorEventDelivery    `json:"deliveries"`
-	DeadLetters []OperatorDeadLetterRecord `json:"dead_letters"`
+	EventID       string                     `json:"event_id"`
+	EventName     string                     `json:"event_name"`
+	EntityID      string                     `json:"entity_id,omitempty"`
+	RunID         string                     `json:"run_id,omitempty"`
+	SourceEventID string                     `json:"source_event_id,omitempty"`
+	CreatedAt     time.Time                  `json:"created_at"`
+	Source        string                     `json:"source"`
+	Payload       map[string]any             `json:"payload"`
+	Deliveries    []OperatorEventDelivery    `json:"deliveries"`
+	DeadLetters   []OperatorDeadLetterRecord `json:"dead_letters"`
 }
 
 type OperatorEventDelivery struct {
@@ -343,6 +344,7 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 			COALESCE(e.event_name, ''),
 			COALESCE(e.entity_id::text, ''),
 			COALESCE(e.run_id::text, ''),
+			COALESCE(e.source_event_id::text, ''),
 			e.created_at,
 			COALESCE(e.produced_by, ''),
 			COALESCE(e.produced_by_type, ''),
@@ -356,7 +358,7 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 		producedByType string
 		payloadRaw     []byte
 	)
-	if err := row.Scan(&event.EventID, &event.EventName, &event.EntityID, &event.RunID, &event.CreatedAt, &producedBy, &producedByType, &payloadRaw); err == sql.ErrNoRows {
+	if err := row.Scan(&event.EventID, &event.EventName, &event.EntityID, &event.RunID, &event.SourceEventID, &event.CreatedAt, &producedBy, &producedByType, &payloadRaw); err == sql.ErrNoRows {
 		return OperatorEventFull{}, ErrEventNotFound
 	} else if err != nil {
 		return OperatorEventFull{}, fmt.Errorf("load operator event: %w", err)


### PR DESCRIPTION
## Summary

- Adds the merge-bearing `event.publish` checkpoint/source-authority policy to `platform-spec.yaml` and regenerated OpenRPC.
- Allows optional `source_event_id` only with explicit `run_id`, validates the parent event exists in the same run, and persists it as `events.source_event_id` / `ParentEventID`.
- Exposes persisted `source_event_id` through EventPublishResult/EventFull and the CLI consumer without moving publication ownership into the CLI.

Closes #1047
Part of #1045

## Governing refs/context

- #1045 pre-audit and independent gate: #1045 approved first slice only and opened #1047.
- Exact spec refs: `platform-spec.yaml#run_model.lineage.source_event_id`, `platform-spec.yaml#api_specification.methods.event.publish`, `platform-spec.yaml#components.schemas.EventPublishResult`, `platform-spec.yaml#components.schemas.EventFull`, `platform-spec.yaml#cli_specification.command_catalog.event_publish`.
- Generated refs: `docs/specs/swarm-platform/platform/contracts/openrpc.json`, `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`.

## Semantic migration

- New canonical owner: `/v1/rpc event.publish` admits and validates public checkpoint parentage through `source_event_id`; store/EventBus remain the persisted lineage owners.
- Old invalid interpretation: unparented/root direct `event.publish` evidence cannot be treated as causal checkpoint proof.
- Checked sibling paths: `run.start` remains root-input wrapper, `event.replay` remains redelivery lineage owner, runtime replay/fork owners remain separate, CLI remains an API consumer.
- Migration complete for #1047; #1045 reliability and failure-quality siblings remain open.

## Tests

- `go test ./internal/apiv1 -run 'TestOperatorEventPublish|TestOpenRPCMutatingHTTPRuntimeProbes|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod|TestOpenRPCSuccessfulResultSchemas' -count=1`\n- `go test ./cmd/swarm -run 'TestEventPublish|TestEventView|TestEventList|TestEventFollow' -count=1`\n- `go run ./cmd/swarm-openrpc-gen --check`\n- `go test ./internal/apispec -count=1`\n- `go test ./...`