### PR TITLE
[agent-a][issue #170] Add RuntimeDeps boot graph

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -32,7 +32,7 @@ type runtimeProjectSupervisor struct {
 	validateSource   func(context.Context, semanticview.Source) error
 	initStateStores  func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
 	newWorkspaces    func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle
-	createRuntime    func(context.Context, *config.Config, runtime.Stores, runtime.RuntimeOptions) (*runtime.Runtime, error)
+	createRuntime    func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
 
 	mu            sync.RWMutex
 	currentRoot   string
@@ -74,8 +74,8 @@ func newRuntimeProjectSupervisor(
 		newWorkspaces: func(stores storeBundle, repoRoot, contractsRoot string, source semanticview.Source) workspace.Lifecycle {
 			return configuredWorkspaceLifecycle(stores.SQLDB, repoRoot, contractsRoot, source)
 		},
-		createRuntime: func(ctx context.Context, cfg *config.Config, stores runtime.Stores, opts runtime.RuntimeOptions) (*runtime.Runtime, error) {
-			return runtime.NewRuntime(ctx, cfg, stores, opts)
+		createRuntime: func(ctx context.Context, deps runtime.RuntimeDeps) (*runtime.Runtime, error) {
+			return runtime.NewRuntime(ctx, deps)
 		},
 		currentRoot:   strings.TrimSpace(initialRoot),
 		currentSource: initialSource,
@@ -166,11 +166,15 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return builderpkg.ProjectStatus{}, err
 	}
 
-	newRT, err := s.createRuntime(ctx, s.cfg, s.stores.runtimeStores(), runtime.RuntimeOptions{
-		SelfCheck:          false,
-		WorkflowModule:     module,
-		WorkspaceLifecycle: workspaces,
-		BundleFingerprint:  bundleIdentity.Fingerprint,
+	newRT, err := s.createRuntime(ctx, runtime.RuntimeDeps{
+		Config: s.cfg,
+		Stores: s.stores.runtimeStores(),
+		Options: runtime.RuntimeOptions{
+			SelfCheck:          false,
+			WorkflowModule:     module,
+			WorkspaceLifecycle: workspaces,
+			BundleFingerprint:  bundleIdentity.Fingerprint,
+		},
 	})
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
@@ -195,7 +194,7 @@ func newSupervisorForLoadProjectFailureTest(
 	t *testing.T,
 	projectRoot string,
 	lifecycle workspace.Lifecycle,
-	createRuntime func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error),
+	createRuntime func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error),
 ) *runtimeProjectSupervisor {
 	t.Helper()
 	bundle := testBuilderSupervisorBundle(t)
@@ -247,7 +246,7 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailure
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, tc.lifecycle, func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
+			supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, tc.lifecycle, func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
 				t.Fatal("createRuntime should not be called when workspace admission fails")
 				return nil, nil
 			})
@@ -270,7 +269,7 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesRuntimeStartFailure(t *te
 	projectRoot := writeProjectRoot(t)
 	var ready atomic.Bool
 	oldRT := &runtimepkg.Runtime{}
-	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(context.Context, *config.Config, runtimepkg.Stores, runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
 		return &runtimepkg.Runtime{}, nil
 	})
 	supervisor.ready = &ready
@@ -307,8 +306,8 @@ func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t 
 	}
 
 	var gotFingerprint string
-	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(_ context.Context, _ *config.Config, _ runtimepkg.Stores, opts runtimepkg.RuntimeOptions) (*runtimepkg.Runtime, error) {
-		gotFingerprint = opts.BundleFingerprint
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(_ context.Context, deps runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		gotFingerprint = deps.Options.BundleFingerprint
 		return &runtimepkg.Runtime{}, nil
 	})
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -276,18 +276,23 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	defer restoreGatewayEnv()
 
-	rt, err := runtime.NewRuntime(ctx, cfg, stores.runtimeStores(), runtime.RuntimeOptions{
-		SelfCheck:          opts.SelfCheck,
-		WorkflowModule:     module,
-		WorkspaceLifecycle: workspaces,
-		EnableToolGateway:  true,
-		ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
-		BundleFingerprint:  bootBundleIdentity.Fingerprint,
-		Credentials:        credentialStore,
-		BootStartedAt:      bootStartedAt,
-		BootProgress:       reporter.runtimeSink(),
-		SystemContainers:   systemContainers,
+	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{
+		Config: cfg,
+		Stores: stores.runtimeStores(),
+		Options: runtime.RuntimeOptions{
+			SelfCheck:          opts.SelfCheck,
+			WorkflowModule:     module,
+			WorkspaceLifecycle: workspaces,
+			EnableToolGateway:  true,
+			ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
+			BundleFingerprint:  bootBundleIdentity.Fingerprint,
+			Credentials:        credentialStore,
+			BootStartedAt:      bootStartedAt,
+			BootProgress:       reporter.runtimeSink(),
+			SystemContainers:   systemContainers,
+		},
 	})
+
 	if err != nil {
 		log.Printf("init runtime: %v", err)
 		return 1

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -180,7 +180,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		t.Fatalf("seed catalog runtime run: %v", err)
 	}
 
-	rt, err := runtime.NewRuntime(ctx, cfg, runtime.Stores{
+	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{Config: cfg, Stores: runtime.Stores{
 		SQLDB:               db,
 		EventStore:          pg,
 		SessionRegistry:     sessions.NewPostgresRegistry(db, cfg.LLM.Session.LockTTL),
@@ -191,11 +191,12 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		RuntimeIngressStore: pg,
 		ConversationStore:   nil,
 		TurnStore:           nil,
-	}, runtime.RuntimeOptions{
+	}, Options: runtime.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     llmRuntime,
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -168,10 +168,11 @@ func newTier8Runtime(t testing.TB, bundle *runtimecontracts.WorkflowContractBund
 	if err != nil {
 		return nil, err
 	}
-	return runtime.NewRuntime(context.Background(), testRuntimeConfig(), runtime.Stores{}, runtime.RuntimeOptions{
+	return runtime.NewRuntime(context.Background(), runtime.RuntimeDeps{Config: testRuntimeConfig(), Stores: runtime.Stores{}, Options: runtime.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
-	})
+	}})
+
 }
 
 func assertTier8RuntimeBootMatchesAuthoritativeStartupTruth(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle, expected tier8ExpectedDocument) {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -788,19 +788,20 @@ func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReade
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+	rt, err := runtimepkg.NewRuntime(ctx, runtimepkg.RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{},
 		LLM:     config.LLMConfig{RuntimeMode: "api"},
-	}, runtimepkg.Stores{
+	}, Stores: runtimepkg.Stores{
 		SQLDB:         db,
 		EventStore:    pg,
 		ManagerStore:  pg,
 		ScheduleStore: pg,
-	}, runtimepkg.RuntimeOptions{
+	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     conformanceNoopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -1162,23 +1163,24 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("UpsertSchedule: %v", err)
 	}
 
-	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+	rt, err := runtimepkg.NewRuntime(ctx, runtimepkg.RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{
 			RecoveryOnStartup: false,
 		},
 		LLM: config.LLMConfig{
 			RuntimeMode: "api",
 		},
-	}, runtimepkg.Stores{
+	}, Stores: runtimepkg.Stores{
 		SQLDB:         db,
 		EventStore:    pg,
 		ManagerStore:  pg,
 		ScheduleStore: pg,
-	}, runtimepkg.RuntimeOptions{
+	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
 		LLMRuntime:     conformanceNoopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -1248,22 +1250,23 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 		claimErr: errors.New("claim failed"),
 	}
 
-	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+	rt, err := runtimepkg.NewRuntime(ctx, runtimepkg.RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{
 			RecoveryOnStartup: true,
 		},
 		LLM: config.LLMConfig{
 			RuntimeMode: "api",
 		},
-	}, runtimepkg.Stores{
+	}, Stores: runtimepkg.Stores{
 		SQLDB:        db,
 		EventStore:   eventStore,
 		ManagerStore: &conformanceManagerReplayStore{},
-	}, runtimepkg.RuntimeOptions{
+	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     conformanceNoopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -1346,23 +1349,24 @@ func TestStartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityRead
 		},
 	}
 
-	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+	rt, err := runtimepkg.NewRuntime(ctx, runtimepkg.RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{
 			RecoveryOnStartup: true,
 		},
 		LLM: config.LLMConfig{
 			RuntimeMode: "api",
 		},
-	}, runtimepkg.Stores{
+	}, Stores: runtimepkg.Stores{
 		SQLDB:         db,
 		EventStore:    conformanceTimerRecoveryEventStore{},
 		ManagerStore:  pg,
 		ScheduleStore: scheduleStore,
-	}, runtimepkg.RuntimeOptions{
+	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
 		LLMRuntime:     conformanceNoopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -1615,22 +1619,23 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 		},
 	}
 
-	rt, err := runtimepkg.NewRuntime(ctx, &config.Config{
+	rt, err := runtimepkg.NewRuntime(ctx, runtimepkg.RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{
 			RecoveryOnStartup: true,
 		},
 		LLM: config.LLMConfig{
 			RuntimeMode: "api",
 		},
-	}, runtimepkg.Stores{
+	}, Stores: runtimepkg.Stores{
 		SQLDB:        db,
 		EventStore:   conformanceTimerRecoveryEventStore{},
 		ManagerStore: managerStore,
-	}, runtimepkg.RuntimeOptions{
+	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     conformanceNoopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -73,6 +73,27 @@ type RuntimeOptions struct {
 	SystemContainers   []string
 }
 
+// RuntimeDeps is the canonical dependency graph for NewRuntime boot wiring.
+type RuntimeDeps struct {
+	Config  *config.Config
+	Stores  Stores
+	Options RuntimeOptions
+}
+
+type validatedRuntimeDeps struct {
+	Config                   *config.Config
+	Stores                   Stores
+	Options                  RuntimeOptions
+	Source                   semanticview.Source
+	PromptResolver           runtimecontracts.PromptResolver
+	Credentials              runtimecredentials.Store
+	Authority                runtimeauthority.Provider
+	EmitRegistry             *runtimetools.EmitRegistry
+	RuntimeLogCapabilities   runtimeLogCapabilityResolver
+	EventReceiptCapability   func(context.Context) (bool, error)
+	TrimmedBundleFingerprint string
+}
+
 const BootProgressTotalSteps = 22
 const DefaultShutdownGrace = runtimemanager.DefaultShutdownGrace
 
@@ -249,27 +270,80 @@ func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.Prom
 	return runtimecontracts.NewBundlePromptResolver(bundle), nil
 }
 
-func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts RuntimeOptions) (*Runtime, error) {
+// Validate checks the NewRuntime boot dependency graph without constructing a runtime.
+func (deps RuntimeDeps) Validate() error {
+	_, err := deps.validated()
+	return err
+}
+
+func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
+	cfg := deps.Config
+	stores := deps.Stores
+	opts := deps.Options
 	if cfg == nil {
-		return nil, fmt.Errorf("runtime config is required")
+		return validatedRuntimeDeps{}, fmt.Errorf("runtime config is required")
 	}
 	if err := cfg.ValidateExtensions(); err != nil {
-		return nil, fmt.Errorf("runtime config validation failed: %w", err)
+		return validatedRuntimeDeps{}, fmt.Errorf("runtime config validation failed: %w", err)
 	}
 	if err := ensureWorkflowBootWiring(opts); err != nil {
-		return nil, fmt.Errorf("workflow contract validation failed: %w", err)
+		return validatedRuntimeDeps{}, fmt.Errorf("workflow contract validation failed: %w", err)
 	}
 	source := opts.WorkflowModule.SemanticSource()
 	if err := validateClaudeStartupConfig(cfg, opts, source); err != nil {
-		return nil, fmt.Errorf("claude runtime startup validation failed: %w", err)
+		return validatedRuntimeDeps{}, fmt.Errorf("claude runtime startup validation failed: %w", err)
 	}
 	promptResolver, err := newRuntimePromptResolver(source)
 	if err != nil {
-		return nil, fmt.Errorf("build prompt resolver: %w", err)
+		return validatedRuntimeDeps{}, fmt.Errorf("build prompt resolver: %w", err)
 	}
-	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	authorityProvider := runtimeauthority.NewSourceProvider(source)
 	emitRegistry := runtimetools.NewEmitRegistry(source, authorityProvider)
+	credentials := opts.Credentials
+	if credentials == nil {
+		credentials = runtimecredentials.NewEnvStore()
+	}
+	return validatedRuntimeDeps{
+		Config:                   cfg,
+		Stores:                   stores,
+		Options:                  opts,
+		Source:                   source,
+		PromptResolver:           promptResolver,
+		Credentials:              credentials,
+		Authority:                authorityProvider,
+		EmitRegistry:             emitRegistry,
+		RuntimeLogCapabilities:   runtimeLogSchemaCapabilities(stores),
+		EventReceiptCapability:   canonicalEventReceiptCapabilities(stores),
+		TrimmedBundleFingerprint: strings.TrimSpace(opts.BundleFingerprint),
+	}, nil
+}
+
+func (deps validatedRuntimeDeps) payloadValidator(logger *RuntimeLogger) runtimebus.PayloadValidator {
+	return newRuntimePayloadValidator(logger, deps.EmitRegistry.EventSchemaSnapshot())
+}
+
+func (deps validatedRuntimeDeps) bindPayloadValidator(payloadValidator runtimebus.PayloadValidator) {
+	type eventPayloadValidationBinder interface {
+		SetEventPayloadValidator(func(eventType string, payload []byte) error)
+	}
+	if binder, ok := deps.Stores.EventStore.(eventPayloadValidationBinder); ok && binder != nil {
+		binder.SetEventPayloadValidator(payloadValidator)
+	}
+	if binder, ok := deps.Stores.InboundStore.(eventPayloadValidationBinder); ok && binder != nil {
+		binder.SetEventPayloadValidator(payloadValidator)
+	}
+}
+
+func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
+	boot, err := deps.validated()
+	if err != nil {
+		return nil, err
+	}
+	cfg := boot.Config
+	stores := boot.Stores
+	opts := boot.Options
+	source := boot.Source
+	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	rt := &Runtime{
 		ownerID:        newRuntimeOwnerID(),
 		Config:         cfg,
@@ -277,32 +351,18 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 		Options:        opts,
 		Workspace:      opts.WorkspaceLifecycle,
 		MCPTurns:       mcpTurns,
-		Authority:      authorityProvider,
-		EmitRegistry:   emitRegistry,
-		PromptResolver: promptResolver,
-	}
-	logCaps := runtimeLogSchemaCapabilities(stores)
-	receiptCaps := canonicalEventReceiptCapabilities(stores)
-	if opts.Credentials != nil {
-		rt.Credentials = opts.Credentials
-	} else {
-		rt.Credentials = runtimecredentials.NewEnvStore()
+		Authority:      boot.Authority,
+		EmitRegistry:   boot.EmitRegistry,
+		PromptResolver: boot.PromptResolver,
+		Credentials:    boot.Credentials,
 	}
 
 	if stores.SQLDB != nil {
-		rt.Logger = NewRuntimeLogger(stores.SQLDB, logCaps)
+		rt.Logger = NewRuntimeLogger(stores.SQLDB, boot.RuntimeLogCapabilities)
 	}
-	payloadValidator := newRuntimePayloadValidator(rt.Logger, emitRegistry.EventSchemaSnapshot())
-	type eventPayloadValidationBinder interface {
-		SetEventPayloadValidator(func(eventType string, payload []byte) error)
-	}
-	if binder, ok := stores.EventStore.(eventPayloadValidationBinder); ok && binder != nil {
-		binder.SetEventPayloadValidator(payloadValidator)
-	}
-	if binder, ok := stores.InboundStore.(eventPayloadValidationBinder); ok && binder != nil {
-		binder.SetEventPayloadValidator(payloadValidator)
-	}
-	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, strings.TrimSpace(opts.BundleFingerprint), func() []runtimebus.EventInterceptor {
+	payloadValidator := boot.payloadValidator(rt.Logger)
+	boot.bindPayloadValidator(payloadValidator)
+	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, boot.TrimmedBundleFingerprint, func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil
 		}
@@ -370,7 +430,7 @@ func NewRuntime(ctx context.Context, cfg *config.Config, stores Stores, opts Run
 			},
 			TimerScheduler:          rt.Scheduler,
 			TimerScheduleStore:      stores.ScheduleStore,
-			EventReceiptsCapability: receiptCaps,
+			EventReceiptsCapability: boot.EventReceiptCapability,
 			ArtifactRoot:            artifactRoot,
 			BundleFingerprint:       opts.BundleFingerprint,
 		})

--- a/internal/runtime/runtime_agent_free_claude_boot_test.go
+++ b/internal/runtime/runtime_agent_free_claude_boot_test.go
@@ -29,11 +29,12 @@ func TestRuntimeStart_AgentFreeCLITestDoesNotRequireClaudeStartupEnv(t *testing.
 		t.Fatalf("agent-free fixture has %d semantic agents", got)
 	}
 
-	rt, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -57,11 +58,12 @@ func TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv(t *testing.
 		t.Fatal("agent-present fixture unexpectedly has zero semantic agents")
 	}
 
-	_, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+	_, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err == nil {
 		t.Fatal("expected agent-present cli_test runtime to require Claude startup env")
 	}
@@ -79,7 +81,7 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
-	rt, err := NewRuntime(context.Background(), cfg, Stores{}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: loadAgentFreeRuntimeWorkflowModule(t),
 		LLMRuntime:     noopLLMRuntime{},
@@ -88,7 +90,8 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.
 		},
 		EnableToolGateway: true,
 		ToolGatewayToken:  "gateway-token",
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/runtime_boot_selfcheck_test.go
+++ b/internal/runtime/runtime_boot_selfcheck_test.go
@@ -59,13 +59,14 @@ func TestRuntimeStart_SelfCheckUsesInternalSubscriberVisibility(t *testing.T) {
 	store := &bootSelfCheckDescriptorStore{
 		descriptors: []runtimebus.ActiveAgentDescriptor{{AgentID: "agent-a"}},
 	}
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		EventStore: store,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      true,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -86,9 +87,9 @@ func TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary(t *testing.T
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	store := &bootSelfCheckDescriptorStore{}
 	progress := []BootProgressEvent{}
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		EventStore: store,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:         true,
 		WorkflowModule:    module,
 		LLMRuntime:        noopLLMRuntime{},
@@ -98,7 +99,8 @@ func TestRuntimeStart_PlatformBootPayloadCarriesBootDecisionSummary(t *testing.T
 		BootProgress: func(evt BootProgressEvent) {
 			progress = append(progress, evt)
 		},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -101,13 +101,14 @@ func TestNewRuntimeRejectsInvalidArtifactRootEnv(t *testing.T) {
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
-	_, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	_, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		SQLDB:      db,
 		EventStore: &minimalRuntimeEventStore{},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err == nil || !strings.Contains(err.Error(), "artifact repo root validation failed") || !strings.Contains(err.Error(), "agent-visible mount /data") {
 		t.Fatalf("NewRuntime error = %v, want invalid artifact root", err)
 	}
@@ -124,11 +125,12 @@ func TestRuntimeStart_FailsWhenRecoveryDisabledAndActiveSchedulesExist(t *testin
 			TaskID:    "recover-me",
 		}},
 	}
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{ScheduleStore: store}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{ScheduleStore: store}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -156,14 +158,15 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithManagerSnapshotWork(t *testing.T
 			Config: runtimeactors.AgentConfig{ID: "persisted-agent"},
 		}},
 	}
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		EventStore:   eventStore,
 		ManagerStore: managerStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -177,15 +180,16 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithManagerSnapshotWork(t *testing.T
 
 func TestRuntimeStart_AllowsRecoveryDisabledWhenNoRecoverableWorkExists(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		ScheduleStore: &recordingRuntimeScheduleStore{},
 		EventStore:    &recoveryGuardEventStore{},
 		ManagerStore:  &recoveryGuardManagerStore{},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -199,15 +203,16 @@ func TestRuntimeStart_AllowsRecoveryDisabledWhenNoRecoverableWorkExists(t *testi
 
 func TestRuntimeStart_AllowsRecoveryDisabledWithNonReplayEventStore(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
-	rt, err := NewRuntime(context.Background(), testOperationalRuntimeConfig(), Stores{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
 		EventStore:    &minimalRuntimeEventStore{},
 		ScheduleStore: &recordingRuntimeScheduleStore{},
 		ManagerStore:  &recoveryGuardManagerStore{},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -221,7 +226,7 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithNonReplayEventStore(t *testing.T
 
 func TestNewRuntime_FailsClosedOnMalformedExtensionConfig(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
-	rt, err := NewRuntime(context.Background(), &config.Config{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{RecoveryOnStartup: false},
 		LLM:     config.LLMConfig{RuntimeMode: "api"},
 		Extensions: map[string]any{
@@ -229,13 +234,14 @@ func TestNewRuntime_FailsClosedOnMalformedExtensionConfig(t *testing.T) {
 				"human_tasks": "oops",
 			},
 		},
-	}, Stores{
+	}, Stores: Stores{
 		EventStore: runtimebus.InMemoryEventStore{},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err == nil || !strings.Contains(err.Error(), "runtime config validation failed") || !strings.Contains(err.Error(), "decode extensions") {
 		t.Fatalf("NewRuntime error = %v, want explicit extension validation failure", err)
 	}

--- a/internal/runtime/runtime_ownership_test.go
+++ b/internal/runtime/runtime_ownership_test.go
@@ -37,17 +37,18 @@ func (f *fakeRuntimeStartupOwnershipLease) Release(context.Context) error {
 func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
-	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+	rt1, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{}, Stores: Stores{
 		StartupOwnership: fakeRuntimeStartupOwnershipStore{
 			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
 				return &fakeRuntimeStartupOwnershipLease{}, nil
 			},
 		},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime(rt1): %v", err)
 	}
@@ -56,17 +57,18 @@ func TestRuntimeStart_FailsWhenSharedStoreOwnershipAlreadyHeld(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = rt1.Shutdown() })
 
-	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+	rt2, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{}, Stores: Stores{
 		StartupOwnership: fakeRuntimeStartupOwnershipStore{
 			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
 				return nil, fmt.Errorf("shared runtime store already owned by another runtime instance")
 			},
 		},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime(rt2): %v", err)
 	}
@@ -83,17 +85,18 @@ func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	lease := &fakeRuntimeStartupOwnershipLease{}
 
-	rt1, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+	rt1, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{}, Stores: Stores{
 		StartupOwnership: fakeRuntimeStartupOwnershipStore{
 			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
 				return lease, nil
 			},
 		},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime(rt1): %v", err)
 	}
@@ -107,17 +110,18 @@ func TestRuntimeShutdown_ReleasesSharedStoreOwnership(t *testing.T) {
 		t.Fatalf("startup ownership lease release count = %d, want 1", got)
 	}
 
-	rt2, err := NewRuntime(context.Background(), &config.Config{}, Stores{
+	rt2, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{}, Stores: Stores{
 		StartupOwnership: fakeRuntimeStartupOwnershipStore{
 			acquire: func(context.Context, string) (runtimestartupownership.Lease, error) {
 				return &fakeRuntimeStartupOwnershipLease{}, nil
 			},
 		},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime(rt2): %v", err)
 	}

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -364,16 +364,17 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *t
 		}},
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(false), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(false), Stores: Stores{
 		SQLDB:         db,
 		EventStore:    startupRecoveryCapabilityEventStore{},
 		ManagerStore:  &recoveryGuardManagerStore{},
 		ScheduleStore: scheduleStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -421,15 +422,16 @@ func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testin
 		}},
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(false), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(false), Stores: Stores{
 		SQLDB:        db,
 		EventStore:   eventStore,
 		ManagerStore: managerStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -495,16 +497,17 @@ func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
 		}},
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:         db,
 		EventStore:    startupRecoveryCapabilityEventStore{},
 		ManagerStore:  &recoveryGuardManagerStore{},
 		ScheduleStore: scheduleStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -581,16 +584,17 @@ func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *te
 		},
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:         db,
 		EventStore:    startupRecoveryCapabilityEventStore{},
 		ManagerStore:  &recoveryGuardManagerStore{},
 		ScheduleStore: scheduleStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -705,15 +709,16 @@ func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *te
 		},
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:        db,
 		EventStore:   startupRecoveryCapabilityEventStore{},
 		ManagerStore: managerStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -803,15 +808,16 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 		claimErr: errors.New("claim failed"),
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:        db,
 		EventStore:   eventStore,
 		ManagerStore: &recoveryGuardManagerStore{},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -852,15 +858,16 @@ func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartu
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:        db,
 		EventStore:   startupRecoveryCapabilityEventStore{},
 		ManagerStore: startupRecoveryManagerStore{loadErr: errors.New("load agents failed")},
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -929,16 +936,17 @@ func TestRuntimeStart_InspectionFailurePreservesDecisionErrorAcrossTimerSkipAndD
 		loadErr:           errors.New("load agents failed"),
 	}
 
-	rt, err := NewRuntime(ctx, testRecoveryDiagnosticsConfig(true), Stores{
+	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
 		SQLDB:         db,
 		EventStore:    startupRecoveryCapabilityEventStore{},
 		ManagerStore:  managerStore,
 		ScheduleStore: scheduleStore,
-	}, RuntimeOptions{
+	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -259,14 +259,15 @@ func TestNewRuntime_SchedulerMarksSchedulesFiredThroughCanonicalTerminalHelper(t
 		t.Fatalf("load bundle: %v", err)
 	}
 	store := &recordingRuntimeScheduleStore{fired: make(chan runtimepipeline.Schedule, 1)}
-	rt, err := NewRuntime(context.Background(), &config.Config{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{RecoveryOnStartup: true},
 		LLM:     config.LLMConfig{RuntimeMode: "api"},
-	}, Stores{ScheduleStore: store}, RuntimeOptions{
+	}, Stores: Stores{ScheduleStore: store}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}
@@ -333,14 +334,15 @@ func TestRuntime_StartRestoresExactSchedulesDistinctByFlowInstance(t *testing.T)
 		},
 		fired: make(chan runtimepipeline.Schedule, 2),
 	}
-	rt, err := NewRuntime(context.Background(), &config.Config{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{
 		Runtime: config.RuntimeConfig{RecoveryOnStartup: true},
 		LLM:     config.LLMConfig{RuntimeMode: "api"},
-	}, Stores{ScheduleStore: store}, RuntimeOptions{
+	}, Stores: Stores{ScheduleStore: store}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: semanticOnlyWorkflowRuntime{source: semanticview.Wrap(bundle)},
 		LLMRuntime:     noopLLMRuntime{},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/runtime_session_scope_startup_test.go
+++ b/internal/runtime/runtime_session_scope_startup_test.go
@@ -25,11 +25,12 @@ func TestRuntimeStart_SoleParentFlowPackageAgentsCarryCanonicalFlowPath(t *testi
 
 func assertRuntimeStartCarriesFlowPath(t *testing.T, source semanticview.Source) {
 	t.Helper()
-	rt, err := NewRuntime(context.Background(), &config.Config{}, Stores{}, RuntimeOptions{
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: &config.Config{}, Stores: Stores{}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		LLMRuntime:     noopLLMRuntime{},
 		WorkflowModule: semanticOnlyWorkflowRuntime{source: source},
-	})
+	}})
+
 	if err != nil {
 		t.Fatalf("NewRuntime: %v", err)
 	}

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"swarm/internal/config"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
@@ -79,6 +80,86 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 				t.Fatalf("ensureWorkflowBootWiring error = %v, want nil", err)
 			}
 		})
+	}
+}
+
+func TestRuntimeDepsValidateOwnsRequiredBootInputs(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	validModule := semanticOnlyWorkflowRuntime{source: semanticview.Wrap(testRuntimeWorkflowValidationBundle())}
+
+	cases := []struct {
+		name        string
+		deps        RuntimeDeps
+		errContains string
+	}{
+		{
+			name:        "nil config",
+			deps:        RuntimeDeps{Options: RuntimeOptions{WorkflowModule: validModule}},
+			errContains: "runtime config is required",
+		},
+		{
+			name:        "missing workflow module",
+			deps:        RuntimeDeps{Config: &config.Config{}},
+			errContains: "workflow contract validation failed: workflow module is required",
+		},
+		{
+			name: "valid dependency graph",
+			deps: RuntimeDeps{
+				Config:  &config.Config{},
+				Options: RuntimeOptions{WorkflowModule: validModule},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.deps.Validate()
+			if tc.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("RuntimeDeps.Validate error = %v, want substring %q", err, tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RuntimeDeps.Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestRuntimeDepsValidatedDerivesCanonicalBootGraph(t *testing.T) {
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+	module := semanticOnlyWorkflowRuntime{source: semanticview.Wrap(testRuntimeWorkflowValidationBundle())}
+
+	boot, err := (RuntimeDeps{
+		Config: &config.Config{},
+		Options: RuntimeOptions{
+			WorkflowModule:    module,
+			BundleFingerprint: "  fingerprint-1  ",
+		},
+	}).validated()
+	if err != nil {
+		t.Fatalf("RuntimeDeps.validated: %v", err)
+	}
+	if boot.Source == nil {
+		t.Fatal("validated RuntimeDeps Source = nil")
+	}
+	if boot.PromptResolver == nil {
+		t.Fatal("validated RuntimeDeps PromptResolver = nil")
+	}
+	if boot.Credentials == nil {
+		t.Fatal("validated RuntimeDeps Credentials = nil")
+	}
+	if boot.Authority == nil {
+		t.Fatal("validated RuntimeDeps Authority = nil")
+	}
+	if boot.EmitRegistry == nil {
+		t.Fatal("validated RuntimeDeps EmitRegistry = nil")
+	}
+	if boot.TrimmedBundleFingerprint != "fingerprint-1" {
+		t.Fatalf("TrimmedBundleFingerprint = %q, want fingerprint-1", boot.TrimmedBundleFingerprint)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #170.

Introduces `runtime.RuntimeDeps` as the canonical dependency object for the direct `NewRuntime` boot path and migrates all direct production/test consumers off the old `(cfg, stores, opts)` tuple signature.

## Governing refs/context

- #170 Pre-Implementation Coverage Audit and independent gate approval.
- `platform-spec.yaml` adjacent binding refs: `handler_specification.dependency_graph`, `handler_specification.atomicity`, `runtime.event_loop.state_management.entity_state`, `runtime_storage.entity_state`, and `runtime.boot_sequence`.
- No platform-spec change is included because this PR preserves runtime behavior and only changes internal constructor ownership.

## Semantic migration

- New canonical owner: `internal/runtime.RuntimeDeps` plus its validation/derived boot graph in `NewRuntime`.
- Old path now invalid: direct `NewRuntime(ctx, cfg, stores, opts)` tuple construction.
- Production paths checked/migrated: `cmd/swarm/main.go` serve runtime construction and `cmd/swarm/builder_project_supervisor.go` reload construction.
- Test/harness paths checked/migrated: `internal/runtime`, `internal/runtime/conformance`, and `internal/runtime/cataloge2e` direct `NewRuntime` consumers.
- Migration completeness: complete for direct `NewRuntime` consumers; sibling seams such as `runforkexecution` remain split parent-tail context per gate.

## Proof

- `go test ./internal/runtime -run 'TestRuntimeDeps|TestNewRuntime|TestRuntimeStart_|TestRuntimeShutdown_|TestRuntimeCleanupStartFailure|TestNewRuntimePromptResolver|TestRuntimeBoot|TestRuntimePayloadValidator|TestNewRuntime_FailsClosedOnMalformedExtensionConfig|TestNewRuntime_AgentFreeCLITestDoesNotRequireClaudeStartupEnv|TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier8|TestRuntimeHarness' -count=1`
- `go test ./cmd/swarm -run 'TestRuntimeProjectSupervisor|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestConfigureServeMCPGatewayEnv|TestRunCommand|TestServe' -count=1`
- `go test ./...`
