### PR TITLE
[agent-e][issue #1074] Harden run.start failure quality

### DIFF
--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -708,7 +708,15 @@ func runCommandTerminalExit(status string) error {
 func runCommandErrorExitCode(err error) int {
 	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
 		notFoundCodes: []string{"RUN_NOT_FOUND"},
-		conflictCodes: []string{"BUNDLE_MISMATCH", "UNSUPPORTED_BUNDLE_HASH", "UNSUPPORTED_BUNDLE_REF", "IDEMPOTENCY_CONFLICT"},
+		conflictCodes: []string{
+			"BUNDLE_MISMATCH",
+			"UNSUPPORTED_BUNDLE_HASH",
+			"UNSUPPORTED_BUNDLE_REF",
+			"EVENT_NOT_DECLARED",
+			"EVENT_PUBLISH_FAILED",
+			"PAYLOAD_VALIDATION_FAILED",
+			"IDEMPOTENCY_CONFLICT",
+		},
 	})
 }
 

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -269,6 +269,52 @@ func TestRunCommandBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testi
 	}
 }
 
+func TestRunCommandStartApplicationErrorsExitSixAndDoNotFollow(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	for _, codeName := range []string{"EVENT_NOT_DECLARED", "PAYLOAD_VALIDATION_FAILED", "EVENT_PUBLISH_FAILED"} {
+		t.Run(codeName, func(t *testing.T) {
+			var calls []jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/rpc":
+					var req jsonRPCRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+						t.Errorf("decode request: %v", err)
+					}
+					calls = append(calls, req)
+					switch req.Method {
+					case "health.check":
+						writeJSONRPCResult(t, w, req.ID, runCommandHealthResult())
+					case "run.start":
+						writeRunCommandJSONRPCError(t, w, req.ID, codeName)
+					default:
+						t.Fatalf("unexpected method = %q", req.Method)
+					}
+				case "/v1/ws":
+					t.Fatalf("run.subscribe_trace must not be opened after failed run.start")
+				default:
+					t.Fatalf("unexpected path = %q", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath}, &stdout, &stderr, testRunCommandOptions(server))
+			if code != 6 {
+				t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			assertRunCommandMethods(t, &calls, []string{"health.check", "run.start"})
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), codeName) {
+				t.Fatalf("stderr = %q, want %s", stderr.String(), codeName)
+			}
+		})
+	}
+}
+
 func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2622,6 +2622,15 @@
                   },
                   "event_name": {
                     "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "routable_events": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
@@ -5004,10 +5013,76 @@
                   },
                   "event_name": {
                     "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "routable_events": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
                   "event_name"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
+          "message": "Application error: EVENT_PUBLISH_FAILED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "EVENT_PUBLISH_FAILED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "event_name": {
+                    "type": "string"
+                  },
+                  "phase": {
+                    "enum": [
+                      "publish"
+                    ],
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "event_name",
+                  "event_id",
+                  "run_id",
+                  "phase",
+                  "reason"
                 ],
                 "type": "object"
               },
@@ -8857,6 +8932,15 @@
                 },
                 "event_name": {
                   "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "routable_events": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "required": [

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7959,11 +7959,12 @@ cli_specification:
         config_readiness_transport_or_malformed_api: 3
         auth_failure: 4
         run_not_found: 5
-        bundle_or_idempotency_conflict: 6
+        start_rejection_bundle_or_idempotency_conflict: 6
         workflow_failed_or_cancelled: 7
         interrupted: 130
       proof_expectations:
       - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; run.start carries optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint only when the corresponding bundle flag is supplied; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted, while --bundle-fingerprint remains the transition boot-fingerprint assertion
+      - connected start failures for EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, EVENT_PUBLISH_FAILED, bundle identity rejection, and IDEMPOTENCY_CONFLICT render canonical API codes on stderr, exit 6, and do not open /v1/ws or follow work after failed run.start
       - exact /v1/ws subscription for run.subscribe_trace where follow is in scope
       - no direct DB/store/runtime/EventBus reads or writes
       - no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or legacy token fallback
@@ -11666,6 +11667,12 @@ api_specification:
             type: array
             items:
               type: string
+          routable_events:
+            type: array
+            items:
+              type: string
+          reason:
+            type: string
       EVENT_PUBLISH_FAILED:
         type: object
         additionalProperties: false
@@ -12316,6 +12323,7 @@ api_specification:
       - UNSUPPORTED_BUNDLE_HASH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
+      - EVENT_PUBLISH_FAILED
       - PAYLOAD_VALIDATION_FAILED
       - IDEMPOTENCY_CONFLICT
     run.stop:

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -444,6 +444,7 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badBundleFingerprint}, "run_id": runID}), Code: BundleMismatchCode},
 		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
 		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"event_name": "scan.missing", "run_id": runID}), Code: EventNotDeclaredCode},
