### PR TITLE
[agent-b][issue #1075] Add forkchat CLI consumer

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -29,6 +29,7 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 		"entities.go":             {},
 		"event_publish.go":        {},
 		"events.go":               {},
+		"forkchat.go":             {},
 		"incidents.go":            {},
 		"logs.go":                 {},
 		"run_command.go":          {},

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -93,6 +93,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newConversationCommand(opts),
 		newAgentsCommand(opts),
 		newAgentCommand(opts),
+		newForkChatCommand(opts),
 		newEntitiesCommand(opts),
 		newEntityCommand(opts),
 		newMailboxCommand(opts),

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -265,7 +265,7 @@ func TestCLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects(t *testing.T) 
 		{name: "trace", args: []string{"trace", "--log-level", "debug"}, wantStderr: "unknown flag"},
 		{name: "run", args: []string{"run", "--log-level", "debug"}, wantStderr: "unknown flag"},
 		{name: "retired investigate", args: []string{"investigate", "runs", "--log-level", "debug"}, wantStderr: "retired in CLI v2"},
-		{name: "absent forkchat", args: []string{"forkchat", "--log-level", "debug"}, wantStderr: "unknown flag"},
+		{name: "forkchat parent", args: []string{"forkchat", "--log-level", "debug"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			beforeRPC := rpcCalls.Load()

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -599,8 +599,8 @@ func TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects(t *testing.T) {
 		{name: "serve log-level", args: []string{"serve", "--log-level", "debug"}, wantStderr: "unknown flag"},
 		{name: "retired investigate", args: []string{"investigate", "runs", "--json"}, wantStderr: "retired in CLI v2"},
 		{name: "retired investigate no-color", args: []string{"investigate", "runs", "--no-color"}, wantStderr: "retired in CLI v2"},
-		{name: "absent forkchat", args: []string{"forkchat", "--json"}, wantStderr: "unknown command"},
-		{name: "absent forkchat no-color", args: []string{"forkchat", "--no-color"}, wantStderr: "unknown command"},
+		{name: "forkchat parent", args: []string{"forkchat", "--json"}, wantStderr: "unknown flag: --json"},
+		{name: "forkchat parent no-color", args: []string{"forkchat", "--no-color"}, wantStderr: "unknown flag: --no-color"},
 		{name: "split log-level", args: []string{"logs", "--log-level", "debug"}, wantStderr: "unknown flag"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/forkchat.go
+++ b/cmd/swarm/forkchat.go
@@ -771,6 +771,23 @@ func validateForkChatSnapshot(snapshot forkChatSnapshot) error {
 	if snapshot.SnapshotOwner != "conversation.fork_chat.snapshot.v1" {
 		return fmt.Errorf("malformed conversation.fork_chat result.snapshot: snapshot_owner=%q is not valid", snapshot.SnapshotOwner)
 	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "fork_id", value: snapshot.ForkID},
+		{name: "source_session_id", value: snapshot.SourceSessionID},
+		{name: "source_agent_id", value: snapshot.SourceAgentID},
+	} {
+		if err := validateConversationOpaqueIDArg("conversation.fork_chat result.snapshot."+field.name, field.value); err != nil {
+			return fmt.Errorf("malformed conversation.fork_chat result.snapshot: %w", err)
+		}
+	}
+	if strings.TrimSpace(snapshot.SourceRunID) != "" {
+		if err := validateConversationOpaqueIDArg("conversation.fork_chat result.snapshot.source_run_id", snapshot.SourceRunID); err != nil {
+			return fmt.Errorf("malformed conversation.fork_chat result.snapshot: %w", err)
+		}
+	}
 	if snapshot.SourceTurn == nil {
 		return fmt.Errorf("malformed conversation.fork_chat result.snapshot: source_turn is required")
 	}
@@ -816,6 +833,9 @@ func validateForkChatDeleteResult(result forkChatDeleteResult) error {
 	}
 	if result.OK == nil {
 		return fmt.Errorf("malformed conversation.fork_delete result: ok is required")
+	}
+	if !*result.OK {
+		return fmt.Errorf("malformed conversation.fork_delete result: ok must be true")
 	}
 	if result.Deleted == nil {
 		return fmt.Errorf("malformed conversation.fork_delete result: deleted is required")

--- a/cmd/swarm/forkchat.go
+++ b/cmd/swarm/forkchat.go
@@ -1,0 +1,974 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	forkChatCreateMethod = "conversation.fork"
+	forkChatChatMethod   = "conversation.fork_chat"
+	forkChatListMethod   = "conversation.fork_list"
+	forkChatViewMethod   = "conversation.fork_view"
+	forkChatDeleteMethod = "conversation.fork_delete"
+)
+
+type forkChatNewCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+	logging    cliLoggingOptions
+
+	turnIndex      int
+	eventID        string
+	at             string
+	message        string
+	idempotencyKey string
+
+	turnIndexSet      bool
+	eventIDSet        bool
+	atSet             bool
+	messageSet        bool
+	idempotencyKeySet bool
+}
+
+type forkChatResumeCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+	logging    cliLoggingOptions
+
+	message        string
+	idempotencyKey string
+
+	messageSet        bool
+	idempotencyKeySet bool
+}
+
+type forkChatListCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+	logging    cliLoggingOptions
+
+	sourceSessionID string
+	limit           int
+	cursor          string
+
+	sourceSessionIDSet bool
+	limitSet           bool
+	cursorSet          bool
+}
+
+type forkChatViewCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+	logging    cliLoggingOptions
+}
+
+type forkChatDeleteCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+	logging    cliLoggingOptions
+
+	idempotencyKey    string
+	idempotencyKeySet bool
+}
+
+type forkChatCreateResult struct {
+	Fork                forkChatSession `json:"fork"`
+	IdempotencyReplayed *bool           `json:"idempotency_replayed"`
+}
+
+type forkChatNewResult struct {
+	Fork                forkChatSession     `json:"fork"`
+	IdempotencyReplayed *bool               `json:"idempotency_replayed"`
+	Chat                *forkChatChatResult `json:"chat,omitempty"`
+}
+
+type forkChatListResult struct {
+	Forks      []forkChatSession `json:"forks"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type forkChatDeleteResult struct {
+	OK                  *bool  `json:"ok"`
+	ForkID              string `json:"fork_id"`
+	Deleted             *bool  `json:"deleted"`
+	AlreadyDeleted      *bool  `json:"already_deleted"`
+	IdempotencyReplayed *bool  `json:"idempotency_replayed"`
+}
+
+type forkChatChatResult struct {
+	ForkID              string                `json:"fork_id"`
+	Turn                forkChatTurn          `json:"turn"`
+	Snapshot            forkChatSnapshot      `json:"snapshot"`
+	SandboxPolicy       forkChatSandboxPolicy `json:"sandbox_policy"`
+	IdempotencyReplayed *bool                 `json:"idempotency_replayed"`
+}
+
+type forkChatSession struct {
+	ForkID          string            `json:"fork_id"`
+	SourceSessionID string            `json:"source_session_id"`
+	SourceRunID     string            `json:"source_run_id,omitempty"`
+	SourceAgentID   string            `json:"source_agent_id"`
+	ForkPoint       forkChatForkPoint `json:"fork_point"`
+	CreatedBy       string            `json:"created_by"`
+	CreatedAt       string            `json:"created_at"`
+	ExpiresAt       string            `json:"expires_at"`
+	DeletedAt       string            `json:"deleted_at,omitempty"`
+	State           string            `json:"state"`
+	Turns           []forkChatTurn    `json:"turns"`
+}
+
+type forkChatForkPoint struct {
+	Kind       string `json:"kind"`
+	TurnIndex  int    `json:"turn_index"`
+	TurnID     string `json:"turn_id"`
+	EventID    string `json:"event_id,omitempty"`
+	At         string `json:"at,omitempty"`
+	SelectedAt string `json:"selected_at"`
+}
+
+type forkChatTurn struct {
+	TurnIndex        int              `json:"turn_index"`
+	TurnID           string           `json:"turn_id"`
+	TriggerEventID   string           `json:"trigger_event_id,omitempty"`
+	TriggerEventType string           `json:"trigger_event_type,omitempty"`
+	RequestPayload   map[string]any   `json:"request_payload,omitempty"`
+	ResponsePayload  map[string]any   `json:"response_payload,omitempty"`
+	ToolCalls        []map[string]any `json:"tool_calls,omitempty"`
+	TurnBlocks       []map[string]any `json:"turn_blocks,omitempty"`
+	ParseOK          *bool            `json:"parse_ok"`
+	LatencyMS        *int             `json:"latency_ms"`
+	Error            string           `json:"error,omitempty"`
+}
+
+type forkChatSnapshot struct {
+	ForkID          string                   `json:"fork_id"`
+	SourceSessionID string                   `json:"source_session_id"`
+	SourceRunID     string                   `json:"source_run_id,omitempty"`
+	SourceAgentID   string                   `json:"source_agent_id"`
+	SourceTurn      map[string]any           `json:"source_turn"`
+	EntitySnapshot  []forkChatEntitySnapshot `json:"entity_snapshot"`
+	SnapshotOwner   string                   `json:"snapshot_owner"`
+	CreatedAt       string                   `json:"created_at"`
+}
+
+type forkChatEntitySnapshot struct {
+	EntityID       string         `json:"entity_id"`
+	CurrentState   string         `json:"current_state,omitempty"`
+	EnteredStateAt string         `json:"entered_state_at,omitempty"`
+	Fields         map[string]any `json:"fields,omitempty"`
+	Gates          map[string]any `json:"gates,omitempty"`
+	Accumulator    map[string]any `json:"accumulator,omitempty"`
+}
+
+type forkChatSandboxPolicy struct {
+	Owner              string   `json:"owner"`
+	ReadPolicy         string   `json:"read_policy"`
+	WritePolicy        string   `json:"write_policy"`
+	SideEffectingTools []string `json:"side_effecting_tools"`
+	StubbedTools       []string `json:"stubbed_tools"`
+}
+
+func newForkChatCommand(opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "forkchat",
+		Short: "Create and inspect sandboxed forkchat sessions through v1 RPC.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newForkChatNewCommand(opts),
+		newForkChatResumeCommand(opts),
+		newForkChatListCommand(opts),
+		newForkChatViewCommand(opts),
+		newForkChatDeleteCommand(opts),
+	)
+	return cmd
+}
+
+func newForkChatNewCommand(opts rootCommandOptions) *cobra.Command {
+	newOpts := forkChatNewCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "new <source-session-id>",
+		Short: "Create a forkchat session through /v1/rpc conversation.fork.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			newOpts.turnIndexSet = cmd.Flags().Changed("turn-index")
+			newOpts.eventIDSet = cmd.Flags().Changed("event-id")
+			newOpts.atSet = cmd.Flags().Changed("at")
+			newOpts.messageSet = cmd.Flags().Changed("message")
+			newOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			if err := newOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := newOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runForkChatNewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), newOpts, args[0])
+		},
+	}
+	cmd.Flags().IntVar(&newOpts.turnIndex, "turn-index", 0, "Fork at this 1-based source conversation turn index")
+	cmd.Flags().StringVar(&newOpts.eventID, "event-id", "", "Fork at the source turn triggered by this event id")
+	cmd.Flags().StringVar(&newOpts.at, "at", "", "Fork at the latest source turn at or before this RFC3339 timestamp")
+	cmd.Flags().StringVarP(&newOpts.message, "message", "m", "", "Optional first sandboxed message after fork creation")
+	cmd.Flags().StringVar(&newOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIOutputFlags(cmd, &newOpts.output)
+	bindCLILoggingFlags(cmd, &newOpts.logging)
+	bindCLIAPIConnectionFlags(cmd, &newOpts.apiOptions)
+	return cmd
+}
+
+func newForkChatResumeCommand(opts rootCommandOptions) *cobra.Command {
+	resumeOpts := forkChatResumeCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "resume <fork-id>",
+		Short: "Send a sandboxed message through /v1/rpc conversation.fork_chat.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resumeOpts.messageSet = cmd.Flags().Changed("message")
+			resumeOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			if err := resumeOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := resumeOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runForkChatResumeCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), resumeOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVarP(&resumeOpts.message, "message", "m", "", "Required sandboxed message to send")
+	cmd.Flags().StringVar(&resumeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIOutputFlags(cmd, &resumeOpts.output)
+	bindCLILoggingFlags(cmd, &resumeOpts.logging)
+	bindCLIAPIConnectionFlags(cmd, &resumeOpts.apiOptions)
+	return cmd
+}
+
+func newForkChatListCommand(opts rootCommandOptions) *cobra.Command {
+	listOpts := forkChatListCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List forkchat sessions through /v1/rpc conversation.fork_list.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listOpts.sourceSessionIDSet = cmd.Flags().Changed("source-session-id")
+			listOpts.limitSet = cmd.Flags().Changed("limit")
+			listOpts.cursorSet = cmd.Flags().Changed("cursor")
+			if err := listOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := listOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runForkChatListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
+		},
+	}
+	cmd.Flags().StringVar(&listOpts.sourceSessionID, "source-session-id", "", "Filter by source conversation session id")
+	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
+	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	bindCLIOutputFlags(cmd, &listOpts.output)
+	bindCLILoggingFlags(cmd, &listOpts.logging)
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
+	return cmd
+}
+
+func newForkChatViewCommand(opts rootCommandOptions) *cobra.Command {
+	viewOpts := forkChatViewCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "view <fork-id>",
+		Short: "View one forkchat session through /v1/rpc conversation.fork_view.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viewOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := viewOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runForkChatViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), viewOpts, args[0])
+		},
+	}
+	bindCLIOutputFlags(cmd, &viewOpts.output)
+	bindCLILoggingFlags(cmd, &viewOpts.logging)
+	bindCLIAPIConnectionFlags(cmd, &viewOpts.apiOptions)
+	return cmd
+}
+
+func newForkChatDeleteCommand(opts rootCommandOptions) *cobra.Command {
+	deleteOpts := forkChatDeleteCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "delete <fork-id>",
+		Short: "Delete one forkchat session through /v1/rpc conversation.fork_delete.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deleteOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			if err := deleteOpts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := deleteOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runForkChatDeleteCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), deleteOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	bindCLIOutputFlags(cmd, &deleteOpts.output)
+	bindCLILoggingFlags(cmd, &deleteOpts.logging)
+	bindCLIAPIConnectionFlags(cmd, &deleteOpts.apiOptions)
+	return cmd
+}
+
+func runForkChatNewCommand(ctx context.Context, out, errOut io.Writer, opts forkChatNewCommandOptions, sourceSessionID string) error {
+	sourceSessionID = strings.TrimSpace(sourceSessionID)
+	if err := validateConversationOpaqueIDArg("source session id", sourceSessionID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	params, err := opts.createParams(sourceSessionID)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	message, err := optionalNonEmptyFlag("--message", opts.message, opts.messageSet)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	var createResult forkChatCreateResult
+	if err := client.call(ctx, forkChatCreateMethod, params, &createResult); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	if err := validateForkChatCreateResult(createResult); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	result := forkChatNewResult{Fork: createResult.Fork, IdempotencyReplayed: createResult.IdempotencyReplayed}
+	if opts.messageSet {
+		chatParams, err := forkChatChatParams(createResult.Fork.ForkID, message, opts.idempotencyKey, opts.idempotencyKeySet)
+		if err != nil {
+			return returnCLIValidationError(errOut, err)
+		}
+		var chatResult forkChatChatResult
+		if err := client.call(ctx, forkChatChatMethod, chatParams, &chatResult); err != nil {
+			return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+		}
+		if err := validateForkChatChatResult(chatResult); err != nil {
+			return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+		}
+		result.Chat = &chatResult
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeForkChatNewResult(w, result)
+	}, func() ([]string, error) {
+		return []string{result.Fork.ForkID}, nil
+	})
+}
+
+func runForkChatResumeCommand(ctx context.Context, out, errOut io.Writer, opts forkChatResumeCommandOptions, forkID string) error {
+	if !opts.messageSet {
+		return returnCLIValidationError(errOut, fmt.Errorf("--message is required"))
+	}
+	params, err := forkChatChatParams(forkID, opts.message, opts.idempotencyKey, opts.idempotencyKeySet)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	var result forkChatChatResult
+	if err := client.call(ctx, forkChatChatMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	if err := validateForkChatChatResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeForkChatChatResult(w, result)
+	}, func() ([]string, error) {
+		return []string{result.Turn.TurnID}, nil
+	})
+}
+
+func runForkChatListCommand(ctx context.Context, out, errOut io.Writer, opts forkChatListCommandOptions) error {
+	params, err := opts.params()
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	var result forkChatListResult
+	if err := client.call(ctx, forkChatListMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	if err := validateForkChatListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeForkChatListResult(w, result)
+	}, func() ([]string, error) {
+		return quietForkChatList(result), nil
+	})
+}
+
+func runForkChatViewCommand(ctx context.Context, out, errOut io.Writer, opts forkChatViewCommandOptions, forkID string) error {
+	forkID = strings.TrimSpace(forkID)
+	if err := validateConversationOpaqueIDArg("fork id", forkID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	var result forkChatSession
+	if err := client.call(ctx, forkChatViewMethod, map[string]any{"fork_id": forkID}, &result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	if err := validateForkChatSession("conversation.fork_view result", result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeForkChatSessionDetail(w, result)
+	}, func() ([]string, error) {
+		return []string{result.ForkID}, nil
+	})
+}
+
+func runForkChatDeleteCommand(ctx context.Context, out, errOut io.Writer, opts forkChatDeleteCommandOptions, forkID string) error {
+	forkID = strings.TrimSpace(forkID)
+	if err := validateConversationOpaqueIDArg("fork id", forkID); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	params := map[string]any{"fork_id": forkID}
+	if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	var result forkChatDeleteResult
+	if err := client.call(ctx, forkChatDeleteMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	if err := validateForkChatDeleteResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, forkChatAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeForkChatDeleteResult(w, result)
+	}, func() ([]string, error) {
+		return []string{result.ForkID}, nil
+	})
+}
+
+func (opts forkChatNewCommandOptions) createParams(sourceSessionID string) (map[string]any, error) {
+	forkPoint, err := opts.forkPoint()
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{
+		"source_session_id": sourceSessionID,
+		"fork_point":        forkPoint,
+	}
+	if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params, nil
+}
+
+func (opts forkChatNewCommandOptions) forkPoint() (map[string]any, error) {
+	count := 0
+	for _, set := range []bool{opts.turnIndexSet, opts.eventIDSet, opts.atSet} {
+		if set {
+			count++
+		}
+	}
+	if count != 1 {
+		return nil, fmt.Errorf("exactly one fork point selector is required: --turn-index, --event-id, or --at")
+	}
+	if opts.turnIndexSet {
+		if opts.turnIndex < 1 || opts.turnIndex > 1000000 {
+			return nil, fmt.Errorf("--turn-index must be an integer from 1 to 1000000")
+		}
+		return map[string]any{"kind": "turn", "turn_index": opts.turnIndex}, nil
+	}
+	if opts.eventIDSet {
+		eventID, err := optionalNonEmptyFlag("--event-id", opts.eventID, opts.eventIDSet)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateConversationOpaqueIDArg("--event-id", eventID); err != nil {
+			return nil, err
+		}
+		return map[string]any{"kind": "event", "event_id": eventID}, nil
+	}
+	at, err := optionalNonEmptyFlag("--at", opts.at, opts.atSet)
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := parseRFC3339Flag("--at", at)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"kind": "time", "at": parsed.UTC().Format(time.RFC3339Nano)}, nil
+}
+
+func forkChatChatParams(forkID, message, idempotencyKey string, idempotencyKeySet bool) (map[string]any, error) {
+	forkID = strings.TrimSpace(forkID)
+	if err := validateConversationOpaqueIDArg("fork id", forkID); err != nil {
+		return nil, err
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return nil, fmt.Errorf("--message must be non-empty")
+	}
+	key, err := optionalNonEmptyFlag("--idempotency-key", idempotencyKey, idempotencyKeySet)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{"fork_id": forkID, "message": message}
+	if key != "" {
+		params["idempotency_key"] = key
+	}
+	return params, nil
+}
+
+func (opts forkChatListCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.sourceSessionIDSet {
+		sourceSessionID, err := optionalNonEmptyFlag("--source-session-id", opts.sourceSessionID, opts.sourceSessionIDSet)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateConversationOpaqueIDArg("--source-session-id", sourceSessionID); err != nil {
+			return nil, err
+		}
+		params["source_session_id"] = sourceSessionID
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = opts.limit
+	}
+	if opts.cursorSet {
+		cursor, err := optionalNonEmptyFlag("--cursor", opts.cursor, opts.cursorSet)
+		if err != nil {
+			return nil, err
+		}
+		params["cursor"] = cursor
+	}
+	return params, nil
+}
+
+func validateForkChatCreateResult(result forkChatCreateResult) error {
+	if err := validateForkChatSession("conversation.fork result.fork", result.Fork); err != nil {
+		return err
+	}
+	if result.IdempotencyReplayed == nil {
+		return fmt.Errorf("malformed conversation.fork result: idempotency_replayed is required")
+	}
+	return nil
+}
+
+func validateForkChatListResult(result forkChatListResult) error {
+	if result.Forks == nil {
+		return fmt.Errorf("malformed conversation.fork_list result: forks is required")
+	}
+	for i, fork := range result.Forks {
+		if err := validateForkChatSession(fmt.Sprintf("conversation.fork_list result.forks[%d]", i), fork); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateForkChatSession(prefix string, fork forkChatSession) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "fork_id", value: fork.ForkID},
+		{name: "source_session_id", value: fork.SourceSessionID},
+		{name: "source_agent_id", value: fork.SourceAgentID},
+		{name: "created_by", value: fork.CreatedBy},
+		{name: "created_at", value: fork.CreatedAt},
+		{name: "expires_at", value: fork.ExpiresAt},
+		{name: "state", value: fork.State},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "fork_id", value: fork.ForkID},
+		{name: "source_session_id", value: fork.SourceSessionID},
+		{name: "source_agent_id", value: fork.SourceAgentID},
+	} {
+		if err := validateConversationOpaqueIDArg(prefix+"."+field.name, field.value); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if strings.TrimSpace(fork.SourceRunID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".source_run_id", fork.SourceRunID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	switch strings.TrimSpace(fork.State) {
+	case "active", "expired", "deleted":
+	default:
+		return fmt.Errorf("malformed %s: state=%q is not valid", prefix, fork.State)
+	}
+	if err := validateRequiredTimestamp(prefix+".created_at", fork.CreatedAt); err != nil {
+		return err
+	}
+	if err := validateRequiredTimestamp(prefix+".expires_at", fork.ExpiresAt); err != nil {
+		return err
+	}
+	if strings.TrimSpace(fork.DeletedAt) != "" {
+		if err := validateRequiredTimestamp(prefix+".deleted_at", fork.DeletedAt); err != nil {
+			return err
+		}
+	}
+	if err := validateForkChatForkPoint(prefix+".fork_point", fork.ForkPoint); err != nil {
+		return err
+	}
+	if fork.Turns == nil {
+		return fmt.Errorf("malformed %s: turns is required", prefix)
+	}
+	for i, turn := range fork.Turns {
+		if err := validateForkChatTurn(fmt.Sprintf("%s.turns[%d]", prefix, i), turn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateForkChatForkPoint(prefix string, point forkChatForkPoint) error {
+	if point.TurnIndex < 1 {
+		return fmt.Errorf("malformed %s: turn_index must be at least 1", prefix)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "kind", value: point.Kind},
+		{name: "turn_id", value: point.TurnID},
+		{name: "selected_at", value: point.SelectedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed %s: %s is required", prefix, field.name)
+		}
+	}
+	switch strings.TrimSpace(point.Kind) {
+	case "turn":
+	case "event":
+		if strings.TrimSpace(point.EventID) == "" {
+			return fmt.Errorf("malformed %s: event_id is required for event fork point", prefix)
+		}
+	case "time":
+		if strings.TrimSpace(point.At) == "" {
+			return fmt.Errorf("malformed %s: at is required for time fork point", prefix)
+		}
+	default:
+		return fmt.Errorf("malformed %s: kind=%q is not valid", prefix, point.Kind)
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".turn_id", point.TurnID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if strings.TrimSpace(point.EventID) != "" {
+		if err := validateConversationOpaqueIDArg(prefix+".event_id", point.EventID); err != nil {
+			return fmt.Errorf("malformed %s: %w", prefix, err)
+		}
+	}
+	if strings.TrimSpace(point.At) != "" {
+		if err := validateRequiredTimestamp(prefix+".at", point.At); err != nil {
+			return err
+		}
+	}
+	return validateRequiredTimestamp(prefix+".selected_at", point.SelectedAt)
+}
+
+func validateForkChatTurn(prefix string, turn forkChatTurn) error {
+	if turn.TurnIndex < 1 {
+		return fmt.Errorf("malformed %s: turn_index must be at least 1", prefix)
+	}
+	if strings.TrimSpace(turn.TurnID) == "" {
+		return fmt.Errorf("malformed %s: turn_id is required", prefix)
+	}
+	if err := validateConversationOpaqueIDArg(prefix+".turn_id", turn.TurnID); err != nil {
+		return fmt.Errorf("malformed %s: %w", prefix, err)
+	}
+	if turn.ParseOK == nil {
+		return fmt.Errorf("malformed %s: parse_ok is required", prefix)
+	}
+	if turn.LatencyMS == nil {
+		return fmt.Errorf("malformed %s: latency_ms is required", prefix)
+	}
+	if *turn.LatencyMS < 0 {
+		return fmt.Errorf("malformed %s: latency_ms must be non-negative", prefix)
+	}
+	return nil
+}
+
+func validateForkChatChatResult(result forkChatChatResult) error {
+	if strings.TrimSpace(result.ForkID) == "" {
+		return fmt.Errorf("malformed conversation.fork_chat result: fork_id is required")
+	}
+	if err := validateConversationOpaqueIDArg("conversation.fork_chat result.fork_id", result.ForkID); err != nil {
+		return fmt.Errorf("malformed conversation.fork_chat result: %w", err)
+	}
+	if err := validateForkChatTurn("conversation.fork_chat result.turn", result.Turn); err != nil {
+		return err
+	}
+	if err := validateForkChatSnapshot(result.Snapshot); err != nil {
+		return err
+	}
+	if err := validateForkChatSandboxPolicy(result.SandboxPolicy); err != nil {
+		return err
+	}
+	if result.IdempotencyReplayed == nil {
+		return fmt.Errorf("malformed conversation.fork_chat result: idempotency_replayed is required")
+	}
+	return nil
+}
+
+func validateForkChatSnapshot(snapshot forkChatSnapshot) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "fork_id", value: snapshot.ForkID},
+		{name: "source_session_id", value: snapshot.SourceSessionID},
+		{name: "source_agent_id", value: snapshot.SourceAgentID},
+		{name: "snapshot_owner", value: snapshot.SnapshotOwner},
+		{name: "created_at", value: snapshot.CreatedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed conversation.fork_chat result.snapshot: %s is required", field.name)
+		}
+	}
+	if snapshot.SnapshotOwner != "conversation.fork_chat.snapshot.v1" {
+		return fmt.Errorf("malformed conversation.fork_chat result.snapshot: snapshot_owner=%q is not valid", snapshot.SnapshotOwner)
+	}
+	if snapshot.SourceTurn == nil {
+		return fmt.Errorf("malformed conversation.fork_chat result.snapshot: source_turn is required")
+	}
+	if snapshot.EntitySnapshot == nil {
+		return fmt.Errorf("malformed conversation.fork_chat result.snapshot: entity_snapshot is required")
+	}
+	for i, entity := range snapshot.EntitySnapshot {
+		if strings.TrimSpace(entity.EntityID) == "" {
+			return fmt.Errorf("malformed conversation.fork_chat result.snapshot.entity_snapshot[%d]: entity_id is required", i)
+		}
+		if err := validateConversationOpaqueIDArg(fmt.Sprintf("conversation.fork_chat result.snapshot.entity_snapshot[%d].entity_id", i), entity.EntityID); err != nil {
+			return fmt.Errorf("malformed conversation.fork_chat result.snapshot: %w", err)
+		}
+	}
+	return validateRequiredTimestamp("conversation.fork_chat result.snapshot.created_at", snapshot.CreatedAt)
+}
+
+func validateForkChatSandboxPolicy(policy forkChatSandboxPolicy) error {
+	if policy.Owner != "conversation.fork_chat.sandbox.v1" {
+		return fmt.Errorf("malformed conversation.fork_chat result.sandbox_policy: owner=%q is not valid", policy.Owner)
+	}
+	if policy.ReadPolicy != "fork_snapshot_only" {
+		return fmt.Errorf("malformed conversation.fork_chat result.sandbox_policy: read_policy=%q is not valid", policy.ReadPolicy)
+	}
+	if policy.WritePolicy != "stub_record_only_no_live_mutation" {
+		return fmt.Errorf("malformed conversation.fork_chat result.sandbox_policy: write_policy=%q is not valid", policy.WritePolicy)
+	}
+	if policy.SideEffectingTools == nil {
+		return fmt.Errorf("malformed conversation.fork_chat result.sandbox_policy: side_effecting_tools is required")
+	}
+	if policy.StubbedTools == nil {
+		return fmt.Errorf("malformed conversation.fork_chat result.sandbox_policy: stubbed_tools is required")
+	}
+	return nil
+}
+
+func validateForkChatDeleteResult(result forkChatDeleteResult) error {
+	if strings.TrimSpace(result.ForkID) == "" {
+		return fmt.Errorf("malformed conversation.fork_delete result: fork_id is required")
+	}
+	if err := validateConversationOpaqueIDArg("conversation.fork_delete result.fork_id", result.ForkID); err != nil {
+		return fmt.Errorf("malformed conversation.fork_delete result: %w", err)
+	}
+	if result.OK == nil {
+		return fmt.Errorf("malformed conversation.fork_delete result: ok is required")
+	}
+	if result.Deleted == nil {
+		return fmt.Errorf("malformed conversation.fork_delete result: deleted is required")
+	}
+	if result.AlreadyDeleted == nil {
+		return fmt.Errorf("malformed conversation.fork_delete result: already_deleted is required")
+	}
+	if result.IdempotencyReplayed == nil {
+		return fmt.Errorf("malformed conversation.fork_delete result: idempotency_replayed is required")
+	}
+	return nil
+}
+
+func writeForkChatNewResult(out io.Writer, result forkChatNewResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Fork %s\n", result.Fork.ForkID)
+	writeForkChatSessionHeader(out, result.Fork)
+	if result.Chat != nil {
+		fmt.Fprintln(out, "Initial chat:")
+		writeForkChatChatSummary(out, *result.Chat)
+	}
+}
+
+func writeForkChatListResult(out io.Writer, result forkChatListResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Forks) == 0 {
+		fmt.Fprintln(out, "No forkchat sessions match the filter.")
+		return
+	}
+	fmt.Fprintln(out, "FORK_ID\tSOURCE_SESSION\tSOURCE_AGENT\tSTATE\tTURNS\tEXPIRES_AT")
+	for _, fork := range result.Forks {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			fork.ForkID,
+			fork.SourceSessionID,
+			fork.SourceAgentID,
+			fork.State,
+			len(fork.Turns),
+			fork.ExpiresAt,
+		)
+	}
+	if strings.TrimSpace(result.NextCursor) != "" {
+		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+	}
+}
+
+func writeForkChatSessionDetail(out io.Writer, fork forkChatSession) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Fork %s\n", fork.ForkID)
+	writeForkChatSessionHeader(out, fork)
+	if len(fork.Turns) == 0 {
+		fmt.Fprintln(out, "No forkchat turns recorded.")
+		return
+	}
+	fmt.Fprintln(out, "TURN\tTURN_ID\tPARSE_OK\tLATENCY_MS\tTOOL_CALLS\tASSISTANT\tERROR")
+	for _, turn := range fork.Turns {
+		fmt.Fprintf(out, "%d\t%s\t%t\t%d\t%d\t%s\t%s\n",
+			turn.TurnIndex,
+			turn.TurnID,
+			*turn.ParseOK,
+			*turn.LatencyMS,
+			len(turn.ToolCalls),
+			conversationDash(forkChatAssistantMessage(turn)),
+			conversationDash(turn.Error),
+		)
+	}
+}
+
+func writeForkChatChatResult(out io.Writer, result forkChatChatResult) {
+	if out == nil {
+		return
+	}
+	writeForkChatChatSummary(out, result)
+}
+
+func writeForkChatDeleteResult(out io.Writer, result forkChatDeleteResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Fork %s deleted=%t already_deleted=%t idempotency_replayed=%t\n",
+		result.ForkID,
+		boolValue(result.Deleted),
+		boolValue(result.AlreadyDeleted),
+		boolValue(result.IdempotencyReplayed),
+	)
+}
+
+func writeForkChatSessionHeader(out io.Writer, fork forkChatSession) {
+	fmt.Fprintf(out, "source_session_id=%s source_agent_id=%s source_run_id=%s state=%s created_by=%s expires_at=%s\n",
+		fork.SourceSessionID,
+		fork.SourceAgentID,
+		conversationDash(fork.SourceRunID),
+		fork.State,
+		fork.CreatedBy,
+		fork.ExpiresAt,
+	)
+	point := fork.ForkPoint
+	fmt.Fprintf(out, "fork_point kind=%s turn_index=%d turn_id=%s event_id=%s at=%s selected_at=%s\n",
+		point.Kind,
+		point.TurnIndex,
+		point.TurnID,
+		conversationDash(point.EventID),
+		conversationDash(point.At),
+		point.SelectedAt,
+	)
+}
+
+func writeForkChatChatSummary(out io.Writer, result forkChatChatResult) {
+	turn := result.Turn
+	fmt.Fprintf(out, "Fork %s turn %d\n", result.ForkID, turn.TurnIndex)
+	fmt.Fprintf(out, "turn_id=%s parse_ok=%t latency_ms=%d tool_calls=%d snapshot_owner=%s sandbox_owner=%s idempotency_replayed=%t error=%s\n",
+		turn.TurnID,
+		*turn.ParseOK,
+		*turn.LatencyMS,
+		len(turn.ToolCalls),
+		result.Snapshot.SnapshotOwner,
+		result.SandboxPolicy.Owner,
+		boolValue(result.IdempotencyReplayed),
+		conversationDash(turn.Error),
+	)
+	if message := forkChatAssistantMessage(turn); message != "" {
+		fmt.Fprintf(out, "assistant=%s\n", message)
+	}
+}
+
+func quietForkChatList(result forkChatListResult) []string {
+	out := make([]string, 0, len(result.Forks))
+	for _, fork := range result.Forks {
+		out = append(out, fork.ForkID)
+	}
+	return out
+}
+
+func forkChatAssistantMessage(turn forkChatTurn) string {
+	if turn.ResponsePayload == nil {
+		return ""
+	}
+	message, _ := turn.ResponsePayload["message"].(string)
+	return strings.TrimSpace(message)
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func forkChatAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{
+		notFoundCodes: []string{"FORK_NOT_FOUND", "SESSION_NOT_FOUND", "TURN_NOT_FOUND", "EVENT_NOT_FOUND"},
+		conflictCodes: []string{"IDEMPOTENCY_CONFLICT"},
+	}
+}

--- a/cmd/swarm/forkchat_test.go
+++ b/cmd/swarm/forkchat_test.go
@@ -1,0 +1,420 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestForkChatNewCreatesForkAndOptionalChatViaCanonicalRPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var requests []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		switch req.Method {
+		case forkChatCreateMethod:
+			writeJSONRPCResult(t, w, req.ID, validForkChatCreateResult("fork-1"))
+		case forkChatChatMethod:
+			writeJSONRPCResult(t, w, req.ID, validForkChatChatResult("fork-1", "fork-turn-1"))
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+			writeJSONRPCResult(t, w, req.ID, map[string]any{})
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"forkchat", "new", "sess-1",
+		"--turn-index", "2",
+		"--message", "inspect fork",
+		"--idempotency-key", "idem-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if requests[0].Method != forkChatCreateMethod || requests[1].Method != forkChatChatMethod {
+		t.Fatalf("methods = %q/%q, want %q/%q", requests[0].Method, requests[1].Method, forkChatCreateMethod, forkChatChatMethod)
+	}
+	wantCreateParams := map[string]any{
+		"source_session_id": "sess-1",
+		"fork_point": map[string]any{
+			"kind":       "turn",
+			"turn_index": float64(2),
+		},
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(requests[0].Params, wantCreateParams) {
+		t.Fatalf("create params = %#v, want %#v", requests[0].Params, wantCreateParams)
+	}
+	wantChatParams := map[string]any{
+		"fork_id":         "fork-1",
+		"message":         "inspect fork",
+		"idempotency_key": "idem-1",
+	}
+	if !reflect.DeepEqual(requests[1].Params, wantChatParams) {
+		t.Fatalf("chat params = %#v, want %#v", requests[1].Params, wantChatParams)
+	}
+	for _, want := range []string{"Fork fork-1", "Initial chat:", "snapshot_owner=conversation.fork_chat.snapshot.v1", "assistant=sandbox answer"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestForkChatNewSelectorMappings(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		wantForkPoint map[string]any
+	}{
+		{
+			name:          "event",
+			args:          []string{"forkchat", "new", "sess-1", "--event-id", "event-1"},
+			wantForkPoint: map[string]any{"kind": "event", "event_id": "event-1"},
+		},
+		{
+			name:          "time",
+			args:          []string{"forkchat", "new", "sess-1", "--at", "2026-05-25T12:00:00+01:00"},
+			wantForkPoint: map[string]any{"kind": "time", "at": "2026-05-25T11:00:00Z"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, validForkChatCreateResult("fork-1"))
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if captured.Method != forkChatCreateMethod {
+				t.Fatalf("method = %q, want %s", captured.Method, forkChatCreateMethod)
+			}
+			wantParams := map[string]any{"source_session_id": "sess-1", "fork_point": tc.wantForkPoint}
+			if !reflect.DeepEqual(captured.Params, wantParams) {
+				t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+			}
+		})
+	}
+}
+
+func TestForkChatResumeJSONUsesConversationForkChat(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validForkChatChatResult("fork-1", "fork-turn-2"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"forkchat", "resume", "fork-1",
+		"--message", "continue",
+		"--idempotency-key", "idem-chat",
+		"--json",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != forkChatChatMethod {
+		t.Fatalf("method = %q, want %s", captured.Method, forkChatChatMethod)
+	}
+	wantParams := map[string]any{"fork_id": "fork-1", "message": "continue", "idempotency_key": "idem-chat"}
+	if !reflect.DeepEqual(captured.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode stdout json: %v\n%s", err, stdout.String())
+	}
+	if result["fork_id"] != "fork-1" {
+		t.Fatalf("json fork_id = %#v, want fork-1", result["fork_id"])
+	}
+}
+
+func TestForkChatListViewDeleteUseCanonicalMethods(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var requests []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		switch req.Method {
+		case forkChatListMethod:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"forks":       []map[string]any{validForkChatSession("fork-1")},
+				"next_cursor": "fork-cursor-2",
+			})
+		case forkChatViewMethod:
+			writeJSONRPCResult(t, w, req.ID, validForkChatSession("fork-1"))
+		case forkChatDeleteMethod:
+			writeJSONRPCResult(t, w, req.ID, validForkChatDeleteResult("fork-1", false))
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+			writeJSONRPCResult(t, w, req.ID, map[string]any{})
+		}
+	}))
+	defer server.Close()
+
+	commands := []struct {
+		args       []string
+		wantStdout string
+	}{
+		{args: []string{"forkchat", "list", "--source-session-id", "sess-1", "--limit", "25", "--cursor", "cursor-1", "--quiet"}, wantStdout: "fork-1"},
+		{args: []string{"forkchat", "view", "fork-1"}, wantStdout: "Fork fork-1"},
+		{args: []string{"forkchat", "delete", "fork-1", "--idempotency-key", "idem-delete", "--quiet"}, wantStdout: "fork-1"},
+	}
+	for _, command := range commands {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), command.args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 0 {
+			t.Fatalf("args %v code = %d stderr=%s stdout=%s", command.args, code, stderr.String(), stdout.String())
+		}
+		if !strings.Contains(stdout.String(), command.wantStdout) {
+			t.Fatalf("args %v stdout = %q, want substring %q", command.args, stdout.String(), command.wantStdout)
+		}
+	}
+	if len(requests) != 3 {
+		t.Fatalf("requests = %d, want 3", len(requests))
+	}
+	assertForkChatRequest(t, requests[0], forkChatListMethod, map[string]any{
+		"source_session_id": "sess-1",
+		"limit":             float64(25),
+		"cursor":            "cursor-1",
+	})
+	assertForkChatRequest(t, requests[1], forkChatViewMethod, map[string]any{"fork_id": "fork-1"})
+	assertForkChatRequest(t, requests[2], forkChatDeleteMethod, map[string]any{"fork_id": "fork-1", "idempotency_key": "idem-delete"})
+}
+
+func TestForkChatCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validForkChatCreateResult("fork-1"))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "new missing selector", args: []string{"forkchat", "new", "sess-1"}, wantStderr: "exactly one fork point selector is required"},
+		{name: "new multiple selectors", args: []string{"forkchat", "new", "sess-1", "--turn-index", "1", "--event-id", "event-1"}, wantStderr: "exactly one fork point selector is required"},
+		{name: "new turn index low", args: []string{"forkchat", "new", "sess-1", "--turn-index", "0"}, wantStderr: "--turn-index must be an integer from 1 to 1000000"},
+		{name: "new blank event id", args: []string{"forkchat", "new", "sess-1", "--event-id", " "}, wantStderr: "--event-id must be non-empty"},
+		{name: "new invalid at", args: []string{"forkchat", "new", "sess-1", "--at", "tomorrow"}, wantStderr: "--at must be an RFC3339 timestamp"},
+		{name: "new blank message", args: []string{"forkchat", "new", "sess-1", "--turn-index", "1", "--message", " "}, wantStderr: "--message must be non-empty"},
+		{name: "resume missing message", args: []string{"forkchat", "resume", "fork-1"}, wantStderr: "--message is required"},
+		{name: "resume invalid fork id", args: []string{"forkchat", "resume", "bad id!", "--message", "hello"}, wantStderr: "fork id must match OpaqueId pattern"},
+		{name: "list invalid limit", args: []string{"forkchat", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
+		{name: "list blank cursor", args: []string{"forkchat", "list", "--cursor", " "}, wantStderr: "--cursor must be non-empty"},
+		{name: "view invalid fork id", args: []string{"forkchat", "view", "bad id!"}, wantStderr: "fork id must match OpaqueId pattern"},
+		{name: "delete blank idempotency key", args: []string{"forkchat", "delete", "fork-1", "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestForkChatAPIErrorAndMalformedResultHandling(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		handler    func(t *testing.T, w http.ResponseWriter, req jsonRPCRequest)
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "not found",
+			args: []string{"forkchat", "view", "fork-missing"},
+			handler: func(t *testing.T, w http.ResponseWriter, req jsonRPCRequest) {
+				writeConversationJSONRPCError(t, w, req.ID, "FORK_NOT_FOUND")
+			},
+			wantCode:   5,
+			wantStderr: "FORK_NOT_FOUND",
+		},
+		{
+			name: "idempotency conflict",
+			args: []string{"forkchat", "delete", "fork-1", "--idempotency-key", "conflict"},
+			handler: func(t *testing.T, w http.ResponseWriter, req jsonRPCRequest) {
+				writeConversationJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   6,
+			wantStderr: "IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "malformed list",
+			args: []string{"forkchat", "list"},
+			handler: func(t *testing.T, w http.ResponseWriter, req jsonRPCRequest) {
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"next_cursor": "cursor-2"})
+			},
+			wantCode:   3,
+			wantStderr: "forks is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				tc.handler(t, w, req)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func assertForkChatRequest(t *testing.T, req jsonRPCRequest, wantMethod string, wantParams map[string]any) {
+	t.Helper()
+	if req.Method != wantMethod {
+		t.Fatalf("method = %q, want %s", req.Method, wantMethod)
+	}
+	if !reflect.DeepEqual(req.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
+	}
+}
+
+func validForkChatCreateResult(forkID string) map[string]any {
+	return map[string]any{
+		"fork":                 validForkChatSession(forkID),
+		"idempotency_replayed": false,
+	}
+}
+
+func validForkChatSession(forkID string) map[string]any {
+	return map[string]any{
+		"fork_id":           forkID,
+		"source_session_id": "sess-1",
+		"source_run_id":     "run-1",
+		"source_agent_id":   "agent-1",
+		"fork_point": map[string]any{
+			"kind":        "turn",
+			"turn_index":  2,
+			"turn_id":     "turn-2",
+			"selected_at": "2026-05-25T11:00:00Z",
+		},
+		"created_by": "token-1",
+		"created_at": "2026-05-25T11:01:00Z",
+		"expires_at": "2026-05-26T11:01:00Z",
+		"state":      "active",
+		"turns":      []map[string]any{},
+	}
+}
+
+func validForkChatChatResult(forkID, turnID string) map[string]any {
+	return map[string]any{
+		"fork_id":              forkID,
+		"turn":                 validForkChatTurn(turnID),
+		"snapshot":             validForkChatSnapshot(forkID),
+		"sandbox_policy":       validForkChatSandboxPolicy(),
+		"idempotency_replayed": false,
+	}
+}
+
+func validForkChatTurn(turnID string) map[string]any {
+	return map[string]any{
+		"turn_index":       1,
+		"turn_id":          turnID,
+		"request_payload":  map[string]any{"message": "inspect fork"},
+		"response_payload": map[string]any{"message": "sandbox answer"},
+		"tool_calls":       []map[string]any{},
+		"turn_blocks":      []map[string]any{},
+		"parse_ok":         true,
+		"latency_ms":       12,
+	}
+}
+
+func validForkChatSnapshot(forkID string) map[string]any {
+	return map[string]any{
+		"fork_id":           forkID,
+		"source_session_id": "sess-1",
+		"source_run_id":     "run-1",
+		"source_agent_id":   "agent-1",
+		"source_turn":       map[string]any{"turn_id": "turn-2", "turn_index": 2},
+		"entity_snapshot": []map[string]any{
+			{"entity_id": "entity-1", "current_state": "active"},
+		},
+		"snapshot_owner": "conversation.fork_chat.snapshot.v1",
+		"created_at":     "2026-05-25T11:02:00Z",
+	}
+}
+
+func validForkChatSandboxPolicy() map[string]any {
+	return map[string]any{
+		"owner":                "conversation.fork_chat.sandbox.v1",
+		"read_policy":          "fork_snapshot_only",
+		"write_policy":         "stub_record_only_no_live_mutation",
+		"side_effecting_tools": []string{},
+		"stubbed_tools":        []string{},
+	}
+}
+
+func validForkChatDeleteResult(forkID string, alreadyDeleted bool) map[string]any {
+	return map[string]any{
+		"ok":                   true,
+		"fork_id":              forkID,
+		"deleted":              !alreadyDeleted,
+		"already_deleted":      alreadyDeleted,
+		"idempotency_replayed": false,
+	}
+}

--- a/cmd/swarm/forkchat_test.go
+++ b/cmd/swarm/forkchat_test.go
@@ -301,6 +301,17 @@ func TestForkChatAPIErrorAndMalformedResultHandling(t *testing.T) {
 			wantCode:   3,
 			wantStderr: "forks is required",
 		},
+		{
+			name: "malformed delete ok false",
+			args: []string{"forkchat", "delete", "fork-1"},
+			handler: func(t *testing.T, w http.ResponseWriter, req jsonRPCRequest) {
+				result := validForkChatDeleteResult("fork-1", false)
+				result["ok"] = false
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "ok must be true",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -316,6 +327,66 @@ func TestForkChatAPIErrorAndMalformedResultHandling(t *testing.T) {
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
 			if code != tc.wantCode {
 				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestForkChatRejectsMalformedSnapshotIdentityFields(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	for _, tc := range []struct {
+		name       string
+		mutate     func(map[string]any)
+		wantStderr string
+	}{
+		{
+			name: "fork id",
+			mutate: func(result map[string]any) {
+				result["snapshot"].(map[string]any)["fork_id"] = "bad id!"
+			},
+			wantStderr: "snapshot.fork_id must match OpaqueId pattern",
+		},
+		{
+			name: "source session id",
+			mutate: func(result map[string]any) {
+				result["snapshot"].(map[string]any)["source_session_id"] = "bad id!"
+			},
+			wantStderr: "snapshot.source_session_id must match OpaqueId pattern",
+		},
+		{
+			name: "source run id",
+			mutate: func(result map[string]any) {
+				result["snapshot"].(map[string]any)["source_run_id"] = "bad id!"
+			},
+			wantStderr: "snapshot.source_run_id must match OpaqueId pattern",
+		},
+		{
+			name: "source agent id",
+			mutate: func(result map[string]any) {
+				result["snapshot"].(map[string]any)["source_agent_id"] = "bad id!"
+			},
+			wantStderr: "snapshot.source_agent_id must match OpaqueId pattern",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				result := validForkChatChatResult("fork-1", "fork-turn-1")
+				tc.mutate(result)
+				writeJSONRPCResult(t, w, req.ID, result)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"forkchat", "resume", "fork-1", "--message", "continue"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
 			if !strings.Contains(stderr.String(), tc.wantStderr) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -107,7 +107,7 @@ func TestCLI_RootNoArgsPrintsHelpAndDoesNotStartRuntime(t *testing.T) {
 		}
 	}
 	for _, retired := range []string{"fork", "investigate"} {
-		if strings.Contains(stdout.String(), "\n  "+retired) {
+		if strings.Contains(stdout.String(), "\n  "+retired+" ") {
 			t.Fatalf("root help advertises retired command %q:\n%s", retired, stdout.String())
 		}
 	}
@@ -211,7 +211,7 @@ func TestCLI_RetiredCommandsHiddenFromHelpAndCompletion(t *testing.T) {
 				t.Fatalf("root help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 			}
 			for _, retired := range []string{"fork", "investigate"} {
-				if strings.Contains(stdout.String(), "\n  "+retired) {
+				if strings.Contains(stdout.String(), "\n  "+retired+" ") {
 					t.Fatalf("root help advertises retired command %q:\n%s", retired, stdout.String())
 				}
 			}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -6625,11 +6625,13 @@ cli_specification:
           spellings; their current generic Cobra unknown-command behavior is intentional unless a
           later tracked spec row promotes hidden fail-closed stubs.
       forkchat:
-        disposition: blocked
+        disposition: promoted_first_slice
         tracker: '#749'
-        action: Forkchat CLI remains blocked until CLI consumer contracts exist over the promoted `conversation.fork_chat`
-          execution/sandbox/snapshot owners and lifecycle `conversation.fork|fork_list|fork_view|fork_delete` source
-          authority.
+        action: >
+          `swarm forkchat new|resume|list|view|delete` is promoted as a bounded CLI consumer over the
+          `conversation.fork|fork_chat|fork_list|fork_view|fork_delete` APIs. Full `--include-forks`
+          cross-surface conversation behavior, Dashboard/Builder views, sharing/ACL/pinning, and public
+          `run.fork` / `swarm fork` work remain split.
     platform_spec_refinements_not_cleanly_present_in_review_artifact:
       agent_replay_backlog:
         classification: required_current_contract
@@ -8894,10 +8896,82 @@ cli_specification:
     forkchat:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
-      implementation_status: absent
-      blocker_state: '#749; conversation.fork_chat, sandbox/snapshot owners, and lifecycle conversation.fork|fork_list|fork_view|fork_delete
-        exist, but the swarm forkchat CLI consumer contract is not present.'
-      owners: conversation.fork, conversation.fork_chat, conversation.fork_list, conversation.fork_view, conversation.fork_delete
+      implementation_status: implemented
+      owners:
+      - /v1/rpc conversation.fork
+      - /v1/rpc conversation.fork_chat
+      - /v1/rpc conversation.fork_list
+      - /v1/rpc conversation.fork_view
+      - /v1/rpc conversation.fork_delete
+      command_contract:
+        namespace: swarm forkchat
+        subcommands:
+        - command: swarm forkchat new <source-session-id>
+          owner_call: /v1/rpc conversation.fork
+          optional_second_call: /v1/rpc conversation.fork_chat when --message is supplied
+          required_selector_rule: exactly one of --turn-index, --event-id, or --at
+          params:
+          - flag: --turn-index <1-1000000>
+            api_param: fork_point.kind=turn, fork_point.turn_index
+          - flag: --event-id <opaque-id>
+            api_param: fork_point.kind=event, fork_point.event_id
+          - flag: --at <RFC3339 timestamp>
+            api_param: fork_point.kind=time, fork_point.at
+          - flag: --message / -m <text>
+            api_param: conversation.fork_chat.message on the optional second call
+          - flag: --idempotency-key <key>
+            api_param: idempotency_key on conversation.fork and on the optional conversation.fork_chat call
+          result_owner: ConversationForkCreateResult; when --message is supplied, ConversationForkChatResult is also rendered
+        - command: swarm forkchat resume <fork-id>
+          owner_call: /v1/rpc conversation.fork_chat
+          required_flags:
+          - --message / -m <text>
+          optional_flags:
+          - --idempotency-key <key>
+          result_owner: ConversationForkChatResult
+        - command: swarm forkchat list
+          owner_call: /v1/rpc conversation.fork_list
+          optional_flags:
+          - --source-session-id <opaque-id>
+          - --limit <1-500>
+          - --cursor <cursor>
+          result_owner: conversation.fork_list result envelope
+        - command: swarm forkchat view <fork-id>
+          owner_call: /v1/rpc conversation.fork_view
+          result_owner: ConversationForkSession
+        - command: swarm forkchat delete <fork-id>
+          owner_call: /v1/rpc conversation.fork_delete
+          optional_flags:
+          - --idempotency-key <key>
+          result_owner: ConversationForkDeleteResult
+      validation:
+      - CLI validates required args, OpaqueId envelope, required selector exclusivity, --turn-index range, --at RFC3339 parsing, non-empty message/key/cursor values, and --limit range before opening an API request.
+      - Validation failures are no-call failures and exit with the standard CLI validation code.
+      output:
+        human: Renders server-owned fork lifecycle fields, fork point, turn summaries, sandbox/snapshot owners, next_cursor, and delete idempotency state.
+        json: Emits the canonical API result shape, with `new --message` wrapping the create result and chat result together.
+        quiet: Emits fork_id for new/view/delete, fork_ids for list, and turn_id for resume.
+      errors:
+        not_found: FORK_NOT_FOUND, SESSION_NOT_FOUND, TURN_NOT_FOUND, and EVENT_NOT_FOUND map to the standard not-found exit.
+        conflict: IDEMPOTENCY_CONFLICT maps to the standard conflict exit.
+        malformed_result: Missing required canonical result fields fail closed as runtime errors.
+      no_bypass_rule: >
+        The CLI must call only the shared `/v1/rpc` API client. It must not import or read internal store, runtime,
+        EventBus, dashboard, Builder, conversation_forks tables, conversation_fork_snapshots, or conversation_fork_turns.
+      split_out:
+        include_forks_cross_surface: '#749 parent tail; normal conversation/dashboard surfaces do not consume fork-local turns in this slice.'
+        dashboard_builder: '#749 parent tail.'
+        sharing_acl_pinning: '#749 parent tail; fixed TTL/delete lifecycle only.'
+        run_fork_swarm_fork: '#989/#1023/#1038 source-authority work; distinct run-fork concept.'
+        direct_storage_or_runtime_reads: forbidden for the CLI consumer.
+      proof_expectations:
+      - fake API server tests prove exact JSON-RPC method names and params for every subcommand
+      - validation no-call tests cover selector exclusivity, invalid IDs, blank values, bad timestamps, and bad pagination bounds
+      - output tests cover human, --json, and --quiet behavior
+      - typed API error tests cover not-found and idempotency conflict mappings
+      - static grep/no-bypass proof shows the CLI consumes only /v1/rpc conversation.fork* methods
+      - 'go run ./cmd/swarm-openrpc-gen --check'
+      - focused cmd/swarm forkchat tests and existing conversation.fork API/store regression tests
     entities_list:
       command: swarm entities list
       tier: should_have
@@ -9156,9 +9230,12 @@ cli_specification:
       current_openrpc_reality: 'event.publish, event.replay, agent.replay, conversation.get_turn, runtime.subscribe_logs, and runtime.nuke are present in current OpenRPC/API.'
       remaining_role: 'Track deprecations/ratification cleanup only if kept open; do not block those CLI commands solely on method existence.'
     '#749':
-      state: active_blocker
-      reason: 'conversation.fork_chat execution/sandbox/snapshot ownership and lifecycle conversation.fork, conversation.fork_list,
-        conversation.fork_view, and conversation.fork_delete are present. swarm forkchat CLI remains absent.'
+      state: cli_consumer_promoted
+      reason: >
+        conversation.fork_chat execution/sandbox/snapshot ownership and lifecycle conversation.fork,
+        conversation.fork_list, conversation.fork_view, and conversation.fork_delete are present.
+        `swarm forkchat new|resume|list|view|delete` is the promoted CLI consumer; remaining #749 tails are
+        cross-surface `--include-forks`, Dashboard/Builder, sharing/ACL/pinning, and public run-fork work.
     '#750':
       state: parent_runtime_tail
       closed_slices:


### PR DESCRIPTION
## Summary
- Promotes `swarm forkchat new|resume|list|view|delete` in `platform-spec.yaml` and implements the CLI consumer over `/v1/rpc conversation.fork*` only.
- Adds local validation/no-call handling, human/JSON/quiet rendering, typed not-found/conflict error mapping, and malformed-result fail-closed checks.
- Updates command inventory/retired-command guards now that `forkchat` is a live API-backed CLI namespace.

Closes #1075
Part of #749

## Governing refs / context
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.forkchat`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.conversation.fork`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.conversation.fork_chat`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.conversation.fork_list`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.conversation.fork_view`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.methods.conversation.fork_delete`
- Generated OpenRPC for the same `conversation.fork*` methods
- Binding tracker/gate context: #749 parent, #1049/#1054, #1063/#1067, #1075 Pre-Implementation Coverage Audit and approved gate

## Semantic migration
- New canonical consumer: `cmd/swarm/forkchat.go` CLI over `/v1/rpc conversation.fork|fork_chat|fork_list|fork_view|fork_delete`, with the command contract promoted in `platform-spec.yaml`.
- Old producer/reader/writer path now invalid: absent CLI / any CLI-local direct store, runtime, EventBus, dashboard, Builder, or conversation_fork* table reads.
- Production paths checked for surviving old behavior: `cmd/swarm/conversations.go`, `cmd/swarm/main.go` forkchat API runtime wiring, run-fork `swarm fork`, trace/events/logs/mailbox namespaces, and API/store conversation fork owners.
- Migration complete for #1075. Remaining #749 parent tails stay split: full `--include-forks` cross-surface behavior, Dashboard/Builder, sharing/ACL/pinning, public `run.fork` / `swarm fork`.

## Proof
- `go test ./cmd/swarm -run 'ForkChat|CLIRuntimeStateAPIConsumersAreExplicitlyAccounted|CLI_RootNoArgsPrintsHelpAndDoesNotStartRuntime|CLI_RetiredCommandsHiddenFromHelpAndCompletion'`
- `go test ./cmd/swarm -run 'ForkChat|CLIOutputModeExceptionRowsFailClosedBeforeSideEffects|CLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects'`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'ConversationFork|OpenRPC|RegistryMethodNames'`
- `go test ./internal/store -run 'ConversationFork|DestructiveReset|SchemaDDL|SchemaCapabilities'`
- static grep/no-bypass inspection of `cmd/swarm/forkchat.go`, `cmd/swarm/forkchat_test.go`, and root command registration
- `go test ./...`
