### PR TITLE
[agent-e][issue #1056] Harden event.publish commit diagnostics

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -263,7 +263,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -301,7 +301,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -356,7 +356,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -416,7 +416,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -470,7 +470,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -528,7 +528,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -669,7 +669,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -795,7 +795,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1015,7 +1015,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1053,7 +1053,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1156,7 +1156,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1319,7 +1319,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1357,7 +1357,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1438,7 +1438,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1526,7 +1526,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1564,7 +1564,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1697,7 +1697,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1757,7 +1757,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1834,7 +1834,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1872,7 +1872,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2388,7 +2388,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2467,7 +2467,64 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32007,
+          "message": "Application error: EVENT_PUBLISH_FAILED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_PUBLISH_FAILED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "event_name": {
+                    "type": "string"
+                  },
+                  "phase": {
+                    "enum": [
+                      "publish"
+                    ],
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_name",
+                  "event_id",
+                  "run_id",
+                  "phase",
+                  "reason"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32019,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2525,7 +2582,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2601,7 +2658,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2643,7 +2700,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2780,7 +2837,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -2818,7 +2875,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -2873,7 +2930,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -2933,7 +2990,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -2987,7 +3044,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3045,7 +3102,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3226,7 +3283,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3264,7 +3321,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3316,7 +3373,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -3358,7 +3415,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3453,7 +3510,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3491,7 +3548,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3543,7 +3600,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -3588,7 +3645,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3669,7 +3726,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3824,7 +3881,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3862,7 +3919,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3914,7 +3971,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4022,7 +4079,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4060,7 +4117,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4102,7 +4159,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4183,7 +4240,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4252,7 +4309,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4385,7 +4442,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4423,7 +4480,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4465,7 +4522,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4503,7 +4560,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4670,7 +4727,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -4749,7 +4806,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -4807,7 +4864,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4895,7 +4952,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4933,7 +4990,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4975,7 +5032,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5075,7 +5132,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5176,7 +5233,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5440,7 +5497,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -5478,7 +5535,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5559,7 +5616,7 @@
       },
       "errors": [
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5590,7 +5647,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5671,7 +5728,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5702,7 +5759,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -8434,8 +8491,65 @@
           "type": "object"
         }
       },
