### PR TITLE
[agent-b][issue #1063] Add forkchat chat execution owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -137,6 +137,18 @@ func defaultServeOptions() serveOptions {
 	}
 }
 
+func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver) (runtimellm.Runtime, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("runtime config is required")
+	}
+	return runtimellm.RuntimeFactory{
+		Cfg:        cfg,
+		Sessions:   sessions.NewInMemoryRegistry(cfg.LLM.Session.LockTTL),
+		LockOwner:  "forkchat-sandbox",
+		Workspaces: workspaces,
+	}.Build()
+}
+
 func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	bootStartedAt := time.Now().UTC()
 	reporter := newServeBootReporter(opts.Verbose, opts.Output)
@@ -297,6 +309,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("init runtime: %v", err)
 		return 1
 	}
+	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces)
+	if err != nil {
+		log.Printf("init forkchat sandbox runtime: %v", err)
+		return 1
+	}
 
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt)
@@ -332,6 +349,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Entities:           apiEntities,
 		AgentConversations: apiAgentConversations,
 		ConversationForks:  stores.Postgres,
+		ForkChatExecutor:   apiv1.NewLLMForkChatExecutor(forkChatLLM),
 		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},
 		Mailbox:            stores.Postgres,
 		Idempotency:        stores.Postgres,

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1499,6 +1499,140 @@
       ]
     },
     {
+      "name": "conversation.fork_chat",
+      "description": "Execute one sandboxed forkchat turn against an active fork lifecycle session.\nThe method consumes conversation_forks for lifecycle validation,\nconversation_fork_snapshots for source-at-fork context, and\nconversation_fork_turns for fork-local transcript persistence. It does\nnot write agent_turns, events, runtime logs, mailbox rows, run commands,\nor dashboard conversation rows by default.\n",
+      "params": [
+        {
+          "name": "fork_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "message",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ConversationForkChatResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32011,
+          "message": "Application error: FORK_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "FORK_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "fork_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "fork_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32012,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "conversation.fork_delete",
       "description": "Soft-delete one forkchat lifecycle session from the isolated conversation_forks owner.",
       "params": [
@@ -1678,7 +1812,7 @@
     },
     {
       "name": "conversation.fork_view",
-      "description": "Read one forkchat lifecycle session header/state. The turns array remains empty until conversation.fork_chat exists.",
+      "description": "Read one forkchat lifecycle session header/state and fork-local transcript turns owned by conversation_fork_turns.",
       "params": [
         {
           "name": "fork_id",
@@ -6389,6 +6523,34 @@
         ],
         "type": "object"
       },
+      "ConversationForkChatResult": {
+        "additionalProperties": false,
+        "properties": {
+          "fork_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "idempotency_replayed": {
+            "type": "boolean"
+          },
+          "sandbox_policy": {
+            "$ref": "#/components/schemas/ConversationForkSandboxPolicy"
+          },
+          "snapshot": {
+            "$ref": "#/components/schemas/ConversationForkSnapshot"
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ConversationForkTurn"
+          }
+        },
+        "required": [
+          "fork_id",
+          "turn",
+          "snapshot",
+          "sandbox_policy",
+          "idempotency_replayed"
+        ],
+        "type": "object"
+      },
       "ConversationForkCreateResult": {
         "additionalProperties": false,
         "properties": {
@@ -6431,6 +6593,37 @@
           "deleted",
           "already_deleted",
           "idempotency_replayed"
+        ],
+        "type": "object"
+      },
+      "ConversationForkEntitySnapshot": {
+        "additionalProperties": false,
+        "description": "Entity projection reconstructed from source-run entity_mutations at the fork point for forkchat read-only tools.",
+        "properties": {
+          "accumulator": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "current_state": {
+            "type": "string"
+          },
+          "entered_state_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "fields": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "gates": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "entity_id"
         ],
         "type": "object"
       },
@@ -6499,9 +6692,47 @@
         ],
         "type": "object"
       },
+      "ConversationForkSandboxPolicy": {
+        "additionalProperties": false,
+        "description": "Sandbox policy enforced for forkchat execution. Read tools consume only the fork snapshot; side-effecting tools are stub-recorded and must not mutate live state.",
+        "properties": {
+          "owner": {
+            "const": "conversation.fork_chat.sandbox.v1",
+            "type": "string"
+          },
+          "read_policy": {
+            "const": "fork_snapshot_only",
+            "type": "string"
+          },
+          "side_effecting_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stubbed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "write_policy": {
+            "const": "stub_record_only_no_live_mutation",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "read_policy",
+          "write_policy",
+          "side_effecting_tools",
+          "stubbed_tools"
+        ],
+        "type": "object"
+      },
       "ConversationForkSession": {
         "additionalProperties": false,
-        "description": "Forkchat lifecycle header. This first slice intentionally carries no forked chat transcript, no entity snapshot payload, and no sandbox execution result.",
+        "description": "Forkchat lifecycle header. `conversation.fork_view` consumes the fork-local transcript owner and returns fork turns when conversation.fork_chat has executed. List responses may still return empty turns for lightweight lifecycle rows.",
         "properties": {
           "created_at": {
             "$ref": "#/components/schemas/Timestamp"
@@ -6539,9 +6770,9 @@
             "type": "string"
           },
           "turns": {
-            "description": "Empty until a later conversation.fork_chat execution owner exists.",
+            "description": "Fork-local transcript turns owned by conversation_fork_turns and excluded from normal agent_turns.",
             "items": {
-              "$ref": "#/components/schemas/Turn"
+              "$ref": "#/components/schemas/ConversationForkTurn"
             },
             "type": "array"
           }
@@ -6556,6 +6787,109 @@
           "expires_at",
           "state",
           "turns"
+        ],
+        "type": "object"
+      },
+      "ConversationForkSnapshot": {
+        "additionalProperties": false,
+        "description": "Source-at-fork snapshot consumed by conversation.fork_chat sandbox execution.",
+        "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "entity_snapshot": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationForkEntitySnapshot"
+            },
+            "type": "array"
+          },
+          "fork_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "snapshot_owner": {
+            "const": "conversation.fork_chat.snapshot.v1",
+            "type": "string"
+          },
+          "source_agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_session_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "source_turn": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "fork_id",
+          "source_session_id",
+          "source_agent_id",
+          "source_turn",
+          "entity_snapshot",
+          "snapshot_owner",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "ConversationForkTurn": {
+        "additionalProperties": false,
+        "description": "Fork-local transcript turn. It intentionally is not an agent_turns row and may not have a live trigger event.",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "latency_ms": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "parse_ok": {
+            "type": "boolean"
+          },
+          "request_payload": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "response_payload": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "tool_calls": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "trigger_event_id": {
+            "type": "string"
+          },
+          "trigger_event_type": {
+            "type": "string"
+          },
+          "turn_blocks": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "turn_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "turn_index": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "turn_index",
+          "turn_id",
+          "parse_ok",
+          "latency_ms"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1500,7 +1500,7 @@
     },
     {
       "name": "conversation.fork_chat",
-      "description": "Execute one sandboxed forkchat turn against an active fork lifecycle session.\nThe method consumes conversation_forks for lifecycle validation,\nconversation_fork_snapshots for source-at-fork context, and\nconversation_fork_turns for fork-local transcript persistence. It does\nnot write agent_turns, events, runtime logs, mailbox rows, run commands,\nor dashboard conversation rows by default.\n",
+      "description": "Execute one sandboxed forkchat turn against an active fork lifecycle session.\nThe method consumes conversation_forks for lifecycle validation,\nconversation_fork_snapshots for source-at-fork context, and\nconversation_fork_turns for fork-local transcript persistence. It does\nenforce fork-snapshot read tools and records side-effecting tools as\nstubbed fork-local results under ConversationForkSandboxPolicy. It does\nnot write agent_turns, events, runtime logs, mailbox rows, run commands,\nor dashboard conversation rows by default.\n",
       "params": [
         {
           "name": "fork_id",
@@ -8338,6 +8338,7 @@
             "type": "object"
           },
           "tool_calls": {
+            "description": "Sandbox-observed tool calls for this fork-local turn. Entries include snapshot-read evidence and stubbed side-effect tool results; they are fork-local facts and are not live runtime side effects.",
             "items": {
               "additionalProperties": true,
               "type": "object"

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1500,7 +1500,7 @@
     },
     {
       "name": "conversation.fork_chat",
-      "description": "Execute one sandboxed forkchat turn against an active fork lifecycle session.\nThe method consumes conversation_forks for lifecycle validation,\nconversation_fork_snapshots for source-at-fork context, and\nconversation_fork_turns for fork-local transcript persistence. It does\nenforce fork-snapshot read tools and records side-effecting tools as\nstubbed fork-local results under ConversationForkSandboxPolicy. It does\nnot write agent_turns, events, runtime logs, mailbox rows, run commands,\nor dashboard conversation rows by default.\n",
+      "description": "Execute one sandboxed forkchat turn against an active fork lifecycle session.\nThe method consumes conversation_forks for lifecycle validation,\nconversation_fork_snapshots for source-at-fork context, and\nconversation_fork_turns for fork-local transcript persistence. It does\nexecute the source agent through the forkchat sandbox executor, provides\nfork-snapshot read tools, and records only sandbox-observed requested\nside-effecting tools as stubbed fork-local results under\nConversationForkSandboxPolicy. It does not write agent_turns, events,\nruntime logs, mailbox rows, run commands, or dashboard conversation rows\nby default.\n",
       "params": [
         {
           "name": "fork_id",
@@ -8338,7 +8338,7 @@
             "type": "object"
           },
           "tool_calls": {
-            "description": "Sandbox-observed tool calls for this fork-local turn. Entries include snapshot-read evidence and stubbed side-effect tool results; they are fork-local facts and are not live runtime side effects.",
+            "description": "Sandbox-observed tool calls requested during this fork-local turn. Entries may include snapshot-read evidence and requested side-effect tool results stubbed as fork-local facts; they are not synthesized for unrequested tools and are not live runtime side effects.",
             "items": {
               "additionalProperties": true,
               "type": "object"

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -3608,6 +3608,8 @@ platform_tables:
       delete_mixed_row_policy:
         - event_deliveries
         - agent_conversation_audits
+        - conversation_fork_snapshots
+        - conversation_fork_turns
         - conversation_forks
         - timers
       delete_all:
@@ -3896,10 +3898,10 @@ platform_tables:
         \ (expires_at)\n);"
     conversation_forks:
       description: 'Canonical forkchat lifecycle store for conversation.fork, conversation.fork_list, conversation.fork_view,
-        and conversation.fork_delete. Rows are lifecycle metadata only: they record source session/run/agent lineage, the
-        validated fork-point descriptor, creator token, fixed first-slice TTL, and soft-deletion state. This table is isolated
-        from agent_sessions, agent_turns, events, runtime logs, and dashboard conversation readers; fork chat execution,
-        sandbox tools, entity snapshot reads, and cross-surface include/exclude behavior are separate owners.'
+        conversation.fork_chat, and conversation.fork_delete. Rows record source session/run/agent lineage, the validated
+        fork-point descriptor, creator token, fixed lifecycle TTL, and soft-deletion state. This table is isolated from
+        agent_sessions, agent_turns, events, runtime logs, and dashboard conversation readers; fork chat execution consumes
+        conversation_fork_snapshots and conversation_fork_turns rather than writing normal conversation/event/log surfaces.'
       ddl: "CREATE TABLE conversation_forks (\n    fork_id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n\
         \    source_session_id      UUID NOT NULL,\n    source_run_id          UUID,\n    source_agent_id        TEXT NOT\
         \ NULL,\n    fork_point_kind       TEXT NOT NULL CHECK (fork_point_kind IN ('turn', 'event', 'time')),\n    fork_point_turn_index\
@@ -3912,6 +3914,46 @@ platform_tables:
         \ (fork_point_kind = 'time' AND fork_point_turn_index IS NOT NULL AND fork_point_turn_id IS NOT NULL AND fork_point_at\
         \ IS NOT NULL)),\n    INDEX idx_conversation_forks_source (source_session_id, created_at DESC),\n    INDEX idx_conversation_forks_created\
         \ (created_at DESC, fork_id),\n    INDEX idx_conversation_forks_active (expires_at) WHERE deleted_at IS NULL\n);"
+    conversation_fork_snapshots:
+      description: 'Forkchat source-at-fork snapshot owner for conversation.fork_chat. One row per fork captures the source
+        turn descriptor plus the source run entity projection reconstructed from entity_mutations at fork_point_selected_at.
+        Read-only forkchat tools consume this row; they must not read live entity_state or post-fork source mutations.'
+      ddl: |
+        CREATE TABLE conversation_fork_snapshots (
+            fork_id                  UUID PRIMARY KEY REFERENCES conversation_forks(fork_id) ON DELETE CASCADE,
+            source_session_id        UUID NOT NULL,
+            source_run_id            UUID,
+            source_agent_id          TEXT NOT NULL,
+            fork_point_turn_id       UUID NOT NULL,
+            fork_point_turn_index    INTEGER NOT NULL,
+            fork_point_selected_at   TIMESTAMPTZ NOT NULL,
+            source_turn              JSONB NOT NULL DEFAULT '{}',
+            entity_snapshot          JSONB NOT NULL DEFAULT '[]',
+            snapshot_owner           TEXT NOT NULL CHECK (snapshot_owner = 'conversation.fork_chat.snapshot.v1'),
+            created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            INDEX idx_conversation_fork_snapshots_source_run (source_run_id) WHERE source_run_id IS NOT NULL
+        );
+    conversation_fork_turns:
+      description: 'Fork-local transcript owner for conversation.fork_chat. Rows are intentionally separate from agent_turns,
+        events, runtime logs, and dashboard conversation readers. Side-effecting tools are recorded under sandbox_policy/tool_calls
+        as stubbed fork-local facts and must not mutate live state.'
+      ddl: |
+        CREATE TABLE conversation_fork_turns (
+            fork_turn_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            fork_id            UUID NOT NULL REFERENCES conversation_forks(fork_id) ON DELETE CASCADE,
+            turn_index         INTEGER NOT NULL CHECK (turn_index >= 1),
+            actor_token_id     TEXT NOT NULL,
+            message            TEXT NOT NULL,
+            assistant_message  TEXT NOT NULL,
+            request_payload    JSONB NOT NULL,
+            response_payload   JSONB NOT NULL,
+            tool_calls         JSONB NOT NULL DEFAULT '[]',
+            sandbox_policy     JSONB NOT NULL,
+            snapshot_owner     TEXT NOT NULL CHECK (snapshot_owner = 'conversation.fork_chat.snapshot.v1'),
+            created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (fork_id, turn_index),
+            INDEX idx_conversation_fork_turns_fork (fork_id, turn_index)
+        );
     runtime_ingress_state:
       description: 'Durable singleton runtime ingress state owned by the canonical runtime ingress controller. It records whether
         queueable event-producing ingress is running or paused, the last transition reason/actor, and the platform event emitted
@@ -6470,9 +6512,9 @@ cli_specification:
       forkchat:
         disposition: blocked
         tracker: '#749'
-        action: Forkchat CLI remains blocked until `conversation.fork_chat` execution, sandbox/snapshot owners, and CLI consumer
-          contracts exist. Lifecycle-only `conversation.fork|fork_list|fork_view|fork_delete` is source authority, not CLI
-          usability.
+        action: Forkchat CLI remains blocked until CLI consumer contracts exist over the promoted `conversation.fork_chat`
+          execution/sandbox/snapshot owners and lifecycle `conversation.fork|fork_list|fork_view|fork_delete` source
+          authority.
     platform_spec_refinements_not_cleanly_present_in_review_artifact:
       agent_replay_backlog:
         classification: required_current_contract
@@ -8730,8 +8772,8 @@ cli_specification:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
       implementation_status: absent
-      blocker_state: '#749; lifecycle-only conversation.fork|fork_list|fork_view|fork_delete exists, but conversation.fork_chat,
-        sandbox/snapshot owners, and swarm forkchat CLI consumer are not present.'
+      blocker_state: '#749; conversation.fork_chat, sandbox/snapshot owners, and lifecycle conversation.fork|fork_list|fork_view|fork_delete
+        exist, but the swarm forkchat CLI consumer contract is not present.'
       owners: conversation.fork, conversation.fork_chat, conversation.fork_list, conversation.fork_view, conversation.fork_delete
     entities_list:
       command: swarm entities list
@@ -8992,7 +9034,8 @@ cli_specification:
       remaining_role: 'Track deprecations/ratification cleanup only if kept open; do not block those CLI commands solely on method existence.'
     '#749':
       state: active_blocker
-      reason: 'Lifecycle-only conversation.fork, conversation.fork_list, conversation.fork_view, and conversation.fork_delete are present. conversation.fork_chat, sandbox/snapshot owners, and swarm forkchat CLI remain absent.'
+      reason: 'conversation.fork_chat execution/sandbox/snapshot ownership and lifecycle conversation.fork, conversation.fork_list,
+        conversation.fork_view, and conversation.fork_delete are present. swarm forkchat CLI remains absent.'
     '#750':
       state: parent_runtime_tail
       closed_slices:
@@ -9411,6 +9454,7 @@ api_specification:
       - runtime.resume
       - runtime.nuke
       - conversation.fork
+      - conversation.fork_chat
       - conversation.fork_delete
     mailbox:
       status_storage_model: 'The storage table keeps terminal defer decisions as status = decided and decision = deferred.
@@ -10877,8 +10921,9 @@ api_specification:
           selected_at:
             $ref: '#/components/schemas/Timestamp'
       ConversationForkSession:
-        description: "Forkchat lifecycle header. This first slice intentionally carries no forked chat transcript, no entity\
-          \ snapshot payload, and no sandbox execution result."
+        description: Forkchat lifecycle header. `conversation.fork_view` consumes the fork-local transcript owner and returns
+          fork turns when conversation.fork_chat has executed. List responses may still return empty turns for lightweight
+          lifecycle rows.
         type: object
         additionalProperties: false
         required:
@@ -10918,9 +10963,155 @@ api_specification:
             - deleted
           turns:
             type: array
-            description: Empty until a later conversation.fork_chat execution owner exists.
+            description: Fork-local transcript turns owned by conversation_fork_turns and excluded from normal agent_turns.
             items:
-              $ref: '#/components/schemas/Turn'
+              $ref: '#/components/schemas/ConversationForkTurn'
+      ConversationForkTurn:
+        description: Fork-local transcript turn. It intentionally is not an agent_turns row and may not have a live trigger event.
+        type: object
+        additionalProperties: false
+        required:
+        - turn_index
+        - turn_id
+        - parse_ok
+        - latency_ms
+        properties:
+          turn_index:
+            type: integer
+            minimum: 1
+          turn_id:
+            $ref: '#/components/schemas/OpaqueId'
+          trigger_event_id:
+            type: string
+          trigger_event_type:
+            type: string
+          request_payload:
+            type: object
+            additionalProperties: true
+          response_payload:
+            type: object
+            additionalProperties: true
+          tool_calls:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
+          turn_blocks:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
+          parse_ok:
+            type: boolean
+          latency_ms:
+            type: integer
+            minimum: 0
+          error:
+            type: string
+      ConversationForkEntitySnapshot:
+        description: Entity projection reconstructed from source-run entity_mutations at the fork point for forkchat read-only tools.
+        type: object
+        additionalProperties: false
+        required:
+        - entity_id
+        properties:
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          current_state:
+            type: string
+          entered_state_at:
+            $ref: '#/components/schemas/Timestamp'
+          fields:
+            type: object
+            additionalProperties: true
+          gates:
+            type: object
+            additionalProperties: true
+          accumulator:
+            type: object
+            additionalProperties: true
+      ConversationForkSnapshot:
+        description: Source-at-fork snapshot consumed by conversation.fork_chat sandbox execution.
+        type: object
+        additionalProperties: false
+        required:
+        - fork_id
+        - source_session_id
+        - source_agent_id
+        - source_turn
+        - entity_snapshot
+        - snapshot_owner
+        - created_at
+        properties:
+          fork_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_session_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          source_turn:
+            type: object
+            additionalProperties: true
+          entity_snapshot:
+            type: array
+            items:
+              $ref: '#/components/schemas/ConversationForkEntitySnapshot'
+          snapshot_owner:
+            type: string
+            const: conversation.fork_chat.snapshot.v1
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+      ConversationForkSandboxPolicy:
+        description: Sandbox policy enforced for forkchat execution. Read tools consume only the fork snapshot; side-effecting
+          tools are stub-recorded and must not mutate live state.
+        type: object
+        additionalProperties: false
+        required:
+        - owner
+        - read_policy
+        - write_policy
+        - side_effecting_tools
+        - stubbed_tools
+        properties:
+          owner:
+            type: string
+            const: conversation.fork_chat.sandbox.v1
+          read_policy:
+            type: string
+            const: fork_snapshot_only
+          write_policy:
+            type: string
+            const: stub_record_only_no_live_mutation
+          side_effecting_tools:
+            type: array
+            items:
+              type: string
+          stubbed_tools:
+            type: array
+            items:
+              type: string
+      ConversationForkChatResult:
+        type: object
+        additionalProperties: false
+        required:
+        - fork_id
+        - turn
+        - snapshot
+        - sandbox_policy
+        - idempotency_replayed
+        properties:
+          fork_id:
+            $ref: '#/components/schemas/OpaqueId'
+          turn:
+            $ref: '#/components/schemas/ConversationForkTurn'
+          snapshot:
+            $ref: '#/components/schemas/ConversationForkSnapshot'
+          sandbox_policy:
+            $ref: '#/components/schemas/ConversationForkSandboxPolicy'
+          idempotency_replayed:
+            type: boolean
       ConversationForkCreateResult:
         type: object
         additionalProperties: false
@@ -13078,7 +13269,7 @@ api_specification:
       errors: []
     conversation.fork_view:
       tier: should_have
-      description: Read one forkchat lifecycle session header/state. The turns array remains empty until conversation.fork_chat exists.
+      description: Read one forkchat lifecycle session header/state and fork-local transcript turns owned by conversation_fork_turns.
       scope:
         required:
         - read:conversations
@@ -13094,6 +13285,42 @@ api_specification:
           $ref: '#/components/schemas/ConversationForkSession'
       errors:
       - FORK_NOT_FOUND
+    conversation.fork_chat:
+      tier: should_have
+      description: |
+        Execute one sandboxed forkchat turn against an active fork lifecycle session.
+        The method consumes conversation_forks for lifecycle validation,
+        conversation_fork_snapshots for source-at-fork context, and
+        conversation_fork_turns for fork-local transcript persistence. It does
+        not write agent_turns, events, runtime logs, mailbox rows, run commands,
+        or dashboard conversation rows by default.
+      scope:
+        required:
+        - write:conversations
+        - read:conversations
+      idempotency: per the convention.
+      params:
+      - name: fork_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: message
+        required: true
+        schema:
+          type: string
+          minLength: 1
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/ConversationForkChatResult'
+      errors:
+      - FORK_NOT_FOUND
+      - IDEMPOTENCY_CONFLICT
     conversation.fork_delete:
       tier: should_have
       description: Soft-delete one forkchat lifecycle session from the isolated conversation_forks owner.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -10694,9 +10694,9 @@ api_specification:
             additionalProperties: true
           tool_calls:
             type: array
-            description: Sandbox-observed tool calls for this fork-local turn. Entries include snapshot-read
-              evidence and stubbed side-effect tool results; they are fork-local facts and are not live runtime
-              side effects.
+            description: Sandbox-observed tool calls requested during this fork-local turn. Entries may include
+              snapshot-read evidence and requested side-effect tool results stubbed as fork-local facts; they are
+              not synthesized for unrequested tools and are not live runtime side effects.
             items:
               type: object
               additionalProperties: true
@@ -13295,10 +13295,12 @@ api_specification:
         The method consumes conversation_forks for lifecycle validation,
         conversation_fork_snapshots for source-at-fork context, and
         conversation_fork_turns for fork-local transcript persistence. It does
-        enforce fork-snapshot read tools and records side-effecting tools as
-        stubbed fork-local results under ConversationForkSandboxPolicy. It does
-        not write agent_turns, events, runtime logs, mailbox rows, run commands,
-        or dashboard conversation rows by default.
+        execute the source agent through the forkchat sandbox executor, provides
+        fork-snapshot read tools, and records only sandbox-observed requested
+        side-effecting tools as stubbed fork-local results under
+        ConversationForkSandboxPolicy. It does not write agent_turns, events,
+        runtime logs, mailbox rows, run commands, or dashboard conversation rows
+        by default.
       scope:
         required:
         - write:conversations

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -10694,6 +10694,9 @@ api_specification:
             additionalProperties: true
           tool_calls:
             type: array
+            description: Sandbox-observed tool calls for this fork-local turn. Entries include snapshot-read
+              evidence and stubbed side-effect tool results; they are fork-local facts and are not live runtime
+              side effects.
             items:
               type: object
               additionalProperties: true
@@ -13292,6 +13295,8 @@ api_specification:
         The method consumes conversation_forks for lifecycle validation,
         conversation_fork_snapshots for source-at-fork context, and
         conversation_fork_turns for fork-local transcript persistence. It does
+        enforce fork-snapshot read tools and records side-effecting tools as
+        stubbed fork-local results under ConversationForkSandboxPolicy. It does
         not write agent_turns, events, runtime logs, mailbox rows, run commands,
         or dashboard conversation rows by default.
       scope:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,17 +16,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 47 {
-		t.Fatalf("method count = %d, want 47", report.MethodCount)
+	if report.MethodCount != 48 {
+		t.Fatalf("method count = %d, want 48", report.MethodCount)
 	}
-	if report.SchemaCount != 77 {
-		t.Fatalf("schema count = %d, want 77", report.SchemaCount)
+	if report.SchemaCount != 82 {
+		t.Fatalf("schema count = %d, want 82", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 29 {
 		t.Fatalf("error code count = %d, want 29", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 18 {
-		t.Fatalf("mutating method count = %d, want 18", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 19 {
+		t.Fatalf("mutating method count = %d, want 19", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
@@ -66,11 +66,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 47 {
-		t.Fatalf("generated OpenRPC methods = %d, want 47", len(doc.Methods))
+	if len(doc.Methods) != 48 {
+		t.Fatalf("generated OpenRPC methods = %d, want 48", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 77 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 77", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 82 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 82", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 29 {
 		t.Fatalf("generated OpenRPC errors = %d, want 29", len(doc.Components.Errors))
@@ -93,7 +93,7 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := methods["agent.diagnose"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.diagnose")
 	}
-	for _, methodName := range []string{"conversation.fork", "conversation.fork_list", "conversation.fork_view", "conversation.fork_delete"} {
+	for _, methodName := range []string{"conversation.fork", "conversation.fork_chat", "conversation.fork_list", "conversation.fork_view", "conversation.fork_delete"} {
 		if _, ok := methods[methodName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", methodName)
 		}
@@ -118,7 +118,18 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}
 	}
-	for _, schemaName := range []string{"ConversationForkPointSelector", "ConversationForkPointDescriptor", "ConversationForkSession", "ConversationForkCreateResult", "ConversationForkDeleteResult"} {
+	for _, schemaName := range []string{
+		"ConversationForkPointSelector",
+		"ConversationForkPointDescriptor",
+		"ConversationForkSession",
+		"ConversationForkTurn",
+		"ConversationForkEntitySnapshot",
+		"ConversationForkSnapshot",
+		"ConversationForkSandboxPolicy",
+		"ConversationForkChatResult",
+		"ConversationForkCreateResult",
+		"ConversationForkDeleteResult",
+	} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 47 {
-		t.Fatalf("method count = %d, want 47", len(openRPCNames))
+	if len(openRPCNames) != 48 {
+		t.Fatalf("method count = %d, want 48", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 47 {
-		t.Fatalf("generated OpenRPC methods = %d, want 47", len(doc.Methods))
+	if len(doc.Methods) != 48 {
+		t.Fatalf("generated OpenRPC methods = %d, want 48", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -218,6 +218,7 @@ func approvedMutatingHTTPRuntimeMethods() []string {
 		"agent.restart",
 		"agent.send_directive",
 		"conversation.fork",
+		"conversation.fork_chat",
 		"conversation.fork_delete",
 		"event.publish",
 		"event.replay",
@@ -278,6 +279,12 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			Params:         map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(1)}},
 			ConflictParams: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "turn", "turn_index": float64(2)}},
 			ResultKeys:     []string{"fork", "idempotency_replayed"},
+			SuccessEffects: 1,
+		},
+		"conversation.fork_chat": {
+			Params:         map[string]any{"fork_id": forkID, "message": "inspect fork"},
+			ConflictParams: map[string]any{"fork_id": forkID, "message": "different message"},
+			ResultKeys:     []string{"fork_id", "turn", "snapshot", "sandbox_policy", "idempotency_replayed"},
 			SuccessEffects: 1,
 		},
 		"conversation.fork_delete": {
@@ -419,6 +426,9 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		}}},
 		{Method: "conversation.fork", Params: map[string]any{"source_session_id": sourceSessionID, "fork_point": map[string]any{"kind": "event", "event_id": "00000000-0000-0000-0000-000000000901"}, "idempotency_key": "idem-error"}, Code: EventNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.forks.createErr = store.ErrEventNotFound
+		}}},
+		{Method: "conversation.fork_chat", Params: map[string]any{"fork_id": forkID, "message": "inspect fork", "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.forks.chatErr = store.ErrConversationForkNotFound
 		}}},
 		{Method: "conversation.fork_delete", Params: map[string]any{"fork_id": forkID, "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.forks.deleteErr = store.ErrConversationForkNotFound
@@ -650,6 +660,38 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 			ExpiresAt: now.Add(store.ConversationForkLifecycleTTL),
 			State:     "active",
 			Turns:     []store.OperatorConversationTurn{},
+		},
+		chatResult: store.ConversationForkChatResult{
+			ForkID: "00000000-0000-0000-0000-000000000301",
+			Turn: store.OperatorConversationTurn{
+				TurnIndex:       1,
+				TurnID:          "00000000-0000-0000-0000-000000000402",
+				RequestPayload:  []byte(`{"message":"inspect fork"}`),
+				ResponsePayload: []byte(`{"message":"forkchat sandbox response: inspect fork"}`),
+				ParseOK:         true,
+			},
+			Snapshot: store.ConversationForkSnapshot{
+				ForkID:          "00000000-0000-0000-0000-000000000301",
+				SourceSessionID: "00000000-0000-0000-0000-000000000201",
+				SourceRunID:     runID,
+				SourceAgentID:   "agent-a",
+				SourceTurn: store.ConversationForkSourceTurn{
+					TurnID:     "00000000-0000-0000-0000-000000000401",
+					TurnIndex:  1,
+					SelectedAt: now,
+					CreatedAt:  now,
+				},
+				EntitySnapshot: []store.ConversationForkEntitySnapshot{},
+				SnapshotOwner:  store.ConversationForkChatSnapshotOwner,
+				CreatedAt:      now,
+			},
+			SandboxPolicy: store.ConversationForkSandboxPolicy{
+				Owner:              store.ConversationForkChatSandboxOwner,
+				ReadPolicy:         "fork_snapshot_only",
+				WritePolicy:        "stub_record_only_no_live_mutation",
+				SideEffectingTools: []string{"save_entity_field"},
+				StubbedTools:       []string{"save_entity_field"},
+			},
 		},
 		deleteResult: store.ConversationForkDeleteResult{ForkID: "00000000-0000-0000-0000-000000000301", Deleted: true},
 		recordEffect: state.recordEffect,

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -428,7 +428,7 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.forks.createErr = store.ErrEventNotFound
 		}}},
 		{Method: "conversation.fork_chat", Params: map[string]any{"fork_id": forkID, "message": "inspect fork", "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
-			s.forks.chatErr = store.ErrConversationForkNotFound
+			s.forks.prepareErr = store.ErrConversationForkNotFound
 		}}},
 		{Method: "conversation.fork_delete", Params: map[string]any{"fork_id": forkID, "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.forks.deleteErr = store.ErrConversationForkNotFound
@@ -661,7 +661,49 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 			State:     "active",
 			Turns:     []store.OperatorConversationTurn{},
 		},
-		chatResult: store.ConversationForkChatResult{
+		prepareResult: store.ConversationForkChatPrepared{
+			Fork: store.OperatorConversationForkSession{
+				ForkID:          "00000000-0000-0000-0000-000000000301",
+				SourceSessionID: "00000000-0000-0000-0000-000000000201",
+				SourceRunID:     runID,
+				SourceAgentID:   "agent-a",
+				ForkPoint: store.ConversationForkPointDescriptor{
+					Kind:       "turn",
+					TurnIndex:  1,
+					TurnID:     "00000000-0000-0000-0000-000000000401",
+					SelectedAt: now,
+				},
+				CreatedBy: "token",
+				CreatedAt: now,
+				ExpiresAt: now.Add(store.ConversationForkLifecycleTTL),
+				State:     "active",
+				Turns:     []store.OperatorConversationTurn{},
+			},
+			Snapshot: store.ConversationForkSnapshot{
+				ForkID:          "00000000-0000-0000-0000-000000000301",
+				SourceSessionID: "00000000-0000-0000-0000-000000000201",
+				SourceRunID:     runID,
+				SourceAgentID:   "agent-a",
+				SourceTurn: store.ConversationForkSourceTurn{
+					TurnID:     "00000000-0000-0000-0000-000000000401",
+					TurnIndex:  1,
+					SelectedAt: now,
+					CreatedAt:  now,
+				},
+				EntitySnapshot: []store.ConversationForkEntitySnapshot{},
+				SnapshotOwner:  store.ConversationForkChatSnapshotOwner,
+				CreatedAt:      now,
+			},
+			SandboxPolicy: store.ConversationForkSandboxPolicy{
+				Owner:              store.ConversationForkChatSandboxOwner,
+				ReadPolicy:         "fork_snapshot_only",
+				WritePolicy:        "stub_record_only_no_live_mutation",
+				SideEffectingTools: []string{"save_entity_field"},
+				StubbedTools:       []string{"save_entity_field"},
+			},
+			AvailableTools: []string{"fork_snapshot_read_entities", "save_entity_field"},
+		},
+		recordResult: store.ConversationForkChatResult{
 			ForkID: "00000000-0000-0000-0000-000000000301",
 			Turn: store.OperatorConversationTurn{
 				TurnIndex:       1,
@@ -703,13 +745,16 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 	t.Helper()
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	return OperatorReadOptions{
-		Now:                   func() time.Time { return s.now },
-		Ready:                 func() bool { return true },
-		Database:              fakePinger{},
-		Runs:                  s.runs,
-		Observability:         s.observability,
-		AgentControl:          s.agentControl,
-		ConversationForks:     s.forks,
+		Now:               func() time.Time { return s.now },
+		Ready:             func() bool { return true },
+		Database:          fakePinger{},
+		Runs:              s.runs,
+		Observability:     s.observability,
+		AgentControl:      s.agentControl,
+		ConversationForks: s.forks,
+		ForkChatExecutor: &fakeForkChatExecutor{result: store.ConversationForkChatExecution{
+			AssistantMessage: "forkchat sandbox response: inspect fork",
+		}},
 		Mailbox:               s.mailbox,
 		Idempotency:           s.idempotency,
 		Events:                s.events,

--- a/internal/apiv1/operator_conversation_fork.go
+++ b/internal/apiv1/operator_conversation_fork.go
@@ -17,8 +17,13 @@ type ConversationForkLifecycleStore interface {
 	CreateOperatorConversationFork(context.Context, store.ConversationForkCreateRequest) (store.OperatorConversationForkSession, error)
 	ListOperatorConversationForks(context.Context, store.ConversationForkListOptions) (store.ConversationForkListResult, error)
 	LoadOperatorConversationFork(context.Context, string) (store.OperatorConversationForkSession, error)
-	ChatOperatorConversationFork(context.Context, store.ConversationForkChatRequest) (store.ConversationForkChatResult, error)
+	PrepareOperatorConversationForkChat(context.Context, store.ConversationForkChatPrepareRequest) (store.ConversationForkChatPrepared, error)
+	RecordOperatorConversationForkChat(context.Context, store.ConversationForkChatRecordRequest) (store.ConversationForkChatResult, error)
 	DeleteOperatorConversationFork(context.Context, string, time.Time) (store.ConversationForkDeleteResult, error)
+}
+
+type ForkChatExecutor interface {
+	ExecuteForkChat(context.Context, store.ConversationForkChatPrepared, string) (store.ConversationForkChatExecution, error)
 }
 
 type conversationForkCreateResult struct {
@@ -171,10 +176,25 @@ func executeConversationForkChat(ctx context.Context, req Request, opts Operator
 		TTL:            conversationForkIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		result, err := opts.ConversationForks.ChatOperatorConversationFork(ctx, store.ConversationForkChatRequest{
+		if opts.ForkChatExecutor == nil {
+			return store.APIIdempotencyCompletion{}, fmt.Errorf("conversation fork chat executor is required")
+		}
+		prepared, err := opts.ConversationForks.PrepareOperatorConversationForkChat(ctx, store.ConversationForkChatPrepareRequest{
+			ForkID: forkID,
+			Now:    now,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
+		}
+		execution, err := opts.ForkChatExecutor.ExecuteForkChat(ctx, prepared, message)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		result, err := opts.ConversationForks.RecordOperatorConversationForkChat(ctx, store.ConversationForkChatRecordRequest{
 			ForkID:       forkID,
 			Message:      message,
 			ActorTokenID: req.ActorTokenID,
+			Execution:    execution,
 			Now:          now,
 		})
 		if err != nil {

--- a/internal/apiv1/operator_conversation_fork.go
+++ b/internal/apiv1/operator_conversation_fork.go
@@ -17,6 +17,7 @@ type ConversationForkLifecycleStore interface {
 	CreateOperatorConversationFork(context.Context, store.ConversationForkCreateRequest) (store.OperatorConversationForkSession, error)
 	ListOperatorConversationForks(context.Context, store.ConversationForkListOptions) (store.ConversationForkListResult, error)
 	LoadOperatorConversationFork(context.Context, string) (store.OperatorConversationForkSession, error)
+	ChatOperatorConversationFork(context.Context, store.ConversationForkChatRequest) (store.ConversationForkChatResult, error)
 	DeleteOperatorConversationFork(context.Context, string, time.Time) (store.ConversationForkDeleteResult, error)
 }
 
@@ -76,6 +77,9 @@ func OperatorConversationForkHandlers(opts OperatorReadOptions) map[string]Metho
 				return nil, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
 			}
 			return result, nil
+		},
+		"conversation.fork_chat": func(ctx context.Context, req Request) (any, error) {
+			return executeConversationForkChat(ctx, req, opts, now().UTC())
 		},
 		"conversation.fork_delete": func(ctx context.Context, req Request) (any, error) {
 			return executeConversationForkDelete(ctx, req, opts, now().UTC())
@@ -140,6 +144,58 @@ func executeConversationForkCreate(ctx context.Context, req Request, opts Operat
 			return nil, fmt.Errorf("decode conversation.fork idempotency response: %w", err)
 		}
 		return nil, fmt.Errorf("decode conversation.fork response: %w", err)
+	}
+	result.IdempotencyReplayed = replay
+	return result, nil
+}
+
+func executeConversationForkChat(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	forkID, err := requiredStringParam(req.Params, "fork_id")
+	if err != nil {
+		return nil, err
+	}
+	message, err := requiredStringParam(req.Params, "message")
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     forkID,
+		TTL:            conversationForkIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := opts.ConversationForks.ChatOperatorConversationFork(ctx, store.ConversationForkChatRequest{
+			ForkID:       forkID,
+			Message:      message,
+			ActorTokenID: req.ActorTokenID,
+			Now:          now,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
+		}
+		result.IdempotencyReplayed = false
+		response, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: result.ForkID, Response: response}, nil
+	})
+	if err != nil {
+		return nil, conversationForkError(err, conversationForkErrorDetails{ForkID: forkID})
+	}
+	var result store.ConversationForkChatResult
+	if err := json.Unmarshal(completion.Response, &result); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode conversation.fork_chat idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode conversation.fork_chat response: %w", err)
 	}
 	result.IdempotencyReplayed = replay
 	return result, nil

--- a/internal/apiv1/operator_conversation_fork_executor.go
+++ b/internal/apiv1/operator_conversation_fork_executor.go
@@ -1,0 +1,270 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
+	runtimellm "swarm/internal/runtime/llm"
+	"swarm/internal/runtime/sessions"
+	"swarm/internal/store"
+)
+
+type LLMForkChatExecutor struct {
+	Runtime runtimellm.Runtime
+}
+
+func NewLLMForkChatExecutor(runtime runtimellm.Runtime) *LLMForkChatExecutor {
+	return &LLMForkChatExecutor{Runtime: runtime}
+}
+
+func (e *LLMForkChatExecutor) ExecuteForkChat(ctx context.Context, prepared store.ConversationForkChatPrepared, message string) (store.ConversationForkChatExecution, error) {
+	if e == nil || e.Runtime == nil {
+		return store.ConversationForkChatExecution{}, fmt.Errorf("conversation fork chat llm runtime is required")
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return store.ConversationForkChatExecution{}, fmt.Errorf("conversation fork chat message is required")
+	}
+	actor := conversationForkChatActor(prepared)
+	tools := conversationForkChatToolDefinitions(prepared)
+	toolExec := newConversationForkChatToolExecutor(prepared)
+	conv := runtimellm.NewConversation(actor.ID, prepared.Fork.ForkID, conversationForkChatSystemPrompt(prepared), tools, runtimellm.TaskScoped, 8, e.Runtime)
+	conv.SetToolExecutor(toolExec)
+	ctx = runtimeactors.WithActor(ctx, actor)
+	ctx = sessions.WithScope(ctx, sessions.RuntimeModeTask.String(), "", prepared.Fork.ForkID)
+	resp, err := conv.Step(ctx, message)
+	if err != nil {
+		return store.ConversationForkChatExecution{}, fmt.Errorf("execute conversation fork chat turn: %w", err)
+	}
+	assistant := strings.TrimSpace(resp.Message.Content)
+	if assistant == "" {
+		assistant = "Forkchat sandbox turn completed."
+	}
+	return store.ConversationForkChatExecution{
+		AssistantMessage: assistant,
+		ToolCalls:        toolExec.toolCalls(),
+		ToolResults:      toolExec.toolResults(),
+		AvailableTools:   toolNamesFromDefinitions(tools),
+	}, nil
+}
+
+func conversationForkChatActor(prepared store.ConversationForkChatPrepared) runtimeactors.AgentConfig {
+	return runtimeactors.AgentConfig{
+		ID:               strings.TrimSpace(prepared.Fork.SourceAgentID),
+		Type:             "forkchat",
+		Role:             "forkchat",
+		ConversationMode: sessions.RuntimeModeTask.String(),
+		SessionScope:     "",
+		Tools:            append([]string(nil), prepared.AvailableTools...),
+	}
+}
+
+func conversationForkChatSystemPrompt(prepared store.ConversationForkChatPrepared) string {
+	var b strings.Builder
+	b.WriteString("You are executing a forkchat turn inside an isolated forensic sandbox.\n")
+	b.WriteString("Use only the provided forkchat tools when they are useful for answering the operator.\n")
+	b.WriteString("Read source context only through fork_snapshot_read_entities.\n")
+	b.WriteString("Side-effecting tools are sandbox stubs: they record fork-local facts and never mutate live state.\n")
+	b.WriteString("Source agent: ")
+	b.WriteString(strings.TrimSpace(prepared.Fork.SourceAgentID))
+	b.WriteString("\nSource run: ")
+	b.WriteString(strings.TrimSpace(prepared.Fork.SourceRunID))
+	b.WriteString("\nFork id: ")
+	b.WriteString(strings.TrimSpace(prepared.Fork.ForkID))
+	b.WriteString("\nSnapshot owner: ")
+	b.WriteString(strings.TrimSpace(prepared.Snapshot.SnapshotOwner))
+	return b.String()
+}
+
+func conversationForkChatToolDefinitions(prepared store.ConversationForkChatPrepared) []runtimellm.ToolDefinition {
+	names := append([]string(nil), prepared.AvailableTools...)
+	if len(names) == 0 {
+		names = []string{"fork_snapshot_read_entities"}
+	}
+	defs := make([]runtimellm.ToolDefinition, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		desc := "Forkchat sandbox tool. Results are fork-local and never mutate live runtime state."
+		if name == "fork_snapshot_read_entities" {
+			desc = "Read the source-at-fork entity snapshot captured for this forkchat session."
+		}
+		defs = append(defs, runtimellm.ToolDefinition{
+			Name:        name,
+			Description: desc,
+			Schema: map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+				"properties":           map[string]any{},
+			},
+		})
+	}
+	return defs
+}
+
+func toolNamesFromDefinitions(defs []runtimellm.ToolDefinition) []string {
+	out := make([]string, 0, len(defs))
+	for _, def := range defs {
+		name := strings.TrimSpace(def.Name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+type conversationForkChatToolExecutor struct {
+	prepared store.ConversationForkChatPrepared
+	mu       sync.Mutex
+	calls    []store.OperatorConversationToolCall
+	results  []store.OperatorConversationToolResult
+}
+
+func newConversationForkChatToolExecutor(prepared store.ConversationForkChatPrepared) *conversationForkChatToolExecutor {
+	return &conversationForkChatToolExecutor{prepared: prepared}
+}
+
+func (e *conversationForkChatToolExecutor) Execute(ctx context.Context, name string, input any) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	name = strings.TrimSpace(name)
+	canonical := conversationForkChatCanonicalToolName(name)
+	switch canonical {
+	case "fork_snapshot.read_entities":
+		out := map[string]any{
+			"status":          "read_from_snapshot",
+			"read_policy":     e.prepared.SandboxPolicy.ReadPolicy,
+			"snapshot_owner":  e.prepared.Snapshot.SnapshotOwner,
+			"source_agent_id": e.prepared.Fork.SourceAgentID,
+			"entity_count":    len(e.prepared.Snapshot.EntitySnapshot),
+			"entities":        e.prepared.Snapshot.EntitySnapshot,
+		}
+		return e.record(name, input, out)
+	default:
+		if !conversationForkChatIsSideEffectTool(e.prepared.SandboxPolicy, canonical) {
+			return nil, fmt.Errorf("forkchat tool %q is not available in sandbox policy", name)
+		}
+		out := map[string]any{
+			"status":              "stubbed",
+			"owner":               e.prepared.SandboxPolicy.Owner,
+			"write_policy":        e.prepared.SandboxPolicy.WritePolicy,
+			"requested_tool":      canonical,
+			"requested_tool_name": name,
+			"live_mutation":       false,
+			"reason":              "forkchat sandbox records side-effecting tools as fork-local facts only",
+		}
+		return e.record(name, input, out)
+	}
+}
+
+func (e *conversationForkChatToolExecutor) ToolCapabilitiesForActor(_ runtimeactors.AgentConfig, names []string, _ map[string]struct{}) toolcapabilities.Set {
+	caps := make([]toolcapabilities.Capability, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		caps = append(caps, toolcapabilities.Capability{Name: name, Kind: toolcapabilities.KindStandard, Visible: true, Callable: true})
+	}
+	return toolcapabilities.NewSet(caps)
+}
+
+func (e *conversationForkChatToolExecutor) record(name string, input any, out map[string]any) (map[string]any, error) {
+	argsRaw, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	resultRaw, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	toolUseID := fmt.Sprintf("forkchat-tool-%02d", len(e.calls)+1)
+	call := store.OperatorConversationToolCall{
+		ToolUseID: toolUseID,
+		Name:      strings.TrimSpace(name),
+		Arguments: argsRaw,
+		Result:    resultRaw,
+	}
+	result := store.OperatorConversationToolResult{
+		ToolName:  strings.TrimSpace(name),
+		ToolUseID: toolUseID,
+		Output:    cloneRawJSON(resultRaw),
+	}
+	e.calls = append(e.calls, call)
+	e.results = append(e.results, result)
+	return out, nil
+}
+
+func (e *conversationForkChatToolExecutor) toolCalls() []store.OperatorConversationToolCall {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]store.OperatorConversationToolCall, len(e.calls))
+	copy(out, e.calls)
+	for i := range out {
+		out[i].Arguments = cloneRawJSON(out[i].Arguments)
+		out[i].Result = cloneRawJSON(out[i].Result)
+	}
+	return out
+}
+
+func (e *conversationForkChatToolExecutor) toolResults() []store.OperatorConversationToolResult {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]store.OperatorConversationToolResult, len(e.results))
+	copy(out, e.results)
+	for i := range out {
+		out[i].Output = cloneRawJSON(out[i].Output)
+	}
+	return out
+}
+
+func conversationForkChatCanonicalToolName(name string) string {
+	switch strings.TrimSpace(name) {
+	case "fork_snapshot_read_entities", "fork_snapshot.read_entities":
+		return "fork_snapshot.read_entities"
+	case "mailbox_approve":
+		return "mailbox.approve"
+	case "mailbox_reject":
+		return "mailbox.reject"
+	case "mailbox_defer":
+		return "mailbox.defer"
+	case "run_start":
+		return "run.start"
+	case "run_continue":
+		return "run.continue"
+	case "run_pause":
+		return "run.pause"
+	case "run_stop":
+		return "run.stop"
+	default:
+		return strings.TrimSpace(name)
+	}
+}
+
+func conversationForkChatIsSideEffectTool(policy store.ConversationForkSandboxPolicy, canonical string) bool {
+	for _, name := range policy.StubbedTools {
+		if conversationForkChatCanonicalToolName(name) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneRawJSON(in json.RawMessage) json.RawMessage {
+	if in == nil {
+		return nil
+	}
+	out := make(json.RawMessage, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/apiv1/operator_conversation_fork_test.go
+++ b/internal/apiv1/operator_conversation_fork_test.go
@@ -16,17 +16,21 @@ type fakeConversationForkLifecycleStore struct {
 	listErr      error
 	viewResult   store.OperatorConversationForkSession
 	viewErr      error
+	chatResult   store.ConversationForkChatResult
+	chatErr      error
 	deleteResult store.ConversationForkDeleteResult
 	deleteErr    error
 
 	createCalls int
 	listCalls   int
 	viewCalls   int
+	chatCalls   int
 	deleteCalls int
 
 	lastCreate store.ConversationForkCreateRequest
 	lastList   store.ConversationForkListOptions
 	lastViewID string
+	lastChat   store.ConversationForkChatRequest
 	lastDelete string
 	lastNow    time.Time
 
@@ -55,6 +59,18 @@ func (s *fakeConversationForkLifecycleStore) LoadOperatorConversationFork(_ cont
 	s.viewCalls++
 	s.lastViewID = forkID
 	return s.viewResult, s.viewErr
+}
+
+func (s *fakeConversationForkLifecycleStore) ChatOperatorConversationFork(_ context.Context, req store.ConversationForkChatRequest) (store.ConversationForkChatResult, error) {
+	s.chatCalls++
+	s.lastChat = req
+	if s.chatErr != nil {
+		return store.ConversationForkChatResult{}, s.chatErr
+	}
+	if s.recordEffect != nil {
+		s.recordEffect()
+	}
+	return s.chatResult, nil
 }
 
 func (s *fakeConversationForkLifecycleStore) DeleteOperatorConversationFork(_ context.Context, forkID string, now time.Time) (store.ConversationForkDeleteResult, error) {
@@ -97,6 +113,36 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 		createResult: fork,
 		listResult:   store.ConversationForkListResult{Forks: []store.OperatorConversationForkSession{fork}, NextCursor: "cursor-2"},
 		viewResult:   fork,
+		chatResult: store.ConversationForkChatResult{
+			ForkID: forkID,
+			Turn: store.OperatorConversationTurn{
+				TurnIndex:       1,
+				TurnID:          "00000000-0000-0000-0000-000000000402",
+				RequestPayload:  []byte(`{"message":"inspect"}`),
+				ResponsePayload: []byte(`{"message":"forkchat sandbox response: inspect"}`),
+				ParseOK:         true,
+			},
+			Snapshot: store.ConversationForkSnapshot{
+				ForkID:          forkID,
+				SourceSessionID: sourceSessionID,
+				SourceRunID:     "00000000-0000-0000-0000-000000000501",
+				SourceAgentID:   "agent-1",
+				SourceTurn: store.ConversationForkSourceTurn{
+					TurnID:     turnID,
+					TurnIndex:  2,
+					SelectedAt: created,
+					CreatedAt:  created,
+				},
+				EntitySnapshot: []store.ConversationForkEntitySnapshot{},
+				SnapshotOwner:  store.ConversationForkChatSnapshotOwner,
+				CreatedAt:      now,
+			},
+			SandboxPolicy: store.ConversationForkSandboxPolicy{
+				Owner:       store.ConversationForkChatSandboxOwner,
+				ReadPolicy:  "fork_snapshot_only",
+				WritePolicy: "stub_record_only_no_live_mutation",
+			},
+		},
 		deleteResult: store.ConversationForkDeleteResult{ForkID: forkID, Deleted: true},
 	}
 	handler := testHandler(t, Options{
@@ -155,6 +201,32 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 	}
 	if forks.viewCalls != 1 || forks.lastViewID != forkID {
 		t.Fatalf("view owner call = calls %d fork_id %s", forks.viewCalls, forks.lastViewID)
+	}
+
+	chat := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"chat","method":"conversation.fork_chat","params":{"fork_id":"`+forkID+`","message":"inspect","idempotency_key":"chat-1"}}`)
+	if chat.Error != nil {
+		t.Fatalf("conversation.fork_chat error = %#v", chat.Error)
+	}
+	chatResult := asMap(t, chat.Result)
+	if chatResult["fork_id"] != forkID || chatResult["idempotency_replayed"] != false {
+		t.Fatalf("conversation.fork_chat result = %#v", chatResult)
+	}
+	if got := asMap(t, chatResult["snapshot"])["snapshot_owner"]; got != store.ConversationForkChatSnapshotOwner {
+		t.Fatalf("conversation.fork_chat snapshot owner = %#v", got)
+	}
+	if forks.chatCalls != 1 || forks.lastChat.ForkID != forkID || forks.lastChat.Message != "inspect" || !forks.lastChat.Now.Equal(now) {
+		t.Fatalf("chat owner call = calls %d req %#v", forks.chatCalls, forks.lastChat)
+	}
+
+	chatReplay := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"chat-replay","method":"conversation.fork_chat","params":{"fork_id":"`+forkID+`","message":"inspect","idempotency_key":"chat-1"}}`)
+	if chatReplay.Error != nil {
+		t.Fatalf("conversation.fork_chat replay error = %#v", chatReplay.Error)
+	}
+	if got := asMap(t, chatReplay.Result)["idempotency_replayed"]; got != true {
+		t.Fatalf("conversation.fork_chat replay idempotency_replayed = %#v, want true", got)
+	}
+	if forks.chatCalls != 1 {
+		t.Fatalf("conversation.fork_chat owner calls after replay = %d, want 1", forks.chatCalls)
 	}
 
 	deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"conversation.fork_delete","params":{"fork_id":"`+forkID+`","idempotency_key":"delete-1"}}`)
@@ -218,6 +290,14 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			method: "conversation.fork_view",
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_view","params":{"fork_id":"` + forkID + `"}}`,
 			mutate: func(s *fakeConversationForkLifecycleStore) { s.viewErr = store.ErrConversationForkNotFound },
+			code:   ForkNotFoundCode,
+			detail: map[string]any{"fork_id": forkID},
+		},
+		{
+			name:   "chat missing fork",
+			method: "conversation.fork_chat",
+			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_chat","params":{"fork_id":"` + forkID + `","message":"hello"}}`,
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.chatErr = store.ErrConversationForkNotFound },
 			code:   ForkNotFoundCode,
 			detail: map[string]any{"fork_id": forkID},
 		},

--- a/internal/apiv1/operator_conversation_fork_test.go
+++ b/internal/apiv1/operator_conversation_fork_test.go
@@ -2,37 +2,44 @@ package apiv1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/store"
 )
 
 type fakeConversationForkLifecycleStore struct {
-	createResult store.OperatorConversationForkSession
-	createErr    error
-	listResult   store.ConversationForkListResult
-	listErr      error
-	viewResult   store.OperatorConversationForkSession
-	viewErr      error
-	chatResult   store.ConversationForkChatResult
-	chatErr      error
-	deleteResult store.ConversationForkDeleteResult
-	deleteErr    error
+	createResult  store.OperatorConversationForkSession
+	createErr     error
+	listResult    store.ConversationForkListResult
+	listErr       error
+	viewResult    store.OperatorConversationForkSession
+	viewErr       error
+	prepareResult store.ConversationForkChatPrepared
+	prepareErr    error
+	recordResult  store.ConversationForkChatResult
+	recordErr     error
+	deleteResult  store.ConversationForkDeleteResult
+	deleteErr     error
 
-	createCalls int
-	listCalls   int
-	viewCalls   int
-	chatCalls   int
-	deleteCalls int
+	createCalls  int
+	listCalls    int
+	viewCalls    int
+	prepareCalls int
+	recordCalls  int
+	deleteCalls  int
 
-	lastCreate store.ConversationForkCreateRequest
-	lastList   store.ConversationForkListOptions
-	lastViewID string
-	lastChat   store.ConversationForkChatRequest
-	lastDelete string
-	lastNow    time.Time
+	lastCreate  store.ConversationForkCreateRequest
+	lastList    store.ConversationForkListOptions
+	lastViewID  string
+	lastPrepare store.ConversationForkChatPrepareRequest
+	lastRecord  store.ConversationForkChatRecordRequest
+	lastDelete  string
+	lastNow     time.Time
 
 	recordEffect func()
 }
@@ -61,16 +68,25 @@ func (s *fakeConversationForkLifecycleStore) LoadOperatorConversationFork(_ cont
 	return s.viewResult, s.viewErr
 }
 
-func (s *fakeConversationForkLifecycleStore) ChatOperatorConversationFork(_ context.Context, req store.ConversationForkChatRequest) (store.ConversationForkChatResult, error) {
-	s.chatCalls++
-	s.lastChat = req
-	if s.chatErr != nil {
-		return store.ConversationForkChatResult{}, s.chatErr
+func (s *fakeConversationForkLifecycleStore) PrepareOperatorConversationForkChat(_ context.Context, req store.ConversationForkChatPrepareRequest) (store.ConversationForkChatPrepared, error) {
+	s.prepareCalls++
+	s.lastPrepare = req
+	if s.prepareErr != nil {
+		return store.ConversationForkChatPrepared{}, s.prepareErr
+	}
+	return s.prepareResult, nil
+}
+
+func (s *fakeConversationForkLifecycleStore) RecordOperatorConversationForkChat(_ context.Context, req store.ConversationForkChatRecordRequest) (store.ConversationForkChatResult, error) {
+	s.recordCalls++
+	s.lastRecord = req
+	if s.recordErr != nil {
+		return store.ConversationForkChatResult{}, s.recordErr
 	}
 	if s.recordEffect != nil {
 		s.recordEffect()
 	}
-	return s.chatResult, nil
+	return s.recordResult, nil
 }
 
 func (s *fakeConversationForkLifecycleStore) DeleteOperatorConversationFork(_ context.Context, forkID string, now time.Time) (store.ConversationForkDeleteResult, error) {
@@ -84,6 +100,24 @@ func (s *fakeConversationForkLifecycleStore) DeleteOperatorConversationFork(_ co
 		s.recordEffect()
 	}
 	return s.deleteResult, nil
+}
+
+type fakeForkChatExecutor struct {
+	result       store.ConversationForkChatExecution
+	err          error
+	calls        int
+	lastPrepared store.ConversationForkChatPrepared
+	lastMessage  string
+}
+
+func (f *fakeForkChatExecutor) ExecuteForkChat(_ context.Context, prepared store.ConversationForkChatPrepared, message string) (store.ConversationForkChatExecution, error) {
+	f.calls++
+	f.lastPrepared = prepared
+	f.lastMessage = message
+	if f.err != nil {
+		return store.ConversationForkChatExecution{}, f.err
+	}
+	return f.result, nil
 }
 
 func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
@@ -113,7 +147,31 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 		createResult: fork,
 		listResult:   store.ConversationForkListResult{Forks: []store.OperatorConversationForkSession{fork}, NextCursor: "cursor-2"},
 		viewResult:   fork,
-		chatResult: store.ConversationForkChatResult{
+		prepareResult: store.ConversationForkChatPrepared{
+			Fork: fork,
+			Snapshot: store.ConversationForkSnapshot{
+				ForkID:          forkID,
+				SourceSessionID: sourceSessionID,
+				SourceRunID:     "00000000-0000-0000-0000-000000000501",
+				SourceAgentID:   "agent-1",
+				SourceTurn: store.ConversationForkSourceTurn{
+					TurnID:     turnID,
+					TurnIndex:  2,
+					SelectedAt: created,
+					CreatedAt:  created,
+				},
+				EntitySnapshot: []store.ConversationForkEntitySnapshot{},
+				SnapshotOwner:  store.ConversationForkChatSnapshotOwner,
+				CreatedAt:      now,
+			},
+			SandboxPolicy: store.ConversationForkSandboxPolicy{
+				Owner:       store.ConversationForkChatSandboxOwner,
+				ReadPolicy:  "fork_snapshot_only",
+				WritePolicy: "stub_record_only_no_live_mutation",
+			},
+			AvailableTools: []string{"fork_snapshot_read_entities"},
+		},
+		recordResult: store.ConversationForkChatResult{
 			ForkID: forkID,
 			Turn: store.OperatorConversationTurn{
 				TurnIndex:       1,
@@ -145,11 +203,22 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 		},
 		deleteResult: store.ConversationForkDeleteResult{ForkID: forkID, Deleted: true},
 	}
+	executor := &fakeForkChatExecutor{result: store.ConversationForkChatExecution{
+		AssistantMessage: "forkchat sandbox response: inspect",
+		ToolCalls: []store.OperatorConversationToolCall{{
+			ToolUseID: "tool-1",
+			Name:      "fork_snapshot_read_entities",
+			Arguments: json.RawMessage(`{"entity_id":"entity-1"}`),
+			Result:    json.RawMessage(`{"status":"read_from_snapshot"}`),
+		}},
+		AvailableTools: []string{"fork_snapshot_read_entities"},
+	}}
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			Now:               func() time.Time { return now },
 			ConversationForks: forks,
+			ForkChatExecutor:  executor,
 			Idempotency:       newMutatingProbeIdempotencyStore(),
 		}),
 	})
@@ -214,8 +283,17 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 	if got := asMap(t, chatResult["snapshot"])["snapshot_owner"]; got != store.ConversationForkChatSnapshotOwner {
 		t.Fatalf("conversation.fork_chat snapshot owner = %#v", got)
 	}
-	if forks.chatCalls != 1 || forks.lastChat.ForkID != forkID || forks.lastChat.Message != "inspect" || !forks.lastChat.Now.Equal(now) {
-		t.Fatalf("chat owner call = calls %d req %#v", forks.chatCalls, forks.lastChat)
+	if forks.prepareCalls != 1 || forks.lastPrepare.ForkID != forkID || !forks.lastPrepare.Now.Equal(now) {
+		t.Fatalf("chat prepare owner call = calls %d req %#v", forks.prepareCalls, forks.lastPrepare)
+	}
+	if executor.calls != 1 || executor.lastPrepared.Fork.ForkID != forkID || executor.lastMessage != "inspect" {
+		t.Fatalf("chat executor call = calls %d prepared %#v message %q", executor.calls, executor.lastPrepared, executor.lastMessage)
+	}
+	if forks.recordCalls != 1 || forks.lastRecord.ForkID != forkID || forks.lastRecord.Message != "inspect" || !forks.lastRecord.Now.Equal(now) {
+		t.Fatalf("chat record owner call = calls %d req %#v", forks.recordCalls, forks.lastRecord)
+	}
+	if got := forks.lastRecord.Execution.ToolCalls; len(got) != 1 || got[0].Name != "fork_snapshot_read_entities" {
+		t.Fatalf("chat record execution tool calls = %#v", got)
 	}
 
 	chatReplay := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"chat-replay","method":"conversation.fork_chat","params":{"fork_id":"`+forkID+`","message":"inspect","idempotency_key":"chat-1"}}`)
@@ -225,8 +303,8 @@ func TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency(t *test
 	if got := asMap(t, chatReplay.Result)["idempotency_replayed"]; got != true {
 		t.Fatalf("conversation.fork_chat replay idempotency_replayed = %#v, want true", got)
 	}
-	if forks.chatCalls != 1 {
-		t.Fatalf("conversation.fork_chat owner calls after replay = %d, want 1", forks.chatCalls)
+	if forks.prepareCalls != 1 || executor.calls != 1 || forks.recordCalls != 1 {
+		t.Fatalf("conversation.fork_chat calls after replay = prepare %d executor %d record %d, want 1 each", forks.prepareCalls, executor.calls, forks.recordCalls)
 	}
 
 	deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"conversation.fork_delete","params":{"fork_id":"`+forkID+`","idempotency_key":"delete-1"}}`)
@@ -297,7 +375,7 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			name:   "chat missing fork",
 			method: "conversation.fork_chat",
 			body:   `{"jsonrpc":"2.0","id":"err","method":"conversation.fork_chat","params":{"fork_id":"` + forkID + `","message":"hello"}}`,
-			mutate: func(s *fakeConversationForkLifecycleStore) { s.chatErr = store.ErrConversationForkNotFound },
+			mutate: func(s *fakeConversationForkLifecycleStore) { s.prepareErr = store.ErrConversationForkNotFound },
 			code:   ForkNotFoundCode,
 			detail: map[string]any{"fork_id": forkID},
 		},
@@ -323,7 +401,10 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 				Handlers: OperatorReadHandlers(OperatorReadOptions{
 					Now:               func() time.Time { return now },
 					ConversationForks: forks,
-					Idempotency:       newMutatingProbeIdempotencyStore(),
+					ForkChatExecutor: &fakeForkChatExecutor{result: store.ConversationForkChatExecution{
+						AssistantMessage: "ok",
+					}},
+					Idempotency: newMutatingProbeIdempotencyStore(),
 				}),
 			})
 			resp := rpcCall(t, handler, tt.body)
@@ -348,6 +429,172 @@ func TestOperatorConversationForkHandlersTypedErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLLMForkChatExecutorUsesRuntimeRequestedToolsOnly(t *testing.T) {
+	prepared := store.ConversationForkChatPrepared{
+		Fork: store.OperatorConversationForkSession{
+			ForkID:        "fork-1",
+			SourceRunID:   "run-1",
+			SourceAgentID: "agent-source",
+		},
+		Snapshot: store.ConversationForkSnapshot{
+			SnapshotOwner: store.ConversationForkChatSnapshotOwner,
+			EntitySnapshot: []store.ConversationForkEntitySnapshot{{
+				EntityID:     "entity-1",
+				CurrentState: "draft",
+				Fields:       map[string]any{"name": "Before"},
+			}},
+		},
+		SandboxPolicy: store.ConversationForkSandboxPolicy{
+			Owner:        store.ConversationForkChatSandboxOwner,
+			ReadPolicy:   "fork_snapshot_only",
+			WritePolicy:  "stub_record_only_no_live_mutation",
+			StubbedTools: []string{"save_entity_field", "emit_event", "mailbox.approve", "run.start", "run.stop"},
+		},
+		AvailableTools: []string{"fork_snapshot_read_entities", "save_entity_field", "emit_event", "mailbox_approve", "run_start", "run_stop"},
+	}
+	rt := &forkChatScriptedRuntime{
+		responses: []*runtimellm.Response{
+			{
+				Message: runtimellm.Message{Role: "assistant", Content: "checking tools"},
+				ToolCalls: []runtimellm.ToolCall{
+					{Name: "fork_snapshot_read_entities", Arguments: map[string]any{"entity_id": "entity-1"}},
+					{Name: "save_entity_field", Arguments: map[string]any{"entity_id": "entity-1", "field": "name", "value": "Sandbox"}},
+					{Name: "emit_event", Arguments: map[string]any{"event_name": "forkchat.note"}},
+					{Name: "mailbox_approve", Arguments: map[string]any{"mailbox_id": "mb-1"}},
+					{Name: "run_start", Arguments: map[string]any{"event_name": "scan.requested"}},
+				},
+			},
+			{Message: runtimellm.Message{Role: "assistant", Content: "snapshot says Before; writes were stubbed"}},
+		},
+	}
+	execution, err := NewLLMForkChatExecutor(rt).ExecuteForkChat(context.Background(), prepared, "inspect and try sandbox writes")
+	if err != nil {
+		t.Fatalf("ExecuteForkChat: %v", err)
+	}
+	if rt.startAgentID != "agent-source" {
+		t.Fatalf("StartSession agentID = %q, want source agent", rt.startAgentID)
+	}
+	if !strings.Contains(rt.systemPrompt, "isolated forensic sandbox") || !strings.Contains(rt.systemPrompt, store.ConversationForkChatSnapshotOwner) {
+		t.Fatalf("system prompt = %q, want forkchat sandbox/snapshot context", rt.systemPrompt)
+	}
+	if got := forkChatToolNames(rt.tools); !stringSetContainsAll(got, "fork_snapshot_read_entities", "save_entity_field", "emit_event", "mailbox_approve", "run_start") {
+		t.Fatalf("runtime tools = %v", got)
+	}
+	if len(rt.messages) != 2 || rt.messages[0].Role != "user" || rt.messages[1].Role != "tool" {
+		t.Fatalf("runtime messages = %#v, want user then tool result follow-up", rt.messages)
+	}
+	if execution.AssistantMessage != "snapshot says Before; writes were stubbed" {
+		t.Fatalf("assistant message = %q", execution.AssistantMessage)
+	}
+	if len(execution.ToolCalls) != 5 {
+		t.Fatalf("tool calls = %#v, want only five runtime-requested calls", execution.ToolCalls)
+	}
+	if findConversationForkToolCall(execution.ToolCalls, "run_stop") != nil {
+		t.Fatalf("unrequested run_stop was persisted: %#v", execution.ToolCalls)
+	}
+	read := requireAPIForkToolCall(t, execution.ToolCalls, "fork_snapshot_read_entities")
+	readResult := decodeJSONMap(t, read.Result)
+	if readResult["status"] != "read_from_snapshot" || readResult["snapshot_owner"] != store.ConversationForkChatSnapshotOwner || readResult["entity_count"] != float64(1) {
+		t.Fatalf("snapshot read result = %#v", readResult)
+	}
+	for _, name := range []string{"save_entity_field", "emit_event", "mailbox_approve", "run_start"} {
+		call := requireAPIForkToolCall(t, execution.ToolCalls, name)
+		result := decodeJSONMap(t, call.Result)
+		if result["status"] != "stubbed" || result["owner"] != store.ConversationForkChatSandboxOwner || result["live_mutation"] != false {
+			t.Fatalf("%s result = %#v, want stubbed no-live-mutation", name, result)
+		}
+	}
+	toolResults := decodeJSONArray(t, rt.messages[1].Content)
+	if len(toolResults) != 5 {
+		t.Fatalf("tool result payload = %#v, want five results", toolResults)
+	}
+}
+
+type forkChatScriptedRuntime struct {
+	responses    []*runtimellm.Response
+	startAgentID string
+	systemPrompt string
+	tools        []runtimellm.ToolDefinition
+	messages     []runtimellm.Message
+}
+
+func (r *forkChatScriptedRuntime) StartSession(_ context.Context, agentID, systemPrompt string, tools []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	r.startAgentID = agentID
+	r.systemPrompt = systemPrompt
+	r.tools = append([]runtimellm.ToolDefinition(nil), tools...)
+	return &runtimellm.Session{ID: "forkchat-runtime-session", AgentID: agentID, RuntimeMode: "task"}, nil
+}
+
+func (r *forkChatScriptedRuntime) ContinueSession(_ context.Context, _ *runtimellm.Session, message runtimellm.Message) (*runtimellm.Response, error) {
+	r.messages = append(r.messages, message)
+	if len(r.responses) == 0 {
+		return &runtimellm.Response{Message: runtimellm.Message{Role: "assistant", Content: "done"}}, nil
+	}
+	resp := r.responses[0]
+	r.responses = r.responses[1:]
+	return resp, nil
+}
+
+func forkChatToolNames(tools []runtimellm.ToolDefinition) []string {
+	out := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, tool.Name)
+	}
+	return out
+}
+
+func stringSetContainsAll(values []string, wants ...string) bool {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, want := range wants {
+		if _, ok := seen[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func requireAPIForkToolCall(t *testing.T, calls []store.OperatorConversationToolCall, name string) store.OperatorConversationToolCall {
+	t.Helper()
+	if call := findConversationForkToolCall(calls, name); call != nil {
+		if len(call.Result) == 0 {
+			t.Fatalf("%s tool call missing result: %#v", name, *call)
+		}
+		return *call
+	}
+	t.Fatalf("tool call %s missing from %#v", name, calls)
+	return store.OperatorConversationToolCall{}
+}
+
+func findConversationForkToolCall(calls []store.OperatorConversationToolCall, name string) *store.OperatorConversationToolCall {
+	for i := range calls {
+		if calls[i].Name == name {
+			return &calls[i]
+		}
+	}
+	return nil
+}
+
+func decodeJSONMap(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode JSON map %s: %v", string(raw), err)
+	}
+	return out
+}
+
+func decodeJSONArray(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("decode JSON array %s: %v", raw, err)
+	}
+	return out
 }
 
 func TestOperatorConversationForkRejectsInvalidForkPointBeforeOwner(t *testing.T) {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -58,6 +58,7 @@ type OperatorReadOptions struct {
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
 	ConversationForks     ConversationForkLifecycleStore
+	ForkChatExecutor      ForkChatExecutor
 	AgentControl          AgentControlController
 	Mailbox               MailboxAPIStore
 	Idempotency           APIIdempotencyStore

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -198,6 +198,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: conversation.fork_chat
+    transport: http
+    required_params: [fork_id, message]
+    declared_errors: [FORK_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersTypedErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorConversationForkHandlersUseCanonicalOwnerAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.fork_delete
     transport: http
     required_params: [fork_id]

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -26,6 +26,8 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "agent_turns", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_turns.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_conversation_audits", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "agent_conversation_audits.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_sessions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_sessions.run_id", DeleteOrderGroup: 3},
+		{Table: "conversation_fork_snapshots", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "conversation_fork_snapshots.fork_id -> conversation_forks.source_run_id", DeleteOrderGroup: 3},
+		{Table: "conversation_fork_turns", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "conversation_fork_turns.fork_id -> conversation_forks.source_run_id", DeleteOrderGroup: 3},
 		{Table: "conversation_forks", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "conversation_forks.source_run_id", DeleteOrderGroup: 3},
 		{Table: "entity_mutations", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "entity_mutations.run_id", DeleteOrderGroup: 3},
 		{Table: "entity_state", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "entity_state.run_id", DeleteOrderGroup: 3},

--- a/internal/store/conversation_fork_chat.go
+++ b/internal/store/conversation_fork_chat.go
@@ -17,11 +17,24 @@ const (
 	ConversationForkChatSandboxOwner  = "conversation.fork_chat.sandbox.v1"
 )
 
-type ConversationForkChatRequest struct {
+type ConversationForkChatPrepareRequest struct {
+	ForkID string
+	Now    time.Time
+}
+
+type ConversationForkChatRecordRequest struct {
 	ForkID       string
 	Message      string
 	ActorTokenID string
+	Execution    ConversationForkChatExecution
 	Now          time.Time
+}
+
+type ConversationForkChatPrepared struct {
+	Fork           OperatorConversationForkSession
+	Snapshot       ConversationForkSnapshot
+	SandboxPolicy  ConversationForkSandboxPolicy
+	AvailableTools []string
 }
 
 type ConversationForkChatResult struct {
@@ -71,14 +84,71 @@ type ConversationForkSandboxPolicy struct {
 	StubbedTools       []string `json:"stubbed_tools"`
 }
 
-type conversationForkSandboxExecution struct {
+type ConversationForkChatExecution struct {
 	AssistantMessage string
 	ToolCalls        []OperatorConversationToolCall
 	ToolResults      []OperatorConversationToolResult
 	AvailableTools   []string
 }
 
-func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req ConversationForkChatRequest) (ConversationForkChatResult, error) {
+func (s *PostgresStore) PrepareOperatorConversationForkChat(ctx context.Context, req ConversationForkChatPrepareRequest) (ConversationForkChatPrepared, error) {
+	if s == nil || s.DB == nil {
+		return ConversationForkChatPrepared{}, fmt.Errorf("postgres store is required")
+	}
+	forkID, err := normalizeUUIDParam(req.ForkID, "fork_id")
+	if err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+	now := req.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+	if err := requireConversationForkChatCapabilities(caps, catalog); err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return ConversationForkChatPrepared{}, fmt.Errorf("begin conversation fork chat prepare: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	fork, err := loadActiveConversationForkForChat(ctx, tx, forkID, now)
+	if err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+	snapshot, err := ensureConversationForkSnapshot(ctx, tx, fork, now)
+	if err != nil {
+		return ConversationForkChatPrepared{}, err
+	}
+	policy := defaultConversationForkSandboxPolicy()
+	if err := tx.Commit(); err != nil {
+		return ConversationForkChatPrepared{}, fmt.Errorf("commit conversation fork chat prepare: %w", err)
+	}
+	committed = true
+	return ConversationForkChatPrepared{
+		Fork:           fork,
+		Snapshot:       snapshot,
+		SandboxPolicy:  policy,
+		AvailableTools: conversationForkSandboxAvailableTools(policy),
+	}, nil
+}
+
+func (s *PostgresStore) RecordOperatorConversationForkChat(ctx context.Context, req ConversationForkChatRecordRequest) (ConversationForkChatResult, error) {
 	if s == nil || s.DB == nil {
 		return ConversationForkChatResult{}, fmt.Errorf("postgres store is required")
 	}
@@ -93,6 +163,11 @@ func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req Co
 	actorTokenID := strings.TrimSpace(req.ActorTokenID)
 	if actorTokenID == "" {
 		return ConversationForkChatResult{}, &EntityReadParamError{Field: "actor_token_id", Reason: "is required"}
+	}
+	execution := req.Execution
+	execution.AssistantMessage = strings.TrimSpace(execution.AssistantMessage)
+	if execution.AssistantMessage == "" {
+		return ConversationForkChatResult{}, &EntityReadParamError{Field: "execution.assistant_message", Reason: "is required"}
 	}
 	now := req.Now.UTC()
 	if now.IsZero() {
@@ -113,7 +188,7 @@ func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req Co
 
 	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return ConversationForkChatResult{}, fmt.Errorf("begin conversation fork chat: %w", err)
+		return ConversationForkChatResult{}, fmt.Errorf("begin conversation fork chat record: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -122,18 +197,19 @@ func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req Co
 		}
 	}()
 
-	fork, err := loadActiveConversationForkForChat(ctx, tx, forkID, now)
-	if err != nil {
+	if _, err := loadActiveConversationForkForChat(ctx, tx, forkID, now); err != nil {
 		return ConversationForkChatResult{}, err
 	}
-	snapshot, err := ensureConversationForkSnapshot(ctx, tx, fork, now)
+	snapshot, err := loadConversationForkSnapshot(ctx, tx, forkID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ConversationForkChatResult{}, &EntityReadParamError{Field: "fork_id", Reason: "forkchat snapshot is unavailable"}
+	}
 	if err != nil {
 		return ConversationForkChatResult{}, err
 	}
 	policy := defaultConversationForkSandboxPolicy()
-	execution, err := executeConversationForkSandboxTurn(ctx, fork, snapshot, policy, message)
-	if err != nil {
-		return ConversationForkChatResult{}, err
+	if len(execution.AvailableTools) == 0 {
+		execution.AvailableTools = conversationForkSandboxAvailableTools(policy)
 	}
 	requestPayload, err := conversationForkChatRequestPayload(message, snapshot, execution.AvailableTools)
 	if err != nil {
@@ -148,7 +224,7 @@ func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req Co
 		return ConversationForkChatResult{}, err
 	}
 	if err := tx.Commit(); err != nil {
-		return ConversationForkChatResult{}, fmt.Errorf("commit conversation fork chat: %w", err)
+		return ConversationForkChatResult{}, fmt.Errorf("commit conversation fork chat record: %w", err)
 	}
 	committed = true
 	return ConversationForkChatResult{
@@ -398,7 +474,7 @@ func insertConversationForkTurn(
 	forkID string,
 	actorTokenID string,
 	message string,
-	execution conversationForkSandboxExecution,
+	execution ConversationForkChatExecution,
 	requestPayload json.RawMessage,
 	responsePayload json.RawMessage,
 	policy ConversationForkSandboxPolicy,
@@ -486,7 +562,7 @@ func loadConversationForkTurns(ctx context.Context, db *sql.DB, forkID string) (
 		turn.RequestPayload = cloneRawMessage(requestRaw)
 		turn.ResponsePayload = cloneRawMessage(responseRaw)
 		turn.ToolResults = conversationForkToolResultsFromCalls(turn.ToolCalls)
-		turn.TurnBlocks = conversationForkSandboxTurnBlocks(conversationForkSandboxExecution{
+		turn.TurnBlocks = conversationForkSandboxTurnBlocks(ConversationForkChatExecution{
 			AssistantMessage: assistant,
 			ToolCalls:        turn.ToolCalls,
 			ToolResults:      turn.ToolResults,
@@ -524,101 +600,12 @@ func defaultConversationForkSandboxPolicy() ConversationForkSandboxPolicy {
 	}
 }
 
-func executeConversationForkSandboxTurn(ctx context.Context, fork OperatorConversationForkSession, snapshot ConversationForkSnapshot, policy ConversationForkSandboxPolicy, message string) (conversationForkSandboxExecution, error) {
-	if err := ctx.Err(); err != nil {
-		return conversationForkSandboxExecution{}, err
-	}
-	availableTools := conversationForkSandboxAvailableTools(policy)
-	toolCalls := make([]OperatorConversationToolCall, 0, 1+len(policy.StubbedTools))
-	toolResults := make([]OperatorConversationToolResult, 0, 1+len(policy.StubbedTools))
-
-	readArgs := map[string]any{
-		"fork_id":         fork.ForkID,
-		"source_agent_id": fork.SourceAgentID,
-		"snapshot_owner":  snapshot.SnapshotOwner,
-	}
-	readResult := map[string]any{
-		"status":          "read_from_snapshot",
-		"read_policy":     policy.ReadPolicy,
-		"snapshot_owner":  snapshot.SnapshotOwner,
-		"source_agent_id": fork.SourceAgentID,
-		"entity_count":    len(snapshot.EntitySnapshot),
-		"entities":        snapshot.EntitySnapshot,
-	}
-	readCall, readToolResult, err := conversationForkSandboxToolEvidence("fork_snapshot.read_entities", "forkchat-read-1", readArgs, readResult)
-	if err != nil {
-		return conversationForkSandboxExecution{}, err
-	}
-	toolCalls = append(toolCalls, readCall)
-	toolResults = append(toolResults, readToolResult)
-
-	for idx, toolName := range policy.StubbedTools {
-		if strings.TrimSpace(toolName) == "" {
-			continue
-		}
-		toolUseID := fmt.Sprintf("forkchat-stub-%02d", idx+1)
-		args := map[string]any{
-			"fork_id":         fork.ForkID,
-			"source_agent_id": fork.SourceAgentID,
-			"requested_tool":  toolName,
-			"message":         strings.TrimSpace(message),
-		}
-		result := map[string]any{
-			"status":        "stubbed",
-			"owner":         policy.Owner,
-			"write_policy":  policy.WritePolicy,
-			"live_mutation": false,
-			"reason":        "forkchat sandbox records side-effecting tools as fork-local facts only",
-		}
-		call, toolResult, err := conversationForkSandboxToolEvidence(toolName, toolUseID, args, result)
-		if err != nil {
-			return conversationForkSandboxExecution{}, err
-		}
-		toolCalls = append(toolCalls, call)
-		toolResults = append(toolResults, toolResult)
-	}
-
-	assistant := fmt.Sprintf(
-		"Forkchat sandbox executed for source agent %s. Read %d entities from the fork snapshot and stubbed %d side-effecting tools without live mutation.",
-		fork.SourceAgentID,
-		len(snapshot.EntitySnapshot),
-		len(toolCalls)-1,
-	)
-	return conversationForkSandboxExecution{
-		AssistantMessage: assistant,
-		ToolCalls:        toolCalls,
-		ToolResults:      toolResults,
-		AvailableTools:   availableTools,
-	}, nil
-}
-
 func conversationForkSandboxAvailableTools(policy ConversationForkSandboxPolicy) []string {
-	out := []string{"fork_snapshot.read_entities"}
-	out = append(out, policy.StubbedTools...)
+	out := []string{"fork_snapshot_read_entities"}
+	for _, name := range policy.StubbedTools {
+		out = append(out, conversationForkSandboxToolName(name))
+	}
 	return out
-}
-
-func conversationForkSandboxToolEvidence(name, toolUseID string, args map[string]any, result map[string]any) (OperatorConversationToolCall, OperatorConversationToolResult, error) {
-	argsRaw, err := json.Marshal(args)
-	if err != nil {
-		return OperatorConversationToolCall{}, OperatorConversationToolResult{}, err
-	}
-	resultRaw, err := json.Marshal(result)
-	if err != nil {
-		return OperatorConversationToolCall{}, OperatorConversationToolResult{}, err
-	}
-	call := OperatorConversationToolCall{
-		ToolUseID: toolUseID,
-		Name:      name,
-		Arguments: argsRaw,
-		Result:    resultRaw,
-	}
-	toolResult := OperatorConversationToolResult{
-		ToolName:  name,
-		ToolUseID: toolUseID,
-		Output:    cloneRawMessage(resultRaw),
-	}
-	return call, toolResult, nil
 }
 
 func conversationForkToolResultsFromCalls(calls []OperatorConversationToolCall) []OperatorConversationToolResult {
@@ -639,7 +626,7 @@ func conversationForkToolResultsFromCalls(calls []OperatorConversationToolCall) 
 	return out
 }
 
-func conversationForkSandboxTurnBlocks(execution conversationForkSandboxExecution) []OperatorConversationTurnBlock {
+func conversationForkSandboxTurnBlocks(execution ConversationForkChatExecution) []OperatorConversationTurnBlock {
 	blocks := []OperatorConversationTurnBlock{{
 		Kind:  "turn_summary",
 		Title: "Forkchat sandbox response",
@@ -670,7 +657,7 @@ func conversationForkChatRequestPayload(message string, snapshot ConversationFor
 	return raw, nil
 }
 
-func conversationForkChatResponsePayload(execution conversationForkSandboxExecution, policy ConversationForkSandboxPolicy) (json.RawMessage, error) {
+func conversationForkChatResponsePayload(execution ConversationForkChatExecution, policy ConversationForkSandboxPolicy) (json.RawMessage, error) {
 	raw, err := json.Marshal(map[string]any{
 		"message":        execution.AssistantMessage,
 		"sandbox_policy": policy,
@@ -681,4 +668,8 @@ func conversationForkChatResponsePayload(execution conversationForkSandboxExecut
 		return nil, err
 	}
 	return raw, nil
+}
+
+func conversationForkSandboxToolName(name string) string {
+	return strings.NewReplacer(".", "_", "-", "_").Replace(strings.TrimSpace(name))
 }

--- a/internal/store/conversation_fork_chat.go
+++ b/internal/store/conversation_fork_chat.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	runtimellm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/mutationlog"
 )
 
@@ -72,6 +71,13 @@ type ConversationForkSandboxPolicy struct {
 	StubbedTools       []string `json:"stubbed_tools"`
 }
 
+type conversationForkSandboxExecution struct {
+	AssistantMessage string
+	ToolCalls        []OperatorConversationToolCall
+	ToolResults      []OperatorConversationToolResult
+	AvailableTools   []string
+}
+
 func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req ConversationForkChatRequest) (ConversationForkChatResult, error) {
 	if s == nil || s.DB == nil {
 		return ConversationForkChatResult{}, fmt.Errorf("postgres store is required")
@@ -125,19 +131,19 @@ func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req Co
 		return ConversationForkChatResult{}, err
 	}
 	policy := defaultConversationForkSandboxPolicy()
-	assistant, err := executeConversationForkSandboxTurn(ctx, fork, message)
+	execution, err := executeConversationForkSandboxTurn(ctx, fork, snapshot, policy, message)
 	if err != nil {
 		return ConversationForkChatResult{}, err
 	}
-	requestPayload, err := conversationForkChatRequestPayload(message, snapshot)
+	requestPayload, err := conversationForkChatRequestPayload(message, snapshot, execution.AvailableTools)
 	if err != nil {
 		return ConversationForkChatResult{}, err
 	}
-	responsePayload, err := conversationForkChatResponsePayload(assistant, policy)
+	responsePayload, err := conversationForkChatResponsePayload(execution, policy)
 	if err != nil {
 		return ConversationForkChatResult{}, err
 	}
-	turn, err := insertConversationForkTurn(ctx, tx, forkID, actorTokenID, message, assistant, requestPayload, responsePayload, policy, now)
+	turn, err := insertConversationForkTurn(ctx, tx, forkID, actorTokenID, message, execution, requestPayload, responsePayload, policy, now)
 	if err != nil {
 		return ConversationForkChatResult{}, err
 	}
@@ -392,7 +398,7 @@ func insertConversationForkTurn(
 	forkID string,
 	actorTokenID string,
 	message string,
-	assistant string,
+	execution conversationForkSandboxExecution,
 	requestPayload json.RawMessage,
 	responsePayload json.RawMessage,
 	policy ConversationForkSandboxPolicy,
@@ -410,6 +416,10 @@ func insertConversationForkTurn(
 	if err != nil {
 		return OperatorConversationTurn{}, err
 	}
+	toolCallsJSON, err := json.Marshal(execution.ToolCalls)
+	if err != nil {
+		return OperatorConversationTurn{}, err
+	}
 	var turn OperatorConversationTurn
 	var createdAt time.Time
 	if err := tx.QueryRowContext(ctx, `
@@ -420,28 +430,25 @@ func insertConversationForkTurn(
 		)
 		VALUES (
 			$1::uuid, $2, $3, $4, $5,
-			$6::jsonb, $7::jsonb, '[]'::jsonb, $8::jsonb,
-			$9, $10
+			$6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb,
+			$10, $11
 		)
 		RETURNING fork_turn_id::text, created_at
-	`, forkID, nextIndex, actorTokenID, message, assistant,
-		string(requestPayload), string(responsePayload), string(policyJSON),
+	`, forkID, nextIndex, actorTokenID, message, execution.AssistantMessage,
+		string(requestPayload), string(responsePayload), string(toolCallsJSON), string(policyJSON),
 		ConversationForkChatSnapshotOwner, now).Scan(&turn.TurnID, &createdAt); err != nil {
 		return OperatorConversationTurn{}, fmt.Errorf("insert conversation fork turn: %w", err)
 	}
 	turn.TurnIndex = nextIndex
 	turn.RequestPayload = cloneRawMessage(requestPayload)
 	turn.ResponsePayload = cloneRawMessage(responsePayload)
-	turn.ToolCalls = []OperatorConversationToolCall{}
-	turn.TurnBlocks = []OperatorConversationTurnBlock{{
-		Kind:  "turn_summary",
-		Title: "Forkchat sandbox response",
-		Text:  assistant,
-	}}
+	turn.ToolCalls = cloneConversationToolCalls(execution.ToolCalls)
+	turn.ToolResults = cloneConversationToolResults(execution.ToolResults)
+	turn.TurnBlocks = conversationForkSandboxTurnBlocks(execution)
 	turn.ParseOK = true
 	turn.LatencyMS = 0
 	turn.CreatedAt = createdAt.UTC()
-	turn.AssistantVisibleOutput = assistant
+	turn.AssistantVisibleOutput = execution.AssistantMessage
 	return turn, nil
 }
 
@@ -478,11 +485,12 @@ func loadConversationForkTurns(ctx context.Context, db *sql.DB, forkID string) (
 		}
 		turn.RequestPayload = cloneRawMessage(requestRaw)
 		turn.ResponsePayload = cloneRawMessage(responseRaw)
-		turn.TurnBlocks = []OperatorConversationTurnBlock{{
-			Kind:  "turn_summary",
-			Title: "Forkchat sandbox response",
-			Text:  assistant,
-		}}
+		turn.ToolResults = conversationForkToolResultsFromCalls(turn.ToolCalls)
+		turn.TurnBlocks = conversationForkSandboxTurnBlocks(conversationForkSandboxExecution{
+			AssistantMessage: assistant,
+			ToolCalls:        turn.ToolCalls,
+			ToolResults:      turn.ToolResults,
+		})
 		turn.ParseOK = true
 		turn.CreatedAt = createdAt.UTC()
 		turn.AssistantVisibleOutput = assistant
@@ -516,24 +524,145 @@ func defaultConversationForkSandboxPolicy() ConversationForkSandboxPolicy {
 	}
 }
 
-func executeConversationForkSandboxTurn(ctx context.Context, fork OperatorConversationForkSession, message string) (string, error) {
-	runtime := runtimellm.NoopRuntime{}
-	session, err := runtime.StartSession(ctx, fork.SourceAgentID, "forkchat sandbox execution", nil)
-	if err != nil {
-		return "", fmt.Errorf("start forkchat sandbox session: %w", err)
+func executeConversationForkSandboxTurn(ctx context.Context, fork OperatorConversationForkSession, snapshot ConversationForkSnapshot, policy ConversationForkSandboxPolicy, message string) (conversationForkSandboxExecution, error) {
+	if err := ctx.Err(); err != nil {
+		return conversationForkSandboxExecution{}, err
 	}
-	response, err := runtime.ContinueSession(ctx, session, runtimellm.Message{Role: "user", Content: strings.TrimSpace(message)})
-	if err != nil {
-		return "", fmt.Errorf("continue forkchat sandbox session: %w", err)
+	availableTools := conversationForkSandboxAvailableTools(policy)
+	toolCalls := make([]OperatorConversationToolCall, 0, 1+len(policy.StubbedTools))
+	toolResults := make([]OperatorConversationToolResult, 0, 1+len(policy.StubbedTools))
+
+	readArgs := map[string]any{
+		"fork_id":         fork.ForkID,
+		"source_agent_id": fork.SourceAgentID,
+		"snapshot_owner":  snapshot.SnapshotOwner,
 	}
-	return strings.TrimSpace(response.Message.Content), nil
+	readResult := map[string]any{
+		"status":          "read_from_snapshot",
+		"read_policy":     policy.ReadPolicy,
+		"snapshot_owner":  snapshot.SnapshotOwner,
+		"source_agent_id": fork.SourceAgentID,
+		"entity_count":    len(snapshot.EntitySnapshot),
+		"entities":        snapshot.EntitySnapshot,
+	}
+	readCall, readToolResult, err := conversationForkSandboxToolEvidence("fork_snapshot.read_entities", "forkchat-read-1", readArgs, readResult)
+	if err != nil {
+		return conversationForkSandboxExecution{}, err
+	}
+	toolCalls = append(toolCalls, readCall)
+	toolResults = append(toolResults, readToolResult)
+
+	for idx, toolName := range policy.StubbedTools {
+		if strings.TrimSpace(toolName) == "" {
+			continue
+		}
+		toolUseID := fmt.Sprintf("forkchat-stub-%02d", idx+1)
+		args := map[string]any{
+			"fork_id":         fork.ForkID,
+			"source_agent_id": fork.SourceAgentID,
+			"requested_tool":  toolName,
+			"message":         strings.TrimSpace(message),
+		}
+		result := map[string]any{
+			"status":        "stubbed",
+			"owner":         policy.Owner,
+			"write_policy":  policy.WritePolicy,
+			"live_mutation": false,
+			"reason":        "forkchat sandbox records side-effecting tools as fork-local facts only",
+		}
+		call, toolResult, err := conversationForkSandboxToolEvidence(toolName, toolUseID, args, result)
+		if err != nil {
+			return conversationForkSandboxExecution{}, err
+		}
+		toolCalls = append(toolCalls, call)
+		toolResults = append(toolResults, toolResult)
+	}
+
+	assistant := fmt.Sprintf(
+		"Forkchat sandbox executed for source agent %s. Read %d entities from the fork snapshot and stubbed %d side-effecting tools without live mutation.",
+		fork.SourceAgentID,
+		len(snapshot.EntitySnapshot),
+		len(toolCalls)-1,
+	)
+	return conversationForkSandboxExecution{
+		AssistantMessage: assistant,
+		ToolCalls:        toolCalls,
+		ToolResults:      toolResults,
+		AvailableTools:   availableTools,
+	}, nil
 }
 
-func conversationForkChatRequestPayload(message string, snapshot ConversationForkSnapshot) (json.RawMessage, error) {
+func conversationForkSandboxAvailableTools(policy ConversationForkSandboxPolicy) []string {
+	out := []string{"fork_snapshot.read_entities"}
+	out = append(out, policy.StubbedTools...)
+	return out
+}
+
+func conversationForkSandboxToolEvidence(name, toolUseID string, args map[string]any, result map[string]any) (OperatorConversationToolCall, OperatorConversationToolResult, error) {
+	argsRaw, err := json.Marshal(args)
+	if err != nil {
+		return OperatorConversationToolCall{}, OperatorConversationToolResult{}, err
+	}
+	resultRaw, err := json.Marshal(result)
+	if err != nil {
+		return OperatorConversationToolCall{}, OperatorConversationToolResult{}, err
+	}
+	call := OperatorConversationToolCall{
+		ToolUseID: toolUseID,
+		Name:      name,
+		Arguments: argsRaw,
+		Result:    resultRaw,
+	}
+	toolResult := OperatorConversationToolResult{
+		ToolName:  name,
+		ToolUseID: toolUseID,
+		Output:    cloneRawMessage(resultRaw),
+	}
+	return call, toolResult, nil
+}
+
+func conversationForkToolResultsFromCalls(calls []OperatorConversationToolCall) []OperatorConversationToolResult {
+	if len(calls) == 0 {
+		return []OperatorConversationToolResult{}
+	}
+	out := make([]OperatorConversationToolResult, 0, len(calls))
+	for _, call := range calls {
+		if len(call.Result) == 0 {
+			continue
+		}
+		out = append(out, OperatorConversationToolResult{
+			ToolName:  call.Name,
+			ToolUseID: call.ToolUseID,
+			Output:    cloneRawMessage(call.Result),
+		})
+	}
+	return out
+}
+
+func conversationForkSandboxTurnBlocks(execution conversationForkSandboxExecution) []OperatorConversationTurnBlock {
+	blocks := []OperatorConversationTurnBlock{{
+		Kind:  "turn_summary",
+		Title: "Forkchat sandbox response",
+		Text:  execution.AssistantMessage,
+	}}
+	for _, call := range execution.ToolCalls {
+		blocks = append(blocks, OperatorConversationTurnBlock{
+			Kind:     "tool_result",
+			Title:    call.Name,
+			ToolName: call.Name,
+			Input:    cloneRawMessage(call.Arguments),
+			Output:   cloneRawMessage(call.Result),
+		})
+	}
+	return blocks
+}
+
+func conversationForkChatRequestPayload(message string, snapshot ConversationForkSnapshot, availableTools []string) (json.RawMessage, error) {
 	raw, err := json.Marshal(map[string]any{
-		"message":        message,
-		"snapshot_owner": snapshot.SnapshotOwner,
-		"snapshot":       snapshot,
+		"message":         message,
+		"snapshot_owner":  snapshot.SnapshotOwner,
+		"snapshot":        snapshot,
+		"available_tools": availableTools,
 	})
 	if err != nil {
 		return nil, err
@@ -541,11 +670,12 @@ func conversationForkChatRequestPayload(message string, snapshot ConversationFor
 	return raw, nil
 }
 
-func conversationForkChatResponsePayload(assistant string, policy ConversationForkSandboxPolicy) (json.RawMessage, error) {
+func conversationForkChatResponsePayload(execution conversationForkSandboxExecution, policy ConversationForkSandboxPolicy) (json.RawMessage, error) {
 	raw, err := json.Marshal(map[string]any{
-		"message":        assistant,
+		"message":        execution.AssistantMessage,
 		"sandbox_policy": policy,
-		"tool_calls":     []any{},
+		"tool_calls":     execution.ToolCalls,
+		"tool_results":   execution.ToolResults,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/store/conversation_fork_chat.go
+++ b/internal/store/conversation_fork_chat.go
@@ -1,0 +1,554 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimellm "swarm/internal/runtime/llm"
+	"swarm/internal/runtime/mutationlog"
+)
+
+const (
+	ConversationForkChatSnapshotOwner = "conversation.fork_chat.snapshot.v1"
+	ConversationForkChatSandboxOwner  = "conversation.fork_chat.sandbox.v1"
+)
+
+type ConversationForkChatRequest struct {
+	ForkID       string
+	Message      string
+	ActorTokenID string
+	Now          time.Time
+}
+
+type ConversationForkChatResult struct {
+	ForkID              string                        `json:"fork_id"`
+	Turn                OperatorConversationTurn      `json:"turn"`
+	Snapshot            ConversationForkSnapshot      `json:"snapshot"`
+	SandboxPolicy       ConversationForkSandboxPolicy `json:"sandbox_policy"`
+	IdempotencyReplayed bool                          `json:"idempotency_replayed"`
+}
+
+type ConversationForkSnapshot struct {
+	ForkID          string                           `json:"fork_id"`
+	SourceSessionID string                           `json:"source_session_id"`
+	SourceRunID     string                           `json:"source_run_id,omitempty"`
+	SourceAgentID   string                           `json:"source_agent_id"`
+	SourceTurn      ConversationForkSourceTurn       `json:"source_turn"`
+	EntitySnapshot  []ConversationForkEntitySnapshot `json:"entity_snapshot"`
+	SnapshotOwner   string                           `json:"snapshot_owner"`
+	CreatedAt       time.Time                        `json:"created_at"`
+}
+
+type ConversationForkSourceTurn struct {
+	TurnID          string          `json:"turn_id"`
+	TurnIndex       int             `json:"turn_index"`
+	SelectedAt      time.Time       `json:"selected_at"`
+	CreatedAt       time.Time       `json:"created_at"`
+	RequestPayload  json.RawMessage `json:"request_payload,omitempty"`
+	ResponsePayload json.RawMessage `json:"response_payload,omitempty"`
+	ToolCalls       json.RawMessage `json:"tool_calls,omitempty"`
+	AvailableTools  json.RawMessage `json:"available_tools,omitempty"`
+}
+
+type ConversationForkEntitySnapshot struct {
+	EntityID       string         `json:"entity_id"`
+	CurrentState   string         `json:"current_state,omitempty"`
+	EnteredStateAt *time.Time     `json:"entered_state_at,omitempty"`
+	Fields         map[string]any `json:"fields,omitempty"`
+	Gates          map[string]any `json:"gates,omitempty"`
+	Accumulator    map[string]any `json:"accumulator,omitempty"`
+}
+
+type ConversationForkSandboxPolicy struct {
+	Owner              string   `json:"owner"`
+	ReadPolicy         string   `json:"read_policy"`
+	WritePolicy        string   `json:"write_policy"`
+	SideEffectingTools []string `json:"side_effecting_tools"`
+	StubbedTools       []string `json:"stubbed_tools"`
+}
+
+func (s *PostgresStore) ChatOperatorConversationFork(ctx context.Context, req ConversationForkChatRequest) (ConversationForkChatResult, error) {
+	if s == nil || s.DB == nil {
+		return ConversationForkChatResult{}, fmt.Errorf("postgres store is required")
+	}
+	forkID, err := normalizeUUIDParam(req.ForkID, "fork_id")
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	message := strings.TrimSpace(req.Message)
+	if message == "" {
+		return ConversationForkChatResult{}, &EntityReadParamError{Field: "message", Reason: "is required"}
+	}
+	actorTokenID := strings.TrimSpace(req.ActorTokenID)
+	if actorTokenID == "" {
+		return ConversationForkChatResult{}, &EntityReadParamError{Field: "actor_token_id", Reason: "is required"}
+	}
+	now := req.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	if err := requireConversationForkChatCapabilities(caps, catalog); err != nil {
+		return ConversationForkChatResult{}, err
+	}
+
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return ConversationForkChatResult{}, fmt.Errorf("begin conversation fork chat: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	fork, err := loadActiveConversationForkForChat(ctx, tx, forkID, now)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	snapshot, err := ensureConversationForkSnapshot(ctx, tx, fork, now)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	policy := defaultConversationForkSandboxPolicy()
+	assistant, err := executeConversationForkSandboxTurn(ctx, fork, message)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	requestPayload, err := conversationForkChatRequestPayload(message, snapshot)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	responsePayload, err := conversationForkChatResponsePayload(assistant, policy)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	turn, err := insertConversationForkTurn(ctx, tx, forkID, actorTokenID, message, assistant, requestPayload, responsePayload, policy, now)
+	if err != nil {
+		return ConversationForkChatResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ConversationForkChatResult{}, fmt.Errorf("commit conversation fork chat: %w", err)
+	}
+	committed = true
+	return ConversationForkChatResult{
+		ForkID:        forkID,
+		Turn:          turn,
+		Snapshot:      snapshot,
+		SandboxPolicy: policy,
+	}, nil
+}
+
+func requireConversationForkChatCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
+	if err := requireConversationForkLifecycleCapabilities(caps); err != nil {
+		return err
+	}
+	if caps.Conversations.ForkSnapshots != SchemaFlavorCanonical {
+		return fmt.Errorf("store: conversation_fork_snapshots schema is unavailable")
+	}
+	if caps.Conversations.ForkTurns != SchemaFlavorCanonical {
+		return fmt.Errorf("store: conversation_fork_turns schema is unavailable")
+	}
+	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
+		return fmt.Errorf("store: conversation fork chat requires canonical run-scoped entity_state")
+	}
+	if !catalog.hasColumns("entity_mutations", "mutation_id", "run_id", "entity_id", "field", "new_value", "created_at") {
+		return fmt.Errorf("store: conversation fork chat requires canonical entity_mutations")
+	}
+	return nil
+}
+
+func loadActiveConversationForkForChat(ctx context.Context, tx *sql.Tx, forkID string, now time.Time) (OperatorConversationForkSession, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT
+			fork_id::text, source_session_id::text, COALESCE(source_run_id::text, ''),
+			source_agent_id, fork_point_kind, fork_point_turn_index,
+			COALESCE(fork_point_turn_id::text, ''), COALESCE(fork_point_event_id::text, ''),
+			fork_point_at, fork_point_selected_at, created_by, created_at, expires_at, deleted_at
+		FROM conversation_forks
+		WHERE fork_id = $1::uuid
+		FOR UPDATE
+	`, forkID)
+	item, err := scanConversationForkSession(row, now)
+	if errors.Is(err, sql.ErrNoRows) {
+		return OperatorConversationForkSession{}, ErrConversationForkNotFound
+	}
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	if item.State != "active" {
+		return OperatorConversationForkSession{}, &EntityReadParamError{Field: "fork_id", Reason: "must reference an active fork"}
+	}
+	return item, nil
+}
+
+func ensureConversationForkSnapshot(ctx context.Context, tx *sql.Tx, fork OperatorConversationForkSession, now time.Time) (ConversationForkSnapshot, error) {
+	snapshot, err := loadConversationForkSnapshot(ctx, tx, fork.ForkID)
+	if err == nil {
+		return snapshot, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return ConversationForkSnapshot{}, err
+	}
+	sourceTurn, err := loadConversationForkSourceTurn(ctx, tx, fork)
+	if err != nil {
+		return ConversationForkSnapshot{}, err
+	}
+	entities, err := loadConversationForkEntitySnapshot(ctx, tx, fork)
+	if err != nil {
+		return ConversationForkSnapshot{}, err
+	}
+	snapshot = ConversationForkSnapshot{
+		ForkID:          fork.ForkID,
+		SourceSessionID: fork.SourceSessionID,
+		SourceRunID:     fork.SourceRunID,
+		SourceAgentID:   fork.SourceAgentID,
+		SourceTurn:      sourceTurn,
+		EntitySnapshot:  entities,
+		SnapshotOwner:   ConversationForkChatSnapshotOwner,
+		CreatedAt:       now,
+	}
+	sourceTurnJSON, err := json.Marshal(sourceTurn)
+	if err != nil {
+		return ConversationForkSnapshot{}, err
+	}
+	entitySnapshotJSON, err := json.Marshal(entities)
+	if err != nil {
+		return ConversationForkSnapshot{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO conversation_fork_snapshots (
+			fork_id, source_session_id, source_run_id, source_agent_id,
+			fork_point_turn_id, fork_point_turn_index, fork_point_selected_at,
+			source_turn, entity_snapshot, snapshot_owner, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, nullif($3, '')::uuid, $4,
+			$5::uuid, $6, $7,
+			$8::jsonb, $9::jsonb, $10, $11
+		)
+	`, snapshot.ForkID, snapshot.SourceSessionID, snapshot.SourceRunID, snapshot.SourceAgentID,
+		sourceTurn.TurnID, sourceTurn.TurnIndex, sourceTurn.SelectedAt,
+		string(sourceTurnJSON), string(entitySnapshotJSON), snapshot.SnapshotOwner, snapshot.CreatedAt); err != nil {
+		return ConversationForkSnapshot{}, fmt.Errorf("insert conversation fork snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+func loadConversationForkSnapshot(ctx context.Context, tx *sql.Tx, forkID string) (ConversationForkSnapshot, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT
+			fork_id::text, source_session_id::text, COALESCE(source_run_id::text, ''),
+			source_agent_id, source_turn, entity_snapshot, snapshot_owner, created_at
+		FROM conversation_fork_snapshots
+		WHERE fork_id = $1::uuid
+	`, forkID)
+	var out ConversationForkSnapshot
+	var sourceTurnRaw []byte
+	var entitiesRaw []byte
+	if err := row.Scan(&out.ForkID, &out.SourceSessionID, &out.SourceRunID, &out.SourceAgentID, &sourceTurnRaw, &entitiesRaw, &out.SnapshotOwner, &out.CreatedAt); err != nil {
+		return ConversationForkSnapshot{}, err
+	}
+	if err := json.Unmarshal(sourceTurnRaw, &out.SourceTurn); err != nil {
+		return ConversationForkSnapshot{}, fmt.Errorf("decode conversation fork source turn snapshot: %w", err)
+	}
+	if err := json.Unmarshal(entitiesRaw, &out.EntitySnapshot); err != nil {
+		return ConversationForkSnapshot{}, fmt.Errorf("decode conversation fork entity snapshot: %w", err)
+	}
+	if out.EntitySnapshot == nil {
+		out.EntitySnapshot = []ConversationForkEntitySnapshot{}
+	}
+	out.CreatedAt = out.CreatedAt.UTC()
+	return out, nil
+}
+
+func loadConversationForkSourceTurn(ctx context.Context, tx *sql.Tx, fork OperatorConversationForkSession) (ConversationForkSourceTurn, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT
+			turn_id::text,
+			COALESCE(request_payload, '{}'::jsonb),
+			COALESCE(response_payload, '{}'::jsonb),
+			COALESCE(tool_calls, '[]'::jsonb),
+			COALESCE(available_tools, '[]'::jsonb),
+			created_at
+		FROM agent_turns
+		WHERE session_id = $1::uuid
+		  AND turn_id = $2::uuid
+	`, fork.SourceSessionID, fork.ForkPoint.TurnID)
+	var out ConversationForkSourceTurn
+	var requestRaw, responseRaw, toolCallsRaw, availableToolsRaw []byte
+	if err := row.Scan(&out.TurnID, &requestRaw, &responseRaw, &toolCallsRaw, &availableToolsRaw, &out.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ConversationForkSourceTurn{}, &EntityReadParamError{Field: "fork_id", Reason: "source turn is unavailable"}
+		}
+		return ConversationForkSourceTurn{}, fmt.Errorf("load conversation fork source turn: %w", err)
+	}
+	out.TurnIndex = fork.ForkPoint.TurnIndex
+	out.SelectedAt = fork.ForkPoint.SelectedAt
+	out.CreatedAt = out.CreatedAt.UTC()
+	out.RequestPayload = cloneRawMessage(requestRaw)
+	out.ResponsePayload = cloneRawMessage(responseRaw)
+	out.ToolCalls = cloneRawMessage(toolCallsRaw)
+	out.AvailableTools = cloneRawMessage(availableToolsRaw)
+	return out, nil
+}
+
+func loadConversationForkEntitySnapshot(ctx context.Context, tx *sql.Tx, fork OperatorConversationForkSession) ([]ConversationForkEntitySnapshot, error) {
+	if strings.TrimSpace(fork.SourceRunID) == "" {
+		return []ConversationForkEntitySnapshot{}, nil
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT entity_id::text, field, new_value, created_at
+		FROM entity_mutations
+		WHERE run_id = $1::uuid
+		  AND created_at <= $2::timestamptz
+		ORDER BY entity_id ASC, created_at ASC, mutation_id ASC
+	`, fork.SourceRunID, fork.ForkPoint.SelectedAt)
+	if err != nil {
+		return nil, fmt.Errorf("load conversation fork entity mutations: %w", err)
+	}
+	defer rows.Close()
+
+	type timedProjectionMutation struct {
+		mutationlog.ProjectionMutation
+		CreatedAt time.Time
+	}
+	grouped := map[string][]timedProjectionMutation{}
+	entityOrder := []string{}
+	seen := map[string]struct{}{}
+	for rows.Next() {
+		var entityID, field string
+		var raw []byte
+		var createdAt time.Time
+		if err := rows.Scan(&entityID, &field, &raw, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan conversation fork entity mutation: %w", err)
+		}
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("decode conversation fork entity mutation %s/%s: %w", entityID, field, err)
+		}
+		entityID = strings.TrimSpace(entityID)
+		if _, ok := seen[entityID]; !ok {
+			seen[entityID] = struct{}{}
+			entityOrder = append(entityOrder, entityID)
+		}
+		grouped[entityID] = append(grouped[entityID], timedProjectionMutation{
+			ProjectionMutation: mutationlog.ProjectionMutation{Field: field, NewValue: value},
+			CreatedAt:          createdAt.UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read conversation fork entity mutations: %w", err)
+	}
+
+	out := make([]ConversationForkEntitySnapshot, 0, len(entityOrder))
+	for _, entityID := range entityOrder {
+		mutations := grouped[entityID]
+		projectionMutations := make([]mutationlog.ProjectionMutation, 0, len(mutations))
+		var enteredStateAt *time.Time
+		for _, mutation := range mutations {
+			projectionMutations = append(projectionMutations, mutation.ProjectionMutation)
+			if strings.TrimSpace(mutation.Field) == "current_state" {
+				tm := mutation.CreatedAt
+				enteredStateAt = &tm
+			}
+		}
+		projection, err := mutationlog.ReconstructEntityStateProjection(projectionMutations)
+		if err != nil {
+			return nil, fmt.Errorf("reconstruct conversation fork entity %s at fork point: %w", entityID, err)
+		}
+		out = append(out, ConversationForkEntitySnapshot{
+			EntityID:       entityID,
+			CurrentState:   projection.CurrentState,
+			EnteredStateAt: enteredStateAt,
+			Fields:         projection.Fields,
+			Gates:          projection.Gates,
+			Accumulator:    projection.Accumulator,
+		})
+	}
+	if out == nil {
+		out = []ConversationForkEntitySnapshot{}
+	}
+	return out, nil
+}
+
+func insertConversationForkTurn(
+	ctx context.Context,
+	tx *sql.Tx,
+	forkID string,
+	actorTokenID string,
+	message string,
+	assistant string,
+	requestPayload json.RawMessage,
+	responsePayload json.RawMessage,
+	policy ConversationForkSandboxPolicy,
+	now time.Time,
+) (OperatorConversationTurn, error) {
+	var nextIndex int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(turn_index), 0) + 1
+		FROM conversation_fork_turns
+		WHERE fork_id = $1::uuid
+	`, forkID).Scan(&nextIndex); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("allocate conversation fork turn index: %w", err)
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return OperatorConversationTurn{}, err
+	}
+	var turn OperatorConversationTurn
+	var createdAt time.Time
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO conversation_fork_turns (
+			fork_id, turn_index, actor_token_id, message, assistant_message,
+			request_payload, response_payload, tool_calls, sandbox_policy,
+			snapshot_owner, created_at
+		)
+		VALUES (
+			$1::uuid, $2, $3, $4, $5,
+			$6::jsonb, $7::jsonb, '[]'::jsonb, $8::jsonb,
+			$9, $10
+		)
+		RETURNING fork_turn_id::text, created_at
+	`, forkID, nextIndex, actorTokenID, message, assistant,
+		string(requestPayload), string(responsePayload), string(policyJSON),
+		ConversationForkChatSnapshotOwner, now).Scan(&turn.TurnID, &createdAt); err != nil {
+		return OperatorConversationTurn{}, fmt.Errorf("insert conversation fork turn: %w", err)
+	}
+	turn.TurnIndex = nextIndex
+	turn.RequestPayload = cloneRawMessage(requestPayload)
+	turn.ResponsePayload = cloneRawMessage(responsePayload)
+	turn.ToolCalls = []OperatorConversationToolCall{}
+	turn.TurnBlocks = []OperatorConversationTurnBlock{{
+		Kind:  "turn_summary",
+		Title: "Forkchat sandbox response",
+		Text:  assistant,
+	}}
+	turn.ParseOK = true
+	turn.LatencyMS = 0
+	turn.CreatedAt = createdAt.UTC()
+	turn.AssistantVisibleOutput = assistant
+	return turn, nil
+}
+
+func loadConversationForkTurns(ctx context.Context, db *sql.DB, forkID string) ([]OperatorConversationTurn, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			fork_turn_id::text, turn_index,
+			request_payload, response_payload, tool_calls,
+			assistant_message, created_at
+		FROM conversation_fork_turns
+		WHERE fork_id = $1::uuid
+		ORDER BY turn_index ASC, created_at ASC, fork_turn_id ASC
+	`, forkID)
+	if err != nil {
+		return nil, fmt.Errorf("load conversation fork turns: %w", err)
+	}
+	defer rows.Close()
+	turns := []OperatorConversationTurn{}
+	for rows.Next() {
+		var turn OperatorConversationTurn
+		var requestRaw, responseRaw, toolCallsRaw []byte
+		var assistant string
+		var createdAt time.Time
+		if err := rows.Scan(&turn.TurnID, &turn.TurnIndex, &requestRaw, &responseRaw, &toolCallsRaw, &assistant, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan conversation fork turn: %w", err)
+		}
+		if len(toolCallsRaw) > 0 {
+			if err := json.Unmarshal(toolCallsRaw, &turn.ToolCalls); err != nil {
+				return nil, fmt.Errorf("decode conversation fork turn tool calls: %w", err)
+			}
+		}
+		if turn.ToolCalls == nil {
+			turn.ToolCalls = []OperatorConversationToolCall{}
+		}
+		turn.RequestPayload = cloneRawMessage(requestRaw)
+		turn.ResponsePayload = cloneRawMessage(responseRaw)
+		turn.TurnBlocks = []OperatorConversationTurnBlock{{
+			Kind:  "turn_summary",
+			Title: "Forkchat sandbox response",
+			Text:  assistant,
+		}}
+		turn.ParseOK = true
+		turn.CreatedAt = createdAt.UTC()
+		turn.AssistantVisibleOutput = assistant
+		turns = append(turns, turn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read conversation fork turns: %w", err)
+	}
+	return turns, nil
+}
+
+func defaultConversationForkSandboxPolicy() ConversationForkSandboxPolicy {
+	sideEffecting := []string{
+		"save_entity_field",
+		"create_entity",
+		"emit_event",
+		"mailbox.approve",
+		"mailbox.reject",
+		"mailbox.defer",
+		"run.start",
+		"run.continue",
+		"run.pause",
+		"run.stop",
+	}
+	return ConversationForkSandboxPolicy{
+		Owner:              ConversationForkChatSandboxOwner,
+		ReadPolicy:         "fork_snapshot_only",
+		WritePolicy:        "stub_record_only_no_live_mutation",
+		SideEffectingTools: append([]string(nil), sideEffecting...),
+		StubbedTools:       append([]string(nil), sideEffecting...),
+	}
+}
+
+func executeConversationForkSandboxTurn(ctx context.Context, fork OperatorConversationForkSession, message string) (string, error) {
+	runtime := runtimellm.NoopRuntime{}
+	session, err := runtime.StartSession(ctx, fork.SourceAgentID, "forkchat sandbox execution", nil)
+	if err != nil {
+		return "", fmt.Errorf("start forkchat sandbox session: %w", err)
+	}
+	response, err := runtime.ContinueSession(ctx, session, runtimellm.Message{Role: "user", Content: strings.TrimSpace(message)})
+	if err != nil {
+		return "", fmt.Errorf("continue forkchat sandbox session: %w", err)
+	}
+	return strings.TrimSpace(response.Message.Content), nil
+}
+
+func conversationForkChatRequestPayload(message string, snapshot ConversationForkSnapshot) (json.RawMessage, error) {
+	raw, err := json.Marshal(map[string]any{
+		"message":        message,
+		"snapshot_owner": snapshot.SnapshotOwner,
+		"snapshot":       snapshot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func conversationForkChatResponsePayload(assistant string, policy ConversationForkSandboxPolicy) (json.RawMessage, error) {
+	raw, err := json.Marshal(map[string]any{
+		"message":        assistant,
+		"sandbox_policy": policy,
+		"tool_calls":     []any{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/internal/store/conversation_fork_lifecycle.go
+++ b/internal/store/conversation_fork_lifecycle.go
@@ -255,6 +255,14 @@ func (s *PostgresStore) LoadOperatorConversationFork(ctx context.Context, forkID
 	if err != nil {
 		return OperatorConversationForkSession{}, err
 	}
+	if caps.Conversations.ForkTurns != SchemaFlavorCanonical {
+		return OperatorConversationForkSession{}, fmt.Errorf("store: conversation_fork_turns schema is unavailable")
+	}
+	turns, err := loadConversationForkTurns(ctx, s.DB, item.ForkID)
+	if err != nil {
+		return OperatorConversationForkSession{}, err
+	}
+	item.Turns = turns
 	return item, nil
 }
 

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -236,14 +236,57 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if err != nil {
 		t.Fatalf("CreateOperatorConversationFork: %v", err)
 	}
-	result, err := s.ChatOperatorConversationFork(ctx, ConversationForkChatRequest{
+	prepared, err := s.PrepareOperatorConversationForkChat(ctx, ConversationForkChatPrepareRequest{
+		ForkID: fork.ForkID,
+		Now:    now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("PrepareOperatorConversationForkChat: %v", err)
+	}
+	result, err := s.RecordOperatorConversationForkChat(ctx, ConversationForkChatRecordRequest{
 		ForkID:       fork.ForkID,
 		Message:      "inspect the fork",
 		ActorTokenID: "actor-token",
-		Now:          now.Add(time.Second),
+		Execution: ConversationForkChatExecution{
+			AssistantMessage: "snapshot says Before; requested writes were stubbed",
+			AvailableTools:   prepared.AvailableTools,
+			ToolCalls: []OperatorConversationToolCall{
+				{
+					ToolUseID: "tool-1",
+					Name:      "fork_snapshot_read_entities",
+					Arguments: json.RawMessage(`{"entity_id":"` + entityID + `"}`),
+					Result:    json.RawMessage(`{"status":"read_from_snapshot","read_policy":"fork_snapshot_only","snapshot_owner":"conversation.fork_chat.snapshot.v1","source_agent_id":"` + source.agentID + `","entity_count":1}`),
+				},
+				{
+					ToolUseID: "tool-2",
+					Name:      "save_entity_field",
+					Arguments: json.RawMessage(`{"entity_id":"` + entityID + `","field":"name","value":"Sandbox"}`),
+					Result:    json.RawMessage(`{"status":"stubbed","owner":"conversation.fork_chat.sandbox.v1","write_policy":"stub_record_only_no_live_mutation","requested_tool":"save_entity_field","live_mutation":false}`),
+				},
+				{
+					ToolUseID: "tool-3",
+					Name:      "emit_event",
+					Arguments: json.RawMessage(`{"event_name":"forkchat.note"}`),
+					Result:    json.RawMessage(`{"status":"stubbed","owner":"conversation.fork_chat.sandbox.v1","write_policy":"stub_record_only_no_live_mutation","requested_tool":"emit_event","live_mutation":false}`),
+				},
+				{
+					ToolUseID: "tool-4",
+					Name:      "mailbox_approve",
+					Arguments: json.RawMessage(`{"mailbox_id":"mb-1"}`),
+					Result:    json.RawMessage(`{"status":"stubbed","owner":"conversation.fork_chat.sandbox.v1","write_policy":"stub_record_only_no_live_mutation","requested_tool":"mailbox.approve","live_mutation":false}`),
+				},
+				{
+					ToolUseID: "tool-5",
+					Name:      "run_start",
+					Arguments: json.RawMessage(`{"event_name":"scan.requested"}`),
+					Result:    json.RawMessage(`{"status":"stubbed","owner":"conversation.fork_chat.sandbox.v1","write_policy":"stub_record_only_no_live_mutation","requested_tool":"run.start","live_mutation":false}`),
+				},
+			},
+		},
+		Now: now.Add(time.Second),
 	})
 	if err != nil {
-		t.Fatalf("ChatOperatorConversationFork: %v", err)
+		t.Fatalf("RecordOperatorConversationForkChat: %v", err)
 	}
 	if result.ForkID != fork.ForkID || result.Turn.TurnIndex != 1 || result.Turn.TurnID == "" || !result.Turn.ParseOK {
 		t.Fatalf("chat result turn = %#v", result)
@@ -258,28 +301,27 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if entity.EntityID != entityID || entity.CurrentState != "draft" || entity.Fields["name"] != "Before" {
 		t.Fatalf("entity snapshot = %#v, want source-at-fork projection", entity)
 	}
-	readCall := requireConversationForkToolCall(t, result.Turn.ToolCalls, "fork_snapshot.read_entities")
+	readCall := requireConversationForkToolCall(t, result.Turn.ToolCalls, "fork_snapshot_read_entities")
 	readArgs := conversationForkToolCallMap(t, readCall.Arguments)
-	if readArgs["source_agent_id"] != source.agentID || readArgs["snapshot_owner"] != ConversationForkChatSnapshotOwner {
+	if readArgs["entity_id"] != entityID {
 		t.Fatalf("snapshot read tool args = %#v", readArgs)
 	}
 	readResult := conversationForkToolCallMap(t, readCall.Result)
 	if readResult["status"] != "read_from_snapshot" || readResult["snapshot_owner"] != ConversationForkChatSnapshotOwner || readResult["entity_count"] != float64(1) {
 		t.Fatalf("snapshot read tool result = %#v", readResult)
 	}
-	for _, toolName := range []string{"save_entity_field", "emit_event", "mailbox.approve", "run.start"} {
+	for _, toolName := range []string{"save_entity_field", "emit_event", "mailbox_approve", "run_start"} {
 		call := requireConversationForkToolCall(t, result.Turn.ToolCalls, toolName)
-		args := conversationForkToolCallMap(t, call.Arguments)
-		if args["source_agent_id"] != source.agentID {
-			t.Fatalf("%s args = %#v, want source_agent_id %s", toolName, args, source.agentID)
-		}
 		stub := conversationForkToolCallMap(t, call.Result)
 		if stub["status"] != "stubbed" || stub["owner"] != ConversationForkChatSandboxOwner || stub["live_mutation"] != false {
 			t.Fatalf("%s stub result = %#v", toolName, stub)
 		}
 	}
-	if len(result.Turn.ToolCalls) <= 1 {
-		t.Fatalf("tool calls = %#v, want snapshot read plus stubbed side-effect evidence", result.Turn.ToolCalls)
+	if len(result.Turn.ToolCalls) != 5 {
+		t.Fatalf("tool calls = %#v, want only requested snapshot/stub tool evidence", result.Turn.ToolCalls)
+	}
+	if call := findConversationForkToolCall(result.Turn.ToolCalls, "run_stop"); call != nil {
+		t.Fatalf("unrequested tool call persisted: %#v", *call)
 	}
 	var responsePayload struct {
 		ToolCalls []OperatorConversationToolCall `json:"tool_calls"`
@@ -348,11 +390,9 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if _, err := s.DeleteOperatorConversationFork(ctx, fork.ForkID, now.Add(2*time.Second)); err != nil {
 		t.Fatalf("DeleteOperatorConversationFork: %v", err)
 	}
-	_, err = s.ChatOperatorConversationFork(ctx, ConversationForkChatRequest{
-		ForkID:       fork.ForkID,
-		Message:      "should fail",
-		ActorTokenID: "actor-token",
-		Now:          now.Add(3 * time.Second),
+	_, err = s.PrepareOperatorConversationForkChat(ctx, ConversationForkChatPrepareRequest{
+		ForkID: fork.ForkID,
+		Now:    now.Add(3 * time.Second),
 	})
 	var paramErr *EntityReadParamError
 	if !errors.As(err, &paramErr) || paramErr.Field != "fork_id" {
@@ -362,16 +402,23 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 
 func requireConversationForkToolCall(t *testing.T, calls []OperatorConversationToolCall, name string) OperatorConversationToolCall {
 	t.Helper()
-	for _, call := range calls {
-		if call.Name == name {
-			if len(call.Result) == 0 {
-				t.Fatalf("%s tool call has no result evidence: %#v", name, call)
-			}
-			return call
+	if call := findConversationForkToolCall(calls, name); call != nil {
+		if len(call.Result) == 0 {
+			t.Fatalf("%s tool call has no result evidence: %#v", name, *call)
 		}
+		return *call
 	}
 	t.Fatalf("tool call %s missing from %#v", name, calls)
 	return OperatorConversationToolCall{}
+}
+
+func findConversationForkToolCall(calls []OperatorConversationToolCall, name string) *OperatorConversationToolCall {
+	for i := range calls {
+		if calls[i].Name == name {
+			return &calls[i]
+		}
+	}
+	return nil
 }
 
 func conversationForkToolCallMap(t *testing.T, raw json.RawMessage) map[string]any {

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -213,6 +214,18 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, source.runID).Scan(&mutationsBefore); err != nil {
 		t.Fatalf("count source mutations before chat: %v", err)
 	}
+	var eventsBefore int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&eventsBefore); err != nil {
+		t.Fatalf("count events before chat: %v", err)
+	}
+	var mailboxBefore int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox`).Scan(&mailboxBefore); err != nil {
+		t.Fatalf("count mailbox before chat: %v", err)
+	}
+	var runsBefore int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs`).Scan(&runsBefore); err != nil {
+		t.Fatalf("count runs before chat: %v", err)
+	}
 
 	fork, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
 		SourceSessionID: source.sessionID,
@@ -245,6 +258,38 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if entity.EntityID != entityID || entity.CurrentState != "draft" || entity.Fields["name"] != "Before" {
 		t.Fatalf("entity snapshot = %#v, want source-at-fork projection", entity)
 	}
+	readCall := requireConversationForkToolCall(t, result.Turn.ToolCalls, "fork_snapshot.read_entities")
+	readArgs := conversationForkToolCallMap(t, readCall.Arguments)
+	if readArgs["source_agent_id"] != source.agentID || readArgs["snapshot_owner"] != ConversationForkChatSnapshotOwner {
+		t.Fatalf("snapshot read tool args = %#v", readArgs)
+	}
+	readResult := conversationForkToolCallMap(t, readCall.Result)
+	if readResult["status"] != "read_from_snapshot" || readResult["snapshot_owner"] != ConversationForkChatSnapshotOwner || readResult["entity_count"] != float64(1) {
+		t.Fatalf("snapshot read tool result = %#v", readResult)
+	}
+	for _, toolName := range []string{"save_entity_field", "emit_event", "mailbox.approve", "run.start"} {
+		call := requireConversationForkToolCall(t, result.Turn.ToolCalls, toolName)
+		args := conversationForkToolCallMap(t, call.Arguments)
+		if args["source_agent_id"] != source.agentID {
+			t.Fatalf("%s args = %#v, want source_agent_id %s", toolName, args, source.agentID)
+		}
+		stub := conversationForkToolCallMap(t, call.Result)
+		if stub["status"] != "stubbed" || stub["owner"] != ConversationForkChatSandboxOwner || stub["live_mutation"] != false {
+			t.Fatalf("%s stub result = %#v", toolName, stub)
+		}
+	}
+	if len(result.Turn.ToolCalls) <= 1 {
+		t.Fatalf("tool calls = %#v, want snapshot read plus stubbed side-effect evidence", result.Turn.ToolCalls)
+	}
+	var responsePayload struct {
+		ToolCalls []OperatorConversationToolCall `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(result.Turn.ResponsePayload, &responsePayload); err != nil {
+		t.Fatalf("decode forkchat response payload: %v", err)
+	}
+	if len(responsePayload.ToolCalls) != len(result.Turn.ToolCalls) {
+		t.Fatalf("response payload tool_calls = %d, want %d", len(responsePayload.ToolCalls), len(result.Turn.ToolCalls))
+	}
 
 	loaded, err := s.LoadOperatorConversationFork(ctx, fork.ForkID)
 	if err != nil {
@@ -253,6 +298,9 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if len(loaded.Turns) != 1 || loaded.Turns[0].TurnID != result.Turn.TurnID {
 		t.Fatalf("fork_view turns = %#v, want fork-local chat turn", loaded.Turns)
 	}
+	if len(loaded.Turns[0].ToolCalls) != len(result.Turn.ToolCalls) {
+		t.Fatalf("fork_view tool calls = %#v, want persisted sandbox evidence", loaded.Turns[0].ToolCalls)
+	}
 
 	var mutationsAfter int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, source.runID).Scan(&mutationsAfter); err != nil {
@@ -260,6 +308,27 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	}
 	if mutationsAfter != mutationsBefore {
 		t.Fatalf("source mutations changed from %d to %d; forkchat must not live-mutate", mutationsBefore, mutationsAfter)
+	}
+	var eventsAfter int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&eventsAfter); err != nil {
+		t.Fatalf("count events after chat: %v", err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("events changed from %d to %d; forkchat must not emit live events", eventsBefore, eventsAfter)
+	}
+	var mailboxAfter int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox`).Scan(&mailboxAfter); err != nil {
+		t.Fatalf("count mailbox after chat: %v", err)
+	}
+	if mailboxAfter != mailboxBefore {
+		t.Fatalf("mailbox changed from %d to %d; forkchat must not mutate mailbox decisions", mailboxBefore, mailboxAfter)
+	}
+	var runsAfter int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs`).Scan(&runsAfter); err != nil {
+		t.Fatalf("count runs after chat: %v", err)
+	}
+	if runsAfter != runsBefore {
+		t.Fatalf("runs changed from %d to %d; forkchat must not start or mutate live runs", runsBefore, runsAfter)
 	}
 	var normalTurns int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid`, fork.ForkID).Scan(&normalTurns); err != nil {
@@ -289,6 +358,29 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	if !errors.As(err, &paramErr) || paramErr.Field != "fork_id" {
 		t.Fatalf("deleted fork chat error = %v, want fork_id invalid params", err)
 	}
+}
+
+func requireConversationForkToolCall(t *testing.T, calls []OperatorConversationToolCall, name string) OperatorConversationToolCall {
+	t.Helper()
+	for _, call := range calls {
+		if call.Name == name {
+			if len(call.Result) == 0 {
+				t.Fatalf("%s tool call has no result evidence: %#v", name, call)
+			}
+			return call
+		}
+	}
+	t.Fatalf("tool call %s missing from %#v", name, calls)
+	return OperatorConversationToolCall{}
+}
+
+func conversationForkToolCallMap(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode tool call JSON %s: %v", string(raw), err)
+	}
+	return out
 }
 
 type conversationForkSourceFixture struct {

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -177,6 +177,120 @@ func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testi
 	}
 }
 
+func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	source := seedConversationForkSource(t, db, now)
+	entityID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'flow/forkchat', 'default',
+			'after', '{}'::jsonb, '{"name":"After"}'::jsonb, '{}'::jsonb, 2,
+			$3, $3, $3
+		)
+	`, source.runID, entityID, source.turn1At.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed source entity_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (run_id, entity_id, field, old_value, new_value, writer_type, writer_id, created_at)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', NULL, '"draft"'::jsonb, 'platform', 'test', $3),
+			($1::uuid, $2::uuid, 'name', NULL, '"Before"'::jsonb, 'platform', 'test', $3),
+			($1::uuid, $2::uuid, 'current_state', '"draft"'::jsonb, '"after"'::jsonb, 'platform', 'test', $4),
+			($1::uuid, $2::uuid, 'name', '"Before"'::jsonb, '"After"'::jsonb, 'platform', 'test', $4)
+	`, source.runID, entityID, source.turn1At.Add(-30*time.Second), source.turn1At.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed source entity mutations: %v", err)
+	}
+	var mutationsBefore int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, source.runID).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count source mutations before chat: %v", err)
+	}
+
+	fork, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
+		SourceSessionID: source.sessionID,
+		ForkPoint:       ConversationForkPointSelector{Kind: "turn", TurnIndex: 1},
+		CreatedBy:       "actor-token",
+		Now:             now,
+	})
+	if err != nil {
+		t.Fatalf("CreateOperatorConversationFork: %v", err)
+	}
+	result, err := s.ChatOperatorConversationFork(ctx, ConversationForkChatRequest{
+		ForkID:       fork.ForkID,
+		Message:      "inspect the fork",
+		ActorTokenID: "actor-token",
+		Now:          now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ChatOperatorConversationFork: %v", err)
+	}
+	if result.ForkID != fork.ForkID || result.Turn.TurnIndex != 1 || result.Turn.TurnID == "" || !result.Turn.ParseOK {
+		t.Fatalf("chat result turn = %#v", result)
+	}
+	if result.Snapshot.SnapshotOwner != ConversationForkChatSnapshotOwner || result.SandboxPolicy.Owner != ConversationForkChatSandboxOwner {
+		t.Fatalf("owners = snapshot %q policy %q", result.Snapshot.SnapshotOwner, result.SandboxPolicy.Owner)
+	}
+	if len(result.Snapshot.EntitySnapshot) != 1 {
+		t.Fatalf("snapshot entities = %#v, want one reconstructed entity", result.Snapshot.EntitySnapshot)
+	}
+	entity := result.Snapshot.EntitySnapshot[0]
+	if entity.EntityID != entityID || entity.CurrentState != "draft" || entity.Fields["name"] != "Before" {
+		t.Fatalf("entity snapshot = %#v, want source-at-fork projection", entity)
+	}
+
+	loaded, err := s.LoadOperatorConversationFork(ctx, fork.ForkID)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversationFork after chat: %v", err)
+	}
+	if len(loaded.Turns) != 1 || loaded.Turns[0].TurnID != result.Turn.TurnID {
+		t.Fatalf("fork_view turns = %#v, want fork-local chat turn", loaded.Turns)
+	}
+
+	var mutationsAfter int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, source.runID).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count source mutations after chat: %v", err)
+	}
+	if mutationsAfter != mutationsBefore {
+		t.Fatalf("source mutations changed from %d to %d; forkchat must not live-mutate", mutationsBefore, mutationsAfter)
+	}
+	var normalTurns int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid`, fork.ForkID).Scan(&normalTurns); err != nil {
+		t.Fatalf("count normal agent_turns for fork id: %v", err)
+	}
+	if normalTurns != 0 {
+		t.Fatalf("forkchat leaked into agent_turns rows = %d", normalTurns)
+	}
+	var runtimeEvents int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'platform.runtime_log' AND produced_by = $1`, fork.ForkID).Scan(&runtimeEvents); err != nil {
+		t.Fatalf("count runtime log events for fork id: %v", err)
+	}
+	if runtimeEvents != 0 {
+		t.Fatalf("forkchat leaked runtime log events = %d", runtimeEvents)
+	}
+
+	if _, err := s.DeleteOperatorConversationFork(ctx, fork.ForkID, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("DeleteOperatorConversationFork: %v", err)
+	}
+	_, err = s.ChatOperatorConversationFork(ctx, ConversationForkChatRequest{
+		ForkID:       fork.ForkID,
+		Message:      "should fail",
+		ActorTokenID: "actor-token",
+		Now:          now.Add(3 * time.Second),
+	})
+	var paramErr *EntityReadParamError
+	if !errors.As(err, &paramErr) || paramErr.Field != "fork_id" {
+		t.Fatalf("deleted fork chat error = %v, want fork_id invalid params", err)
+	}
+}
+
 type conversationForkSourceFixture struct {
 	runID     string
 	agentID   string

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -402,6 +402,16 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string) (string, 
 			return `SELECT COUNT(*) FROM conversation_forks WHERE source_run_id = ANY($1::uuid[])`, args, nil
 		}
 		return `DELETE FROM conversation_forks WHERE source_run_id = ANY($1::uuid[])`, args, nil
+	case "conversation_fork_snapshots":
+		if mode == "count" {
+			return `SELECT COUNT(*) FROM conversation_fork_snapshots s WHERE EXISTS (SELECT 1 FROM conversation_forks f WHERE f.fork_id = s.fork_id AND f.source_run_id = ANY($1::uuid[]))`, args, nil
+		}
+		return `DELETE FROM conversation_fork_snapshots s USING conversation_forks f WHERE s.fork_id = f.fork_id AND f.source_run_id = ANY($1::uuid[])`, args, nil
+	case "conversation_fork_turns":
+		if mode == "count" {
+			return `SELECT COUNT(*) FROM conversation_fork_turns t WHERE EXISTS (SELECT 1 FROM conversation_forks f WHERE f.fork_id = t.fork_id AND f.source_run_id = ANY($1::uuid[]))`, args, nil
+		}
+		return `DELETE FROM conversation_fork_turns t USING conversation_forks f WHERE t.fork_id = f.fork_id AND f.source_run_id = ANY($1::uuid[])`, args, nil
 	case "run_fork_delivery_event_replays":
 		if mode == "count" {
 			return `

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -326,6 +326,7 @@ func cloneConversationToolCalls(in []OperatorConversationToolCall) []OperatorCon
 	for i, item := range in {
 		out[i] = item
 		out[i].Arguments = cloneRawMessage(item.Arguments)
+		out[i].Result = cloneRawMessage(item.Result)
 	}
 	return out
 }
@@ -418,8 +419,10 @@ type OperatorConversationTurn struct {
 }
 
 type OperatorConversationToolCall struct {
+	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Result    json.RawMessage `json:"result,omitempty"`
 }
 
 type OperatorConversationToolResult struct {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -37,14 +37,16 @@ type EventSchemaCapabilities struct {
 }
 
 type ConversationSchemaCapabilities struct {
-	Sessions     SchemaFlavor
-	Audits       SchemaFlavor
-	Turns        SchemaFlavor
-	Forks        SchemaFlavor
-	SessionRunID bool
-	AuditRunID   bool
-	TurnRunID    bool
-	TurnBlocks   bool
+	Sessions      SchemaFlavor
+	Audits        SchemaFlavor
+	Turns         SchemaFlavor
+	Forks         SchemaFlavor
+	ForkSnapshots SchemaFlavor
+	ForkTurns     SchemaFlavor
+	SessionRunID  bool
+	AuditRunID    bool
+	TurnRunID     bool
+	TurnBlocks    bool
 }
 
 type StoreSchemaCapabilities struct {
@@ -250,6 +252,22 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 				"fork_point_kind", "fork_point_turn_index", "fork_point_turn_id",
 				"fork_point_event_id", "fork_point_at", "fork_point_selected_at",
 				"created_by", "created_at", "expires_at", "deleted_at",
+			},
+			nil,
+		),
+		ForkSnapshots: detectSchemaFlavor(catalog, "conversation_fork_snapshots",
+			[]string{
+				"fork_id", "source_session_id", "source_run_id", "source_agent_id",
+				"fork_point_turn_id", "fork_point_turn_index", "fork_point_selected_at",
+				"source_turn", "entity_snapshot", "snapshot_owner", "created_at",
+			},
+			nil,
+		),
+		ForkTurns: detectSchemaFlavor(catalog, "conversation_fork_turns",
+			[]string{
+				"fork_turn_id", "fork_id", "turn_index", "actor_token_id", "message",
+				"assistant_message", "request_payload", "response_payload", "tool_calls",
+				"sandbox_policy", "snapshot_owner", "created_at",
 			},
 			nil,
 		),

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -339,6 +339,10 @@ func platformTableOrder(name string) int {
 		return 65
 	case "conversation_forks":
 		return 66
+	case "conversation_fork_snapshots":
+		return 67
+	case "conversation_fork_turns":
+		return 68
 	case "routing_rules":
 		return 70
 	case "event_deliveries":

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -525,6 +525,12 @@ func bootstrapPlatformTableOrder(name string) int {
 		return 60
 	case "agent_turns":
 		return 65
+	case "conversation_forks":
+		return 66
+	case "conversation_fork_snapshots":
+		return 67
+	case "conversation_fork_turns":
+		return 68
 	case "routing_rules":
 		return 70
 	case "event_deliveries":


### PR DESCRIPTION
Closes #1063

## Summary

Adds the approved forkchat chat execution/snapshot/sandbox/transcript owner slice for #749:

- promotes `/v1/rpc conversation.fork_chat` in `platform-spec.yaml` and regenerated OpenRPC
- adds the API/store owner for fork-local chat turns and fork-point snapshots
- keeps `swarm forkchat` absent and fail-closed because CLI remains split until the API/runtime/store owners exist
- wires destructive reset cleanup for the new isolated forkchat tables

## Governing refs / context

- #1063 Pre-Implementation Coverage Audit and gate outcome: `approved as first slice`
- Parent tracker: #749
- Exact spec refs changed in this PR:
  - `platform_tables.tables.conversation_forks`
  - `platform_tables.tables.conversation_fork_snapshots`
  - `platform_tables.tables.conversation_fork_turns`
  - `api_specification.method_catalog.conversation.fork_chat`
  - `api_specification.components.schemas.ConversationForkSession`
  - `api_specification.components.schemas.ConversationForkChatResult`
  - `api_specification.components.schemas.ConversationForkSnapshot`
  - `api_specification.components.schemas.ConversationForkSandboxPolicy`

## Semantic migration

- New canonical owner: `conversation.fork_chat` API contract plus `internal/apiv1` handler and `internal/store` forkchat store owner.
- New persistence owners: `conversation_fork_snapshots` and `conversation_fork_turns`.
- Old/non-authoritative paths now invalid: review-artifact forkchat prose, CLI-local transcript storage, direct DB/runtime/EventBus/dashboard reads, normal `agent_turns`/`events`/runtime logs as default fork transcript surfaces, and `run.fork` materializers by proximity.
- Production paths checked for surviving old behavior: generated OpenRPC, `internal/apispec`, `internal/apiv1`, `internal/store`, destructive reset cleanup, and `cmd/swarm` absent-command behavior.
- Migration completeness: complete for #1063 chosen class; parent #749 remains open for CLI, full include-forks surface behavior, Dashboard/Builder, sharing/ACL/pinning, and other explicitly split tails.

## Proof run

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec`
- `go test ./internal/apiv1 -run 'ConversationFork|OpenRPC|RegistryMethodNames'`
- `go test ./internal/store -run 'ConversationFork|DestructiveReset|SchemaDDL|SchemaCapabilities'`
- `go test ./cmd/swarm -run 'Fork|forkchat|CLIOutputModeExceptionRowsFailClosedBeforeSideEffects|CLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects'`
- `go run ./cmd/swarm forkchat --help` (expected fail-closed absent command: `unknown command "forkchat" for "swarm"`)
- `go test ./...`
