### PR TITLE
[agent-f][issue #1013] Multi-bundle schema foundation

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3564,6 +3564,7 @@ platform_tables:
         - agents
         - flow_instances
         - routing_rules
+        - bundles
       split_preserve:
         - mailbox
         - spend_ledger
@@ -3571,6 +3572,13 @@ platform_tables:
         - generated node-state tables from GenerateNodeStateTableDDLs
         - contract-driven product optimization tables
   tables:
+    bundles:
+      description: 'Content-addressed bundle catalog. The primary key is the canonical bundle_hash
+        (`bundle-v1:sha256:<64 lowercase hex>`) from multi_bundle_persistence.bundle_identity.
+        Rows store durable bundle bytes and a parsed JSON projection for server-side inspection.
+        This table is global platform catalog state, not run-scoped state, and is not referenced
+        by runs through a database foreign key.'
+      ddl: "CREATE TABLE bundles (\n    bundle_hash      TEXT PRIMARY KEY CHECK (bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'),\n    content_yaml     TEXT NOT NULL,\n    parsed_json      JSONB NOT NULL DEFAULT '{}'::jsonb,\n    data_blob        BYTEA,\n    metadata         JSONB NOT NULL DEFAULT '{}'::jsonb,\n    ingested_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_bundles_ingested_at (ingested_at)\n);"
     events:
       description: 'Append-only event store. Every event persisted before delivery. Three scopes: entity (entity_id + flow_instance
         projection set), flow (flow_instance projection set, entity_id NULL), global (both NULL — system bootstrap,
@@ -3914,11 +3922,15 @@ platform_tables:
         their parent via forked_from_run_id and forked_from_event_id.'
       ddl: "CREATE TABLE runs (\n    run_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    status            TEXT\
         \ NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'paused', 'completed', 'failed', 'cancelled', 'forked')),\n\
+        \    bundle_hash        TEXT CHECK (bundle_hash IS NULL OR bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'),\n\
+        \    bundle_source      TEXT NOT NULL DEFAULT 'legacy' CHECK (bundle_source IN ('persisted', 'ephemeral', 'deleted', 'legacy')),\n\
         \    bundle_fingerprint TEXT,\n    trigger_event_id  UUID,\n    trigger_event_type TEXT,\n    forked_from_run_id UUID REFERENCES runs(run_id),\n\
         \    forked_from_event_id UUID,\n    entity_count      INTEGER NOT NULL DEFAULT 0,\n    event_count       INTEGER\
         \ NOT NULL DEFAULT 0,\n    error_summary     TEXT,\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n\
         \    ended_at          TIMESTAMPTZ,\n    INDEX idx_runs_status (status, started_at),\n    INDEX idx_runs_fork\
-        \ (forked_from_run_id) WHERE forked_from_run_id IS NOT NULL\n);"
+        \ (forked_from_run_id) WHERE forked_from_run_id IS NOT NULL,\n    INDEX idx_runs_bundle_hash (bundle_hash) WHERE bundle_hash IS NOT NULL,\n\
+        \    INDEX idx_runs_bundle_source_status (bundle_source, status, started_at),\n    INDEX idx_runs_bundle_delete_planning\
+        \ (bundle_hash, status) WHERE bundle_hash IS NOT NULL\n);"
       lifecycle:
         running: Active execution. Events being processed.
         paused: Execution suspended (budget threshold, admin action). Resumable.
@@ -3931,13 +3943,15 @@ platform_tables:
         When a handler emits a new event, the child event inherits run_id from the parent event.
         External events (API, webhook, admin CLI) start a new run or join an existing one
         based on the ingress configuration.'
-      bundle_fingerprint: 'Optional boot bundle fingerprint pinned when the run row is first created.
-        New v1 run.start-created rows persist the orchestrator boot fingerprint after bundle_ref
-        validation. UPSERT/reopen paths must not overwrite an existing non-NULL fingerprint, but may
-        fill an unknown NULL fingerprint when a canonical boot-owned writer supplies one. Legacy NULL
-        values mean unknown bundle and are allowed by serve bundle-match admission. This current live DDL
-        is superseded for multi-bundle source authority by multi_bundle_persistence.persistence_model,
-        but remains in platform_tables until #1001 and the database migration child replace the live runtime schema.'
+      bundle_hash: 'Nullable canonical bundle identity for the run. Values use the
+        multi_bundle_persistence.bundle_identity format and intentionally have no database foreign key
+        to bundles.bundle_hash so historical audit identity survives bundle deletion.'
+      bundle_source: 'Required bundle availability/source classifier. Existing rows are legacy; current
+        writers without a gate-approved canonical v1 source fact write legacy with bundle_hash NULL.
+        Later multi-bundle children own persisted/ephemeral/deleted source stamping.'
+      bundle_fingerprint: 'Legacy pre-multi-bundle compatibility column. It is not the canonical run
+        bundle identity after #1013 and must not be copied into bundle_hash. Remaining public/code
+        migration is tracked by #1001; reader migration is tracked by #1014.'
     entity_mutations:
       description: 'Append-only mutation log for entity_state changes. Every write to entity_state.fields,
         entity_state.current_state, entity_state.gates, or entity_state.accumulator produces a row.
@@ -4946,10 +4960,10 @@ multi_bundle_persistence:
       - hash namespace/version prefix
   persistence_model:
     live_schema_boundary: >
-      platform_tables.tables remains the current runtime DDL source. #1012 does not change live generated tables because
-      that would be runtime/schema implementation. The bundles table and runs.bundle_hash/runs.bundle_source fields below
-      are promoted source authority for the database migration child, which must update platform_tables, migrations, store
-      readers/writers, generated artifacts, and proof together.
+      platform_tables.tables is the current runtime DDL source. #1013 promotes the bundles table and
+      runs.bundle_hash/runs.bundle_source into the live schema foundation. API/runtime behavior,
+      reader migration, ingest/source stamping, and public dual-accept naming remain separately
+      gated implementation work unless a later PR explicitly promotes and proves them.
     bundles_table:
       planned_live_owner_after_migration: platform_tables.tables.bundles
       primary_key: bundle_hash
@@ -5162,6 +5176,7 @@ multi_bundle_persistence:
   explicit_splits:
     schema_foundation:
       tracker: '#1013'
+      implementation_status: live_schema_foundation_promoted
       reason: Live bundles table, runs.bundle_hash, runs.bundle_source, indexes, and no-FK migration are database/schema implementation.
     reader_migration:
       tracker: '#1014'

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -192,12 +192,14 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	assertScalarContains(t, mustMappingValue(t, renamePolicy, "dual_accept_transition"), "#1001")
 
 	persistence := mustMappingValue(t, multi, "persistence_model")
-	assertScalarContains(t, mustMappingValue(t, persistence, "live_schema_boundary"), "does not change live generated tables")
+	assertScalarContains(t, mustMappingValue(t, persistence, "live_schema_boundary"), "#1013 promotes the bundles table")
 	platformTables := mustMappingValue(t, mustMappingValue(t, root, "platform_tables"), "tables")
