### PR TITLE
[agent-e][issue #1021] Scope multi-bundle API read lists

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -2348,11 +2348,11 @@
     },
     {
       "name": "event.list",
-      "description": "Canonical event store query. Folds dead-letter inspection in via the\nhas_dead_letter and reason_code filters; no separate dead_letter.*\nnamespace in v1.\n",
+      "description": "Canonical event store query. Folds dead-letter inspection in via the\nhas_dead_letter and reason_code filters; no separate dead_letter.*\nnamespace in v1. Multi-bundle-safe reads require explicit filter.run_id; unscoped event firehose reads are not a public v1 surface.\n",
       "params": [
         {
           "name": "filter",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/EventListFilter"
           }
@@ -3349,11 +3349,11 @@
     },
     {
       "name": "event.subscribe",
-      "description": "Live event stream with the same filter shape as event.list. Filter\nparity is required by the conventions section. Pagination params\n(limit, cursor) and the time-window `until` are NOT accepted here\n— subscriptions deliver everything matching the filter live.\n",
+      "description": "Live event stream with the same filter shape as event.list. Filter\nparity is required by the conventions section. Pagination params\n(limit, cursor) and the time-window `until` are NOT accepted here\n— subscriptions deliver everything matching the filter live. Multi-bundle-safe streams require\nexplicit filter.run_id; unscoped event firehose subscriptions are not a public v1 surface.\n",
       "params": [
         {
           "name": "filter",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/EventListFilter"
           }
@@ -4535,8 +4535,16 @@
     },
     {
       "name": "run.list",
-      "description": "List runs with optional filters. Cursor-paginated.",
+      "description": "List runs with optional filters. Cursor-paginated. The optional bundle_hash filter is a canonical persisted run-bundle selector over runs.bundle_hash; callers must not use legacy bundle fingerprints for this field.",
       "params": [
+        {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
         {
           "name": "status",
           "required": false,
@@ -5568,8 +5576,16 @@
     },
     {
       "name": "runtime.incidents",
-      "description": "Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage).",
+      "description": "Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage). The optional bundle_hash filter is applied to source runtime-log rows before aggregation.",
       "params": [
+        {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
         {
           "name": "since_hours",
           "required": false,
@@ -5644,8 +5660,16 @@
     },
     {
       "name": "runtime.logs",
-      "description": "Filtered structured runtime log query.",
+      "description": "Filtered structured runtime log query. The optional bundle_hash filter is a canonical persisted run-bundle selector over runs.bundle_hash and composes with run_id and other filters as AND.",
       "params": [
+        {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
         {
           "name": "run_id",
           "required": false,
@@ -6117,6 +6141,14 @@
       "name": "runtime.subscribe_logs",
       "description": "Live structured runtime log stream for `runtime.logs` follow mode.\nNotifications carry one `LogEntry` row from the same persisted runtime log read owner used by `runtime.logs`.\nThe method accepts the same runtime-log identity/content filter fields as `runtime.logs`, but snapshot pagination, sort, and fixed-window controls (`limit`, `cursor`, `order`, `since`, `until`) are not accepted on the subscription. Use `replay_since` for catch-up.\n",
       "params": [
+        {
+          "name": "bundle_hash",
+          "required": false,
+          "description": "Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e.",
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
         {
           "name": "run_id",
           "required": false,
@@ -7515,6 +7547,9 @@
             "$ref": "#/components/schemas/SubscriberType"
           }
         },
+        "required": [
+          "run_id"
+        ],
         "type": "object"
       },
       "EventPublishDelivery": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5345,17 +5345,19 @@ multi_bundle_persistence:
       run.start:
         rule: Deprecated wrapper follows event.publish bundle_hash semantics while it remains present.
       run.list:
-        rule: May accept optional bundle_hash filter.
+        rule: Accepts optional bundle_hash filter over canonical runs.bundle_hash.
       runtime.logs:
-        rule: May accept optional bundle_hash filter.
+        rule: Accepts optional bundle_hash filter over canonical runs.bundle_hash.
+      runtime.subscribe_logs:
+        rule: Accepts the same optional bundle_hash runtime-log source filter as runtime.logs.
       runtime.incidents:
-        rule: May accept optional bundle_hash filter.
+        rule: Accepts optional bundle_hash filter over source runtime-log rows before incident aggregation.
       agent.list:
         rule: Future bundle-aware listing must disambiguate run-scoped loaded agents from persisted bundle agent catalog.
       event.list:
-        rule: Future multi-bundle event listing must avoid ambient bundle assumptions; run_id remains the primary run-scoped owner.
+        rule: Multi-bundle-safe event listing requires explicit filter.run_id; unscoped event firehose reads are not public v1.
       event.subscribe:
-        rule: Future multi-bundle subscription filters must avoid ambient bundle assumptions; run_id remains the primary run-scoped owner.
+        rule: Multi-bundle-safe event subscriptions require explicit filter.run_id; unscoped event firehose streams are not public v1.
     run_fork:
       method: run.fork
       params:
@@ -10342,6 +10344,8 @@ api_specification:
       EventListFilter:
         type: object
         additionalProperties: false
+        required:
+        - run_id
         properties:
           run_id:
             $ref: '#/components/schemas/OpaqueId'
@@ -12542,11 +12546,17 @@ api_specification:
       - RUN_NOT_FOUND
     run.list:
       tier: must_have
-      description: List runs with optional filters. Cursor-paginated.
+      description: List runs with optional filters. Cursor-paginated. The optional bundle_hash filter is a canonical persisted
+        run-bundle selector over runs.bundle_hash; callers must not use legacy bundle fingerprints for this field.
       scope:
         required:
         - read:runs
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:<64 lowercase hex>.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: status
         required: false
         schema:
@@ -12818,7 +12828,8 @@ api_specification:
 
         has_dead_letter and reason_code filters; no separate dead_letter.*
 
-        namespace in v1.
+        namespace in v1. Multi-bundle-safe reads require explicit filter.run_id;
+        unscoped event firehose reads are not a public v1 surface.
 
         '
       scope:
@@ -12826,7 +12837,7 @@ api_specification:
         - read:events
       params:
       - name: filter
-        required: false
+        required: true
         schema:
           $ref: '#/components/schemas/EventListFilter'
       - name: since
@@ -12886,13 +12897,14 @@ api_specification:
       tier: should_have
       description: "Live event stream with the same filter shape as event.list. Filter\nparity is required by the conventions\
         \ section. Pagination params\n(limit, cursor) and the time-window `until` are NOT accepted here\n\u2014 subscriptions\
-        \ deliver everything matching the filter live.\n"
+        \ deliver everything matching the filter live. Multi-bundle-safe streams require\nexplicit filter.run_id; unscoped\
+        \ event firehose subscriptions are not a public v1 surface.\n"
       scope:
         required:
         - read:events
       params:
       - name: filter
-        required: false
+        required: true
         schema:
           $ref: '#/components/schemas/EventListFilter'
       - name: replay_since
@@ -13649,11 +13661,17 @@ api_specification:
       - IDEMPOTENCY_CONFLICT
     runtime.logs:
       tier: should_have
-      description: Filtered structured runtime log query.
+      description: Filtered structured runtime log query. The optional bundle_hash filter is a canonical persisted
+        run-bundle selector over runs.bundle_hash and composes with run_id and other filters as AND.
       scope:
         required:
         - read:runtime
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:<64 lowercase hex>.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: run_id
         required: false
         schema:
@@ -13735,6 +13753,11 @@ api_specification:
         required:
         - read:runtime
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:<64 lowercase hex>.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: run_id
         required: false
         schema:
@@ -13780,11 +13803,17 @@ api_specification:
       errors: []
     runtime.incidents:
       tier: should_have
-      description: Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage).
+      description: Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage). The optional
+        bundle_hash filter is applied to source runtime-log rows before aggregation.
       scope:
         required:
         - read:runtime
       params:
+      - name: bundle_hash
+        required: false
+        description: Optional canonical bundle selector over runs.bundle_hash. Must be bundle-v1:sha256:<64 lowercase hex>.
+        schema:
+          $ref: '#/components/schemas/BundleHash'
       - name: since_hours
         required: false
         schema:

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -349,7 +349,8 @@ func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
 		t.Fatalf("run.get trigger_event_id = %v, want %s", got, eventID)
 	}
 
-	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"run.list","params":{"limit":1}}`)
+	bundleHash := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"run.list","params":{"bundle_hash":"`+bundleHash+`","limit":1}}`)
 	if list.Error != nil {
 		t.Fatalf("run.list error = %#v", list.Error)
 	}
@@ -359,6 +360,9 @@ func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
 	}
 	if fakeRuns.lastListOpts.Limit != 1 {
 		t.Fatalf("run.list limit = %d, want 1", fakeRuns.lastListOpts.Limit)
+	}
+	if fakeRuns.lastListOpts.BundleHash != bundleHash {
+		t.Fatalf("run.list bundle_hash = %q, want %q", fakeRuns.lastListOpts.BundleHash, bundleHash)
 	}
 
 	diagnose := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"diagnose","method":"run.diagnose","params":{"run_id":"run-1"}}`)
@@ -437,6 +441,10 @@ func TestOperatorReadHandlersRunListRejectsInvalidFilters(t *testing.T) {
 		{
 			name: "numeric until",
 			body: `{"jsonrpc":"2.0","id":"bad-until","method":"run.list","params":{"until":123}}`,
+		},
+		{
+			name: "invalid bundle hash",
+			body: `{"jsonrpc":"2.0","id":"bad-bundle","method":"run.list","params":{"bundle_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`,
 		},
 	}
 	for _, tc := range tests {

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -279,7 +279,7 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"entity.get":                     {Params: map[string]any{"entity_id": "entity-1"}, ResultKeys: []string{"entity", "fields", "gates", "accumulated"}},
 		"entity.list":                    {Params: map[string]any{}, ResultKeys: []string{"entities"}},
 		"event.get":                      {Params: map[string]any{"event_id": "evt-1"}, ResultKeys: []string{"event_id", "event_name", "payload", "deliveries", "dead_letters"}},
-		"event.list":                     {Params: map[string]any{}, ResultKeys: []string{"events"}},
+		"event.list":                     {Params: map[string]any{"filter": map[string]any{"run_id": "run-1"}}, ResultKeys: []string{"events"}},
 		"health.check":                   {Params: map[string]any{}, ResultKeys: []string{"alive", "ready", "db_ok", "runtime_ok", "bundle"}},
 		"health.ping":                    {Params: map[string]any{}, ResultKeys: []string{"ok", "ts"}},
 		"mailbox.get":                    {Params: map[string]any{"mailbox_id": "mailbox-1"}, ResultKeys: []string{"item", "payload", "history", "decision_sheet"}},

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -123,14 +123,15 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		t.Fatalf("event.get event_id = %#v", got)
 	}
 
-	logs := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":"run-1","session_id":"sess-1","component":"scheduler","level":"warn","since":"2023-11-14T22:12:00Z","until":"2023-11-14T22:14:00Z","limit":5}}`)
+	bundleHash := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	logs := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"bundle_hash":"`+bundleHash+`","run_id":"run-1","session_id":"sess-1","component":"scheduler","level":"warn","since":"2023-11-14T22:12:00Z","until":"2023-11-14T22:14:00Z","limit":5}}`)
 	if logs.Error != nil {
 		t.Fatalf("runtime.logs error = %#v", logs.Error)
 	}
 	if rows, _ := asMap(t, logs.Result)["logs"].([]any); len(rows) != 1 {
 		t.Fatalf("runtime.logs rows = %#v", asMap(t, logs.Result)["logs"])
 	}
-	if observability.lastRuntimeLogs.RunID != "run-1" || observability.lastRuntimeLogs.SessionID != "sess-1" || observability.lastRuntimeLogs.Component != "scheduler" {
+	if observability.lastRuntimeLogs.BundleHash != bundleHash || observability.lastRuntimeLogs.RunID != "run-1" || observability.lastRuntimeLogs.SessionID != "sess-1" || observability.lastRuntimeLogs.Component != "scheduler" {
 		t.Fatalf("runtime.logs options = %#v", observability.lastRuntimeLogs)
 	}
 	if observability.lastRuntimeLogs.Since == nil || observability.lastRuntimeLogs.Until == nil {
@@ -141,15 +142,28 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 		t.Fatalf("runtime.logs invalid window error = %#v, want invalid params", invalidWindow.Error)
 	}
 
-	incidents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"incidents","method":"runtime.incidents","params":{"since_hours":24,"component":"scheduler","limit":5}}`)
+	invalidBundleHash := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"logs-invalid-bundle","method":"runtime.logs","params":{"bundle_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`)
+	if invalidBundleHash.Error == nil || invalidBundleHash.Error.Code != codeInvalidParams {
+		t.Fatalf("runtime.logs invalid bundle_hash error = %#v, want invalid params", invalidBundleHash.Error)
+	}
+
+	incidents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"incidents","method":"runtime.incidents","params":{"bundle_hash":"`+bundleHash+`","since_hours":24,"component":"scheduler","limit":5}}`)
 	if incidents.Error != nil {
 		t.Fatalf("runtime.incidents error = %#v", incidents.Error)
 	}
 	if rows, _ := asMap(t, incidents.Result)["incidents"].([]any); len(rows) != 1 {
 		t.Fatalf("runtime.incidents rows = %#v", asMap(t, incidents.Result)["incidents"])
 	}
-	if observability.lastIncidents.Component != "scheduler" || observability.lastIncidents.SinceHours != 24 {
+	if observability.lastIncidents.BundleHash != bundleHash || observability.lastIncidents.Component != "scheduler" || observability.lastIncidents.SinceHours != 24 {
 		t.Fatalf("runtime.incidents options = %#v", observability.lastIncidents)
+	}
+
+	missingEventRun := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events-missing-run","method":"event.list","params":{"filter":{"event_name":"scan.requested"},"limit":10}}`)
+	if missingEventRun.Error == nil || missingEventRun.Error.Code != codeInvalidParams {
+		t.Fatalf("event.list missing run scope error = %#v, want invalid params", missingEventRun.Error)
+	}
+	if details := asMap(t, asMap(t, missingEventRun.Error.Data)["details"]); details["field"] != "filter.run_id" {
+		t.Fatalf("event.list missing run scope details = %#v, want filter.run_id", details)
 	}
 }
 