+		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
 		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 
 		{Method: "run.stop", Params: map[string]any{"run_id": runID, "idempotency_key": "idem-error"}, Code: RunNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -320,10 +320,7 @@ func validateEventPublication(ctx context.Context, opts OperatorReadOptions, par
 	if cfg.rootInputOnly {
 		set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
 		if err != nil {
-			return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
-				"event_name":      params.EventName,
-				"declared_events": set.Declared,
-			})
+			return runStartRootInputError(params.EventName, set, err)
 		}
 		return nil
 	}
@@ -372,6 +369,33 @@ func validateEventPublication(ctx context.Context, opts OperatorReadOptions, par
 		}
 	}
 	return nil
+}
+
+func runStartRootInputError(eventName string, set runtimerunstart.RootInputSet, err error) error {
+	declared := append([]string{}, set.Declared...)
+	routable := append([]string{}, set.Routable...)
+	details := map[string]any{
+		"event_name":      eventName,
+		"declared_events": declared,
+		"routable_events": routable,
+		"reason":          strings.TrimSpace(err.Error()),
+	}
+	if !stringSliceContains(declared, eventName) {
+		details["reason"] = "not_declared_root_input"
+	} else if !stringSliceContains(routable, eventName) {
+		details["reason"] = "declared_root_input_not_routable"
+	}
+	return NewApplicationError(EventNotDeclaredCode, false, details)
+}
+
+func stringSliceContains(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
 }
 
 func eventPublishSourceAgent(req Request) string {

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -56,6 +56,7 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 		sourceAgent:                    func(Request) string { return "api.v1" },
 		rootInputOnly:                  true,
 		injectRunIDEntityIDWhenMissing: true,
+		publishError:                   eventPublishPublishError,
 		buildCompletion: func(_ context.Context, _ OperatorReadOptions, params eventPublicationParams) (any, string, error) {
 			return runStartResult{RunID: params.RunID, Status: "running"}, params.RunID, nil
 		},

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -1,14 +1,17 @@
 package apiv1
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/flowmodel"
@@ -231,6 +234,56 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		}
 		if data := asMap(t, resp.Error.Data); data["code"] != EventNotDeclaredCode {
 			t.Fatalf("undeclared event data = %#v", data)
+		} else {
+			details := asMap(t, data["details"])
+			if details["event_name"] != "scan.missing" || details["reason"] != "not_declared_root_input" {
+				t.Fatalf("undeclared event details = %#v", details)
+			}
+			if got := stringSliceFromAny(t, details["declared_events"]); len(got) != 1 || got[0] != "scan.requested" {
+				t.Fatalf("undeclared declared_events = %#v", got)
+			}
+			if got := stringSliceFromAny(t, details["routable_events"]); len(got) != 1 || got[0] != "scan.requested" {
+				t.Fatalf("undeclared routable_events = %#v", got)
+			}
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+
+	t.Run("declared but unroutable root input", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		const eventName = "scan.unroutable_requested"
+		bundle := runStartTestBundle(eventName)
+		bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"] = runtimecontracts.SystemNodeContract{
+			ID:           "scan-orchestrator",
+			SubscribesTo: []string{"scan.other_requested"},
+		}
+		bundle.Nodes["scan-orchestrator"] = bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"]
+		source := semanticview.Wrap(bundle)
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, eventName, `{"topic":"medicine"}`, "idem-unroutable-event"))
+		if resp.Error == nil {
+			t.Fatal("run.start declared unroutable event error = nil")
+		}
+		data := asMap(t, resp.Error.Data)
+		if data["code"] != EventNotDeclaredCode {
+			t.Fatalf("declared unroutable event data = %#v", data)
+		}
+		details := asMap(t, data["details"])
+		if details["event_name"] != eventName || details["reason"] != "declared_root_input_not_routable" {
+			t.Fatalf("declared unroutable event details = %#v", details)
+		}
+		if got := stringSliceFromAny(t, details["declared_events"]); len(got) != 1 || got[0] != eventName {
+			t.Fatalf("declared unroutable declared_events = %#v", got)
+		}
+		if got := stringSliceFromAny(t, details["routable_events"]); len(got) != 0 {
+			t.Fatalf("declared unroutable routable_events = %#v, want empty", got)
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
@@ -326,6 +379,28 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		assertInvalidRunStartParam(t, resp, "payload.entity_id")
 		assertNoRunStartPersistence(t, db, runID)
 	})
