### PR TITLE
[agent-e][issue #1059] Defer mailbox approval publish dispatch

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -3248,7 +3248,7 @@
     },
     {
       "name": "mailbox.approve",
-      "description": "Approve a pending mailbox item. Triggers the downstream event configured for the item's type by api_specification.conventions.mailbox.approval_event_routes.",
+      "description": "Approve a pending mailbox item. Triggers the downstream event configured for the item's type by api_specification.conventions.mailbox.approval_event_routes.\nThe mailbox row decision, `mailbox.item_decided` event persistence, delivery/replay-scope evidence, and API idempotency completion commit atomically. Downstream subscriber/interceptor/runtime work from the transactional approval publish runs only after that decision transaction commits, or remains queued while ingress is paused.\n",
       "params": [
         {
           "name": "mailbox_id",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -9523,6 +9523,17 @@ api_specification:
           The producer MUST NOT emit the retired top-level `payload` member and
           validators MUST NOT add a special allowlist for it. Contracts that need
           the mailbox row payload must declare and consume `mailbox_payload`.
+      approval_transaction_boundary: >
+        `mailbox.approve` owns a caller-owned transactional publish boundary:
+        the mailbox row decision, `mailbox.item_decided` event persistence,
+        event delivery/replay-scope evidence, and API idempotency completion
+        commit atomically. Downstream subscriber/interceptor/runtime work MUST
+        run only after that decision transaction commits, or be durably queued
+        while ingress is paused. Post-commit downstream failures are recorded
+        as event receipt/recovery diagnostics; they MUST NOT leave the mailbox
+        decision transaction open, block later run/event writes, duplicate the
+        approval event, or roll back already-committed mailbox/idempotency
+        evidence.
     scopes:
       vocabulary: action-resource (read:<resource>, write:<resource>, control:<resource>, admin:<resource>, approve:<resource>,
         verify:<resource>)
@@ -12593,7 +12604,16 @@ api_specification:
       - MAILBOX_NOT_FOUND
     mailbox.approve:
       tier: must_have
-      description: Approve a pending mailbox item. Triggers the downstream event configured for the item's type by api_specification.conventions.mailbox.approval_event_routes.
+      description: >
+        Approve a pending mailbox item. Triggers the downstream event configured
+        for the item's type by
+        api_specification.conventions.mailbox.approval_event_routes.
+
+        The mailbox row decision, `mailbox.item_decided` event persistence,
+        delivery/replay-scope evidence, and API idempotency completion commit
+        atomically. Downstream subscriber/interceptor/runtime work from the
+        transactional approval publish runs only after that decision transaction
+        commits, or remains queued while ingress is paused.
       scope:
         required:
         - approve:mailbox

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -15,6 +15,7 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimeingress "swarm/internal/runtime/ingress"
 	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
@@ -666,6 +667,141 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	}
 	approvalPayload := loadEventPayload(t, db, downstreamID)
 	assertMailboxItemDecidedPayloadShape(t, approvalPayload, "review this", true)
+}
+
+func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:      sourceEventID,
+		Type:    "review.requested",
+		RunID:   runID,
+		Payload: json.RawMessage(`{"request":true}`),
+	}.WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+		t.Fatalf("append source event: %v", err)
+	}
+	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   sourceEventID,
+		EntityID:  entityID,
+		FromAgent: "empire-agent",
+		Type:      "review_request",
+		Priority:  "high",
+		Context:   []byte(`{"title":"review this"}`),
+		Summary:   "needs approval",
+	})
+	if err != nil {
+		t.Fatalf("insert mailbox: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE mailbox SET flow_instance = 'empire/review' WHERE item_id = $1::uuid`, mailboxID); err != nil {
+		t.Fatalf("set flow instance: %v", err)
+	}
+
+	interceptorCalls := make(chan string, 1)
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(true)),
+		Interceptors: []runtimebus.EventInterceptor{interceptorFunc(func(interceptCtx context.Context, evt events.Event) (bool, []events.Event, error) {
+			if evt.Type != events.EventType("mailbox.item_decided") {
+				return true, nil, nil
+			}
+			if tx, ok := runtimepipeline.PipelineSQLTxFromContext(interceptCtx); ok && tx != nil {
+				t.Fatal("mailbox approval dispatch ran with mailbox decision sql tx still in context")
+			}
+			var status string
+			if err := db.QueryRowContext(interceptCtx, `SELECT status FROM mailbox WHERE item_id = $1::uuid`, mailboxID).Scan(&status); err != nil {
+				t.Fatalf("query mailbox status from interceptor: %v", err)
+			}
+			if status != "decided" {
+				t.Fatalf("mailbox status visible to interceptor = %s, want decided", status)
+			}
+			var idempotencyRows int
+			if err := db.QueryRowContext(interceptCtx, `
+				SELECT COUNT(*)
+				FROM api_idempotency
+				WHERE method = 'mailbox.approve'
+				  AND idempotency_key = 'idem-post-commit-approve'
+			`).Scan(&idempotencyRows); err != nil {
+				t.Fatalf("query idempotency from interceptor: %v", err)
+			}
+			if idempotencyRows != 1 {
+				t.Fatalf("api_idempotency rows visible to interceptor = %d, want 1", idempotencyRows)
+			}
+			select {
+			case interceptorCalls <- evt.ID:
+			default:
+			}
+			return true, nil, nil
+		})},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:      func() time.Time { return now },
+			Ready:    func() bool { return true },
+			Database: fakePinger{},
+			Mailbox:  pg,
+			Events:   bus,
+			MailboxApprovalRoutes: map[string]string{
+				"review_request": "mailbox.item_decided",
+			},
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "empire",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+		}),
+	})
+
+	approveBody := `{"jsonrpc":"2.0","id":"approve","method":"mailbox.approve","params":{"mailbox_id":"` + mailboxID + `","decision_payload":{"approved":true},"idempotency_key":"idem-post-commit-approve"}}`
+	approved := rpcCall(t, handler, approveBody)
+	if approved.Error != nil {
+		t.Fatalf("mailbox.approve error = %#v", approved.Error)
+	}
+	downstreamID, _ := asMap(t, approved.Result)["downstream_event_id"].(string)
+	if downstreamID == "" {
+		t.Fatalf("mailbox.approve downstream event id = %#v", approved.Result)
+	}
+	select {
+	case got := <-interceptorCalls:
+		if got != downstreamID {
+			t.Fatalf("interceptor event id = %s, want %s", got, downstreamID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for mailbox approval post-commit dispatch")
+	}
+	if got := countEventsByName(t, db, "mailbox.item_decided"); got != 1 {
+		t.Fatalf("mailbox.item_decided event count = %d, want 1", got)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, downstreamID); got != 1 {
+		t.Fatalf("mailbox approval pipeline receipts = %d, want 1", got)
+	}
+	approvalPayload := loadEventPayload(t, db, downstreamID)
+	assertMailboxItemDecidedPayloadShape(t, approvalPayload, "review this", true)
+
+	replay := rpcCall(t, handler, approveBody)
+	if replay.Error != nil {
+		t.Fatalf("mailbox.approve replay error = %#v", replay.Error)
+	}
+	if got := asMap(t, replay.Result)["downstream_event_id"]; got != downstreamID {
+		t.Fatalf("replay downstream_event_id = %v, want %s", got, downstreamID)
+	}
+	select {
+	case got := <-interceptorCalls:
+		t.Fatalf("idempotency replay re-dispatched mailbox event %s", got)
+	default:
+	}
+	if got := countEventsByName(t, db, "mailbox.item_decided"); got != 1 {
+		t.Fatalf("mailbox.item_decided event count after replay = %d, want 1", got)
+	}
 }
 
 func countEventsByName(t *testing.T, db *sql.DB, eventName string) int {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -338,21 +338,62 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 		eb.logDispatchQueued(txctx, reason, evt, len(inboundPlan.Recipients), false, true)
 		return nil
 	}
-	passthrough, deferred, err := eb.runInterceptors(txctx, evt)
-	if err != nil {
-		return err
-	}
-	if !passthrough {
-		return errors.New("transactional publish interceptors cannot consume v1 API events")
-	}
-	if len(deferred) > 0 {
-		return errors.New("transactional publish interceptors cannot defer v1 API events")
-	}
-	status, errText := pipelineReceiptStatus(txctx, nil)
-	if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID, status, errText); err != nil {
-		return fmt.Errorf("persist pipeline receipt: %w", err)
+	if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
+		eb.completePublishTxDispatch(runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(txctx)), evt, inboundPlan)
+	}) {
+		return errors.New("transactional publish post-commit actions are required")
 	}
 	return nil