@@ -177,7 +191,7 @@ func TestOperatorObservabilityHandlersKeepPayloadEntityOutOfTopLevelEventIdentit
 		}),
 	})
 
-	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"limit":10}}`)
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"filter":{"run_id":"run-1"},"limit":10}}`)
 	if list.Error != nil {
 		t.Fatalf("event.list error = %#v", list.Error)
 	}
@@ -193,7 +207,7 @@ func TestOperatorObservabilityHandlersKeepPayloadEntityOutOfTopLevelEventIdentit
 		t.Fatalf("event.list payload = %#v, want preserved entity_id", payload)
 	}
 
-	filtered := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events-filtered","method":"event.list","params":{"filter":{"entity_id":"`+payloadEntityID+`"},"limit":10}}`)
+	filtered := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events-filtered","method":"event.list","params":{"filter":{"run_id":"run-1","entity_id":"`+payloadEntityID+`"},"limit":10}}`)
 	if filtered.Error != nil {
 		t.Fatalf("event.list filtered error = %#v", filtered.Error)
 	}
@@ -243,7 +257,7 @@ func TestOperatorObservabilityHandlersTypedErrors(t *testing.T) {
 	}
 
 	observability.listErr = store.ErrInvalidObservabilityCursor
-	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"cursor":"bad"}}`)
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"events","method":"event.list","params":{"filter":{"run_id":"run-1"},"cursor":"bad"}}`)
 	if list.Error == nil || list.Error.Code != codeInvalidParams {
 		t.Fatalf("event.list error = %#v, want invalid params", list.Error)
 	}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -875,6 +875,9 @@ func operatorEventListOptionsFromParams(params map[string]any) (store.OperatorEv
 	if err != nil {
 		return store.OperatorEventListOptions{}, err
 	}
+	if err := requireEventListRunScope(filter); err != nil {
+		return store.OperatorEventListOptions{}, err
+	}
 	out.Filter = filter
 	limit, err := boundedIntegerParam(params, "limit", 1, 1000)
 	if err != nil {
@@ -956,6 +959,13 @@ func eventListFilterParam(params map[string]any) (store.OperatorEventListFilter,
 		out.HasDeadLetter = &value
 	}
 	return out, nil
+}
+
+func requireEventListRunScope(filter store.OperatorEventListFilter) error {
+	if strings.TrimSpace(filter.RunID) == "" {
+		return NewInvalidParamsError(map[string]any{"field": "filter.run_id", "reason": "required run scope is missing"})
+	}
+	return nil
 }
 
 func runTraceFilterParam(params map[string]any) (store.RunDebugTraceFilter, error) {
@@ -1056,6 +1066,9 @@ func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.Opera
 	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
 	}
+	if out.BundleHash, err = optionalBundleHashParam(params, "bundle_hash"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, err
+	}
 	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, err
 	}