-      "EVENT_REPLAY_NOT_ELIGIBLE": {
+      "EVENT_PUBLISH_FAILED": {
         "code": -32007,
+        "message": "Application error: EVENT_PUBLISH_FAILED",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "EVENT_PUBLISH_FAILED",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "event_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                },
+                "event_name": {
+                  "type": "string"
+                },
+                "phase": {
+                  "enum": [
+                    "publish"
+                  ],
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "run_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                }
+              },
+              "required": [
+                "event_name",
+                "event_id",
+                "run_id",
+                "phase",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "EVENT_REPLAY_NOT_ELIGIBLE": {
+        "code": -32008,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -8489,7 +8603,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -8527,7 +8641,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -8582,7 +8696,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -8642,7 +8756,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8680,7 +8794,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -8739,7 +8853,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -8784,7 +8898,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -8836,7 +8950,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -8878,7 +8992,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -8916,7 +9030,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -8954,7 +9068,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -9012,7 +9126,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9043,7 +9157,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9074,7 +9188,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -9112,7 +9226,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9150,7 +9264,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -9192,7 +9306,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9230,7 +9344,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9272,7 +9386,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9310,7 +9424,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9353,7 +9467,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -11361,6 +11361,28 @@ api_specification:
             type: array
             items:
               type: string
+      EVENT_PUBLISH_FAILED:
+        type: object
+        additionalProperties: false
+        required:
+        - event_name
+        - event_id
+        - run_id
+        - phase
+        - reason
+        properties:
+          event_name:
+            type: string
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          phase:
+            type: string
+            enum:
+            - publish
+          reason:
+            type: string
       PAYLOAD_VALIDATION_FAILED:
         type: object
         additionalProperties: false
@@ -11835,6 +11857,7 @@ api_specification:
       - BUNDLE_MISMATCH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
+      - EVENT_PUBLISH_FAILED
       - PAYLOAD_VALIDATION_FAILED
       - RUN_NOT_FOUND
       - EVENT_NOT_FOUND

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -22,8 +22,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 77 {
 		t.Fatalf("schema count = %d, want 77", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 29 {
-		t.Fatalf("error code count = %d, want 29", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 30 {
+		t.Fatalf("error code count = %d, want 30", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 18 {
 		t.Fatalf("mutating method count = %d, want 18", report.MutatingMethodCount)
@@ -72,8 +72,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 77 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 77", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 29 {
-		t.Fatalf("generated OpenRPC errors = %d, want 29", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 30 {
+		t.Fatalf("generated OpenRPC errors = %d, want 30", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -382,6 +383,7 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badFingerprint}}), Code: BundleMismatchCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
+		{Method: "event.publish", Params: validEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
 		{Method: "event.publish", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -52,6 +52,7 @@ type eventPublicationConfig struct {
 	requireExistingExplicitRun     bool
 	injectRunIDEntityIDWhenMissing bool
 	injectRunIDEntityIDOnlyNewRun  bool
+	publishError                   func(eventPublicationParams, error) error
 	buildCompletion                func(context.Context, OperatorReadOptions, eventPublicationParams) (any, string, error)
 }
 
@@ -81,6 +82,7 @@ func executeEventPublish(ctx context.Context, req Request, opts OperatorReadOpti
 		requireExistingExplicitRun:     true,
 		injectRunIDEntityIDWhenMissing: true,
 		injectRunIDEntityIDOnlyNewRun:  true,
+		publishError:                   eventPublishPublishError,
 		buildCompletion: func(_ context.Context, _ OperatorReadOptions, params eventPublicationParams) (any, string, error) {
 			return eventPublishResult{
 				EventID:       params.EventID,
@@ -179,6 +181,9 @@ func executeOperatorEventPublication(
 			Payload:       params.Payload,
 			CreatedAt:     now,
 		}.WithEntityID(params.EntityID)); err != nil {
+			if cfg.publishError != nil {
+				return store.APIIdempotencyCompletion{}, cfg.publishError(params, err)
+			}
 			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
 		}
 		result, resourceID, err := cfg.buildCompletion(ctx, opts, params)
@@ -372,6 +377,21 @@ func eventPublishSourceAgent(req Request) string {
 		actor = "anonymous"
 	}
 	return "cli-publish:" + actor
+}
+
+func eventPublishPublishError(params eventPublicationParams, err error) error {
+	mapped := runStartPublishError(params.EventName, err)
+	var appErr *ApplicationError
+	if errors.As(mapped, &appErr) {
+		return mapped
+	}
+	return NewApplicationError(EventPublishFailedCode, true, map[string]any{
+		"event_name": params.EventName,
+		"event_id":   params.EventID,
+		"run_id":     params.RunID,
+		"phase":      "publish",
+		"reason":     strings.TrimSpace(err.Error()),
+	})
 }
 
 func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDelivery {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -15,6 +15,7 @@ import (
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeingress "swarm/internal/runtime/ingress"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	"swarm/internal/testutil"
@@ -150,6 +151,109 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 	}
 	if got := len(asSlice(t, replayResult["deliveries"])); got != 1 {
 		t.Fatalf("replay deliveries = %d, want persisted delivery result", got)
+	}
+}
+
+func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	failing := &failStandalonePipelineReceiptOnceStore{
+		PostgresStore: pg,
+		err:           errors.New("simulated post-commit receipt failure"),
+	}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ctx := context.Background()
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "scan-orchestrator")
+	ch := bus.Subscribe("scan-orchestrator", events.EventType("scan.requested"))
+	defer bus.Unsubscribe("scan-orchestrator")
+	handler := eventPublishTestHandlerWithStores(t, failing, failing, failing, bus, source)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-post-commit-receipt")
+
+	published := rpcCall(t, handler, body)
+	if published.Error != nil {
+		t.Fatalf("event.publish post-commit receipt failure error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after post-commit receipt failure = %d, want 1", count)
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("event deliveries after post-commit receipt failure = %d, want 1", got)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after post-commit receipt failure = %d, want 1", count)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts after injected failure = %d, want 0", got)
+	}
+	missing, err := pg.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
+	}
+	if !containsMissingPipelineReceiptEvent(missing, eventID) {
+		t.Fatalf("missing pipeline receipt events = %#v, want %s", missing, eventID)
+	}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event delivery after post-commit receipt failure")
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("event.publish replay after post-commit receipt failure error = %#v", replay.Error)
+	}
+	if replayEventID := stringValue(t, asMap(t, replay.Result)["event_id"], "event_id"); replayEventID != eventID {
+		t.Fatalf("event.publish replay event_id = %q, want original %q", replayEventID, eventID)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after replay = %d, want 1", count)
+	}
+}
+
+func TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	failing := &failCommittedReplayScopeStore{
+		PostgresStore: pg,
+		err:           errors.New("simulated pre-commit replay scope failure"),
+	}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ctx := context.Background()
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "scan-orchestrator")
+	handler := eventPublishTestHandlerWithStores(t, failing, failing, failing, bus, source)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-pre-commit")
+
+	published := rpcCall(t, handler, body)
+	if published.Error == nil {
+		t.Fatal("event.publish pre-commit failure error = nil")
+	}
+	data := asMap(t, published.Error.Data)
+	if data["code"] != EventPublishFailedCode {
+		t.Fatalf("event.publish pre-commit error data = %#v, want %s", data, EventPublishFailedCode)
+	}
+	details := asMap(t, data["details"])
+	if details["event_name"] != "scan.requested" || details["phase"] != "publish" || !strings.Contains(fmt.Sprint(details["reason"]), "simulated pre-commit replay scope failure") {
+		t.Fatalf("event.publish pre-commit error details = %#v", details)
+	}
+	assertNoEventPublishPersistence(t, db)
+	if got := countAllEventDeliveries(t, db); got != 0 {
+		t.Fatalf("event_deliveries rows after pre-commit failure = %d, want 0", got)
+	}
+	if _, err := db.ExecContext(ctx, `SELECT 1`); err != nil {
+		t.Fatalf("database unusable after pre-commit failure: %v", err)
 	}
 }
 
@@ -523,16 +627,21 @@ func eventPublishTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtime
 
 func eventPublishTestHandlerWithObservability(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source, observability ObservabilityReadStore) *Handler {
 	t.Helper()
+	return eventPublishTestHandlerWithStores(t, pg, observability, pg, bus, source)
+}
+
+func eventPublishTestHandlerWithStores(t *testing.T, runs RunReadStore, observability ObservabilityReadStore, idempotency APIIdempotencyStore, publisher EventPublisher, source semanticview.Source) *Handler {
+	t.Helper()
 	return testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			Now:           func() time.Time { return time.Now().UTC() },
 			Ready:         func() bool { return true },
 			Database:      fakePinger{},
-			Runs:          pg,
+			Runs:          runs,
 			Observability: observability,
-			Idempotency:   pg,
-			Events:        bus,
+			Idempotency:   idempotency,
+			Events:        publisher,
 			Source:        source,
 			Bundle: runtimecontracts.BundleIdentity{
 				WorkflowName:    "review",
@@ -541,6 +650,36 @@ func eventPublishTestHandlerWithObservability(t *testing.T, pg *store.PostgresSt
 			},
 		}),
 	})
+}
+
+type failStandalonePipelineReceiptOnceStore struct {
+	*store.PostgresStore
+	err error
+}
+
+func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return s.UpsertPipelineReceiptTx(ctx, nil, eventID, status, errText)
+}
+
+func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {
+	if tx == nil && s.err != nil {
+		err := s.err
+		s.err = nil
+		return err
+	}
+	return s.PostgresStore.UpsertPipelineReceiptTx(ctx, tx, eventID, status, errText)
+}
+
+type failCommittedReplayScopeStore struct {
+	*store.PostgresStore
+	err error
+}
+
+func (s *failCommittedReplayScopeStore) UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.PostgresStore.UpsertCommittedReplayScopeTx(ctx, tx, eventID, scope)
 }
 
 type failOnceEventReadStore struct {
@@ -642,6 +781,24 @@ func assertNoEventPublishPersistence(t *testing.T, db *sql.DB) {
 	if count := countAPIIdempotencyRows(t, db); count != 0 {
 		t.Fatalf("api_idempotency rows = %d, want 0", count)
 	}
+}
+
+func countAllEventDeliveries(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM event_deliveries`).Scan(&count); err != nil {
+		t.Fatalf("count event_deliveries rows: %v", err)
+	}
+	return count
+}
+
+func containsMissingPipelineReceiptEvent(items []events.PersistedReplayEvent, eventID string) bool {
+	for _, evt := range items {
+		if strings.TrimSpace(evt.Event.ID) == strings.TrimSpace(eventID) {
+			return true
+		}
+	}
+	return false
 }
 
 func stringValue(t *testing.T, value any, field string) string {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -219,6 +219,65 @@ func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *
 	}
 }
 
+func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	failing := &failNormalRunCompletionStore{
+		PostgresStore: pg,
+		err:           errors.New("simulated normal-run completion failure"),
+	}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ctx := context.Background()
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "scan-orchestrator")
+	ch := bus.Subscribe("scan-orchestrator", events.EventType("scan.requested"))
+	defer bus.Unsubscribe("scan-orchestrator")
+	handler := eventPublishTestHandlerWithStores(t, failing, failing, failing, bus, source)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-post-commit-completion")
+
+	published := rpcCall(t, handler, body)
+	if published.Error != nil {
+		t.Fatalf("event.publish post-commit completion failure error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after post-commit completion failure = %d, want 1", count)
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("event deliveries after post-commit completion failure = %d, want 1", got)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after post-commit completion failure = %d, want 1", count)
+	}
+	outcome, errText := loadPipelineReceiptOutcomeAndError(t, ctx, db, eventID)
+	if outcome != "dead_letter" || !strings.Contains(errText, "simulated normal-run completion failure") {
+		t.Fatalf("pipeline receipt outcome=%q error=%q, want dead_letter with completion failure", outcome, errText)
+	}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event delivery after post-commit completion failure")
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("event.publish replay after post-commit completion failure error = %#v", replay.Error)
+	}
+	if replayEventID := stringValue(t, asMap(t, replay.Result)["event_id"], "event_id"); replayEventID != eventID {
+		t.Fatalf("event.publish replay event_id = %q, want original %q", replayEventID, eventID)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
+		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after replay = %d, want 1", count)
+	}
+}
+
 func TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -682,6 +741,15 @@ func (s *failCommittedReplayScopeStore) UpsertCommittedReplayScopeTx(ctx context
 	return s.PostgresStore.UpsertCommittedReplayScopeTx(ctx, tx, eventID, scope)
 }
 
+type failNormalRunCompletionStore struct {
+	*store.PostgresStore
+	err error
+}
+
+func (s *failNormalRunCompletionStore) ConvergeNormalRunCompletion(context.Context, string, []string, map[string][]string) error {
+	return s.err
+}
+
 type failOnceEventReadStore struct {
 	ObservabilityReadStore
 	err error
@@ -790,6 +858,21 @@ func countAllEventDeliveries(t *testing.T, db *sql.DB) int {
 		t.Fatalf("count event_deliveries rows: %v", err)
 	}
 	return count
+}
+
+func loadPipelineReceiptOutcomeAndError(t *testing.T, ctx context.Context, db *sql.DB, eventID string) (string, string) {
+	t.Helper()
+	var outcome, errText string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(side_effects->>'error', '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&outcome, &errText); err != nil {
+		t.Fatalf("load pipeline receipt for %s: %v", eventID, err)
+	}
+	return outcome, errText
 }
 
 func containsMissingPipelineReceiptEvent(items []events.PersistedReplayEvent, eventID string) bool {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -16,6 +16,7 @@ const (
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
 	EventNotFoundCode                    = "EVENT_NOT_FOUND"
+	EventPublishFailedCode               = "EVENT_PUBLISH_FAILED"
 	EventReplayNoDeliveryHistoryCode     = "EVENT_REPLAY_NO_DELIVERY_HISTORY"
 	EventReplaySubscriberNotOriginalCode = "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL"
 	EventReplaySubscriberUnavailableCode = "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -321,7 +321,7 @@ methods:
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -489,13 +489,15 @@ func (eb *EventBus) publishTransactional(
 		if len(inboundPlan.Recipients) > 0 {
 			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
 			if err := eb.deliverToRecipientsWithRoutes(ctx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
-				return err
+				eb.recordCommittedPublishReceipt(ctx, evt, err)
+				return nil
 			}
 			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
 		}
 		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
 			if err := eb.publishDeferred(ctx, *inboundPlan.CycleEscalation); err != nil {
-				return err
+				eb.recordCommittedPublishReceipt(ctx, evt, err)
+				return nil
 			}
 		}
 		if strings.TrimSpace(inboundPlan.ContradictionReason) != "" {
@@ -506,14 +508,17 @@ func (eb *EventBus) publishTransactional(
 
 	for _, d := range deferred {
 		if err := eb.publishDeferred(ctx, d); err != nil {
-			return err
+			eb.recordCommittedPublishReceipt(ctx, evt, err)
+			return nil
 		}
 	}
-	status, errText := pipelineReceiptStatus(txctx, nil)
-	if err := txStore.UpsertPipelineReceiptTx(ctx, nil, evt.ID, status, errText); err != nil {
-		return fmt.Errorf("persist pipeline receipt: %w", err)
-	}
+	eb.recordCommittedPublishReceipt(ctx, evt, nil)
 	return nil
+}
+
+func (eb *EventBus) recordCommittedPublishReceipt(ctx context.Context, evt events.Event, publishErr error) {
+	status, errText := pipelineReceiptStatus(ctx, publishErr)
+	_ = eb.markPipelineReceipt(ctx, evt.ID, status, errText)
 }
 
 func txTableExists(ctx context.Context, tx *sql.Tx, table string) bool {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -196,7 +196,8 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		if err := eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore); err != nil {
 			return err
 		}
-		return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
+		eb.recordCommittedPublishConvergence(ictx, evt)
+		return nil
 	}
 
 	persisted := false
@@ -519,6 +520,15 @@ func (eb *EventBus) publishTransactional(
 func (eb *EventBus) recordCommittedPublishReceipt(ctx context.Context, evt events.Event, publishErr error) {
 	status, errText := pipelineReceiptStatus(ctx, publishErr)
 	_ = eb.markPipelineReceipt(ctx, evt.ID, status, errText)
+}
+
+func (eb *EventBus) recordCommittedPublishConvergence(ctx context.Context, evt events.Event) {
+	if err := eb.convergeStandaloneRuntimePlatformRun(ctx, evt); err != nil {
+		eb.recordCommittedPublishReceipt(ctx, evt, err)
+		eb.logRuntime(ctx, "error", "Post-commit publish convergence failed", "eventbus", "publish_post_commit_convergence_failed", evt.ID, string(evt.Type), evt.SourceAgent, evt.EntityID(), "", nil, map[string]any{
+			"error": err.Error(),
+		}, err.Error(), 0)
+	}
 }
 
 func txTableExists(ctx context.Context, tx *sql.Tx, table string) bool {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -363,6 +363,107 @@ func countPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB
 	return count
 }
 
+func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	failing := &failStandalonePipelineReceiptOnceStore{
+		PostgresStore: pg,
+		err:           errors.New("simulated post-commit receipt failure"),
+	}
+	logger := &recordingLoggerHook{}
+	eb, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+
+	agentID := "agent-post-commit-receipt"
+	eventID := "21000000-0000-0000-0000-000000000011"
+	seedActiveRuntimeBusAgent(t, ctx, pg, agentID)
+	ch := eb.Subscribe(agentID, events.EventType("custom.receipt_failure"))
+	defer eb.Unsubscribe(agentID)
+
+	if err := eb.Publish(ctx, events.Event{
+		ID:          eventID,
+		RunID:       eventBusTestRunID,
+		Type:        events.EventType("custom.receipt_failure"),
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"entity_id":"21000000-0000-0000-0000-000000000012"}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID("21000000-0000-0000-0000-000000000012")); err != nil {
+		t.Fatalf("Publish with post-commit receipt failure: %v", err)
+	}
+	ok, err := pg.EventExists(ctx, eventID)
+	if err != nil {
+		t.Fatalf("EventExists: %v", err)
+	}
+	if !ok {
+		t.Fatalf("event %s was not persisted", eventID)
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("event deliveries = %d, want 1", got)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts = %d, want 0 after injected failure", got)
+	}
+	missing, err := pg.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
+	}
+	if !containsMissingPipelineReceiptEvent(missing, eventID) {
+		t.Fatalf("missing pipeline receipt events = %#v, want %s", missing, eventID)
+	}
+	if !hasRuntimeLogAction(logger.entries, "pipeline_receipt_persist_failed") {
+		t.Fatalf("logger entries = %#v, want pipeline_receipt_persist_failed", logger.entries)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delivered event")
+	}
+}
+
+type failStandalonePipelineReceiptOnceStore struct {
+	*store.PostgresStore
+	err error
+}
+
+func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return s.UpsertPipelineReceiptTx(ctx, nil, eventID, status, errText)
+}
+
+func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {
+	if tx == nil && s.err != nil {
+		err := s.err
+		s.err = nil
+		return err
+	}
+	return s.PostgresStore.UpsertPipelineReceiptTx(ctx, tx, eventID, status, errText)
+}
+
+func containsMissingPipelineReceiptEvent(items []events.PersistedReplayEvent, eventID string) bool {
+	for _, evt := range items {
+		if strings.TrimSpace(evt.Event.ID) == strings.TrimSpace(eventID) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRuntimeLogAction(entries []recordedLogEntry, action string) bool {
+	for _, entry := range entries {
+		if entry.Action == action {
+			return true
+		}
+	}
+	return false
+}
+
 func loadAgentDeliveryForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID, agentID string) (string, string) {
 	t.Helper()
 	var status, runStatus string

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -428,6 +428,65 @@ func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *te
 	}
 }
 
+func TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	failing := &failNormalRunCompletionStore{
+		PostgresStore: pg,
+		err:           errors.New("simulated normal-run completion failure"),
+	}
+	logger := &recordingLoggerHook{}
+	eb, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+
+	agentID := "agent-post-commit-completion"
+	eventID := "21000000-0000-0000-0000-000000000021"
+	seedActiveRuntimeBusAgent(t, ctx, pg, agentID)
+	ch := eb.Subscribe(agentID, events.EventType("custom.completion_failure"))
+	defer eb.Unsubscribe(agentID)
+
+	if err := eb.Publish(ctx, events.Event{
+		ID:          eventID,
+		RunID:       eventBusTestRunID,
+		Type:        events.EventType("custom.completion_failure"),
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"entity_id":"21000000-0000-0000-0000-000000000022"}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID("21000000-0000-0000-0000-000000000022")); err != nil {
+		t.Fatalf("Publish with post-commit completion failure: %v", err)
+	}
+	ok, err := pg.EventExists(ctx, eventID)
+	if err != nil {
+		t.Fatalf("EventExists: %v", err)
+	}
+	if !ok {
+		t.Fatalf("event %s was not persisted", eventID)
+	}
+	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("event deliveries = %d, want 1", got)
+	}
+	outcome, errText := loadPipelineReceiptOutcomeAndError(t, ctx, db, eventID)
+	if outcome != "dead_letter" || !strings.Contains(errText, "simulated normal-run completion failure") {
+		t.Fatalf("pipeline receipt outcome=%q error=%q, want dead_letter with completion failure", outcome, errText)
+	}
+	if !hasRuntimeLogAction(logger.entries, "publish_post_commit_convergence_failed") {
+		t.Fatalf("logger entries = %#v, want publish_post_commit_convergence_failed", logger.entries)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delivered event")
+	}
+}
+
 type failStandalonePipelineReceiptOnceStore struct {
 	*store.PostgresStore
 	err error
@@ -444,6 +503,30 @@ func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceiptTx(ctx con
 		return err
 	}
 	return s.PostgresStore.UpsertPipelineReceiptTx(ctx, tx, eventID, status, errText)
+}
+
+type failNormalRunCompletionStore struct {
+	*store.PostgresStore
+	err error
+}
+
+func (s *failNormalRunCompletionStore) ConvergeNormalRunCompletion(context.Context, string, []string, map[string][]string) error {
+	return s.err
+}
+
+func loadPipelineReceiptOutcomeAndError(t *testing.T, ctx context.Context, db *sql.DB, eventID string) (string, string) {
+	t.Helper()
+	var outcome, errText string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(side_effects->>'error', '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&outcome, &errText); err != nil {
+		t.Fatalf("load pipeline receipt for %s: %v", eventID, err)
+	}
+	return outcome, errText
 }
 
 func containsMissingPipelineReceiptEvent(items []events.PersistedReplayEvent, eventID string) bool {


### PR DESCRIPTION
## Summary
- Hardened transactional `EventBus.Publish` so post-commit receipt/dispatch/deferred failures no longer make a durable `/v1/rpc event.publish` look like a failed, non-idempotent RPC.
- Added declared `EVENT_PUBLISH_FAILED` diagnostics for pre-commit `event.publish` publication failures and regenerated OpenRPC.
- Added deterministic API/EventBus fault-injection proof for rollback, idempotency completion, replay, missing-receipt recovery evidence, and no duplicate event persistence.

Closes #1056
Part of #1045

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.event.publish`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.conventions.idempotency`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.runtime_control.queueable_ingress`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`
- #1056 pre-audit and independent gate outcome

## Semantic Migration / Ownership
- New canonical diagnostic: `EVENT_PUBLISH_FAILED` in `platform-spec.yaml`, generated OpenRPC, `internal/apiv1/registry.go`, and mutating runtime probes.
- Canonical completion owner after this change: transactional `EventBus.Publish` records committed publish receipt/recovery evidence after commit without returning a post-commit bookkeeping failure to API idempotency.
- Old invalid path: `publishTransactional` returned `persist pipeline receipt` or post-commit dispatch/deferred errors after event/delivery rows had already committed, before API idempotency completion was stored.
- Production paths checked: `/v1/rpc event.publish`, transactional `EventBus.Publish`, `run.start` wrapper regression, OpenRPC generated mutating probes, compliance matrix, and full suite.
- Migration completeness: complete for #1056 `event.publish` reliability/commit-diagnostics boundary. `run.start`/CLI failure quality remains split under #1045 as gated.

## Verification
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate|TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError|TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun|TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure|TestOperatorEventPublishQueuesWhileRuntimePaused|TestOpenRPCMutatingHTTPRuntimeProbes|TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod|TestOpenRPCSuccessfulResultSchemas|TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable|TestEventBusPublishTransactional|TestEventBusPublish_QueuesWhileRuntimePaused|TestEventBusPublish_PayloadValidatorFailureAbortsPublish|TestEventBusPublish_FailsClosedWhenReplayCapableAtomicStoreOmitsCommittedReplayScope' -count=1`
- `go test ./internal/apispec -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
- `git diff --check`