+}
+
+func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Event, inboundPlan eventDeliveryPlan) {
+	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
+	postCommitActions := make([]func(), 0, 8)
+	afterPublishActions := make([]func(), 0, 4)
+	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
+	ctx = runtimepipeline.WithPipelineTransitionCollector(ctx, &deferredTransitions, eb.pipelineTransitionCapability())
+	ctx = runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
+	ctx = runtimepipeline.WithPipelineAfterPublishActions(ctx, &afterPublishActions)
+	ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
+	defer runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
+
+	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
+	if err != nil {
+		eb.recordCommittedPublishReceipt(ctx, evt, err)
+		return
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	runtimepipeline.FlushDeferredPipelineTransitions(ctx, deferredTransitions)
+
+	if passthrough {
+		if len(inboundPlan.Recipients) > 0 {
+			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
+			if err := eb.deliverToRecipientsWithRoutes(ctx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
+				eb.recordCommittedPublishReceipt(ctx, evt, err)
+				return
+			}
+			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
+		}
+		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
+			if err := eb.publishDeferred(ctx, *inboundPlan.CycleEscalation); err != nil {
+				eb.recordCommittedPublishReceipt(ctx, evt, err)
+				return
+			}
+		}
+		if strings.TrimSpace(inboundPlan.ContradictionReason) != "" {
+			_ = eb.emitContradiction(ctx, evt, inboundPlan.ContradictionReason)
+		}
+	}
+	eb.logPublished(ctx, evt, 0)
+
+	for _, d := range deferred {
+		if err := eb.publishDeferred(ctx, d); err != nil {
+			eb.recordCommittedPublishReceipt(ctx, evt, err)
+			return
+		}
+	}
+	eb.recordCommittedPublishReceipt(ctx, evt, nil)
+	eb.recordCommittedPublishConvergence(ctx, evt)
 }
 
 func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -160,6 +160,32 @@ func (i eventVisibleInTxInterceptor) Intercept(ctx context.Context, _ events.Eve
 	return true, nil, nil
 }
 
