### PR TITLE
[agent-b][issue #1049] Add forkchat lifecycle API owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -331,6 +331,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Observability:      stores.Postgres,
 		Entities:           apiEntities,
 		AgentConversations: apiAgentConversations,
+		ConversationForks:  stores.Postgres,
 		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},
 		Mailbox:            stores.Postgres,
 		Idempotency:        stores.Postgres,

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -470,7 +470,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -528,7 +528,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -669,7 +669,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -795,7 +795,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1015,7 +1015,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1053,7 +1053,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1156,7 +1156,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1285,6 +1285,458 @@
       ]
     },
     {
+      "name": "conversation.fork",
+      "description": "Create a forkchat lifecycle session from an existing conversation source\nsession and a validated fork point. This first slice is lifecycle-only:\nit persists source session/run/agent lineage, fork point descriptor,\ncreator token, fixed 24-hour TTL, and deletion state. It does not\nexecute a forked LLM turn, return entity snapshots, expose inherited\ntranscript counts, or write into normal conversation/event/log surfaces.\n",
+      "params": [
+        {
+          "name": "source_session_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "fork_point",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ConversationForkPointSelector"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ConversationForkCreateResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32026,
+          "message": "Application error: SESSION_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "SESSION_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "session_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "session_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32027,
+          "message": "Application error: TURN_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "TURN_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "session_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "turn_index": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "session_id",
+                  "turn_index"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32006,
+          "message": "Application error: EVENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32012,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
+      "name": "conversation.fork_delete",
+      "description": "Soft-delete one forkchat lifecycle session from the isolated conversation_forks owner.",
+      "params": [
+        {
+          "name": "fork_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ConversationForkDeleteResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32011,
+          "message": "Application error: FORK_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "FORK_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "fork_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "fork_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32012,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
+      "name": "conversation.fork_list",
+      "description": "List active forkchat lifecycle sessions from the isolated conversation_forks owner.",
+      "params": [
+        {
+          "name": "source_session_id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "limit",
+          "required": false,
+          "schema": {
+            "default": 50,
+            "maximum": 500,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Cursor"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "additionalProperties": false,
+          "properties": {
+            "forks": {
+              "items": {
+                "$ref": "#/components/schemas/ConversationForkSession"
+              },
+              "type": "array"
+            },
+            "next_cursor": {
+              "$ref": "#/components/schemas/Cursor"
+            }
+          },
+          "required": [
+            "forks"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "conversation.fork_view",
+      "description": "Read one forkchat lifecycle session header/state. The turns array remains empty until conversation.fork_chat exists.",
+      "params": [
+        {
+          "name": "fork_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ConversationForkSession"
+        }
+      },
+      "errors": [
+        {
+          "code": -32011,
+          "message": "Application error: FORK_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "FORK_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "fork_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "fork_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "conversation.get",
       "description": "Read one conversation in full — session metadata plus all turns and turn blocks.",
       "params": [
@@ -1305,7 +1757,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1382,7 +1834,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1420,7 +1872,7 @@
           }
         },
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1936,7 +2388,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2015,7 +2467,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2073,7 +2525,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2149,7 +2601,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2191,7 +2643,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2535,7 +2987,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2593,7 +3045,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2774,7 +3226,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2812,7 +3264,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -2864,7 +3316,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -2906,7 +3358,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3001,7 +3453,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3039,7 +3491,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3091,7 +3543,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -3136,7 +3588,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3217,7 +3669,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3372,7 +3824,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3410,7 +3862,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3462,7 +3914,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3570,7 +4022,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3608,7 +4060,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -3650,7 +4102,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3731,7 +4183,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3800,7 +4252,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3933,7 +4385,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3971,7 +4423,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4013,7 +4465,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4051,7 +4503,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4218,7 +4670,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -4297,7 +4749,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -4355,7 +4807,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4443,7 +4895,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4481,7 +4933,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4523,7 +4975,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4623,7 +5075,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4724,7 +5176,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4988,7 +5440,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -5026,7 +5478,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5107,7 +5559,7 @@
       },
       "errors": [
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5138,7 +5590,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5219,7 +5671,7 @@
       },
       "errors": [
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5250,7 +5702,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5933,6 +6385,176 @@
         },
         "required": [
           "conversation",
+          "turns"
+        ],
+        "type": "object"
+      },
+      "ConversationForkCreateResult": {
+        "additionalProperties": false,
+        "properties": {
+          "fork": {
+            "$ref": "#/components/schemas/ConversationForkSession"
+          },
+          "idempotency_replayed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "fork",
+          "idempotency_replayed"
+        ],
+        "type": "object"
+      },
+      "ConversationForkDeleteResult": {
+        "additionalProperties": false,
+        "properties": {
+          "already_deleted": {
+            "type": "boolean"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "fork_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "idempotency_replayed": {
+            "type": "boolean"
+          },
+          "ok": {
+            "const": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "fork_id",
+          "deleted",
+          "already_deleted",
+          "idempotency_replayed"
+        ],
+        "type": "object"
+      },
+      "ConversationForkPointDescriptor": {
+        "additionalProperties": false,
+        "description": "Canonical validated fork-point descriptor persisted by the conversation fork lifecycle owner.",
+        "properties": {
+          "at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "kind": {
+            "enum": [
+              "turn",
+              "event",
+              "time"
+            ],
+            "type": "string"
+          },
+          "selected_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "turn_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "turn_index": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "kind",
+          "turn_index",
+          "turn_id",
+          "selected_at"
+        ],
+        "type": "object"
+      },
+      "ConversationForkPointSelector": {
+        "additionalProperties": false,
+        "description": "Selector for the source conversation fork point. Exactly one selector kind is accepted. For `turn`, turn_index is the canonical 1-based conversation order used by conversation.get_turn. For `event`, event_id must be the trigger_event_id for exactly one turn in the source session. For `time`, at resolves to the latest source turn with agent_turns.created_at \u003c= at, using created_at ASC then turn_id ASC as the canonical order.",
+        "properties": {
+          "at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "kind": {
+            "enum": [
+              "turn",
+              "event",
+              "time"
+            ],
+            "type": "string"
+          },
+          "turn_index": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "type": "object"
+      },
+      "ConversationForkSession": {
+        "additionalProperties": false,
+        "description": "Forkchat lifecycle header. This first slice intentionally carries no forked chat transcript, no entity snapshot payload, and no sandbox execution result.",
+        "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "expires_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "fork_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "fork_point": {
+            "$ref": "#/components/schemas/ConversationForkPointDescriptor"
+          },
+          "source_agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_session_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "state": {
+            "enum": [
+              "active",
+              "expired",
+              "deleted"
+            ],
+            "type": "string"
+          },
+          "turns": {
+            "description": "Empty until a later conversation.fork_chat execution owner exists.",
+            "items": {
+              "$ref": "#/components/schemas/Turn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "fork_id",
+          "source_session_id",
+          "source_agent_id",
+          "fork_point",
+          "created_by",
+          "created_at",
+          "expires_at",
+          "state",
           "turns"
         ],
         "type": "object"
@@ -7300,6 +7922,7 @@
           "read:agents",
           "control:agents",
           "read:conversations",
+          "write:conversations",
           "read:runtime",
           "control:runtime",
           "admin:runtime"
@@ -8018,8 +8641,46 @@
           "type": "object"
         }
       },
-      "IDEMPOTENCY_CONFLICT": {
+      "FORK_NOT_FOUND": {
         "code": -32011,
+        "message": "Application error: FORK_NOT_FOUND",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "FORK_NOT_FOUND",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "fork_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                }
+              },
+              "required": [
+                "fork_id"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "IDEMPOTENCY_CONFLICT": {
+        "code": -32012,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -8078,7 +8739,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -8123,7 +8784,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -8175,7 +8836,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -8217,7 +8878,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8255,7 +8916,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -8293,7 +8954,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -8351,7 +9012,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -8382,7 +9043,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -8413,7 +9074,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -8451,7 +9112,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -8489,7 +9150,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -8531,7 +9192,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8569,7 +9230,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -8611,7 +9272,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8649,7 +9310,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8692,7 +9353,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3607,6 +3607,7 @@ platform_tables:
       delete_mixed_row_policy:
         - event_deliveries
         - agent_conversation_audits
+        - conversation_forks
         - timers
       delete_all:
         - runs
@@ -3884,6 +3885,24 @@ platform_tables:
         \    response          JSONB NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    expires_at\
         \        TIMESTAMPTZ NOT NULL,\n    PRIMARY KEY (method, actor_token_id, idempotency_key),\n    INDEX idx_api_idempotency_expires\
         \ (expires_at)\n);"
+    conversation_forks:
+      description: 'Canonical forkchat lifecycle store for conversation.fork, conversation.fork_list, conversation.fork_view,
+        and conversation.fork_delete. Rows are lifecycle metadata only: they record source session/run/agent lineage, the
+        validated fork-point descriptor, creator token, fixed first-slice TTL, and soft-deletion state. This table is isolated
+        from agent_sessions, agent_turns, events, runtime logs, and dashboard conversation readers; fork chat execution,
+        sandbox tools, entity snapshot reads, and cross-surface include/exclude behavior are separate owners.'
+      ddl: "CREATE TABLE conversation_forks (\n    fork_id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n\
+        \    source_session_id      UUID NOT NULL,\n    source_run_id          UUID,\n    source_agent_id        TEXT NOT\
+        \ NULL,\n    fork_point_kind       TEXT NOT NULL CHECK (fork_point_kind IN ('turn', 'event', 'time')),\n    fork_point_turn_index\
+        \ INTEGER,\n    fork_point_turn_id UUID,\n    fork_point_event_id UUID,\n    fork_point_at         TIMESTAMPTZ,\n\
+        \    fork_point_selected_at TIMESTAMPTZ NOT NULL,\n    created_by            TEXT NOT NULL,\n    created_at   \
+        \         TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    expires_at            TIMESTAMPTZ NOT NULL,\n    deleted_at\
+        \            TIMESTAMPTZ,\n    CHECK ((fork_point_kind = 'turn' AND fork_point_turn_index IS NOT NULL AND fork_point_turn_id\
+        \ IS NOT NULL AND fork_point_event_id IS NULL AND fork_point_at IS NULL) OR (fork_point_kind = 'event' AND fork_point_turn_index\
+        \ IS NOT NULL AND fork_point_turn_id IS NOT NULL AND fork_point_event_id IS NOT NULL AND fork_point_at IS NULL) OR\
+        \ (fork_point_kind = 'time' AND fork_point_turn_index IS NOT NULL AND fork_point_turn_id IS NOT NULL AND fork_point_at\
+        \ IS NOT NULL)),\n    INDEX idx_conversation_forks_source (source_session_id, created_at DESC),\n    INDEX idx_conversation_forks_created\
+        \ (created_at DESC, fork_id),\n    INDEX idx_conversation_forks_active (expires_at) WHERE deleted_at IS NULL\n);"
     runtime_ingress_state:
       description: 'Durable singleton runtime ingress state owned by the canonical runtime ingress controller. It records whether
         queueable event-producing ingress is running or paused, the last transition reason/actor, and the platform event emitted
@@ -6435,7 +6454,9 @@ cli_specification:
       forkchat:
         disposition: blocked
         tracker: '#749'
-        action: Forkchat remains blocked until `conversation.fork*` API/runtime contract exists.
+        action: Forkchat CLI remains blocked until `conversation.fork_chat` execution, sandbox/snapshot owners, and CLI consumer
+          contracts exist. Lifecycle-only `conversation.fork|fork_list|fork_view|fork_delete` is source authority, not CLI
+          usability.
     platform_spec_refinements_not_cleanly_present_in_review_artifact:
       agent_replay_backlog:
         classification: required_current_contract
@@ -8693,7 +8714,8 @@ cli_specification:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
       implementation_status: absent
-      blocker_state: '#749; conversation.fork* API methods and runtime subsystem are not present in current OpenRPC.'
+      blocker_state: '#749; lifecycle-only conversation.fork|fork_list|fork_view|fork_delete exists, but conversation.fork_chat,
+        sandbox/snapshot owners, and swarm forkchat CLI consumer are not present.'
       owners: conversation.fork, conversation.fork_chat, conversation.fork_list, conversation.fork_view, conversation.fork_delete
     entities_list:
       command: swarm entities list
@@ -8954,7 +8976,7 @@ cli_specification:
       remaining_role: 'Track deprecations/ratification cleanup only if kept open; do not block those CLI commands solely on method existence.'
     '#749':
       state: active_blocker
-      reason: 'conversation.fork, conversation.fork_chat, conversation.fork_list, conversation.fork_view, and conversation.fork_delete are absent.'
+      reason: 'Lifecycle-only conversation.fork, conversation.fork_list, conversation.fork_view, and conversation.fork_delete are present. conversation.fork_chat, sandbox/snapshot owners, and swarm forkchat CLI remain absent.'
     '#750':
       state: parent_runtime_tail
       closed_slices:
@@ -9372,6 +9394,8 @@ api_specification:
       - runtime.pause
       - runtime.resume
       - runtime.nuke
+      - conversation.fork
+      - conversation.fork_delete
     mailbox:
       status_storage_model: 'The storage table keeps terminal defer decisions as status = decided and decision = deferred.
         v1 read projections expose that row as MailboxStatus deferred. Approval/reject terminal rows remain status = decided
@@ -9434,6 +9458,7 @@ api_specification:
       - read:agents
       - control:agents
       - read:conversations
+      - write:conversations
       - read:runtime
       - control:runtime
       - admin:runtime
@@ -9525,6 +9550,7 @@ api_specification:
         - read:agents
         - control:agents
         - read:conversations
+        - write:conversations
         - read:runtime
         - control:runtime
         - admin:runtime
@@ -10784,6 +10810,133 @@ api_specification:
             type: array
             items:
               $ref: '#/components/schemas/Turn'
+      ConversationForkPointSelector:
+        description: "Selector for the source conversation fork point. Exactly one selector kind is accepted. For `turn`,\
+          \ turn_index is the canonical 1-based conversation order used by conversation.get_turn. For `event`, event_id must\
+          \ be the trigger_event_id for exactly one turn in the source session. For `time`, at resolves to the latest source\
+          \ turn with agent_turns.created_at <= at, using created_at ASC then turn_id ASC as the canonical order."
+        type: object
+        additionalProperties: false
+        required:
+        - kind
+        properties:
+          kind:
+            type: string
+            enum:
+            - turn
+            - event
+            - time
+          turn_index:
+            type: integer
+            minimum: 1
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          at:
+            $ref: '#/components/schemas/Timestamp'
+      ConversationForkPointDescriptor:
+        description: Canonical validated fork-point descriptor persisted by the conversation fork lifecycle owner.
+        type: object
+        additionalProperties: false
+        required:
+        - kind
+        - turn_index
+        - turn_id
+        - selected_at
+        properties:
+          kind:
+            type: string
+            enum:
+            - turn
+            - event
+            - time
+          turn_index:
+            type: integer
+            minimum: 1
+          turn_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          at:
+            $ref: '#/components/schemas/Timestamp'
+          selected_at:
+            $ref: '#/components/schemas/Timestamp'
+      ConversationForkSession:
+        description: "Forkchat lifecycle header. This first slice intentionally carries no forked chat transcript, no entity\
+          \ snapshot payload, and no sandbox execution result."
+        type: object
+        additionalProperties: false
+        required:
+        - fork_id
+        - source_session_id
+        - source_agent_id
+        - fork_point
+        - created_by
+        - created_at
+        - expires_at
+        - state
+        - turns
+        properties:
+          fork_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_session_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          fork_point:
+            $ref: '#/components/schemas/ConversationForkPointDescriptor'
+          created_by:
+            type: string
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+          expires_at:
+            $ref: '#/components/schemas/Timestamp'
+          deleted_at:
+            $ref: '#/components/schemas/Timestamp'
+          state:
+            type: string
+            enum:
+            - active
+            - expired
+            - deleted
+          turns:
+            type: array
+            description: Empty until a later conversation.fork_chat execution owner exists.
+            items:
+              $ref: '#/components/schemas/Turn'
+      ConversationForkCreateResult:
+        type: object
+        additionalProperties: false
+        required:
+        - fork
+        - idempotency_replayed
+        properties:
+          fork:
+            $ref: '#/components/schemas/ConversationForkSession'
+          idempotency_replayed:
+            type: boolean
+      ConversationForkDeleteResult:
+        type: object
+        additionalProperties: false
+        required:
+        - ok
+        - fork_id
+        - deleted
+        - already_deleted
+        - idempotency_replayed
+        properties:
+          ok:
+            type: boolean
+            const: true
+          fork_id:
+            $ref: '#/components/schemas/OpaqueId'
+          deleted:
+            type: boolean
+          already_deleted:
+            type: boolean
+          idempotency_replayed:
+            type: boolean
       LogLevel:
         type: string
         enum:
@@ -11463,6 +11616,14 @@ api_specification:
           turn_index:
             type: integer
             minimum: 1
+      FORK_NOT_FOUND:
+        type: object
+        additionalProperties: false
+        required:
+        - fork_id
+        properties:
+          fork_id:
+            $ref: '#/components/schemas/OpaqueId'
       RUNTIME_ALREADY_PAUSED:
         type: object
         additionalProperties: false
@@ -12824,6 +12985,123 @@ api_specification:
           - type: 'null'
       errors:
       - AGENT_NOT_FOUND
+    conversation.fork:
+      tier: should_have
+      description: |
+        Create a forkchat lifecycle session from an existing conversation source
+        session and a validated fork point. This first slice is lifecycle-only:
+        it persists source session/run/agent lineage, fork point descriptor,
+        creator token, fixed 24-hour TTL, and deletion state. It does not
+        execute a forked LLM turn, return entity snapshots, expose inherited
+        transcript counts, or write into normal conversation/event/log surfaces.
+      scope:
+        required:
+        - write:conversations
+        - read:conversations
+      idempotency: per the convention.
+      params:
+      - name: source_session_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: fork_point
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationForkPointSelector'
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationForkCreateResult'
+      errors:
+      - SESSION_NOT_FOUND
+      - TURN_NOT_FOUND
+      - EVENT_NOT_FOUND
+      - IDEMPOTENCY_CONFLICT
+    conversation.fork_list:
+      tier: should_have
+      description: List active forkchat lifecycle sessions from the isolated conversation_forks owner.
+      scope:
+        required:
+        - read:conversations
+      params:
+      - name: source_session_id
+        required: false
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: limit
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 500
+          default: 50
+      - name: cursor
+        required: false
+        schema:
+          $ref: '#/components/schemas/Cursor'
+      result:
+        name: result
+        required: true
+        schema:
+          type: object
+          additionalProperties: false
+          required:
+          - forks
+          properties:
+            forks:
+              type: array
+              items:
+                $ref: '#/components/schemas/ConversationForkSession'
+            next_cursor:
+              $ref: '#/components/schemas/Cursor'
+      errors: []
+    conversation.fork_view:
+      tier: should_have
+      description: Read one forkchat lifecycle session header/state. The turns array remains empty until conversation.fork_chat exists.
+      scope:
+        required:
+        - read:conversations
+      params:
+      - name: fork_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationForkSession'
+      errors:
+      - FORK_NOT_FOUND
+    conversation.fork_delete:
+      tier: should_have
+      description: Soft-delete one forkchat lifecycle session from the isolated conversation_forks owner.
+      scope:
+        required:
+        - write:conversations
+      idempotency: per the convention.
+      params:
+      - name: fork_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationForkDeleteResult'
+      errors:
+      - FORK_NOT_FOUND
+      - IDEMPOTENCY_CONFLICT
     runtime.logs:
       tier: should_have
       description: Filtered structured runtime log query.

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,17 +16,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 43 {
-		t.Fatalf("method count = %d, want 43", report.MethodCount)
+	if report.MethodCount != 47 {
+		t.Fatalf("method count = %d, want 47", report.MethodCount)
 	}
-	if report.SchemaCount != 72 {
-		t.Fatalf("schema count = %d, want 72", report.SchemaCount)
+	if report.SchemaCount != 77 {
+		t.Fatalf("schema count = %d, want 77", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 28 {
-		t.Fatalf("error code count = %d, want 28", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 29 {
+		t.Fatalf("error code count = %d, want 29", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 16 {
-		t.Fatalf("mutating method count = %d, want 16", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 18 {
+		t.Fatalf("mutating method count = %d, want 18", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
@@ -66,14 +66,14 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 43 {
-		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
+	if len(doc.Methods) != 47 {
+		t.Fatalf("generated OpenRPC methods = %d, want 47", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 72 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 72", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 77 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 77", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 28 {
-		t.Fatalf("generated OpenRPC errors = %d, want 28", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 29 {
+		t.Fatalf("generated OpenRPC errors = %d, want 29", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
@@ -93,6 +93,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := methods["agent.diagnose"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.diagnose")
 	}
+	for _, methodName := range []string{"conversation.fork", "conversation.fork_list", "conversation.fork_view", "conversation.fork_delete"} {
+		if _, ok := methods[methodName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", methodName)
+		}
+	}
 	if _, ok := doc.Components.Schemas["AgentPendingDelivery"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentPendingDelivery")
 	}
@@ -109,6 +114,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisLastToolOutcome")
 	}
 	for _, schemaName := range []string{"MailboxDecisionSheet", "MailboxEntityContext", "MailboxDownstreamPreview"} {
+		if _, ok := doc.Components.Schemas[schemaName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", schemaName)
+		}
+	}
+	for _, schemaName := range []string{"ConversationForkPointSelector", "ConversationForkPointDescriptor", "ConversationForkSession", "ConversationForkCreateResult", "ConversationForkDeleteResult"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 43 {
-		t.Fatalf("method count = %d, want 43", len(openRPCNames))
+	if len(openRPCNames) != 47 {
+		t.Fatalf("method count = %d, want 47", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 43 {
-		t.Fatalf("generated OpenRPC methods = %d, want 43", len(doc.Methods))
+	if len(doc.Methods) != 47 {
+		t.Fatalf("generated OpenRPC methods = %d, want 47", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -217,6 +217,8 @@ func approvedMutatingHTTPRuntimeMethods() []string {
 		"agent.replay_backlog",
 		"agent.restart",
 		"agent.send_directive",
+		"conversation.fork",
+		"conversation.fork_delete",
 		"event.publish",
 		"event.replay",
 		"mailbox.approve",
@@ -243,6 +245,8 @@ type mutatingHTTPRuntimeFixture struct {
 func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 	runID := "00000000-0000-0000-0000-000000000101"
 	otherRunID := "00000000-0000-0000-0000-000000000102"
+	sourceSessionID := "00000000-0000-0000-0000-000000000201"
+	forkID := "00000000-0000-0000-0000-000000000301"
 	until := time.Unix(1700003600, 0).UTC().Format(time.RFC3339Nano)
 	later := time.Unix(1700007200, 0).UTC().Format(time.RFC3339Nano)
 	return map[string]mutatingHTTPRuntimeFixture{
@@ -268,6 +272,18 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			Params:         map[string]any{"agent_id": "agent-a", "directive": "continue", "run_id": runID},
 			ConflictParams: map[string]any{"agent_id": "agent-a", "directive": "pause", "run_id": runID},
 			ResultKeys:     []string{"ok", "run_id", "run_id_resolution", "directive_event_id", "directive_event_type"},
+			SuccessEffects: 1,
+		},
+		"conversation.fork": {
+			Params:         map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(1)}},
+			ConflictParams: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(2)}},
+			ResultKeys:     []string{"fork", "idempotency_replayed"},
+			SuccessEffects: 1,
+		},
+		"conversation.fork_delete": {
+			Params:         map[string]any{"fork_id": forkID},
+			ConflictParams: map[string]any{"fork_id": "00000000-0000-0000-0000-000000000302"},
+			ResultKeys:     []string{"ok", "fork_id", "deleted", "already_deleted", "idempotency_replayed"},
 			SuccessEffects: 1,
 		},
 		"event.publish": {
@@ -360,6 +376,8 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 	missingRunID := "00000000-0000-0000-0000-000000000999"
 	badFingerprint := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	validEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	sourceSessionID := "00000000-0000-0000-0000-000000000201"
+	forkID := "00000000-0000-0000-0000-000000000301"
 	return []mutatingHTTPRuntimeErrorProbe{
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badFingerprint}}), Code: BundleMismatchCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
@@ -392,6 +410,19 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.observability.events["evt-pending"] = mutatingProbeOriginalEvent("evt-pending", []string{"agent-a"}, eventReplayStatusPending)
 		}}},
 		{Method: "agent.replay", Params: map[string]any{"event_id": "evt-1", "agent_id": "agent-a", "idempotency_key": "idem-error"}, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.checkErr = runtimebus.ErrPayloadValidation }}},
+
+		{Method: "conversation.fork", Params: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(1)}, "idempotency_key": "idem-error"}, Code: SessionNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.forks.createErr = store.ErrSessionNotFound
+		}}},
+		{Method: "conversation.fork", Params: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(1)}, "idempotency_key": "idem-error"}, Code: TurnNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.forks.createErr = store.ErrTurnNotFound
+		}}},
+		{Method: "conversation.fork", Params: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "event", "event_id": "00000000-0000-0000-0000-000000000901"}, "idempotency_key": "idem-error"}, Code: EventNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.forks.createErr = store.ErrEventNotFound
+		}}},
+		{Method: "conversation.fork_delete", Params: map[string]any{"fork_id": forkID, "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.forks.deleteErr = store.ErrConversationForkNotFound
+		}}},
 
 		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badFingerprint}, "run_id": runID}), Code: BundleMismatchCode},
 		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
@@ -570,6 +601,7 @@ type mutatingRuntimeProbeState struct {
 	agentControl   *mutatingProbeAgentControl
 	runtimeIngress *mutatingProbeRuntimeIngress
 	mailbox        *mutatingProbeMailboxStore
+	forks          *fakeConversationForkLifecycleStore
 	nuke           *recordingRuntimeNukeOwners
 	effects        int
 }
@@ -601,6 +633,27 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 	state.agentControl.state = state
 	state.runtimeIngress.state = state
 	state.mailbox = newMutatingProbeMailboxStore(state)
+	state.forks = &fakeConversationForkLifecycleStore{
+		createResult: store.OperatorConversationForkSession{
+			ForkID:          "00000000-0000-0000-0000-000000000301",
+			SourceSessionID: "00000000-0000-0000-0000-000000000201",
+			SourceRunID:     runID,
+			SourceAgentID:   "agent-a",
+			ForkPoint: store.ConversationForkPointDescriptor{
+				Kind:       "turn",
+				TurnIndex:  1,
+				TurnID:     "00000000-0000-0000-0000-000000000401",
+				SelectedAt: now,
+			},
+			CreatedBy: "token",
+			CreatedAt: now,
+			ExpiresAt: now.Add(store.ConversationForkLifecycleTTL),
+			State:     "active",
+			Turns:     []store.OperatorConversationTurn{},
+		},
+		deleteResult: store.ConversationForkDeleteResult{ForkID: "00000000-0000-0000-0000-000000000301", Deleted: true},
+		recordEffect: state.recordEffect,
+	}
 	return state
 }
 
@@ -614,6 +667,7 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 		Runs:                  s.runs,
 		Observability:         s.observability,
 		AgentControl:          s.agentControl,
+		ConversationForks:     s.forks,
 		Mailbox:               s.mailbox,
 		Idempotency:           s.idempotency,
 		Events:                s.events,

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -241,6 +241,8 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 		"agent.get",
 		"agent.list",
 		"conversation.current_for_agent",
+		"conversation.fork_list",
+		"conversation.fork_view",
 		"conversation.get",
 		"conversation.get_turn",
 		"conversation.list",
@@ -268,6 +270,8 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
+		"conversation.fork_list":         {Params: map[string]any{}, ResultKeys: []string{"forks"}},
+		"conversation.fork_view":         {Params: map[string]any{"fork_id": "00000000-0000-0000-0000-000000000301"}, ResultKeys: []string{"fork_id", "source_session_id", "source_agent_id", "fork_point", "created_by", "created_at", "expires_at", "state", "turns"}},
 		"conversation.get":               {Params: map[string]any{"session_id": "sess-1"}, ResultKeys: []string{"conversation", "turns"}},
 		"conversation.get_turn":          {Params: map[string]any{"session_id": "sess-1", "turn_index": 1}, ResultKeys: []string{"session", "turn"}},
 		"conversation.list":              {Params: map[string]any{}, ResultKeys: []string{"conversations"}},
@@ -352,6 +356,16 @@ func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 			},
 		},
 		{
+			Method: "conversation.fork_view",
+			Params: map[string]any{"fork_id": "00000000-0000-0000-0000-000000000999"},
+			Code:   ForkNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.ConversationForks = &fakeConversationForkLifecycleStore{viewErr: store.ErrConversationForkNotFound}
+				return opts
+			},
+		},
+		{
 			Method: "entity.get",
 			Params: map[string]any{"entity_id": "missing"},
 			Code:   EntityNotFoundCode,
@@ -412,6 +426,26 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 	runID := "run-1"
 	eventID := "evt-1"
 	sessionID := "sess-1"
+	forkID := "00000000-0000-0000-0000-000000000301"
+	forkSessionID := "00000000-0000-0000-0000-000000000201"
+	forkTurnID := "00000000-0000-0000-0000-000000000401"
+	fork := store.OperatorConversationForkSession{
+		ForkID:          forkID,
+		SourceSessionID: forkSessionID,
+		SourceRunID:     "00000000-0000-0000-0000-000000000501",
+		SourceAgentID:   "agent-1",
+		ForkPoint: store.ConversationForkPointDescriptor{
+			Kind:       "turn",
+			TurnIndex:  1,
+			TurnID:     forkTurnID,
+			SelectedAt: now,
+		},
+		CreatedBy: "token",
+		CreatedAt: now,
+		ExpiresAt: now.Add(store.ConversationForkLifecycleTTL),
+		State:     "active",
+		Turns:     []store.OperatorConversationTurn{},
+	}
 	return OperatorReadOptions{
 		Now:      func() time.Time { return now },
 		Ready:    func() bool { return true },
@@ -597,7 +631,12 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 				Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-current-1", TriggerEventID: eventID, TriggerEventType: "scan.requested", ParseOK: true}},
 			},
 		},
-		Mailbox: newReadOnlyMailboxProbeStore(now),
+		ConversationForks: &fakeConversationForkLifecycleStore{
+			listResult: store.ConversationForkListResult{Forks: []store.OperatorConversationForkSession{fork}},
+			viewResult: fork,
+		},
+		Idempotency: newMutatingProbeIdempotencyStore(),
+		Mailbox:     newReadOnlyMailboxProbeStore(now),
 		Bundle: runtimecontracts.BundleIdentity{
 			WorkflowName:    "review",
 			WorkflowVersion: "1.0.0",

--- a/internal/apiv1/operator_conversation_fork.go
+++ b/internal/apiv1/operator_conversation_fork.go
@@ -33,6 +33,13 @@ type conversationForkDeleteResult struct {
 	IdempotencyReplayed bool   `json:"idempotency_replayed"`
 }
 
+type conversationForkErrorDetails struct {
+	SessionID string
+	ForkID    string
+	TurnIndex int
+	EventID   string
+}
+
 func OperatorConversationForkHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	if opts.ConversationForks == nil || opts.Idempotency == nil {
 		return nil
@@ -52,7 +59,7 @@ func OperatorConversationForkHandlers(opts OperatorReadOptions) map[string]Metho
 			}
 			result, err := opts.ConversationForks.ListOperatorConversationForks(ctx, listOpts)
 			if err != nil {
-				return nil, conversationForkError(err, "", 0)
+				return nil, conversationForkError(err, conversationForkErrorDetails{})
 			}
 			if result.Forks == nil {
 				result.Forks = []store.OperatorConversationForkSession{}
@@ -66,7 +73,7 @@ func OperatorConversationForkHandlers(opts OperatorReadOptions) map[string]Metho
 			}
 			result, err := opts.ConversationForks.LoadOperatorConversationFork(ctx, forkID)
 			if err != nil {
-				return nil, conversationForkError(err, forkID, 0)
+				return nil, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
 			}
 			return result, nil
 		},
@@ -105,7 +112,11 @@ func executeConversationForkCreate(ctx context.Context, req Request, opts Operat
 			Now:             now,
 		})
 		if err != nil {
-			return store.APIIdempotencyCompletion{}, conversationForkError(err, "", forkPoint.TurnIndex)
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, conversationForkErrorDetails{
+				SessionID: sourceSessionID,
+				TurnIndex: forkPoint.TurnIndex,
+				EventID:   forkPoint.EventID,
+			})
 		}
 		response, err := json.Marshal(conversationForkCreateResult{
 			Fork:                fork,
@@ -117,7 +128,11 @@ func executeConversationForkCreate(ctx context.Context, req Request, opts Operat
 		return store.APIIdempotencyCompletion{ResourceID: fork.ForkID, Response: response}, nil
 	})
 	if err != nil {
-		return nil, conversationForkError(err, "", forkPoint.TurnIndex)
+		return nil, conversationForkError(err, conversationForkErrorDetails{
+			SessionID: sourceSessionID,
+			TurnIndex: forkPoint.TurnIndex,
+			EventID:   forkPoint.EventID,
+		})
 	}
 	var result conversationForkCreateResult
 	if err := json.Unmarshal(completion.Response, &result); err != nil {
@@ -150,7 +165,7 @@ func executeConversationForkDelete(ctx context.Context, req Request, opts Operat
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
 		deleted, err := opts.ConversationForks.DeleteOperatorConversationFork(ctx, forkID, now)
 		if err != nil {
-			return store.APIIdempotencyCompletion{}, conversationForkError(err, forkID, 0)
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
 		}
 		response, err := json.Marshal(conversationForkDeleteResult{
 			OK:                  true,
@@ -165,7 +180,7 @@ func executeConversationForkDelete(ctx context.Context, req Request, opts Operat
 		return store.APIIdempotencyCompletion{ResourceID: deleted.ForkID, Response: response}, nil
 	})
 	if err != nil {
-		return nil, conversationForkError(err, forkID, 0)
+		return nil, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
 	}
 	var result conversationForkDeleteResult
 	if err := json.Unmarshal(completion.Response, &result); err != nil {
@@ -238,7 +253,7 @@ func conversationForkPointSelectorFromParams(params map[string]any) (store.Conve
 	}
 }
 
-func conversationForkError(err error, forkID string, turnIndex int) error {
+func conversationForkError(err error, details conversationForkErrorDetails) error {
 	var conflict *store.APIIdempotencyConflictError
 	if errors.As(err, &conflict) {
 		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
@@ -251,20 +266,20 @@ func conversationForkError(err error, forkID string, turnIndex int) error {
 		})
 	}
 	if errors.Is(err, store.ErrSessionNotFound) {
-		return NewApplicationError(SessionNotFoundCode, false, map[string]any{})
+		return NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": details.SessionID})
 	}
 	if errors.Is(err, store.ErrTurnNotFound) {
-		details := map[string]any{}
-		if turnIndex > 0 {
-			details["turn_index"] = turnIndex
+		errorDetails := map[string]any{"session_id": details.SessionID}
+		if details.TurnIndex > 0 {
+			errorDetails["turn_index"] = details.TurnIndex
 		}
-		return NewApplicationError(TurnNotFoundCode, false, details)
+		return NewApplicationError(TurnNotFoundCode, false, errorDetails)
 	}
 	if errors.Is(err, store.ErrEventNotFound) {
-		return NewApplicationError(EventNotFoundCode, false, map[string]any{})
+		return NewApplicationError(EventNotFoundCode, false, map[string]any{"event_id": details.EventID})
 	}
 	if errors.Is(err, store.ErrConversationForkNotFound) {
-		return NewApplicationError(ForkNotFoundCode, false, map[string]any{"fork_id": forkID})
+		return NewApplicationError(ForkNotFoundCode, false, map[string]any{"fork_id": details.ForkID})
 	}
 	if errors.Is(err, store.ErrInvalidConversationForkCursor) {
 		return NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid conversation fork cursor"})

--- a/internal/apiv1/operator_conversation_fork.go
+++ b/internal/apiv1/operator_conversation_fork.go
@@ -223,6 +223,13 @@ func conversationForkPointSelectorFromParams(params map[string]any) (store.Conve
 	if !ok {
 		return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point", "reason": "must be an object"})
 	}
+	for key := range obj {
+		switch key {
+		case "kind", "turn_index", "event_id", "at":
+		default:
+			return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point." + key, "reason": "unknown field"})
+		}
+	}
 	kind, err := requiredStringParam(obj, "kind")
 	if err != nil {
 		return store.ConversationForkPointSelector{}, err

--- a/internal/apiv1/operator_conversation_fork.go
+++ b/internal/apiv1/operator_conversation_fork.go
@@ -1,0 +1,276 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/store"
+)
+
+const conversationForkIdempotencyTTL = 24 * time.Hour
+
+type ConversationForkLifecycleStore interface {
+	CreateOperatorConversationFork(context.Context, store.ConversationForkCreateRequest) (store.OperatorConversationForkSession, error)
+	ListOperatorConversationForks(context.Context, store.ConversationForkListOptions) (store.ConversationForkListResult, error)
+	LoadOperatorConversationFork(context.Context, string) (store.OperatorConversationForkSession, error)
+	DeleteOperatorConversationFork(context.Context, string, time.Time) (store.ConversationForkDeleteResult, error)
+}
+
+type conversationForkCreateResult struct {
+	Fork                store.OperatorConversationForkSession `json:"fork"`
+	IdempotencyReplayed bool                                  `json:"idempotency_replayed"`
+}
+
+type conversationForkDeleteResult struct {
+	OK                  bool   `json:"ok"`
+	ForkID              string `json:"fork_id"`
+	Deleted             bool   `json:"deleted"`
+	AlreadyDeleted      bool   `json:"already_deleted"`
+	IdempotencyReplayed bool   `json:"idempotency_replayed"`
+}
+
+func OperatorConversationForkHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.ConversationForks == nil || opts.Idempotency == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"conversation.fork": func(ctx context.Context, req Request) (any, error) {
+			return executeConversationForkCreate(ctx, req, opts, now().UTC())
+		},
+		"conversation.fork_list": func(ctx context.Context, req Request) (any, error) {
+			listOpts, err := conversationForkListOptionsFromParams(req.Params, now().UTC())
+			if err != nil {
+				return nil, err
+			}
+			result, err := opts.ConversationForks.ListOperatorConversationForks(ctx, listOpts)
+			if err != nil {
+				return nil, conversationForkError(err, "", 0)
+			}
+			if result.Forks == nil {
+				result.Forks = []store.OperatorConversationForkSession{}
+			}
+			return result, nil
+		},
+		"conversation.fork_view": func(ctx context.Context, req Request) (any, error) {
+			forkID, err := requiredStringParam(req.Params, "fork_id")
+			if err != nil {
+				return nil, err
+			}
+			result, err := opts.ConversationForks.LoadOperatorConversationFork(ctx, forkID)
+			if err != nil {
+				return nil, conversationForkError(err, forkID, 0)
+			}
+			return result, nil
+		},
+		"conversation.fork_delete": func(ctx context.Context, req Request) (any, error) {
+			return executeConversationForkDelete(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func executeConversationForkCreate(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	sourceSessionID, err := requiredStringParam(req.Params, "source_session_id")
+	if err != nil {
+		return nil, err
+	}
+	forkPoint, err := conversationForkPointSelectorFromParams(req.Params)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     sourceSessionID,
+		TTL:            conversationForkIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		fork, err := opts.ConversationForks.CreateOperatorConversationFork(ctx, store.ConversationForkCreateRequest{
+			SourceSessionID: sourceSessionID,
+			ForkPoint:       forkPoint,
+			CreatedBy:       req.ActorTokenID,
+			Now:             now,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, "", forkPoint.TurnIndex)
+		}
+		response, err := json.Marshal(conversationForkCreateResult{
+			Fork:                fork,
+			IdempotencyReplayed: false,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: fork.ForkID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, conversationForkError(err, "", forkPoint.TurnIndex)
+	}
+	var result conversationForkCreateResult
+	if err := json.Unmarshal(completion.Response, &result); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode conversation.fork idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode conversation.fork response: %w", err)
+	}
+	result.IdempotencyReplayed = replay
+	return result, nil
+}
+
+func executeConversationForkDelete(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	forkID, err := requiredStringParam(req.Params, "fork_id")
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     forkID,
+		TTL:            conversationForkIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		deleted, err := opts.ConversationForks.DeleteOperatorConversationFork(ctx, forkID, now)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, forkID, 0)
+		}
+		response, err := json.Marshal(conversationForkDeleteResult{
+			OK:                  true,
+			ForkID:              deleted.ForkID,
+			Deleted:             deleted.Deleted,
+			AlreadyDeleted:      deleted.AlreadyDeleted,
+			IdempotencyReplayed: false,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: deleted.ForkID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, conversationForkError(err, forkID, 0)
+	}
+	var result conversationForkDeleteResult
+	if err := json.Unmarshal(completion.Response, &result); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode conversation.fork_delete idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode conversation.fork_delete response: %w", err)
+	}
+	result.IdempotencyReplayed = replay
+	return result, nil
+}
+
+func conversationForkListOptionsFromParams(params map[string]any, now time.Time) (store.ConversationForkListOptions, error) {
+	sourceSessionID, _, err := optionalStringParam(params, "source_session_id")
+	if err != nil {
+		return store.ConversationForkListOptions{}, err
+	}
+	cursor, _, err := optionalStringParam(params, "cursor")
+	if err != nil {
+		return store.ConversationForkListOptions{}, err
+	}
+	limit, err := boundedIntegerParam(params, "limit", 1, 500)
+	if err != nil {
+		return store.ConversationForkListOptions{}, err
+	}
+	return store.ConversationForkListOptions{
+		SourceSessionID: sourceSessionID,
+		Limit:           limit,
+		Cursor:          cursor,
+		Now:             now,
+	}, nil
+}
+
+func conversationForkPointSelectorFromParams(params map[string]any) (store.ConversationForkPointSelector, error) {
+	raw, ok := params["fork_point"]
+	if !ok || isEmptyParam(raw) {
+		return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point", "reason": "is required"})
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point", "reason": "must be an object"})
+	}
+	kind, err := requiredStringParam(obj, "kind")
+	if err != nil {
+		return store.ConversationForkPointSelector{}, err
+	}
+	selector := store.ConversationForkPointSelector{Kind: strings.ToLower(strings.TrimSpace(kind))}
+	if rawTurnIndex, ok := obj["turn_index"]; ok && !isEmptyParam(rawTurnIndex) {
+		turnIndex, ok := integerParam(rawTurnIndex)
+		if !ok || turnIndex < 1 {
+			return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point.turn_index", "reason": "must be an integer from 1 to 1000000"})
+		}
+		selector.TurnIndex = turnIndex
+	}
+	if eventID, present, err := optionalStringParam(obj, "event_id"); err != nil {
+		return store.ConversationForkPointSelector{}, err
+	} else if present {
+		selector.EventID = eventID
+	}
+	if at, err := timestampParam(obj, "at"); err != nil {
+		return store.ConversationForkPointSelector{}, err
+	} else if at != nil {
+		selector.At = at
+	}
+	switch selector.Kind {
+	case "turn", "event", "time":
+		return selector, nil
+	default:
+		return store.ConversationForkPointSelector{}, NewInvalidParamsError(map[string]any{"field": "fork_point.kind", "reason": "must be one of turn, event, time"})
+	}
+}
+
+func conversationForkError(err error, forkID string, turnIndex int) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	if errors.Is(err, store.ErrSessionNotFound) {
+		return NewApplicationError(SessionNotFoundCode, false, map[string]any{})
+	}
+	if errors.Is(err, store.ErrTurnNotFound) {
+		details := map[string]any{}
+		if turnIndex > 0 {
+			details["turn_index"] = turnIndex
+		}
+		return NewApplicationError(TurnNotFoundCode, false, details)
+	}
+	if errors.Is(err, store.ErrEventNotFound) {
+		return NewApplicationError(EventNotFoundCode, false, map[string]any{})
+	}
+	if errors.Is(err, store.ErrConversationForkNotFound) {
+		return NewApplicationError(ForkNotFoundCode, false, map[string]any{"fork_id": forkID})
+	}
+	if errors.Is(err, store.ErrInvalidConversationForkCursor) {
+		return NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid conversation fork cursor"})
+	}
+	if paramErr := entityReadParamError(err); paramErr != nil {
+		return NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+	}
+	return err
+}

--- a/internal/apiv1/operator_conversation_fork_test.go
+++ b/internal/apiv1/operator_conversation_fork_test.go
@@ -1,0 +1,325 @@
+package apiv1
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"swarm/internal/store"
+)
+
+type fakeConversationForkLifecycleStore struct {
+	createResult store.OperatorConversationForkSession
+	createErr    error
+	listResult   store.ConversationForkListResult
+	listErr      error
+	viewResult   store.OperatorConversationForkSession
+	viewErr      error
+	deleteResult store.ConversationForkDeleteResult
+	deleteErr    error
+
+	createCalls int
+	listCalls   int
+	viewCalls   int
+	deleteCalls int
+
+	lastCreate store.ConversationForkCreateRequest
+	lastList   store.ConversationForkListOptions
+	lastViewID string
+	lastDelete string
+	lastNow    time.Time
+
+	recordEffect func()
+}
+
+func (s *fakeConversationForkLifecycleStore) CreateOperatorConversationFork(_ context.Context, req store.ConversationForkCreateRequest) (store.OperatorConversationForkSession, error) {
+	s.createCalls++
+	s.lastCreate = req
+	if s.createErr != nil {
+		return store.OperatorConversationForkSession{}, s.createErr
+	}
+	if s.recordEffect != nil {
+		s.recordEffect()
+	}
+	return s.createResult, nil
+}
+
+func (s *fakeConversationForkLifecycleStore) ListOperatorConversationForks(_ context.Context, opts store.ConversationForkListOptions) (store.ConversationForkListResult, error) {
+	s.listCalls++
+	s.lastList = opts
+	return s.listResult, s.listErr
+}
+
+func (s *fakeConversationForkLifecycleStore) LoadOperatorConversationFork(_ context.Context, forkID string) (store.OperatorConversationForkSession, error) {
+	s.viewCalls++
+	s.lastViewID = forkID
+	return s.viewResult, s.viewErr
+}
+
+func (s *fakeConversationForkLifecycleStore) DeleteOperatorConversationFork(_ context.Context, forkID string, now time.Time) (store.ConversationForkDeleteResult, error) {
+	s.deleteCalls++
+	s.lastDelete = forkID
+	s.lastNow = now
+	if s.deleteErr != nil {
+		return store.ConversationForkDeleteResult{}, s.deleteErr
+	}
+	if s.recordEffect != nil {
+		s.recordEffect()
+	}
+	return s.deleteResult, nil
+}
+
+func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	sourceSessionID := "00000000-0000-0000-0000-000000000201"
+	forkID := "00000000-0000-0000-0000-000000000301"
+	turnID := "00000000-0000-0000-0000-000000000401"
+	created := now.Add(-time.Minute)
+	fork := store.OperatorConversationForkSession{
+		ForkID:          forkID,
+		SourceSessionID: sourceSessionID,
+		SourceRunID:     "00000000-0000-0000-0000-000000000501",
+		SourceAgentID:   "agent-1",
+		ForkPoint: store.ConversationForkPointDescriptor{
+			Kind:       "turn",
+			TurnIndex:  2,
+			TurnID:     turnID,
+			SelectedAt: created,
+		},
+		CreatedBy: "token",
+		CreatedAt: created,
+		ExpiresAt: created.Add(store.ConversationForkLifecycleTTL),
+		State:     "active",
+		Turns:     []store.OperatorConversationTurn{},
+	}
+	forks := &fakeConversationForkLifecycleStore{
+		createResult: fork,
+		listResult:   store.ConversationForkListResult{Forks: []store.OperatorConversationForkSession{fork}, NextCursor: "cursor-2"},
+		viewResult:   fork,
+		deleteResult: store.ConversationForkDeleteResult{ForkID: forkID, Deleted: true},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:               func() time.Time { return now },
+			ConversationForks: forks,
+			Idempotency:       newMutatingProbeIdempotencyStore(),
+		}),
+	})
+
+	create := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"create","method":"conversation.fork","params":{"source_session_id":"`+sourceSessionID+`","fork_point":{"kind":"turn","turn_index":2},"idempotency_key":"create-1"}}`)
+	if create.Error != nil {
+		t.Fatalf("conversation.fork error = %#v", create.Error)
+	}
+	createResult := asMap(t, create.Result)
+	if createResult["idempotency_replayed"] != false {
+		t.Fatalf("conversation.fork idempotency_replayed = %#v", createResult["idempotency_replayed"])
+	}
+	if got := asMap(t, createResult["fork"])["fork_id"]; got != forkID {
+		t.Fatalf("conversation.fork fork_id = %#v, want %s", got, forkID)
+	}
+	if forks.createCalls != 1 || forks.lastCreate.SourceSessionID != sourceSessionID || forks.lastCreate.ForkPoint.Kind != "turn" || forks.lastCreate.ForkPoint.TurnIndex != 2 {
+		t.Fatalf("create owner call = calls %d req %#v", forks.createCalls, forks.lastCreate)
+	}
+
+	replay := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"replay","method":"conversation.fork","params":{"source_session_id":"`+sourceSessionID+`","fork_point":{"kind":"turn","turn_index":2},"idempotency_key":"create-1"}}`)
+	if replay.Error != nil {
+		t.Fatalf("conversation.fork replay error = %#v", replay.Error)
+	}
+	if got := asMap(t, replay.Result)["idempotency_replayed"]; got != true {
+		t.Fatalf("conversation.fork replay idempotency_replayed = %#v, want true", got)
+	}
+	if forks.createCalls != 1 {
+		t.Fatalf("conversation.fork create owner calls after replay = %d, want 1", forks.createCalls)
+	}
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"conversation.fork_list","params":{"source_session_id":"`+sourceSessionID+`","limit":25,"cursor":"cursor-1"}}`)
+	if list.Error != nil {
+		t.Fatalf("conversation.fork_list error = %#v", list.Error)
+	}
+	listResult := asMap(t, list.Result)
+	if listResult["next_cursor"] != "cursor-2" {
+		t.Fatalf("conversation.fork_list next_cursor = %#v", listResult["next_cursor"])
+	}
+	if forks.listCalls != 1 || forks.lastList.SourceSessionID != sourceSessionID || forks.lastList.Limit != 25 || forks.lastList.Cursor != "cursor-1" {
+		t.Fatalf("list owner call = calls %d opts %#v", forks.listCalls, forks.lastList)
+	}
+
+	view := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"view","method":"conversation.fork_view","params":{"fork_id":"`+forkID+`"}}`)
+	if view.Error != nil {
+		t.Fatalf("conversation.fork_view error = %#v", view.Error)
+	}
+	if got := asMap(t, view.Result)["fork_id"]; got != forkID {
+		t.Fatalf("conversation.fork_view fork_id = %#v, want %s", got, forkID)
+	}
+	if forks.viewCalls != 1 || forks.lastViewID != forkID {
+		t.Fatalf("view owner call = calls %d fork_id %s", forks.viewCalls, forks.lastViewID)
+	}
+
+	deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"conversation.fork_delete","params":{"fork_id":"`+forkID+`","idempotency_key":"delete-1"}}`)
+	if deleted.Error != nil {
+		t.Fatalf("conversation.fork_delete error = %#v", deleted.Error)
+	}
+	deleteResult := asMap(t, deleted.Result)
+	if deleteResult["ok"] != true || deleteResult["fork_id"] != forkID || deleteResult["deleted"] != true || deleteResult["idempotency_replayed"] != false {
+		t.Fatalf("conversation.fork_delete result = %#v", deleteResult)
+	}
+	if forks.deleteCalls != 1 || forks.lastDelete != forkID || !forks.lastNow.Equal(now) {
+		t.Fatalf("delete owner call = calls %d fork_id %s now %s", forks.deleteCalls, forks.lastDelete, forks.lastNow)
+	}
+}
+
+func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	sourceSessionID := "00000000-0000-0000-0000-000000000201"
+	forkID := "00000000-0000-0000-0000-000000000301"
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		mutate func(*fakeConversationForkLifecycleStore)
+		code   string
+	}{
+		{
+			name:   "create missing source session",
+			method: "conversation.fork",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"turn","turn_index":1}}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrSessionNotFound },
+			code:   SessionNotFoundCode,
+		},
+		{
+			name:   "create missing turn",
+			method: "conversation.fork",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"turn","turn_index":99}}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrTurnNotFound },
+			code:   TurnNotFoundCode,
+		},
+		{
+			name:   "create missing event",
+			method: "conversation.fork",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"event","event_id":"00000000-0000-0000-0000-000000000999"}}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrEventNotFound },
+			code:   EventNotFoundCode,
+		},
+		{
+			name:   "list bad cursor",
+			method: "conversation.fork_list",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_list","params":{"cursor":"bad"}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.listErr = store.ErrInvalidConversationForkCursor },
+			code:   "",
+		},
+		{
+			name:   "view missing fork",
+			method: "conversation.fork_view",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_view","params":{"fork_id":"` + forkID + `"}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.viewErr = store.ErrConversationForkNotFound },
+			code:   ForkNotFoundCode,
+		},
+		{
+			name:   "delete missing fork",
+			method: "conversation.fork_delete",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_delete","params":{"fork_id":"` + forkID + `"}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.deleteErr = store.ErrConversationForkNotFound },
+			code:   ForkNotFoundCode,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			forks := &fakeConversationForkLifecycleStore{
+				createResult: store.OperatorConversationForkSession{ForkID: forkID, SourceSessionID: sourceSessionID, SourceAgentID: "agent-1", ForkPoint: store.ConversationForkPointDescriptor{Kind: "turn", TurnIndex: 1, TurnID: "00000000-0000-0000-0000-000000000401", SelectedAt: now}, CreatedBy: "token", CreatedAt: now, ExpiresAt: now.Add(time.Hour), State: "active", Turns: []store.OperatorConversationTurn{}},
+				deleteResult: store.ConversationForkDeleteResult{ForkID: forkID, Deleted: true},
+			}
+			tt.mutate(forks)
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					Now:               func() time.Time { return now },
+					ConversationForks: forks,
+					Idempotency:       newMutatingProbeIdempotencyStore(),
+				}),
+			})
+			resp := rpcCall(t, handler, tt.body)
+			if tt.code == "" {
+				if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+					t.Fatalf("%s error = %#v, want invalid params", tt.method, resp.Error)
+				}
+				return
+			}
+			if resp.Error == nil {
+				t.Fatalf("%s error = nil, want %s", tt.method, tt.code)
+			}
+			data := asMap(t, resp.Error.Data)
+			if data["code"] != tt.code {
+				t.Fatalf("%s error data = %#v, want code %s", tt.method, data, tt.code)
+			}
+		})
+	}
+}
+
+func TestOperatorConversationForkRejectsUnsupportedForkPointKindBeforeOwner(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	forks := &fakeConversationForkLifecycleStore{}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:               func() time.Time { return now },
+			ConversationForks: forks,
+			Idempotency:       newMutatingProbeIdempotencyStore(),
+		}),
+	})
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"bad","method":"conversation.fork","params":{"source_session_id":"00000000-0000-0000-0000-000000000201","fork_point":{"kind":"bogus"}}}`)
+	if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+		t.Fatalf("conversation.fork malformed fork_point error = %#v, want invalid params", resp.Error)
+	}
+	if forks.createCalls != 0 {
+		t.Fatalf("create owner calls = %d, want 0 for malformed fork_point", forks.createCalls)
+	}
+}
+
+func TestOperatorConversationForkIdempotencyConflict(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	sourceSessionID := "00000000-0000-0000-0000-000000000201"
+	forks := &fakeConversationForkLifecycleStore{
+		createResult: store.OperatorConversationForkSession{
+			ForkID:          "00000000-0000-0000-0000-000000000301",
+			SourceSessionID: sourceSessionID,
+			SourceAgentID:   "agent-1",
+			ForkPoint:       store.ConversationForkPointDescriptor{Kind: "turn", TurnIndex: 1, TurnID: "00000000-0000-0000-0000-000000000401", SelectedAt: now},
+			CreatedBy:       "token",
+			CreatedAt:       now,
+			ExpiresAt:       now.Add(time.Hour),
+			State:           "active",
+			Turns:           []store.OperatorConversationTurn{},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:               func() time.Time { return now },
+			ConversationForks: forks,
+			Idempotency:       newMutatingProbeIdempotencyStore(),
+		}),
+	})
+	first := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"first","method":"conversation.fork","params":{"source_session_id":"`+sourceSessionID+`","fork_point":{"kind":"turn","turn_index":1},"idempotency_key":"fork-key"}}`)
+	if first.Error != nil {
+		t.Fatalf("conversation.fork first error = %#v", first.Error)
+	}
+	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"conflict","method":"conversation.fork","params":{"source_session_id":"`+sourceSessionID+`","fork_point":{"kind":"turn","turn_index":2},"idempotency_key":"fork-key"}}`)
+	if conflict.Error == nil {
+		t.Fatal("conversation.fork conflict error = nil")
+	}
+	data := asMap(t, conflict.Error.Data)
+	if data["code"] != IdempotencyConflictCode {
+		t.Fatalf("conversation.fork conflict data = %#v, want %s", data, IdempotencyConflictCode)
+	}
+}
+
+func TestConversationForkErrorMapsParamErrors(t *testing.T) {
+	err := conversationForkError(&store.EntityReadParamError{Field: "source_session_id", Reason: "must be a UUID"}, "", 0)
+	var invalid *InvalidParamsError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("conversationForkError = %T, want InvalidParamsError", err)
+	}
+}