@@ -1098,6 +1111,9 @@ func operatorRuntimeLogListOptionsFromParams(params map[string]any) (store.Opera
 func operatorRuntimeIncidentListOptionsFromParams(params map[string]any) (store.OperatorRuntimeIncidentListOptions, error) {
 	out := store.OperatorRuntimeIncidentListOptions{}
 	var err error
+	if out.BundleHash, err = optionalBundleHashParam(params, "bundle_hash"); err != nil {
+		return store.OperatorRuntimeIncidentListOptions{}, err
+	}
 	if out.Component, _, err = optionalStringParam(params, "component"); err != nil {
 		return store.OperatorRuntimeIncidentListOptions{}, err
 	}
@@ -1141,6 +1157,9 @@ func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListO
 		return store.RunHeaderListOptions{}, err
 	}
 	out.Cursor = cursor
+	if out.BundleHash, err = optionalBundleHashParam(params, "bundle_hash"); err != nil {
+		return store.RunHeaderListOptions{}, err
+	}
 	if raw, ok := params["limit"]; ok && !isEmptyParam(raw) {
 		limit, ok := integerParam(raw)
 		if !ok || limit < 1 || limit > 500 {
@@ -1155,6 +1174,20 @@ func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListO
 		return store.RunHeaderListOptions{}, err
 	}
 	return out, nil
+}
+
+func optionalBundleHashParam(params map[string]any, name string) (string, error) {
+	value, _, err := optionalStringParam(params, name)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		return "", nil
+	}
+	if !bundleHashPattern.MatchString(value) {
+		return "", NewInvalidParamsError(map[string]any{"field": name, "reason": "must be bundle-v1:sha256:<64 lowercase hex>"})
+	}
+	return value, nil
 }
 
 func timestampParam(params map[string]any, name string) (*time.Time, error) {

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -148,6 +148,9 @@ func (r *SubscriptionRuntime) prepareEventSubscription(session *webSocketSession
 	if err != nil {
 		return subscriptionPlan{}, err
 	}
+	if err := requireEventListRunScope(filter); err != nil {
+		return subscriptionPlan{}, err
+	}
 	replaySince, err := timestampParam(req.Params, "replay_since")
 	if err != nil {
 		return subscriptionPlan{}, err
@@ -222,6 +225,7 @@ func (r *SubscriptionRuntime) prepareRuntimeLogSubscription(session *webSocketSe
 func runtimeLogSubscriptionOptionsFromParams(params map[string]any) (store.OperatorRuntimeLogListOptions, *time.Time, error) {
 	allowed := map[string]struct{}{
 		"run_id":       {},
+		"bundle_hash":  {},
 		"entity_id":    {},
 		"session_id":   {},
 		"component":    {},
@@ -238,6 +242,9 @@ func runtimeLogSubscriptionOptionsFromParams(params map[string]any) (store.Opera
 	out := store.OperatorRuntimeLogListOptions{}
 	var err error
 	if out.RunID, _, err = optionalStringParam(params, "run_id"); err != nil {
+		return store.OperatorRuntimeLogListOptions{}, nil, err
+	}
+	if out.BundleHash, err = optionalBundleHashParam(params, "bundle_hash"); err != nil {
 		return store.OperatorRuntimeLogListOptions{}, nil, err
 	}
 	if out.EntityID, _, err = optionalStringParam(params, "entity_id"); err != nil {

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -195,6 +195,14 @@ func TestEventListFilterValidationCoversListAndSubscribe(t *testing.T) {
 		t.Fatalf("event.list enum details = %#v", details)
 	}
 
+	listMissingRun := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list-missing-run","method":"event.list","params":{"filter":{"event_name":"scan.requested"}}}`)
+	if listMissingRun.Error == nil || listMissingRun.Error.Code != codeInvalidParams {
+		t.Fatalf("event.list missing run scope error = %#v, want invalid params", listMissingRun.Error)
+	}
+	if details := asMap(t, asMap(t, listMissingRun.Error.Data)["details"]); details["field"] != "filter.run_id" {
+		t.Fatalf("event.list missing run scope details = %#v", details)
+	}
+
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	conn := dialTestWS(t, server.URL)
@@ -230,6 +238,22 @@ func TestEventListFilterValidationCoversListAndSubscribe(t *testing.T) {
 	if details := asMap(t, asMap(t, subEnum.Error.Data)["details"]); details["field"] != "filter.subscriber_type" {
 		t.Fatalf("event.subscribe enum details = %#v", details)
 	}
+
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-missing-run",
+		"method":  "event.subscribe",
+		"params": map[string]any{
+			"filter": map[string]any{"event_name": "scan.requested"},
+		},
+	})
+	subMissingRun := readWSResponse(t, conn)
+	if subMissingRun.Error == nil || subMissingRun.Error.Code != codeInvalidParams {
+		t.Fatalf("event.subscribe missing run scope error = %#v, want invalid params", subMissingRun.Error)
+	}
+	if details := asMap(t, asMap(t, subMissingRun.Error.Data)["details"]); details["field"] != "filter.run_id" {
+		t.Fatalf("event.subscribe missing run scope details = %#v", details)
+	}
 }
 
 func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
@@ -249,7 +273,9 @@ func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
 		"jsonrpc": "2.0",
 		"id":      "sub-events",
 		"method":  "event.subscribe",
-		"params":  map[string]any{},
+		"params": map[string]any{
+			"filter": map[string]any{"run_id": "run-1"},
+		},
 	})
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	defer conn.SetReadDeadline(time.Time{})
@@ -471,6 +497,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 		"id":      "sub-runtime-logs",
 		"method":  "runtime.subscribe_logs",
 		"params": map[string]any{
+			"bundle_hash":  "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			"run_id":       "run-1",
 			"entity_id":    "entity-1",
 			"session_id":   "sess-1",
@@ -495,6 +522,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay(t *testin
 		t.Fatalf("runtime log notification result = %#v", got)
 	}
 	if observability.lastRuntimeLogs.RunID != "run-1" ||
+		observability.lastRuntimeLogs.BundleHash != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ||
 		observability.lastRuntimeLogs.EntityID != "entity-1" ||
 		observability.lastRuntimeLogs.SessionID != "sess-1" ||
 		observability.lastRuntimeLogs.Component != "scheduler" ||
@@ -610,6 +638,24 @@ func TestRuntimeSubscribeLogsRejectsSnapshotControls(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("invalid bundle_hash", func(t *testing.T) {
+		conn := dialTestWS(t, server.URL)
+		defer conn.Close()
+		writeWSRequest(t, conn, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "bad-runtime-logs-bundle",
+			"method":  "runtime.subscribe_logs",
+			"params":  map[string]any{"bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		})
+		resp := readWSResponse(t, conn)
+		if resp.Error == nil || resp.Error.Code != codeInvalidParams {
+			t.Fatalf("runtime.subscribe_logs invalid bundle_hash response = %#v, want invalid params", resp)
+		}
+		if details := asMap(t, asMap(t, resp.Error.Data)["details"]); details["field"] != "bundle_hash" {
+			t.Fatalf("runtime.subscribe_logs invalid bundle_hash details = %#v", details)
+		}
+	})
 }
 
 func TestWebSocketSessionBackpressureAndUnsubscribeCancelState(t *testing.T) {

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -320,10 +320,10 @@ methods:
     gap_classification: []
   - method: event.list
     transport: http
-    required_params: []
+    required_params: [filter]
     declared_errors: []
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorObservabilityHandlersExposePersistedReadMethods}]}
-    required_param_validation: {status: not_applicable}
+    required_param_validation: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestEventListFilterValidationCoversListAndSubscribe}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
     declared_error_tests: {status: not_applicable}
@@ -365,10 +365,10 @@ methods:
     gap_classification: []
   - method: event.subscribe
     transport: ws
-    required_params: []
+    required_params: [filter]
     declared_errors: []
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay}]}
-    required_param_validation: {status: not_applicable}
+    required_param_validation: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestEventListFilterValidationCoversListAndSubscribe}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}, {kind: go_test, name: TestHandlerWebSocketAuthAndFrameValidation}]}
     declared_error_tests: {status: not_applicable}

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -78,6 +78,7 @@ type OperatorDeadLetterRecord struct {
 
 type OperatorRuntimeLogListOptions struct {
 	RunID             string
+	BundleHash        string
 	EntityID          string
 	SessionID         string
 	Component         string
@@ -113,6 +114,7 @@ type OperatorRuntimeLogEntry struct {
 
 type OperatorRuntimeIncidentListOptions struct {
 	SinceHours int
+	BundleHash string
 	Component  string
 	Level      string
 	MCPOnly    bool
@@ -175,6 +177,9 @@ func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Con
 		"events": {
 			"event_id", "run_id", "event_name", "entity_id", "scope", "payload",
 			"produced_by", "produced_by_type", "source_event_id", "created_at",
+		},
+		"runs": {
+			"run_id", "bundle_hash",
 		},
 		"event_deliveries": {
 			"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id",
@@ -459,7 +464,7 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 	}
 	opts = defaultOperatorRuntimeLogListOptions(opts)
 	cursorClause := ""
-	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType, opts.SessionID}
+	args := []any{opts.RunID, opts.EntityID, opts.Component, opts.Level, opts.ErrorCode, opts.Source, opts.ActionOrEventType, opts.SessionID, opts.BundleHash}
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())
 		cursorClause += fmt.Sprintf(" AND e.created_at > $%d", len(args))
@@ -512,6 +517,12 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'agent_id', e.produced_by, '') = $6)
 		  AND ($7 = '' OR COALESCE(e.payload->'details'->>'action', '') = $7 OR COALESCE(e.payload->'details'->>'event_name', e.payload->'details'->>'event_type', '') = $7)
 		  AND ($8 = '' OR COALESCE(e.payload->'details'->>'session_id', '') = $8)