+type postCommitTxAbsentInterceptor struct {
+	t       *testing.T
+	store   *store.PostgresStore
+	eventID string
+	called  chan struct{}
+}
+
+func (i postCommitTxAbsentInterceptor) Intercept(ctx context.Context, _ events.Event) (bool, []events.Event, error) {
+	i.t.Helper()
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		i.t.Fatal("transactional PublishTx interceptor ran with caller sql tx still in context")
+	}
+	ok, err := i.store.EventExists(ctx, i.eventID)
+	if err != nil {
+		i.t.Fatalf("EventExists(%s): %v", i.eventID, err)
+	}
+	if !ok {
+		i.t.Fatalf("expected event %s to be committed before interceptor ran", i.eventID)
+	}
+	select {
+	case i.called <- struct{}{}:
+	default:
+	}
+	return true, nil, nil
+}
+
 type deferredEventVisibleInterceptor struct {
 	t        *testing.T
 	store    *store.PostgresStore
@@ -1139,6 +1165,74 @@ func TestEventBusPublishTransactional_PersistsInboundEventBeforeInterceptorsRun(
 		Payload:   []byte(`{}`),
 	}); err != nil {
 		t.Fatalf("Publish: %v", err)
+	}
+}
+
+func TestEventBusPublishTxRunsInterceptorsAfterCallerCommit(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	eventID := "11111111-1111-1111-1111-111111111112"
+	called := make(chan struct{}, 1)
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{postCommitTxAbsentInterceptor{
+			t:       t,
+			store:   pg,
+			eventID: eventID,
+			called:  called,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	postCommitActions := make([]func(), 0, 1)
+	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
+	if err := eb.PublishTx(txctx, tx, events.Event{
+		ID:          eventID,
+		RunID:       eventBusTestRunID,
+		Type:        events.EventType("custom.publish_tx_post_commit"),
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID("11111111-1111-1111-1111-111111111113")); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("PublishTx: %v", err)
+	}
+	select {
+	case <-called:
+		_ = tx.Rollback()
+		t.Fatal("interceptor ran before caller committed")
+	default:
+	}
+	if len(postCommitActions) != 1 {
+		_ = tx.Rollback()
+		t.Fatalf("post-commit actions = %d, want 1", len(postCommitActions))
+	}
+	ok, err := pg.EventExists(ctx, eventID)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("EventExists before commit: %v", err)
+	}
+	if ok {
+		_ = tx.Rollback()
+		t.Fatal("event visible outside caller transaction before commit")
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for post-commit interceptor")
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts = %d, want 1", got)
 	}
 }
 

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -311,6 +311,10 @@ func withoutSQLTxContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, sqlTxContextKey{}, (*sql.Tx)(nil))
 }
 