--- a/internal/apiv1/operator_conversation_fork_test.go
+++ b/internal/apiv1/operator_conversation_fork_test.go
@@ -270,23 +270,52 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 	}
 }
 
-func TestOperatorConversationForkRejectsUnsupportedForkPointKindBeforeOwner(t *testing.T) {
+func TestOperatorConversationForkRejectsInvalidForkPointBeforeOwner(t *testing.T) {
 	now := time.Unix(1700000000, 0).UTC()
-	forks := &fakeConversationForkLifecycleStore{}
-	handler := testHandler(t, Options{
-		AuthTokens: []string{testToken},
-		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:               func() time.Time { return now },
-			ConversationForks: forks,
-			Idempotency:       newMutatingProbeIdempotencyStore(),
-		}),
-	})
-	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"bad","method":"conversation.fork","params":{"source_session_id":"00000000-0000-0000-0000-000000000201","fork_point":{"kind":"bogus"}}}`)
-	if resp.Error == nil || resp.Error.Code != codeInvalidParams {
-		t.Fatalf("conversation.fork malformed fork_point error = %#v, want invalid params", resp.Error)
+	tests := []struct {
+		name      string
+		forkPoint string
+		wantField string
+	}{
+		{
+			name:      "unsupported kind",
+			forkPoint: `{"kind":"bogus"}`,
+			wantField: "fork_point.kind",
+		},
+		{
+			name:      "unknown entity snapshot",
+			forkPoint: `{"kind":"turn","turn_index":1,"entity_snapshot":{}}`,
+			wantField: "fork_point.entity_snapshot",
+		},
+		{
+			name:      "unknown include original",
+			forkPoint: `{"kind":"turn","turn_index":1,"include_original":true}`,
+			wantField: "fork_point.include_original",
+		},
 	}
-	if forks.createCalls != 0 {
-		t.Fatalf("create owner calls = %d, want 0 for malformed fork_point", forks.createCalls)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			forks := &fakeConversationForkLifecycleStore{}
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					Now:               func() time.Time { return now },
+					ConversationForks: forks,
+					Idempotency:       newMutatingProbeIdempotencyStore(),
+				}),
+			})
+			resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"bad","method":"conversation.fork","params":{"source_session_id":"00000000-0000-0000-0000-000000000201","fork_point":`+tt.forkPoint+`}}`)
+			if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+				t.Fatalf("conversation.fork malformed fork_point error = %#v, want invalid params", resp.Error)
+			}
+			if got := asMap(t, asMap(t, resp.Error.Data)["details"])["field"]; got != tt.wantField {
+				t.Fatalf("conversation.fork invalid field = %#v, want %s", got, tt.wantField)
+			}
+			if forks.createCalls != 0 {
+				t.Fatalf("create owner calls = %d, want 0 for malformed fork_point", forks.createCalls)
+			}
+		})
 	}
 }
 

