### PR TITLE
[agent-a][issue #757] Fail closed duplicate flow instance creates

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -1329,7 +1329,8 @@ handler_specification:
         declare authored payload fields; runtime-owned action instructions construct and validate any follow-up payload.
       valid_values:
         create_flow_instance:
-          description: Create a new dynamic flow instance.
+          description: Create a new dynamic flow instance. Duplicate resolved instance IDs fail closed; they are never updates
+            or already-exists successes.
           required_sibling_fields:
             template: 'string — flow template ID (must be mode: template)'
             instance_id_from: string — payload field containing the unique instance ID
@@ -1832,11 +1833,12 @@ engine:
         decides when to create instances based on its product logic. Same pattern as agent sharding — nodes orchestrate instance
         creation.
       instance_id: Supplied by the node (from event payload or generated). Must be unique within the template scope. If already
-        exists, creation fails with error.
+        exists, creation fails with error before mutating flow_instances, entity_state, routes, agents, or auto_emit_on_create.
       process:
       - 1. Node handler calls create_flow_instance with template ID and instance_id
       - '2. Platform validates: template exists and is mode: template'
-      - '3. Platform validates: instance_id is unique within template scope'
+      - '3. Platform validates: instance_id is unique within template scope; duplicate resolved IDs fail closed before create side
+        effects'
       - 4. Platform loads flow template contracts from flows/{template}/
       - '5. Platform constructs paths: {template_id}/{instance_id}/{local_name}'
       - 6. Platform registers new nodes, agents, events in runtime registry
@@ -1856,7 +1858,8 @@ engine:
           before emitting a structurally routed pin output.
         single_parent_v1: Each child has exactly one ParentRoute in v1. Multiple parents are v2.
       auto_emit: Flow schemas may declare auto_emit_on_create. When the platform creates an instance, it automatically emits
-        the declared event after the instance is fully started. This bootstraps the flow without requiring an external trigger.
+        the declared event after the instance is fully started. Duplicate create failures MUST NOT auto-emit. This bootstraps
+        the flow without requiring an external trigger.
     addressing:
       static_flows: '{flow_id}/{local_name} — one level, no instance segment'
       template_instances: '{template_id}/{instance_id}/{local_name} — extra segment for instance'

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -25,7 +25,7 @@ import (
 )
 
 type flowInstancePersistence interface {
-	Upsert(ctx context.Context, instance runtimepipeline.WorkflowInstance) error
+	Create(ctx context.Context, instance runtimepipeline.WorkflowInstance) error
 	MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error
 	Load(ctx context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error)
 }
@@ -79,7 +79,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if err != nil {
 		return err
 	}
-	if err := am.workflowInstances.Upsert(ctx, runtimepipeline.WorkflowInstance{
+	if err := am.workflowInstances.Create(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      instanceID,
 		StorageRef:      flowPath,
 		WorkflowName:    templateID,

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,7 @@ type flowActivationTestRouteStore struct {
 }
 
 type flowActivationTestInstanceStore struct {
+	creates          []runtimepipeline.WorkflowInstance
 	upserts          []runtimepipeline.WorkflowInstance
 	terminatedPaths  []string
 	terminatedAtSeen []time.Time
@@ -72,6 +74,26 @@ func (s *flowActivationTestRouteStore) DeleteFlowInstanceRoute(_ context.Context
 
 func (s *flowActivationTestInstanceStore) Upsert(_ context.Context, instance runtimepipeline.WorkflowInstance) error {
 	s.upserts = append(s.upserts, instance)
+	s.storeInstance(instance)
+	return nil
+}
+
+func (s *flowActivationTestInstanceStore) Create(_ context.Context, instance runtimepipeline.WorkflowInstance) error {
+	if s.byStorageRef == nil {
+		s.byStorageRef = map[string]runtimepipeline.WorkflowInstance{}
+	}
+	ref := strings.TrimSpace(instance.StorageRef)
+	if ref != "" {
+		if _, ok := s.byStorageRef[ref]; ok {
+			return fmt.Errorf("flow instance already exists: %s", ref)
+		}
+	}
+	s.creates = append(s.creates, instance)
+	s.storeInstance(instance)
+	return nil
+}
+
+func (s *flowActivationTestInstanceStore) storeInstance(instance runtimepipeline.WorkflowInstance) {
 	if s.byStorageRef == nil {
 		s.byStorageRef = map[string]runtimepipeline.WorkflowInstance{}
 	}
@@ -81,7 +103,6 @@ func (s *flowActivationTestInstanceStore) Upsert(_ context.Context, instance run
 		stored.Status = "active"
 		s.byStorageRef[stored.StorageRef] = stored
 	}
-	return nil
 }
 
 func (s *flowActivationTestInstanceStore) MarkTerminated(_ context.Context, storageRef string, terminatedAt time.Time) error {
@@ -423,6 +444,40 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	}
 }
 
+func TestActivateFlowInstanceRejectsDuplicateInstanceIDBeforeSideEffects(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	instances := &flowActivationTestInstanceStore{}
+	store := &flowActivationTestStore{}
+	am := newFlowActivationManager(bus, instances, store)
+	bundle := testFlowBundle("task.started")
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("first ActivateFlowInstance: %v", err)
+	}
+	firstCreates := len(instances.creates)
+	firstRoutes := len(bus.addedPaths)
+	firstPublished := len(bus.published)
+	firstAgents := len(store.upserts)
+
+	err := am.ActivateFlowInstance(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "flow instance already exists: review/inst-1") {
+		t.Fatalf("duplicate ActivateFlowInstance error = %v, want already-exists failure", err)
+	}
+	if len(instances.creates) != firstCreates {
+		t.Fatalf("creates = %d, want unchanged %d", len(instances.creates), firstCreates)
+	}
+	if len(bus.addedPaths) != firstRoutes {
+		t.Fatalf("added paths = %#v, want unchanged route side effects", bus.addedPaths)
+	}
+	if len(bus.published) != firstPublished {
+		t.Fatalf("published events = %#v, want unchanged auto-emit side effects", bus.published)
+	}
+	if len(store.upserts) != firstAgents {
+		t.Fatalf("persisted agents = %#v, want unchanged agent side effects", store.upserts)
+	}
+}
+
 func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	instances := &flowActivationTestInstanceStore{}
@@ -447,8 +502,8 @@ func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testin
 	if len(bus.runtimeLogs) != 0 {
 		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
 	}
-	if len(instances.upserts) != 0 {
-		t.Fatalf("instance upserts = %#v, want none", instances.upserts)
+	if len(instances.creates) != 0 {
+		t.Fatalf("instance creates = %#v, want none", instances.creates)
 	}
 	if len(bus.addedPaths) != 0 {
 		t.Fatalf("added paths = %#v, want none", bus.addedPaths)
@@ -483,8 +538,8 @@ func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t 
 	if len(bus.runtimeLogs) != 0 {
 		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
 	}
-	if len(instances.upserts) != 0 {
-		t.Fatalf("instance upserts = %#v, want none", instances.upserts)
+	if len(instances.creates) != 0 {
+		t.Fatalf("instance creates = %#v, want none", instances.creates)
 	}
 	if len(bus.addedPaths) != 0 {
 		t.Fatalf("added paths = %#v, want none", bus.addedPaths)
@@ -630,10 +685,10 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
-	if len(instances.upserts) != 1 {
-		t.Fatalf("upserts = %d, want 1", len(instances.upserts))
+	if len(instances.creates) != 1 {
+		t.Fatalf("creates = %d, want 1", len(instances.creates))
 	}
-	got := instances.upserts[0]
+	got := instances.creates[0]
 	if got.StorageRef != "review/inst-1" {
 		t.Fatalf("storage_ref = %q, want review/inst-1", got.StorageRef)
 	}

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -46,6 +46,7 @@ type WorkflowInstancePersistence interface {
 	Enabled() bool
 	Load(ctx context.Context, instanceID string) (WorkflowInstance, bool, error)
 	List(ctx context.Context) ([]WorkflowInstance, error)
+	Create(ctx context.Context, instance WorkflowInstance) error
 	Upsert(ctx context.Context, instance WorkflowInstance) error
 	MarkTerminated(ctx context.Context, instanceID string, terminatedAt time.Time) error
 	Mutate(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -167,12 +167,37 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	if s == nil || s.db == nil {
 		return nil
 	}
+	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.upsertSpec(ctx, identity.RowID(), identity.StorageRef, instance)
+}
+
+func (s *WorkflowInstanceStore) Create(ctx context.Context, instance WorkflowInstance) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.createSpec(ctx, identity.RowID(), identity.StorageRef, instance)
+}
+
+func normalizeWorkflowInstanceForPersistence(instance WorkflowInstance) (WorkflowInstance, runtimeflowidentity.Persisted, bool, error) {
 	instance.InstanceID = strings.TrimSpace(instance.InstanceID)
 	instance.WorkflowName = strings.TrimSpace(instance.WorkflowName)
 	instance.WorkflowVersion = strings.TrimSpace(instance.WorkflowVersion)
 	instance.CurrentState = strings.TrimSpace(instance.CurrentState)
 	if instance.InstanceID == "" || instance.WorkflowName == "" || instance.WorkflowVersion == "" || instance.CurrentState == "" {
-		return fmt.Errorf(
+		return WorkflowInstance{}, runtimeflowidentity.Persisted{}, false, fmt.Errorf(
 			"workflow instance requires instance_id, workflow_name, workflow_version, and current_state (id=%q workflow=%q version=%q state=%q)",
 			instance.InstanceID,
 			instance.WorkflowName,
@@ -189,13 +214,13 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	instance.StorageRef = strings.TrimSpace(instance.StorageRef)
 	identity, err := workflowInstancePersistedIdentity(nil, instance)
 	if err != nil {
-		return err
+		return WorkflowInstance{}, runtimeflowidentity.Persisted{}, false, err
 	}
 	if strings.TrimSpace(identity.StorageRef) == "" {
-		return nil
+		return WorkflowInstance{}, runtimeflowidentity.Persisted{}, false, nil
 	}
 	if strings.TrimSpace(identity.RowID()) == "" {
-		return nil
+		return WorkflowInstance{}, runtimeflowidentity.Persisted{}, false, nil
 	}
 	if instance.Metadata == nil {
 		instance.Metadata = map[string]any{}
@@ -215,7 +240,7 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	if identity.ParentRoute.FlowInstance != "" {
 		instance.Metadata["parent_flow_instance"] = identity.ParentRoute.FlowInstance
 	}
-	return s.upsertSpec(ctx, identity.RowID(), identity.StorageRef, instance)
+	return instance, identity, true, nil
 }
 
 func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error {
@@ -796,6 +821,169 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 		committed = true
 	}
 	return nil
+}
+
+func (s *WorkflowInstanceStore) createSpec(ctx context.Context, rowID, storageRef string, instance WorkflowInstance) error {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return err
+	}
+	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	committed := !ownedTx
+	if ownedTx {
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+	}
+	if err := lockWorkflowInstanceMutation(ctx, tx, storageRef); err != nil {
+		return err
+	}
+	exists, err := workflowInstanceCreateTargetExists(ctx, tx, runID, rowID, storageRef)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("flow instance already exists: %s", storageRef)
+	}
+	projection, err := workflowInstancePersistedProjectionFromInstance(instance, storageRef)
+	if err != nil {
+		return err
+	}
+	fieldsJSON, err := json.Marshal(projection.Fields)
+	if err != nil {
+		return err
+	}
+	gatesJSON, err := json.Marshal(projection.GatesAny())
+	if err != nil {
+		return err
+	}
+	config := projection.ConfigPayload(instance.WorkflowVersion)
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	accumulatorState, err := json.Marshal(projection.Accumulator)
+	if err != nil {
+		return err
+	}
+	mode := workflowInstanceMode(storageRef)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO flow_instances (
+			instance_id, flow_template, mode, config, status, created_at
+		)
+		VALUES (
+			$1, $2, $3, $4::jsonb, 'active', now()
+		)
+	`, storageRef, instance.WorkflowName, mode, jsonOrDefault(configJSON, "{}")); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3, $4, NULLIF($5,''), NULLIF($6,''),
+			$7, $8::jsonb, $9::jsonb, $10::jsonb, 1,
+			$11, now(), now()
+		)
+	`, runID, rowID, storageRef, projection.Control.EntityType, projection.Control.Slug, projection.Control.Name, instance.CurrentState,
+		jsonOrDefault(gatesJSON, "{}"),
+		jsonOrDefault(fieldsJSON, "{}"),
+		jsonOrDefault(accumulatorState, "{}"),
+		instance.EnteredStageAt,
+	); err != nil {
+		return err
+	}
+	afterProjection := runtimemutationlog.EntityStateProjection{
+		CurrentState: strings.TrimSpace(instance.CurrentState),
+		Fields:       projection.Fields,
+		Gates:        projection.GatesAny(),
+		Accumulator:  projection.Accumulator,
+	}
+	previousForDiff := runtimemutationlog.EntityStateProjection{}
+	if createInfo, ok := workflowCreateEntityInitialValuesFromContext(ctx); ok {
+		nextPrevious, err := insertWorkflowCreateEntityInitialValueMutations(ctx, tx, rowID, previousForDiff, afterProjection, createInfo.Fields)
+		if err != nil {
+			return err
+		}
+		previousForDiff = nextPrevious
+	}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rowID, previousForDiff, afterProjection, runtimemutationlog.Writer{
+		Type:        "platform",
+		ID:          "workflow_instance_store",
+		HandlerStep: "create",
+	}); err != nil {
+		return err
+	}
+	for _, timer := range instance.TimerState {
+		payloadJSON, err := json.Marshal(map[string]any{
+			"started_by": strings.TrimSpace(timer.StartedBy),
+			"timer_id":   strings.TrimSpace(timer.TimerID),
+		})
+		if err != nil {
+			return err
+		}
+		status := "active"
+		if timer.Cancelled {
+			status = "cancelled"
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO timers (
+				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+				fire_at, recurring, owner_node, task_type, status, created_at
+			)
+			VALUES (
+				$1::uuid, $2::uuid, $3, $4::uuid, $5, $6, $7::jsonb,
+				$8, $9, $10, $11, $12, $13
+			)
+		`, workflowInstanceTimerRowID(runID, strings.TrimSpace(timer.TimerID), rowID), runID, strings.TrimSpace(timer.TimerID), rowID, storageRef,
+			strings.TrimSpace(timer.EventType), jsonOrDefault(payloadJSON, "{}"), timer.FiresAt, timer.Recurring,
+			workflowInstanceTimerOwnerNode, workflowInstanceTimerTaskType(timer), status, workflowTimeOrNow(timer.CreatedAt),
+		); err != nil {
+			return err
+		}
+	}
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		committed = true
+	}
+	return nil
+}
+
+func workflowInstanceCreateTargetExists(ctx context.Context, tx *sql.Tx, runID, rowID, storageRef string) (bool, error) {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM flow_instances
+			WHERE instance_id = $1
+		)
+	`, storageRef).Scan(&exists); err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM entity_state
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+		)
+	`, runID, rowID).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, error) {

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -202,6 +202,104 @@ func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField
 	}
 }
 
+func TestWorkflowInstanceStoreCreateRejectsDuplicateWithoutMutatingProjection(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	ctx := testWorkflowStoreRunContext(t, store)
+	const storageRef = "review/inst-1"
+	first := WorkflowInstance{
+		InstanceID:      "inst-1",
+		StorageRef:      storageRef,
+		WorkflowName:    "review",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Config: map[string]any{
+			"name": "alpha",
+		},
+		Metadata: map[string]any{
+			"business_brief": "first",
+			"entity_type":    "workflow_subject",
+			"flow_path":      storageRef,
+			"instance_id":    "inst-1",
+		},
+		StateBuckets: map[string]any{
+			"score": map[string]any{"value": float64(1)},
+		},
+	}
+	if err := store.Create(ctx, first); err != nil {
+		t.Fatalf("create workflow instance: %v", err)
+	}
+
+	duplicate := first
+	duplicate.CurrentState = "mutated"
+	duplicate.Config = map[string]any{
+		"name": "beta",
+	}
+	duplicate.Metadata = map[string]any{
+		"business_brief": "second",
+		"entity_type":    "workflow_subject",
+		"flow_path":      storageRef,
+		"instance_id":    "inst-1",
+	}
+	duplicate.StateBuckets = map[string]any{
+		"score": map[string]any{"value": float64(99)},
+	}
+	err := store.Create(ctx, duplicate)
+	if err == nil || !strings.Contains(err.Error(), "flow instance already exists: "+storageRef) {
+		t.Fatalf("duplicate create error = %v, want already-exists failure", err)
+	}
+
+	loaded, ok, err := store.Load(ctx, storageRef)
+	if err != nil {
+		t.Fatalf("load workflow instance after duplicate create: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected original workflow instance to remain")
+	}
+	if got := loaded.CurrentState; got != "queued" {
+		t.Fatalf("CurrentState = %q, want queued", got)
+	}
+	if got := loaded.Config["name"]; got != "alpha" {
+		t.Fatalf("Config name = %#v, want alpha", got)
+	}
+	if got := loaded.Metadata["business_brief"]; got != "first" {
+		t.Fatalf("Metadata business_brief = %#v, want first", got)
+	}
+	gotScore, ok := workflowStateBucketObject(loaded, "score")
+	if !ok || gotScore["value"] != float64(1) {
+		t.Fatalf("StateBuckets score = %#v ok=%v, want 1", gotScore, ok)
+	}
+
+	var (
+		revision   int
+		configName string
+		fieldsRaw  []byte
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT es.revision, COALESCE(fi.config->>'name', ''), es.fields
+		FROM entity_state es
+		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = $1::uuid AND es.entity_id = $2::uuid
+	`, testPipelineRunID, workflowInstanceRowID(storageRef)).Scan(&revision, &configName, &fieldsRaw); err != nil {
+		t.Fatalf("query persisted projection after duplicate create: %v", err)
+	}
+	if revision != 1 {
+		t.Fatalf("entity_state.revision = %d, want 1", revision)
+	}
+	if configName != "alpha" {
+		t.Fatalf("flow_instances.config name = %q, want alpha", configName)
+	}
+	fields, err := decodeWorkflowInstanceJSONMap("entity_state.fields", fieldsRaw)
+	if err != nil {
+		t.Fatalf("decode entity_state.fields: %v", err)
+	}
+	if got := fields["business_brief"]; got != "first" {
+		t.Fatalf("entity_state.fields business_brief = %#v, want first", got)
+	}
+}
+
 func TestWorkflowInstanceStoreProjection_StaticRowsDoNotGainMaterializedFlowPathOnRoundTrip(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)


### PR DESCRIPTION
## Summary
- Adds a create-only workflow instance persistence path and moves dynamic flow activation off the generic `Upsert` success path.
- Fails duplicate resolved `create_flow_instance.instance_id` attempts before `flow_instances`, `entity_state`, route, agent, or `auto_emit_on_create` side effects.
- Updates the authoritative platform spec to state duplicate create attempts fail closed and never auto-emit.

Closes #757 under the approved narrowed boundary.

## Governing Refs / Context
- Refreshed `Pre-Implementation Coverage Audit`: https://github.com/yazzaoui/Swarm/issues/757#issuecomment-4539334453
- Independent gate outcome: https://github.com/yazzaoui/Swarm/issues/757#issuecomment-4539413009
- Exact spec sections updated/cited: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `handler_specification.action_instruction.valid_values.create_flow_instance`, `engine.dynamic_instance_lifecycle.creation.instance_id`, `engine.dynamic_instance_lifecycle.creation.process`, and `engine.dynamic_instance_lifecycle.creation.auto_emit`.

## Semantic Migration
- New canonical owner: `WorkflowInstanceStore.Create` for create-only workflow instance persistence, consumed by `AgentManager.ActivateFlowInstance`.
- Old invalid path: `AgentManager.ActivateFlowInstance -> WorkflowInstanceStore.Upsert` for dynamic `create_flow_instance` creation.
- Surviving old behavior checked: `WorkflowInstanceStore.Upsert` remains only for true update/recovery/mutation owners; exact event replay remains governed by canonical event receipts.
- Migration completeness: complete for `runtime.create_flow_instance.instance_id_create_only`; no business-key/idempotency/source-field surfaces are changed.

## Proof
- `go test ./internal/runtime/pipeline ./internal/runtime/manager -run 'TestCreateFlowInstance|TestWorkflowInstanceStore|TestActivateFlowInstance' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency|TestBackgroundWorkflowNodeSelectOrCreateEntityDuplicateSameEventIsReceiptIdempotent|TestBackgroundWorkflowNodeSelectEntityDuplicateSameEventIsReceiptIdempotent' -count=1`
- `go test ./...`
