### PR TITLE
[agent-c][issue #1009] Land bundle delete atomicity authority

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5011,6 +5011,38 @@ multi_bundle_persistence:
     cli_command: swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     non_force_rule: >
       Without --force, deleting a bundle with any active run using that bundle fails closed with BUNDLE_HAS_ACTIVE_RUNS.
+    phase_5_atomicity:
+      tracker: '#1009'
+      implementation_status: source_authority_only_no_runtime_behavior
+      canonical_runtime_owner: future bundle catalog store transaction/mutator
+      applies_to:
+        - '#1018 non-force bundle.delete final bundle availability mutation'
+        - '#1019 bundle.delete --force final bundle availability mutation after preservation cleanup succeeds'
+      transaction_rule: >
+        The final bundle availability mutation MUST execute in one database transaction. The transaction updates every
+        eligible referencing run from bundle_source=persisted to bundle_source=deleted before deleting the matching bundles
+        row. API handlers, CLI consumers, force-delete orchestration, and non-force delete orchestration MUST consume the
+        shared store transaction owner rather than issuing local raw SQL for this transition.
+      transaction_order:
+        - update_eligible_runs_bundle_source_to_deleted
+        - delete_matching_bundles_row
+      eligible_runs: >
+        Only runs that are already non-active for the delete operation may be marked deleted in Phase 5. Active-run refusal
+        is owned by #1018 for non-force delete, and active-run quiescence plus preservation cleanup is owned by #1019/#1008
+        for force delete before Phase 5 is reachable.
+      isolation: >
+        PostgreSQL READ COMMITTED is sufficient when both statements are inside the same transaction: concurrent readers
+        observe either the pre-delete persisted source with an existing bundle row or the post-delete deleted source with no
+        row. They must not observe a legitimate delete as bundle_source=persisted with a missing bundle row.
+      reader_invariant: >
+        Bundle availability readers MUST read runs.bundle_source before consulting bundles. Readers only look up bundles
+        when bundle_source=persisted. bundle_source in (ephemeral, deleted, legacy) returns BUNDLE_UNAVAILABLE without a
+        bundle-row lookup; bundle_source=persisted with a missing row remains BUNDLE_DATA_INTEGRITY_ERROR.
+      invalid_implementations:
+        - deleting the bundles row before marking eligible runs deleted
+        - splitting the runs update and bundle row delete across transactions
+        - implementing separate raw-SQL Phase 5 transitions in non-force and force delete paths
+        - reading bundles before runs.bundle_source when classifying bundle availability
     force_owner_chain:
       - acquire shared destructive-operation mutex/idempotency owner
       - plan affected runs and deliveries for the bundle_hash

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -213,6 +213,40 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 
 	apiSurface := mustMappingValue(t, multi, "api_surface")
 	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "source_authority_not_generated_openrpc_until_runtime_api_implementation")
+
+	bundleDelete := mustMappingValue(t, multi, "bundle_delete")
+	phaseFive := mustMappingValue(t, bundleDelete, "phase_5_atomicity")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "tracker"), "#1009")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "implementation_status"), "source_authority_only_no_runtime_behavior")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "canonical_runtime_owner"), "future bundle catalog store transaction/mutator")
+	appliesTo := mustMappingValue(t, phaseFive, "applies_to")
+	if !sequenceContainsScalar(appliesTo, "#1018 non-force bundle.delete final bundle availability mutation") {
+		t.Fatal("phase_5_atomicity must bind non-force bundle.delete")
+	}
+	if !sequenceContainsScalar(appliesTo, "#1019 bundle.delete --force final bundle availability mutation after preservation cleanup succeeds") {
+		t.Fatal("phase_5_atomicity must bind force bundle.delete")
+	}
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "one database transaction")
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "before deleting the matching bundles")
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "shared store transaction owner")
+	order := mustMappingValue(t, phaseFive, "transaction_order")
+	if len(order.Content) != 2 {
+		t.Fatalf("phase_5_atomicity transaction_order has %d items, want 2", len(order.Content))
+	}
+	if got := scalarValue(order.Content[0]); got != "update_eligible_runs_bundle_source_to_deleted" {
+		t.Fatalf("phase_5_atomicity transaction_order[0] = %q, want update first", got)
+	}
+	if got := scalarValue(order.Content[1]); got != "delete_matching_bundles_row" {
+		t.Fatalf("phase_5_atomicity transaction_order[1] = %q, want delete second", got)
+	}
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "read runs.bundle_source before consulting bundles")
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_UNAVAILABLE")
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_DATA_INTEGRITY_ERROR")
+	invalid := mustMappingValue(t, phaseFive, "invalid_implementations")
+	if !sequenceContainsScalar(invalid, "deleting the bundles row before marking eligible runs deleted") {
+		t.Fatal("phase_5_atomicity must reject delete-before-update implementations")
+	}
+
 	apiRunFork := mustMappingValue(t, apiSurface, "run_fork")
 	assertScalarValue(t, mustMappingValue(t, apiRunFork, "method"), "run.fork")
 	apiRunForkParams := mustMappingValue(t, apiRunFork, "params")


### PR DESCRIPTION
Part of #1009.

Landing repair for PR #1050. PR #1050 carried the already-gated #1009 source-authority delta, but it merged into the non-default branch `agent-f/1012-multi-bundle-source-authority`. Commit `588d537d3a260dff76462c867de5377034b137c8` is not reachable from `origin/master`, so this PR targets `master` and carries only that already-gated source-authority delta.

## Scope

- Add `multi_bundle_persistence.bundle_delete.phase_5_atomicity` to `platform-spec.yaml`.
- Bind both future Phase 5 consumers: #1018 non-force `bundle.delete` and #1019 `bundle.delete --force` after cleanup succeeds.
- Record update-first/delete-second ordering in one database transaction.
- Record the source-first reader invariant: readers inspect `runs.bundle_source` before consulting `bundles`.
- Extend the existing source-authority proof test.

## Explicit Non-Scope

- No #1019 force-delete implementation.
- No runtime cleanup behavior.
- No bundle.delete runtime/API/CLI/schema/OpenRPC implementation.
- No force-delete preservation cleanup.
- No reader migration or schema work.
- No runtime.nuke behavior.

## Governing Refs / Context

- #1009 pre-audit: https://github.com/yazzaoui/Swarm/issues/1009#issuecomment-4531551277
- #1009 independent gate: approved as first slice on the issue thread.
- PR #1050 proof audit: https://github.com/yazzaoui/Swarm/pull/1050#issuecomment-4535136446
- #1012 source authority is now on `master`; this PR repairs only the #1009 source-authority landing gap.

## Semantic Migration

New canonical owner: `platform-spec.yaml#multi_bundle_persistence.bundle_delete.phase_5_atomicity` as source authority, with a future bundle catalog store transaction/mutator as runtime owner.

Old invalid producer/reader/writer paths:
- Deleting the `bundles` row before marking eligible runs deleted.
- Splitting the run update and bundle-row delete across transactions.
- Implementing separate raw-SQL Phase 5 mutations in force and non-force paths.
- Reading `bundles` before `runs.bundle_source` when classifying availability.

Production paths checked for surviving old behavior: no runtime/API/CLI/schema/OpenRPC implementation is introduced in this PR. Runtime migration remains split to #1013/#1014/#1018/#1019.

Migration complete for this source-authority landing repair only; parent multi-bundle implementation remains open.

## Proof

- `git merge-base --is-ancestor 588d537d3a260dff76462c867de5377034b137c8 origin/master` returned non-zero before this repair.
- `git diff --check`
- `go test ./internal/apispec -run TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
