### PR TITLE
[agent-c][issue #1065] Reconcile tool bootcheck source authority

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -120,9 +120,10 @@ spec_authority:
       authority_language_risk: false
       disposition: Candidate design context only unless exact timer typing semantics are promoted here.
     - path: docs/specs/swarm-platform/platform/contracts/review/platform-spec.tool-usage-hints.yaml
-      classification: promote_commit_needed
+      classification: already_promoted
       authority_language_risk: true
-      disposition: Tool-usage hint semantics are not merge-bearing until promoted into this file with matching implementation.
+      disposition: Tool-usage hint semantics are promoted into engine.boot_verification.checks and engine.agent_tool_filtering;
+        the review draft is evidence only.
     - path: docs/specs/swarm-platform/platform/contracts/review/platform-spec.user-facing-rpc-api.yaml
       classification: stale_header_repair
       authority_language_risk: true
@@ -2729,8 +2730,21 @@ engine:
     - id: tool_resolution
       severity: warning
       scope: per-agent
-      trigger: An agent's tools list references a tool name that does not exist in the merged tool registry (tools.yaml +
-        MCP server catalogs).
+      trigger: An agent's tools list references a tool name that does not exist in the merged runtime tool registry
+        (platform builtin tools, authored tools.yaml/http tools, and MCP server catalogs).
+      when: boot-only
+    - id: platform_tool_usage_hints
+      severity: hard_invalidity
+      scope: per-tool
+      trigger: A platform-owned delivered tool or generated emit tool lacks the shared provider-facing usage hint, the
+        generated emit usage hint instructs CEL/expression arguments instead of concrete payload values, or a delivered
+        tool usage hint exceeds the provider-facing lint limit.
+      when: boot-only
+    - id: generated_tool_schema_closure
+      severity: hard_invalidity
+      scope: per-tool
+      trigger: A generated platform-owned emit/entity tool schema is not provider-closed, omits declared required properties,
+        requires undeclared properties, declares an empty enum, or cannot be lowered to the provider JSON Schema contract.
       when: boot-only
     - id: prompt_exists
       severity: warning
@@ -3228,6 +3242,12 @@ tool_model:
     rule: When constructing an agent session, the platform resolves tools entries against the merged tool registry
       (platform_builtin + mcp + http). Only resolved tools are included in the LLM tool definitions. Unresolvable entries
       log a warning per the tool_resolution boot check.
+    usage_hints: Provider-facing tool definitions for platform-owned delivered tools and generated emit tools MUST include
+      the shared platform usage guidance. Generated emit tool usage guidance MUST describe concrete JSON payload arguments,
+      not CEL or workflow expression arguments. Boot verification reports this through platform_tool_usage_hints.
+    generated_schema_closure: Generated platform-owned emit/entity tool schemas MUST be recursively closed, require every
+      declared property, reject undeclared required properties, and declare non-empty enums. Boot verification and workflow
+      validation report this through generated_tool_schema_closure and consume the shared runtime tool-schema owner.
     universal_tools: 'The following tools are included in every agent session without listing in tools: agent_message
       and mailbox_send. Emit tools (emit_{event_name}) are auto-generated from emit_events. Neither universal communication
       tools nor emit tools require explicit tools entry.'

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -643,6 +643,7 @@ The most important checks to recognize:
 - `state_machine_coherence` — verify state transitions make sense.
 - `required_agents_match` — verify agent roles are fulfilled.
 - `handler_field_compliance` — verify handler fields and supported handler action declarations match the platform handler contract.
+- `tool_resolution`, `platform_tool_usage_hints`, `generated_tool_schema_closure` — verify agent tool references resolve through the merged runtime registry and that platform-owned/generated tool surfaces have provider-facing usage guidance and closed schemas.
 - `single_node_per_event` — verify each event is handled by at most one system node.
 - `event_cycle_detection` — verify no infinite event loops.
 

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1137,6 +1137,8 @@ timers:
 - `id`: required_agents_match; `severity`: error
 - `id`: handler_field_compliance; `severity`: error
 - `id`: tool_resolution; `severity`: warning
+- `id`: platform_tool_usage_hints; `severity`: hard_invalidity
+- `id`: generated_tool_schema_closure; `severity`: hard_invalidity
 - `id`: prompt_exists; `severity`: warning
 - `id`: produces_drift; `severity`: warning
 - `id`: invalid_field_detection; `severity`: error
