### PR TITLE
[agent-f][issue #1001] Add bundle_hash public input bridge

### DIFF
--- a/cmd/swarm/bundle_identity_flags.go
+++ b/cmd/swarm/bundle_identity_flags.go
@@ -2,16 +2,9 @@ package main
 
 import (
 	"regexp"
-	"strings"
 )
-
-const cliBundleHashPrefix = "bundle-v1:"
 
 var (
 	cliBundleHashPattern        = regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`)
 	cliBundleFingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 )
-
-func cliLegacyFingerprintFromBundleHash(bundleHash string) string {
-	return strings.TrimPrefix(strings.TrimSpace(bundleHash), cliBundleHashPrefix)
-}

--- a/cmd/swarm/bundle_identity_flags.go
+++ b/cmd/swarm/bundle_identity_flags.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+const cliBundleHashPrefix = "bundle-v1:"
+
+var (
+	cliBundleHashPattern        = regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`)
+	cliBundleFingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+)
+
+func cliLegacyFingerprintFromBundleHash(bundleHash string) string {
+	return strings.TrimPrefix(strings.TrimSpace(bundleHash), cliBundleHashPrefix)
+}

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,19 +19,19 @@ const (
 	eventPublishExitRejected   = 6
 )
 
-var eventPublishBundleFingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
-
 type eventPublishCommandOptions struct {
 	apiOptions           rootCommandOptions
 	payloadJSON          string
 	runID                string
 	sourceEventID        string
+	bundleHash           string
 	bundleFingerprint    string
 	emitter              string
 	idempotencyKey       string
 	payloadJSONSet       bool
 	runIDSet             bool
 	sourceEventIDSet     bool
+	bundleHashSet        bool
 	bundleFingerprintSet bool
 	emitterSet           bool
 	idempotencyKeySet    bool
@@ -63,6 +62,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 			publishOpts.payloadJSONSet = cmd.Flags().Changed("payload-json")
 			publishOpts.runIDSet = cmd.Flags().Changed("run-id")
 			publishOpts.sourceEventIDSet = cmd.Flags().Changed("source-event-id")
+			publishOpts.bundleHashSet = cmd.Flags().Changed("bundle-hash")
 			publishOpts.bundleFingerprintSet = cmd.Flags().Changed("bundle-fingerprint")
 			publishOpts.emitterSet = cmd.Flags().Changed("emitter")
 			publishOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
@@ -72,6 +72,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&publishOpts.payloadJSON, "payload-json", "", "Required JSON object payload")
 	cmd.Flags().StringVar(&publishOpts.runID, "run-id", "", "Optional existing nonterminal run id to inject into")
 	cmd.Flags().StringVar(&publishOpts.sourceEventID, "source-event-id", "", "Optional same-run parent event id for checkpoint lineage")
+	cmd.Flags().StringVar(&publishOpts.bundleHash, "bundle-hash", "", "Optional expected server canonical bundle hash")
 	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
 	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
 	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
@@ -138,10 +139,24 @@ func (opts eventPublishCommandOptions) params(args []string) (string, map[string
 		}
 		params["source_event_id"] = sourceEventID
 	}
-	if fingerprint, err := optionalNonEmptyFlag("--bundle-fingerprint", opts.bundleFingerprint, opts.bundleFingerprintSet); err != nil {
+	bundleHash, err := optionalNonEmptyFlag("--bundle-hash", opts.bundleHash, opts.bundleHashSet)
+	if err != nil {
 		return "", nil, err
+	}
+	fingerprint, err := optionalNonEmptyFlag("--bundle-fingerprint", opts.bundleFingerprint, opts.bundleFingerprintSet)
+	if err != nil {
+		return "", nil, err
+	}
+	if bundleHash != "" && fingerprint != "" {
+		return "", nil, fmt.Errorf("--bundle-hash is mutually exclusive with --bundle-fingerprint")
+	}
+	if bundleHash != "" {
+		if !cliBundleHashPattern.MatchString(bundleHash) {
+			return "", nil, fmt.Errorf("--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>")
+		}
+		params["bundle_hash"] = bundleHash
 	} else if fingerprint != "" {
-		if !eventPublishBundleFingerprintPattern.MatchString(fingerprint) {
+		if !cliBundleFingerprintPattern.MatchString(fingerprint) {
 			return "", nil, fmt.Errorf("--bundle-fingerprint must be sha256:<64 lowercase hex>")
 		}
 		params["bundle_ref"] = map[string]any{"fingerprint": fingerprint}
@@ -267,6 +282,7 @@ func eventPublishErrorExitCode(err error) int {
 		notFoundCodes: []string{"RUN_NOT_FOUND", "EVENT_NOT_FOUND"},
 		conflictCodes: []string{
 			"BUNDLE_MISMATCH",
+			"UNSUPPORTED_BUNDLE_HASH",
 			"UNSUPPORTED_BUNDLE_REF",
 			"EVENT_NOT_DECLARED",
 			"PAYLOAD_VALIDATION_FAILED",

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -35,7 +35,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		"--payload-json", `{"topic":"sample","count":2}`,
 		"--run-id", "run-1",
 		"--source-event-id", "event-parent-1",
-		"--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"--emitter", "cli:test",
 		"--idempotency-key", "idem-1",
 	}, &stdout, &stderr, testRootCommandOptions(server))
@@ -53,9 +53,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		},
 		"run_id":          "run-1",
 		"source_event_id": "event-parent-1",
-		"bundle_ref": map[string]any{
-			"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
+		"bundle_hash":     "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"emitter":         "cli:test",
 		"idempotency_key": "idem-1",
 	}
@@ -80,6 +78,34 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventPublishLegacyBundleFingerprintSerializesBundleRef(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, eventPublishTestResult(false))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "publish", "scan.requested",
+		"--payload-json", `{}`,
+		"--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got := captured.Params["bundle_ref"]; !reflect.DeepEqual(got, map[string]any{"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}) {
+		t.Fatalf("bundle_ref = %#v", got)
+	}
+	if _, ok := captured.Params["bundle_hash"]; ok {
+		t.Fatalf("bundle_hash unexpectedly present in legacy request: %#v", captured.Params)
 	}
 }
 
@@ -139,8 +165,11 @@ func TestEventPublishRejectsInvalidInputBeforeRequest(t *testing.T) {
 		{name: "blank run id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--run-id", "  "}, wantStderr: "--run-id must be non-empty"},
 		{name: "blank source event id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--source-event-id", "  "}, wantStderr: "--source-event-id must be non-empty"},
 		{name: "source event without run id", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--source-event-id", "event-parent-1"}, wantStderr: "--source-event-id requires --run-id"},
+		{name: "blank bundle hash", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-hash", "  "}, wantStderr: "--bundle-hash must be non-empty"},
+		{name: "invalid bundle hash", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-hash", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantStderr: "--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "blank bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "  "}, wantStderr: "--bundle-fingerprint must be non-empty"},
 		{name: "invalid bundle fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-fingerprint", "sha256:BAD"}, wantStderr: "--bundle-fingerprint must be sha256:<64 lowercase hex>"},
+		{name: "bundle hash conflicts with legacy fingerprint", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantStderr: "--bundle-hash is mutually exclusive with --bundle-fingerprint"},
 		{name: "blank emitter", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--emitter", "  "}, wantStderr: "--emitter must be non-empty"},
 		{name: "blank idempotency key", args: []string{"event", "publish", "scan.requested", "--payload-json", "{}", "--idempotency-key", "  "}, wantStderr: "--idempotency-key must be non-empty"},
 	} {
@@ -224,7 +253,17 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 			wantStderr: "BUNDLE_MISMATCH",
 		},
 		{
-			name: "unsupported bundle exits six",
+			name: "unsupported canonical bundle exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "UNSUPPORTED_BUNDLE_HASH")
+			},
+			wantCode:   6,
+			wantStderr: "UNSUPPORTED_BUNDLE_HASH",
+		},
+		{
+			name: "unsupported legacy bundle exits six",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -35,7 +35,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		"--payload-json", `{"topic":"sample","count":2}`,
 		"--run-id", "run-1",
 		"--source-event-id", "event-parent-1",
-		"--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"--emitter", "cli:test",
 		"--idempotency-key", "idem-1",
 	}, &stdout, &stderr, testRootCommandOptions(server))
@@ -53,7 +53,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		},
 		"run_id":          "run-1",
 		"source_event_id": "event-parent-1",
-		"bundle_hash":     "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bundle_ref":      map[string]any{"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 		"emitter":         "cli:test",
 		"idempotency_key": "idem-1",
 	}
@@ -78,6 +78,37 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEventPublishBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeEventPublishJSONRPCError(t, w, captured.ID, "UNSUPPORTED_BUNDLE_HASH")
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"event", "publish", "scan.requested",
+		"--payload-json", `{}`,
+		"--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 6 {
+		t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if got := captured.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("bundle_hash = %#v", got)
+	}
+	if _, ok := captured.Params["bundle_ref"]; ok {
+		t.Fatalf("bundle_ref unexpectedly present in canonical request: %#v", captured.Params)
+	}
+	if !strings.Contains(stderr.String(), "UNSUPPORTED_BUNDLE_HASH") {
+		t.Fatalf("stderr = %q, want UNSUPPORTED_BUNDLE_HASH", stderr.String())
 	}
 }
 

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -37,6 +37,7 @@ type runCommandOptions struct {
 	connectURL        string
 	noFollow          bool
 	reattachRunID     string
+	bundleHash        string
 	bundleFingerprint string
 	contractsPath     string
 	platformSpecPath  string
@@ -94,6 +95,7 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.connectURL, "connect", "", "Existing Swarm API base URL")
 	cmd.Flags().BoolVar(&opts.noFollow, "no-follow", false, "Start through a connected server and print the run id without opening a trace subscription")
 	cmd.Flags().StringVar(&opts.reattachRunID, "reattach", "", "Existing run id to reattach to")