+		  AND ($9 = '' OR EXISTS (
+		  	SELECT 1
+		  	FROM runs r
+		  	WHERE r.run_id = e.run_id
+		  	  AND r.bundle_hash = $9
+		  ))
 		  %s
 		ORDER BY e.created_at %s, e.event_id::text %s
 		LIMIT $%d
@@ -578,8 +589,14 @@ func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts O
 		  AND e.created_at >= $1
 		  AND ($2 = '' OR COALESCE(e.payload->'details'->>'component', '') = $2)
 		  AND ($3 = '' OR COALESCE(e.payload->>'log_level', '') = $3)
+		  AND ($4 = '' OR EXISTS (
+		  	SELECT 1
+		  	FROM runs r
+		  	WHERE r.run_id = e.run_id
+		  	  AND r.bundle_hash = $4
+		  ))
 		ORDER BY e.created_at DESC, e.event_id::text DESC
-	`, cutoff, opts.Component, opts.Level)
+	`, cutoff, opts.Component, opts.Level, opts.BundleHash)
 	if err != nil {
 		return OperatorRuntimeIncidentListResult{}, fmt.Errorf("list operator runtime incident logs: %w", err)
 	}
@@ -757,6 +774,7 @@ func defaultOperatorEventListOptions(opts OperatorEventListOptions) OperatorEven
 
 func defaultOperatorRuntimeLogListOptions(opts OperatorRuntimeLogListOptions) OperatorRuntimeLogListOptions {
 	opts.RunID = strings.TrimSpace(opts.RunID)
+	opts.BundleHash = strings.TrimSpace(opts.BundleHash)
 	opts.EntityID = strings.TrimSpace(opts.EntityID)
 	opts.SessionID = strings.TrimSpace(opts.SessionID)
 	opts.Component = strings.TrimSpace(opts.Component)
@@ -782,6 +800,7 @@ func defaultOperatorRuntimeLogListOptions(opts OperatorRuntimeLogListOptions) Op
 }
 
 func defaultOperatorRuntimeIncidentListOptions(opts OperatorRuntimeIncidentListOptions) OperatorRuntimeIncidentListOptions {
+	opts.BundleHash = strings.TrimSpace(opts.BundleHash)
 	opts.Component = strings.TrimSpace(opts.Component)
 	opts.Level = strings.TrimSpace(opts.Level)
 	opts.Cursor = strings.TrimSpace(opts.Cursor)

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -373,6 +373,87 @@ func TestOperatorRuntimeLogsFilterBySessionAndTimeWindow(t *testing.T) {
 	}
 }
 