@@ -1151,8 +1153,8 @@ timers:
   - `error`: Boot aborts. System does not start.
   - `warning`: Boot continues. Warning logged with finding details.
 
-- `reference_implementation`: verify.py implements structural checks (payload fields, handler fields and supported handler action declaration shapes, state machine, tools, dialect, cycles, produces). It does NOT implement: CEL parsing, runtime executor resolution, deep artifact result-event type resolution, pin wiring, permission validation, entity schema coverage, or namespace collision detection. Those require the Go runtime loader.
-- `check_count`: 19 checks (10 error, 9 warning)
+- `reference_implementation`: verify.py implements structural checks (payload fields, handler fields and supported handler action declaration shapes, state machine, tools, dialect, cycles, produces). It does NOT implement: CEL parsing, runtime executor resolution, discovered MCP tool inventory, platform_tool_usage_hints, generated_tool_schema_closure, deep artifact result-event type resolution, pin wiring, permission validation, entity schema coverage, or namespace collision detection. Those require the Go runtime loader.
+- `check_count`: See `platform/contracts/platform-spec.yaml`; this markdown summary is not the merge-bearing boot-check catalog.
 # compliance
 
 Boot-time and runtime compliance enforcement.

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -99,6 +99,24 @@ for flow in FLOWS:
 
 events_defined = set(k for k, v in all_events.items() if isinstance(v, dict))
 
+RUNTIME_BUILTIN_TOOLS = {
+    'agent_message',
+    'schedule',
+    'agent_hire',
+    'agent_fire',
+    'agent_reconfigure',
+    'get_entity',
+    'save_entity_field',
+    'create_entity',
+    'query_entities',
+    'search_entities',
+    'query_metrics',
+    'mailbox_send',
+    'human_task_request',
+    'human_task_decide',
+    'read_flow_data',
+}
+
 # ============================================================
 # Helpers
 # ============================================================
@@ -137,6 +155,23 @@ def payload_field_exists(fields, ref):
         if ref == candidate or ref.startswith(candidate + '.') or candidate.startswith(ref + '.'):
             return True
     return False
+
+def declared_mcp_prefixes():
+    prefixes = set()
+    policy = all_policy.get('mcp_servers', {})
+    if not isinstance(policy, dict): return prefixes
+    for server in policy.values():
+        if not isinstance(server, dict): continue
+        prefix = str(server.get('prefix') or '').strip()
+        if prefix:
+            prefixes.add(prefix)
+    return prefixes
+
+def tool_allowed_by_mcp_prefix(tool, prefixes):
+    tool = str(tool or '').strip()
+    if '.' not in tool: return False
+    prefix = tool.split('.', 1)[0].strip()
+    return bool(prefix and prefix in prefixes)
 
 def extract_payload_refs(s):
     return re.findall(r'payload\.([a-zA-Z_][a-zA-Z0-9_.]*)', str(s))
@@ -656,12 +691,16 @@ for flow, nodes in iter_flows_with_nodes():
 # ============================================================
 # CHECK: tool_resolution [warning, per-agent]
 # ============================================================
+runtime_tool_names = set(all_tools.keys()) | RUNTIME_BUILTIN_TOOLS
+mcp_prefixes = declared_mcp_prefixes()
 for flow, agents in iter_flows_with_agents():
     for aid, agent in agents.items():
         if not isinstance(agent, dict): continue
         for tool in agent.get('tools', agent.get('tools_tier2', [])):
-            if tool not in all_tools:
-                warn("tool_resolution", "tool '%s' not in any tools.yaml" % tool, "%s/%s" % (flow, aid))
+            tool_name = str(tool or '').strip()
+            if not tool_name: continue
+            if tool_name not in runtime_tool_names and not tool_allowed_by_mcp_prefix(tool_name, mcp_prefixes):
+                warn("tool_resolution", "tool '%s' not in the structural runtime tool registry subset" % tool_name, "%s/%s" % (flow, aid))
 
 # ============================================================
 # CHECK: prompt_exists [warning, per-agent]
@@ -957,7 +996,7 @@ t = sum(1 for v in all_tools.values() if isinstance(v, dict))
 if deferred_count:
     print("\n[INFO]  %d prompts marked DEFERRED" % deferred_count)
 