+
+	t.Run("publish failure", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		handler := runStartTestHandler(t, pg, failingRunStartPublisher{err: errors.New("simulated run.start publish failure")}, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-publish-failure"))
+		if resp.Error == nil {
+			t.Fatal("run.start publish failure error = nil")
+		}
+		data := asMap(t, resp.Error.Data)
+		if data["code"] != EventPublishFailedCode {
+			t.Fatalf("publish failure data = %#v", data)
+		}
+		details := asMap(t, data["details"])
+		if details["event_name"] != "scan.requested" || details["run_id"] != runID || details["phase"] != "publish" || !strings.Contains(fmt.Sprint(details["reason"]), "simulated run.start publish failure") {
+			t.Fatalf("publish failure details = %#v", details)
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
 }
 
 func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.T) {
@@ -361,7 +436,7 @@ func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.
 	}
 }
 
-func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, source semanticview.Source) *Handler {
+func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus EventPublisher, source semanticview.Source) *Handler {
 	t.Helper()
 	return testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -380,6 +455,14 @@ func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus *runtimebus.
 			},
 		}),
 	})
+}
+
+type failingRunStartPublisher struct {
+	err error
+}
+
+func (p failingRunStartPublisher) Publish(context.Context, events.Event) error {
+	return p.err
 }
 
 func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string) string {
@@ -436,6 +519,27 @@ func assertInvalidRunStartParam(t *testing.T, resp rpcResponse, field string) {
 	}
 	if details := asMap(t, resp.Error.Data)["details"]; asMap(t, details)["field"] != field {
 		t.Fatalf("invalid %s details = %#v", field, details)
+	}
+}
+
+func stringSliceFromAny(t *testing.T, value any) []string {
+	t.Helper()
+	switch typed := value.(type) {
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				t.Fatalf("slice item = %#v, want string", item)
+			}
+			out = append(out, text)
+		}
+		return out
+	case []string:
+		return append([]string(nil), typed...)
+	default:
+		t.Fatalf("value = %#v, want string slice", value)
+		return nil
 	}
 }
 

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -591,7 +591,7 @@ methods:
   - method: run.start
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}


### PR DESCRIPTION
## Summary

- Preserves actionable `/v1/rpc run.start` root-input failure details for undeclared and declared-but-unroutable start events.
- Maps generic `run.start` publish failures to the declared `EVENT_PUBLISH_FAILED` application error and updates platform-spec, generated OpenRPC, and the compliance matrix.
- Teaches `swarm run` to classify start-path `EVENT_NOT_DECLARED`, `PAYLOAD_VALIDATION_FAILED`, and `EVENT_PUBLISH_FAILED` as canonical start rejections with exit 6 and no follow work after failed start.

Closes #1074
Part of #1045

## Governing refs / context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.run.start`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.event.publish`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.conventions.queueable_ingress`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.conventions.idempotency`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.run`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.error_channel_and_exit_code_contract`
- #1074 approved Pre-Implementation Coverage Audit and independent gate

## Canonical ownership / migration note

No semantic migration is performed. `swarm run` still consumes deprecated `/v1/rpc run.start` as specified. This PR keeps `run.start` honest as the active compatibility wrapper for the subset it owns, with shared `event.publish` reliability, mailbox publish, checkpoint provenance, and event CLI siblings left as closed/regression-only surfaces.

## Proof

- `go test ./internal/apiv1 -run 'TestOperatorRunStartHandlers(FailClosedBeforePersistence|PersistRootEventAndReplayIdempotency)|TestOpenRPCMutatingHTTPRuntimeProbes|TestOperatorEventPublish(HandlersFailClosedBeforePersistence|ExplicitRunTargetRequiresExistingNonterminalRun|SourceEventIDRejectsInvalidLineageBeforePersistence)' -count=1`
- `go test ./cmd/swarm -run 'TestRunCommand(StartApplicationErrorsExitSixAndDoNotFollow|ConnectedNoFollowUsesHealthAndRunStartOnly|MapsRPCAndMalformedFailures|StartIncludesOptionalRunIDAndIdempotencyKey|BundleHashSerializesCanonicalParamAndMapsUnsupported)|TestCLIAPIErrorExitCodeClassifiesSharedCategories|TestEventPublish' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`