--- a/internal/apiv1/operator_conversation_fork_test.go
+++ b/internal/apiv1/operator_conversation_fork_test.go
@@ -180,6 +180,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 		body   string
 		mutate func(*fakeConversationForkLifecycleStore)
 		code   string
+		detail map[string]any
 	}{
 		{
 			name:   "create missing source session",
@@ -187,6 +188,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"turn","turn_index":1}}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrSessionNotFound },
 			code:   SessionNotFoundCode,
+			detail: map[string]any{"session_id": sourceSessionID},
 		},
 		{
 			name:   "create missing turn",
@@ -194,6 +196,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"turn","turn_index":99}}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrTurnNotFound },
 			code:   TurnNotFoundCode,
+			detail: map[string]any{"session_id": sourceSessionID, "turn_index": float64(99)},
 		},
 		{
 			name:   "create missing event",
@@ -201,6 +204,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork","params":{"source_session_id":"` + sourceSessionID + `","fork_point":{"kind":"event","event_id":"00000000-0000-0000-0000-000000000999"}}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.createErr = store.ErrEventNotFound },
 			code:   EventNotFoundCode,
+			detail: map[string]any{"event_id": "00000000-0000-0000-0000-000000000999"},
 		},
 		{
 			name:   "list bad cursor",
@@ -215,6 +219,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_view","params":{"fork_id":"` + forkID + `"}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.viewErr = store.ErrConversationForkNotFound },
 			code:   ForkNotFoundCode,
+			detail: map[string]any{"fork_id": forkID},
 		},
 		{
 			name:   "delete missing fork",
@@ -222,6 +227,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_delete","params":{"fork_id":"` + forkID + `"}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.deleteErr = store.ErrConversationForkNotFound },
 			code:   ForkNotFoundCode,
+			detail: map[string]any{"fork_id": forkID},
 		},
 	}
 	for _, tt := range tests {
@@ -253,6 +259,12 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			data := asMap(t, resp.Error.Data)
 			if data["code"] != tt.code {
 				t.Fatalf("%s error data = %#v, want code %s", tt.method, data, tt.code)
+			}
+			details := asMap(t, data["details"])
+			for key, want := range tt.detail {
+				if details[key] != want {
+					t.Fatalf("%s error details[%s] = %#v, want %#v in %#v", tt.method, key, details[key], want, details)
+				}
 			}
 		})
 	}