-print("\n[INFO]  structural verifier subset; Go runtime owns CEL, runtime executor resolution, deep artifact result-event typing, MCP, credential, and entity-write-target checks")
+print("\n[INFO]  structural verifier subset; Go runtime owns CEL, runtime executor resolution, discovered MCP tool inventory, platform_tool_usage_hints, generated_tool_schema_closure, deep artifact result-event typing, credential, and entity-write-target checks")
 
 print("\n" + "=" * 70)
 print("SUMMARY: %d errors, %d warnings" % (len(errors_list), len(warnings_list)))

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -158,7 +158,7 @@ def payload_field_exists(fields, ref):
 
 def declared_mcp_prefixes():
     prefixes = set()
-    policy = all_policy.get('mcp_servers', {})
+    policy = root_policy.get('mcp_servers', {})
     if not isinstance(policy, dict): return prefixes
     for server in policy.values():
         if not isinstance(server, dict): continue

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -156,6 +156,10 @@ active_issues:
     title: Reconcile handler_field_compliance owner and runtime-contract scope
     maps_to:
       - boot_check_definition_drift
+  - id: 1065
+    title: Reconcile platform tool bootverify source authority
+    maps_to:
+      - boot_check_definition_drift
 nodes:
   - id: persisted_normal_run_completion_quiescence_owner
     title: Persisted Normal Run Completion/Quiescence Owner
@@ -252,11 +256,14 @@ nodes:
       - gate schema validation treats missing or empty gate_state as an open schema for handler-level sets_gate
       - condition payload-reference validation treats existing empty event payload schemas as open schemas
       - handler_field_compliance is interpreted as handler field vocabulary only in spec/reference surfaces while Go bootverify uses it for supported handler action declarations, executable owner resolution, and runtime-handled event executor presence
+      - platform_tool_usage_hints and generated_tool_schema_closure are live runtime tool-surface checks that need authoritative boot-check definitions and shared consumer proof
+      - tool_resolution can drift when structural verifier scripts interpret only tools.yaml while Go bootverify consumes the merged runtime tool registry and MCP discovery boundary
     representative_issues:
       - 447
       - 448
       - 974
       - 1055
+      - 1065
     common_framing_mistakes:
       too_broad:
         - all bootverify drift
@@ -511,23 +518,10 @@ nodes:
       - emit grammar, loader, semantic-view, runtime selection, and boot/verify consumers that must interpret the same emit-site ownership model
     why_this_node_exists: the platform cannot make event schema the strict cross-flow contract while different emit sites still share one ambiguous handler-level payload model or while supported consumers interpret emit authorship differently.
     known_manifestations:
-      - closed child seams under this node:
-        - structured emit ownership across handler top level, rules, on_complete, accumulate.on_timeout, and fan_out
-        - strict declarative runtime emit construction and verify/boot proof parity
-        - strict agent emit parity
-        - strict action-originated emit parity
-        - strict auto_emit_on_create parity
-      - remaining compatibility-reference tail addressed by #470:
-        - dead contract/type residue for PayloadTransformSpec after retired authored surfaces stopped being accepted on supported handler/rule/fan_out paths
-        - stale verify/report wording and dead-event audit text that still described payload_transform-era proof surfaces
-        - supported proof-harness allowlists and active prose/reference surfaces that still described payload_transform, fan_out.emit_per_item, or implicit passthrough as current behavior
-      - adjacent split promoted by #472:
-        - canonical event-store admission validation remains intentionally separate from supported emit-surface validation;
-          emit surfaces own producer-authored payload proof before publish, while runtime/store admission validates all events
-          before persistence and residual ingress/store append paths; routing, delivery, source/target, and recipient semantics
-          stay split to #926
-      - adjacent supporting migration tracked by #605:
-        - canonical event-level swarm metadata now owns non-derivable external/lifecycle topology proof so flat event payload fields and verifier metadata no longer share ambiguous underscore ownership
+      - "closed child seams under this node: structured emit ownership across handler top level, rules, on_complete, accumulate.on_timeout, fan_out; strict declarative runtime emit construction and verify/boot proof parity; strict agent/action/auto_emit_on_create parity"
+      - "remaining compatibility-reference tail addressed by #470: dead PayloadTransformSpec residue, stale verify/report wording, and active prose/reference surfaces describing retired payload_transform/fan_out.emit_per_item/implicit passthrough behavior"
+      - "adjacent split promoted by #472: canonical event-store admission validation remains separate from supported emit-surface validation; routing, delivery, source/target, and recipient semantics stay split to #926"
+      - "adjacent supporting migration tracked by #605: canonical event-level swarm metadata owns non-derivable external/lifecycle topology proof so flat event payload fields and verifier metadata no longer share ambiguous underscore ownership"
     representative_issues:
       - 455
       - 457

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -270,12 +270,7 @@ func checkStateMachineCoherence(c *checkerContext) []Finding { return c.stateMac
 func checkNodeStateSchemaTypedCounterpart(c *checkerContext) []Finding {
 	return c.nodeStateSchemaTypedCounterpart()
 }
-func checkRequiredAgentsMatch(c *checkerContext) []Finding    { return c.requiredAgentsMatch() }
-func checkToolResolution(c *checkerContext) []Finding         { return c.toolResolution() }
-func checkPlatformToolUsageHints(c *checkerContext) []Finding { return c.platformToolUsageHints() }
-func checkGeneratedToolSchemaClosure(c *checkerContext) []Finding {
-	return c.generatedToolSchemaClosure()
-}
+func checkRequiredAgentsMatch(c *checkerContext) []Finding        { return c.requiredAgentsMatch() }
 func checkPromptExists(c *checkerContext) []Finding               { return c.promptExists() }
 func checkInvalidFieldDetection(c *checkerContext) []Finding      { return c.invalidFieldDetection() }
 func checkPolicyConflictDetection(c *checkerContext) []Finding    { return c.policyConflicts() }
@@ -454,103 +449,6 @@ func (c *checkerContext) promptExists() []Finding {
 		c.promptFindings = append(c.promptFindings, promptFindingsForDir(scope.PromptsDir, scopeLabel, scope.Agents)...)
 	}
 	return c.promptFindings
-}
-
-func (c *checkerContext) toolResolution() []Finding {
-	if c.toolLoaded {
-		return c.toolFindings
-	}
-	c.toolLoaded = true
-	mcpPrefixes := declaredMCPPrefixes(c.source)
-	discoveredTools := c.mcpDiscovered()
-	// Boot tool warnings must consume the same runtime inventory truth that the
-	// generic runtime ships, then layer MCP discovery on top of it.
-	runtimeToolNames := c.runtimeAvailableToolNames()
-	for agentID, agent := range c.source.AgentEntries() {
-		agentID = strings.TrimSpace(agentID)
-		for _, toolID := range agent.ConfiguredTools() {
-			toolID = strings.TrimSpace(toolID)
-			if toolID == "" {
-				continue
-			}
-			if entry, ok := c.source.ToolEntryForAgent(agentID, toolID); ok {
-				if mcpToolEntryRequiresDiscovery(entry) && !toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
-					c.toolFindings = append(c.toolFindings, Finding{
-						CheckID:  "tool_resolution",
-						Severity: "warning",
-						Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
-						Location: agentID,
-					})
-				}
-				continue
-			}
-			if toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
-				continue
-			}
-			if _, ok := runtimeToolNames[toolID]; ok {
-				continue
-			}
-			c.toolFindings = append(c.toolFindings, Finding{
-				CheckID:  "tool_resolution",
-				Severity: "warning",
-				Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
-				Location: agentID,
-			})
-		}
-	}
-	return c.toolFindings
-}
-
-func (c *checkerContext) platformToolUsageHints() []Finding {
-	if c.toolUsageLoaded {
-		return c.toolUsageFindings
-	}
-	c.toolUsageLoaded = true
-	for _, item := range runtimetools.ValidateUsageHintCoverage(c.source, c.mcpDiscovered()) {
-		severity := SeverityLintEvidence
-		if item.Severity == "error" {
-			severity = SeverityHardInvalidity
-		}
-		location := strings.TrimSpace(item.ToolName)
-		if location == "" {
-			location = "runtime-tools"
-		}
-		c.toolUsageFindings = append(c.toolUsageFindings, Finding{
-			CheckID:  "platform_tool_usage_hints",
-			Severity: severity,
-			Message:  item.Message,
-			Location: location,
-		})
-	}
-	return c.toolUsageFindings
-}
-
-func (c *checkerContext) generatedToolSchemaClosure() []Finding {
-	if c.generatedToolSchemaClosureLoaded {
-		return c.generatedToolSchemaClosureFindings
-	}
-	c.generatedToolSchemaClosureLoaded = true
-	for _, err := range runtimetools.ValidateGeneratedToolSchemaClosureForSource(c.source) {
-		c.generatedToolSchemaClosureFindings = append(c.generatedToolSchemaClosureFindings, Finding{
-			CheckID:  "generated_tool_schema_closure",
-			Severity: SeverityHardInvalidity,
-			Message:  err.Error(),
-			Location: "generated-tools",
-		})
-	}
-	return c.generatedToolSchemaClosureFindings
-}
-
-func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {
-	if c.runtimeToolNamesLoaded {
-		return c.runtimeToolNames
-	}
-	c.runtimeToolNamesLoaded = true
-	c.runtimeToolNames = make(map[string]struct{})
-	for _, name := range runtimetools.RuntimeAvailableToolNamesForSource(c.source) {
-		c.runtimeToolNames[strings.TrimSpace(name)] = struct{}{}
-	}
-	return c.runtimeToolNames
 }
 
 func (c *checkerContext) policyConflicts() []Finding {
@@ -1402,60 +1300,6 @@ func scopedObjectLabel(scopeLabel, objectID string) string {
 		return scopeLabel
 	}
 	return scopeLabel + "/" + objectID
-}
-
-func declaredMCPPrefixes(source semanticview.Source) map[string]struct{} {
-	if source == nil {
-		return nil
-	}
-	value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers")
-	if !ok {
-		return nil
-	}
-	root, ok := anyMap(value.Value)
-	if !ok || len(root) == 0 {
-		return nil
-	}
-	out := make(map[string]struct{}, len(root))
-	for _, raw := range root {
-		server, ok := anyMap(raw)
-		if !ok {
-			continue
-		}
-		prefix := strings.TrimSpace(anyString(server["prefix"]))
-		if prefix != "" {
-			out[prefix] = struct{}{}
-		}
-	}
-	return out
-}
-
-func toolReferenceAllowedByMCPPrefix(toolID string, prefixes map[string]struct{}) bool {
-	if len(prefixes) == 0 {
-		return false
-	}
-	prefix, _, ok := strings.Cut(strings.TrimSpace(toolID), ".")
-	if !ok || strings.TrimSpace(prefix) == "" {
-		return false
-	}
-	_, exists := prefixes[strings.TrimSpace(prefix)]
-	return exists
-}
-
-func toolReferenceAllowedByMCPCatalog(toolID string, discovered map[string]runtimemcp.DiscoveredTool, prefixes map[string]struct{}) bool {
-	toolID = strings.TrimSpace(toolID)
-	if toolID == "" {
-		return false
-	}
-	if len(discovered) > 0 {
-		_, ok := discovered[toolID]
-		return ok
-	}
-	return toolReferenceAllowedByMCPPrefix(toolID, prefixes)
-}
-
-func mcpToolEntryRequiresDiscovery(entry runtimecontracts.ToolSchemaEntry) bool {
-	return strings.EqualFold(strings.TrimSpace(entry.HandlerType), "mcp")
 }
 
 func rootPolicyScope(scopes []semanticview.ProjectScope) semanticview.ProjectScope {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -176,6 +176,43 @@ func TestRun_MapsMissingContractMCPToolToToolResolutionWarning(t *testing.T) {
 	}
 }
 