+func TestOperatorRuntimeObservabilityFiltersByBundleHash(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES
+			($1::uuid, 'running', $2, 'persisted', $3),
+			($4::uuid, 'running', $5, 'persisted', $3)
+	`, runA, bundleA, base, runB, bundleB); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	insertLog := func(runID, code string, createdAt time.Time) string {
+		t.Helper()
+		eventID := uuid.NewString()
+		payload := `{
+			"log_level":"error",
+			"message":"runtime failed",
+			"details":{
+				"component":"mcp-gateway",
+				"action":"request_failed",
+				"agent_id":"agent-1",
+				"error":"runtime failed",
+				"error_code":"` + code + `"
+			}
+		}`
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'platform.runtime_log', 'global', $3::jsonb, 'runtime', 'platform', $4)
+		`, eventID, runID, payload, createdAt); err != nil {
+			t.Fatalf("seed runtime log: %v", err)
+		}
+		return eventID
+	}
+	logA := insertLog(runA, "bundle_a_code", base.Add(time.Second))
+	_ = insertLog(runB, "bundle_b_code", base.Add(2*time.Second))
+
+	logs, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		BundleHash: bundleA,
+		Limit:      10,
+		Order:      "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs bundle_hash: %v", err)
+	}
+	if len(logs.Logs) != 1 || logs.Logs[0].LogID != logA || logs.Logs[0].RunID != runA {
+		t.Fatalf("bundle-filtered logs = %#v, want only run A log", logs.Logs)
+	}
+
+	mismatched, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:      runB,
+		BundleHash: bundleA,
+		Limit:      10,
+		Order:      "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs run_id+bundle_hash mismatch: %v", err)
+	}
+	if len(mismatched.Logs) != 0 {
+		t.Fatalf("mismatched run_id+bundle_hash logs = %#v, want none", mismatched.Logs)
+	}
+
+	incidents, err := pg.ListOperatorRuntimeIncidents(ctx, OperatorRuntimeIncidentListOptions{
+		BundleHash: bundleA,
+		SinceHours: 2,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeIncidents bundle_hash: %v", err)
+	}
+	if len(incidents.Incidents) != 1 || incidents.Incidents[0].ErrorCode != "bundle_a_code" {
+		t.Fatalf("bundle-filtered incidents = %#v, want only bundle A aggregate", incidents.Incidents)
+	}
+}
+
 func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/store/run_api_read_surface.go