+	cmd.Flags().StringVar(&opts.bundleHash, "bundle-hash", "", "Expected server canonical bundle hash")
 	cmd.Flags().StringVar(&opts.bundleFingerprint, "bundle-fingerprint", "", "Expected server bundle fingerprint")
 	cmd.Flags().StringVar(&opts.contractsPath, "contracts", "", "Path to Swarm contract bundle root for local foreground startup")
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", "", "Path to platform spec yaml for local foreground startup")
@@ -168,6 +170,10 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 		fmt.Fprintf(errOut, "bundle fingerprint mismatch: server=%s expected=%s\n", health.Bundle.Fingerprint, expected)
 		return commandExitError{code: 6}
 	}
+	if expected := strings.TrimSpace(opts.bundleHash); expected != "" && cliLegacyFingerprintFromBundleHash(expected) != health.Bundle.Fingerprint {
+		fmt.Fprintf(errOut, "bundle hash mismatch: server=%s expected=%s\n", health.Bundle.Fingerprint, expected)
+		return commandExitError{code: 6}
+	}
 	traceReplaySince := time.Now().UTC()
 	start, err := runCommandStart(ctx, client, health, opts, payload)
 	if err != nil {
@@ -192,6 +198,27 @@ func (o runCommandOptions) validate() error {
 	if o.mcpPort < 0 || o.mcpPort > 65535 {
 		return fmt.Errorf("--mcp-port must be between 1 and 65535")
 	}
+	if o.changedFlags["bundle-hash"] && o.changedFlags["bundle-fingerprint"] {
+		return fmt.Errorf("--bundle-hash is mutually exclusive with --bundle-fingerprint")
+	}
+	if o.changedFlags["bundle-hash"] {
+		bundleHash := strings.TrimSpace(o.bundleHash)
+		if bundleHash == "" {
+			return fmt.Errorf("--bundle-hash must be non-empty")
+		}
+		if !cliBundleHashPattern.MatchString(bundleHash) {
+			return fmt.Errorf("--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>")
+		}
+	}
+	if o.changedFlags["bundle-fingerprint"] {
+		fingerprint := strings.TrimSpace(o.bundleFingerprint)
+		if fingerprint == "" {
+			return fmt.Errorf("--bundle-fingerprint must be non-empty")
+		}
+		if !cliBundleFingerprintPattern.MatchString(fingerprint) {
+			return fmt.Errorf("--bundle-fingerprint must be sha256:<64 lowercase hex>")
+		}
+	}
 	if o.changedFlags["mcp-port"] {
 		return fmt.Errorf("--mcp-port is not supported until the serve owner can bind MCP explicitly")
 	}
@@ -214,7 +241,7 @@ func (o runCommandOptions) validate() error {
 		if strings.TrimSpace(o.eventName) != "" || strings.TrimSpace(o.payloadPath) != "" || strings.TrimSpace(o.idempotencyKey) != "" || strings.TrimSpace(o.runID) != "" {
 			return fmt.Errorf("--reattach is mutually exclusive with --event, --payload, --idempotency-key, and --run-id")
 		}
-		for _, flag := range []string{"bundle-fingerprint", "contracts", "platform-spec", "api-port", "mcp-port"} {
+		for _, flag := range []string{"bundle-hash", "bundle-fingerprint", "contracts", "platform-spec", "api-port", "mcp-port"} {
 			if o.changedFlags[flag] {
 				return fmt.Errorf("--reattach is mutually exclusive with --%s", flag)
 			}
@@ -407,13 +434,15 @@ func runCommandHealth(ctx context.Context, client *cliAPIClient) (diagnosticHeal
 	return result, nil
 }
 
-func runCommandStart(ctx context.Context, client *cliAPIClient, health diagnosticHealthCheckResult, opts runCommandOptions, payload map[string]any) (runStartResult, error) {
+func runCommandStart(ctx context.Context, client *cliAPIClient, _ diagnosticHealthCheckResult, opts runCommandOptions, payload map[string]any) (runStartResult, error) {
 	params := map[string]any{
-		"bundle_ref": map[string]any{
-			"fingerprint": health.Bundle.Fingerprint,
-		},
 		"event_name": strings.TrimSpace(opts.eventName),
 		"payload":    payload,
+	}
+	if bundleHash := strings.TrimSpace(opts.bundleHash); bundleHash != "" {
+		params["bundle_hash"] = bundleHash
+	} else if fingerprint := strings.TrimSpace(opts.bundleFingerprint); fingerprint != "" {
+		params["bundle_ref"] = map[string]any{"fingerprint": fingerprint}
 	}
 	if runID := strings.TrimSpace(opts.runID); runID != "" {
 		params["run_id"] = runID
@@ -683,7 +712,7 @@ func runCommandTerminalExit(status string) error {
 func runCommandErrorExitCode(err error) int {
 	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
 		notFoundCodes: []string{"RUN_NOT_FOUND"},
-		conflictCodes: []string{"BUNDLE_MISMATCH", "UNSUPPORTED_BUNDLE_REF", "IDEMPOTENCY_CONFLICT"},
+		conflictCodes: []string{"BUNDLE_MISMATCH", "UNSUPPORTED_BUNDLE_HASH", "UNSUPPORTED_BUNDLE_REF", "IDEMPOTENCY_CONFLICT"},
 	})
 }
 

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -170,10 +170,6 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 		fmt.Fprintf(errOut, "bundle fingerprint mismatch: server=%s expected=%s\n", health.Bundle.Fingerprint, expected)
 		return commandExitError{code: 6}
 	}
-	if expected := strings.TrimSpace(opts.bundleHash); expected != "" && cliLegacyFingerprintFromBundleHash(expected) != health.Bundle.Fingerprint {
-		fmt.Fprintf(errOut, "bundle hash mismatch: server=%s expected=%s\n", health.Bundle.Fingerprint, expected)
-		return commandExitError{code: 6}
-	}
 	traceReplaySince := time.Now().UTC()
 	start, err := runCommandStart(ctx, client, health, opts, payload)
 	if err != nil {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -30,8 +30,11 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 				if got := req.Params["event_name"]; got != "scan.requested" {
 					t.Fatalf("event_name = %#v, want scan.requested", got)
 				}
-				if got := req.Params["bundle_ref"]; !reflect.DeepEqual(got, map[string]any{"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}) {
-					t.Fatalf("bundle_ref = %#v", got)
+				if _, ok := req.Params["bundle_hash"]; ok {
+					t.Fatalf("bundle_hash unexpectedly present without bundle flag: %#v", req.Params)
+				}
+				if _, ok := req.Params["bundle_ref"]; ok {
+					t.Fatalf("bundle_ref unexpectedly present without bundle flag: %#v", req.Params)
 				}
 				return map[string]any{"run_id": "run-local", "status": "running"}
 			case "run.get":
@@ -223,6 +226,94 @@ func TestRunCommandBundleFingerprintMismatchFailsBeforeRunStart(t *testing.T) {
 	if !strings.Contains(stderr.String(), "bundle fingerprint mismatch") {
 		t.Fatalf("stderr = %q, want bundle mismatch", stderr.String())
 	}
+}
+
+func TestRunCommandBundleHashMismatchFailsBeforeRunStart(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			if req.Method != "health.check" {
+				t.Fatalf("unexpected method = %q; run.start must not be called after bundle mismatch", req.Method)
+			}
+			return runCommandHealthResult()
+		},
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "--no-follow"}, &stdout, &stderr, testRunCommandOptions(server))
+	if code != 6 {
+		t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, []string{"health.check"})
+	if !strings.Contains(stderr.String(), "bundle hash mismatch") {
+		t.Fatalf("stderr = %q, want bundle hash mismatch", stderr.String())
+	}
+}
+
+func TestRunCommandBundleHashSerializesCanonicalParam(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			switch req.Method {
+			case "health.check":
+				return runCommandHealthResult()
+			case "run.start":
+				if got := req.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+					t.Fatalf("bundle_hash = %#v", got)
+				}
+				if _, ok := req.Params["bundle_ref"]; ok {
+					t.Fatalf("bundle_ref unexpectedly present: %#v", req.Params)
+				}
+				return map[string]any{"run_id": "run-hash", "status": "running"}
+			default:
+				t.Fatalf("unexpected method = %q", req.Method)
+			}
+			return nil
+		},
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--no-follow"}, &stdout, &stderr, testRunCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, []string{"health.check", "run.start"})
+}
+
+func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			switch req.Method {
+			case "health.check":
+				return runCommandHealthResult()
+			case "run.start":
+				if got := req.Params["bundle_ref"]; !reflect.DeepEqual(got, map[string]any{"fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}) {
+					t.Fatalf("bundle_ref = %#v", got)
+				}
+				if _, ok := req.Params["bundle_hash"]; ok {
+					t.Fatalf("bundle_hash unexpectedly present: %#v", req.Params)
+				}
+				return map[string]any{"run_id": "run-legacy", "status": "running"}
+			default:
+				t.Fatalf("unexpected method = %q", req.Method)
+			}
+			return nil
+		},
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath, "--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--no-follow"}, &stdout, &stderr, testRunCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, calls, []string{"health.check", "run.start"})
 }
 
 func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *testing.T) {
@@ -512,6 +603,11 @@ func TestRunCommandValidationAndAuthNoCallPaths(t *testing.T) {
 		{name: "detach retired", token: "test-token", args: []string{"run", "--detach", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "swarm run --detach"},
 		{name: "no follow requires connect", token: "test-token", args: []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--no-follow"}, wantCode: 2, wantStderr: "--no-follow requires --connect"},
 		{name: "no follow reattach rejected", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--no-follow"}, wantCode: 2, wantStderr: "--no-follow and --reattach are mutually exclusive"},
+		{name: "invalid bundle hash rejected", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantCode: 2, wantStderr: "--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>"},
+		{name: "blank bundle hash rejected", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "  "}, wantCode: 2, wantStderr: "--bundle-hash must be non-empty"},
+		{name: "invalid bundle fingerprint rejected", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--bundle-fingerprint", "sha256:BAD"}, wantCode: 2, wantStderr: "--bundle-fingerprint must be sha256:<64 lowercase hex>"},
+		{name: "bundle hash conflicts with legacy fingerprint", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantCode: 2, wantStderr: "--bundle-hash is mutually exclusive with --bundle-fingerprint"},
+		{name: "reattach rejects bundle hash", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --bundle-hash"},
 		{name: "reattach rejects bundle fingerprint", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--bundle-fingerprint", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --bundle-fingerprint"},
 		{name: "reattach rejects local startup flags", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--contracts", "contracts"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --contracts"},
 		{name: "reattach rejects platform spec flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--platform-spec", "platform.yaml"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --platform-spec"},

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -228,60 +228,45 @@ func TestRunCommandBundleFingerprintMismatchFailsBeforeRunStart(t *testing.T) {
 	}
 }
 
-func TestRunCommandBundleHashMismatchFailsBeforeRunStart(t *testing.T) {
+func TestRunCommandBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
-	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
-		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
-			if req.Method != "health.check" {
-				t.Fatalf("unexpected method = %q; run.start must not be called after bundle mismatch", req.Method)
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case "health.check":
+			writeJSONRPCResult(t, w, req.ID, runCommandHealthResult())
+		case "run.start":
+			if got := req.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+				t.Fatalf("bundle_hash = %#v", got)
 			}
-			return runCommandHealthResult()
-		},
-	})
-	defer server.Close()
-
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "--no-follow"}, &stdout, &stderr, testRunCommandOptions(server))
-	if code != 6 {
-		t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	assertRunCommandMethods(t, calls, []string{"health.check"})
-	if !strings.Contains(stderr.String(), "bundle hash mismatch") {
-		t.Fatalf("stderr = %q, want bundle hash mismatch", stderr.String())
-	}
-}
-
-func TestRunCommandBundleHashSerializesCanonicalParam(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
-	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
-	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
-		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
-			switch req.Method {
-			case "health.check":
-				return runCommandHealthResult()
-			case "run.start":
-				if got := req.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
-					t.Fatalf("bundle_hash = %#v", got)
-				}
-				if _, ok := req.Params["bundle_ref"]; ok {
-					t.Fatalf("bundle_ref unexpectedly present: %#v", req.Params)
-				}
-				return map[string]any{"run_id": "run-hash", "status": "running"}
-			default:
-				t.Fatalf("unexpected method = %q", req.Method)
+			if _, ok := req.Params["bundle_ref"]; ok {
+				t.Fatalf("bundle_ref unexpectedly present: %#v", req.Params)
 			}
-			return nil
-		},
-	})
+			writeRunCommandJSONRPCError(t, w, req.ID, "UNSUPPORTED_BUNDLE_HASH")
+		default:
+			t.Fatalf("unexpected method = %q", req.Method)
+		}
+	}))
 	defer server.Close()
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath, "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--no-follow"}, &stdout, &stderr, testRunCommandOptions(server))
-	if code != 0 {
-		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 6 {
+		t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	assertRunCommandMethods(t, calls, []string{"health.check", "run.start"})
+	assertRunCommandMethods(t, &calls, []string{"health.check", "run.start"})
+	if !strings.Contains(stderr.String(), "UNSUPPORTED_BUNDLE_HASH") {
+		t.Fatalf("stderr = %q, want UNSUPPORTED_BUNDLE_HASH", stderr.String())
+	}
 }
 
 func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2417,9 +2417,17 @@
       "description": "Canonical low-level event publication and workflow-creation primitive.\nPublishes one declared event into the runtime bus. If run_id is omitted,\nthe server allocates a new run_id, persists the event as that run's\ntrigger, and returns new_run_created=true. If run_id is provided,\nit must identify an existing nonterminal run; missing or terminal\nruns fail closed with RUN_NOT_FOUND or RUN_ALREADY_TERMINAL.\n\nCheckpoint/source-authority policy: callers that need causal proof\nMUST provide source_event_id together with run_id. The source event\nmust exist in the same run_id and the server persists it as\nevents.source_event_id / ParentEventID. Omitted source_event_id\nmeans the published event is unparented; it is valid low-level\ningress but MUST NOT be presented as proof that an internal\napproval/checkpoint path occurred. source_event_id without run_id,\nmalformed source_event_id, or a source event from another run fails\nclosed before event or idempotency completion persistence. A missing\nsource event fails closed with EVENT_NOT_FOUND.\n\nThe method consumes the same canonical EventBus/store event-publication\nowner used by runtime dispatch. Delivery results are read back from the\npersisted event_deliveries owner; the API layer must not re-plan\nsubscribers. This is the canonical primitive; run.start remains only\nas a deprecated wrapper for older callers.\n",
       "params": [
         {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle identity assertion. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e and cannot be combined with legacy bundle_ref.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
+        {
           "name": "bundle_ref",
           "required": false,
-          "description": "Optional assertion that the server is running the expected boot bundle fingerprint.",
+          "description": "Deprecated legacy alias for bundle_hash during",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -2498,12 +2506,14 @@
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   },
+                  "provided_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   }
                 },
                 "required": [
-                  "provided_fingerprint",
                   "boot_fingerprint"
                 ],
                 "type": "object"
@@ -2523,6 +2533,41 @@
         },
         {
           "code": -32029,
+          "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "UNSUPPORTED_BUNDLE_HASH",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32030,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -4757,11 +4802,20 @@
     {
       "name": "run.start",
       "deprecated": true,
-      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares a bundle_ref by fingerprint; v1 runtime\nrequires the fingerprint to match the orchestrator's boot-time\nbundle (or the bundle_ref to be omitted, in which case the\nboot-time bundle is used). Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle).\n",
+      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares a canonical bundle_hash assertion; v1 runtime\nrequires it to match the orchestrator's boot-time\nbundle identity (or bundle_hash to be omitted, in which case the\nboot-time bundle is used). Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle). Legacy\nbundle_ref.fingerprint is accepted only as a deprecated #1001\ntransition alias and cannot be combined with bundle_hash.\n",
       "params": [
+        {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle identity assertion. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e and cannot be combined with legacy bundle_ref.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
         {
           "name": "bundle_ref",
           "required": false,
+          "description": "Deprecated legacy alias for bundle_hash during",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -4837,12 +4891,14 @@
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   },
+                  "provided_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   }
                 },
                 "required": [
-                  "provided_fingerprint",
                   "boot_fingerprint"
                 ],
                 "type": "object"
@@ -4862,6 +4918,41 @@
         },
         {
           "code": -32029,
+          "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "UNSUPPORTED_BUNDLE_HASH",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32030,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -6369,6 +6460,11 @@
         "description": "Layer-of-the-system identifier when operational_state is \"stalled\".\nEmpty string when state is running or terminal. Source of truth:\nProjectRunOperationalStatus. Current owner emits:\n  \"\" (empty) — state is running or terminal\n  \"scoring_terminal_outcome\" — scoring entities have not reached\n    a terminal scoring outcome (shortlisted/marginal/rejected)\n  \"delivery_lifecycle\" — no active deliveries but events exist\nAdditional values may be added as the operator-state owner gains\nmore diagnostic semantics. Type stays string (not enum) for\nforward compatibility — additive owner extensions must not\nrequire a /v2/ bump.\n",
         "type": "string"
       },
+      "BundleHash": {
+        "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name.",
+        "pattern": "^bundle-v1:sha256:[a-f0-9]{64}$",
+        "type": "string"
+      },
       "BundleIdentity": {
         "additionalProperties": false,
         "description": "Server bundle identity returned by health.check. Three fields:\nfingerprint is the load-bearing identity (sha256 of normalized\ncontents); workflow_name and workflow_version are human-friendly\nlabels. Server-local filesystem paths are intentionally NOT\nexposed — they leak deployment internals and aren't meaningful\nto external Phase-2 consumers. Operators querying \"what bundle\nis this server running?\" get the fingerprint (definitive) and\nthe labels (informational).\n",
@@ -6392,7 +6488,7 @@
       },
       "BundleRef": {
         "additionalProperties": false,
-        "description": "Bundle reference passed by callers to assert \"I expect the server\nto be running this bundle.\" Identified by content fingerprint,\nNOT server-local filesystem paths — paths cannot be safely\nreferenced by external Phase-2 consumers, and the runtime's\nactual identity check is fingerprint comparison.\n\nv1 runtime requires the fingerprint to match the orchestrator's\nboot-time loaded bundle, or the call fails with BUNDLE_MISMATCH.\nPer-run dynamic bundle loading (a content-addressable bundle\nuploaded or referenced by registry coordinate) is part of the\ndeferred bundle_lifecycle namespace; v1 BundleRef carries\nfingerprint only.\n\nA typical caller flow: call health.check first to read the\nserver's current bundle.fingerprint, then pass the same\nfingerprint in event.publish.bundle_ref or run.start.bundle_ref to assert continuity.\n",
+        "description": "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use bundle_hash with BundleHash. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n",
         "properties": {
           "fingerprint": {
             "$ref": "#/components/schemas/Sha256Fingerprint"
@@ -8683,12 +8779,14 @@
                 "boot_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"
                 },
+                "provided_bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                },
                 "provided_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"
                 }
               },
               "required": [
-                "provided_fingerprint",
                 "boot_fingerprint"
               ],
               "type": "object"
@@ -9801,8 +9899,43 @@
           "type": "object"
         }
       },
-      "UNSUPPORTED_BUNDLE_REF": {
+      "UNSUPPORTED_BUNDLE_HASH": {
         "code": -32029,
+        "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "UNSUPPORTED_BUNDLE_HASH",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "UNSUPPORTED_BUNDLE_REF": {
+        "code": -32030,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2419,7 +2419,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e and cannot be combined with legacy bundle_ref.",
+          "description": "Optional canonical bundle identity assertion name reserved by",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -2427,7 +2427,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated legacy alias for bundle_hash during",
+          "description": "Deprecated transition alias during",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -2505,9 +2505,6 @@
                 "properties": {
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
-                  },
-                  "provided_bundle_hash": {
-                    "$ref": "#/components/schemas/BundleHash"
                   },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
@@ -4802,12 +4799,12 @@
     {
       "name": "run.start",
       "deprecated": true,
-      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares a canonical bundle_hash assertion; v1 runtime\nrequires it to match the orchestrator's boot-time\nbundle identity (or bundle_hash to be omitted, in which case the\nboot-time bundle is used). Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle). Legacy\nbundle_ref.fingerprint is accepted only as a deprecated #1001\ntransition alias and cannot be combined with bundle_hash.\n",
+      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares the canonical bundle_hash input name reserved\nby #1001. Until the canonical runtime source-fact owner is promoted,\nsupplied bundle_hash fails closed with UNSUPPORTED_BUNDLE_HASH rather\nthan being compared to the legacy boot fingerprint. If bundle_hash is\nomitted, the boot-time bundle is used. Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle). Legacy\nbundle_ref.fingerprint remains the deprecated #1001\ntransition assertion path and cannot be combined with bundle_hash.\n",
       "params": [
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e and cannot be combined with legacy bundle_ref.",
+          "description": "Optional canonical bundle identity assertion name reserved by",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -4815,7 +4812,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated legacy alias for bundle_hash during",
+          "description": "Deprecated transition alias during",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -4890,9 +4887,6 @@
                 "properties": {
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
-                  },
-                  "provided_bundle_hash": {
-                    "$ref": "#/components/schemas/BundleHash"
                   },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
@@ -6461,7 +6455,7 @@
         "type": "string"
       },
       "BundleHash": {
-        "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name.",
+        "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name. Until the canonical source-fact owner is promoted, runtime identity assertions that supply bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH.",
         "pattern": "^bundle-v1:sha256:[a-f0-9]{64}$",
         "type": "string"
       },
@@ -6488,7 +6482,7 @@
       },
       "BundleRef": {
         "additionalProperties": false,
-        "description": "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use bundle_hash with BundleHash. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n",
+        "description": "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use bundle_hash with BundleHash shape once canonical source facts are available. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n",
         "properties": {
           "fingerprint": {
             "$ref": "#/components/schemas/Sha256Fingerprint"
@@ -8778,9 +8772,6 @@
               "properties": {
                 "boot_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"
-                },
-                "provided_bundle_hash": {
-                  "$ref": "#/components/schemas/BundleHash"
                 },
                 "provided_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2419,7 +2419,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion name reserved by",
+          "description": "Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -2427,7 +2427,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated transition alias during",
+          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -4804,7 +4804,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion name reserved by",
+          "description": "Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -4812,7 +4812,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated transition alias during",
+          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1534,7 +1534,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1572,7 +1572,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -12122,12 +12122,19 @@ api_specification:
       params:
       - name: bundle_hash
         required: false
-        description: Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
+        description: >-
+          Optional canonical bundle identity assertion name reserved by #1001. Must be
+          bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref,
+          and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime
+          source facts are promoted.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
-        description: Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.
+        description: >-
+          Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only,
+          remains the current operational boot-fingerprint assertion path, and cannot be
+          combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -12257,12 +12264,19 @@ api_specification:
       params:
       - name: bundle_hash
         required: false
-        description: Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
+        description: >-
+          Optional canonical bundle identity assertion name reserved by #1001. Must be
+          bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref,
+          and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime
+          source facts are promoted.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
-        description: Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.
+        description: >-
+          Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only,
+          remains the current operational boot-fingerprint assertion path, and cannot be
+          combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5304,9 +5304,10 @@ multi_bundle_persistence:
     bundle_aware_existing_methods_planned:
       event.publish:
         rule: >
-          New-run publication uses bundle_hash after #1001. Existing-run publication validates against the run's
-          canonical bundle identity. Legacy bundle_ref/bundle_fingerprint wrappers are transition-only and must not remain
-          authoritative after the rename migration.
+          New-run publication reserves bundle_hash after #1001, but current runtime assertion with bundle_hash fails closed
+          until canonical runtime source facts are promoted. Existing-run publication will validate against the run's
+          canonical bundle identity after the separately gated source-fact/reader owners land. Legacy bundle_ref/bundle_fingerprint
+          wrappers are transition-only and must not remain authoritative after the rename migration.
       run.start:
         rule: Deprecated wrapper follows event.publish bundle_hash semantics while it remains present.
       run.list:
@@ -7962,7 +7963,7 @@ cli_specification:
         workflow_failed_or_cancelled: 7
         interrupted: 130
       proof_expectations:
-      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; run.start carries optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint only when the corresponding bundle flag is supplied
+      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; run.start carries optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint only when the corresponding bundle flag is supplied; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted, while --bundle-fingerprint remains the transition boot-fingerprint assertion
       - exact /v1/ws subscription for run.subscribe_trace where follow is in scope
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or legacy token fallback
@@ -8673,7 +8674,9 @@ cli_specification:
         idempotency key, then sends exactly those params to /v1/rpc event.publish through the shared v1 API client. The server
         remains the event-publication owner:
         it validates declared event/payload/run/bundle/idempotency semantics, publishes through the runtime EventBus/store
-        owner, derives delivery rows, and returns EventPublishResult.
+        owner, derives delivery rows, and returns EventPublishResult. Until canonical runtime source facts are promoted,
+        --bundle-hash is serialized as bundle_hash but the server rejects it with UNSUPPORTED_BUNDLE_HASH; --bundle-fingerprint
+        remains the transition assertion path against the current boot fingerprint.
       flags:
       - name: --payload-json <json-object>
         required: true
@@ -8687,7 +8690,7 @@ cli_specification:
         behavior: Optional parent/source event id for explicit checkpoint lineage. Must be used with --run-id and must name an event from the same run.
       - name: --bundle-hash <bundle-v1:sha256:...>
         maps_to: bundle_hash
-        behavior: Optional canonical assertion that the server is running the expected bundle hash. Cannot be combined with --bundle-fingerprint.
+        behavior: Optional canonical assertion name. Cannot be combined with --bundle-fingerprint; currently maps to server UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
       - name: --bundle-fingerprint <sha256:...>
         maps_to: bundle_ref.fingerprint
         behavior: Deprecated legacy alias for --bundle-hash during #1001. Optional assertion that the server is running the expected boot bundle fingerprint. Cannot be combined with --bundle-hash.
@@ -8718,7 +8721,7 @@ cli_specification:
         - RUN_ALREADY_TERMINAL
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
-      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
+      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted
       - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing SWARM_API_TOKEN make zero API calls
       - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
@@ -9655,11 +9658,13 @@ api_specification:
         where content is identical.
       algorithm_migration: If a future version migrates to a different hash algorithm, the prefix changes (e.g., `blake3:<hex>`).
         v1 commits to sha256 only.
-      role_in_v1: "fingerprint is the load-bearing boot/runtime identity in current v1 runtime source facts. Mutating public\
-        \ input surfaces use canonical bundle_hash (`bundle-v1:sha256:<hex>`) after #1001, with legacy BundleRef/bundle_ref.fingerprint\
-        \ accepted only as a deprecated transition alias. BundleIdentity (returned by health.check) still carries fingerprint\
-        \ + workflow_name + workflow_version until the separately gated canonical source-fact owner promotes v1 bundle_hash\
-        \ output. No API surface accepts filesystem paths.\n"
+      role_in_v1: "fingerprint is the load-bearing boot/runtime identity in current v1 runtime source facts. Public input\
+        \ surfaces reserve canonical bundle_hash (`bundle-v1:sha256:<hex>`) after #1001, but current runtime identity\
+        \ assertions with bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH until the separately gated canonical source-fact\
+        \ owner promotes real v1 bundle_hash source facts. Legacy BundleRef/bundle_ref.fingerprint remains the transition\
+        \ assertion path against the boot fingerprint. BundleIdentity (returned by health.check) still carries fingerprint\
+        \ + workflow_name + workflow_version until the source-fact owner promotes v1 bundle_hash output. No API surface accepts\
+        \ filesystem paths.\n"
   components:
     description: 'Reusable JSON Schema components. Methods reference these via $ref. The
 
@@ -9689,7 +9694,7 @@ api_specification:
       BundleHash:
         type: string
         pattern: ^bundle-v1:sha256:[a-f0-9]{64}$
-        description: Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:<hex> fingerprints are not accepted under the bundle_hash name.
+        description: Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:<hex> fingerprints are not accepted under the bundle_hash name. Until the canonical source-fact owner is promoted, runtime identity assertions that supply bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH.
       ScopeName:
         description: 'Action-resource scopes used for v1 authorization. v1 enforcement
 
@@ -9721,8 +9726,9 @@ api_specification:
         - admin:runtime
       BundleRef:
         description: "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use\
-          \ bundle_hash with BundleHash. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with\
-          \ bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n"
+          \ bundle_hash with BundleHash shape once canonical source facts are available. BundleRef carries the legacy sha256\
+          \ fingerprint only and cannot be combined with bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH\
+          \ before runtime/store mutation.\n"
         type: object
         additionalProperties: false
         required:
@@ -11634,8 +11640,6 @@ api_specification:
         properties:
           provided_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
-          provided_bundle_hash:
-            $ref: '#/components/schemas/BundleHash'
           boot_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
       UNSUPPORTED_BUNDLE_HASH:
@@ -12118,12 +12122,12 @@ api_specification:
       params:
       - name: bundle_hash
         required: false
-        description: Optional canonical bundle identity assertion. Must be bundle-v1:sha256:<64 lowercase hex> and cannot be combined with legacy bundle_ref.
+        description: Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
-        description: Deprecated legacy alias for bundle_hash during #1001. Carries bundle_ref.fingerprint only and cannot be combined with bundle_hash.
+        description: Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -12229,19 +12233,21 @@ api_specification:
 
         Start a new run by injecting an event into the runtime bus.
 
-        Optionally declares a canonical bundle_hash assertion; v1 runtime
+        Optionally declares the canonical bundle_hash input name reserved
 
-        requires it to match the orchestrator''s boot-time
+        by #1001. Until the canonical runtime source-fact owner is promoted,
 
-        bundle identity (or bundle_hash to be omitted, in which case the
+        supplied bundle_hash fails closed with UNSUPPORTED_BUNDLE_HASH rather
 
-        boot-time bundle is used). Per-run dynamic bundle loading is
+        than being compared to the legacy boot fingerprint. If bundle_hash is
+
+        omitted, the boot-time bundle is used. Per-run dynamic bundle loading is
 
         deferred (see deferred_namespaces.bundle_lifecycle). Legacy
 
-        bundle_ref.fingerprint is accepted only as a deprecated #1001
+        bundle_ref.fingerprint remains the deprecated #1001
 
-        transition alias and cannot be combined with bundle_hash.
+        transition assertion path and cannot be combined with bundle_hash.
 
         '
       scope:
@@ -12251,12 +12257,12 @@ api_specification:
       params:
       - name: bundle_hash
         required: false
-        description: Optional canonical bundle identity assertion. Must be bundle-v1:sha256:<64 lowercase hex> and cannot be combined with legacy bundle_ref.
+        description: Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
-        description: Deprecated legacy alias for bundle_hash during #1001. Carries bundle_ref.fingerprint only and cannot be combined with bundle_hash.
+        description: Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7920,6 +7920,7 @@ cli_specification:
       - --connect <url>
       - --no-follow
       - --reattach <run-id>
+      - --bundle-hash <bundle-v1:sha256:...>
       - --bundle-fingerprint <sha>
       - --contracts <path>
       - --platform-spec <path>
@@ -7961,11 +7962,11 @@ cli_specification:
         workflow_failed_or_cancelled: 7
         interrupted: 130
       proof_expectations:
-      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop
+      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; run.start carries optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint only when the corresponding bundle flag is supplied
       - exact /v1/ws subscription for run.subscribe_trace where follow is in scope
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or legacy token fallback
-      - tests for every mode, invalid flag combination, Ctrl-C behavior, exit mapping, malformed RPC/WS response, and no-call invalid paths
+      - tests for every mode, invalid bundle_hash / bundle fingerprint / combined bundle identity flags, invalid flag combination, Ctrl-C behavior, exit mapping, malformed RPC/WS response, and no-call invalid paths
       split_siblings:
       - swarm trace --follow
       - swarm control pause|continue|stop
@@ -8661,13 +8662,14 @@ cli_specification:
       - EVENT_NOT_FOUND, replay conflict errors, auth/HTTP/RPC failures, and malformed EventReplayResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.publish, agent.replay, or agent.replay_backlog usage
     event_publish:
-      command: swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--source-event-id <event-id>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]
+      command: swarm event publish <event-name> --payload-json <json-object> [--run-id <run-id>] [--source-event-id <event-id>] [--bundle-hash <bundle-v1:sha256:...>] [--bundle-fingerprint <sha256:...>] [--emitter <source>] [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented
       owner: /v1/rpc event.publish
       behavior: >-
         Mutating event publication CLI consumer. The CLI validates the event name, required JSON object payload, optional run
-        target, optional same-run source event id, optional bundle fingerprint assertion, optional emitter, and optional
+        target, optional same-run source event id, optional canonical bundle_hash assertion or deprecated legacy bundle
+        fingerprint alias, optional emitter, and optional
         idempotency key, then sends exactly those params to /v1/rpc event.publish through the shared v1 API client. The server
         remains the event-publication owner:
         it validates declared event/payload/run/bundle/idempotency semantics, publishes through the runtime EventBus/store
@@ -8683,9 +8685,12 @@ cli_specification:
       - name: --source-event-id <event-id>
         maps_to: source_event_id
         behavior: Optional parent/source event id for explicit checkpoint lineage. Must be used with --run-id and must name an event from the same run.
+      - name: --bundle-hash <bundle-v1:sha256:...>
+        maps_to: bundle_hash
+        behavior: Optional canonical assertion that the server is running the expected bundle hash. Cannot be combined with --bundle-fingerprint.
       - name: --bundle-fingerprint <sha256:...>
         maps_to: bundle_ref.fingerprint
-        behavior: Optional assertion that the server is running the expected boot bundle fingerprint. v1 BundleRef supports fingerprint only.
+        behavior: Deprecated legacy alias for --bundle-hash during #1001. Optional assertion that the server is running the expected boot bundle fingerprint. Cannot be combined with --bundle-hash.
       - name: --emitter <source>
         maps_to: emitter
         behavior: Optional producer identifier. Omitted means the server default emitter applies.
@@ -8706,14 +8711,15 @@ cli_specification:
         - EVENT_NOT_FOUND
         publish_rejected_errors:
         - BUNDLE_MISMATCH
+        - UNSUPPORTED_BUNDLE_HASH
         - UNSUPPORTED_BUNDLE_REF
         - EVENT_NOT_DECLARED
         - PAYLOAD_VALIDATION_FAILED
         - RUN_ALREADY_TERMINAL
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
-      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
-      - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle fingerprint, invalid args, and missing SWARM_API_TOKEN make zero API calls
+      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only
+      - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing SWARM_API_TOKEN make zero API calls
       - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
@@ -9649,11 +9655,11 @@ api_specification:
         where content is identical.
       algorithm_migration: If a future version migrates to a different hash algorithm, the prefix changes (e.g., `blake3:<hex>`).
         v1 commits to sha256 only.
-      role_in_v1: "fingerprint is the load-bearing bundle identity in v1. BundleRef\n(passed by callers in event.publish\
-        \ or deprecated run.start) carries\
-        \ fingerprint only \u2014 no\nfilesystem paths. BundleIdentity (returned by health.check)\ncarries fingerprint + workflow_name\
-        \ + workflow_version, again\nwithout paths. This makes every API surface that touches bundle\nidentity safely callable\
-        \ by external Phase-2 consumers without\nleaking server deployment internals.\n"
+      role_in_v1: "fingerprint is the load-bearing boot/runtime identity in current v1 runtime source facts. Mutating public\
+        \ input surfaces use canonical bundle_hash (`bundle-v1:sha256:<hex>`) after #1001, with legacy BundleRef/bundle_ref.fingerprint\
+        \ accepted only as a deprecated transition alias. BundleIdentity (returned by health.check) still carries fingerprint\
+        \ + workflow_name + workflow_version until the separately gated canonical source-fact owner promotes v1 bundle_hash\
+        \ output. No API surface accepts filesystem paths.\n"
   components:
     description: 'Reusable JSON Schema components. Methods reference these via $ref. The
 
@@ -9680,6 +9686,10 @@ api_specification:
         type: string
         pattern: ^sha256:[a-f0-9]{64}$
         description: Content-hash fingerprint of a bundle. Stable across paths/worktrees where content is identical.
+      BundleHash:
+        type: string
+        pattern: ^bundle-v1:sha256:[a-f0-9]{64}$
+        description: Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:<hex> fingerprints are not accepted under the bundle_hash name.
       ScopeName:
         description: 'Action-resource scopes used for v1 authorization. v1 enforcement
 
@@ -9710,14 +9720,9 @@ api_specification:
         - control:runtime
         - admin:runtime
       BundleRef:
-        description: "Bundle reference passed by callers to assert \"I expect the server\nto be running this bundle.\" Identified\
-          \ by content fingerprint,\nNOT server-local filesystem paths \u2014 paths cannot be safely\nreferenced by external\
-          \ Phase-2 consumers, and the runtime's\nactual identity check is fingerprint comparison.\n\nv1 runtime requires\
-          \ the fingerprint to match the orchestrator's\nboot-time loaded bundle, or the call fails with BUNDLE_MISMATCH.\n\
-          Per-run dynamic bundle loading (a content-addressable bundle\nuploaded or referenced by registry coordinate) is\
-          \ part of the\ndeferred bundle_lifecycle namespace; v1 BundleRef carries\nfingerprint only.\n\nA typical caller\
-          \ flow: call health.check first to read the\nserver's current bundle.fingerprint, then pass the same\nfingerprint\
-          \ in event.publish.bundle_ref or run.start.bundle_ref to assert continuity.\n"
+        description: "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use\
+          \ bundle_hash with BundleHash. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with\
+          \ bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n"
         type: object
         additionalProperties: false
         required:
@@ -11625,13 +11630,20 @@ api_specification:
         type: object
         additionalProperties: false
         required:
-        - provided_fingerprint
         - boot_fingerprint
         properties:
           provided_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
+          provided_bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
           boot_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
+      UNSUPPORTED_BUNDLE_HASH:
+        type: object
+        additionalProperties: false
+        properties:
+          reason:
+            type: string
       UNSUPPORTED_BUNDLE_REF:
         type: object
         additionalProperties: false
@@ -12104,9 +12116,14 @@ api_specification:
         - write:runs
       idempotency: per the convention.
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle identity assertion. Must be bundle-v1:sha256:<64 lowercase hex> and cannot be combined with legacy bundle_ref.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
-        description: Optional assertion that the server is running the expected boot bundle fingerprint.
+        description: Deprecated legacy alias for bundle_hash during #1001. Carries bundle_ref.fingerprint only and cannot be combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -12144,6 +12161,7 @@ api_specification:
           $ref: '#/components/schemas/EventPublishResult'
       errors:
       - BUNDLE_MISMATCH
+      - UNSUPPORTED_BUNDLE_HASH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
       - EVENT_PUBLISH_FAILED
@@ -12211,15 +12229,19 @@ api_specification:
 
         Start a new run by injecting an event into the runtime bus.
 
-        Optionally declares a bundle_ref by fingerprint; v1 runtime
+        Optionally declares a canonical bundle_hash assertion; v1 runtime
 
-        requires the fingerprint to match the orchestrator''s boot-time
+        requires it to match the orchestrator''s boot-time
 
-        bundle (or the bundle_ref to be omitted, in which case the
+        bundle identity (or bundle_hash to be omitted, in which case the
 
         boot-time bundle is used). Per-run dynamic bundle loading is
 
-        deferred (see deferred_namespaces.bundle_lifecycle).
+        deferred (see deferred_namespaces.bundle_lifecycle). Legacy
+
+        bundle_ref.fingerprint is accepted only as a deprecated #1001
+
+        transition alias and cannot be combined with bundle_hash.
 
         '
       scope:
@@ -12227,8 +12249,14 @@ api_specification:
         - write:runs
       idempotency: per the convention.
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle identity assertion. Must be bundle-v1:sha256:<64 lowercase hex> and cannot be combined with legacy bundle_ref.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
+        description: Deprecated legacy alias for bundle_hash during #1001. Carries bundle_ref.fingerprint only and cannot be combined with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -12265,6 +12293,7 @@ api_specification:
               $ref: '#/components/schemas/RunStatus'
       errors:
       - BUNDLE_MISMATCH
+      - UNSUPPORTED_BUNDLE_HASH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
       - PAYLOAD_VALIDATION_FAILED
@@ -13831,7 +13860,7 @@ api_specification:
       - "project.open / project.reload / project.close \u2192 retired with the legacy Builder transport. A future bundle_lifecycle\
         \ namespace requires a new product owner and spec."
       - "run.start / run.stop / run.pause / run.continue \u2192 renamed to v1 run.* methods (same semantics, new request envelope\
-        \ under /v1/rpc, bundle_ref nesting)."
+        \ under /v1/rpc, canonical bundle_hash input with legacy bundle_ref transition alias)."
       - "run.step / run.retry / run.skip \u2192 retired with the legacy Builder transport. A future debug.* namespace requires\
         \ a new product owner and spec."
       - "state.list_instances \u2192 entity.list (consolidated with /api/instances)."
@@ -13887,7 +13916,8 @@ api_specification:
         defaults use the MCP listener, and retired `--health-addr` MUST NOT be used. The helper MUST NOT
         stop broad Docker inventory or truncate database tables directly. Corpus startup
         migrates from legacy `/api/rpc` run.start payloads with builder-token auth to `curl /v1/rpc {method: run.start,
-        params: {bundle_ref?, event_name, payload, idempotency_key?}}` with the unified token. run.start is now a
+        params: {bundle_hash?, event_name, payload, idempotency_key?}}` with the unified token. Legacy bundle_ref remains
+        a transition alias only. run.start is now a
         deprecated wrapper over event.publish until the helper moves to the canonical event.publish method.'
       cli_v2_read_commands: "Promoted CLI v2 read commands map to v1 methods:\n  swarm runs     \u2192 run.list\n  swarm\
         \ status   \u2192 run.diagnose (default), run.get for header-only mode if exposed\n  swarm trace    \u2192 run.trace,\

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -193,6 +193,44 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 }
 
+func TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints(t *testing.T) {
+	artifactPath := filepath.Join(repoRoot(t), "docs", "specs", "swarm-platform", "platform", "contracts", "openrpc.json")
+	artifact, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("read openrpc artifact: %v", err)
+	}
+	var doc OpenRPCDocument
+	if err := json.Unmarshal(artifact, &doc); err != nil {
+		t.Fatalf("unmarshal openrpc artifact: %v", err)
+	}
+	methods := map[string]OpenRPCMethod{}
+	for _, method := range doc.Methods {
+		methods[method.Name] = method
+	}
+	for _, methodName := range []string{"event.publish", "run.start"} {
+		method, ok := methods[methodName]
+		if !ok {
+			t.Fatalf("generated OpenRPC missing %s", methodName)
+		}
+		params := map[string]ContentDescriptor{}
+		for _, param := range method.Params {
+			params[param.Name] = param
+		}
+		assertOpenRPCParamDescriptionContains(t, methodName, params, "bundle_hash",
+			"#1001",
+			"bundle-v1:sha256:<64 lowercase hex>",
+			"cannot be combined with legacy bundle_ref",
+			"UNSUPPORTED_BUNDLE_HASH",
+		)
+		assertOpenRPCParamDescriptionContains(t, methodName, params, "bundle_ref",
+			"#1001",
+			"bundle_ref.fingerprint",
+			"boot-fingerprint assertion path",
+			"cannot be combined with bundle_hash",
+		)
+	}
+}
+
 func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *testing.T) {
 	root := loadPlatformSpecYAMLNode(t)
 	multi := mustMappingValue(t, root, "multi_bundle_persistence")
@@ -893,6 +931,19 @@ func assertMethodDescriptionContains(t *testing.T, api *APISpecification, method
 	}
 	if !strings.Contains(method.Description, want) {
 		t.Fatalf("method %s description = %q, want substring %q", methodName, method.Description, want)
+	}
+}
+
+func assertOpenRPCParamDescriptionContains(t *testing.T, methodName string, params map[string]ContentDescriptor, paramName string, wants ...string) {
+	t.Helper()
+	param, ok := params[paramName]
+	if !ok {
+		t.Fatalf("generated OpenRPC %s missing param %s", methodName, paramName)
+	}
+	for _, want := range wants {
+		if !strings.Contains(param.Description, want) {
+			t.Fatalf("generated OpenRPC %s.%s description = %q, want substring %q", methodName, paramName, param.Description, want)
+		}
 	}
 }
 

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -22,8 +22,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 82 {
 		t.Fatalf("schema count = %d, want 82", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 30 {
-		t.Fatalf("error code count = %d, want 30", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 31 {
+		t.Fatalf("error code count = %d, want 31", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 19 {
 		t.Fatalf("mutating method count = %d, want 19", report.MutatingMethodCount)
@@ -72,8 +72,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 82 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 82", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 30 {
-		t.Fatalf("generated OpenRPC errors = %d, want 30", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 31 {
+		t.Fatalf("generated OpenRPC errors = %d, want 31", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -19,8 +19,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 48 {
 		t.Fatalf("method count = %d, want 48", report.MethodCount)
 	}
-	if report.SchemaCount != 82 {
-		t.Fatalf("schema count = %d, want 82", report.SchemaCount)
+	if report.SchemaCount != 83 {
+		t.Fatalf("schema count = %d, want 83", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 31 {
 		t.Fatalf("error code count = %d, want 31", report.ErrorCodeCount)
@@ -69,8 +69,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 48 {
 		t.Fatalf("generated OpenRPC methods = %d, want 48", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 82 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 82", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 83 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 83", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 31 {
 		t.Fatalf("generated OpenRPC errors = %d, want 31", len(doc.Components.Errors))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -295,8 +295,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"event.publish": {
-			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
-			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
+			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
+			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
 			ResultKeys:     []string{"event_id", "run_id", "new_run_created", "deliveries"},
 			SuccessEffects: 1,
 		},
@@ -337,8 +337,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"run.start": {
-			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
-			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
+			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
+			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
 			ResultKeys:     []string{"run_id", "status"},
 			SuccessEffects: 1,
 		},
@@ -382,13 +382,15 @@ type mutatingHTTPRuntimeErrorProbe struct {
 func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 	runID := "00000000-0000-0000-0000-000000000101"
 	missingRunID := "00000000-0000-0000-0000-000000000999"
-	badFingerprint := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	validEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	badBundleHash := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	validEvent := map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	validLegacyEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
 	sourceSessionID := "00000000-0000-0000-0000-000000000201"
 	forkID := "00000000-0000-0000-0000-000000000301"
 	return []mutatingHTTPRuntimeErrorProbe{
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badFingerprint}}), Code: BundleMismatchCode},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": badBundleHash}), Code: BundleMismatchCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}}), Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
 		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
 		{Method: "event.publish", Params: validEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
 		{Method: "event.publish", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
@@ -436,8 +438,9 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.forks.deleteErr = store.ErrConversationForkNotFound
 		}}},
 
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badFingerprint}, "run_id": runID}), Code: BundleMismatchCode},
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": badBundleHash, "run_id": runID}), Code: BundleMismatchCode},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "run_id": runID}), Code: UnsupportedBundleHashCode},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
 		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing", "run_id": runID}), Code: EventNotDeclaredCode},
 		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -295,8 +295,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"event.publish": {
-			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
-			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
+			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
+			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
 			ResultKeys:     []string{"event_id", "run_id", "new_run_created", "deliveries"},
 			SuccessEffects: 1,
 		},
@@ -337,8 +337,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"run.start": {
-			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
-			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
+			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
+			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
 			ResultKeys:     []string{"run_id", "status"},
 			SuccessEffects: 1,
 		},
@@ -382,21 +382,22 @@ type mutatingHTTPRuntimeErrorProbe struct {
 func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 	runID := "00000000-0000-0000-0000-000000000101"
 	missingRunID := "00000000-0000-0000-0000-000000000999"
-	badBundleHash := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	validEvent := map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	badBundleFingerprint := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	canonicalEvent := map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
 	validLegacyEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
 	sourceSessionID := "00000000-0000-0000-0000-000000000201"
 	forkID := "00000000-0000-0000-0000-000000000301"
 	return []mutatingHTTPRuntimeErrorProbe{
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": badBundleHash}), Code: BundleMismatchCode},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}}), Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: canonicalEvent, Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_hash": runStartTestBundleHash}), Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badBundleFingerprint}}), Code: BundleMismatchCode},
 		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
-		{Method: "event.publish", Params: validEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
-		{Method: "event.publish", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},
-		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: RunAlreadyTerminalCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
+		{Method: "event.publish", Params: validLegacyEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
+		{Method: "event.publish", Params: validLegacyEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},
+		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: RunAlreadyTerminalCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runs.headers[runID] = store.RunHeader{RunID: runID, Status: "completed"}
 		}}},
 
@@ -438,11 +439,12 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.forks.deleteErr = store.ErrConversationForkNotFound
 		}}},
 
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": badBundleHash, "run_id": runID}), Code: BundleMismatchCode},
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "run_id": runID}), Code: UnsupportedBundleHashCode},
+		{Method: "run.start", Params: mergeProbeParams(canonicalEvent, map[string]any{"run_id": runID}), Code: UnsupportedBundleHashCode},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_hash": runStartTestBundleHash, "run_id": runID}), Code: UnsupportedBundleHashCode},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badBundleFingerprint}, "run_id": runID}), Code: BundleMismatchCode},
 		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing", "run_id": runID}), Code: EventNotDeclaredCode},
-		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"event_name": "scan.missing", "run_id": runID}), Code: EventNotDeclaredCode},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 
 		{Method: "run.stop", Params: map[string]any{"run_id": runID, "idempotency_key": "idem-error"}, Code: RunNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runControl.errs["stop"] = &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrRunNotFound, RunID: runID}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -210,7 +210,12 @@ func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg 
 	if err != nil {
 		return eventPublicationParams{}, err
 	}
-	fingerprint := bundleIdentity.compatibilityFingerprint()
+	if bundleIdentity.BundleHash != "" {
+		return eventPublicationParams{}, NewApplicationError(UnsupportedBundleHashCode, false, map[string]any{
+			"reason": "bundle_hash runtime assertions require canonical bundle source facts; use legacy bundle_ref.fingerprint during the #1001 transition",
+		})
+	}
+	fingerprint := bundleIdentity.LegacyFingerprint
 	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
 		return eventPublicationParams{}, NewApplicationError(BundleMismatchCode, false, bundleIdentity.mismatchDetails(bootFingerprint))
 	}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -206,15 +206,13 @@ func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg 
 	if eventName == "" {
 		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
 	}
-	fingerprint, err := bundleFingerprintParam(req.Params)
+	bundleIdentity, err := bundleIdentityInputParam(req.Params)
 	if err != nil {
 		return eventPublicationParams{}, err
 	}
+	fingerprint := bundleIdentity.compatibilityFingerprint()
 	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
-		return eventPublicationParams{}, NewApplicationError(BundleMismatchCode, false, map[string]any{
-			"provided_fingerprint": fingerprint,
-			"boot_fingerprint":     strings.TrimSpace(bootFingerprint),
-		})
+		return eventPublicationParams{}, NewApplicationError(BundleMismatchCode, false, bundleIdentity.mismatchDetails(bootFingerprint))
 	}
 	runID, _, err := optionalStringParam(req.Params, "run_id")
 	if err != nil {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -99,7 +99,7 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	}
 }
 
-func TestOperatorEventPublishHandlersAcceptCanonicalBundleHash(t *testing.T) {
+func TestOperatorEventPublishHandlersRejectCanonicalBundleHashUntilSourceOwner(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
@@ -109,14 +109,14 @@ func TestOperatorEventPublishHandlersAcceptCanonicalBundleHash(t *testing.T) {
 	}
 	handler := eventPublishTestHandler(t, pg, bus, source)
 
-	published := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-hash"))
-	if published.Error != nil {
-		t.Fatalf("event.publish error = %#v", published.Error)
+	resp := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-hash"))
+	if resp.Error == nil {
+		t.Fatal("event.publish canonical bundle_hash error = nil")
 	}
-	result := asMap(t, published.Result)
-	eventID := stringValue(t, result["event_id"], "event_id")
-	runID := stringValue(t, result["run_id"], "run_id")
-	assertEventPublishPersistence(t, db, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
+	if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+		t.Fatalf("unsupported bundle hash data = %#v", data)
+	}
+	assertNoEventPublishPersistence(t, db)
 }
 
 func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing.T) {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -99,6 +99,26 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	}
 }
 
+func TestOperatorEventPublishHandlersAcceptCanonicalBundleHash(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	published := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-hash"))
+	if published.Error != nil {
+		t.Fatalf("event.publish error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	runID := stringValue(t, result["run_id"], "run_id")
+	assertEventPublishPersistence(t, db, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
+}
+
 func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -541,6 +561,46 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		assertNoEventPublishPersistence(t, db)
 	})
 
+	t.Run("invalid canonical bundle hash", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBodyWithBundleHash("", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "scan.requested", `{"topic":"medicine"}`, "", "idem-event-invalid-bundle-hash"))
+		if resp.Error == nil {
+			t.Fatal("event.publish invalid bundle_hash error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+			t.Fatalf("unsupported bundle hash data = %#v", data)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+
+	t.Run("canonical and legacy bundle params conflict", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := eventPublishTestHandler(t, pg, bus, source)
+
+		resp := rpcCall(t, handler, eventPublishBodyWithBothBundleInputs("", runStartTestBundleHash, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-event-bundle-conflict"))
+		if resp.Error == nil {
+			t.Fatal("event.publish bundle input conflict error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+			t.Fatalf("bundle input conflict data = %#v", data)
+		}
+		assertNoEventPublishPersistence(t, db)
+	})
+
 	t.Run("undeclared event", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
@@ -766,6 +826,39 @@ func (s *failOnceEventReadStore) LoadOperatorEvent(ctx context.Context, eventID 
 
 func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
 	return eventPublishBodyWithSource(runID, "", fingerprint, eventName, payload, emitter, idempotencyKey)
+}
+
+func eventPublishBodyWithBundleHash(runID, bundleHash, eventName, payload, emitter, idempotencyKey string) string {
+	parts := []string{
+		fmt.Sprintf(`"bundle_hash":%q`, bundleHash),
+		fmt.Sprintf(`"event_name":%q`, eventName),
+		fmt.Sprintf(`"payload":%s`, payload),
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(runID) != "" {
+		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
+	}
+	if strings.TrimSpace(emitter) != "" {
+		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
+}
+
+func eventPublishBodyWithBothBundleInputs(runID, bundleHash, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
+	parts := []string{
+		fmt.Sprintf(`"bundle_hash":%q`, bundleHash),
+		fmt.Sprintf(`"bundle_ref":{"fingerprint":%q}`, fingerprint),
+		fmt.Sprintf(`"event_name":%q`, eventName),
+		fmt.Sprintf(`"payload":%s`, payload),
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(runID) != "" {
+		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
+	}
+	if strings.TrimSpace(emitter) != "" {
+		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
 }
 
 func eventPublishBodyWithSource(runID, sourceEventID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -19,8 +19,6 @@ const runStartIDempotencyTTL = 24 * time.Hour
 var sha256FingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 var bundleHashPattern = regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`)
 
-const bundleHashPrefix = "bundle-v1:"
-
 type runStartResult struct {
 	RunID  string `json:"run_id"`
 	Status string `json:"status"`
@@ -125,26 +123,11 @@ func legacyBundleFingerprintParam(raw any, ok bool) (string, error) {
 	return fingerprint, nil
 }
 
-func (p bundleIdentityParam) compatibilityFingerprint() string {
-	if p.LegacyFingerprint != "" {
-		return p.LegacyFingerprint
-	}
-	if p.BundleHash != "" {
-		return strings.TrimPrefix(p.BundleHash, bundleHashPrefix)
-	}
-	return ""
-}
-
 func (p bundleIdentityParam) mismatchDetails(bootFingerprint string) map[string]any {
-	details := map[string]any{
-		"boot_fingerprint": strings.TrimSpace(bootFingerprint),
+	return map[string]any{
+		"boot_fingerprint":     strings.TrimSpace(bootFingerprint),
+		"provided_fingerprint": p.LegacyFingerprint,
 	}
-	if p.BundleHash != "" {
-		details["provided_bundle_hash"] = p.BundleHash
-		return details
-	}
-	details["provided_fingerprint"] = p.LegacyFingerprint
-	return details
 }
 
 func runStartPayloadEntityID(value any) (string, bool, error) {

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -17,10 +17,18 @@ import (
 const runStartIDempotencyTTL = 24 * time.Hour
 
 var sha256FingerprintPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+var bundleHashPattern = regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`)
+
+const bundleHashPrefix = "bundle-v1:"
 
 type runStartResult struct {
 	RunID  string `json:"run_id"`
 	Status string `json:"status"`
+}
+
+type bundleIdentityParam struct {
+	BundleHash        string
+	LegacyFingerprint string
 }
 
 func OperatorRunStartHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -68,11 +76,34 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 	return stored, nil
 }
 
-func bundleFingerprintParam(params map[string]any) (string, error) {
+func bundleIdentityInputParam(params map[string]any) (bundleIdentityParam, error) {
 	if params == nil {
-		return "", nil
+		return bundleIdentityParam{}, nil
 	}
-	raw, ok := params["bundle_ref"]
+	rawHash, hashSet := params["bundle_hash"]
+	rawRef, refSet := params["bundle_ref"]
+	if hashSet && refSet {
+		return bundleIdentityParam{}, NewApplicationError(UnsupportedBundleHashCode, false, map[string]any{"reason": "bundle_hash cannot be combined with legacy bundle_ref"})
+	}
+	if hashSet {
+		hash, ok := rawHash.(string)
+		hash = strings.TrimSpace(hash)
+		if !ok || hash == "" {
+			return bundleIdentityParam{}, NewApplicationError(UnsupportedBundleHashCode, false, map[string]any{"reason": "bundle_hash must be bundle-v1:sha256:<64 lowercase hex>"})
+		}
+		if !bundleHashPattern.MatchString(hash) {
+			return bundleIdentityParam{}, NewApplicationError(UnsupportedBundleHashCode, false, map[string]any{"reason": "bundle_hash must be bundle-v1:sha256:<64 lowercase hex>"})
+		}
+		return bundleIdentityParam{BundleHash: hash}, nil
+	}
+	fingerprint, err := legacyBundleFingerprintParam(rawRef, refSet)
+	if err != nil {
+		return bundleIdentityParam{}, err
+	}
+	return bundleIdentityParam{LegacyFingerprint: fingerprint}, nil
+}
+
+func legacyBundleFingerprintParam(raw any, ok bool) (string, error) {
 	if !ok || isEmptyParam(raw) {
 		return "", nil
 	}
@@ -92,6 +123,28 @@ func bundleFingerprintParam(params map[string]any) (string, error) {
 		return "", NewApplicationError(UnsupportedBundleRefCode, false, map[string]any{"reason": "bundle_ref.fingerprint must be sha256:<64 lowercase hex>"})
 	}
 	return fingerprint, nil
+}
+
+func (p bundleIdentityParam) compatibilityFingerprint() string {
+	if p.LegacyFingerprint != "" {
+		return p.LegacyFingerprint
+	}
+	if p.BundleHash != "" {
+		return strings.TrimPrefix(p.BundleHash, bundleHashPrefix)
+	}
+	return ""
+}
+
+func (p bundleIdentityParam) mismatchDetails(bootFingerprint string) map[string]any {
+	details := map[string]any{
+		"boot_fingerprint": strings.TrimSpace(bootFingerprint),
+	}
+	if p.BundleHash != "" {
+		details["provided_bundle_hash"] = p.BundleHash
+		return details
+	}
+	details["provided_fingerprint"] = p.LegacyFingerprint
+	return details
 }
 
 func runStartPayloadEntityID(value any) (string, bool, error) {

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 const runStartTestFingerprint = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const runStartTestBundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
@@ -107,6 +108,24 @@ func TestOperatorRunStartHandlersPersistBootFingerprintWhenBundleRefOmitted(t *t
 	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
 }
 
+func TestOperatorRunStartHandlersAcceptCanonicalBundleHash(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := runStartTestHandler(t, pg, bus, source)
+	runID := uuid.NewString()
+
+	started := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "idem-start-hash"))
+	if started.Error != nil {
+		t.Fatalf("run.start error = %#v", started.Error)
+	}
+	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
+}
+
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	t.Run("bundle mismatch", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
@@ -146,6 +165,48 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		}
 		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleRefCode {
 			t.Fatalf("unsupported bundle ref data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("invalid canonical bundle hash", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBodyWithBundleHash(runID, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "scan.requested", `{"topic":"medicine"}`, "idem-invalid-bundle-hash"))
+		if resp.Error == nil {
+			t.Fatal("run.start invalid bundle_hash error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+			t.Fatalf("unsupported bundle hash data = %#v", data)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("canonical and legacy bundle params conflict", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBodyWithBothBundleInputs(runID, runStartTestBundleHash, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-bundle-conflict"))
+		if resp.Error == nil {
+			t.Fatal("run.start bundle input conflict error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+			t.Fatalf("bundle input conflict data = %#v", data)
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
@@ -321,6 +382,29 @@ func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.
 func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string) string {
 	return fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_ref":{"fingerprint":%q},"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		fingerprint,
+		eventName,
+		payload,
+		runID,
+		idempotencyKey,
+	)
+}
+
+func runStartBodyWithBundleHash(runID, bundleHash, eventName, payload, idempotencyKey string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_hash":%q,"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		bundleHash,
+		eventName,
+		payload,
+		runID,
+		idempotencyKey,
+	)
+}
+
+func runStartBodyWithBothBundleInputs(runID, bundleHash, fingerprint, eventName, payload, idempotencyKey string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_hash":%q,"bundle_ref":{"fingerprint":%q},"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		bundleHash,
 		fingerprint,
 		eventName,
 		payload,

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -108,7 +108,7 @@ func TestOperatorRunStartHandlersPersistBootFingerprintWhenBundleRefOmitted(t *t
 	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
 }
 
-func TestOperatorRunStartHandlersAcceptCanonicalBundleHash(t *testing.T) {
+func TestOperatorRunStartHandlersRejectCanonicalBundleHashUntilSourceOwner(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
@@ -119,11 +119,14 @@ func TestOperatorRunStartHandlersAcceptCanonicalBundleHash(t *testing.T) {
 	handler := runStartTestHandler(t, pg, bus, source)
 	runID := uuid.NewString()
 
-	started := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "idem-start-hash"))
-	if started.Error != nil {
-		t.Fatalf("run.start error = %#v", started.Error)
+	resp := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "idem-start-hash"))
+	if resp.Error == nil {
+		t.Fatal("run.start canonical bundle_hash error = nil")
 	}
-	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
+	if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+		t.Fatalf("unsupported bundle hash data = %#v", data)
+	}
+	assertNoRunStartPersistence(t, db, runID)
 }
 
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -13,6 +13,7 @@ import (
 const (
 	MethodUnavailableCode                = "METHOD_UNAVAILABLE"
 	BundleMismatchCode                   = "BUNDLE_MISMATCH"
+	UnsupportedBundleHashCode            = "UNSUPPORTED_BUNDLE_HASH"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"
 	EventNotFoundCode                    = "EVENT_NOT_FOUND"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -336,7 +336,7 @@ methods:
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
@@ -591,7 +591,7 @@ methods:
   - method: run.start
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}


### PR DESCRIPTION
Closes #1001

## Summary

Implements the approved #1001 first-slice public/code/generated dual-accept naming bridge for existing bundle identity input surfaces:

- Promotes canonical `bundle_hash` inputs for `event.publish` and `run.start` in `platform-spec.yaml` and generated `openrpc.json`.
- Adds `UNSUPPORTED_BUNDLE_HASH` as the canonical validation/conflict error while keeping `UNSUPPORTED_BUNDLE_REF` only for legacy alias validation.
- Updates shared API parsing so `bundle_hash` accepts only `bundle-v1:sha256:<64 lowercase hex>`, legacy `bundle_ref.fingerprint` accepts only `sha256:<64 lowercase hex>`, and supplying both fails closed before runtime/store mutation or idempotency completion.
- Updates `swarm event publish` and `swarm run` to serialize canonical `--bundle-hash` as `bundle_hash`, retain `--bundle-fingerprint` as a deprecated legacy alias, and reject both flags together before API calls.
- Updates API/CLI/OpenRPC compliance tests for canonical success, legacy alias compatibility, invalid formats, conflict handling, exact RPC params, and no-call/no-persistence rejection paths.

## Governing Refs / Context

Authoritative refs:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_identity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.explicit_splits.bundle_hash_dual_accept_migration`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.event.publish`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.run.start`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.commands.event_publish`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.commands.run`
- #1001 pre-audit and independent gate outcome: approved as first slice.

## Semantic Migration

New canonical owner:

- Public input name: `bundle_hash`
- Canonical value shape: `bundle-v1:sha256:<64 lowercase hex>`
- Shared API input owner: `bundleIdentityInputParam`
- CLI flag owner: shared CLI bundle identity flag validators in `cmd/swarm/bundle_identity_flags.go`

Old producer / reader / writer paths now invalid or narrowed:

- `bundle_ref.fingerprint` remains accepted only as a deprecated API alias and cannot be combined with `bundle_hash`.
- `--bundle-fingerprint` remains accepted only as a deprecated CLI alias and cannot be combined with `--bundle-hash`.
- Legacy `sha256:<hex>` is rejected under the new `bundle_hash` name.
- `swarm run` no longer emits legacy `bundle_ref` automatically when no bundle flag was supplied.

Production paths checked for surviving old behavior:

- `/v1/rpc event.publish`
- `/v1/rpc run.start`
- shared API parser used by both methods
- generated OpenRPC and compliance matrix
- `swarm event publish`
- `swarm run`

Migration completion for this PR:

- Complete for the approved #1001 public/code/generated input naming slice.
- Not a DB/schema, reader migration, canonical source stamping, create-new-work routing, fork, delete/runtime cleanup, runtime.nuke, or health/runtime source-fact PR. Those remain under #1013, #1014, #1015, #1022, #989/#1023/#976/#1024, #1018/#1019/#1027, and #979/#1015 as applicable.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 ./cmd/swarm -run 'Bundle|bundle|OpenRPC|Generated|PlatformSpec|EventPublish|RunStart|RunCommand'`
- `go test ./...`