@@ -317,7 +329,7 @@ func TestOperatorConversationForkIdempotencyConflict(t *testing.T) {
 }
 
 func TestConversationForkErrorMapsParamErrors(t *testing.T) {
-	err := conversationForkError(&store.EntityReadParamError{Field: "source_session_id", Reason: "must be a UUID"}, "", 0)
+	err := conversationForkError(&store.EntityReadParamError{Field: "source_session_id", Reason: "must be a UUID"}, conversationForkErrorDetails{})
 	var invalid *InvalidParamsError
 	if !errors.As(err, &invalid) {
 		t.Fatalf("conversationForkError = %T, want InvalidParamsError", err)

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -57,6 +57,7 @@ type OperatorReadOptions struct {
 	Observability         ObservabilityReadStore
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
+	ConversationForks     ConversationForkLifecycleStore
 	AgentControl          AgentControlController
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore
@@ -226,6 +227,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorAgentConversationHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorConversationForkHandlers(opts) {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorAgentControlHandlers(opts) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -25,6 +25,7 @@ const (
 	AgentNotRunningCode                  = "AGENT_NOT_RUNNING"
 	SessionNotFoundCode                  = "SESSION_NOT_FOUND"
 	TurnNotFoundCode                     = "TURN_NOT_FOUND"
+	ForkNotFoundCode                     = "FORK_NOT_FOUND"
 	PayloadValidationFailedCode          = "PAYLOAD_VALIDATION_FAILED"
 	RunNotFoundCode                      = "RUN_NOT_FOUND"
 	RunAlreadyTerminalCode               = "RUN_ALREADY_TERMINAL"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -183,6 +183,66 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: conversation.fork
+    transport: http
+    required_params: [source_session_id, fork_point]
+    declared_errors: [SESSION_NOT_FOUND, TURN_NOT_FOUND, EVENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestOperatorConversationForkRejectsUnsupportedForkPointKindBeforeOwner}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersTypedErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}, {kind: go_test, name: TestOperatorConversationForkIdempotencyConflict}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
+  - method: conversation.fork_delete
+    transport: http
+    required_params: [fork_id]
+    declared_errors: [FORK_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersTypedErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
+  - method: conversation.fork_list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
+  - method: conversation.fork_view
+    transport: http
+    required_params: [fork_id]
+    declared_errors: [FORK_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersTypedErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: entity.aggregate
     transport: http
     required_params: []

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -188,7 +188,7 @@ methods:
     required_params: [source_session_id, fork_point]
     declared_errors: [SESSION_NOT_FOUND, TURN_NOT_FOUND, EVENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
-    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestOperatorConversationForkRejectsUnsupportedForkPointKindBeforeOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestOperatorConversationForkRejectsInvalidForkPointBeforeOwner}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersTypedErrors}]}

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -26,6 +26,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "agent_turns", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_turns.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_conversation_audits", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "agent_conversation_audits.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_sessions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_sessions.run_id", DeleteOrderGroup: 3},
+		{Table: "conversation_forks", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "conversation_forks.source_run_id", DeleteOrderGroup: 3},
 		{Table: "entity_mutations", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "entity_mutations.run_id", DeleteOrderGroup: 3},
 		{Table: "entity_state", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "entity_state.run_id", DeleteOrderGroup: 3},
 		{Table: "timers", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "timers.run_id|forked_from_run_id|forked_from_event_id -> events.run_id", DeleteOrderGroup: 3},

--- a/internal/store/conversation_fork_lifecycle.go
+++ b/internal/store/conversation_fork_lifecycle.go
@@ -1,0 +1,617 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const ConversationForkLifecycleTTL = 24 * time.Hour
+
+type ConversationForkPointSelector struct {
+	Kind      string
+	TurnIndex int
+	EventID   string
+	At        *time.Time
+}
+
+type ConversationForkPointDescriptor struct {
+	Kind       string     `json:"kind"`
+	TurnIndex  int        `json:"turn_index"`
+	TurnID     string     `json:"turn_id"`
+	EventID    string     `json:"event_id,omitempty"`
+	At         *time.Time `json:"at,omitempty"`
+	SelectedAt time.Time  `json:"selected_at"`
+}
+
+type OperatorConversationForkSession struct {
+	ForkID          string                          `json:"fork_id"`
+	SourceSessionID string                          `json:"source_session_id"`
+	SourceRunID     string                          `json:"source_run_id,omitempty"`
+	SourceAgentID   string                          `json:"source_agent_id"`
+	ForkPoint       ConversationForkPointDescriptor `json:"fork_point"`
+	CreatedBy       string                          `json:"created_by"`
+	CreatedAt       time.Time                       `json:"created_at"`
+	ExpiresAt       time.Time                       `json:"expires_at"`
+	DeletedAt       *time.Time                      `json:"deleted_at,omitempty"`
+	State           string                          `json:"state"`
+	Turns           []OperatorConversationTurn      `json:"turns"`
+}
+
+type ConversationForkCreateRequest struct {
+	SourceSessionID string
+	ForkPoint       ConversationForkPointSelector
+	CreatedBy       string
+	Now             time.Time
+}
+
+type ConversationForkListOptions struct {
+	SourceSessionID string
+	Limit           int
+	Cursor          string
+	Now             time.Time
+}
+
+type ConversationForkListResult struct {
+	Forks      []OperatorConversationForkSession `json:"forks"`
+	NextCursor string                            `json:"next_cursor,omitempty"`
+}
+
+type ConversationForkDeleteResult struct {
+	ForkID         string `json:"fork_id"`
+	Deleted        bool   `json:"deleted"`
+	AlreadyDeleted bool   `json:"already_deleted"`
+}
+
+type conversationForkSource struct {
+	SessionID string
+	AgentID   string
+	RunID     string
+}
+
+type conversationForkCursor struct {
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at"`
+	ForkID    string `json:"fork_id"`
+}
+
+func (s *PostgresStore) CreateOperatorConversationFork(ctx context.Context, req ConversationForkCreateRequest) (OperatorConversationForkSession, error) {
+	if s == nil || s.DB == nil {
+		return OperatorConversationForkSession{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	if err := requireConversationForkLifecycleCapabilities(caps); err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	now := req.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	createdBy := strings.TrimSpace(req.CreatedBy)
+	if createdBy == "" {
+		return OperatorConversationForkSession{}, &EntityReadParamError{Field: "created_by", Reason: "is required"}
+	}
+	source, err := s.loadConversationForkSource(ctx, caps, req.SourceSessionID)
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	descriptor, err := s.resolveConversationForkPoint(ctx, req.SourceSessionID, req.ForkPoint)
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	expiresAt := now.Add(ConversationForkLifecycleTTL).UTC()
+	row := s.DB.QueryRowContext(ctx, `
+		INSERT INTO conversation_forks (
+			source_session_id, source_run_id, source_agent_id,
+			fork_point_kind, fork_point_turn_index, fork_point_turn_id,
+			fork_point_event_id, fork_point_at, fork_point_selected_at,
+			created_by, created_at, expires_at
+		)
+		VALUES (
+			$1::uuid, nullif($2, '')::uuid, $3,
+			$4, $5, $6::uuid,
+			nullif($7, '')::uuid, $8, $9,
+			$10, $11, $12
+		)
+		RETURNING
+			fork_id::text, source_session_id::text, COALESCE(source_run_id::text, ''),
+			source_agent_id, fork_point_kind, fork_point_turn_index,
+			COALESCE(fork_point_turn_id::text, ''), COALESCE(fork_point_event_id::text, ''),
+			fork_point_at, fork_point_selected_at, created_by, created_at, expires_at, deleted_at
+	`, source.SessionID, source.RunID, source.AgentID, descriptor.Kind, descriptor.TurnIndex, descriptor.TurnID,
+		descriptor.EventID, descriptor.At, descriptor.SelectedAt, createdBy, now, expiresAt)
+	return scanConversationForkSession(row, now)
+}
+
+func (s *PostgresStore) ListOperatorConversationForks(ctx context.Context, opts ConversationForkListOptions) (ConversationForkListResult, error) {
+	if s == nil || s.DB == nil {
+		return ConversationForkListResult{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return ConversationForkListResult{}, err
+	}
+	if err := requireConversationForkLifecycleCapabilities(caps); err != nil {
+		return ConversationForkListResult{}, err
+	}
+	opts, err = defaultConversationForkListOptions(opts)
+	if err != nil {
+		return ConversationForkListResult{}, err
+	}
+	args := make([]any, 0, 6)
+	where := []string{"deleted_at IS NULL", "expires_at > $1"}
+	args = append(args, opts.Now.UTC())
+	if opts.SourceSessionID != "" {
+		sessionID, err := normalizeUUIDParam(opts.SourceSessionID, "source_session_id")
+		if err != nil {
+			return ConversationForkListResult{}, err
+		}
+		args = append(args, sessionID)
+		where = append(where, fmt.Sprintf("source_session_id = $%d::uuid", len(args)))
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeConversationForkCursor(opts.Cursor)
+		if err != nil {
+			return ConversationForkListResult{}, err
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, cursor.CreatedAt)
+		if err != nil || strings.TrimSpace(cursor.ForkID) == "" {
+			return ConversationForkListResult{}, ErrInvalidConversationForkCursor
+		}
+		forkID, err := normalizeUUIDParam(cursor.ForkID, "cursor.fork_id")
+		if err != nil {
+			return ConversationForkListResult{}, ErrInvalidConversationForkCursor
+		}
+		args = append(args, createdAt.UTC(), forkID)
+		nTime := len(args) - 1
+		nFork := len(args)
+		where = append(where, fmt.Sprintf(`(
+			created_at < $%d
+			OR (created_at = $%d AND fork_id > $%d::uuid)
+		)`, nTime, nTime, nFork))
+	}
+	args = append(args, opts.Limit+1)
+	limitArg := len(args)
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			fork_id::text, source_session_id::text, COALESCE(source_run_id::text, ''),
+			source_agent_id, fork_point_kind, fork_point_turn_index,
+			COALESCE(fork_point_turn_id::text, ''), COALESCE(fork_point_event_id::text, ''),
+			fork_point_at, fork_point_selected_at, created_by, created_at, expires_at, deleted_at
+		FROM conversation_forks
+		WHERE %s
+		ORDER BY created_at DESC, fork_id ASC
+		LIMIT $%d
+	`, strings.Join(where, " AND "), limitArg), args...)
+	if err != nil {
+		return ConversationForkListResult{}, fmt.Errorf("list conversation forks: %w", err)
+	}
+	defer rows.Close()
+	forks := []OperatorConversationForkSession{}
+	for rows.Next() {
+		item, err := scanConversationForkSession(rows, opts.Now)
+		if err != nil {
+			return ConversationForkListResult{}, err
+		}
+		forks = append(forks, item)
+	}
+	if err := rows.Err(); err != nil {
+		return ConversationForkListResult{}, fmt.Errorf("read conversation forks: %w", err)
+	}
+	nextCursor := ""
+	if len(forks) > opts.Limit {
+		forks = forks[:opts.Limit]
+		last := forks[len(forks)-1]
+		nextCursor = encodeConversationForkCursor(conversationForkCursor{
+			Kind:      "conversation.fork_list",
+			CreatedAt: last.CreatedAt.UTC().Format(time.RFC3339Nano),
+			ForkID:    last.ForkID,
+		})
+	}
+	if forks == nil {
+		forks = []OperatorConversationForkSession{}
+	}
+	return ConversationForkListResult{Forks: forks, NextCursor: nextCursor}, nil
+}
+
+func (s *PostgresStore) LoadOperatorConversationFork(ctx context.Context, forkID string) (OperatorConversationForkSession, error) {
+	if s == nil || s.DB == nil {
+		return OperatorConversationForkSession{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	if err := requireConversationForkLifecycleCapabilities(caps); err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	id, err := normalizeUUIDParam(forkID, "fork_id")
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT
+			fork_id::text, source_session_id::text, COALESCE(source_run_id::text, ''),
+			source_agent_id, fork_point_kind, fork_point_turn_index,
+			COALESCE(fork_point_turn_id::text, ''), COALESCE(fork_point_event_id::text, ''),
+			fork_point_at, fork_point_selected_at, created_by, created_at, expires_at, deleted_at
+		FROM conversation_forks
+		WHERE fork_id = $1::uuid
+	`, id)
+	item, err := scanConversationForkSession(row, time.Now().UTC())
+	if errors.Is(err, sql.ErrNoRows) {
+		return OperatorConversationForkSession{}, ErrConversationForkNotFound
+	}
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	return item, nil
+}
+
+func (s *PostgresStore) DeleteOperatorConversationFork(ctx context.Context, forkID string, now time.Time) (ConversationForkDeleteResult, error) {
+	if s == nil || s.DB == nil {
+		return ConversationForkDeleteResult{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return ConversationForkDeleteResult{}, err
+	}
+	if err := requireConversationForkLifecycleCapabilities(caps); err != nil {
+		return ConversationForkDeleteResult{}, err
+	}
+	id, err := normalizeUUIDParam(forkID, "fork_id")
+	if err != nil {
+		return ConversationForkDeleteResult{}, err
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var existingDeleted sql.NullTime
+	if err := s.DB.QueryRowContext(ctx, `SELECT deleted_at FROM conversation_forks WHERE fork_id = $1::uuid`, id).Scan(&existingDeleted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ConversationForkDeleteResult{}, ErrConversationForkNotFound
+		}
+		return ConversationForkDeleteResult{}, fmt.Errorf("load conversation fork delete state: %w", err)
+	}
+	if existingDeleted.Valid {
+		return ConversationForkDeleteResult{ForkID: id, Deleted: false, AlreadyDeleted: true}, nil
+	}
+	if _, err := s.DB.ExecContext(ctx, `UPDATE conversation_forks SET deleted_at = $2 WHERE fork_id = $1::uuid AND deleted_at IS NULL`, id, now); err != nil {
+		return ConversationForkDeleteResult{}, fmt.Errorf("delete conversation fork: %w", err)
+	}
+	return ConversationForkDeleteResult{ForkID: id, Deleted: true, AlreadyDeleted: false}, nil
+}
+
+func requireConversationForkLifecycleCapabilities(caps StoreSchemaCapabilities) error {
+	if caps.Conversations.Forks != SchemaFlavorCanonical {
+		return fmt.Errorf("store: conversation_forks schema is unavailable")
+	}
+	if caps.Conversations.Turns != SchemaFlavorCanonical {
+		return fmt.Errorf("store: conversation fork lifecycle requires canonical agent_turns")
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical && caps.Conversations.Audits != SchemaFlavorCanonical {
+		return fmt.Errorf("store: conversation fork lifecycle requires canonical conversation source")
+	}
+	return nil
+}
+
+func defaultConversationForkListOptions(opts ConversationForkListOptions) (ConversationForkListOptions, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	opts.SourceSessionID = strings.TrimSpace(opts.SourceSessionID)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	opts.Now = opts.Now.UTC()
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	}
+	return opts, nil
+}
+
+func (s *PostgresStore) loadConversationForkSource(ctx context.Context, caps StoreSchemaCapabilities, sourceSessionID string) (conversationForkSource, error) {
+	sessionID, err := normalizeUUIDParam(sourceSessionID, "source_session_id")
+	if err != nil {
+		return conversationForkSource{}, err
+	}
+	sources := operatorConversationQuerySources(caps)
+	if len(sources) == 0 {
+		return conversationForkSource{}, ErrSessionNotFound
+	}
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		SELECT session_id, agent_id, run_id
+		FROM (
+			%s
+		) conversations
+		WHERE session_id = $1
+		LIMIT 2
+	`, strings.Join(sources, "\nUNION ALL\n")), sessionID)
+	if err != nil {
+		return conversationForkSource{}, fmt.Errorf("load conversation fork source: %w", err)
+	}
+	defer rows.Close()
+	items := []conversationForkSource{}
+	for rows.Next() {
+		var item conversationForkSource
+		if err := rows.Scan(&item.SessionID, &item.AgentID, &item.RunID); err != nil {
+			return conversationForkSource{}, err
+		}
+		item.SessionID = strings.TrimSpace(item.SessionID)
+		item.AgentID = strings.TrimSpace(item.AgentID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return conversationForkSource{}, err
+	}
+	if len(items) == 0 {
+		return conversationForkSource{}, ErrSessionNotFound
+	}
+	if len(items) > 1 {
+		return conversationForkSource{}, &EntityReadParamError{Field: "source_session_id", Reason: "ambiguous source session"}
+	}
+	return items[0], nil
+}
+
+func (s *PostgresStore) resolveConversationForkPoint(ctx context.Context, sourceSessionID string, selector ConversationForkPointSelector) (ConversationForkPointDescriptor, error) {
+	sessionID, err := normalizeUUIDParam(sourceSessionID, "source_session_id")
+	if err != nil {
+		return ConversationForkPointDescriptor{}, err
+	}
+	kind := strings.ToLower(strings.TrimSpace(selector.Kind))
+	switch kind {
+	case "turn":
+		if selector.TurnIndex <= 0 || strings.TrimSpace(selector.EventID) != "" || selector.At != nil {
+			return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point", Reason: "turn selector requires only turn_index"}
+		}
+		return s.resolveConversationForkTurnPoint(ctx, sessionID, selector.TurnIndex, kind, "", nil)
+	case "event":
+		eventID, err := normalizeUUIDParam(selector.EventID, "fork_point.event_id")
+		if err != nil {
+			return ConversationForkPointDescriptor{}, err
+		}
+		if selector.TurnIndex != 0 || selector.At != nil {
+			return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point", Reason: "event selector requires only event_id"}
+		}
+		return s.resolveConversationForkEventPoint(ctx, sessionID, eventID)
+	case "time":
+		if selector.At == nil || selector.TurnIndex != 0 || strings.TrimSpace(selector.EventID) != "" {
+			return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point", Reason: "time selector requires only at"}
+		}
+		return s.resolveConversationForkTimePoint(ctx, sessionID, selector.At.UTC())
+	default:
+		return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point.kind", Reason: "must be one of turn, event, time"}
+	}
+}
+
+func (s *PostgresStore) resolveConversationForkTurnPoint(ctx context.Context, sessionID string, turnIndex int, kind string, eventID string, at *time.Time) (ConversationForkPointDescriptor, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		WITH ordered AS (
+			SELECT
+				ROW_NUMBER() OVER (ORDER BY created_at ASC, turn_id ASC)::int AS turn_index,
+				turn_id::text AS turn_id,
+				COALESCE(trigger_event_id::text, '') AS event_id,
+				created_at
+			FROM agent_turns
+			WHERE session_id = $1::uuid
+		)
+		SELECT turn_id, event_id, created_at
+		FROM ordered
+		WHERE turn_index = $2
+	`, sessionID, turnIndex)
+	var turnID string
+	var triggerEventID string
+	var selectedAt time.Time
+	if err := row.Scan(&turnID, &triggerEventID, &selectedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ConversationForkPointDescriptor{}, ErrTurnNotFound
+		}
+		return ConversationForkPointDescriptor{}, fmt.Errorf("resolve conversation fork turn point: %w", err)
+	}
+	if eventID == "" && kind != "turn" {
+		eventID = triggerEventID
+	}
+	return ConversationForkPointDescriptor{
+		Kind:       kind,
+		TurnIndex:  turnIndex,
+		TurnID:     turnID,
+		EventID:    eventID,
+		At:         at,
+		SelectedAt: selectedAt.UTC(),
+	}, nil
+}
+
+func (s *PostgresStore) resolveConversationForkEventPoint(ctx context.Context, sessionID string, eventID string) (ConversationForkPointDescriptor, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		WITH ordered AS (
+			SELECT
+				ROW_NUMBER() OVER (ORDER BY created_at ASC, turn_id ASC)::int AS turn_index,
+				turn_id::text AS turn_id,
+				COALESCE(trigger_event_id::text, '') AS event_id,
+				created_at
+			FROM agent_turns
+			WHERE session_id = $1::uuid
+		)
+		SELECT turn_index, turn_id, created_at
+		FROM ordered
+		WHERE event_id = $2
+		LIMIT 2
+	`, sessionID, eventID)
+	if err != nil {
+		return ConversationForkPointDescriptor{}, fmt.Errorf("resolve conversation fork event point: %w", err)
+	}
+	defer rows.Close()
+	type match struct {
+		turnIndex int
+		turnID    string
+		createdAt time.Time
+	}
+	matches := []match{}
+	for rows.Next() {
+		var item match
+		if err := rows.Scan(&item.turnIndex, &item.turnID, &item.createdAt); err != nil {
+			return ConversationForkPointDescriptor{}, err
+		}
+		matches = append(matches, item)
+	}
+	if err := rows.Err(); err != nil {
+		return ConversationForkPointDescriptor{}, err
+	}
+	if len(matches) == 0 {
+		return ConversationForkPointDescriptor{}, ErrEventNotFound
+	}
+	if len(matches) > 1 {
+		return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point.event_id", Reason: "event matches multiple source turns"}
+	}
+	return ConversationForkPointDescriptor{
+		Kind:       "event",
+		TurnIndex:  matches[0].turnIndex,
+		TurnID:     matches[0].turnID,
+		EventID:    eventID,
+		SelectedAt: matches[0].createdAt.UTC(),
+	}, nil
+}
+
+func (s *PostgresStore) resolveConversationForkTimePoint(ctx context.Context, sessionID string, at time.Time) (ConversationForkPointDescriptor, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		WITH ordered AS (
+			SELECT
+				ROW_NUMBER() OVER (ORDER BY created_at ASC, turn_id ASC)::int AS turn_index,
+				turn_id::text AS turn_id,
+				COALESCE(trigger_event_id::text, '') AS event_id,
+				created_at
+			FROM agent_turns
+			WHERE session_id = $1::uuid
+		)
+		SELECT turn_index, turn_id, event_id, created_at
+		FROM ordered
+		WHERE created_at <= $2
+		ORDER BY created_at DESC, turn_id DESC
+		LIMIT 1
+	`, sessionID, at.UTC())
+	var turnIndex int
+	var turnID string
+	var eventID string
+	var selectedAt time.Time
+	if err := row.Scan(&turnIndex, &turnID, &eventID, &selectedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ConversationForkPointDescriptor{}, ErrTurnNotFound
+		}
+		return ConversationForkPointDescriptor{}, fmt.Errorf("resolve conversation fork time point: %w", err)
+	}
+	atCopy := at.UTC()
+	return ConversationForkPointDescriptor{
+		Kind:       "time",
+		TurnIndex:  turnIndex,
+		TurnID:     turnID,
+		EventID:    eventID,
+		At:         &atCopy,
+		SelectedAt: selectedAt.UTC(),
+	}, nil
+}
+
+func scanConversationForkSession(scanner interface {
+	Scan(dest ...any) error
+}, now time.Time) (OperatorConversationForkSession, error) {
+	var item OperatorConversationForkSession
+	var turnIndex sql.NullInt64
+	var turnID string
+	var eventID string
+	var at sql.NullTime
+	var deletedAt sql.NullTime
+	if err := scanner.Scan(
+		&item.ForkID,
+		&item.SourceSessionID,
+		&item.SourceRunID,
+		&item.SourceAgentID,
+		&item.ForkPoint.Kind,
+		&turnIndex,
+		&turnID,
+		&eventID,
+		&at,
+		&item.ForkPoint.SelectedAt,
+		&item.CreatedBy,
+		&item.CreatedAt,
+		&item.ExpiresAt,
+		&deletedAt,
+	); err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	if turnIndex.Valid {
+		item.ForkPoint.TurnIndex = int(turnIndex.Int64)
+	}
+	item.ForkPoint.TurnID = strings.TrimSpace(turnID)
+	item.ForkPoint.EventID = strings.TrimSpace(eventID)
+	if at.Valid {
+		atValue := at.Time.UTC()
+		item.ForkPoint.At = &atValue
+	}
+	if deletedAt.Valid {
+		value := deletedAt.Time.UTC()
+		item.DeletedAt = &value
+	}
+	item.CreatedAt = item.CreatedAt.UTC()
+	item.ExpiresAt = item.ExpiresAt.UTC()
+	item.ForkPoint.SelectedAt = item.ForkPoint.SelectedAt.UTC()
+	item.State = conversationForkState(item, now)
+	item.Turns = []OperatorConversationTurn{}
+	return item, nil
+}
+
+func conversationForkState(item OperatorConversationForkSession, now time.Time) string {
+	if item.DeletedAt != nil {
+		return "deleted"
+	}
+	if now.UTC().IsZero() {
+		now = time.Now().UTC()
+	}
+	if !item.ExpiresAt.IsZero() && !item.ExpiresAt.After(now.UTC()) {
+		return "expired"
+	}
+	return "active"
+}
+
+func normalizeUUIDParam(value, field string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", &EntityReadParamError{Field: field, Reason: "is required"}
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return "", &EntityReadParamError{Field: field, Reason: "must be a UUID"}
+	}
+	return parsed.String(), nil
+}
+
+func encodeConversationForkCursor(cursor conversationForkCursor) string {
+	raw, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeConversationForkCursor(raw string) (conversationForkCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return conversationForkCursor{}, ErrInvalidConversationForkCursor
+	}
+	var cursor conversationForkCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return conversationForkCursor{}, ErrInvalidConversationForkCursor
+	}
+	if strings.TrimSpace(cursor.Kind) != "conversation.fork_list" {
+		return conversationForkCursor{}, ErrInvalidConversationForkCursor
+	}
+	return cursor, nil
+}