+func TestRun_MapsPlatformToolUsageHintCoverageToBootCheck(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"custom_platform_tool": {HandlerType: "platform_builtin"},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "platform_tool_usage_hints", "custom_platform_tool") {
+		t.Fatalf("expected platform_tool_usage_hints hard invalidity, got %#v", report.Errors())
+	}
+}
+
+func TestRun_MapsGeneratedToolSchemaClosureToBootCheck(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-1": {ID: "agent-1", Role: "agent", EmitEvents: []string{"ready.event"}},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"ready.event": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"unsupported": {Type: "NotDeclared"},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "generated_tool_schema_closure", "NotDeclared") {
+		t.Fatalf("expected generated_tool_schema_closure hard invalidity, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsEventNoSchemaToEventChainIntegrityWarning(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-event-no-schema")
 

--- a/internal/runtime/bootverify/runtime_tool_surface_checks.go
+++ b/internal/runtime/bootverify/runtime_tool_surface_checks.go
@@ -1,0 +1,170 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimemcp "swarm/internal/runtime/mcp"
+	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+func checkToolResolution(c *checkerContext) []Finding { return c.toolResolution() }
+func checkPlatformToolUsageHints(c *checkerContext) []Finding {
+	return c.platformToolUsageHints()
+}
+func checkGeneratedToolSchemaClosure(c *checkerContext) []Finding {
+	return c.generatedToolSchemaClosure()
+}
+
+func (c *checkerContext) toolResolution() []Finding {
+	if c.toolLoaded {
+		return c.toolFindings
+	}
+	c.toolLoaded = true
+	mcpPrefixes := declaredMCPPrefixes(c.source)
+	discoveredTools := c.mcpDiscovered()
+	// Boot tool warnings must consume the same runtime inventory truth that the
+	// generic runtime ships, then layer MCP discovery on top of it.
+	runtimeToolNames := c.runtimeAvailableToolNames()
+	for agentID, agent := range c.source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		for _, toolID := range agent.ConfiguredTools() {
+			toolID = strings.TrimSpace(toolID)
+			if toolID == "" {
+				continue
+			}
+			if entry, ok := c.source.ToolEntryForAgent(agentID, toolID); ok {
+				if mcpToolEntryRequiresDiscovery(entry) && !toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
+					c.toolFindings = append(c.toolFindings, Finding{
+						CheckID:  "tool_resolution",
+						Severity: "warning",
+						Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
+						Location: agentID,
+					})
+				}
+				continue
+			}
+			if toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
+				continue
+			}
+			if _, ok := runtimeToolNames[toolID]; ok {
+				continue
+			}
+			c.toolFindings = append(c.toolFindings, Finding{
+				CheckID:  "tool_resolution",
+				Severity: "warning",
+				Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
+				Location: agentID,
+			})
+		}
+	}
+	return c.toolFindings
+}
+
+func (c *checkerContext) platformToolUsageHints() []Finding {
+	if c.toolUsageLoaded {
+		return c.toolUsageFindings
+	}
+	c.toolUsageLoaded = true
+	for _, item := range runtimetools.ValidateUsageHintCoverage(c.source, c.mcpDiscovered()) {
+		severity := SeverityLintEvidence
+		if item.Severity == "error" {
+			severity = SeverityHardInvalidity
+		}
+		location := strings.TrimSpace(item.ToolName)
+		if location == "" {
+			location = "runtime-tools"
+		}
+		c.toolUsageFindings = append(c.toolUsageFindings, Finding{
+			CheckID:  "platform_tool_usage_hints",
+			Severity: severity,
+			Message:  item.Message,
+			Location: location,
+		})
+	}
+	return c.toolUsageFindings
+}
+
+func (c *checkerContext) generatedToolSchemaClosure() []Finding {
+	if c.generatedToolSchemaClosureLoaded {
+		return c.generatedToolSchemaClosureFindings
+	}
+	c.generatedToolSchemaClosureLoaded = true
+	for _, err := range runtimetools.ValidateGeneratedToolSchemaClosureForSource(c.source) {
+		c.generatedToolSchemaClosureFindings = append(c.generatedToolSchemaClosureFindings, Finding{
+			CheckID:  "generated_tool_schema_closure",
+			Severity: SeverityHardInvalidity,
+			Message:  err.Error(),
+			Location: "generated-tools",
+		})
+	}
+	return c.generatedToolSchemaClosureFindings
+}
+
+func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {
+	if c.runtimeToolNamesLoaded {
+		return c.runtimeToolNames
+	}
+	c.runtimeToolNamesLoaded = true
+	c.runtimeToolNames = make(map[string]struct{})
+	for _, name := range runtimetools.RuntimeAvailableToolNamesForSource(c.source) {
+		c.runtimeToolNames[strings.TrimSpace(name)] = struct{}{}
+	}
+	return c.runtimeToolNames
+}
+
+func declaredMCPPrefixes(source semanticview.Source) map[string]struct{} {
+	if source == nil {
+		return nil
+	}
+	value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers")
+	if !ok {
+		return nil
+	}
+	root, ok := anyMap(value.Value)
+	if !ok || len(root) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(root))
+	for _, raw := range root {
+		server, ok := anyMap(raw)
+		if !ok {
+			continue
+		}
+		prefix := strings.TrimSpace(anyString(server["prefix"]))
+		if prefix != "" {
+			out[prefix] = struct{}{}
+		}
+	}
+	return out
+}
+
+func toolReferenceAllowedByMCPPrefix(toolID string, prefixes map[string]struct{}) bool {
+	if len(prefixes) == 0 {
+		return false
+	}
+	prefix, _, ok := strings.Cut(strings.TrimSpace(toolID), ".")
+	if !ok || strings.TrimSpace(prefix) == "" {
+		return false
+	}
+	_, exists := prefixes[strings.TrimSpace(prefix)]
+	return exists
+}
+
+func toolReferenceAllowedByMCPCatalog(toolID string, discovered map[string]runtimemcp.DiscoveredTool, prefixes map[string]struct{}) bool {
+	toolID = strings.TrimSpace(toolID)
+	if toolID == "" {
+		return false
+	}
+	if len(discovered) > 0 {
+		_, ok := discovered[toolID]
+		return ok
+	}
+	return toolReferenceAllowedByMCPPrefix(toolID, prefixes)
+}
+
+func mcpToolEntryRequiresDiscovery(entry runtimecontracts.ToolSchemaEntry) bool {
+	return strings.EqualFold(strings.TrimSpace(entry.HandlerType), "mcp")
+}