+++ b/internal/store/run_api_read_surface.go
@@ -27,11 +27,12 @@ type RunHeader struct {
 }
 
 type RunHeaderListOptions struct {
-	Status string
-	Since  *time.Time
-	Until  *time.Time
-	Limit  int
-	Cursor string
+	Status     string
+	BundleHash string
+	Since      *time.Time
+	Until      *time.Time
+	Limit      int
+	Cursor     string
 }
 
 type runHeaderCursor struct {
@@ -41,6 +42,7 @@ type runHeaderCursor struct {
 
 func defaultRunHeaderListOptions(opts RunHeaderListOptions) RunHeaderListOptions {
 	opts.Status = strings.ToLower(strings.TrimSpace(opts.Status))
+	opts.BundleHash = strings.TrimSpace(opts.BundleHash)
 	opts.Cursor = strings.TrimSpace(opts.Cursor)
 	if opts.Limit <= 0 {
 		opts.Limit = 50
@@ -70,7 +72,7 @@ func (s *PostgresStore) requireRunHeaderCapabilities(ctx context.Context) error 
 		return err
 	}
 	required := map[string][]string{
-		"runs":   {"run_id", "status", "trigger_event_id", "trigger_event_type", "forked_from_run_id", "entity_count", "event_count", "error_summary", "started_at", "ended_at"},
+		"runs":   {"run_id", "status", "bundle_hash", "trigger_event_id", "trigger_event_type", "forked_from_run_id", "entity_count", "event_count", "error_summary", "started_at", "ended_at"},
 		"events": {"run_id", "event_id", "event_name", "created_at"},
 	}
 	for tableName, columns := range required {
@@ -125,6 +127,10 @@ func (s *PostgresStore) ListRunHeaders(ctx context.Context, opts RunHeaderListOp
 	if opts.Status != "" {
 		args = append(args, opts.Status)
 		where = append(where, fmt.Sprintf("lower(r.status) = $%d", len(args)))
+	}
+	if opts.BundleHash != "" {
+		args = append(args, opts.BundleHash)
+		where = append(where, fmt.Sprintf("r.bundle_hash = $%d", len(args)))
 	}
 	if opts.Since != nil {
 		args = append(args, opts.Since.UTC())

--- a/internal/store/run_api_read_surface_test.go
+++ b/internal/store/run_api_read_surface_test.go
@@ -22,15 +22,17 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	newerEvent := uuid.NewString()
 	middleEvent := uuid.NewString()
 	olderEvent := uuid.NewString()
+	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (
-			run_id, status, trigger_event_id, trigger_event_type, forked_from_run_id, entity_count, event_count, error_summary, started_at, ended_at
+			run_id, status, bundle_hash, bundle_source, trigger_event_id, trigger_event_type, forked_from_run_id, entity_count, event_count, error_summary, started_at, ended_at
 		)
 		VALUES
-			($1::uuid, 'running', $2::uuid, 'scan.requested', NULL, 3, 2, NULL, $3, NULL),
-			($4::uuid, 'completed', $5::uuid, 'scan.requested', $1::uuid, 5, 1, NULL, $6, $7),
-			($8::uuid, 'failed', $9::uuid, 'scan.failed', NULL, 1, 1, 'boom', $10, $11)
-	`, newer, newerEvent, now, middle, middleEvent, now.Add(-time.Hour), now.Add(-30*time.Minute), older, olderEvent, now.Add(-2*time.Hour), now.Add(-90*time.Minute)); err != nil {
+			($1::uuid, 'running', $2, 'persisted', $3::uuid, 'scan.requested', NULL, 3, 2, NULL, $4, NULL),
+			($5::uuid, 'completed', $6, 'persisted', $7::uuid, 'scan.requested', $1::uuid, 5, 1, NULL, $8, $9),
+			($10::uuid, 'failed', $2, 'persisted', $11::uuid, 'scan.failed', NULL, 1, 1, 'boom', $12, $13)
+	`, newer, bundleA, newerEvent, now, middle, bundleB, middleEvent, now.Add(-time.Hour), now.Add(-30*time.Minute), older, olderEvent, now.Add(-2*time.Hour), now.Add(-90*time.Minute)); err != nil {
 		t.Fatalf("seed runs: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -91,6 +93,20 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	}
 	if len(recent) != 2 {
 		t.Fatalf("recent runs len = %d, want 2: %#v", len(recent), recent)
+	}
+	bundleRuns, _, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{BundleHash: bundleA, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRunHeaders bundle_hash: %v", err)
+	}
+	if len(bundleRuns) != 2 || bundleRuns[0].RunID != newer || bundleRuns[1].RunID != older {
+		t.Fatalf("bundle-filtered runs = %#v, want newer and older only", bundleRuns)
+	}
+	runningBundleRuns, _, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Status: "running", BundleHash: bundleA, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRunHeaders status+bundle_hash: %v", err)
+	}
+	if len(runningBundleRuns) != 1 || runningBundleRuns[0].RunID != newer {
+		t.Fatalf("status+bundle-filtered runs = %#v, want newer only", runningBundleRuns)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #1021.

Implements the gate-approved first slice for non-agent multi-bundle-safe API read/list scoping:

- requires explicit `filter.run_id` for `event.list` and `event.subscribe`
- adds canonical `bundle_hash` filters to `run.list`, `runtime.logs`, `runtime.subscribe_logs`, and `runtime.incidents`
- keeps single-ID reads row-resolved and unchanged
- keeps `agent.*` slug/catalog strictness split to #977 and #1017

## Governing Refs / Context

- #1021 Pre-Implementation Coverage Audit and recorded gate outcome: `approved as first slice`
- `platform-spec.yaml#api_specification.method_catalog`
- `platform-spec.yaml#api_specification.components.schemas.EventListFilter`
- `platform-spec.yaml#multi_bundle_persistence.bundle_aware_existing_methods_planned`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apispec` validation and `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`

## Semantic Migration

- New canonical owners:
  - API contract: `platform-spec.yaml#api_specification` plus generated OpenRPC
  - event run scope: `OperatorEventListFilter` consumed by `event.list` and `event.subscribe`
  - run bundle filtering: `RunHeaderListOptions` / `ListRunHeaders`
  - runtime log bundle filtering: `OperatorRuntimeLogListOptions` / `ListOperatorRuntimeLogs`, consumed by `runtime.logs` and `runtime.subscribe_logs`
  - runtime incident bundle filtering: `OperatorRuntimeIncidentListOptions` / `ListOperatorRuntimeIncidents`
- Old invalid path:
  - unscoped `event.list` / `event.subscribe` as public event firehose behavior
  - runtime list/stream/incident readers bypassing canonical `runs.bundle_hash` when a bundle selector is supplied
- Production paths checked for surviving old behavior:
  - `/v1/rpc event.list`
  - `/v1/ws event.subscribe`
  - `/v1/rpc run.list`
  - `/v1/rpc runtime.logs`
  - `/v1/ws runtime.subscribe_logs`
  - `/v1/rpc runtime.incidents`
  - single-ID read methods stayed row-resolved with no caller-supplied bundle context
- Migration completeness:
  - complete for the approved non-agent read/list slice
  - parent multi-bundle API work remains open for #977/#1017/#1022 siblings; this PR does not claim strict `agent.*` slug/catalog closure

## Tests

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 ./internal/store -run 'OpenRPC|ReadOnly|WebSocket|Compliance|OperatorObservability|RunAPIReadSurface|RuntimeObservability|RuntimeLogsFilterBySession|EventListFilter|RunListRejectsInvalid|ExposeHealthAndRun' -count=1`
- `go test ./internal/runtime/cataloge2e ./internal/runtime/tools -count=1`
- `go test ./...`