+func WithoutPipelineSQLTxContext(ctx context.Context) context.Context {
+	return withoutSQLTxContext(ctx)
+}
+
 func withPipelinePostCommitActions(ctx context.Context, actions *[]func()) context.Context {
 	if actions == nil {
 		return ctx

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 )
 
@@ -271,6 +272,8 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	if err != nil {
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("begin v1 mailbox decision tx: %w", err)
 	}
+	postCommitActions := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
 	committed := false
 	defer func() {
 		if !committed {
@@ -401,7 +404,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		if publishTx == nil {
 			publishTx = s.appendMailboxV1ApprovalEventTx
 		}
-		if err := publishTx(ctx, tx, *outcome.ApprovalEvent); err != nil {
+		if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
 			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish v1 mailbox approval event: %w", err)
 		}
 	}
@@ -421,6 +424,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("commit v1 mailbox decision tx: %w", err)
 	}
 	committed = true
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	return outcome, nil
 }
 


### PR DESCRIPTION
Closes #1059
Part of #1045

## Summary

- Promote the `mailbox.approve` transactional-publish boundary into `platform-spec.yaml` and regenerated OpenRPC.
- Change `EventBus.PublishTx` so running-path downstream interceptor/dispatch work is queued as a caller post-commit action instead of running inside the caller-owned mailbox decision transaction.
- Flush mailbox approval post-commit publish actions only after the mailbox row, approval event, delivery/replay-scope evidence, and API idempotency completion commit.
- Add deterministic EventBus and `/v1/rpc mailbox.approve` proofs that dispatch sees committed mailbox/idempotency state and no caller SQL transaction.

## Governing Refs / Context

- `platform-spec.yaml#api_specification.methods.mailbox.approve`
- `platform-spec.yaml#api_specification.conventions.mailbox.approval_event_routes`
- `platform-spec.yaml#api_specification.conventions.mailbox.approval_event_payload_contract`
- `platform-spec.yaml#api_specification.conventions.mailbox.approval_transaction_boundary`
- `platform-spec.yaml#api_specification.conventions.idempotency`
- `platform-spec.yaml#api_specification.conventions.queueable_ingress`
- #1059 Pre-Implementation Coverage Audit and independent gate.
- Closed #1056/#1061 covers standalone `/v1/rpc event.publish`; this PR covers caller-owned `PublishTx` inside mailbox approval.

## Semantic Migration

- New canonical owner: `platform-spec.yaml` defines the mailbox approval caller-owned transactional publish boundary; implementation owners are `internal/store/mailbox_v1.go` and `internal/runtime/bus/eventbus_publish.go`.
- Old path now invalid: `EventBus.PublishTx` running interceptors/downstream runtime work while the caller-owned mailbox decision SQL transaction is still open.
- Production paths checked: `/v1/rpc mailbox.approve`, `cmd/swarm mailbox approve` consumer tests, paused runtime queueing, EventBus `PublishTx`, standalone `event.publish` regression, mailbox publish failure rollback.
- Migration complete for the chosen #1059 class; broader #1045 `run.start` / CLI failure-quality sibling remains split.

## Validation

- `go test ./internal/runtime/bus -run 'TestEventBusPublishTxRunsInterceptorsAfterCallerCommit|TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable|TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable|TestEventBusPublishTransactional_PersistsInboundEventBeforeInterceptorsRun|TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit|TestOperatorMailboxHandlersSupportedRPCPath|TestOperatorMailboxApprovePublishFailureLeavesItemRetryable|TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused|TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack|TestOpenRPCMutatingHTTPRuntimeProbes|TestOpenRPCSuccessfulResultSchemas' -count=1`
- `go test ./cmd/swarm -run 'TestMailboxApprove|TestMailboxDecision|TestMailbox' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_V1Mailbox|TestPostgresStore_ConvergeNormalRunCompletion' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./...`
