### PR TITLE
[agent-a][issue #983] Add LLM provider contract owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Less an agent library, more a distributed operating system for LLMs. It assumes 
 
 **Long-term direction:** Support entire divisions (engineering, support, operations) running as autonomous Swarm flows. Humans in the loop where judgment is required; agents and deterministic system nodes everywhere else.
 
-Single Go binary, Postgres for persistence. Two LLM runtimes ship today: an Anthropic API mode and a CLI-driven mode wrapping the Claude CLI as a subprocess. The runtime factory is provider-agnostic and more providers will follow.
+Single Go binary, Postgres for persistence. Two LLM runtimes ship today: an Anthropic API mode and a CLI-driven mode wrapping the Claude CLI as a subprocess. Both consume the shared LLM provider adapter contract; adding another provider is separate gated runtime/config work.
 
 ---
 
@@ -81,7 +81,7 @@ Guard failures have explicit semantics: `reject` (default), `discard`, `kill`, o
 
 ## Quickstart
 
-Requires Docker, a contract bundle, and credentials for whichever LLM you plan to use.
+Requires Docker, a contract bundle, and credentials for the configured shipped LLM runtime.
 
 ```bash
 # 1. clone
@@ -89,7 +89,8 @@ git clone https://github.com/<org>/swarm && cd swarm
 
 # 2. point at a contract bundle
 export SWARM_CONTRACTS_HOST_DIR=/absolute/path/to/your/contracts
-echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> .env   # or your provider of choice
+echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> .env   # for cli_test mode
+# or set ANTHROPIC_API_KEY=... for api mode
 
 # 3. boot
 docker compose up -d postgres orchestrator

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2115,6 +2115,59 @@ engine:
     agent_invocation: 'Agents are invoked via claude -p (CLI) or equivalent LLM API call. The platform constructs the invocation:
       system prompt + event context + tool schemas. Agents are short-lived and task-scoped. No persistent memory between sessions.
       Context from previous interactions is provided via event payload and entity state.'
+    llm_provider_adapter_contract:
+      description: Runtime LLM provider adapters are the canonical boundary between platform agent execution and provider-specific
+        API or CLI transports. A provider adapter is production-ready only when it declares and satisfies the full adjacency
+        contract for tool-schema translation, session lifecycle, response normalization, native-tool capability truth, turn/audit
+        persistence, and budget usage accounting. A runtime mode switch or StartSession/ContinueSession implementation alone
+        is not sufficient provider ownership.
+      owner: internal/runtime/llm provider contract
+      required_contract_dimensions:
+        tool_schema:
+          rules:
+          - Platform tool definitions must be translated to the provider-facing schema format before invocation.
+          - Provider-facing input schemas must be validated before execution reaches the provider.
+          - Platform tool results must be returned through the provider adapter in a normalized message form.
+        session_lifecycle:
+          rules:
+          - The adapter must preserve task, session, and session_per_entity conversation modes.
+          - Platform session IDs remain platform-owned; external provider session IDs, when present, are stored only as provider
+            implementation details.
+          - Session rotation and retry lineage must be accounted for by the adapter contract.
+        response_normalization:
+          rules:
+          - Provider responses must normalize assistant messages and tool calls into the platform response model.
+          - Raw provider responses must be preserved for turn/audit persistence.
+          - Provider-specific stream parsers are implementation details behind the adapter contract, not generic platform truth.
+        native_tools:
+          rules:
+          - The adapter must declare whether it is strict provider-native for native_tools and which native capabilities are callable.
+          - Strict provider-native adapters must fail closed rather than satisfying native_tools through fallback paths.
+          - Persisted turn visible-tool facts must reflect callable truth for the adapter's turn.
+        persistence:
+          rules:
+          - Agent turns and task-mode audits must be persisted consistently across adapters.
+          - Conversation snapshots for reusable session modes must be explicit adapter behavior.
+        budget:
+          rules:
+          - The adapter must declare whether usage accounting is exact provider-reported usage or an estimate.
+          - Budget records must include enough runtime/provider metadata for audit and cost attribution.
+      current_runtime_modes:
+        api:
+          provider: anthropic
+          transport: api
+          budget_usage_accounting: exact
+          native_tool_policy: fallback-aware non-strict runtime
+        cli_test:
+          provider: claude
+          transport: cli
+          budget_usage_accounting: estimated
+          native_tool_policy: strict provider-native runtime
+      split_boundaries:
+      - Adding new provider identities such as OpenAI, Ollama, Bedrock, Azure OpenAI, Vertex, or vLLM requires a separate
+        provider-selection/config gate.
+      - Renaming cli_test is a separate compatibility/semantics decision.
+      - Provider-selection UI and runtime mode/env/config policy are outside this adapter-contract slice.
     conversation_modes:
       description: How the platform manages agent session context across invocations.
       modes:

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -73,6 +73,10 @@ active_issues:
     title: Introduce an explicit runtime dependency graph object for boot wiring
     maps_to:
       - boot_wiring_dependency_ownership
+  - id: 983
+    title: Clean/compact LLM provider interface for arbitrary backends
+    maps_to:
+      - llm_provider_adjacency_contract_ownership
   - id: 175
     title: Add first-class launch, stalled-run, and long-running session observability
     maps_to:
@@ -257,6 +261,30 @@ active_issues:
     maps_to:
       - delivery_and_replay_ownership
 nodes:
+  - id: llm_provider_adjacency_contract_ownership
+    title: LLM Provider Adjacency Contract Ownership
+    parent_class: runtime LLM provider abstraction not production-ready
+    canonical_owners:
+      - internal/runtime/llm provider contract for runtime mode, provider identity, transport, tool schema translation, session lifecycle, response normalization, native-tool capability truth, persistence, and budget accounting
+    why_this_node_exists: LLM provider behavior drifts when a runtime implementation satisfies StartSession and ContinueSession but leaves tool schema, stream parsing, session persistence, native tools, and budget behavior implicit in adjacent files
+    known_manifestations:
+      - RuntimeFactory can make provider identity look like a local mode switch rather than a contract-backed provider selection boundary
+      - the public Runtime interface alone does not name provider obligations for tool schemas, provider session IDs, response normalization, task-mode audit, native-tool capability truth, or budget usage
+      - Anthropic API and Claude CLI encode provider-specific request, response, stream, and budget behavior separately without one named adjacency contract
+      - CLI strict native-tool behavior and API fallback-aware behavior can drift if agent tool composition and boot validation read optional runtime helpers instead of the provider contract
+      - config llm.runtime_mode and persisted agents.llm_backend currently conflate provider identity, transport, and runtime mode; adding a new provider before a contract owner would freeze under-specified semantics
+      - README/provider-extensibility wording can overstate provider neutrality unless implementation and docs consume the same provider contract truth
+    representative_issues:
+      - 983
+    common_framing_mistakes:
+      too_broad:
+        - add all providers
+        - make Swarm model-neutral
+      too_narrow:
+        - add one factory switch case
+        - document how to copy the Anthropic runtime
+        - rename cli_test
+    current_action_pressure: active
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity
     parent_class: runtime execution-boundary policy drift

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -618,10 +618,7 @@ func extractNativeToolConfig(cfg models.AgentConfig) map[string]bool {
 }
 
 func supportedNativeToolCapabilities(runtime llm.Runtime) llm.NativeToolCapabilities {
-	if provider, ok := runtime.(llm.NativeToolCapabilityProvider); ok && provider != nil {
-		return provider.NativeToolCapabilities()
-	}
-	return llm.NativeToolCapabilities{}
+	return llm.NativeToolCapabilitiesForRuntime(runtime)
 }
 
 func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runtime) []llm.ToolDefinition {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -1041,8 +1041,12 @@ type nativeCapabilityRuntimeStub struct {
 	caps llm.NativeToolCapabilities
 }
 
-func (s nativeCapabilityRuntimeStub) NativeToolCapabilities() llm.NativeToolCapabilities {
-	return s.caps
+func (s nativeCapabilityRuntimeStub) ProviderContract() llm.ProviderContract {
+	contract := llm.AnthropicAPIProviderContract()
+	contract.RuntimeMode = "stub"
+	contract.Provider = "stub"
+	contract.NativeTools.Capabilities = s.caps
+	return contract
 }
 
 func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testing.T) {

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -50,8 +50,46 @@ func NewAnthropicAPIRuntime(cfg *config.Config, sessions sessions.Registry, lock
 	}
 }
 
-func (r *AnthropicAPIRuntime) NativeToolCapabilities() NativeToolCapabilities {
-	return NativeToolCapabilities{}
+func (r *AnthropicAPIRuntime) ProviderContract() ProviderContract {
+	return AnthropicAPIProviderContract()
+}
+
+func AnthropicAPIProviderContract() ProviderContract {
+	return ProviderContract{
+		RuntimeMode: "api",
+		Provider:    "anthropic",
+		Transport:   ProviderTransportAPI,
+		ToolSchema: ProviderToolSchemaContract{
+			ValidatesInputSchemas: true,
+			TranslatesTools:       true,
+			ReturnsToolResults:    true,
+		},
+		SessionLifecycle: ProviderSessionLifecycleContract{
+			StartsSessions:            true,
+			ContinuesSessions:         true,
+			SupportsConversationModes: true,
+			ProviderSessionIDStrategy: "platform_managed",
+			RotatesSessions:           true,
+			PreservesRetryLineage:     true,
+		},
+		Response: ProviderResponseContract{
+			NormalizesMessages:   true,
+			NormalizesToolCalls:  true,
+			PreservesRawResponse: true,
+			StreamingParser:      "anthropic_messages_json",
+		},
+		NativeTools: ProviderNativeToolContract{
+			FallbackToolsAllowed: true,
+		},
+		Persistence: ProviderPersistenceContract{
+			PersistsTurns:                 true,
+			PersistsConversationSnapshots: true,
+			PersistsTaskModeAudit:         true,
+		},
+		Budget: ProviderBudgetContract{
+			UsageAccounting: BudgetUsageExact,
+		},
+	}
 }
 
 func (r *AnthropicAPIRuntime) PersistConversationSnapshot(ctx context.Context, s *Session) error {

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -85,16 +85,53 @@ func NewClaudeCLIRuntimeWithOptions(
 	}
 }
 
-func (r *ClaudeCLIRuntime) NativeToolCapabilities() NativeToolCapabilities {
-	return NativeToolCapabilities{
-		Bash:      true,
-		WebSearch: true,
-		FileIO:    true,
-	}
+func (r *ClaudeCLIRuntime) ProviderContract() ProviderContract {
+	return ClaudeCLIProviderContract()
 }
 
-func (r *ClaudeCLIRuntime) EnforceProviderNativeToolSupport() bool {
-	return true
+func ClaudeCLIProviderContract() ProviderContract {
+	return ProviderContract{
+		RuntimeMode: "cli_test",
+		Provider:    "claude",
+		Transport:   ProviderTransportCLI,
+		ToolSchema: ProviderToolSchemaContract{
+			ValidatesInputSchemas: true,
+			TranslatesTools:       true,
+			ReturnsToolResults:    true,
+		},
+		SessionLifecycle: ProviderSessionLifecycleContract{
+			StartsSessions:            true,
+			ContinuesSessions:         true,
+			SupportsConversationModes: true,
+			ProviderSessionIDStrategy: "provider_adopted",
+			RotatesSessions:           true,
+			PreservesRetryLineage:     true,
+		},
+		Response: ProviderResponseContract{
+			NormalizesMessages:     true,
+			NormalizesToolCalls:    true,
+			PreservesRawResponse:   true,
+			NormalizesVisibleTools: true,
+			StreamingParser:        "claude_cli_stream_json",
+		},
+		NativeTools: ProviderNativeToolContract{
+			Capabilities: NativeToolCapabilities{
+				Bash:      true,
+				WebSearch: true,
+				FileIO:    true,
+			},
+			StrictProviderNativeSupport: true,
+			StartupVisibleSurfaceProbe:  true,
+		},
+		Persistence: ProviderPersistenceContract{
+			PersistsTurns:                 true,
+			PersistsConversationSnapshots: true,
+			PersistsTaskModeAudit:         true,
+		},
+		Budget: ProviderBudgetContract{
+			UsageAccounting: BudgetUsageEstimated,
+		},
+	}
 }
 
 func (r *ClaudeCLIRuntime) PersistConversationSnapshot(ctx context.Context, s *Session) error {

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -93,10 +93,6 @@ func ConversationModeString(mode ConversationMode) string {
 	}
 }
 
-type conversationSnapshotPersister interface {
-	PersistConversationSnapshot(ctx context.Context, s *Session) error
-}
-
 func NewConversation(agentID, taskID, systemPrompt string, tools []ToolDefinition, mode ConversationMode, maxTurns int, runtime Runtime) *Conversation {
 	if maxTurns <= 0 {
 		maxTurns = 25
@@ -596,9 +592,7 @@ func (c *Conversation) appendMessage(ctx context.Context, msg Message) error {
 	if c.Session != nil {
 		c.Session.Messages = append(c.Session.Messages, msg)
 	}
-	if p, ok := c.runtime.(conversationSnapshotPersister); ok && c.Session != nil {
-		_ = p.PersistConversationSnapshot(ctx, c.Session)
-	}
+	_ = PersistConversationSnapshotForRuntime(ctx, c.runtime, c.Session)
 	return nil
 }
 

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -25,6 +25,9 @@ type RuntimeFactory struct {
 }
 
 func (f RuntimeFactory) Build() (Runtime, error) {
+	if f.Cfg == nil {
+		return nil, fmt.Errorf("llm runtime config is required")
+	}
 	if f.Sessions == nil {
 		f.Sessions = sessions.NewInMemoryRegistry(f.Cfg.LLM.Session.LockTTL)
 	}
@@ -32,16 +35,21 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 		f.LockOwner = defaultLockOwner()
 	}
 
+	var runtime Runtime
 	switch f.Cfg.LLM.RuntimeMode {
 	case "api":
-		return NewAnthropicAPIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events), nil
+		runtime = NewAnthropicAPIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
 	case "cli_test":
-		return NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
+		runtime = NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
 			MCPTurnContextStore: f.MCPTurns,
-		}), nil
+		})
 	default:
 		return nil, fmt.Errorf("unsupported llm runtime mode: %s", f.Cfg.LLM.RuntimeMode)
 	}
+	if _, err := RequireProviderContract(f.Cfg.LLM.RuntimeMode, runtime); err != nil {
+		return nil, err
+	}
+	return runtime, nil
 }
 
 // NoopRuntime is useful in early bootstrap phases and tests.

--- a/internal/runtime/llm/provider_contract.go
+++ b/internal/runtime/llm/provider_contract.go
@@ -1,0 +1,219 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ProviderTransport string
+
+const (
+	ProviderTransportAPI ProviderTransport = "api"
+	ProviderTransportCLI ProviderTransport = "cli"
+)
+
+type BudgetUsageAccounting string
+
+const (
+	BudgetUsageExact     BudgetUsageAccounting = "exact"
+	BudgetUsageEstimated BudgetUsageAccounting = "estimated"
+)
+
+type ProviderContract struct {
+	RuntimeMode string
+	Provider    string
+	Transport   ProviderTransport
+
+	ToolSchema       ProviderToolSchemaContract
+	SessionLifecycle ProviderSessionLifecycleContract
+	Response         ProviderResponseContract
+	NativeTools      ProviderNativeToolContract
+	Persistence      ProviderPersistenceContract
+	Budget           ProviderBudgetContract
+}
+
+type ProviderToolSchemaContract struct {
+	ValidatesInputSchemas bool
+	TranslatesTools       bool
+	ReturnsToolResults    bool
+}
+
+type ProviderSessionLifecycleContract struct {
+	StartsSessions            bool
+	ContinuesSessions         bool
+	SupportsConversationModes bool
+	ProviderSessionIDStrategy string
+	RotatesSessions           bool
+	PreservesRetryLineage     bool
+}
+
+type ProviderResponseContract struct {
+	NormalizesMessages     bool
+	NormalizesToolCalls    bool
+	PreservesRawResponse   bool
+	NormalizesVisibleTools bool
+	StreamingParser        string
+}
+
+type ProviderNativeToolContract struct {
+	Capabilities                NativeToolCapabilities
+	StrictProviderNativeSupport bool
+	FallbackToolsAllowed        bool
+	StartupVisibleSurfaceProbe  bool
+}
+
+type ProviderPersistenceContract struct {
+	PersistsTurns                 bool
+	PersistsConversationSnapshots bool
+	PersistsTaskModeAudit         bool
+}
+
+type ProviderBudgetContract struct {
+	UsageAccounting BudgetUsageAccounting
+}
+
+type ProviderContractProvider interface {
+	ProviderContract() ProviderContract
+}
+
+type ConversationSnapshotPersister interface {
+	PersistConversationSnapshot(ctx context.Context, s *Session) error
+}
+
+func ProviderContractForRuntime(runtime Runtime) (ProviderContract, bool) {
+	provider, ok := runtime.(ProviderContractProvider)
+	if !ok || provider == nil {
+		return ProviderContract{}, false
+	}
+	return provider.ProviderContract(), true
+}
+
+func RequireProviderContract(runtimeMode string, runtime Runtime) (ProviderContract, error) {
+	if runtime == nil {
+		return ProviderContract{}, fmt.Errorf("llm runtime is required")
+	}
+	contract, ok := ProviderContractForRuntime(runtime)
+	if !ok {
+		return ProviderContract{}, fmt.Errorf("llm runtime %T does not expose provider contract", runtime)
+	}
+	if err := contract.Validate(); err != nil {
+		return ProviderContract{}, err
+	}
+	if contract.Persistence.PersistsConversationSnapshots {
+		if _, ok := runtime.(ConversationSnapshotPersister); !ok {
+			return ProviderContract{}, fmt.Errorf("llm runtime %T declares conversation snapshot persistence but does not implement it", runtime)
+		}
+	}
+	if contract.NativeTools.StartupVisibleSurfaceProbe {
+		if _, ok := runtime.(StartupVisibleToolSurfaceProber); !ok {
+			return ProviderContract{}, fmt.Errorf("llm runtime %T declares startup visible tool probe but does not implement it", runtime)
+		}
+	}
+	if want := strings.TrimSpace(runtimeMode); want != "" && contract.RuntimeMode != want {
+		return ProviderContract{}, fmt.Errorf("llm runtime mode %q exposes provider contract for %q", want, contract.RuntimeMode)
+	}
+	return contract, nil
+}
+
+func (c ProviderContract) Validate() error {
+	if strings.TrimSpace(c.RuntimeMode) == "" {
+		return fmt.Errorf("llm provider contract runtime mode is required")
+	}
+	if strings.TrimSpace(c.Provider) == "" {
+		return fmt.Errorf("llm provider contract provider is required")
+	}
+	switch c.Transport {
+	case ProviderTransportAPI, ProviderTransportCLI:
+	default:
+		return fmt.Errorf("llm provider contract %s has unsupported transport %q", c.RuntimeMode, c.Transport)
+	}
+	if !c.ToolSchema.ValidatesInputSchemas {
+		return fmt.Errorf("llm provider contract %s must validate provider input schemas", c.RuntimeMode)
+	}
+	if !c.ToolSchema.TranslatesTools {
+		return fmt.Errorf("llm provider contract %s must translate platform tools to provider tools", c.RuntimeMode)
+	}
+	if !c.ToolSchema.ReturnsToolResults {
+		return fmt.Errorf("llm provider contract %s must return platform tool results to the provider", c.RuntimeMode)
+	}
+	if !c.SessionLifecycle.StartsSessions || !c.SessionLifecycle.ContinuesSessions {
+		return fmt.Errorf("llm provider contract %s must own start and continue session behavior", c.RuntimeMode)
+	}
+	if !c.SessionLifecycle.SupportsConversationModes {
+		return fmt.Errorf("llm provider contract %s must preserve conversation mode semantics", c.RuntimeMode)
+	}
+	if strings.TrimSpace(c.SessionLifecycle.ProviderSessionIDStrategy) == "" {
+		return fmt.Errorf("llm provider contract %s must declare provider session id strategy", c.RuntimeMode)
+	}
+	if !c.SessionLifecycle.RotatesSessions {
+		return fmt.Errorf("llm provider contract %s must account for session rotation", c.RuntimeMode)
+	}
+	if !c.SessionLifecycle.PreservesRetryLineage {
+		return fmt.Errorf("llm provider contract %s must preserve retry lineage", c.RuntimeMode)
+	}
+	if !c.Response.NormalizesMessages || !c.Response.NormalizesToolCalls {
+		return fmt.Errorf("llm provider contract %s must normalize provider messages and tool calls", c.RuntimeMode)
+	}
+	if !c.Response.PreservesRawResponse {
+		return fmt.Errorf("llm provider contract %s must preserve raw provider response", c.RuntimeMode)
+	}
+	if strings.TrimSpace(c.Response.StreamingParser) == "" {
+		return fmt.Errorf("llm provider contract %s must declare response parser strategy", c.RuntimeMode)
+	}
+	if c.NativeTools.StrictProviderNativeSupport && c.NativeTools.FallbackToolsAllowed {
+		return fmt.Errorf("llm provider contract %s cannot allow fallback native tools in strict provider-native mode", c.RuntimeMode)
+	}
+	if !c.Persistence.PersistsTurns {
+		return fmt.Errorf("llm provider contract %s must persist turns", c.RuntimeMode)
+	}
+	if !c.Persistence.PersistsConversationSnapshots {
+		return fmt.Errorf("llm provider contract %s must persist conversation snapshots", c.RuntimeMode)
+	}
+	if !c.Persistence.PersistsTaskModeAudit {
+		return fmt.Errorf("llm provider contract %s must preserve task-mode audit", c.RuntimeMode)
+	}
+	switch c.Budget.UsageAccounting {
+	case BudgetUsageExact, BudgetUsageEstimated:
+	default:
+		return fmt.Errorf("llm provider contract %s must declare budget usage accounting", c.RuntimeMode)
+	}
+	return nil
+}
+
+func NativeToolCapabilitiesForRuntime(runtime Runtime) NativeToolCapabilities {
+	contract, ok := ProviderContractForRuntime(runtime)
+	if !ok {
+		return NativeToolCapabilities{}
+	}
+	return contract.NativeTools.Capabilities
+}
+
+func RuntimeEnforcesProviderNativeTools(runtime Runtime) bool {
+	contract, ok := ProviderContractForRuntime(runtime)
+	return ok && contract.NativeTools.StrictProviderNativeSupport
+}
+
+func StartupVisibleToolSurfaceProberForRuntime(runtime Runtime) (StartupVisibleToolSurfaceProber, bool) {
+	contract, ok := ProviderContractForRuntime(runtime)
+	if !ok || !contract.NativeTools.StartupVisibleSurfaceProbe {
+		return nil, false
+	}
+	prober, ok := runtime.(StartupVisibleToolSurfaceProber)
+	return prober, ok && prober != nil
+}
+
+func PersistConversationSnapshotForRuntime(ctx context.Context, runtime Runtime, session *Session) error {
+	if session == nil {
+		return nil
+	}
+	contract, ok := ProviderContractForRuntime(runtime)
+	if !ok || !contract.Persistence.PersistsConversationSnapshots {
+		return nil
+	}
+	persister, ok := runtime.(ConversationSnapshotPersister)
+	if !ok || persister == nil {
+		return fmt.Errorf("llm runtime %T declares conversation snapshot persistence but does not implement it", runtime)
+	}
+	return persister.PersistConversationSnapshot(ctx, session)
+}

--- a/internal/runtime/llm/provider_contract_test.go
+++ b/internal/runtime/llm/provider_contract_test.go
@@ -1,0 +1,177 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	"swarm/internal/runtime/sessions"
+)
+
+func TestProviderContractsValidateShippedRuntimes(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              string
+		runtime           Runtime
+		provider          string
+		transport         ProviderTransport
+		usageAccounting   BudgetUsageAccounting
+		strictNativeTools bool
+		startupProbe      bool
+		caps              NativeToolCapabilities
+	}{
+		{
+			name:            "anthropic api",
+			mode:            "api",
+			runtime:         NewAnthropicAPIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil),
+			provider:        "anthropic",
+			transport:       ProviderTransportAPI,
+			usageAccounting: BudgetUsageExact,
+		},
+		{
+			name:              "claude cli",
+			mode:              "cli_test",
+			runtime:           NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil),
+			provider:          "claude",
+			transport:         ProviderTransportCLI,
+			usageAccounting:   BudgetUsageEstimated,
+			strictNativeTools: true,
+			startupProbe:      true,
+			caps: NativeToolCapabilities{
+				Bash:      true,
+				WebSearch: true,
+				FileIO:    true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contract, err := RequireProviderContract(tt.mode, tt.runtime)
+			if err != nil {
+				t.Fatalf("RequireProviderContract: %v", err)
+			}
+			if contract.Provider != tt.provider {
+				t.Fatalf("provider = %q, want %q", contract.Provider, tt.provider)
+			}
+			if contract.Transport != tt.transport {
+				t.Fatalf("transport = %q, want %q", contract.Transport, tt.transport)
+			}
+			if contract.Budget.UsageAccounting != tt.usageAccounting {
+				t.Fatalf("usage accounting = %q, want %q", contract.Budget.UsageAccounting, tt.usageAccounting)
+			}
+			if contract.NativeTools.StrictProviderNativeSupport != tt.strictNativeTools {
+				t.Fatalf("strict native tools = %v, want %v", contract.NativeTools.StrictProviderNativeSupport, tt.strictNativeTools)
+			}
+			if contract.NativeTools.StartupVisibleSurfaceProbe != tt.startupProbe {
+				t.Fatalf("startup probe = %v, want %v", contract.NativeTools.StartupVisibleSurfaceProbe, tt.startupProbe)
+			}
+			if contract.NativeTools.Capabilities != tt.caps {
+				t.Fatalf("capabilities = %#v, want %#v", contract.NativeTools.Capabilities, tt.caps)
+			}
+		})
+	}
+}
+
+func TestRuntimeFactoryValidatesProviderContract(t *testing.T) {
+	tests := []struct {
+		mode     string
+		provider string
+	}{
+		{mode: "api", provider: "anthropic"},
+		{mode: "cli_test", provider: "claude"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			runtime, err := RuntimeFactory{
+				Cfg: &config.Config{
+					LLM: config.LLMConfig{
+						RuntimeMode: tt.mode,
+					},
+				},
+			}.Build()
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			contract, err := RequireProviderContract(tt.mode, runtime)
+			if err != nil {
+				t.Fatalf("RequireProviderContract: %v", err)
+			}
+			if contract.Provider != tt.provider {
+				t.Fatalf("provider = %q, want %q", contract.Provider, tt.provider)
+			}
+		})
+	}
+}
+
+func TestProviderContractRejectsRuntimeWithoutContract(t *testing.T) {
+	_, err := RequireProviderContract("api", NoopRuntime{})
+	if err == nil || !strings.Contains(err.Error(), "does not expose provider contract") {
+		t.Fatalf("RequireProviderContract error = %v, want missing contract", err)
+	}
+}
+
+func TestProviderContractRejectsIncompleteContract(t *testing.T) {
+	contract := ProviderContract{
+		RuntimeMode: "api",
+		Provider:    "anthropic",
+		Transport:   ProviderTransportAPI,
+	}
+	if err := contract.Validate(); err == nil || !strings.Contains(err.Error(), "must validate provider input schemas") {
+		t.Fatalf("Validate error = %v, want provider schema error", err)
+	}
+}
+
+func TestProviderContractHelpersUseCanonicalContract(t *testing.T) {
+	runtime := nativeContractRuntimeStub{
+		contract: ProviderContract{
+			RuntimeMode: "stub",
+			Provider:    "stub",
+			Transport:   ProviderTransportAPI,
+			ToolSchema: ProviderToolSchemaContract{
+				ValidatesInputSchemas: true,
+				TranslatesTools:       true,
+				ReturnsToolResults:    true,
+			},
+			SessionLifecycle: ProviderSessionLifecycleContract{
+				StartsSessions:            true,
+				ContinuesSessions:         true,
+				SupportsConversationModes: true,
+				ProviderSessionIDStrategy: "stub",
+				RotatesSessions:           true,
+			},
+			Response: ProviderResponseContract{
+				NormalizesMessages:   true,
+				NormalizesToolCalls:  true,
+				PreservesRawResponse: true,
+			},
+			NativeTools: ProviderNativeToolContract{
+				Capabilities: NativeToolCapabilities{
+					WebSearch: true,
+				},
+				StrictProviderNativeSupport: true,
+			},
+			Persistence: ProviderPersistenceContract{
+				PersistsTurns:         true,
+				PersistsTaskModeAudit: true,
+			},
+			Budget: ProviderBudgetContract{
+				UsageAccounting: BudgetUsageEstimated,
+			},
+		},
+	}
+	if !RuntimeEnforcesProviderNativeTools(runtime) {
+		t.Fatal("RuntimeEnforcesProviderNativeTools = false, want true")
+	}
+	if !NativeToolCapabilitiesForRuntime(runtime).WebSearch {
+		t.Fatal("NativeToolCapabilitiesForRuntime().WebSearch = false, want true")
+	}
+}
+
+type nativeContractRuntimeStub struct {
+	NoopRuntime
+	contract ProviderContract
+}
+
+func (s nativeContractRuntimeStub) ProviderContract() ProviderContract {
+	return s.contract
+}

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -112,14 +112,6 @@ type NativeToolCapabilities struct {
 	FileIO    bool
 }
 
-type NativeToolCapabilityProvider interface {
-	NativeToolCapabilities() NativeToolCapabilities
-}
-
-type NativeToolStrictProvider interface {
-	EnforceProviderNativeToolSupport() bool
-}
-
 type StartupVisibleToolSurfaceProber interface {
 	ProbeStartupVisibleToolSurface(ctx context.Context, actor models.AgentConfig, systemPrompt string, tools []ToolDefinition) (*Response, error)
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -882,7 +882,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		return fmt.Errorf("claude runtime workspace validation failed: %w", err)
 	}
 	rt.emitBootProgress(15, "workspace_validation_and_system_containers", "ok", fmt.Sprintf("%d system containers", len(rt.Options.SystemContainers)))
-	startupProbe, _ := rt.LLM.(llm.StartupVisibleToolSurfaceProber)
+	startupProbe, _ := llm.StartupVisibleToolSurfaceProberForRuntime(rt.LLM)
 	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, source, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
 		rt.emitBootProgress(16, "mcp_tool_validation", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)

--- a/internal/runtime/tools/native_tools_validation.go
+++ b/internal/runtime/tools/native_tools_validation.go
@@ -22,11 +22,7 @@ func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Sourc
 	if !runtimeEnforcesProviderNativeTools(runtime) {
 		return validateFallbackNativeToolBootConfig(ctx, source, store, runtime)
 	}
-	provider, ok := runtime.(llm.NativeToolCapabilityProvider)
-	if !ok || provider == nil {
-		return nil, fmt.Errorf("native tools are enabled but runtime does not expose native tool capabilities")
-	}
-	caps := provider.NativeToolCapabilities()
+	caps := llm.NativeToolCapabilitiesForRuntime(runtime)
 	unsupported := make([]string, 0, len(enabled))
 	for _, capability := range enabled {
 		if nativeToolCapabilitySupported(caps, capability) {
@@ -46,18 +42,14 @@ func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Sourc
 }
 
 func runtimeEnforcesProviderNativeTools(runtime llm.Runtime) bool {
-	strict, ok := runtime.(llm.NativeToolStrictProvider)
-	return ok && strict != nil && strict.EnforceProviderNativeToolSupport()
+	return llm.RuntimeEnforcesProviderNativeTools(runtime)
 }
 
 func validateFallbackNativeToolBootConfig(ctx context.Context, source semanticview.Source, store runtimecredentials.Store, runtime llm.Runtime) ([]error, error) {
 	if !nativeToolCapabilityEnabled(source, "web_search") {
 		return nil, nil
 	}
-	caps := llm.NativeToolCapabilities{}
-	if provider, ok := runtime.(llm.NativeToolCapabilityProvider); ok && provider != nil {
-		caps = provider.NativeToolCapabilities()
-	}
+	caps := llm.NativeToolCapabilitiesForRuntime(runtime)
 	if caps.WebSearch {
 		return nil, nil
 	}

--- a/internal/runtime/tools/native_tools_validation_test.go
+++ b/internal/runtime/tools/native_tools_validation_test.go
@@ -16,12 +16,14 @@ type nativeCapabilityRuntimeStub struct {
 	strict bool
 }
 
-func (s nativeCapabilityRuntimeStub) NativeToolCapabilities() llm.NativeToolCapabilities {
-	return s.caps
-}
-
-func (s nativeCapabilityRuntimeStub) EnforceProviderNativeToolSupport() bool {
-	return s.strict
+func (s nativeCapabilityRuntimeStub) ProviderContract() llm.ProviderContract {
+	contract := llm.AnthropicAPIProviderContract()
+	contract.RuntimeMode = "stub"
+	contract.Provider = "stub"
+	contract.NativeTools.Capabilities = s.caps
+	contract.NativeTools.StrictProviderNativeSupport = s.strict
+	contract.NativeTools.FallbackToolsAllowed = !s.strict
+	return contract
 }
 
 func TestValidateNativeToolBootConfig_FailsClosedWhenRuntimeLacksNativeCapability(t *testing.T) {


### PR DESCRIPTION
## Summary

Part of #983.

Implements the approved first slice `runtime.llm_provider_adjacency_contract_ownership`: a typed LLM provider adapter contract owned by `internal/runtime/llm`, consumed by the runtime factory and adjacent native-tool/startup/persistence consumers, with both shipped runtimes (`api` Anthropic API and `cli_test` Claude CLI) proving contract conformance.

This PR does not add OpenAI/Ollama/Bedrock/etc., does not rename `cli_test`, and does not change provider-selection config/env behavior.

## Governing refs/context

- #983 Pre-Implementation Coverage Audit and Gate A approval.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `agent_session_management.agent_invocation`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `agent_session_management.conversation_modes` and `provider_session_ids`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `agent_session_management.native_tools`.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `runtime_storage.agents.llm_backend` and `runtime_storage.spend_ledger`.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`.

## Semantic migration

- New canonical owner: `internal/runtime/llm.ProviderContract` plus helpers for provider contract validation, native-tool capabilities, startup visible-tool probing, and conversation snapshot persistence.
- Old paths now invalid: `NativeToolCapabilityProvider` / `NativeToolStrictProvider` as independent semantic owners for runtime native-tool truth; treating `StartSession`/`ContinueSession` alone as sufficient provider readiness.
- Production paths checked/migrated: `RuntimeFactory.Build`, Anthropic API runtime, Claude CLI runtime, `LLMAgent` native fallback tool composition, native-tool boot validation, runtime startup MCP validation, and conversation snapshot persistence.
- Surviving split paths: provider-selection config/env, new provider implementations, `cli_test` naming, and broader provider docs remain under #983 parent/watchlist.
- Migration completeness: complete for the approved first slice; #983 remains open as parent for provider-selection and first non-Anthropic provider proof.

## Proof

- `ruby -e 'require "yaml"; YAML.load_file("docs/watchlists/runtime-operations.yaml"); YAML.load_file("docs/specs/swarm-platform/platform/contracts/platform-spec.yaml")'`
- `go test ./internal/runtime/llm ./internal/runtime/agents ./internal/runtime/tools ./internal/runtime -run 'TestProviderContract|TestRuntimeFactory|TestNewLLMAgent_.*Native|TestValidateNativeToolBootConfig|TestNewRuntime|TestRuntimeBoot|TestRuntimePayloadValidator|TestNewRuntimePromptResolver' -count=1`
- `go test ./...`
