### PR TITLE
[agent-a][issue #1070] Add OpenAI-compatible LLM provider proof

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1381,6 +1381,11 @@ func defaultRuntimeConfig() (*config.Config, error) {
 				NoSessionPersistence: envBool("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", false),
 				UseTMux:              envBool("SWARM_CLAUDE_CLI_USE_TMUX", false),
 			},
+			OpenAICompatible: config.OpenAICompatibleConfig{
+				BaseURL:      envOrDefault(llmselection.OpenAICompatibleBaseURLEnv, ""),
+				DefaultModel: envOrDefault(llmselection.OpenAICompatibleDefaultModelEnv, ""),
+				LowCostModel: envOrDefault(llmselection.OpenAICompatibleLowCostModelEnv, ""),
+			},
 		},
 	}
 	if err := cfg.Validate(); err != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3154,6 +3154,29 @@ func TestDefaultRuntimeConfig_DoesNotInferLLMBackendFromCredentials(t *testing.T
 	}
 }
 
+func TestDefaultRuntimeConfig_OpenAICompatibleConsumesCanonicalProfileEnv(t *testing.T) {
+	t.Setenv("SWARM_LLM_BACKEND", "openai_compatible")
+	t.Setenv("SWARM_OPENAI_COMPATIBLE_BASE_URL", "https://example.test/v1")
+	t.Setenv("SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL", "gpt-compatible")
+	t.Setenv("SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL", "gpt-compatible-mini")
+	cfg, err := defaultRuntimeConfig()
+	if err != nil {
+		t.Fatalf("defaultRuntimeConfig: %v", err)
+	}
+	if cfg.LLM.Backend != "openai_compatible" {
+		t.Fatalf("llm backend = %q, want openai_compatible", cfg.LLM.Backend)
+	}
+	if cfg.LLM.OpenAICompatible.BaseURL != "https://example.test/v1" {
+		t.Fatalf("openai compatible base url = %q", cfg.LLM.OpenAICompatible.BaseURL)
+	}
+	if cfg.LLM.OpenAICompatible.DefaultModel != "gpt-compatible" {
+		t.Fatalf("openai compatible default model = %q", cfg.LLM.OpenAICompatible.DefaultModel)
+	}
+	if cfg.LLM.OpenAICompatible.LowCostModel != "gpt-compatible-mini" {
+		t.Fatalf("openai compatible low cost model = %q", cfg.LLM.OpenAICompatible.LowCostModel)
+	}
+}
+
 func TestLoadRuntimeConfig_RejectsUnsupportedRuntimeControlsFromFile(t *testing.T) {
 	cfgText := strings.Join([]string{
 		"runtime:",

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2164,9 +2164,15 @@ engine:
           transport: cli
           budget_usage_accounting: estimated
           native_tool_policy: strict provider-native runtime
+        openai_compatible:
+          provider: openai_compatible
+          transport: api
+          budget_usage_accounting: exact
+          native_tool_policy: fallback-aware non-strict runtime
+          protocol: chat_completions_compatible_json
       split_boundaries:
-      - Adding new provider identities such as OpenAI, Ollama, Bedrock, Azure OpenAI, Vertex, or vLLM requires a separate
-        provider implementation/parity gate that consumes llm_provider_selection_config_authority.
+      - Adding additional provider identities or protocol families such as OpenAI Responses, OpenRouter, Ollama, Bedrock,
+        Azure OpenAI, Vertex, or vLLM requires a separate provider implementation/parity gate that consumes llm_provider_selection_config_authority.
       - Renaming cli_test is a separate compatibility/semantics decision.
       - Provider-selection UI is outside this adapter-contract slice.
     llm_provider_selection_config_authority:
@@ -2214,6 +2220,30 @@ engine:
             model_tier_source: agents.model_tier
             accounting_model: CLI budget estimation records the configured model_tier string because the Claude CLI shipped
               runtime does not expose exact model usage metadata in a stable non-interactive surface.
+        openai_compatible:
+          provider: openai_compatible
+          transport: api
+          provider_contract_runtime_mode: openai_compatible
+          protocol: Chat Completions-compatible HTTP JSON at /v1/chat/completions relative to the configured base URL.
+          credential_source:
+            env_var: OPENAI_COMPATIBLE_API_KEY
+            required: true
+          endpoint_source:
+            config_key: llm.openai_compatible.base_url
+            env_var: SWARM_OPENAI_COMPATIBLE_BASE_URL
+            required: true
+            rule: This is the API base URL, not the chat completions endpoint path; the runtime appends /v1/chat/completions.
+          model_tier_mapping:
+            default_model_config: llm.openai_compatible.default_model
+            default_model_env: SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL
+            low_cost_model_config: llm.openai_compatible.low_cost_model
+            low_cost_model_env: SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL
+            model_tier_source: agents.model_tier
+            throttle_degrade_rule: If the budget guard marks the actor entity throttled and the low-cost model is configured,
+              the OpenAI-compatible runtime uses the low-cost model for that turn.
+          proof_boundary: This profile proves one non-Anthropic Chat Completions-compatible HTTP provider path. It is not
+            an OpenAI Responses API provider, not an official-OpenAI-only provider identity, not OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM
+            closure, and not a provider matrix.
       reserved_persisted_backend_profiles:
         mock: Reserved persisted profile id for fixture replay. It is not a supported active runtime backend until a dedicated
           provider/runtime owner lands.
@@ -2226,8 +2256,8 @@ engine:
         mode strings.
       - Readers must consume persisted llm_backend as a backend profile id and fail closed on unknown values.
       split_boundaries:
-      - Implementing OpenAI, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other new provider remains a
-        separate provider implementation/parity gate.
+      - Implementing OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other additional
+        provider remains a separate provider implementation/parity gate.
       - Renaming cli_test remains a separate compatibility/storage/spec migration.
       - Provider UI and docs beyond the selector/config truth remain under the #983 parent tail.
     conversation_modes:
@@ -3825,13 +3855,13 @@ platform_tables:
         — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth and
         permissions_bundle is resolved at boot into the persisted permissions array rather than being stored directly.
         llm_backend stores the backend profile id owned by llm_provider_selection_config_authority. Active runtime profiles
-        are api (Anthropic API transport) and cli_test (Claude CLI transport); mock and local are reserved persisted profile
-        ids and are not active runtimes until a dedicated provider/runtime owner lands. This value is provider-selection
+        are api (Anthropic API transport), cli_test (Claude CLI transport), and openai_compatible (Chat Completions-compatible
+        HTTP transport); mock and local are reserved persisted profile ids and are not active runtimes until a dedicated provider/runtime owner lands. This value is provider-selection
         deployment truth, not provider identity alone and not transport mode alone. This is a deployment/agent property, not
         a session property. agent_sessions.runtime_mode tracks conversation scope only.'
       ddl: "CREATE TABLE agents (\n    agent_id          TEXT PRIMARY KEY,\n    flow_instance     TEXT,\n    role        \
         \      TEXT NOT NULL,\n    model_tier        TEXT NOT NULL,\n    llm_backend       TEXT NOT NULL DEFAULT 'api' CHECK\
-        \ (llm_backend IN ('api', 'cli_test', 'mock', 'local')),\n    conversation_mode TEXT NOT NULL CHECK (conversation_mode\
+        \ (llm_backend IN ('api', 'cli_test', 'openai_compatible', 'mock', 'local')),\n    conversation_mode TEXT NOT NULL CHECK (conversation_mode\
         \ IN ('task', 'session', 'session_per_entity')),\n    parent_agent_id   TEXT,\n    entity_id         UUID,\n    config\
         \            JSONB NOT NULL DEFAULT '{}',\n    subscriptions     JSONB NOT NULL DEFAULT '[]',\n    emit_events   \
         \    JSONB NOT NULL DEFAULT '[]',\n    tools             JSONB NOT NULL DEFAULT '[]',\n    permissions       JSONB\

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2232,7 +2232,7 @@ engine:
             config_key: llm.openai_compatible.base_url
             env_var: SWARM_OPENAI_COMPATIBLE_BASE_URL
             required: true
-            rule: This is the API base URL, not the chat completions endpoint path; the runtime appends /v1/chat/completions.
+            rule: This is the API base URL, not the chat completions endpoint path; the runtime normalizes a root or /v1 base to exactly /v1/chat/completions.
           model_tier_mapping:
             default_model_config: llm.openai_compatible.default_model
             default_model_env: SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -1609,7 +1609,7 @@ CREATE TABLE entity_state (
 
 ### agents
 
-- `description`: Runtime agent registry. One row per agent instance. Carries the full runtime descriptor: role (from agents.yaml), parent_agent_id (managerial hierarchy), config (agent-specific configuration from contracts), subscriptions/emit_events/tools/permissions (materialized from contracts at boot for fast runtime lookup). flow_instance nullable for root-level agents not scoped to any flow. entity_id nullable — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth. This table is the runtime materialization. llm_backend specifies the LLM invocation backend — api (production), cli_test (test harness), mock (fixture replay), local (local model). This is a deployment/agent property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.
+- `description`: Runtime agent registry. One row per agent instance. Carries the full runtime descriptor: role (from agents.yaml), parent_agent_id (managerial hierarchy), config (agent-specific configuration from contracts), subscriptions/emit_events/tools/permissions (materialized from contracts at boot for fast runtime lookup). flow_instance nullable for root-level agents not scoped to any flow. entity_id nullable — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth. This table is the runtime materialization. llm_backend specifies the LLM invocation backend — api (Anthropic API transport), cli_test (Claude CLI transport), openai_compatible (Chat Completions-compatible HTTP transport), mock (fixture replay), local (local model). This is a deployment/agent property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.
 ### ddl
 
 ```sql
@@ -1618,7 +1618,7 @@ CREATE TABLE agents (
     flow_instance     TEXT,
     role              TEXT NOT NULL,
     model_tier        TEXT NOT NULL,
-    llm_backend       TEXT NOT NULL DEFAULT 'api' CHECK (llm_backend IN ('api', 'cli_test', 'mock', 'local')),
+    llm_backend       TEXT NOT NULL DEFAULT 'api' CHECK (llm_backend IN ('api', 'cli_test', 'openai_compatible', 'mock', 'local')),
     conversation_mode TEXT NOT NULL CHECK (conversation_mode IN ('task', 'session', 'session_per_entity')),
     parent_agent_id   TEXT,
     entity_id         UUID,

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -302,11 +302,12 @@ nodes:
       - the backend profile id resolves provider identity, transport/protocol mode, credential source, provider-contract runtime mode, and model-tier mapping
       - command defaults must not infer provider/backend selection from credential or model env presence
       - RuntimeFactory, selected-fork runtime materialization, provider credential checks, AgentManager, store projection/hydration, and model selection must consume the same profile resolver
-      - agents.llm_backend stores a backend profile id; api and cli_test are active runtime profiles while mock and local are reserved persisted-only profiles
-      - first non-Anthropic provider implementation remains blocked until it consumes this authority instead of inventing config/env/model semantics locally
+      - agents.llm_backend stores a backend profile id; api, cli_test, and openai_compatible are active runtime profiles while mock and local are reserved persisted-only profiles
+      - openai_compatible closes the first non-Anthropic Chat Completions-compatible HTTP proof only; OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure, Vertex, vLLM, provider docs/sample config, and cli_test rename remain split tails
     representative_issues:
       - 983
       - 1062
+      - 1070
     common_framing_mistakes:
       too_broad:
         - implement OpenAI, OpenRouter, Ollama, Bedrock, or another provider in the selection-authority slice

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,11 +41,12 @@ type DatabaseConfig struct {
 }
 
 type LLMConfig struct {
-	Backend     string           `yaml:"backend"`
-	RuntimeMode string           `yaml:"runtime_mode"`
-	Session     LLMSessionConfig `yaml:"session"`
-	ClaudeAPI   ClaudeAPIConfig  `yaml:"claude_api"`
-	ClaudeCLI   ClaudeCLIConfig  `yaml:"claude_cli"`
+	Backend          string                 `yaml:"backend"`
+	RuntimeMode      string                 `yaml:"runtime_mode"`
+	Session          LLMSessionConfig       `yaml:"session"`
+	ClaudeAPI        ClaudeAPIConfig        `yaml:"claude_api"`
+	ClaudeCLI        ClaudeCLIConfig        `yaml:"claude_cli"`
+	OpenAICompatible OpenAICompatibleConfig `yaml:"openai_compatible"`
 }
 
 type LLMSessionConfig struct {
@@ -68,6 +69,12 @@ type ClaudeCLIConfig struct {
 	Retries              int           `yaml:"retries"`
 	NoSessionPersistence bool          `yaml:"no_session_persistence"`
 	UseTMux              bool          `yaml:"use_tmux"`
+}
+
+type OpenAICompatibleConfig struct {
+	BaseURL      string `yaml:"base_url"`
+	DefaultModel string `yaml:"default_model"`
+	LowCostModel string `yaml:"low_cost_model"`
 }
 
 func Load(path string) (*Config, error) {
@@ -114,6 +121,19 @@ func (c *Config) Validate() error {
 		}
 		if c.LLM.ClaudeCLI.NoSessionPersistence {
 			return errors.New("llm.claude_cli.no_session_persistence must be false for continuity")
+		}
+	}
+	if profile.ID == llmselection.BackendOpenAICompatible {
+		if _, err := llmselection.ResolveBaseURL(profile, c.LLM.OpenAICompatible.BaseURL); err != nil {
+			return err
+		}
+		if _, err := llmselection.ResolveModelName(profile, llmselection.ModelResolution{
+			Models: llmselection.ModelMap{
+				Default: c.LLM.OpenAICompatible.DefaultModel,
+				LowCost: c.LLM.OpenAICompatible.LowCostModel,
+			},
+		}); err != nil {
+			return err
 		}
 	}
 	if c.LLM.Session.LockTTL <= 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,25 @@ func TestValidate_RejectsReservedActiveBackend(t *testing.T) {
 	}
 }
 
+func TestValidate_OpenAICompatibleRequiresProfileOwnedConfig(t *testing.T) {
+	c := &Config{}
+	c.LLM.Backend = "openai_compatible"
+	c.LLM.Session.LockTTL = 1 * time.Second
+	c.LLM.Session.RotateAfterTurns = 1
+	c.LLM.Session.RotateOnParseFailures = 1
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "llm.openai_compatible.base_url") {
+		t.Fatalf("Validate error = %v, want openai-compatible base url requirement", err)
+	}
+	c.LLM.OpenAICompatible.BaseURL = "https://example.test/v1"
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "llm.openai_compatible.default_model") {
+		t.Fatalf("Validate error = %v, want openai-compatible model requirement", err)
+	}
+	c.LLM.OpenAICompatible.DefaultModel = "gpt-compatible"
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
 func TestValidate_RejectsRetiredRuntimeMode(t *testing.T) {
 	c := &Config{}
 	c.LLM.RuntimeMode = "api"

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -432,7 +432,7 @@ func (r *AnthropicAPIRuntime) buildRequest(ctx context.Context, s *Session, inpu
 	modelReq := llmselection.ModelResolution{
 		Models: llmselection.ModelMap{
 			Default: r.cfg.LLM.ClaudeAPI.DefaultModel,
-			Haiku:   r.cfg.LLM.ClaudeAPI.HaikuModel,
+			LowCost: r.cfg.LLM.ClaudeAPI.HaikuModel,
 		},
 	}
 	if actor, ok := runtimeactors.ActorFromContext(ctx); ok {
@@ -563,6 +563,7 @@ func convertAnthropicResponse(parsed anthropicResponse) Response {
 		}
 	}
 	resp.Message.Content = strings.TrimSpace(strings.Join(textParts, "\n"))
+	resp.Message.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
 	return resp
 }
 

--- a/internal/runtime/llm/conversation.go
+++ b/internal/runtime/llm/conversation.go
@@ -229,6 +229,9 @@ func (c *Conversation) executeToolCalls(ctx context.Context, calls []ToolCall) (
 		entry := map[string]any{
 			"name": tc.Name,
 		}
+		if id := strings.TrimSpace(tc.ID); id != "" {
+			entry["tool_call_id"] = id
+		}
 		if err == nil {
 			projected, projectErr := c.projectToolResult(ctx, tc.Name, tc.Arguments, out)
 			if projectErr != nil {

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -49,6 +49,8 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 		runtime = NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
 			MCPTurnContextStore: f.MCPTurns,
 		})
+	case llmselection.BackendOpenAICompatible:
+		runtime = NewOpenAICompatibleRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
 	default:
 		return nil, fmt.Errorf("unsupported llm backend profile: %s", profile.ID)
 	}

--- a/internal/runtime/llm/openai_compatible_runtime.go
+++ b/internal/runtime/llm/openai_compatible_runtime.go
@@ -1,0 +1,709 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	llmselection "swarm/internal/runtime/llm/selection"
+	"swarm/internal/runtime/sessions"
+)
+
+type OpenAICompatibleRuntime struct {
+	cfg           *config.Config
+	sessions      sessions.Registry
+	turns         TurnPersistence
+	conversations ConversationPersistence
+	budget        BudgetGuard
+	lockOwner     string
+	httpClient    *http.Client
+	baseURL       string
+	apiKey        string
+	events        EventPublisher
+}
+
+func NewOpenAICompatibleRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAICompatibleRuntime {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAICompatible)
+	baseURL, _ := llmselection.ResolveBaseURL(profile, cfg.LLM.OpenAICompatible.BaseURL)
+	return &OpenAICompatibleRuntime{
+		cfg:           cfg,
+		sessions:      sessions,
+		turns:         turns,
+		conversations: conversations,
+		budget:        budget,
+		lockOwner:     lockOwner,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+		baseURL: baseURL,
+		apiKey:  llmselection.CredentialValue(profile, os.LookupEnv),
+		events:  publisher,
+	}
+}
+
+func (r *OpenAICompatibleRuntime) ProviderContract() ProviderContract {
+	return OpenAICompatibleProviderContract()
+}
+
+func OpenAICompatibleProviderContract() ProviderContract {
+	return ProviderContract{
+		RuntimeMode: llmselection.BackendOpenAICompatible,
+		Provider:    llmselection.ProviderOpenAICompatible,
+		Transport:   ProviderTransportAPI,
+		ToolSchema: ProviderToolSchemaContract{
+			ValidatesInputSchemas: true,
+			TranslatesTools:       true,
+			ReturnsToolResults:    true,
+		},
+		SessionLifecycle: ProviderSessionLifecycleContract{
+			StartsSessions:            true,
+			ContinuesSessions:         true,
+			SupportsConversationModes: true,
+			ProviderSessionIDStrategy: "platform_managed",
+			RotatesSessions:           true,
+			PreservesRetryLineage:     true,
+		},
+		Response: ProviderResponseContract{
+			NormalizesMessages:   true,
+			NormalizesToolCalls:  true,
+			PreservesRawResponse: true,
+			StreamingParser:      "openai_compatible_chat_completions_json",
+		},
+		NativeTools: ProviderNativeToolContract{
+			FallbackToolsAllowed: true,
+		},
+		Persistence: ProviderPersistenceContract{
+			PersistsTurns:                 true,
+			PersistsConversationSnapshots: true,
+			PersistsTaskModeAudit:         true,
+		},
+		Budget: ProviderBudgetContract{
+			UsageAccounting: BudgetUsageExact,
+		},
+	}
+}
+
+func (r *OpenAICompatibleRuntime) PersistConversationSnapshot(ctx context.Context, s *Session) error {
+	if r.conversations == nil || s == nil {
+		return nil
+	}
+	mode, err := sessions.ParseConversationRuntimeMode(s.ConversationMode)
+	if err != nil {
+		return err
+	}
+	if !shouldPersistConversationMode(mode) {
+		return nil
+	}
+	return r.conversations.UpsertConversation(ctx, ConversationRecord{
+		SessionID:    s.ID,
+		AgentID:      s.AgentID,
+		SessionScope: strings.TrimSpace(s.SessionScope),
+		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
+		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
+		Mode:         mode.String(),
+		Messages:     s.Messages,
+		Summary:      BuildSessionSummary(s),
+		TurnCount:    s.TurnCount,
+		Status:       "active",
+	})
+}
+
+func (r *OpenAICompatibleRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
+	scope := sessions.ScopeFromContext(ctx)
+	actor, _ := runtimeactors.ActorFromContext(ctx)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(scope.ConversationMode), sessions.NormalizeSessionScope(scope.SessionScope), scope.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var lease *sessions.Lease
+	if !resolved.Stateless {
+		lease, err = r.sessions.Acquire(ctx, agentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, resolved.ScopeKey)
+		if err != nil {
+			return nil, err
+		}
+		if err := r.sessions.Release(ctx, lease); err != nil {
+			return nil, err
+		}
+	}
+
+	s := &Session{
+		ID: ensurePlatformSessionID(func() string {
+			if lease != nil {
+				return lease.SessionID
+			}
+			return ""
+		}()),
+		AgentID:          agentID,
+		RuntimeMode:      resolved.RuntimeMode.String(),
+		ConversationMode: resolved.RuntimeMode.String(),
+		SessionScope:     resolved.Scope.String(),
+		ScopeKey:         resolved.ScopeKey,
+		RetryReason: func() string {
+			if lease != nil {
+				return lease.RetryReason
+			}
+			return ""
+		}(),
+		RetriesFromSessionID: func() string {
+			if lease != nil {
+				return lease.RetriesFromSessionID
+			}
+			return ""
+		}(),
+		ProviderSessionID: func() string {
+			if lease != nil {
+				return lease.ProviderSessionID
+			}
+			return ""
+		}(),
+		SystemPrompt: augmentAgentSystemPrompt(systemPrompt, actor, tools),
+		Tools:        tools,
+		Messages:     nil,
+	}
+	if r.conversations != nil && !resolved.Stateless {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
+			s.Messages = rec.Messages
+			s.TurnCount = rec.TurnCount
+			s.RetryReason = strings.TrimSpace(rec.RetryReason)
+			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
+			s.Watchdog = rec.Watchdog
+		}
+	}
+	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))
+	return s, nil
+}
+
+func (r *OpenAICompatibleRuntime) ContinueSession(ctx context.Context, s *Session, message Message) (*Response, error) {
+	if s == nil {
+		return nil, errors.New("nil session")
+	}
+	actor, _ := runtimeactors.ActorFromContext(ctx)
+	entityID := actor.EffectiveEntityID()
+	scopeKey := budgetExecutionScopeKey(actor)
+	if r.budget != nil {
+		unlockScope := r.budget.LockExecutionScope(scopeKey)
+		defer unlockScope()
+		if r.budget.IsEntityEmergency(entityID) {
+			return nil, fmt.Errorf("budget emergency: refusing llm execution (entity=%s)", entityID)
+		}
+	}
+
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode)), sessions.NormalizeSessionScope(coalesce(s.SessionScope, "")), s.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+	var lease *sessions.Lease
+	if !resolved.Stateless {
+		lease, err = r.sessions.Acquire(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, resolved.ScopeKey)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = r.sessions.Release(ctx, lease) }()
+		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
+			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the OpenAI-compatible session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
+				"runtime_mode": resolved.RuntimeMode.String(),
+				"scope_key":    resolved.ScopeKey,
+			}, heartbeatErr)
+		})
+		defer stopLeaseHeartbeat()
+
+		if lease.SessionID != s.ID {
+			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), s.ID, lease.SessionID, resolved.ScopeKey)
+			s.ID = lease.SessionID
+		}
+	}
+	if err := requireInboundDeliveryActiveForSession(ctx, r.events, s, "error", "Marking the reused agent delivery in progress failed", map[string]any{
+		"runtime_mode": resolved.RuntimeMode.String(),
+		"scope_key":    resolved.ScopeKey,
+	}, entityID); err != nil {
+		return nil, fmt.Errorf("mark inbound delivery active for reused openai-compatible session: %w", err)
+	}
+
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAICompatible)
+	if strings.TrimSpace(r.apiKey) == "" {
+		r.apiKey = llmselection.CredentialValue(profile, os.LookupEnv)
+		if strings.TrimSpace(r.apiKey) == "" {
+			return nil, llmselection.RequireCredential(profile, os.LookupEnv)
+		}
+	}
+	if strings.TrimSpace(r.baseURL) == "" {
+		baseURL, err := llmselection.ResolveBaseURL(profile, r.cfg.LLM.OpenAICompatible.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+		r.baseURL = baseURL
+	}
+
+	reqBody, err := r.buildRequest(ctx, s, message)
+	if err != nil {
+		return nil, err
+	}
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal openai-compatible request: %w", err)
+	}
+
+	start := time.Now()
+	rawResp, parsed, err := r.sendRequest(ctx, reqJSON)
+	latency := time.Since(start)
+	if err != nil {
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		if !resolved.Stateless {
+			if rotated, rotateErr := MaybeRotateAfterParseFailures(ctx, s, resolved.RuntimeMode, r.sessions, r.lockOwner, r.cfg.LLM.Session.RotateOnParseFailures, r.events); rotateErr == nil && rotated != nil {
+				lease = rotated
+			}
+		}
+		return nil, err
+	}
+
+	usage, ok := openAICompatibleUsage(parsed)
+	if !ok {
+		err := errors.New("openai-compatible response missing usage")
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		return nil, err
+	}
+
+	resp, err := convertOpenAICompatibleResponse(parsed)
+	if err != nil {
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		return nil, err
+	}
+	resp.Raw = rawResp
+
+	s.Messages = append(s.Messages, message, resp.Message)
+	s.TurnCount++
+	s.ParseFailures = 0
+	if !resolved.Stateless {
+		if err := r.sessions.IncrementTurn(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, s.ID, resolved.ScopeKey); err != nil {
+			return nil, err
+		}
+	}
+
+	r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+		AgentID:        s.AgentID,
+		RuntimeMode:    resolved.RuntimeMode.String(),
+		SessionID:      s.ID,
+		RequestPayload: reqJSON,
+		ResponseRaw:    rawResp,
+		ParseOK:        true,
+		Latency:        latency,
+	}, &resp))
+	r.persistConversation(ctx, s)
+
+	if r.budget != nil {
+		usage.Model = strings.TrimSpace(coalesce(usage.Model, reqBody.Model))
+		if err := r.budget.RecordEntityLLMUsage(ctx, entityID, s.AgentID, llmselection.BackendOpenAICompatible, usage, true, map[string]any{
+			"session_id":       s.ID,
+			"backend_profile":  llmselection.BackendOpenAICompatible,
+			"provider":         llmselection.ProviderOpenAICompatible,
+			"transport":        llmselection.TransportAPI,
+			"usage_accounting": string(BudgetUsageExact),
+		}); err != nil {
+			logPublisherRuntime(ctx, r.events, "warn", "record_openai_compatible_llm_usage_failed", "Recording OpenAI-compatible LLM usage failed", s.AgentID, s.ID, entityID, nil, err)
+		}
+	}
+
+	if !resolved.Stateless {
+		if rotated, rotateErr := MaybeRotateAfterTurn(ctx, s, resolved.RuntimeMode, r.sessions, r.lockOwner, r.cfg.LLM.Session.RotateAfterTurns, r.events); rotateErr == nil && rotated != nil {
+			lease = rotated
+		}
+	}
+
+	return &resp, nil
+}
+
+func (r *OpenAICompatibleRuntime) persistConversation(ctx context.Context, s *Session) {
+	if r.conversations == nil || s == nil {
+		return
+	}
+	mode, err := sessions.ParseConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode))
+	if err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_compatible_conversation_invalid_mode", "Persisting the OpenAI-compatible conversation was skipped because the session mode was invalid", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": strings.TrimSpace(s.ConversationMode),
+			"runtime_mode":      strings.TrimSpace(s.RuntimeMode),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+		return
+	}
+	if !shouldPersistConversationMode(mode) {
+		return
+	}
+	if err := r.conversations.UpsertConversation(ctx, ConversationRecord{
+		SessionID:    s.ID,
+		AgentID:      s.AgentID,
+		SessionScope: strings.TrimSpace(s.SessionScope),
+		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
+		Mode:         mode.String(),
+		Messages:     s.Messages,
+		Summary:      BuildSessionSummary(s),
+		TurnCount:    s.TurnCount,
+		Status:       "active",
+	}); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_compatible_conversation_failed", "Persisting the OpenAI-compatible conversation failed", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": mode.String(),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+	}
+}
+
+func (r *OpenAICompatibleRuntime) persistTurn(ctx context.Context, turn AgentTurnRecord) {
+	if r.turns == nil {
+		return
+	}
+	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_compatible_turn_failed", "Persisting the OpenAI-compatible agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
+	}
+}
+
+func (r *OpenAICompatibleRuntime) buildRequest(ctx context.Context, s *Session, input Message) (openAICompatibleRequest, error) {
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAICompatible)
+	msgs := make([]openAICompatibleMessage, 0, len(s.Messages)+2)
+	if system := strings.TrimSpace(s.SystemPrompt); system != "" {
+		msgs = append(msgs, openAICompatibleMessage{Role: "system", Content: system})
+	}
+	for _, m := range s.Messages {
+		msgs = append(msgs, toOpenAICompatibleMessages(m)...)
+	}
+	msgs = append(msgs, toOpenAICompatibleMessages(input)...)
+	if len(msgs) == 0 {
+		return openAICompatibleRequest{}, errors.New("at least one message is required")
+	}
+
+	tools := make([]openAICompatibleTool, 0, len(s.Tools))
+	for _, t := range s.Tools {
+		schema := t.Schema
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		if err := ValidateProviderToolSchema(t.Name, schema); err != nil {
+			return openAICompatibleRequest{}, err
+		}
+		tools = append(tools, openAICompatibleTool{
+			Type: "function",
+			Function: openAICompatibleFunctionTool{
+				Name:        strings.TrimSpace(t.Name),
+				Description: DeliveredToolDescription(t),
+				Parameters:  schema,
+			},
+		})
+	}
+
+	modelReq := llmselection.ModelResolution{
+		Models: llmselection.ModelMap{
+			Default: r.cfg.LLM.OpenAICompatible.DefaultModel,
+			LowCost: r.cfg.LLM.OpenAICompatible.LowCostModel,
+		},
+	}
+	if actor, ok := runtimeactors.ActorFromContext(ctx); ok {
+		modelReq.ModelTier = actor.ModelTier
+		actorEntityID := actor.EffectiveEntityID()
+		if r.budget != nil && r.budget.IsEntityThrottle(actorEntityID) {
+			modelReq.ForceLowCost = true
+		}
+	}
+	model, err := llmselection.ResolveModelName(profile, modelReq)
+	if err != nil {
+		return openAICompatibleRequest{}, err
+	}
+	return openAICompatibleRequest{
+		Model:    model,
+		Messages: msgs,
+		Tools:    tools,
+	}, nil
+}
+
+func (r *OpenAICompatibleRuntime) sendRequest(ctx context.Context, payload []byte) ([]byte, openAICompatibleResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAICompatibleChatCompletionsURL(r.baseURL), bytes.NewReader(payload))
+	if err != nil {
+		return nil, openAICompatibleResponse{}, fmt.Errorf("build openai-compatible request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer "+r.apiKey)
+
+	httpResp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, openAICompatibleResponse{}, fmt.Errorf("openai-compatible request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, openAICompatibleResponse{}, fmt.Errorf("read openai-compatible response: %w", err)
+	}
+
+	var parsed openAICompatibleResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return body, openAICompatibleResponse{}, fmt.Errorf("decode openai-compatible response: %w", err)
+	}
+	if httpResp.StatusCode >= 300 {
+		msg := strings.TrimSpace(parsed.Error.Message)
+		if msg == "" {
+			msg = strings.TrimSpace(string(body))
+		}
+		return body, parsed, openAICompatibleHTTPError{StatusCode: httpResp.StatusCode, Message: msg}
+	}
+	if parsed.Error.Message != "" {
+		return body, parsed, fmt.Errorf("openai-compatible error: %s", parsed.Error.Message)
+	}
+	return body, parsed, nil
+}
+
+func openAICompatibleChatCompletionsURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/v1/chat/completions"
+}
+
+func toOpenAICompatibleMessages(m Message) []openAICompatibleMessage {
+	role := strings.ToLower(strings.TrimSpace(m.Role))
+	content := strings.TrimSpace(m.Content)
+	switch role {
+	case "assistant":
+		msg := openAICompatibleMessage{Role: "assistant", Content: content}
+		msg.ToolCalls = openAICompatibleToolCalls(m.ToolCalls)
+		return []openAICompatibleMessage{msg}
+	case "tool":
+		if msgs := openAICompatibleToolResultMessages(content); len(msgs) > 0 {
+			return msgs
+		}
+		if content == "" {
+			return nil
+		}
+		return []openAICompatibleMessage{{Role: "user", Content: "Tool result:\n" + content}}
+	case "system":
+		if content == "" {
+			return nil
+		}
+		return []openAICompatibleMessage{{Role: "system", Content: content}}
+	default:
+		if content == "" {
+			return nil
+		}
+		return []openAICompatibleMessage{{Role: "user", Content: content}}
+	}
+}
+
+func openAICompatibleToolResultMessages(content string) []openAICompatibleMessage {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(content), &entries); err != nil {
+		return nil
+	}
+	msgs := make([]openAICompatibleMessage, 0, len(entries))
+	for _, entry := range entries {
+		id, _ := entry["tool_call_id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			continue
+		}
+		msgs = append(msgs, openAICompatibleMessage{
+			Role:       "tool",
+			ToolCallID: id,
+			Content:    string(raw),
+		})
+	}
+	return msgs
+}
+
+func openAICompatibleToolCalls(calls []ToolCall) []openAICompatibleToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]openAICompatibleToolCall, 0, len(calls))
+	for _, call := range calls {
+		name := strings.TrimSpace(call.Name)
+		if name == "" {
+			continue
+		}
+		args := "{}"
+		if call.Arguments != nil {
+			if b, err := json.Marshal(call.Arguments); err == nil {
+				args = string(b)
+			}
+		}
+		out = append(out, openAICompatibleToolCall{
+			ID:   strings.TrimSpace(call.ID),
+			Type: "function",
+			Function: openAICompatibleToolCallFunction{
+				Name:      name,
+				Arguments: args,
+			},
+		})
+	}
+	return out
+}
+
+func convertOpenAICompatibleResponse(parsed openAICompatibleResponse) (Response, error) {
+	if len(parsed.Choices) == 0 {
+		return Response{}, errors.New("openai-compatible response missing choices")
+	}
+	msg := parsed.Choices[0].Message
+	resp := Response{
+		Message: Message{
+			Role:    "assistant",
+			Content: strings.TrimSpace(msg.Content),
+		},
+	}
+	for _, tc := range msg.ToolCalls {
+		if strings.TrimSpace(tc.Function.Name) == "" {
+			continue
+		}
+		resp.ToolCalls = append(resp.ToolCalls, ToolCall{
+			ID:        strings.TrimSpace(tc.ID),
+			Name:      strings.TrimSpace(tc.Function.Name),
+			Arguments: parseOpenAICompatibleToolArguments(tc.Function.Arguments),
+		})
+	}
+	resp.Message.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+	return resp, nil
+}
+
+func parseOpenAICompatibleToolArguments(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]any{}
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return raw
+	}
+	return decoded
+}
+
+func openAICompatibleUsage(parsed openAICompatibleResponse) (UsageTokens, bool) {
+	if parsed.Usage.PromptTokens == nil || parsed.Usage.CompletionTokens == nil {
+		return UsageTokens{}, false
+	}
+	return UsageTokens{
+		InputTokens:  *parsed.Usage.PromptTokens,
+		OutputTokens: *parsed.Usage.CompletionTokens,
+		Model:        strings.TrimSpace(parsed.Model),
+	}, true
+}
+
+type openAICompatibleHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e openAICompatibleHTTPError) Error() string {
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = "request failed"
+	}
+	return fmt.Sprintf("openai-compatible status %d: %s", e.StatusCode, msg)
+}
+
+type openAICompatibleRequest struct {
+	Model    string                    `json:"model"`
+	Messages []openAICompatibleMessage `json:"messages"`
+	Tools    []openAICompatibleTool    `json:"tools,omitempty"`
+}
+
+type openAICompatibleMessage struct {
+	Role       string                     `json:"role"`
+	Content    string                     `json:"content,omitempty"`
+	ToolCallID string                     `json:"tool_call_id,omitempty"`
+	ToolCalls  []openAICompatibleToolCall `json:"tool_calls,omitempty"`
+}
+
+type openAICompatibleTool struct {
+	Type     string                       `json:"type"`
+	Function openAICompatibleFunctionTool `json:"function"`
+}
+
+type openAICompatibleFunctionTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Parameters  any    `json:"parameters"`
+}
+
+type openAICompatibleToolCall struct {
+	ID       string                           `json:"id,omitempty"`
+	Type     string                           `json:"type"`
+	Function openAICompatibleToolCallFunction `json:"function"`
+}
+
+type openAICompatibleToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openAICompatibleResponse struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Role      string `json:"role"`
+			Content   string `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     *int `json:"prompt_tokens"`
+		CompletionTokens *int `json:"completion_tokens"`
+		TotalTokens      *int `json:"total_tokens"`
+	} `json:"usage"`
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    any    `json:"code"`
+	} `json:"error"`
+}

--- a/internal/runtime/llm/openai_compatible_runtime.go
+++ b/internal/runtime/llm/openai_compatible_runtime.go
@@ -496,7 +496,11 @@ func (r *OpenAICompatibleRuntime) sendRequest(ctx context.Context, payload []byt
 }
 
 func openAICompatibleChatCompletionsURL(baseURL string) string {
-	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/v1/chat/completions"
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(normalized, "/v1") {
+		return normalized + "/chat/completions"
+	}
+	return normalized + "/v1/chat/completions"
 }
 
 func toOpenAICompatibleMessages(m Message) []openAICompatibleMessage {
@@ -540,11 +544,15 @@ func openAICompatibleToolResultMessages(content string) []openAICompatibleMessag
 	for _, entry := range entries {
 		id, _ := entry["tool_call_id"].(string)
 		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
 		raw, err := json.Marshal(entry)
 		if err != nil {
+			continue
+		}
+		if id == "" {
+			msgs = append(msgs, openAICompatibleMessage{
+				Role:    "user",
+				Content: "Tool result:\n" + string(raw),
+			})
 			continue
 		}
 		msgs = append(msgs, openAICompatibleMessage{

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -155,6 +155,39 @@ func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleChatCompletionsURLNormalizesVersionSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "server root", base: "https://example.test", want: "https://example.test/v1/chat/completions"},
+		{name: "api version base", base: "https://example.test/v1", want: "https://example.test/v1/chat/completions"},
+		{name: "trim slash", base: "https://example.test/v1/", want: "https://example.test/v1/chat/completions"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openAICompatibleChatCompletionsURL(tt.base); got != tt.want {
+				t.Fatalf("openAICompatibleChatCompletionsURL(%q) = %q, want %q", tt.base, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatibleToolResultMessagesPreservesFallbackWithoutToolCallID(t *testing.T) {
+	content := `[{"name":"lookup","tool_call_id":"call_1","ok":true,"result":{"status":"ok"}},{"name":"__runtime_guardrail__","ok":false,"error":"tool output too large"}]`
+	msgs := openAICompatibleToolResultMessages(content)
+	if len(msgs) != 2 {
+		t.Fatalf("messages = %#v, want tool message plus fallback", msgs)
+	}
+	if msgs[0].Role != "tool" || msgs[0].ToolCallID != "call_1" {
+		t.Fatalf("first message = %#v, want call_1 tool result", msgs[0])
+	}
+	if msgs[1].Role != "user" || !strings.Contains(msgs[1].Content, "__runtime_guardrail__") {
+		t.Fatalf("second message = %#v, want preserved guardrail fallback", msgs[1])
+	}
+}
+
 func openAICompatibleTestConfig(baseURL string) *config.Config {
 	return &config.Config{
 		LLM: config.LLMConfig{

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -1,0 +1,232 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/config"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
+	"swarm/internal/runtime/sessions"
+)
+
+func TestOpenAICompatibleRuntimeConversationToolBudgetAndPersistence(t *testing.T) {
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+
+	var requests []openAICompatibleRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("authorization"); got != "Bearer test-key" {
+			t.Fatalf("authorization = %q, want bearer test-key", got)
+		}
+		var req openAICompatibleRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		w.Header().Set("content-type", "application/json")
+		switch len(requests) {
+		case 1:
+			if req.Model != "gpt-compatible-mini" {
+				t.Fatalf("first request model = %q, want low-cost model", req.Model)
+			}
+			if len(req.Tools) != 1 || req.Tools[0].Type != "function" || req.Tools[0].Function.Name != "lookup" {
+				t.Fatalf("tools = %#v, want lookup function tool", req.Tools)
+			}
+			_, _ = w.Write([]byte(`{
+				"model":"gpt-compatible-mini",
+				"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"query\":\"status\"}"}}]}}],
+				"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}
+			}`))
+		case 2:
+			if !requestHasToolResult(req.Messages, "call_1") {
+				t.Fatalf("second request messages missing tool result for call_1: %#v", req.Messages)
+			}
+			if !requestHasAssistantToolCall(req.Messages, "call_1") {
+				t.Fatalf("second request messages missing assistant tool_call call_1: %#v", req.Messages)
+			}
+			_, _ = w.Write([]byte(`{
+				"model":"gpt-compatible-mini",
+				"choices":[{"message":{"role":"assistant","content":"done"}}],
+				"usage":{"prompt_tokens":13,"completion_tokens":5,"total_tokens":18}
+			}`))
+		default:
+			t.Fatalf("unexpected request %d", len(requests))
+		}
+	}))
+	defer server.Close()
+
+	turns := &turnCapture{}
+	conversations := &captureConversationStore{}
+	budget := &budgetCapture{}
+	cfg := openAICompatibleTestConfig(server.URL)
+	runtime, err := RuntimeFactory{
+		Cfg:           cfg,
+		Sessions:      sessions.NewInMemoryRegistry(time.Second),
+		Turns:         turns,
+		Conversations: conversations,
+		Budget:        budget,
+		LockOwner:     "worker-1",
+	}.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, err := RequireProviderContract("openai_compatible", runtime); err != nil {
+		t.Fatalf("RequireProviderContract: %v", err)
+	}
+
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID:        "agent-1",
+		ModelTier: "low_cost",
+		EntityID:  "entity-1",
+	})
+	ctx = sessions.WithScope(ctx, sessions.RuntimeModeSession.String(), sessions.SessionScopeGlobal.String(), "global")
+	conv := NewConversation("agent-1", "task-1", "system prompt", []ToolDefinition{{
+		Name:        "lookup",
+		Description: "Lookup status",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+			"required": []any{"query"},
+		},
+	}}, SessionScoped, 5, runtime)
+	conv.SetToolExecutor(openAIToolExecutor{})
+
+	resp, err := conv.Step(ctx, "check status")
+	if err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if resp.Message.Content != "done" {
+		t.Fatalf("response content = %q, want done", resp.Message.Content)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if len(turns.records) != 2 {
+		t.Fatalf("turn records = %d, want 2", len(turns.records))
+	}
+	if turns.records[0].RuntimeMode != sessions.RuntimeModeSession.String() || !turns.records[0].ParseOK {
+		t.Fatalf("first turn record = %#v", turns.records[0])
+	}
+	if len(turns.records[0].ToolCalls) != 1 || turns.records[0].ToolCalls[0].ID != "call_1" {
+		t.Fatalf("first turn tool calls = %#v, want call_1", turns.records[0].ToolCalls)
+	}
+	if conversations.record.SessionID == "" || conversations.record.Mode != sessions.RuntimeModeSession.String() {
+		t.Fatalf("conversation record = %#v, want session snapshot", conversations.record)
+	}
+	if budget.runtimeMode != "openai_compatible" || !budget.exact {
+		t.Fatalf("budget runtime=%q exact=%v, want openai_compatible exact", budget.runtimeMode, budget.exact)
+	}
+	if budget.usage.InputTokens != 13 || budget.usage.OutputTokens != 5 || budget.usage.Model != "gpt-compatible-mini" {
+		t.Fatalf("budget usage = %#v, want final response usage", budget.usage)
+	}
+}
+
+func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"gpt-compatible","choices":[{"message":{"role":"assistant","content":"done"}}]}`))
+	}))
+	defer server.Close()
+
+	turns := &turnCapture{}
+	runtime := NewOpenAICompatibleRuntime(openAICompatibleTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", turns, nil, nil, nil)
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	_, err = runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "missing usage") {
+		t.Fatalf("ContinueSession error = %v, want missing usage", err)
+	}
+	if len(turns.records) != 1 || turns.records[0].ParseOK {
+		t.Fatalf("turn records = %#v, want parse failure", turns.records)
+	}
+}
+
+func openAICompatibleTestConfig(baseURL string) *config.Config {
+	return &config.Config{
+		LLM: config.LLMConfig{
+			Backend: "openai_compatible",
+			Session: config.LLMSessionConfig{
+				LockTTL:               time.Second,
+				RotateAfterTurns:      40,
+				RotateOnParseFailures: 3,
+			},
+			OpenAICompatible: config.OpenAICompatibleConfig{
+				BaseURL:      baseURL,
+				DefaultModel: "gpt-compatible",
+				LowCostModel: "gpt-compatible-mini",
+			},
+		},
+	}
+}
+
+func requestHasToolResult(messages []openAICompatibleMessage, id string) bool {
+	for _, msg := range messages {
+		if msg.Role == "tool" && msg.ToolCallID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func requestHasAssistantToolCall(messages []openAICompatibleMessage, id string) bool {
+	for _, msg := range messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		for _, call := range msg.ToolCalls {
+			if call.ID == id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type openAIToolExecutor struct{}
+
+func (openAIToolExecutor) Execute(context.Context, string, any) (any, error) {
+	return map[string]any{"answer": "ok"}, nil
+}
+
+func (openAIToolExecutor) ToolCapabilitiesForActor(runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set {
+	return toolcapabilities.NewSet([]toolcapabilities.Capability{{
+		Name:     "lookup",
+		Visible:  true,
+		Callable: true,
+	}})
+}
+
+type budgetCapture struct {
+	runtimeMode string
+	usage       UsageTokens
+	exact       bool
+}
+
+func (b *budgetCapture) LockExecutionScope(string) func() { return func() {} }
+func (b *budgetCapture) IsEntityEmergency(string) bool    { return false }
+func (b *budgetCapture) IsEntityThrottle(string) bool     { return false }
+func (b *budgetCapture) IsEmergency(string) bool          { return false }
+func (b *budgetCapture) IsThrottle(string) bool           { return false }
+func (b *budgetCapture) RecordEntityLLMUsage(_ context.Context, _ string, _ string, runtimeMode string, usage UsageTokens, exact bool, _ any) error {
+	b.runtimeMode = runtimeMode
+	b.usage = usage
+	b.exact = exact
+	return nil
+}
+func (b *budgetCapture) RecordLLMUsage(ctx context.Context, entityID string, agentID string, runtimeMode string, usage UsageTokens, exact bool, meta any) error {
+	return b.RecordEntityLLMUsage(ctx, entityID, agentID, runtimeMode, usage, exact, meta)
+}

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -155,6 +155,29 @@ func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleRuntimeFailsClosedWhenCredentialMissing(t *testing.T) {
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "")
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	runtime := NewOpenAICompatibleRuntime(openAICompatibleTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil)
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	_, err = runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "OPENAI_COMPATIBLE_API_KEY") {
+		t.Fatalf("ContinueSession error = %v, want missing OPENAI_COMPATIBLE_API_KEY", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want fail closed before HTTP request", requests)
+	}
+}
+
 func TestOpenAICompatibleChatCompletionsURLNormalizesVersionSegment(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/runtime/llm/provider_contract_test.go
+++ b/internal/runtime/llm/provider_contract_test.go
@@ -44,6 +44,14 @@ func TestProviderContractsValidateShippedRuntimes(t *testing.T) {
 				FileIO:    true,
 			},
 		},
+		{
+			name:            "openai compatible",
+			mode:            "openai_compatible",
+			runtime:         NewOpenAICompatibleRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil),
+			provider:        "openai_compatible",
+			transport:       ProviderTransportAPI,
+			usageAccounting: BudgetUsageExact,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,15 +88,21 @@ func TestRuntimeFactoryValidatesProviderContract(t *testing.T) {
 	}{
 		{mode: "api", provider: "anthropic"},
 		{mode: "cli_test", provider: "claude"},
+		{mode: "openai_compatible", provider: "openai_compatible"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.mode, func(t *testing.T) {
-			runtime, err := RuntimeFactory{
-				Cfg: &config.Config{
-					LLM: config.LLMConfig{
-						Backend: tt.mode,
-					},
+			cfg := &config.Config{
+				LLM: config.LLMConfig{
+					Backend: tt.mode,
 				},
+			}
+			if tt.mode == "openai_compatible" {
+				cfg.LLM.OpenAICompatible.BaseURL = "https://example.test/v1"
+				cfg.LLM.OpenAICompatible.DefaultModel = "gpt-compatible"
+			}
+			runtime, err := RuntimeFactory{
+				Cfg: cfg,
 			}.Build()
 			if err != nil {
 				t.Fatalf("Build: %v", err)

--- a/internal/runtime/llm/selection/profile.go
+++ b/internal/runtime/llm/selection/profile.go
@@ -6,15 +6,17 @@ import (
 )
 
 const (
-	BackendAPI     = "api"
-	BackendCLITest = "cli_test"
-	BackendMock    = "mock"
-	BackendLocal   = "local"
+	BackendAPI              = "api"
+	BackendCLITest          = "cli_test"
+	BackendOpenAICompatible = "openai_compatible"
+	BackendMock             = "mock"
+	BackendLocal            = "local"
 
-	ProviderAnthropic = "anthropic"
-	ProviderClaude    = "claude"
-	ProviderMock      = "mock"
-	ProviderLocal     = "local"
+	ProviderAnthropic        = "anthropic"
+	ProviderClaude           = "claude"
+	ProviderOpenAICompatible = "openai_compatible"
+	ProviderMock             = "mock"
+	ProviderLocal            = "local"
 
 	TransportAPI   = "api"
 	TransportCLI   = "cli"
@@ -28,6 +30,14 @@ const (
 
 	ConfigBackendField            = "llm.backend"
 	RetiredConfigRuntimeModeField = "llm.runtime_mode"
+
+	OpenAICompatibleCredentialEnv      = "OPENAI_COMPATIBLE_API_KEY"
+	OpenAICompatibleBaseURLEnv         = "SWARM_OPENAI_COMPATIBLE_BASE_URL"
+	OpenAICompatibleDefaultModelEnv    = "SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL"
+	OpenAICompatibleLowCostModelEnv    = "SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL"
+	OpenAICompatibleBaseURLConfigField = "llm.openai_compatible.base_url"
+	OpenAICompatibleDefaultModelConfig = "llm.openai_compatible.default_model"
+	OpenAICompatibleLowCostModelConfig = "llm.openai_compatible.low_cost_model"
 )
 
 type CredentialSource struct {
@@ -36,9 +46,16 @@ type CredentialSource struct {
 	Purpose  string
 }
 
+type BaseURLSource struct {
+	ConfigKey string
+	EnvVar    string
+	Required  bool
+	Purpose   string
+}
+
 type ModelMap struct {
 	Default string
-	Haiku   string
+	LowCost string
 }
 
 type Profile struct {
@@ -47,6 +64,7 @@ type Profile struct {
 	Transport    string
 	RuntimeMode  string
 	Credential   CredentialSource
+	BaseURL      BaseURLSource
 	Active       bool
 	ReservedNote string
 }
@@ -81,6 +99,24 @@ var profiles = map[string]Profile{
 			EnvVar:   "CLAUDE_CODE_OAUTH_TOKEN",
 			Required: true,
 			Purpose:  "claude cli runtime",
+		},
+		Active: true,
+	},
+	BackendOpenAICompatible: {
+		ID:          BackendOpenAICompatible,
+		Provider:    ProviderOpenAICompatible,
+		Transport:   TransportAPI,
+		RuntimeMode: BackendOpenAICompatible,
+		Credential: CredentialSource{
+			EnvVar:   OpenAICompatibleCredentialEnv,
+			Required: true,
+			Purpose:  "openai-compatible http runtime",
+		},
+		BaseURL: BaseURLSource{
+			ConfigKey: OpenAICompatibleBaseURLConfigField,
+			EnvVar:    OpenAICompatibleBaseURLEnv,
+			Required:  true,
+			Purpose:   "openai-compatible chat completions endpoint base url",
 		},
 		Active: true,
 	},
@@ -156,6 +192,28 @@ func CredentialValue(profile Profile, lookup EnvLookup) string {
 	return strings.TrimSpace(value)
 }
 
+func ResolveBaseURL(profile Profile, raw string) (string, error) {
+	baseURL := strings.TrimSpace(raw)
+	if baseURL == "" {
+		if profile.BaseURL.Required {
+			field := strings.TrimSpace(profile.BaseURL.ConfigKey)
+			if field == "" {
+				field = "llm backend base_url"
+			}
+			env := strings.TrimSpace(profile.BaseURL.EnvVar)
+			if env != "" {
+				return "", fmt.Errorf("%s is required for backend %q; set %s or %s", field, profile.ID, field, env)
+			}
+			return "", fmt.Errorf("%s is required for backend %q", field, profile.ID)
+		}
+		return "", nil
+	}
+	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		return "", fmt.Errorf("%s must be an http(s) URL for backend %q", profile.BaseURL.ConfigKey, profile.ID)
+	}
+	return strings.TrimRight(baseURL, "/"), nil
+}
+
 func RequireCredential(profile Profile, lookup EnvLookup) error {
 	if !profile.Credential.Required {
 		return nil
@@ -172,8 +230,8 @@ func ResolveModelName(profile Profile, req ModelResolution) (string, error) {
 	case BackendAPI:
 		model := strings.TrimSpace(req.Models.Default)
 		if req.ForceLowCost || tier == "haiku" {
-			if haiku := strings.TrimSpace(req.Models.Haiku); haiku != "" {
-				model = haiku
+			if lowCost := strings.TrimSpace(req.Models.LowCost); lowCost != "" {
+				model = lowCost
 			}
 		}
 		if model == "" {
@@ -182,6 +240,17 @@ func ResolveModelName(profile Profile, req ModelResolution) (string, error) {
 		return model, nil
 	case BackendCLITest:
 		return tier, nil
+	case BackendOpenAICompatible:
+		model := strings.TrimSpace(req.Models.Default)
+		if req.ForceLowCost || tier == "low_cost" || tier == "haiku" {
+			if lowCost := strings.TrimSpace(req.Models.LowCost); lowCost != "" {
+				model = lowCost
+			}
+		}
+		if model == "" {
+			return "", fmt.Errorf("%s is required for backend %q", OpenAICompatibleDefaultModelConfig, profile.ID)
+		}
+		return model, nil
 	default:
 		return "", fmt.Errorf("llm backend profile %q does not support model resolution", profile.ID)
 	}

--- a/internal/runtime/llm/selection/profile_test.go
+++ b/internal/runtime/llm/selection/profile_test.go
@@ -15,6 +15,7 @@ func TestResolveActiveBackendProfiles(t *testing.T) {
 		{raw: "", wantID: BackendAPI, provider: ProviderAnthropic, transport: TransportAPI},
 		{raw: BackendAPI, wantID: BackendAPI, provider: ProviderAnthropic, transport: TransportAPI},
 		{raw: BackendCLITest, wantID: BackendCLITest, provider: ProviderClaude, transport: TransportCLI},
+		{raw: BackendOpenAICompatible, wantID: BackendOpenAICompatible, provider: ProviderOpenAICompatible, transport: TransportAPI},
 	}
 	for _, tt := range tests {
 		t.Run(tt.raw, func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestResolveActiveBackendRejectsReservedAndUnknown(t *testing.T) {
 }
 
 func TestResolvePersistedBackendAllowsReservedProfiles(t *testing.T) {
-	for _, raw := range []string{BackendAPI, BackendCLITest, BackendMock, BackendLocal} {
+	for _, raw := range []string{BackendAPI, BackendCLITest, BackendOpenAICompatible, BackendMock, BackendLocal} {
 		t.Run(raw, func(t *testing.T) {
 			profile, err := ResolvePersistedBackend(raw)
 			if err != nil {
@@ -93,7 +94,7 @@ func TestResolveModelNameUsesModelTier(t *testing.T) {
 	}
 	req := ModelResolution{
 		ModelTier: "haiku",
-		Models:    ModelMap{Default: "claude-sonnet", Haiku: "claude-haiku"},
+		Models:    ModelMap{Default: "claude-sonnet", LowCost: "claude-haiku"},
 	}
 	if got, err := ResolveModelName(profile, req); err != nil || got != "claude-haiku" {
 		t.Fatalf("ResolveModelName = %q, %v; want claude-haiku", got, err)
@@ -105,6 +106,39 @@ func TestResolveModelNameUsesModelTier(t *testing.T) {
 	req.ForceLowCost = true
 	if got, err := ResolveModelName(profile, req); err != nil || got != "claude-haiku" {
 		t.Fatalf("ResolveModelName forced low cost = %q, %v; want claude-haiku", got, err)
+	}
+}
+
+func TestResolveOpenAICompatibleProfileAuthority(t *testing.T) {
+	profile, err := ResolveActiveBackend(BackendOpenAICompatible)
+	if err != nil {
+		t.Fatalf("ResolveActiveBackend: %v", err)
+	}
+	if profile.Credential.EnvVar != OpenAICompatibleCredentialEnv {
+		t.Fatalf("credential env = %q, want %q", profile.Credential.EnvVar, OpenAICompatibleCredentialEnv)
+	}
+	if _, err := ResolveBaseURL(profile, ""); err == nil || !strings.Contains(err.Error(), OpenAICompatibleBaseURLConfigField) {
+		t.Fatalf("ResolveBaseURL missing error = %v, want %s", err, OpenAICompatibleBaseURLConfigField)
+	}
+	if _, err := ResolveBaseURL(profile, "localhost:11434/v1"); err == nil || !strings.Contains(err.Error(), "http(s)") {
+		t.Fatalf("ResolveBaseURL invalid error = %v, want http(s)", err)
+	}
+	if got, err := ResolveBaseURL(profile, " https://example.test/v1/ "); err != nil || got != "https://example.test/v1" {
+		t.Fatalf("ResolveBaseURL = %q, %v; want normalized base url", got, err)
+	}
+	req := ModelResolution{
+		ModelTier: "low_cost",
+		Models:    ModelMap{Default: "gpt-main", LowCost: "gpt-mini"},
+	}
+	if got, err := ResolveModelName(profile, req); err != nil || got != "gpt-mini" {
+		t.Fatalf("ResolveModelName low cost = %q, %v; want gpt-mini", got, err)
+	}
+	req.ModelTier = "general"
+	if got, err := ResolveModelName(profile, req); err != nil || got != "gpt-main" {
+		t.Fatalf("ResolveModelName default = %q, %v; want gpt-main", got, err)
+	}
+	if _, err := ResolveModelName(profile, ModelResolution{}); err == nil || !strings.Contains(err.Error(), OpenAICompatibleDefaultModelConfig) {
+		t.Fatalf("ResolveModelName missing error = %v, want %s", err, OpenAICompatibleDefaultModelConfig)
 	}
 }
 

--- a/internal/runtime/llm/types.go
+++ b/internal/runtime/llm/types.go
@@ -35,11 +35,13 @@ func DescriptionWithUsage(description, usage string) string {
 }
 
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role      string     `json:"role"`
+	Content   string     `json:"content"`
+	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
 }
 
 type ToolCall struct {
+	ID        string `json:"id,omitempty"`
 	Name      string `json:"name"`
 	Arguments any    `json:"arguments,omitempty"`
 }

--- a/internal/runtime/manager/agent_manager_llm_backend_test.go
+++ b/internal/runtime/manager/agent_manager_llm_backend_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAgentManagerDefaultsLLMBackendFromCanonicalProfile(t *testing.T) {
-	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{LLMBackend: "cli_test"})
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{LLMBackend: "openai_compatible"})
 	if err := am.spawnAgentInternal(context.Background(), PersistedAgent{
 		Config: models.AgentConfig{
 			ID:               "agent-1",
@@ -20,7 +20,7 @@ func TestAgentManagerDefaultsLLMBackendFromCanonicalProfile(t *testing.T) {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
 	got := am.agentCfg["agent-1"].LLMBackend
-	if got != "cli_test" {
-		t.Fatalf("llm_backend = %q, want cli_test", got)
+	if got != "openai_compatible" {
+		t.Fatalf("llm_backend = %q, want openai_compatible", got)
 	}
 }

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5499,6 +5499,20 @@ func TestProjectPersistedAgentConfig_UsesCanonicalLLMBackendProfiles(t *testing.
 		t.Fatalf("llm_backend = %q, want api default profile", projection.LLMBackend)
 	}
 
+	projection, err = projectPersistedAgentConfig(runtimeactors.AgentConfig{
+		ID:               "agent-openai-compatible-backend",
+		Role:             "reviewer",
+		ModelTier:        "sonnet",
+		LLMBackend:       "openai_compatible",
+		ConversationMode: "task",
+	}, "")
+	if err != nil {
+		t.Fatalf("projectPersistedAgentConfig openai_compatible: %v", err)
+	}
+	if projection.LLMBackend != "openai_compatible" {
+		t.Fatalf("llm_backend = %q, want openai_compatible", projection.LLMBackend)
+	}
+
 	_, err = projectPersistedAgentConfig(runtimeactors.AgentConfig{
 		ID:               "agent-bad-backend",
 		Role:             "reviewer",


### PR DESCRIPTION
Closes #1070
Part of #983

## Summary
- Adds the active `openai_compatible` backend profile and OpenAI-compatible Chat Completions HTTP runtime proof.
- Extends provider selection/profile authority, ProviderContract conformance, factory construction, config/env validation, persisted `llm_backend` acceptance, turn/conversation persistence, and exact budget accounting for the approved first non-Anthropic provider proof.
- Updates authoritative `platform-spec.yaml` and runtime watchlist for the new active profile and remaining #983 tails.

## Governing Refs / Context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#agent_session_management.llm_provider_adapter_contract`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#agent_session_management.llm_provider_selection_config_authority`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#runtime_storage.agents`
- `docs/watchlists/runtime-operations.yaml#llm_provider_selection_config_authority`
- #983, #1058, #1062, PR #1064, and the approved #1070 gate.

## Semantic Migration
- New canonical owners: `platform-spec.yaml` plus `internal/runtime/llm/selection` for profile identity/credential/base URL/model mapping, `internal/runtime/llm.ProviderContract` for adapter obligations, and `internal/runtime/llm.OpenAICompatibleRuntime` for the approved Chat Completions-compatible provider adapter.
- Old non-authoritative paths now invalid: factory-only provider switches, runtime-local credential/base URL/model semantics, `OPENAI_API_KEY` compatibility aliases, live external API/key proof, and any provider-matrix closure claim from this child.
- Production paths checked: config/env defaulting, backend profile resolution, `RuntimeFactory`, ProviderContract validation, conversation/tool-call loop, turn/conversation persistence, budget accounting, store projection, and agent-manager backend propagation.
- Migration complete for `runtime.first_non_anthropic_provider_proof.openai_compatible_http`; #983 remains open for later providers/docs/cleanup tails.

## Proof
- `go test ./internal/runtime/llm ./internal/runtime/llm/selection ./internal/config ./cmd/swarm ./internal/runtime/manager ./internal/store -count=1`
- `go test ./...`