--- a/internal/store/conversation_fork_lifecycle.go
+++ b/internal/store/conversation_fork_lifecycle.go
@@ -277,6 +277,17 @@ func (s *PostgresStore) DeleteOperatorConversationFork(ctx context.Context, fork
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
+	res, err := s.DB.ExecContext(ctx, `UPDATE conversation_forks SET deleted_at = $2 WHERE fork_id = $1::uuid AND deleted_at IS NULL`, id, now)
+	if err != nil {
+		return ConversationForkDeleteResult{}, fmt.Errorf("delete conversation fork: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return ConversationForkDeleteResult{}, fmt.Errorf("read conversation fork delete affected rows: %w", err)
+	}
+	if affected > 0 {
+		return ConversationForkDeleteResult{ForkID: id, Deleted: true, AlreadyDeleted: false}, nil
+	}
 	var existingDeleted sql.NullTime
 	if err := s.DB.QueryRowContext(ctx, `SELECT deleted_at FROM conversation_forks WHERE fork_id = $1::uuid`, id).Scan(&existingDeleted); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -287,10 +298,7 @@ func (s *PostgresStore) DeleteOperatorConversationFork(ctx context.Context, fork
 	if existingDeleted.Valid {
 		return ConversationForkDeleteResult{ForkID: id, Deleted: false, AlreadyDeleted: true}, nil
 	}
-	if _, err := s.DB.ExecContext(ctx, `UPDATE conversation_forks SET deleted_at = $2 WHERE fork_id = $1::uuid AND deleted_at IS NULL`, id, now); err != nil {
-		return ConversationForkDeleteResult{}, fmt.Errorf("delete conversation fork: %w", err)
-	}
-	return ConversationForkDeleteResult{ForkID: id, Deleted: true, AlreadyDeleted: false}, nil
+	return ConversationForkDeleteResult{}, fmt.Errorf("conversation fork delete state changed concurrently")
 }
 
 func requireConversationForkLifecycleCapabilities(caps StoreSchemaCapabilities) error {
@@ -508,7 +516,7 @@ func (s *PostgresStore) resolveConversationForkTimePoint(ctx context.Context, se
 	var selectedAt time.Time
 	if err := row.Scan(&turnIndex, &turnID, &eventID, &selectedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ConversationForkPointDescriptor{}, ErrTurnNotFound
+			return ConversationForkPointDescriptor{}, &EntityReadParamError{Field: "fork_point.at", Reason: "does not select a source turn"}
 		}
 		return ConversationForkPointDescriptor{}, fmt.Errorf("resolve conversation fork time point: %w", err)
 	}

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -160,6 +160,17 @@ func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testi
 		t.Fatalf("mixed selector error = %v, want fork_point param error", err)
 	}
 
+	beforeFirstTurn := source.turn1At.Add(-time.Second)
+	_, err = s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "time", At: &beforeFirstTurn},
+		CreatedBy:       "actor-token",
+		Now:             now,
+	})
+	if !errors.As(err, &paramErr) || paramErr.Field != "fork_point.at" {
+		t.Fatalf("time selector before first turn error = %v, want fork_point.at param error", err)
+	}
+
 	_, err = s.ListOperatorConversationForks(ctx, ConversationForkListOptions{Cursor: "not-a-cursor", Now: now})
 	if !errors.Is(err, ErrInvalidConversationForkCursor) {
 		t.Fatalf("invalid cursor error = %v, want ErrInvalidConversationForkCursor", err)

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -1,0 +1,225 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	source := seedConversationForkSource(t, db, now)
+
+	created, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "turn", TurnIndex: 1},
+		CreatedBy:       "actor-token",
+		Now:             now,
+	})
+	if err != nil {
+		t.Fatalf("CreateOperatorConversationFork turn: %v", err)
+	}
+	if created.ForkID == "" || created.SourceSessionID != source.sessionID || created.SourceRunID != source.runID || created.SourceAgentID != source.agentID {
+		t.Fatalf("created fork lineage = %#v", created)
+	}
+	if created.ForkPoint.Kind != "turn" || created.ForkPoint.TurnIndex != 1 || created.ForkPoint.TurnID != source.turn1ID || created.ForkPoint.EventID != "" {
+		t.Fatalf("created fork point = %#v", created.ForkPoint)
+	}
+	if created.CreatedBy != "actor-token" || !created.CreatedAt.Equal(now) || !created.ExpiresAt.Equal(now.Add(ConversationForkLifecycleTTL)) || created.State != "active" {
+		t.Fatalf("created fork lifecycle fields = %#v", created)
+	}
+	if created.Turns == nil || len(created.Turns) != 0 {
+		t.Fatalf("created fork turns = %#v, want empty array", created.Turns)
+	}
+
+	eventFork, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "event", EventID: source.event2ID},
+		CreatedBy:       "actor-token",
+		Now:             now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("CreateOperatorConversationFork event: %v", err)
+	}
+	if eventFork.ForkPoint.Kind != "event" || eventFork.ForkPoint.TurnIndex != 2 || eventFork.ForkPoint.TurnID != source.turn2ID || eventFork.ForkPoint.EventID != source.event2ID {
+		t.Fatalf("event fork point = %#v", eventFork.ForkPoint)
+	}
+
+	timePoint := source.turn1At.Add(30 * time.Second)
+	timeFork, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "time", At: &timePoint},
+		CreatedBy:       "actor-token",
+		Now:             now.Add(2 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("CreateOperatorConversationFork time: %v", err)
+	}
+	if timeFork.ForkPoint.Kind != "time" || timeFork.ForkPoint.TurnIndex != 1 || timeFork.ForkPoint.TurnID != source.turn1ID || timeFork.ForkPoint.At == nil || !timeFork.ForkPoint.At.Equal(timePoint) {
+		t.Fatalf("time fork point = %#v", timeFork.ForkPoint)
+	}
+
+	page, err := s.ListOperatorConversationForks(ctx, ConversationForkListOptions{
+		SourceSessionID: source.sessionID,
+		Limit:           2,
+		Now:             now.Add(3 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorConversationForks page1: %v", err)
+	}
+	if len(page.Forks) != 2 || page.NextCursor == "" {
+		t.Fatalf("page1 = %#v, want 2 forks and cursor", page)
+	}
+	page2, err := s.ListOperatorConversationForks(ctx, ConversationForkListOptions{
+		SourceSessionID: source.sessionID,
+		Limit:           2,
+		Cursor:          page.NextCursor,
+		Now:             now.Add(3 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorConversationForks page2: %v", err)
+	}
+	if len(page2.Forks) != 1 || page2.NextCursor != "" {
+		t.Fatalf("page2 = %#v, want 1 final fork", page2)
+	}
+
+	loaded, err := s.LoadOperatorConversationFork(ctx, created.ForkID)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversationFork: %v", err)
+	}
+	if loaded.ForkID != created.ForkID || loaded.State != "active" {
+		t.Fatalf("loaded fork = %#v", loaded)
+	}
+
+	deleted, err := s.DeleteOperatorConversationFork(ctx, created.ForkID, now.Add(4*time.Second))
+	if err != nil {
+		t.Fatalf("DeleteOperatorConversationFork: %v", err)
+	}
+	if !deleted.Deleted || deleted.AlreadyDeleted || deleted.ForkID != created.ForkID {
+		t.Fatalf("deleted result = %#v", deleted)
+	}
+	deletedAgain, err := s.DeleteOperatorConversationFork(ctx, created.ForkID, now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("DeleteOperatorConversationFork again: %v", err)
+	}
+	if deletedAgain.Deleted || !deletedAgain.AlreadyDeleted {
+		t.Fatalf("deleted again result = %#v", deletedAgain)
+	}
+
+	pageAfterDelete, err := s.ListOperatorConversationForks(ctx, ConversationForkListOptions{SourceSessionID: source.sessionID, Limit: 10, Now: now.Add(6 * time.Second)})
+	if err != nil {
+		t.Fatalf("ListOperatorConversationForks after delete: %v", err)
+	}
+	for _, item := range pageAfterDelete.Forks {
+		if item.ForkID == created.ForkID {
+			t.Fatalf("deleted fork survived active list: %#v", pageAfterDelete.Forks)
+		}
+	}
+
+	var normalSessionRows int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_sessions WHERE session_id = $1::uuid`, created.ForkID).Scan(&normalSessionRows); err != nil {
+		t.Fatalf("count normal session rows for fork id: %v", err)
+	}
+	if normalSessionRows != 0 {
+		t.Fatalf("fork lifecycle leaked into agent_sessions rows = %d", normalSessionRows)
+	}
+}
+
+func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	source := seedConversationForkSource(t, db, now)
+
+	_, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "event", EventID: uuid.NewString()},
+		CreatedBy:       "actor-token",
+		Now:             now,
+	})
+	if !errors.Is(err, ErrEventNotFound) {
+		t.Fatalf("event selector mismatch error = %v, want ErrEventNotFound", err)
+	}
+
+	_, err = s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "turn", TurnIndex: 1, EventID: source.event1ID},
+		CreatedBy:       "actor-token",
+		Now:             now,
+	})
+	var paramErr *EntityReadParamError
+	if !errors.As(err, &paramErr) || paramErr.Field != "fork_point" {
+		t.Fatalf("mixed selector error = %v, want fork_point param error", err)
+	}
+
+	_, err = s.ListOperatorConversationForks(ctx, ConversationForkListOptions{Cursor: "not-a-cursor", Now: now})
+	if !errors.Is(err, ErrInvalidConversationForkCursor) {
+		t.Fatalf("invalid cursor error = %v, want ErrInvalidConversationForkCursor", err)
+	}
+}
+
+type conversationForkSourceFixture struct {
+	runID     string
+	agentID   string
+	sessionID string
+	turn1ID   string
+	turn2ID   string
+	event1ID  string
+	event2ID  string
+	turn1At   time.Time
+	turn2At   time.Time
+}
+
+func seedConversationForkSource(t *testing.T, db execQueryer, base time.Time) conversationForkSourceFixture {
+	t.Helper()
+	source := conversationForkSourceFixture{
+		runID:     uuid.NewString(),
+		agentID:   "agent-fork-source",
+		sessionID: uuid.NewString(),
+		turn1ID:   uuid.NewString(),
+		turn2ID:   uuid.NewString(),
+		event1ID:  uuid.NewString(),
+		event2ID:  uuid.NewString(),
+		turn1At:   base.Add(-2 * time.Minute),
+		turn2At:   base.Add(-1 * time.Minute),
+	}
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, source.runID, base.Add(-3*time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, conversation_mode)
+		VALUES ($1, 'researcher', 'haiku', 'session')
+	`, source.agentID); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope,
+			runtime_mode, status, created_at, updated_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3, 'global', 'global', 'session', 'active', $4, $4)
+	`, source.sessionID, source.runID, source.agentID, base.Add(-3*time.Minute)); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key,
+			trigger_event_id, trigger_event_type, parse_ok, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, $3, $4::uuid, 'session', 'global', $5::uuid, 'task.ready', true, $6),
+			($7::uuid, $2::uuid, $3, $4::uuid, 'session', 'global', $8::uuid, 'task.done', true, $9)
+	`, source.turn1ID, source.runID, source.agentID, source.sessionID, source.event1ID, source.turn1At, source.turn2ID, source.event2ID, source.turn2At); err != nil {
+		t.Fatalf("seed turns: %v", err)
+	}
+	return source
+}

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -397,6 +397,11 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string) (string, 
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}
 		return fmt.Sprintf(`DELETE FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
+	case "conversation_forks":
+		if mode == "count" {
+			return `SELECT COUNT(*) FROM conversation_forks WHERE source_run_id = ANY($1::uuid[])`, args, nil
+		}
+		return `DELETE FROM conversation_forks WHERE source_run_id = ANY($1::uuid[])`, args, nil
 	case "run_fork_delivery_event_replays":
 		if mode == "count" {
 			return `

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -50,6 +50,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesRunScopedRowsAndPrese
 	assertCleanupTableResult(t, result, "event_receipts", 3, 3)
 	assertCleanupTableResult(t, result, "dead_letters", 1, 1)
 	assertCleanupTableResult(t, result, "timers", 3, 3)
+	assertCleanupTableResult(t, result, "conversation_forks", 1, 1)
 	assertCleanupTableResult(t, result, "mailbox", 0, 0)
 	assertCleanupTableResult(t, result, "generated_entity_tables", 0, 0)
 
@@ -71,6 +72,9 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesRunScopedRowsAndPrese
 		if got := countRows(t, ctx, pg, table); got != 0 {
 			t.Fatalf("%s rows after cleanup = %d, want 0", table, got)
 		}
+	}
+	if got := countRows(t, ctx, pg, "conversation_forks"); got != 1 {
+		t.Fatalf("conversation_forks rows after cleanup = %d, want 1 preserved row without source_run_id", got)
 	}
 	for _, table := range []string{"events", "event_receipts", "dead_letters", "timers"} {
 		if got := countRows(t, ctx, pg, table); got != 1 {
@@ -125,6 +129,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunCountsWithoutMutation(
 	}
 	assertCleanupTableResult(t, result, "runs", 2, 0)
 	assertCleanupTableResult(t, result, "events", 4, 0)
+	assertCleanupTableResult(t, result, "conversation_forks", 1, 0)
 	assertCleanupTableResult(t, result, "mailbox", 0, 0)
 	if got := countRows(t, ctx, pg, "runs"); got != 2 {
 		t.Fatalf("runs after dry-run = %d, want 2", got)
@@ -801,6 +806,16 @@ func seedDestructiveResetCleanupRows(t *testing.T, ctx context.Context, pg *Post
 		VALUES ($1::uuid, $2::uuid, 'agent-a', 'agent-a:global', 'global', 'session', 'active')
 	`, sessionID, runA); err != nil {
 		t.Fatalf("seed agent session: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO conversation_forks (
+			fork_id, source_session_id, source_run_id, source_agent_id, fork_point_kind, fork_point_turn_index,
+			fork_point_turn_id, fork_point_selected_at, created_by, expires_at
+		) VALUES
+			($1::uuid, $3::uuid, $5::uuid, 'agent-a', 'turn', 0, $6::uuid, now(), 'operator-token', now() + interval '1 hour'),
+			($2::uuid, $4::uuid, NULL, 'agent-a', 'turn', 0, $7::uuid, now(), 'operator-token', now() + interval '1 hour')
+	`, uuid.NewString(), uuid.NewString(), sessionID, uuid.NewString(), runA, uuid.NewString(), uuid.NewString()); err != nil {
+		t.Fatalf("seed conversation forks: %v", err)
 	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO agent_turns (run_id, agent_id, session_id, runtime_mode, scope_key)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -20,6 +20,10 @@ var ErrSessionNotFound = errors.New("store: session not found")
 
 var ErrTurnNotFound = errors.New("store: turn not found")
 
+var ErrConversationForkNotFound = errors.New("store: conversation fork not found")
+
+var ErrInvalidConversationForkCursor = errors.New("store: invalid conversation fork cursor")
+
 var ErrAmbiguousEntityRunID = errors.New("store: ambiguous entity run_id")
 
 var ErrInvalidEntityCursor = errors.New("store: invalid entity cursor")

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -38,6 +38,7 @@ type ConversationSchemaCapabilities struct {
 	Sessions     SchemaFlavor
 	Audits       SchemaFlavor
 	Turns        SchemaFlavor
+	Forks        SchemaFlavor
 	SessionRunID bool
 	AuditRunID   bool
 	TurnRunID    bool
@@ -236,6 +237,15 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 				"emitted_events", "mcp_servers", "mcp_tools_listed", "mcp_tools_visible",
 				"request_payload", "response_payload", "parse_ok", "latency_ms", "retry_count",
 				"error", "created_at",
+			},
+			nil,
+		),
+		Forks: detectSchemaFlavor(catalog, "conversation_forks",
+			[]string{
+				"fork_id", "source_session_id", "source_run_id", "source_agent_id",
+				"fork_point_kind", "fork_point_turn_index", "fork_point_turn_id",
+				"fork_point_event_id", "fork_point_at", "fork_point_selected_at",
+				"created_by", "created_at", "expires_at", "deleted_at",
 			},
 			nil,
 		),

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -335,6 +335,8 @@ func platformTableOrder(name string) int {
 		return 60
 	case "agent_turns":
 		return 65
+	case "conversation_forks":
+		return 66
 	case "routing_rules":
 		return 70
 	case "event_deliveries":


### PR DESCRIPTION
## Summary

Adds the lifecycle-only forkchat source authority approved for #1049: `conversation.fork`, `conversation.fork_list`, `conversation.fork_view`, and `conversation.fork_delete` over an isolated `conversation_forks` store owner.

Closes #1049
Part of #749

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.conversation.fork`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.conversation.fork_list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.conversation.fork_view`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.conversation.fork_delete`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#platform_tables.tables.conversation_forks`
- #1049 Pre-Implementation Coverage Audit and approved first-slice gate outcome

## Semantic Migration

- New canonical owner: `conversation_forks` plus `internal/store` lifecycle methods and `/v1/rpc conversation.fork*` API handlers.
- Old non-authoritative paths now invalid: #749 prose/review-artifact forkchat shapes, direct store/runtime/DB reads, run-fork helpers, and any CLI-side forkchat state.
- Production paths checked for surviving old behavior: `cmd/swarm`, `internal/apiv1`, `internal/store`, `internal/runtime`, generated OpenRPC, and dashboard/Builder references.
- Migration completeness: complete for the approved lifecycle source-authority child only. `conversation.fork_chat`, sandbox/snapshot owners, cross-surface include/exclude behavior, and `swarm forkchat` CLI remain split under #749.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/runtime/destructivereset -run CleanupCatalog`
- `go test ./internal/store -run 'ConversationFork|DestructiveResetCleanup'`
- `go test ./internal/apiv1 -run 'ConversationFork|OpenRPC|RegistryMethodNames'`
- `go test ./internal/apispec ./internal/apiv1`
- `go test ./cmd/swarm -run 'Fork|forkchat|CLIOutputModeExceptionRowsFailClosedBeforeSideEffects|CLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects'`
- `go test ./...`