### PR DESCRIPTION
Closes #1065
Part of #126

## Summary
- Promotes `platform_tool_usage_hints` and `generated_tool_schema_closure` into the authoritative boot-check list and marks the old tool-usage-hints review draft as promoted evidence only.
- Moves the runtime tool-surface boot checks out of monolithic `checks.go` into `runtime_tool_surface_checks.go`, with Go bootverify consuming the existing `internal/runtime/tools` owners.
- Aligns the structural `verify.py` tool-resolution subset with runtime builtins / declared MCP prefixes and explicitly leaves runtime-only tool-surface checks to Go.
- Adds direct bootverify report proofs for `platform_tool_usage_hints` and `generated_tool_schema_closure`, plus #1065 watchlist mapping.

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml`:
  - `engine.boot_verification.checks`
  - `tool_model.agent_tool_filtering`
  - `spec_authority.review_artifacts` for `platform-spec.tool-usage-hints.yaml`
- Binding gate: #1065 gate outcome, approved as first slice for `tool_resolution`, `platform_tool_usage_hints`, and `generated_tool_schema_closure` source-authority drift.

## Semantic Migration
- New canonical owners:
  - Boot-check IDs and public semantics: `platform-spec.yaml`.
  - Runtime tool registry / usage hint / generated schema semantics: `internal/runtime/tools`.
  - Bootverify consumption boundary: `internal/runtime/bootverify/runtime_tool_surface_checks.go`.
- Old non-authoritative paths now invalid:
  - `checks.go` local helper ownership for the tool-surface checks.
  - `platform-spec.tool-usage-hints.yaml` as an unpromoted merge-bearing source.
  - `verify.py` raw `tools.yaml` interpretation as complete runtime tool-registry truth.
- Production paths checked for surviving old behavior:
  - Go bootverify registry and report tests.
  - `internal/runtime/tools` usage/schema owners.
  - `internal/runtime/workflow_validation.go` generated-schema consumer.
  - `verify.py` structural tool-resolution subset and footer boundary.
- Migration complete for the approved #1065 child. #126 remains open for sibling bootverify tails.

## Verification
- `go test ./internal/runtime/bootverify -run 'TestRun_(MapsMissingToolToToolResolutionWarning|DoesNotWarnForBuiltinRuntimeToolReference|MapsMissingDiscoveredMCPToolToToolResolutionWarning|MapsMissingContractMCPToolToToolResolutionWarning|MapsPlatformToolUsageHintCoverageToBootCheck|MapsGeneratedToolSchemaClosureToBootCheck)' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/tools ./internal/runtime -count=1`
- `go test ./...`
- `python3 docs/specs/swarm-platform/verify.py tests/tier8-boot-verification/test-boot-tool-missing`
- YAML parse checks for `platform-spec.yaml` and `semantic-correctness.yaml`

Note: `semantic-correctness.yaml` had an existing invalid nested-list block in the strict event-schema node. This PR repairs that syntax while adding the required #1065 watchlist mapping so the watchlist remains parseable.