-	if mappingValue(platformTables, "bundles") != nil {
-		t.Fatal("bundles table must not enter live platform_tables before the DB migration child lands")
+	if mappingValue(platformTables, "bundles") == nil {
+		t.Fatal("bundles table must be live in platform_tables after the DB migration child lands")
 	}
 	runsDDL := mustMappingValue(t, mustMappingValue(t, platformTables, "runs"), "ddl")
+	assertScalarContains(t, runsDDL, "bundle_hash")
+	assertScalarContains(t, runsDDL, "bundle_source")
 	assertScalarContains(t, runsDDL, "bundle_fingerprint TEXT")
 
 	cliSurface := mustMappingValue(t, multi, "cli_surface")

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -299,7 +299,7 @@ func TestOperatorAgentSendDirectiveUsesLegacyRunBundleSourceUntilSourceStampingO
 	if newRunID == "" {
 		t.Fatalf("new-run directive result = %#v", first.Result)
 	}
-	assertRunBundleIdentity(t, db, newRunID, "", "legacy", "")
+	assertRunBundleIdentity(t, db, newRunID, "", "legacy", bootFingerprint)
 
 	existingRunID := "00000000-0000-0000-0000-000000000755"
 	if _, err := db.Exec(`

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -264,7 +264,7 @@ func TestOperatorAgentSendDirectivePersistsDirectiveEventOnceOnReplay(t *testing
 	}
 }
 
-func TestOperatorAgentSendDirectivePersistsRunBundleFingerprint(t *testing.T) {
+func TestOperatorAgentSendDirectiveUsesLegacyRunBundleSourceUntilSourceStampingOwnerLands(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
@@ -299,7 +299,7 @@ func TestOperatorAgentSendDirectivePersistsRunBundleFingerprint(t *testing.T) {
 	if newRunID == "" {
 		t.Fatalf("new-run directive result = %#v", first.Result)
 	}
-	assertRunBundleFingerprint(t, db, newRunID, bootFingerprint)
+	assertRunBundleIdentity(t, db, newRunID, "", "legacy", "")
 
 	existingRunID := "00000000-0000-0000-0000-000000000755"
 	if _, err := db.Exec(`
@@ -312,7 +312,7 @@ func TestOperatorAgentSendDirectivePersistsRunBundleFingerprint(t *testing.T) {
 	if explicit.Error != nil {
 		t.Fatalf("existing-run directive error = %#v", explicit.Error)
 	}
-	assertRunBundleFingerprint(t, db, existingRunID, existingFingerprint)
+	assertRunBundleIdentity(t, db, existingRunID, "", "legacy", existingFingerprint)
 }
 
 func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
@@ -471,13 +471,18 @@ func countDirectiveEvents(t *testing.T, db *sql.DB) int {
 	return count
 }
 
-func assertRunBundleFingerprint(t *testing.T, db *sql.DB, runID, want string) {
+func assertRunBundleIdentity(t *testing.T, db *sql.DB, runID, wantHash, wantSource, wantLegacyFingerprint string) {
 	t.Helper()
-	var got string
-	if err := db.QueryRow(`SELECT COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
-		t.Fatalf("load run bundle fingerprint: %v", err)
+	var gotHash, gotSource, gotLegacyFingerprint string
+	if err := db.QueryRow(`
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&gotHash, &gotSource, &gotLegacyFingerprint); err != nil {
+		t.Fatalf("load run bundle identity: %v", err)
 	}
-	if got != want {
-		t.Fatalf("run %s bundle_fingerprint = %q, want %q", runID, got, want)
+	if gotHash != wantHash || gotSource != wantSource || gotLegacyFingerprint != wantLegacyFingerprint {
+		t.Fatalf("run %s bundle identity = hash:%q source:%q fingerprint:%q, want hash:%q source:%q fingerprint:%q",
+			runID, gotHash, gotSource, gotLegacyFingerprint, wantHash, wantSource, wantLegacyFingerprint)
 	}
 }

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -582,15 +582,19 @@ func eventPublishBodyWithSource(runID, sourceEventID, fingerprint, eventName, pa
 
 func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eventName, producedBy string) {
 	t.Helper()
-	var runStatus, triggerType, triggerID, persistedFingerprint string
-	if err := db.QueryRow(`SELECT status, trigger_event_type, trigger_event_id::text, COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType, &triggerID, &persistedFingerprint); err != nil {
+	var runStatus, triggerType, triggerID, bundleHash, bundleSource, legacyFingerprint string
+	if err := db.QueryRow(`
+		SELECT status, trigger_event_type, trigger_event_id::text, COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&runStatus, &triggerType, &triggerID, &bundleHash, &bundleSource, &legacyFingerprint); err != nil {
 		t.Fatalf("load event.publish run row: %v", err)
 	}
 	if runStatus != "running" || triggerType != eventName || triggerID != eventID {
 		t.Fatalf("run row status=%q trigger=%q/%q, want running/%s/%s", runStatus, triggerType, triggerID, eventName, eventID)
 	}
-	if persistedFingerprint != runStartTestFingerprint {
-		t.Fatalf("run row bundle_fingerprint=%q, want %q", persistedFingerprint, runStartTestFingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
 	}
 	var entityID, gotProducedBy string
 	var payload json.RawMessage

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -593,8 +593,8 @@ func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eve
 	if runStatus != "running" || triggerType != eventName || triggerID != eventID {
 		t.Fatalf("run row status=%q trigger=%q/%q, want running/%s/%s", runStatus, triggerType, triggerID, eventName, eventID)
 	}
-	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
-		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != runStartTestFingerprint {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint %q", bundleHash, bundleSource, legacyFingerprint, runStartTestFingerprint)
 	}
 	var entityID, gotProducedBy string
 	var payload json.RawMessage

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -352,7 +352,7 @@ func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
 	}
 }
 
-func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, _ string) {
+func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, bundleFingerprint string) {
 	t.Helper()
 	var runStatus, triggerType, bundleHash, bundleSource, legacyFingerprint string
 	if err := db.QueryRow(`
@@ -365,8 +365,8 @@ func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, _ str
 	if runStatus != "running" || triggerType != eventName {
 		t.Fatalf("run row status=%q trigger=%q, want running/%s", runStatus, triggerType, eventName)
 	}
-	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
-		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != bundleFingerprint {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint %q", bundleHash, bundleSource, legacyFingerprint, bundleFingerprint)
 	}
 	var entityID, producedBy string
 	var payload json.RawMessage

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -352,17 +352,21 @@ func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
 	}
 }
 
-func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, bundleFingerprint string) {
+func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, _ string) {
 	t.Helper()
-	var runStatus, triggerType, persistedFingerprint string
-	if err := db.QueryRow(`SELECT status, trigger_event_type, COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&runStatus, &triggerType, &persistedFingerprint); err != nil {
+	var runStatus, triggerType, bundleHash, bundleSource, legacyFingerprint string
+	if err := db.QueryRow(`
+		SELECT status, trigger_event_type, COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&runStatus, &triggerType, &bundleHash, &bundleSource, &legacyFingerprint); err != nil {
 		t.Fatalf("load run row: %v", err)
 	}
 	if runStatus != "running" || triggerType != eventName {
 		t.Fatalf("run row status=%q trigger=%q, want running/%s", runStatus, triggerType, eventName)
 	}
-	if persistedFingerprint != bundleFingerprint {
-		t.Fatalf("run row bundle_fingerprint=%q, want %q", persistedFingerprint, bundleFingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
 	}
 	var entityID, producedBy string
 	var payload json.RawMessage

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1004,7 +1004,7 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 	}
 }
 
-func TestEventBusPublish_PersistsBootBundleFingerprintThroughRunLifecycleOwner(t *testing.T) {
+func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	runID := uuid.NewString()
@@ -1025,12 +1025,16 @@ func TestEventBusPublish_PersistsBootBundleFingerprintThroughRunLifecycleOwner(t
 	}); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	var got string
-	if err := db.QueryRowContext(context.Background(), `SELECT COALESCE(bundle_fingerprint, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
-		t.Fatalf("load run bundle fingerprint: %v", err)
+	var bundleHash, bundleSource, legacyFingerprint string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&bundleHash, &bundleSource, &legacyFingerprint); err != nil {
+		t.Fatalf("load run bundle source: %v", err)
 	}
-	if got != fingerprint {
-		t.Fatalf("bundle_fingerprint = %q, want %q", got, fingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
+		t.Fatalf("bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1033,8 +1033,8 @@ func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *te
 	`, runID).Scan(&bundleHash, &bundleSource, &legacyFingerprint); err != nil {
 		t.Fatalf("load run bundle source: %v", err)
 	}
-	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != "" {
-		t.Fatalf("bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", bundleHash, bundleSource, legacyFingerprint)
+	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != fingerprint {
+		t.Fatalf("bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint", bundleHash, bundleSource, legacyFingerprint)
 	}
 }
 

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -38,6 +38,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "agents", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "agent registry/config state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "flow_instances", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "product/config state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "routing_rules", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "routing/topology config", PreservationProof: "must survive destructive runtime cleanup"},
+		{Table: "bundles", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "global bundle catalog state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "mailbox", TableKind: CleanupTableKindPlatform, Classification: CleanupSplitPreserve, PredicateOwner: "no run_id; source_event_id policy split", PreservationProof: "preserve until a mailbox cleanup owner exists"},
 		{Table: "spend_ledger", TableKind: CleanupTableKindPlatform, Classification: CleanupSplitPreserve, PredicateOwner: "no run_id; cost audit policy split", PreservationProof: "preserve until a spend cleanup owner exists"},
 	}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1293,7 +1293,7 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	}
 	opts := runLifecycleOptions(caps)
 	opts.ReopenCompleted = reopenCompleted
-	opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
+	opts.BundleSource = storerunlifecycle.BundleSourceLegacy
 	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
 }
 
@@ -1358,11 +1358,12 @@ func (s *PostgresStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context
 
 func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {
 	return storerunlifecycle.EnsureActiveOptions{
-		HasStartedAtCol:         caps.Events.RunStartedAt,
-		HasTriggerCols:          caps.Events.RunTriggerColumns,
-		HasCounterCols:          caps.Events.RunCounterColumns,
-		HasTerminalCols:         caps.Events.RunTerminalFields,
-		HasBundleFingerprintCol: caps.Events.RunBundleFingerprint,
+		HasStartedAtCol:    caps.Events.RunStartedAt,
+		HasTriggerCols:     caps.Events.RunTriggerColumns,
+		HasCounterCols:     caps.Events.RunCounterColumns,
+		HasTerminalCols:    caps.Events.RunTerminalFields,
+		HasBundleHashCol:   caps.Events.RunBundleHash,
+		HasBundleSourceCol: caps.Events.RunBundleSource,
 	}
 }
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1294,6 +1294,7 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	opts := runLifecycleOptions(caps)
 	opts.ReopenCompleted = reopenCompleted
 	opts.BundleSource = storerunlifecycle.BundleSourceLegacy
+	opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
 	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
 }
 
@@ -1358,12 +1359,13 @@ func (s *PostgresStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context
 
 func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {
 	return storerunlifecycle.EnsureActiveOptions{
-		HasStartedAtCol:    caps.Events.RunStartedAt,
-		HasTriggerCols:     caps.Events.RunTriggerColumns,
-		HasCounterCols:     caps.Events.RunCounterColumns,
-		HasTerminalCols:    caps.Events.RunTerminalFields,
-		HasBundleHashCol:   caps.Events.RunBundleHash,
-		HasBundleSourceCol: caps.Events.RunBundleSource,
+		HasStartedAtCol:         caps.Events.RunStartedAt,
+		HasTriggerCols:          caps.Events.RunTriggerColumns,
+		HasCounterCols:          caps.Events.RunCounterColumns,
+		HasTerminalCols:         caps.Events.RunTerminalFields,
+		HasBundleHashCol:        caps.Events.RunBundleHash,
+		HasBundleSourceCol:      caps.Events.RunBundleSource,
+		HasBundleFingerprintCol: caps.Events.RunBundleFingerprint,
 	}
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -189,9 +189,9 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	if err := s.ensureAgentRuntimeDescriptorColumn(ctx); err != nil {
 		return err
 	}
-	if catalog.hasTable("runs") && !catalog.hasColumns("runs", "bundle_fingerprint") {
-		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE runs ADD COLUMN IF NOT EXISTS bundle_fingerprint TEXT`); err != nil {
-			return fmt.Errorf("ensure runs.bundle_fingerprint column: %w", err)
+	if catalog.hasTable("runs") {
+		if err := s.ensureRunBundleSourceSchema(ctx, catalog); err != nil {
+			return err
 		}
 		catalog, err = loadSchemaColumnCatalog(ctx, s.DB)
 		if err != nil {
@@ -353,6 +353,41 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *PostgresStore) ensureRunBundleSourceSchema(ctx context.Context, catalog schemaColumnCatalog) error {
+	if s == nil || s.DB == nil || !catalog.hasTable("runs") {
+		return nil
+	}
+	if !catalog.hasColumns("runs", "bundle_hash") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE runs ADD COLUMN IF NOT EXISTS bundle_hash TEXT`); err != nil {
+			return fmt.Errorf("ensure runs.bundle_hash column: %w", err)
+		}
+	}
+	if !catalog.hasColumns("runs", "bundle_source") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE runs ADD COLUMN IF NOT EXISTS bundle_source TEXT NOT NULL DEFAULT 'legacy'`); err != nil {
+			return fmt.Errorf("ensure runs.bundle_source column: %w", err)
+		}
+	}
+	if !catalog.hasColumns("runs", "bundle_fingerprint") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE runs ADD COLUMN IF NOT EXISTS bundle_fingerprint TEXT`); err != nil {
+			return fmt.Errorf("ensure legacy runs.bundle_fingerprint compatibility column: %w", err)
+		}
+	}
+	for _, stmt := range []string{
+		`UPDATE runs SET bundle_source = 'legacy' WHERE bundle_source IS NULL OR BTRIM(bundle_source) = ''`,
+		`ALTER TABLE runs ALTER COLUMN bundle_source SET DEFAULT 'legacy'`,
+		`ALTER TABLE runs ALTER COLUMN bundle_source SET NOT NULL`,
+		`ALTER TABLE runs DROP CONSTRAINT IF EXISTS runs_bundle_hash_format_check`,
+		`ALTER TABLE runs ADD CONSTRAINT runs_bundle_hash_format_check CHECK (bundle_hash IS NULL OR bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$')`,
+		`ALTER TABLE runs DROP CONSTRAINT IF EXISTS runs_bundle_source_check`,
+		`ALTER TABLE runs ADD CONSTRAINT runs_bundle_source_check CHECK (bundle_source IN ('persisted', 'ephemeral', 'deleted', 'legacy'))`,
+	} {
+		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure runs bundle source schema: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *PostgresStore) ensureEventReceiptsTypedSubscriberIdentity(ctx context.Context) error {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5602,6 +5602,68 @@ func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeK
 	}
 }
 
+func TestPostgresStore_EnsureSchemaCompatibilityColumnsAddsMultiBundleRunColumnsAsLegacy(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS runs CASCADE`); err != nil {
+		t.Fatalf("drop canonical runs table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE runs (
+			run_id UUID PRIMARY KEY,
+			status TEXT NOT NULL DEFAULT 'running',
+			bundle_fingerprint TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create legacy runs table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint)
+		VALUES ($1::uuid, 'running', 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+	`, runID); err != nil {
+		t.Fatalf("seed legacy run row: %v", err)
+	}
+
+	if err := pg.ensureSchemaCompatibilityColumns(ctx); err != nil {
+		t.Fatalf("ensureSchemaCompatibilityColumns: %v", err)
+	}
+
+	var bundleHash sql.NullString
+	var bundleSource string
+	if err := db.QueryRowContext(ctx, `
+		SELECT bundle_hash, bundle_source
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&bundleHash, &bundleSource); err != nil {
+		t.Fatalf("load migrated run row: %v", err)
+	}
+	if bundleHash.Valid {
+		t.Fatalf("bundle_hash = %q, want NULL for legacy row", bundleHash.String)
+	}
+	if bundleSource != "legacy" {
+		t.Fatalf("bundle_source = %q, want legacy", bundleSource)
+	}
+	var fkCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_constraint
+		WHERE conrelid = 'runs'::regclass
+		  AND contype = 'f'
+		  AND pg_get_constraintdef(oid) LIKE '%bundle_hash%'
+	`).Scan(&fkCount); err != nil {
+		t.Fatalf("inspect bundle_hash foreign keys: %v", err)
+	}
+	if fkCount != 0 {
+		t.Fatalf("runs.bundle_hash foreign keys = %d, want none", fkCount)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, bundle_source) VALUES ($1::uuid, 'running', 'unsupported')`, uuid.NewString()); err == nil {
+		t.Fatal("insert unsupported bundle_source succeeded, want check constraint failure")
+	}
+}
+
 func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelTierMissing(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -9,15 +9,17 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
 const (
 	testBootBundleFingerprint  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
 	testOtherBundleFingerprint = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	testCanonicalBundleHash    = "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
 )
 
-func TestPostgresStore_RunBundleFingerprintPersistsAtRunCreationAndNeverOverwrites(t *testing.T) {
+func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyWithoutCopyingFingerprint(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
@@ -33,7 +35,7 @@ func TestPostgresStore_RunBundleFingerprintPersistsAtRunCreationAndNeverOverwrit
 	}); err != nil {
 		t.Fatalf("AppendEvent(first): %v", err)
 	}
-	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(context.Background(), testOtherBundleFingerprint)
 	if err := pg.AppendEvent(changedCtx, events.Event{
@@ -46,10 +48,10 @@ func TestPostgresStore_RunBundleFingerprintPersistsAtRunCreationAndNeverOverwrit
 	}); err != nil {
 		t.Fatalf("AppendEvent(second): %v", err)
 	}
-	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
 }
 
-func TestPostgresStore_RunBundleFingerprintAllowsUnknownLegacyRows(t *testing.T) {
+func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
@@ -64,10 +66,10 @@ func TestPostgresStore_RunBundleFingerprintAllowsUnknownLegacyRows(t *testing.T)
 	}); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
-	assertRunBundleFingerprint(t, db, runID, "")
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
 }
 
-func TestPostgresStore_RunBundleFingerprintFillsUnknownWithoutOverwritingKnown(t *testing.T) {
+func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintOnReopen(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -91,7 +93,7 @@ func TestPostgresStore_RunBundleFingerprintFillsUnknownWithoutOverwritingKnown(t
 	}); err != nil {
 		t.Fatalf("AppendEvent(fill): %v", err)
 	}
-	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(ctx, testOtherBundleFingerprint)
 	if err := pg.AppendEvent(changedCtx, events.Event{
@@ -104,7 +106,24 @@ func TestPostgresStore_RunBundleFingerprintFillsUnknownWithoutOverwritingKnown(t
 	}); err != nil {
 		t.Fatalf("AppendEvent(followup): %v", err)
 	}
-	assertRunBundleFingerprint(t, db, runID, testBootBundleFingerprint)
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
+}
+
+func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+
+	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{
+		HasStartedAtCol:    true,
+		HasBundleHashCol:   true,
+		HasBundleSourceCol: true,
+		BundleHash:         testCanonicalBundleHash,
+		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	}); err != nil {
+		t.Fatalf("EnsureActive: %v", err)
+	}
+	assertRunBundleIdentity(t, db, runID, testCanonicalBundleHash, storerunlifecycle.BundleSourcePersisted, "")
 }
 
 func TestPostgresStore_ActiveRunBundleMismatches(t *testing.T) {
@@ -146,19 +165,32 @@ func TestPostgresStore_ActiveRunBundleMismatches(t *testing.T) {
 	}
 }
 
-func assertRunBundleFingerprint(t *testing.T, db *sql.DB, runID, want string) {
+func assertRunBundleIdentity(t *testing.T, db *sql.DB, runID, wantHash, wantSource, wantLegacyFingerprint string) {
 	t.Helper()
-	var got sql.NullString
-	if err := db.QueryRow(`SELECT bundle_fingerprint FROM runs WHERE run_id = $1::uuid`, runID).Scan(&got); err != nil {
-		t.Fatalf("load run bundle fingerprint: %v", err)
+	var gotHash, gotFingerprint sql.NullString
+	var gotSource string
+	if err := db.QueryRow(`
+		SELECT bundle_hash, bundle_source, bundle_fingerprint
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&gotHash, &gotSource, &gotFingerprint); err != nil {
+		t.Fatalf("load run bundle identity: %v", err)
 	}
-	if want == "" {
-		if got.Valid {
-			t.Fatalf("bundle_fingerprint = %q, want NULL", got.String)
+	if wantHash == "" {
+		if gotHash.Valid {
+			t.Fatalf("bundle_hash = %q, want NULL", gotHash.String)
 		}
-		return
+	} else if !gotHash.Valid || gotHash.String != wantHash {
+		t.Fatalf("bundle_hash = %q valid=%v, want %q", gotHash.String, gotHash.Valid, wantHash)
 	}
-	if !got.Valid || got.String != want {
-		t.Fatalf("bundle_fingerprint = %q valid=%v, want %q", got.String, got.Valid, want)
+	if gotSource != wantSource {
+		t.Fatalf("bundle_source = %q, want %q", gotSource, wantSource)
+	}
+	if wantLegacyFingerprint == "" {
+		if gotFingerprint.Valid {
+			t.Fatalf("bundle_fingerprint = %q, want NULL", gotFingerprint.String)
+		}
+	} else if !gotFingerprint.Valid || gotFingerprint.String != wantLegacyFingerprint {
+		t.Fatalf("bundle_fingerprint = %q valid=%v, want %q", gotFingerprint.String, gotFingerprint.Valid, wantLegacyFingerprint)
 	}
 }

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -19,7 +19,7 @@ const (
 	testCanonicalBundleHash    = "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
 )
 
-func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyWithoutCopyingFingerprint(t *testing.T) {
+func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsServeAdmissionFingerprint(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
@@ -35,7 +35,7 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyWithoutCop
 	}); err != nil {
 		t.Fatalf("AppendEvent(first): %v", err)
 	}
-	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(context.Background(), testOtherBundleFingerprint)
 	if err := pg.AppendEvent(changedCtx, events.Event{
@@ -48,7 +48,7 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyWithoutCop
 	}); err != nil {
 		t.Fatalf("AppendEvent(second): %v", err)
 	}
-	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 }
 
 func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
@@ -69,7 +69,7 @@ func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
 }
 
-func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintOnReopen(t *testing.T) {
+func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleHashOnReopen(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -93,7 +93,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintOnReopen(t 
 	}); err != nil {
 		t.Fatalf("AppendEvent(fill): %v", err)
 	}
-	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(ctx, testOtherBundleFingerprint)
 	if err := pg.AppendEvent(changedCtx, events.Event{
@@ -106,7 +106,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintOnReopen(t 
 	}); err != nil {
 		t.Fatalf("AppendEvent(followup): %v", err)
 	}
-	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
+	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 }
 
 func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) {

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -196,37 +196,11 @@ func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRu
 
 func insertRunForkRun(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID, sourceRunID, forkEventID string, entityCount int, startedAt time.Time) error {
 	opts := storerunlifecycle.InsertForkOptions{
-		HasBundleFingerprintCol: catalog.hasColumns("runs", "bundle_fingerprint"),
-	}
-	if catalog.hasColumns("runs", "bundle_fingerprint") {
-		fingerprint, err := runForkBundleFingerprintForInsert(ctx, tx, sourceRunID)
-		if err != nil {
-			return err
-		}
-		opts.BundleFingerprint = fingerprint
+		HasBundleHashCol:   catalog.hasColumns("runs", "bundle_hash"),
+		HasBundleSourceCol: catalog.hasColumns("runs", "bundle_source"),
+		BundleSource:       storerunlifecycle.BundleSourceLegacy,
 	}
 	return storerunlifecycle.InsertFork(ctx, tx, forkRunID, RunForkMaterializedStatus, sourceRunID, forkEventID, entityCount, startedAt, opts)
-}
-
-func runForkBundleFingerprintForInsert(ctx context.Context, tx *sql.Tx, sourceRunID string) (string, error) {
-	if fingerprint := runtimecorrelation.BundleFingerprintFromContext(ctx); fingerprint != "" {
-		return fingerprint, nil
-	}
-	var source sql.NullString
-	if err := tx.QueryRowContext(ctx, `
-		SELECT bundle_fingerprint
-		FROM runs
-		WHERE run_id = $1::uuid
-	`, sourceRunID).Scan(&source); err != nil {
-		if err == sql.ErrNoRows {
-			return "", fmt.Errorf("source run %s not found", sourceRunID)
-		}
-		return "", fmt.Errorf("load source run bundle fingerprint: %w", err)
-	}
-	if !source.Valid {
-		return "", nil
-	}
-	return strings.TrimSpace(source.String), nil
 }
 
 func loadRunForkEntityMetadata(plan RunForkPlan) (map[string]runForkEntityMetadata, error) {

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -196,11 +196,40 @@ func ensureRunForkNotAlreadyMaterialized(ctx context.Context, tx *sql.Tx, forkRu
 
 func insertRunForkRun(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID, sourceRunID, forkEventID string, entityCount int, startedAt time.Time) error {
 	opts := storerunlifecycle.InsertForkOptions{
-		HasBundleHashCol:   catalog.hasColumns("runs", "bundle_hash"),
-		HasBundleSourceCol: catalog.hasColumns("runs", "bundle_source"),
-		BundleSource:       storerunlifecycle.BundleSourceLegacy,
+		HasBundleHashCol:        catalog.hasColumns("runs", "bundle_hash"),
+		HasBundleSourceCol:      catalog.hasColumns("runs", "bundle_source"),
+		HasBundleFingerprintCol: catalog.hasColumns("runs", "bundle_fingerprint"),
+		BundleSource:            storerunlifecycle.BundleSourceLegacy,
+	}
+	if catalog.hasColumns("runs", "bundle_fingerprint") {
+		fingerprint, err := runForkBundleFingerprintForInsert(ctx, tx, sourceRunID)
+		if err != nil {
+			return err
+		}
+		opts.BundleFingerprint = fingerprint
 	}
 	return storerunlifecycle.InsertFork(ctx, tx, forkRunID, RunForkMaterializedStatus, sourceRunID, forkEventID, entityCount, startedAt, opts)
+}
+
+func runForkBundleFingerprintForInsert(ctx context.Context, tx *sql.Tx, sourceRunID string) (string, error) {
+	if fingerprint := runtimecorrelation.BundleFingerprintFromContext(ctx); fingerprint != "" {
+		return fingerprint, nil
+	}
+	var source sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT bundle_fingerprint
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, sourceRunID).Scan(&source); err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("source run %s not found", sourceRunID)
+		}
+		return "", fmt.Errorf("load source run bundle fingerprint: %w", err)
+	}
+	if !source.Valid {
+		return "", nil
+	}
+	return strings.TrimSpace(source.String), nil
 }
 
 func loadRunForkEntityMetadata(plan RunForkPlan) (map[string]runForkEntityMetadata, error) {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -102,19 +102,19 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		)
 	}
 
-	var forkStatus, forkedFromRun, forkedFromEvent, forkBundleFingerprint string
+	var forkStatus, forkedFromRun, forkedFromEvent, forkBundleHash, forkBundleSource, forkBundleFingerprint string
 	if err := db.QueryRowContext(ctx, `
-		SELECT status, forked_from_run_id::text, forked_from_event_id::text, COALESCE(bundle_fingerprint, '')
+		SELECT status, forked_from_run_id::text, forked_from_event_id::text, COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
 		FROM runs
 		WHERE run_id = $1::uuid
-	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent, &forkBundleFingerprint); err != nil {
+	`, result.ForkRunID).Scan(&forkStatus, &forkedFromRun, &forkedFromEvent, &forkBundleHash, &forkBundleSource, &forkBundleFingerprint); err != nil {
 		t.Fatalf("load fork run: %v", err)
 	}
 	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != secondEventID {
 		t.Fatalf("fork run = status:%s from:%s event:%s", forkStatus, forkedFromRun, forkedFromEvent)
 	}
-	if forkBundleFingerprint != "bundle-source-fingerprint" {
-		t.Fatalf("fork bundle_fingerprint = %q, want source fingerprint", forkBundleFingerprint)
+	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "" {
+		t.Fatalf("fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
 	}
 	var sourceStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -113,8 +113,8 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if forkStatus != "paused" || forkedFromRun != sourceRunID || forkedFromEvent != secondEventID {
 		t.Fatalf("fork run = status:%s from:%s event:%s", forkStatus, forkedFromRun, forkedFromEvent)
 	}
-	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "" {
-		t.Fatalf("fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
+	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "bundle-source-fingerprint" {
+		t.Fatalf("fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
 	}
 	var sourceStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, sourceRunID).Scan(&sourceStatus); err != nil {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -49,16 +49,16 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	if materialized.ForkRunID == "" || materialized.SelectedContractBinding == nil || !materialized.DeliveryResumeBlocked {
 		t.Fatalf("materialization = %#v", materialized)
 	}
-	var forkBundleFingerprint string
+	var forkBundleHash, forkBundleSource, forkBundleFingerprint string
 	if err := db.QueryRowContext(ctx, `
-		SELECT COALESCE(bundle_fingerprint, '')
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
 		FROM runs
 		WHERE run_id = $1::uuid
-	`, materialized.ForkRunID).Scan(&forkBundleFingerprint); err != nil {
-		t.Fatalf("load selected fork bundle fingerprint: %v", err)
+	`, materialized.ForkRunID).Scan(&forkBundleHash, &forkBundleSource, &forkBundleFingerprint); err != nil {
+		t.Fatalf("load selected fork bundle identity: %v", err)
 	}
-	if forkBundleFingerprint != "selected-source-fingerprint" {
-		t.Fatalf("selected fork bundle_fingerprint = %q, want source fingerprint", forkBundleFingerprint)
+	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "" {
+		t.Fatalf("selected fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
 	}
 	var replayRows int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, materialized.ForkRunID).Scan(&replayRows); err != nil {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -57,8 +57,8 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 	`, materialized.ForkRunID).Scan(&forkBundleHash, &forkBundleSource, &forkBundleFingerprint); err != nil {
 		t.Fatalf("load selected fork bundle identity: %v", err)
 	}
-	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "" {
-		t.Fatalf("selected fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy without copied fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
+	if forkBundleHash != "" || forkBundleSource != "legacy" || forkBundleFingerprint != "selected-source-fingerprint" {
+		t.Fatalf("selected fork bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint)
 	}
 	var replayRows int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_delivery_event_replays WHERE fork_run_id = $1::uuid`, materialized.ForkRunID).Scan(&replayRows); err != nil {

--- a/internal/store/runlifecycle/fork.go
+++ b/internal/store/runlifecycle/fork.go
@@ -8,8 +8,10 @@ import (
 )
 
 type InsertForkOptions struct {
-	HasBundleFingerprintCol bool
-	BundleFingerprint       string
+	HasBundleHashCol   bool
+	HasBundleSourceCol bool
+	BundleHash         string
+	BundleSource       string
 }
 
 func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, forkEventID string, entityCount int, startedAt time.Time, opts InsertForkOptions) error {
@@ -32,6 +34,10 @@ func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, fo
 	if forkEventID == "" {
 		return fmt.Errorf("fork event_id is required")
 	}
+	bundleSource, err := CanonicalBundleSource(opts.BundleSource)
+	if err != nil {
+		return err
+	}
 
 	cols := []string{
 		"run_id",
@@ -44,12 +50,17 @@ func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, fo
 	}
 	values := []string{"$1::uuid", "$2", "$3::uuid", "$4::uuid", "$5", "0", "$6"}
 	args := []any{forkRunID, status, sourceRunID, forkEventID, entityCount, startedAt}
-	if opts.HasBundleFingerprintCol {
-		args = append(args, strings.TrimSpace(opts.BundleFingerprint))
-		cols = append(cols, "bundle_fingerprint")
+	if opts.HasBundleHashCol {
+		args = append(args, strings.TrimSpace(opts.BundleHash))
+		cols = append(cols, "bundle_hash")
 		values = append(values, fmt.Sprintf("NULLIF($%d, '')", len(args)))
 	}
-	_, err := db.ExecContext(ctx, `
+	if opts.HasBundleSourceCol {
+		args = append(args, bundleSource)
+		cols = append(cols, "bundle_source")
+		values = append(values, fmt.Sprintf("$%d", len(args)))
+	}
+	_, err = db.ExecContext(ctx, `
 		INSERT INTO runs (`+strings.Join(cols, ", ")+`)
 		VALUES (`+strings.Join(values, ", ")+`)
 	`, args...)

--- a/internal/store/runlifecycle/fork.go
+++ b/internal/store/runlifecycle/fork.go
@@ -8,10 +8,12 @@ import (
 )
 
 type InsertForkOptions struct {
-	HasBundleHashCol   bool
-	HasBundleSourceCol bool
-	BundleHash         string
-	BundleSource       string
+	HasBundleHashCol        bool
+	HasBundleSourceCol      bool
+	HasBundleFingerprintCol bool
+	BundleHash              string
+	BundleSource            string
+	BundleFingerprint       string
 }
 
 func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, forkEventID string, entityCount int, startedAt time.Time, opts InsertForkOptions) error {
@@ -59,6 +61,11 @@ func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, fo
 		args = append(args, bundleSource)
 		cols = append(cols, "bundle_source")
 		values = append(values, fmt.Sprintf("$%d", len(args)))
+	}
+	if opts.HasBundleFingerprintCol {
+		args = append(args, strings.TrimSpace(opts.BundleFingerprint))
+		cols = append(cols, "bundle_fingerprint")
+		values = append(values, fmt.Sprintf("NULLIF($%d, '')", len(args)))
 	}
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO runs (`+strings.Join(cols, ", ")+`)

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -24,14 +24,24 @@ type Snapshot struct {
 }
 
 type EnsureActiveOptions struct {
-	ReopenCompleted         bool
-	HasStartedAtCol         bool
-	HasTriggerCols          bool
-	HasCounterCols          bool
-	HasTerminalCols         bool
-	HasBundleFingerprintCol bool
-	BundleFingerprint       string
+	ReopenCompleted    bool
+	HasStartedAtCol    bool
+	HasTriggerCols     bool
+	HasCounterCols     bool
+	HasTerminalCols    bool
+	HasBundleHashCol   bool
+	HasBundleSourceCol bool
+	BundleHash         string
+	BundleSource       string
 }
+
+const (
+	BundleSourcePersisted = "persisted"
+	BundleSourceEphemeral = "ephemeral"
+	BundleSourceDeleted   = "deleted"
+	BundleSourceLegacy    = "legacy"
+	defaultBundleSource   = BundleSourceLegacy
+)
 
 func CanonicalTerminalStatus(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
@@ -48,6 +58,23 @@ func CanonicalTerminalStatus(raw string) (string, error) {
 	}
 }
 
+func CanonicalBundleSource(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return defaultBundleSource, nil
+	case BundleSourcePersisted:
+		return BundleSourcePersisted, nil
+	case BundleSourceEphemeral:
+		return BundleSourceEphemeral, nil
+	case BundleSourceDeleted:
+		return BundleSourceDeleted, nil
+	case BundleSourceLegacy:
+		return BundleSourceLegacy, nil
+	default:
+		return "", fmt.Errorf("unsupported bundle source %q", raw)
+	}
+}
+
 func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string, opts EnsureActiveOptions) error {
 	if db == nil {
 		return nil
@@ -58,7 +85,11 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	}
 	triggerEventID = strings.TrimSpace(triggerEventID)
 	triggerEventType = strings.TrimSpace(triggerEventType)
-	bundleFingerprint := strings.TrimSpace(opts.BundleFingerprint)
+	bundleHash := strings.TrimSpace(opts.BundleHash)
+	bundleSource, err := CanonicalBundleSource(opts.BundleSource)
+	if err != nil {
+		return err
+	}
 	reopenStatus := "runs.status"
 	reopenErrorSummary := ""
 	reopenEndedAt := ""
@@ -84,8 +115,11 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 		addParam("trigger_event_id", "NULLIF($%d,'')::uuid", triggerEventID)
 		addParam("trigger_event_type", "NULLIF($%d,'')", triggerEventType)
 	}
-	if opts.HasBundleFingerprintCol {
-		addParam("bundle_fingerprint", "NULLIF($%d,'')", bundleFingerprint)
+	if opts.HasBundleHashCol {
+		addParam("bundle_hash", "NULLIF($%d,'')", bundleHash)
+	}
+	if opts.HasBundleSourceCol {
+		addParam("bundle_source", "$%d", bundleSource)
 	}
 	if opts.HasStartedAtCol {
 		insertCols = append(insertCols, "started_at")
@@ -101,16 +135,20 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 			error_summary = ` + reopenErrorSummary + `,
 			ended_at = ` + reopenEndedAt
 	}
-	if opts.HasBundleFingerprintCol {
+	if opts.HasBundleHashCol {
 		query += `,
-			bundle_fingerprint = COALESCE(runs.bundle_fingerprint, EXCLUDED.bundle_fingerprint)`
+			bundle_hash = COALESCE(runs.bundle_hash, EXCLUDED.bundle_hash)`
+	}
+	if opts.HasBundleSourceCol {
+		query += `,
+			bundle_source = COALESCE(runs.bundle_source, EXCLUDED.bundle_source)`
 	}
 	if opts.HasTriggerCols {
 		query += `,
 			trigger_event_id = COALESCE(runs.trigger_event_id, NULLIF($2,'')::uuid),
 			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))`
 	}
-	_, err := db.ExecContext(ctx, query, args...)
+	_, err = db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("ensure run row: %w", err)
 	}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -24,15 +24,17 @@ type Snapshot struct {
 }
 
 type EnsureActiveOptions struct {
-	ReopenCompleted    bool
-	HasStartedAtCol    bool
-	HasTriggerCols     bool
-	HasCounterCols     bool
-	HasTerminalCols    bool
-	HasBundleHashCol   bool
-	HasBundleSourceCol bool
-	BundleHash         string
-	BundleSource       string
+	ReopenCompleted         bool
+	HasStartedAtCol         bool
+	HasTriggerCols          bool
+	HasCounterCols          bool
+	HasTerminalCols         bool
+	HasBundleHashCol        bool
+	HasBundleSourceCol      bool
+	HasBundleFingerprintCol bool
+	BundleHash              string
+	BundleSource            string
+	BundleFingerprint       string
 }
 
 const (
@@ -86,6 +88,7 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	triggerEventID = strings.TrimSpace(triggerEventID)
 	triggerEventType = strings.TrimSpace(triggerEventType)
 	bundleHash := strings.TrimSpace(opts.BundleHash)
+	bundleFingerprint := strings.TrimSpace(opts.BundleFingerprint)
 	bundleSource, err := CanonicalBundleSource(opts.BundleSource)
 	if err != nil {
 		return err
@@ -121,6 +124,9 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	if opts.HasBundleSourceCol {
 		addParam("bundle_source", "$%d", bundleSource)
 	}
+	if opts.HasBundleFingerprintCol {
+		addParam("bundle_fingerprint", "NULLIF($%d,'')", bundleFingerprint)
+	}
 	if opts.HasStartedAtCol {
 		insertCols = append(insertCols, "started_at")
 		insertVals = append(insertVals, "now()")
@@ -142,6 +148,10 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	if opts.HasBundleSourceCol {
 		query += `,
 			bundle_source = COALESCE(runs.bundle_source, EXCLUDED.bundle_source)`
+	}
+	if opts.HasBundleFingerprintCol {
+		query += `,
+			bundle_fingerprint = COALESCE(runs.bundle_fingerprint, EXCLUDED.bundle_fingerprint)`
 	}
 	if opts.HasTriggerCols {
 		query += `,

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -25,6 +25,8 @@ type EventSchemaCapabilities struct {
 	RunTriggerColumns    bool
 	RunCounterColumns    bool
 	RunTerminalFields    bool
+	RunBundleHash        bool
+	RunBundleSource      bool
 	RunBundleFingerprint bool
 	LogRunID             bool
 	DeliveryRunID        bool
@@ -203,6 +205,8 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 		RunTriggerColumns:    catalog.hasColumns("runs", "trigger_event_id", "trigger_event_type"),
 		RunCounterColumns:    catalog.hasColumns("runs", "event_count", "entity_count"),
 		RunTerminalFields:    catalog.hasColumns("runs", "error_summary", "ended_at"),
+		RunBundleHash:        catalog.hasColumns("runs", "bundle_hash"),
+		RunBundleSource:      catalog.hasColumns("runs", "bundle_source"),
 		RunBundleFingerprint: catalog.hasColumns("runs", "bundle_fingerprint"),
 		LogRunID:             catalog.hasColumns("events", "run_id"),
 		DeliveryRunID:        catalog.hasColumns("event_deliveries", "run_id"),

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -21,7 +21,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		}
 	}
 
-	addColumns("runs", "run_id", "status", "bundle_fingerprint")
+	addColumns("runs", "run_id", "status", "bundle_hash", "bundle_source", "bundle_fingerprint")
 	addColumns("agents",
 		"agent_id", "flow_instance", "role", "model_tier", "llm_backend", "conversation_mode",
 		"parent_agent_id", "entity_id", "config", "subscriptions", "emit_events", "tools",
@@ -85,7 +85,7 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	if caps.Agents != SchemaFlavorCanonical {
 		t.Fatalf("agents flavor = %s", caps.Agents)
 	}
-	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey || !caps.Events.RunBundleFingerprint {
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey || !caps.Events.RunBundleHash || !caps.Events.RunBundleSource || !caps.Events.RunBundleFingerprint {
 		t.Fatalf("events caps = %+v", caps.Events)
 	}
 	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -311,6 +311,8 @@ func platformTableOrder(name string) int {
 	switch strings.TrimSpace(name) {
 	case "schema_version":
 		return 0
+	case "bundles":
+		return 3
 	case "runs":
 		return 5
 	case "events":

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -177,7 +177,7 @@ func TestPlatformSpecEntityStateUsesRunScopedIdentity(t *testing.T) {
 	}
 }
 
-func TestPlatformSpecRunsOwnsBundleFingerprint(t *testing.T) {
+func TestPlatformSpecOwnsMultiBundleSchemaFoundation(t *testing.T) {
 	_, file, _, _ := stdruntime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
@@ -193,18 +193,50 @@ func TestPlatformSpecRunsOwnsBundleFingerprint(t *testing.T) {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
 	var runs SchemaTableDDL
+	var bundles SchemaTableDDL
 	for _, plan := range plans {
 		if plan.TableName == "runs" {
 			runs = plan
-			break
+		}
+		if plan.TableName == "bundles" {
+			bundles = plan
+		}
+	}
+	if bundles.TableName == "" {
+		t.Fatal("bundles ddl plan missing")
+	}
+	bundleDDL := strings.Join(bundles.Statements, "\n")
+	for _, want := range []string{
+		"bundle_hash      TEXT PRIMARY KEY",
+		"content_yaml     TEXT NOT NULL",
+		"parsed_json      JSONB NOT NULL",
+		"data_blob        BYTEA",
+		"metadata         JSONB NOT NULL",
+		"ingested_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()",
+		`CREATE INDEX IF NOT EXISTS "idx_bundles_ingested_at" ON "bundles"(ingested_at)`,
+	} {
+		if !strings.Contains(bundleDDL, want) {
+			t.Fatalf("bundles ddl missing %q:\n%s", want, bundleDDL)
 		}
 	}
 	if runs.TableName == "" {
 		t.Fatal("runs ddl plan missing")
 	}
 	joined := strings.Join(runs.Statements, "\n")
-	if !strings.Contains(joined, "bundle_fingerprint TEXT") {
-		t.Fatalf("runs ddl missing bundle_fingerprint:\n%s", joined)
+	for _, want := range []string{
+		"bundle_hash        TEXT CHECK",
+		"bundle_source      TEXT NOT NULL DEFAULT 'legacy'",
+		"bundle_fingerprint TEXT",
+		`CREATE INDEX IF NOT EXISTS "idx_runs_bundle_hash" ON "runs"(bundle_hash) WHERE bundle_hash IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS "idx_runs_bundle_source_status" ON "runs"(bundle_source, status, started_at)`,
+		`CREATE INDEX IF NOT EXISTS "idx_runs_bundle_delete_planning" ON "runs"(bundle_hash, status) WHERE bundle_hash IS NOT NULL`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("runs ddl missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "bundle_hash TEXT REFERENCES") || strings.Contains(joined, "FOREIGN KEY (bundle_hash)") {
+		t.Fatalf("runs ddl must not create a bundle_hash foreign key:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary

Promotes the multi-bundle schema foundation from `multi_bundle_persistence` into live `platform_tables` and store schema handling.

- Adds live `bundles` platform table plus `runs.bundle_hash` and `runs.bundle_source`.
- Keeps `runs.bundle_fingerprint` only as non-authoritative legacy compatibility; central run-row writers no longer copy legacy fingerprints into durable bundle identity.
- Adds schema compatibility migration for legacy `runs` tables, preserving existing rows as `bundle_source='legacy'` with `bundle_hash NULL`.
- Updates direct run-row lifecycle writers (`EnsureActive`, `InsertFork`) to own canonical source classification for this slice.

Closes #1013

## Governing Refs / Context

- `platform-spec.yaml#multi_bundle_persistence.persistence_model.live_schema_boundary`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.bundles_table`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.runs_table`
- `platform-spec.yaml#multi_bundle_persistence.bundle_identity`
- #999 legacy-row migration ordering
- #1004 missing-bundle error policy
- #979 canonical bundle hash v1 authority
- #1012 / PR #1042 source-authority promotion
- #1013 pre-audit and independent gate outcome

## Semantic Migration

New canonical owner:
- Live schema: `platform-spec.yaml#platform_tables.tables.bundles` and `platform-spec.yaml#platform_tables.tables.runs`.
- Store DDL/migration: `internal/store/postgres.go`.
- Central run-row writers: `internal/store/runlifecycle.EnsureActive` and `internal/store/runlifecycle.InsertFork`.

Old producer / reader / writer path now invalid:
- `runs.bundle_fingerprint` is no longer the canonical durable bundle identity.
- `runtimecorrelation.BundleFingerprintFromContext` and fork source-row `bundle_fingerprint` copying are no longer DB write sources for new canonical identity.
- Legacy `bundle_fingerprint` remains only as a compatibility column and test seed for old-reader split work.

Production paths checked for surviving old behavior:
- `internal/store/events.go` -> `EnsureActive`
- `internal/store/run_fork_materializer.go` -> `InsertFork`
- `internal/runtime/mutationlog` and `internal/runtime/diagnostics` backstop paths through `EnsureActive`
- Static probe for production `INSERT INTO runs` and old lifecycle option usage

Migration completeness:
- Complete for the #1013 DB/schema foundation child.
- Not a claim of #1001 API/OpenRPC/CLI dual-accept completion, #1014 reader migration, #1015 ingest/source stamping, #1022 create-new-work routing, fork behavior, delete behavior, or runtime.nuke behavior.

## Validation

- `go test ./internal/store ./internal/apispec ./internal/runtime/destructivereset ./internal/runtime/bus ./internal/apiv1 -run 'Bundle|bundle|Schema|DDL|RunLifecycle|RunFork|Directive|Cleanup|EventBusPublish_Classifies'`
- `go test ./...`
