### PR TITLE
[agent-c][issue #1072] Reconcile required agent fulfillment

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2716,8 +2716,9 @@ engine:
       when: boot-only
     - id: required_agents_match
       severity: error
-      scope: per-flow
-      trigger: A flow schema declares a required_agents role that has no matching agent in agents.yaml (by map key).
+      scope: root-and-per-flow
+      trigger: A flow schema declares a required_agents role that has no matching agent in that scope's agents.yaml by
+        exact map key; or the matching agent does not cover all required subscribes_to / emits events.
       when: boot-only
     - id: handler_field_compliance
       severity: error

--- a/docs/specs/swarm-platform/verify.py
+++ b/docs/specs/swarm-platform/verify.py
@@ -65,6 +65,7 @@ root_nodes = load_if_exists(os.path.join(EC, 'nodes.yaml'))
 root_events = load_if_exists(os.path.join(EC, 'events.yaml'))
 root_tools = load_if_exists(os.path.join(EC, 'tools.yaml'))
 root_policy = load_if_exists(os.path.join(EC, 'policy.yaml'))
+root_schema = load_if_exists(os.path.join(EC, 'schema.yaml'))
 
 flow_data = {}
 for flow in FLOWS:
@@ -583,21 +584,31 @@ for flow in FLOWS:
 # ============================================================
 # CHECK: required_agents_match [error, per-flow]
 # ============================================================
-for flow in FLOWS:
-    if flow not in flow_data: continue
-    schema = flow_data[flow]['schema']
-    agents = flow_data[flow]['agents']
+def check_required_agents_match(scope, schema, agents):
     for ra in schema.get('required_agents', []):
         role = ra.get('role', '')
+        if not role:
+            error("required_agents_match", "required_agents entry missing role", scope)
+            continue
         agent = agents.get(role)
         if not isinstance(agent, dict):
-            error("required_agents_match", "required role '%s' not in agents.yaml" % role, flow)
+            error("required_agents_match", "required role '%s' not in agents.yaml" % role, scope)
             continue
+        schema_subscriptions = set(ra.get('subscribes_to', []))
+        agent_subscriptions = set(agent.get('subscribes_to', []) + agent.get('subscriptions', []) + agent.get('subscriptions_bootstrap', []))
+        sub_diff = schema_subscriptions - agent_subscriptions
+        if sub_diff:
+            error("required_agents_match", "role '%s' schema says subscribes_to %s but agent doesn't" % (role, sub_diff), scope)
         schema_emits = set(ra.get('emits', []))
         agent_emits = set(agent.get('emit_events', []))
         diff = schema_emits - agent_emits
         if diff:
-            error("required_agents_match", "role '%s' schema says emits %s but agent doesn't" % (role, diff), flow)
+            error("required_agents_match", "role '%s' schema says emits %s but agent doesn't" % (role, diff), scope)
+
+check_required_agents_match('root', root_schema, root_agents)
+for flow in FLOWS:
+    if flow not in flow_data: continue
+    check_required_agents_match(flow, flow_data[flow]['schema'], flow_data[flow]['agents'])
 
 # ============================================================
 # CHECK: handler_field_compliance [error, per-node]

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -160,6 +160,10 @@ active_issues:
     title: Reconcile platform tool bootverify source authority
     maps_to:
       - boot_check_definition_drift
+  - id: 1072
+    title: Reconcile required_agents_match owner and runtime required-agent fulfillment
+    maps_to:
+      - boot_check_definition_drift
 nodes:
   - id: persisted_normal_run_completion_quiescence_owner
     title: Persisted Normal Run Completion/Quiescence Owner

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -258,12 +258,14 @@ nodes:
       - handler_field_compliance is interpreted as handler field vocabulary only in spec/reference surfaces while Go bootverify uses it for supported handler action declarations, executable owner resolution, and runtime-handled event executor presence
       - platform_tool_usage_hints and generated_tool_schema_closure are live runtime tool-surface checks that need authoritative boot-check definitions and shared consumer proof
       - tool_resolution can drift when structural verifier scripts interpret only tools.yaml while Go bootverify consumes the merged runtime tool registry and MCP discovery boundary
+      - required_agents_match can drift when spec, bootverify, runtime startup, verifier scripts, and catalog harness disagree on map-key role identity or required subscribes_to / emits coverage
     representative_issues:
       - 447
       - 448
       - 974
       - 1055
       - 1065
+      - 1072
     common_framing_mistakes:
       too_broad:
         - all bootverify drift

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -17,6 +17,7 @@ import (
 	"swarm/internal/runtime/flowdata"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerequiredagents "swarm/internal/runtime/requiredagents"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
@@ -841,85 +842,54 @@ func (c *checkerContext) requiredAgentsMatch() []Finding {
 		return c.requiredFindings
 	}
 	c.requiredLoaded = true
-	for flowID, requiredAgents := range requiredAgentsByFlow(c.source) {
-		for _, required := range requiredAgents {
-			role := strings.TrimSpace(required.Role)
-			if role == "" {
-				c.requiredFindings = append(c.requiredFindings, Finding{
-					CheckID:  "required_agents_match",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s required_agents entry missing role", flowID),
-					Location: strings.TrimSpace(flowID),
-				})
-				continue
-			}
-			agentID, agent, ok := requiredAgentProvider(c.source, role)
-			if !ok {
-				c.requiredFindings = append(c.requiredFindings, Finding{
-					CheckID:  "required_agents_match",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s required agent role %s missing from merged agents", flowID, role),
-					Location: strings.TrimSpace(flowID),
-				})
-				continue
-			}
-			if diff := missingStrings(required.SubscribesTo, agentSubscriptions(agent)); diff != "" {
-				c.requiredFindings = append(c.requiredFindings, Finding{
-					CheckID:  "required_agents_match",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s required agent %s subscriptions mismatch (%s)", flowID, agentID, diff),
-					Location: strings.TrimSpace(flowID),
-				})
-			}
-			if diff := missingStrings(required.Emits, agent.EmitEvents); diff != "" {
-				c.requiredFindings = append(c.requiredFindings, Finding{
-					CheckID:  "required_agents_match",
-					Severity: "error",
-					Message:  fmt.Sprintf("flow %s required agent %s emits mismatch (%s)", flowID, agentID, diff),
-					Location: strings.TrimSpace(flowID),
-				})
-			}
-		}
-	}
-	for _, required := range c.source.RequiredAgents() {
-		role := strings.TrimSpace(required.Role)
-		if role == "" {
-			c.requiredFindings = append(c.requiredFindings, Finding{
-				CheckID:  "required_agents_match",
-				Severity: "error",
-				Message:  "root schema required_agents entry missing role",
-				Location: "root",
-			})
-			continue
-		}
-		agentID, agent, ok := requiredAgentProvider(c.source, role)
-		if !ok {
-			c.requiredFindings = append(c.requiredFindings, Finding{
-				CheckID:  "required_agents_match",
-				Severity: "error",
-				Message:  fmt.Sprintf("root schema required agent role %s missing from merged agents", role),
-				Location: "root",
-			})
-			continue
-		}
-		if diff := missingStrings(required.SubscribesTo, agentSubscriptions(agent)); diff != "" {
-			c.requiredFindings = append(c.requiredFindings, Finding{
-				CheckID:  "required_agents_match",
-				Severity: "error",
-				Message:  fmt.Sprintf("root required agent %s subscriptions mismatch (%s)", agentID, diff),
-				Location: "root",
-			})
-		}
-		if diff := missingStrings(required.Emits, agent.EmitEvents); diff != "" {
-			c.requiredFindings = append(c.requiredFindings, Finding{
-				CheckID:  "required_agents_match",
-				Severity: "error",
-				Message:  fmt.Sprintf("root required agent %s emits mismatch (%s)", agentID, diff),
-				Location: "root",
-			})
+	for _, scope := range runtimerequiredagents.AllScopes(c.source) {
+		for _, finding := range runtimerequiredagents.CheckScope(scope) {
+			c.requiredFindings = append(c.requiredFindings, requiredAgentBootFinding(finding))
 		}
 	}
 	return c.requiredFindings
+}
+
+func requiredAgentBootFinding(finding runtimerequiredagents.Finding) Finding {
+	scopeID := strings.TrimSpace(finding.ScopeID)
+	if scopeID == "" {
+		scopeID = "root"
+	}
+	message := ""
+	switch finding.Kind {
+	case runtimerequiredagents.FindingMissingRole:
+		if scopeID == "root" {
+			message = "root schema required_agents entry missing role"
+		} else {
+			message = fmt.Sprintf("flow %s required_agents entry missing role", scopeID)
+		}
+	case runtimerequiredagents.FindingMissingAgent:
+		if scopeID == "root" {
+			message = fmt.Sprintf("root schema required agent role %s missing from agents.yaml", finding.Role)
+		} else {
+			message = fmt.Sprintf("flow %s required agent role %s missing from agents.yaml", scopeID, finding.Role)
+		}
+	case runtimerequiredagents.FindingMissingSubscriptions:
+		if scopeID == "root" {
+			message = fmt.Sprintf("root required agent %s subscriptions mismatch (%s)", finding.AgentID, runtimerequiredagents.MissingList(finding.Missing))
+		} else {
+			message = fmt.Sprintf("flow %s required agent %s subscriptions mismatch (%s)", scopeID, finding.AgentID, runtimerequiredagents.MissingList(finding.Missing))
+		}
+	case runtimerequiredagents.FindingMissingEmits:
+		if scopeID == "root" {
+			message = fmt.Sprintf("root required agent %s emits mismatch (%s)", finding.AgentID, runtimerequiredagents.MissingList(finding.Missing))
+		} else {
+			message = fmt.Sprintf("flow %s required agent %s emits mismatch (%s)", scopeID, finding.AgentID, runtimerequiredagents.MissingList(finding.Missing))
+		}
+	default:
+		message = fmt.Sprintf("%s required_agents mismatch", scopeID)
+	}
+	return Finding{
+		CheckID:  "required_agents_match",
+		Severity: "error",
+		Message:  message,
+		Location: scopeID,
+	}
 }
 
 func (c *checkerContext) stateMachineCoherence() []Finding {
@@ -1396,55 +1366,6 @@ func entitySchemaFields(source semanticview.Source) map[string]struct{} {
 	return out
 }
 
-func requiredAgentsByFlow(source semanticview.Source) map[string][]runtimecontracts.FlowRequiredAgent {
-	out := map[string][]runtimecontracts.FlowRequiredAgent{}
-	if source == nil {
-		return out
-	}
-	for flowID := range source.FlowSchemaEntries() {
-		out[strings.TrimSpace(flowID)] = source.FlowRequiredAgents(flowID)
-	}
-	return out
-}
-
-func requiredAgentProvider(source semanticview.Source, role string) (string, runtimecontracts.AgentRegistryEntry, bool) {
-	if source == nil {
-		return "", runtimecontracts.AgentRegistryEntry{}, false
-	}
-	role = strings.TrimSpace(role)
-	if role == "" {
-		return "", runtimecontracts.AgentRegistryEntry{}, false
-	}
-	requiredKey := normalizeRoleKey(role)
-	agents := source.AgentEntries()
-	for agentID, agent := range agents {
-		if normalizeRoleKey(agentID) == requiredKey {
-			return strings.TrimSpace(agentID), agent, true
-		}
-	}
-	for agentID, agent := range agents {
-		if roleMatches(agentID, agent.Role, role) {
-			return strings.TrimSpace(agentID), agent, true
-		}
-	}
-	return "", runtimecontracts.AgentRegistryEntry{}, false
-}
-
-func roleMatches(agentID, agentRole, requiredRole string) bool {
-	requiredKey := normalizeRoleKey(requiredRole)
-	if requiredKey == "" {
-		return false
-	}
-	return normalizeRoleKey(agentID) == requiredKey || normalizeRoleKey(agentRole) == requiredKey
-}
-
-func normalizeRoleKey(raw string) string {
-	raw = strings.TrimSpace(strings.ToLower(raw))
-	raw = strings.ReplaceAll(raw, "_", "-")
-	raw = strings.Join(strings.Fields(raw), "-")
-	return raw
-}
-
 func flowSchemaIsTemplate(source semanticview.Source, flowID string) bool {
 	if source == nil {
 		return false
@@ -1465,30 +1386,6 @@ func flowIsStateless(source semanticview.Source, flowID string) bool {
 		return false
 	}
 	return strings.TrimSpace(schema.InitialState) == "" && len(schema.States) == 0
-}
-
-func agentSubscriptions(agent runtimecontracts.AgentRegistryEntry) []string {
-	values := make([]string, 0, len(agent.SubscribesTo)+len(agent.Subscriptions)+len(agent.SubscriptionsBootstrap))
-	values = append(values, agent.SubscribesTo...)
-	values = append(values, agent.Subscriptions...)
-	values = append(values, agent.SubscriptionsBootstrap...)
-	return values
-}
-
-func missingStrings(expected, actual []string) string {
-	actualSet := stringSet(actual)
-	missing := make([]string, 0)
-	for _, value := range expected {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := actualSet[value]; !ok {
-			missing = append(missing, value)
-		}
-	}
-	sort.Strings(missing)
-	return strings.Join(missing, ", ")
 }
 
 func nodeFlowID(source semanticview.Source, nodeID string) string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1209,6 +1209,30 @@ func TestRun_MapsRequiredAgentMismatchToNamedError(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsRequiredAgentRoleFallbackWithoutMapKey(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			RequiredAgents: []runtimecontracts.FlowRequiredAgent{{
+				Role:  "worker",
+				Emits: []string{"task.completed"},
+			}},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker-alias": {
+				ID:         "worker",
+				Role:       "worker",
+				EmitEvents: []string{"task.completed"},
+			},
+		},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "required_agents_match", "worker") {
+		t.Fatalf("expected required_agents_match missing worker error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsRequiredAgentSubscriptionMismatchForTemplateFlow(t *testing.T) {
 	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-pin-wiring"))
 	schema := bundle.FlowSchemas["child"]
@@ -1220,13 +1244,20 @@ func TestRun_ReportsRequiredAgentSubscriptionMismatchForTemplateFlow(t *testing.
 	}}
 	bundle.FlowSchemas["child"] = schema
 	bundle.Semantics.FlowAgents["child"] = append([]runtimecontracts.FlowRequiredAgent(nil), schema.RequiredAgents...)
-	bundle.Agents["worker"] = runtimecontracts.AgentRegistryEntry{
+	worker := runtimecontracts.AgentRegistryEntry{
 		ID:               "worker",
 		Role:             "worker",
 		ModelTier:        "small",
 		ConversationMode: "task",
 		Subscriptions:    []string{"work.requested"},
 		EmitEvents:       []string{"work.completed"},
+	}
+	bundle.Agents["worker"] = worker
+	if view := bundle.FlowTree.ByID["child"]; view != nil {
+		if view.Agents == nil {
+			view.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+		}
+		view.Agents["worker"] = worker
 	}
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
@@ -1237,22 +1268,24 @@ func TestRun_ReportsRequiredAgentSubscriptionMismatchForTemplateFlow(t *testing.
 }
 
 func TestRun_ReportsRootRequiredAgentSubscriptionMismatch(t *testing.T) {
-	bundle := loadTier8FixtureBundle(t, "test-boot-success")
-	if bundle.RootSchema == nil {
-		bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{}
-	}
-	bundle.RootSchema.RequiredAgents = []runtimecontracts.FlowRequiredAgent{{
-		Role:         "worker",
-		SubscribesTo: []string{"task.completed"},
-		Emits:        []string{"task.completed"},
-	}}
-	bundle.Agents["worker"] = runtimecontracts.AgentRegistryEntry{
-		ID:               "worker",
-		Role:             "worker",
-		ModelTier:        "small",
-		ConversationMode: "task",
-		Subscriptions:    []string{"task.requested"},
-		EmitEvents:       []string{"task.completed"},
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			RequiredAgents: []runtimecontracts.FlowRequiredAgent{{
+				Role:         "worker",
+				SubscribesTo: []string{"task.completed"},
+				Emits:        []string{"task.completed"},
+			}},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": {
+				ID:               "worker",
+				Role:             "worker",
+				ModelTier:        "small",
+				ConversationMode: "task",
+				Subscriptions:    []string{"task.requested"},
+				EmitEvents:       []string{"task.completed"},
+			},
+		},
 	}
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -18,6 +18,7 @@ import (
 	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	runtimeeventschema "swarm/internal/runtime/eventschema"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerequiredagents "swarm/internal/runtime/requiredagents"
 	"swarm/internal/runtime/semanticview"
 	runtimesharedjson "swarm/internal/runtime/sharedjson"
 	runtimetools "swarm/internal/runtime/tools"
@@ -336,8 +337,8 @@ func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) (
 		return nil, nil
 	}
 	records := []PersistedAgent{}
-	for _, scope := range source.ProjectScopes() {
-		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", scope.Agents, source.RequiredAgents())
+	if rootScope, ok := runtimerequiredagents.RootScope(source); ok {
+		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", rootScope.Agents, rootScope.Required)
 		if err != nil {
 			return nil, err
 		}
@@ -561,13 +562,13 @@ func staticRequiredAgentsForScope(
 ) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
 	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
-	if len(required) == 0 || len(agents) == 0 {
+	if len(required) == 0 {
 		return nil, nil
 	}
 	localEvents := staticFlowLocalEventSet(agents)
 	records := make([]PersistedAgent, 0, len(required))
 	for _, requiredAgent := range required {
-		logicalID, entry, ok := resolveRequiredAgentEntry(agents, requiredAgent)
+		logicalID, entry, ok := runtimerequiredagents.ResolveAgent(agents, requiredAgent)
 		if !ok {
 			return nil, fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
 		}
@@ -722,16 +723,6 @@ func buildStaticFlowAgentConfig(
 	}
 	cfg.NormalizeRuntimeDescriptor()
 	return cfg, nil
-}
-
-func resolveRequiredAgentEntry(agents map[string]runtimecontracts.AgentRegistryEntry, required runtimecontracts.FlowRequiredAgent) (string, runtimecontracts.AgentRegistryEntry, bool) {
-	role := strings.TrimSpace(required.Role)
-	for logicalID, entry := range agents {
-		if strings.EqualFold(strings.TrimSpace(logicalID), role) || strings.EqualFold(strings.TrimSpace(entry.Role), role) || strings.EqualFold(strings.TrimSpace(entry.ID), role) {
-			return strings.TrimSpace(logicalID), entry, true
-		}
-	}
-	return "", runtimecontracts.AgentRegistryEntry{}, false
 }
 
 func normalizedFlowAgentEmitEvents(events []string, vars map[string]string, localEvents map[string]struct{}, flowPath, templateID, instanceID string) []string {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -875,6 +875,25 @@ func TestEnsureStaticFlowRequiredAgentsRegistersStaticFlowSubscriptions(t *testi
 	}
 }
 
+func TestStaticRequiredAgentsForScopeRejectsRoleFallbackWithoutMapKey(t *testing.T) {
+	records, err := staticRequiredAgentsForScope(nil, "analysis", "analysis", map[string]runtimecontracts.AgentRegistryEntry{
+		"worker-alias": {
+			ID:            "worker",
+			Role:          "worker",
+			Subscriptions: []string{"analysis.requested"},
+			EmitEvents:    []string{"analysis.done"},
+		},
+	}, []runtimecontracts.FlowRequiredAgent{{
+		Role:         "worker",
+		SubscribesTo: []string{"analysis.requested"},
+		Emits:        []string{"analysis.done"},
+	}})
+
+	if err == nil || !strings.Contains(err.Error(), `required agent "worker"`) {
+		t.Fatalf("expected required-agent map-key error, records=%#v err=%v", records, err)
+	}
+}
+
 func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})

--- a/internal/runtime/requiredagents/fulfillment.go
+++ b/internal/runtime/requiredagents/fulfillment.go
@@ -1,0 +1,210 @@
+package requiredagents
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/semanticview"
+)
+
+type Scope struct {
+	ID       string
+	Agents   map[string]runtimecontracts.AgentRegistryEntry
+	Required []runtimecontracts.FlowRequiredAgent
+}
+
+type FindingKind string
+
+const (
+	FindingMissingRole          FindingKind = "missing_role"
+	FindingMissingAgent         FindingKind = "missing_agent"
+	FindingMissingSubscriptions FindingKind = "missing_subscriptions"
+	FindingMissingEmits         FindingKind = "missing_emits"
+)
+
+type Finding struct {
+	Kind    FindingKind
+	ScopeID string
+	Role    string
+	AgentID string
+	Missing []string
+}
+
+func RootScope(source semanticview.Source) (Scope, bool) {
+	if source == nil {
+		return Scope{}, false
+	}
+	scope := Scope{
+		ID:       "root",
+		Required: source.RequiredAgents(),
+	}
+	for _, projectScope := range source.ProjectScopes() {
+		if strings.TrimSpace(projectScope.OwningFlowID) == "" && projectScope.Depth == 0 {
+			scope.Agents = projectScope.Agents
+			return scope, true
+		}
+	}
+	for _, projectScope := range source.ProjectScopes() {
+		if strings.TrimSpace(projectScope.OwningFlowID) == "" {
+			scope.Agents = projectScope.Agents
+			return scope, true
+		}
+	}
+	scope.Agents = source.AgentEntries()
+	return scope, true
+}
+
+func FlowScopes(source semanticview.Source) []Scope {
+	if source == nil {
+		return nil
+	}
+	scopes := source.FlowScopes()
+	out := make([]Scope, 0, len(scopes))
+	for _, flowScope := range scopes {
+		flowID := strings.TrimSpace(flowScope.ID)
+		if flowID == "" {
+			continue
+		}
+		out = append(out, Scope{
+			ID:       flowID,
+			Agents:   flowScope.Agents,
+			Required: source.FlowRequiredAgents(flowID),
+		})
+	}
+	return out
+}
+
+func AllScopes(source semanticview.Source) []Scope {
+	if source == nil {
+		return nil
+	}
+	out := make([]Scope, 0, len(source.FlowScopes())+1)
+	if root, ok := RootScope(source); ok {
+		out = append(out, root)
+	}
+	out = append(out, FlowScopes(source)...)
+	return out
+}
+
+func CheckScope(scope Scope) []Finding {
+	scope.ID = scopeLabel(scope.ID)
+	if len(scope.Required) == 0 {
+		return nil
+	}
+	findings := make([]Finding, 0)
+	for _, required := range scope.Required {
+		role := strings.TrimSpace(required.Role)
+		if role == "" {
+			findings = append(findings, Finding{
+				Kind:    FindingMissingRole,
+				ScopeID: scope.ID,
+			})
+			continue
+		}
+		agentID, agent, ok := ResolveAgent(scope.Agents, required)
+		if !ok {
+			findings = append(findings, Finding{
+				Kind:    FindingMissingAgent,
+				ScopeID: scope.ID,
+				Role:    role,
+			})
+			continue
+		}
+		if missing := missingStrings(required.SubscribesTo, AgentSubscriptions(agent)); len(missing) > 0 {
+			findings = append(findings, Finding{
+				Kind:    FindingMissingSubscriptions,
+				ScopeID: scope.ID,
+				Role:    role,
+				AgentID: agentID,
+				Missing: missing,
+			})
+		}
+		if missing := missingStrings(required.Emits, agent.EmitEvents); len(missing) > 0 {
+			findings = append(findings, Finding{
+				Kind:    FindingMissingEmits,
+				ScopeID: scope.ID,
+				Role:    role,
+				AgentID: agentID,
+				Missing: missing,
+			})
+		}
+	}
+	return findings
+}
+
+func ResolveAgent(agents map[string]runtimecontracts.AgentRegistryEntry, required runtimecontracts.FlowRequiredAgent) (string, runtimecontracts.AgentRegistryEntry, bool) {
+	role := strings.TrimSpace(required.Role)
+	if role == "" {
+		return "", runtimecontracts.AgentRegistryEntry{}, false
+	}
+	agent, ok := agents[role]
+	if !ok {
+		return "", runtimecontracts.AgentRegistryEntry{}, false
+	}
+	return role, agent, true
+}
+
+func AgentSubscriptions(agent runtimecontracts.AgentRegistryEntry) []string {
+	values := make([]string, 0, len(agent.SubscribesTo)+len(agent.Subscriptions)+len(agent.SubscriptionsBootstrap))
+	values = append(values, agent.SubscribesTo...)
+	values = append(values, agent.Subscriptions...)
+	values = append(values, agent.SubscriptionsBootstrap...)
+	return values
+}
+
+func MissingList(values []string) string {
+	clean := normalizeStrings(values)
+	if len(clean) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("missing %v", clean)
+}
+
+func scopeLabel(scopeID string) string {
+	scopeID = strings.TrimSpace(scopeID)
+	if scopeID == "" {
+		return "root"
+	}
+	return scopeID
+}
+
+func missingStrings(expected, actual []string) []string {
+	actualSet := stringSet(actual)
+	missing := make([]string, 0)
+	for _, value := range expected {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := actualSet[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func normalizeStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/requiredagents/fulfillment_test.go
+++ b/internal/runtime/requiredagents/fulfillment_test.go
@@ -1,0 +1,47 @@
+package requiredagents
+
+import (
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+func TestResolveAgentRequiresMapKeyIdentity(t *testing.T) {
+	agents := map[string]runtimecontracts.AgentRegistryEntry{
+		"alias": {
+			ID:   "worker",
+			Role: "worker",
+		},
+	}
+
+	if agentID, _, ok := ResolveAgent(agents, runtimecontracts.FlowRequiredAgent{Role: "worker"}); ok {
+		t.Fatalf("ResolveAgent matched %q through non-key identity", agentID)
+	}
+}
+
+func TestCheckScopeReportsSubscriptionAndEmitCoverage(t *testing.T) {
+	findings := CheckScope(Scope{
+		ID: "child",
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": {
+				Subscriptions: []string{"work.requested"},
+				EmitEvents:    []string{"work.completed"},
+			},
+		},
+		Required: []runtimecontracts.FlowRequiredAgent{{
+			Role:         "worker",
+			SubscribesTo: []string{"work.requested", "work.escalated"},
+			Emits:        []string{"work.completed", "work.failed"},
+		}},
+	})
+
+	if len(findings) != 2 {
+		t.Fatalf("findings = %#v, want subscription and emit findings", findings)
+	}
+	if findings[0].Kind != FindingMissingSubscriptions || findings[0].Missing[0] != "work.escalated" {
+		t.Fatalf("subscription finding = %#v", findings[0])
+	}
+	if findings[1].Kind != FindingMissingEmits || findings[1].Missing[0] != "work.failed" {
+		t.Fatalf("emit finding = %#v", findings[1])
+	}
+}

--- a/internal/runtime/swarmflowtest/catalog_runner_guardrails_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_guardrails_test.go
@@ -142,3 +142,28 @@ func TestCatalogToolRequiredPermission_AcceptsPermissionAlias(t *testing.T) {
 		t.Fatalf("required permission = %q, want %q", got, want)
 	}
 }
+
+func TestCatalogRequiredAgentIssuesRequireMapKeyIdentity(t *testing.T) {
+	issues := catalogRequiredAgentIssues(catalogBootScope{
+		Name: "analysis",
+		Agents: map[string]any{
+			"worker-alias": map[string]any{
+				"id":            "worker",
+				"role":          "worker",
+				"subscriptions": []any{"analysis.requested"},
+				"emit_events":   []any{"analysis.done"},
+			},
+		},
+		Schema: map[string]any{
+			"required_agents": []any{map[string]any{
+				"role":          "worker",
+				"subscribes_to": []any{"analysis.requested"},
+				"emits":         []any{"analysis.done"},
+			}},
+		},
+	})
+
+	if len(issues) != 1 || issues[0].Category != "REQUIRED-AGENT" {
+		t.Fatalf("issues = %#v, want REQUIRED-AGENT", issues)
+	}
+}

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -20,6 +20,7 @@ import (
 	"swarm/internal/runtime/core/paths"
 	"swarm/internal/runtime/core/timeridentity"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimerequiredagents "swarm/internal/runtime/requiredagents"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -1325,40 +1326,7 @@ func catalogCollectBootIssues(bundle catalogBootBundle) []catalogBootIssue {
 				}
 			}
 		}
-		for _, raw := range catalogAnySlice(scope.Schema["required_agents"]) {
-			required := catalogMap(raw)
-			role := catalogBootText(required["role"])
-			if role == "" {
-				continue
-			}
-			agent := catalogMap(scope.Agents[role])
-			if len(agent) == 0 {
-				issues = append(issues, catalogBootIssue{Severity: "error", Category: "REQUIRED-AGENT", Message: fmt.Sprintf("%s: required role '%s' not in agents.yaml", scopeLabel, role)})
-				continue
-			}
-			schemaSubscriptions := catalogBootStringSet(required["subscribes_to"])
-			agentSubscriptions := catalogBootStringSet(agent["subscriptions"])
-			schemaEmits := catalogBootStringSet(required["emits"])
-			agentEmits := catalogBootStringSet(agent["emit_events"])
-			missingSubscriptions := make([]string, 0, len(schemaSubscriptions))
-			for _, ev := range catalogSortedSetKeys(schemaSubscriptions) {
-				if !catalogSetHas(agentSubscriptions, ev) {
-					missingSubscriptions = append(missingSubscriptions, ev)
-				}
-			}
-			if len(missingSubscriptions) > 0 {
-				issues = append(issues, catalogBootIssue{Severity: "error", Category: "SUBSCRIPTION-MISMATCH", Message: fmt.Sprintf("%s/%s: schema says subscribes_to %v but agent doesn't", scopeLabel, role, missingSubscriptions)})
-			}
-			missing := make([]string, 0, len(schemaEmits))
-			for _, ev := range catalogSortedSetKeys(schemaEmits) {
-				if !catalogSetHas(agentEmits, ev) {
-					missing = append(missing, ev)
-				}
-			}
-			if len(missing) > 0 {
-				issues = append(issues, catalogBootIssue{Severity: "error", Category: "EMIT-MISMATCH", Message: fmt.Sprintf("%s/%s: schema says emits %v but agent doesn't", scopeLabel, role, missing)})
-			}
-		}
+		issues = append(issues, catalogRequiredAgentIssues(scope)...)
 		for _, agentID := range catalogSortedKeys(scope.Agents) {
 			agent := catalogMap(scope.Agents[agentID])
 			for _, tool := range catalogStringSlice(agent["tools_tier2"]) {
@@ -1479,6 +1447,59 @@ func catalogBootScopeLabel(scope catalogBootScope) string {
 		return "root"
 	}
 	return strings.TrimSpace(scope.Name)
+}
+
+func catalogRequiredAgentIssues(scope catalogBootScope) []catalogBootIssue {
+	scopeLabel := catalogBootScopeLabel(scope)
+	findings := runtimerequiredagents.CheckScope(runtimerequiredagents.Scope{
+		ID:       scopeLabel,
+		Agents:   catalogRequiredAgentEntries(scope.Agents),
+		Required: catalogRequiredAgentRequirements(scope.Schema),
+	})
+	issues := make([]catalogBootIssue, 0, len(findings))
+	for _, finding := range findings {
+		switch finding.Kind {
+		case runtimerequiredagents.FindingMissingRole:
+			issues = append(issues, catalogBootIssue{Severity: "error", Category: "REQUIRED-AGENT", Message: fmt.Sprintf("%s: required_agents entry missing role", scopeLabel)})
+		case runtimerequiredagents.FindingMissingAgent:
+			issues = append(issues, catalogBootIssue{Severity: "error", Category: "REQUIRED-AGENT", Message: fmt.Sprintf("%s: required role '%s' not in agents.yaml", scopeLabel, finding.Role)})
+		case runtimerequiredagents.FindingMissingSubscriptions:
+			issues = append(issues, catalogBootIssue{Severity: "error", Category: "SUBSCRIPTION-MISMATCH", Message: fmt.Sprintf("%s/%s: schema says subscribes_to %v but agent doesn't", scopeLabel, finding.AgentID, finding.Missing)})
+		case runtimerequiredagents.FindingMissingEmits:
+			issues = append(issues, catalogBootIssue{Severity: "error", Category: "EMIT-MISMATCH", Message: fmt.Sprintf("%s/%s: schema says emits %v but agent doesn't", scopeLabel, finding.AgentID, finding.Missing)})
+		}
+	}
+	return issues
+}
+
+func catalogRequiredAgentEntries(rawAgents map[string]any) map[string]runtimecontracts.AgentRegistryEntry {
+	agents := make(map[string]runtimecontracts.AgentRegistryEntry, len(rawAgents))
+	for agentID, rawAgent := range rawAgents {
+		agent := catalogMap(rawAgent)
+		agents[agentID] = runtimecontracts.AgentRegistryEntry{
+			ID:                     catalogBootText(agent["id"]),
+			Role:                   catalogBootText(agent["role"]),
+			Subscriptions:          catalogStringSlice(agent["subscriptions"]),
+			SubscribesTo:           catalogStringSlice(agent["subscribes_to"]),
+			SubscriptionsBootstrap: catalogStringSlice(agent["subscriptions_bootstrap"]),
+			EmitEvents:             catalogStringSlice(agent["emit_events"]),
+		}
+	}
+	return agents
+}
+
+func catalogRequiredAgentRequirements(schema map[string]any) []runtimecontracts.FlowRequiredAgent {
+	rawRequired := catalogAnySlice(schema["required_agents"])
+	required := make([]runtimecontracts.FlowRequiredAgent, 0, len(rawRequired))
+	for _, raw := range rawRequired {
+		item := catalogMap(raw)
+		required = append(required, runtimecontracts.FlowRequiredAgent{
+			Role:         catalogBootText(item["role"]),
+			SubscribesTo: catalogStringSlice(item["subscribes_to"]),
+			Emits:        catalogStringSlice(item["emits"]),
+		})
+	}
+	return required
 }
 
 func catalogToolRequiredPermission(tool string, spec map[string]any) string {


### PR DESCRIPTION
Closes #1072
Part of #126

## Summary
- Adds `internal/runtime/requiredagents` as the shared required-agent fulfillment owner for exact map-key identity plus required `subscribes_to` / `emits` coverage.
- Migrates Go bootverify, runtime static required-agent materialization, and catalog guardrails to the shared owner.
- Aligns `verify.py` root/flow structural checks and updates `platform-spec.yaml` / semantic watchlist wording for the now-supported class.

## Governing Context
- `platform-spec.yaml` `required_agents.fulfillment_rule`
- `platform-spec.yaml` `engine.cross_flow_routing.required_agents.fulfillment`
- `platform-spec.yaml` `engine.boot_verification.checks.required_agents_match`
- #1072 Pre-Implementation Coverage Audit and Gate C outcome: approved as first slice, with runtime startup included and exact map-key identity binding.

## Semantic Migration
- New canonical owner: `internal/runtime/requiredagents`.
- Old non-authoritative paths now invalid/removed: bootverify local role/ID fallback helpers, runtime manager `resolveRequiredAgentEntry`, catalog inline required-agent logic, and `verify.py` child-only / emits-only structural interpretation.
- Production paths checked for surviving old behavior: Go bootverify, runtime static required-agent materialization, catalog harness, and `verify.py` structural verifier.
- Migration completeness: complete for #1072 `required_agents_match` map-key identity and required subscription/emission coverage. Other #126 tail checks remain split.

## Verification
- `go test ./internal/runtime/requiredagents ./internal/runtime/bootverify ./internal/runtime/manager ./internal/runtime/swarmflowtest`
- `python3 docs/specs/swarm-platform/verify.py tests/tier8-boot-verification/test-boot-required-agent-missing | tail -35`
- Temporary verifier probe removing `subscriptions` from `tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/agents.yaml`
- `go test ./...`
