### PR TITLE
[agent-g][issue #1084] Canonicalize runtime store backend selection

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -127,6 +127,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if opts.NoRequireBundleMatch {
 				opts.RequireBundleMatch = false
 			}
+			opts.StoreModeSet = cmd.Flags().Changed("store")
 			if opts.ShutdownGrace <= 0 {
 				return fmt.Errorf("--shutdown-grace must be a positive duration")
 			}
@@ -161,7 +162,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", opts.ConfigPath, "Optional path to Swarm runtime config")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
-	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Store mode: postgres")
+	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (recognized but unsupported until #1085-#1088)")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")

--- a/cmd/swarm/cli_paths_test.go
+++ b/cmd/swarm/cli_paths_test.go
@@ -10,6 +10,7 @@ import (
 
 	"swarm/internal/config"
 	"swarm/internal/runtime"
+	storebackend "swarm/internal/store/backendselection"
 )
 
 func TestResolveCLIContractPlatformSpecPathsPrecedenceAndDiscovery(t *testing.T) {
@@ -201,7 +202,7 @@ func TestRunServeRuntimeConsumesContractPathResolverBeforeBundleLoad(t *testing.
 		"contracts_path": configContracts,
 	}))
 	originalBuildStores := buildStoresForServe
-	buildStoresForServe = func(context.Context, string, *config.Config) (storeBundle, error) {
+	buildStoresForServe = func(context.Context, storebackend.Selection, *config.Config) (storeBundle, error) {
 		return storeBundle{}, nil
 	}
 	t.Cleanup(func() {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -47,6 +47,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
+	storebackend "swarm/internal/store/backendselection"
 )
 
 const (
@@ -115,6 +116,7 @@ type serveOptions struct {
 	ContractsPath        string
 	PlatformSpecPath     string
 	StoreMode            string
+	StoreModeSet         bool
 	APIListenAddr        string
 	MCPListenAddr        string
 	ShutdownGrace        time.Duration
@@ -129,7 +131,7 @@ type serveOptions struct {
 
 func defaultServeOptions() serveOptions {
 	return serveOptions{
-		StoreMode:          "postgres",
+		StoreMode:          storebackend.ActiveDefaultBackend().String(),
 		APIListenAddr:      defaultAPIListenAddr,
 		MCPListenAddr:      defaultMCPListenAddr,
 		ShutdownGrace:      runtime.DefaultShutdownGrace,
@@ -179,13 +181,19 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	reporter.emit(2, "config_load", "ok", fmt.Sprintf("config=%s contracts=%s", filepath.Clean(resolvedConfigPath), filepath.Clean(resolvedContractsPath)))
-	stores, err := buildStoresForServe(ctx, opts.StoreMode, cfg)
+	storeSelection, err := resolveRuntimeStoreSelection(repo, opts.StoreMode, opts.StoreModeSet, cfg)
+	if err != nil {
+		reporter.emit(3, "db_connection", "FAILED", err.Error())
+		log.Printf("resolve store backend: %v", err)
+		return 1
+	}
+	stores, err := buildStoresForServe(ctx, storeSelection, cfg)
 	if err != nil {
 		reporter.emit(3, "db_connection", "FAILED", err.Error())
 		log.Printf("init stores: %v", err)
 		return 1
 	}
-	reporter.emit(3, "db_connection", "ok", opts.StoreMode)
+	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
@@ -642,7 +650,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
 	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for fork planning or selected-contract execution")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
-	storeMode := fs.String("store", "postgres", "Store mode: postgres")
+	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), "Runtime store backend: postgres (active default) or sqlite (recognized but unsupported until #1085-#1088)")
 	runID := fs.String("run", "", "Source run ID to plan from")
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
@@ -655,6 +663,12 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 		}
 		return 2
 	}
+	storeModeSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "store" {
+			storeModeSet = true
+		}
+	})
 	modeCount := 0
 	for _, enabled := range []bool{*dryRun, *materializeOnly, *activate} {
 		if enabled {
@@ -693,7 +707,14 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 		}
 		return 1
 	}
-	stores, err := buildStores(ctx, *storeMode, cfg)
+	storeSelection, err := resolveRuntimeStoreSelection(repo, *storeMode, storeModeSet, cfg)
+	if err != nil {
+		if out != nil {
+			fmt.Fprintf(out, "fork failed: resolve store backend: %v\n", err)
+		}
+		return 1
+	}
+	stores, err := buildStores(ctx, storeSelection, cfg)
 	if err != nil {
 		if out != nil {
 			fmt.Fprintf(out, "fork failed: init stores: %v\n", err)
@@ -1412,6 +1433,25 @@ func defaultRuntimeConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
+func resolveRuntimeStoreSelection(repo string, storeMode string, storeModeSet bool, cfg *config.Config) (storebackend.Selection, error) {
+	if cfg == nil {
+		return storebackend.Selection{}, errors.New("runtime config is required")
+	}
+	envBackend, envBackendSet := os.LookupEnv(storebackend.EnvStoreBackend)
+	envSQLitePath, envSQLitePathSet := os.LookupEnv(storebackend.EnvSQLitePath)
+	return storebackend.Resolve(storebackend.Input{
+		RepoRoot:         repo,
+		FlagBackend:      storeMode,
+		FlagBackendSet:   storeModeSet,
+		EnvBackend:       envBackend,
+		EnvBackendSet:    envBackendSet,
+		ConfigBackend:    cfg.Store.Backend,
+		EnvSQLitePath:    envSQLitePath,
+		EnvSQLitePathSet: envSQLitePathSet,
+		ConfigSQLitePath: cfg.Store.SQLite.Path,
+	})
+}
+
 func rejectUnsupportedRuntimeControlEnv() error {
 	unsupported := make([]string, 0, 2)
 	if _, ok := os.LookupEnv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS"); ok {
@@ -1570,9 +1610,12 @@ func resolvePath(repoRoot, path string) string {
 	return filepath.Join(repoRoot, path)
 }
 
-func buildStores(ctx context.Context, storeMode string, cfg *config.Config) (storeBundle, error) {
-	switch strings.ToLower(strings.TrimSpace(storeMode)) {
-	case "postgres":
+func buildStores(ctx context.Context, selection storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+	if cfg == nil {
+		return storeBundle{}, errors.New("runtime config is required")
+	}
+	switch selection.Backend {
+	case storebackend.BackendPostgres:
 		dsn := store.DSNFromConfig(cfg.Database)
 		pg, err := store.NewPostgresStore(dsn)
 		if err != nil {
@@ -1594,8 +1637,10 @@ func buildStores(ctx context.Context, storeMode string, cfg *config.Config) (sto
 			ScheduleStore:     pg,
 			TurnStore:         pg,
 		}, nil
+	case storebackend.BackendSQLite:
+		return storeBundle{}, storebackend.SQLiteUnsupportedRuntimeError(selection.SQLitePath)
 	default:
-		return storeBundle{}, fmt.Errorf("store mode %q is unsupported; postgres is required", strings.TrimSpace(storeMode))
+		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -38,6 +38,7 @@ import (
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
+	storebackend "swarm/internal/store/backendselection"
 	"swarm/internal/testutil"
 )
 
@@ -4208,7 +4209,7 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPostgresStore: %v", err)
 	}
-	buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
+	buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
 		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
@@ -4298,7 +4299,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewPostgresStore: %v", err)
 			}
-			buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
+			buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
 				if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 					return storeBundle{}, err
 				}
@@ -4462,7 +4463,7 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 	if err != nil {
 		t.Fatalf("NewPostgresStore: %v", err)
 	}
-	buildStoresForServe = func(ctx context.Context, _ string, cfg *config.Config) (storeBundle, error) {
+	buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
 		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -136,6 +136,9 @@ func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	if serveOpts.MCPListenAddr != defaultMCPListenAddr {
 		t.Fatalf("mcp listen addr = %q, want unchanged default %q", serveOpts.MCPListenAddr, defaultMCPListenAddr)
 	}
+	if serveOpts.StoreMode != "postgres" || serveOpts.StoreModeSet {
+		t.Fatalf("store opts = mode %q set %v, want staged postgres default with no flag source", serveOpts.StoreMode, serveOpts.StoreModeSet)
+	}
 }
 
 func TestRunCommandConnectedNoFollowUsesHealthAndRunStartOnly(t *testing.T) {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"swarm/internal/config"
+	"swarm/internal/runtime"
+	storebackend "swarm/internal/store/backendselection"
+)
+
+func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
+	t.Run("staged default remains postgres", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
+		if got.Backend != storebackend.BackendPostgres || got.BackendSource != storebackend.SourceRolloutDefault {
+			t.Fatalf("selection = %#v, want staged postgres rollout default", got)
+		}
+	})
+
+	t.Run("env beats runtime config", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{
+			Store: config.StoreConfig{Backend: storebackend.BackendSQLite.String()},
+		})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
+		if got.Backend != storebackend.BackendPostgres || got.BackendSource != storebackend.SourceEnvironment {
+			t.Fatalf("selection = %#v, want env-selected postgres", got)
+		}
+	})
+
+	t.Run("flag beats env and config", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		repo := t.TempDir()
+		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		got, err := resolveRuntimeStoreSelection(repo, storebackend.BackendSQLite.String(), true, &config.Config{
+			Store: config.StoreConfig{
+				Backend: storebackend.BackendPostgres.String(),
+				SQLite:  config.StoreSQLiteConfig{Path: "config/dev.db"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
+		if got.Backend != storebackend.BackendSQLite || got.BackendSource != storebackend.SourceFlag {
+			t.Fatalf("selection = %#v, want flag-selected sqlite", got)
+		}
+		if want := filepath.Join(repo, "config", "dev.db"); got.SQLitePath != want {
+			t.Fatalf("sqlite path = %q, want %q", got.SQLitePath, want)
+		}
+	})
+}
+
+func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t *testing.T) {
+	tests := []struct {
+		name        string
+		storeMode   string
+		storeFlag   bool
+		envBackend  string
+		configStore string
+		wantBackend storebackend.Backend
+		wantSource  storebackend.Source
+	}{
+		{
+			name:        "flag postgres reaches store construction",
+			storeMode:   storebackend.BackendPostgres.String(),
+			storeFlag:   true,
+			envBackend:  storebackend.BackendSQLite.String(),
+			configStore: storebackend.BackendSQLite.String(),
+			wantBackend: storebackend.BackendPostgres,
+			wantSource:  storebackend.SourceFlag,
+		},
+		{
+			name:        "env postgres reaches store construction",
+			storeMode:   storebackend.ActiveDefaultBackend().String(),
+			envBackend:  storebackend.BackendPostgres.String(),
+			configStore: storebackend.BackendSQLite.String(),
+			wantBackend: storebackend.BackendPostgres,
+			wantSource:  storebackend.SourceEnvironment,
+		},
+		{
+			name:        "config postgres reaches store construction",
+			storeMode:   storebackend.ActiveDefaultBackend().String(),
+			configStore: storebackend.BackendPostgres.String(),
+			wantBackend: storebackend.BackendPostgres,
+			wantSource:  storebackend.SourceRuntimeConfig,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetStoreSelectorEnv(t)
+			if tt.envBackend != "" {
+				t.Setenv(storebackend.EnvStoreBackend, tt.envBackend)
+			}
+			oldBuildStores := buildStoresForServe
+			var captured storebackend.Selection
+			buildStoresForServe = func(_ context.Context, selection storebackend.Selection, _ *config.Config) (storeBundle, error) {
+				captured = selection
+				return storeBundle{}, errors.New("stop after selector proof")
+			}
+			t.Cleanup(func() {
+				buildStoresForServe = oldBuildStores
+			})
+
+			var out bytes.Buffer
+			code := runServeRuntime(context.Background(), t.TempDir(), serveOptions{
+				ConfigPath:         writeStoreBackendRuntimeConfig(t, tt.configStore, "config/dev.db"),
+				StoreMode:          tt.storeMode,
+				StoreModeSet:       tt.storeFlag,
+				APIListenAddr:      defaultAPIListenAddr,
+				MCPListenAddr:      defaultMCPListenAddr,
+				ShutdownGrace:      runtime.DefaultShutdownGrace,
+				SelfCheck:          true,
+				RequireBundleMatch: true,
+				Verbose:            true,
+				Output:             &out,
+			})
+			if code != 1 {
+				t.Fatalf("runServeRuntime code = %d, want selector proof failure 1; output=%s", code, out.String())
+			}
+			if captured.Backend != tt.wantBackend || captured.BackendSource != tt.wantSource {
+				t.Fatalf("selection = %#v, want %s from %s", captured, tt.wantBackend, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestServeCommandCapturesStoreFlagForCanonicalResolver(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--store", "sqlite"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d, want 0 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if captured.StoreMode != storebackend.BackendSQLite.String() || !captured.StoreModeSet {
+		t.Fatalf("serve store opts = mode %q set %v, want sqlite set=true", captured.StoreMode, captured.StoreModeSet)
+	}
+}
+
+func TestServeHelpDocumentsStagedStoreBackends(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--help"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("serve --help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Runtime store backend", "postgres (active default)", "sqlite (recognized but unsupported until #1085-#1088)"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestBuildStoresRejectsSQLiteBeforeRuntimeSupport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dev.db")
+	_, err := buildStores(context.Background(), storebackend.Selection{
+		Backend:          storebackend.BackendSQLite,
+		BackendSource:    storebackend.SourceFlag,
+		SQLitePath:       path,
+		SQLitePathSource: storebackend.SourceRolloutDefault,
+	}, &config.Config{})
+	if err == nil {
+		t.Fatal("buildStores unexpectedly accepted sqlite before runtime support exists")
+	}
+	for _, want := range []string{"SQLite runtime stores are not implemented yet", "#1085-#1088", path} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath string) string {
+	t.Helper()
+	lines := []string{
+		"runtime:",
+		"  recovery_on_startup: false",
+	}
+	if strings.TrimSpace(backend) != "" || strings.TrimSpace(sqlitePath) != "" {
+		lines = append(lines,
+			"store:",
+			"  backend: "+backend,
+			"  sqlite:",
+			"    path: "+sqlitePath,
+		)
+	}
+	lines = append(lines,
+		"llm:",
+		"  backend: api",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	)
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
+	return path
+}
+
+func unsetStoreSelectorEnv(t *testing.T) {
+	t.Helper()
+	unsetEnvForTest(t, storebackend.EnvStoreBackend)
+	unsetEnvForTest(t, storebackend.EnvSQLitePath)
+}
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	previous, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, previous)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2096,6 +2096,96 @@ engine:
       replays events through the same tracking — already-received items are skipped, accumulator state is consistent.
     cleanup: After completion fires and the handler commits, the accumulator record can be archived or deleted. The entity
       has moved past the accumulation state.
+  runtime_store_backend_selection:
+    promoted_by: '#1084'
+    parent_tracker: '#1066'
+    canonical_owner: internal/store/backendselection runtime store backend resolver
+    description: >
+      Runtime store backend selection is owned by one typed resolver before runtime store construction. CLI flags,
+      environment variables, runtime config, harnesses, and local foreground startup may collect selector input, but they
+      must consume this owner rather than interpreting backend strings independently.
+    backend_ids:
+      postgres:
+        status: active_supported_runtime_backend
+        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
+      sqlite:
+        status: staged_selector_only_until_runtime_portability_lands
+        meaning: >
+          Local/dev SQLite runtime store. #1084 may recognize this backend and resolve its path, but runtime store
+          construction must fail closed until the SQLite schema/store/session/delivery/trace children prove support.
+    selector_precedence:
+      source_order:
+      - flag
+      - environment
+      - runtime_config
+      - rollout_default
+      flag:
+        command: swarm serve
+        name: --store <backend>
+      environment:
+        backend: SWARM_STORE_BACKEND
+      runtime_config:
+        backend_key: store.backend
+      rollout_default:
+        active_no_selection_default_until_sqlite_runtime_support: postgres
+        future_local_dev_default_after_supported_surface_proof: sqlite
+        rule: >
+          No-selection must not expose a broken SQLite runtime default before #1088 proves the supported SQLite runtime
+          path and explicit Postgres opt-in path together.
+    sqlite_path:
+      canonical_owner: internal/store/backendselection SQLite path resolver
+      environment: SWARM_SQLITE_PATH
+      runtime_config_key: store.sqlite.path
+      default_repo_relative_path: .swarm/dev.db
+      source_order:
+      - environment
+      - runtime_config
+      - rollout_default
+      lifecycle:
+      - The default path is repo-relative.
+      - Runtime SQLite support must create parent directories on demand when the SQLite backend is implemented.
+      - The SQLite file is persistent until the operator deletes it.
+      - The runtime must never silently replace the local/dev SQLite store with an in-memory database.
+    postgres_connection_details:
+      env_vars:
+      - SWARM_DB_HOST
+      - SWARM_DB_PORT
+      - SWARM_DB_NAME
+      - SWARM_DB_USER
+      - SWARM_DB_PASSWORD
+      - SWARM_DB_SSLMODE
+      - SWARM_DB_POOL_SIZE
+      - PGHOST
+      - PGPORT
+      - PGDATABASE
+      - PGUSER
+      - PGPASSWORD
+      config_prefix: database.*
+      rule: >
+        Existing SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
+        selector resolves to postgres. They are not generic backend selectors and must not imply backend selection by
+        presence alone.
+    staged_runtime_rule:
+    - Unsupported backend ids fail closed with supported backend guidance.
+    - >
+      Explicit sqlite selection is recognized as a canonical backend id but must fail closed before runtime store construction
+      until #1085-#1088 close the runtime portability tail.
+    - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
+      existing Postgres runtime store path.
+    required_consumers:
+    - cmd/swarm defaultServeOptions
+    - cmd/swarm swarm serve --store
+    - cmd/swarm runServeRuntime and buildStoresForServe
+    - cmd/swarm buildStores
+    - cmd/swarm startLocalRunServe through inherited serve options
+    - cmd/swarm runForkRuntimeOwnerHarness
+    - runtime config loading for store.backend and store.sqlite.path
+    split_boundaries:
+    - "SQLite dialect/schema/bootstrap remains split to #1085."
+    - "Backend-neutral core runtime persistence stores remain split to #1086."
+    - "SQLite sessions, locking, delivery, replay, and trace-stream semantics remain split to #1087."
+    - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
+    - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   agent_session_management:
     description: The platform manages agent sessions — the lifecycle of an agent from receiving an event to completing its
       response.

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -81,6 +81,34 @@ active_issues:
     title: Canonicalize LLM provider selection/config authority
     maps_to:
       - llm_provider_selection_config_authority
+  - id: 1066
+    title: Default to SQLite (Postgres as opt-in external DB) to minimize onboarding friction
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1084
+    title: Define canonical store backend selection and local SQLite path authority
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1085
+    title: Add SQLite dialect, schema bootstrap, and backend capability ownership
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1086
+    title: Port core runtime persistence stores to backend-neutral SQLite/Postgres contracts
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1087
+    title: Port session, locking, delivery, replay, and trace-stream semantics for SQLite local runtime
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1088
+    title: Flip local/dev default to SQLite and prove zero-service swarm run plus Postgres opt-in
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
+  - id: 1089
+    title: Close SQLite-default rollout with docs, CI, repo-wide old-path audit, and parent proof
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
   - id: 175
     title: Add first-class launch, stalled-run, and long-running session observability
     maps_to:
@@ -316,6 +344,39 @@ nodes:
         - add one factory switch case
         - add one env var alias while keeping runtime_mode as semantic owner
         - validate config without moving runtime/store/model consumers
+    current_action_pressure: active
+  - id: runtime_store_backend_default_and_sqlite_portability
+    title: Runtime Store Backend Default And SQLite Portability
+    parent_class: runtime store backend default and durable SQLite local/dev portability
+    canonical_owners:
+      - docs/specs/swarm-platform/platform/contracts/platform-spec.yaml runtime_store_backend_selection
+      - internal/store/backendselection runtime store backend resolver and SQLite path resolver
+      - "future SQLite schema/store/session/delivery/trace owners tracked by #1085-#1088 before public default flip"
+    why_this_node_exists: Runtime store semantics drift when CLI defaults, env/config loading, runtime store construction, schema bootstrap, session locking, event delivery/replay, trace reads, docs, and CI each infer Postgres or SQLite support independently.
+    known_manifestations:
+      - "#1084 owns canonical backend ids postgres/sqlite, selector precedence flag > environment > runtime config > rollout default, SWARM_STORE_BACKEND, SWARM_SQLITE_PATH, store.backend, store.sqlite.path, and the staged SQLite path authority."
+      - "#1085 must own SQLite dialect, schema bootstrap, and backend capability binding before SQLite can construct runtime stores."
+      - "#1086 must port core runtime persistence stores behind backend-neutral SQLite/Postgres contracts."
+      - "#1087 must port session, locking, delivery, replay, and trace-stream semantics for the SQLite local runtime path."
+      - "#1088 must flip the active local/dev default to SQLite only after zero-service swarm run and explicit Postgres opt-in are proven together."
+      - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes."
+    representative_issues:
+      - 1066
+      - 1084
+      - 1085
+      - 1086
+      - 1087
+      - 1088
+      - 1089
+    common_framing_mistakes:
+      too_broad:
+        - make SQLite production-ready in the local/dev default rollout
+        - port all persistence backends in the selector child
+      too_narrow:
+        - flip defaultServeOptions without moving the selector/path owner
+        - add --store sqlite while runtime construction still falls through or silently uses Postgres
+        - treat SWARM_DB_* or PG* variables as generic backend selectors
+        - document SQLite as supported before runtime store/session/delivery/trace proof exists
     current_action_pressure: active
   - id: transport_policy_and_surface_parity
     title: Transport Policy And Surface Parity

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	Runtime    RuntimeConfig  `yaml:"runtime"`
 	Database   DatabaseConfig `yaml:"database"`
+	Store      StoreConfig    `yaml:"store"`
 	LLM        LLMConfig      `yaml:"llm"`
 	Extensions map[string]any `yaml:",inline"`
 
@@ -38,6 +39,15 @@ type DatabaseConfig struct {
 	Password string `yaml:"password"`
 	SSLMode  string `yaml:"sslmode"`
 	PoolSize int    `yaml:"pool_size"`
+}
+
+type StoreConfig struct {
+	Backend string            `yaml:"backend"`
+	SQLite  StoreSQLiteConfig `yaml:"sqlite"`
+}
+
+type StoreSQLiteConfig struct {
+	Path string `yaml:"path"`
 }
 
 type LLMConfig struct {

--- a/internal/store/backendselection/selection.go
+++ b/internal/store/backendselection/selection.go
@@ -1,0 +1,156 @@
+package backendselection
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type Backend string
+
+const (
+	BackendPostgres Backend = "postgres"
+	BackendSQLite   Backend = "sqlite"
+
+	EnvStoreBackend = "SWARM_STORE_BACKEND"
+	EnvSQLitePath   = "SWARM_SQLITE_PATH"
+
+	ConfigStoreBackendKey = "store.backend"
+	ConfigSQLitePathKey   = "store.sqlite.path"
+
+	DefaultSQLiteRelativePath = ".swarm/dev.db"
+)
+
+type Source string
+
+const (
+	SourceFlag           Source = "flag"
+	SourceEnvironment    Source = "environment"
+	SourceRuntimeConfig  Source = "runtime_config"
+	SourceRolloutDefault Source = "rollout_default"
+)
+
+type Input struct {
+	RepoRoot string
+
+	FlagBackend    string
+	FlagBackendSet bool
+
+	EnvBackend    string
+	EnvBackendSet bool
+
+	ConfigBackend string
+
+	EnvSQLitePath    string
+	EnvSQLitePathSet bool
+
+	ConfigSQLitePath string
+}
+
+type Selection struct {
+	Backend          Backend
+	BackendSource    Source
+	SQLitePath       string
+	SQLitePathSource Source
+}
+
+func (b Backend) String() string {
+	return string(b)
+}
+
+func ActiveDefaultBackend() Backend {
+	return BackendPostgres
+}
+
+func FutureDefaultBackend() Backend {
+	return BackendSQLite
+}
+
+func Resolve(in Input) (Selection, error) {
+	backend, source, err := resolveBackend(in)
+	if err != nil {
+		return Selection{}, err
+	}
+	selection := Selection{
+		Backend:       backend,
+		BackendSource: source,
+	}
+	if backend != BackendSQLite {
+		return selection, nil
+	}
+	path, pathSource, err := resolveSQLitePath(in)
+	if err != nil {
+		return Selection{}, err
+	}
+	selection.SQLitePath = path
+	selection.SQLitePathSource = pathSource
+	return selection, nil
+}
+
+func SQLiteUnsupportedRuntimeError(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = filepath.Clean(DefaultSQLiteRelativePath)
+	}
+	return fmt.Errorf("store backend %q is recognized but SQLite runtime stores are not implemented yet; runtime support remains tracked by #1085-#1088 (sqlite_path=%s)", BackendSQLite, path)
+}
+
+func resolveBackend(in Input) (Backend, Source, error) {
+	switch {
+	case in.FlagBackendSet:
+		backend, err := parseBackend(in.FlagBackend, SourceFlag)
+		return backend, SourceFlag, err
+	case in.EnvBackendSet:
+		backend, err := parseBackend(in.EnvBackend, SourceEnvironment)
+		return backend, SourceEnvironment, err
+	case strings.TrimSpace(in.ConfigBackend) != "":
+		backend, err := parseBackend(in.ConfigBackend, SourceRuntimeConfig)
+		return backend, SourceRuntimeConfig, err
+	default:
+		return ActiveDefaultBackend(), SourceRolloutDefault, nil
+	}
+}
+
+func parseBackend(raw string, source Source) (Backend, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", fmt.Errorf("store backend from %s must be non-empty", source)
+	}
+	switch Backend(value) {
+	case BackendPostgres:
+		return BackendPostgres, nil
+	case BackendSQLite:
+		return BackendSQLite, nil
+	default:
+		return "", fmt.Errorf("unsupported store backend %q from %s; supported backends: %s, %s", strings.TrimSpace(raw), source, BackendPostgres, BackendSQLite)
+	}
+}
+
+func resolveSQLitePath(in Input) (string, Source, error) {
+	switch {
+	case in.EnvSQLitePathSet:
+		path, err := normalizeSQLitePath(in.RepoRoot, in.EnvSQLitePath, SourceEnvironment)
+		return path, SourceEnvironment, err
+	case strings.TrimSpace(in.ConfigSQLitePath) != "":
+		path, err := normalizeSQLitePath(in.RepoRoot, in.ConfigSQLitePath, SourceRuntimeConfig)
+		return path, SourceRuntimeConfig, err
+	default:
+		path, err := normalizeSQLitePath(in.RepoRoot, DefaultSQLiteRelativePath, SourceRolloutDefault)
+		return path, SourceRolloutDefault, err
+	}
+}
+
+func normalizeSQLitePath(repoRoot, raw string, source Source) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("sqlite path from %s must be non-empty", source)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	root := strings.TrimSpace(repoRoot)
+	if root == "" {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Clean(filepath.Join(root, path)), nil
+}

--- a/internal/store/backendselection/selection_test.go
+++ b/internal/store/backendselection/selection_test.go
@@ -1,0 +1,177 @@
+package backendselection
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveBackendSourcePrecedence(t *testing.T) {
+	repo := t.TempDir()
+	tests := []struct {
+		name string
+		in   Input
+		want Backend
+		src  Source
+	}{
+		{
+			name: "flag beats environment and config",
+			in: Input{
+				RepoRoot:       repo,
+				FlagBackend:    "sqlite",
+				FlagBackendSet: true,
+				EnvBackend:     "postgres",
+				EnvBackendSet:  true,
+				ConfigBackend:  "postgres",
+			},
+			want: BackendSQLite,
+			src:  SourceFlag,
+		},
+		{
+			name: "environment beats config",
+			in: Input{
+				RepoRoot:      repo,
+				EnvBackend:    "sqlite",
+				EnvBackendSet: true,
+				ConfigBackend: "postgres",
+			},
+			want: BackendSQLite,
+			src:  SourceEnvironment,
+		},
+		{
+			name: "runtime config beats rollout default",
+			in: Input{
+				RepoRoot:      repo,
+				ConfigBackend: "sqlite",
+			},
+			want: BackendSQLite,
+			src:  SourceRuntimeConfig,
+		},
+		{
+			name: "rollout default remains postgres until SQLite runtime support lands",
+			in: Input{
+				RepoRoot: repo,
+			},
+			want: BackendPostgres,
+			src:  SourceRolloutDefault,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve(tt.in)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.Backend != tt.want || got.BackendSource != tt.src {
+				t.Fatalf("selection = backend %q source %q, want %q from %q", got.Backend, got.BackendSource, tt.want, tt.src)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsInvalidSelectedBackend(t *testing.T) {
+	_, err := Resolve(Input{EnvBackend: "mysql", EnvBackendSet: true})
+	if err == nil {
+		t.Fatal("Resolve unexpectedly accepted invalid backend")
+	}
+	if !strings.Contains(err.Error(), "unsupported store backend") || !strings.Contains(err.Error(), "postgres, sqlite") {
+		t.Fatalf("error = %v, want supported backend guidance", err)
+	}
+}
+
+func TestResolveIgnoresInvalidLowerPriorityConfigBackend(t *testing.T) {
+	got, err := Resolve(Input{
+		FlagBackend:    "postgres",
+		FlagBackendSet: true,
+		ConfigBackend:  "mysql",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Backend != BackendPostgres || got.BackendSource != SourceFlag {
+		t.Fatalf("selection = %#v, want flag-selected postgres", got)
+	}
+}
+
+func TestResolveSQLitePathSources(t *testing.T) {
+	repo := t.TempDir()
+	tests := []struct {
+		name string
+		in   Input
+		want string
+		src  Source
+	}{
+		{
+			name: "env path beats config",
+			in: Input{
+				RepoRoot:         repo,
+				FlagBackend:      "sqlite",
+				FlagBackendSet:   true,
+				EnvSQLitePath:    "env/dev.db",
+				EnvSQLitePathSet: true,
+				ConfigSQLitePath: "config/dev.db",
+			},
+			want: filepath.Join(repo, "env", "dev.db"),
+			src:  SourceEnvironment,
+		},
+		{
+			name: "config path beats default",
+			in: Input{
+				RepoRoot:         repo,
+				FlagBackend:      "sqlite",
+				FlagBackendSet:   true,
+				ConfigSQLitePath: "config/dev.db",
+			},
+			want: filepath.Join(repo, "config", "dev.db"),
+			src:  SourceRuntimeConfig,
+		},
+		{
+			name: "default path is repo relative",
+			in: Input{
+				RepoRoot:       repo,
+				FlagBackend:    "sqlite",
+				FlagBackendSet: true,
+			},
+			want: filepath.Join(repo, ".swarm", "dev.db"),
+			src:  SourceRolloutDefault,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve(tt.in)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.SQLitePath != tt.want || got.SQLitePathSource != tt.src {
+				t.Fatalf("sqlite path = %q source %q, want %q from %q", got.SQLitePath, got.SQLitePathSource, tt.want, tt.src)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsEmptyExplicitSQLitePath(t *testing.T) {
+	_, err := Resolve(Input{
+		FlagBackend:      "sqlite",
+		FlagBackendSet:   true,
+		EnvSQLitePath:    " ",
+		EnvSQLitePathSet: true,
+	})
+	if err == nil {
+		t.Fatal("Resolve unexpectedly accepted empty explicit SQLite path")
+	}
+	if !strings.Contains(err.Error(), "sqlite path from environment must be non-empty") {
+		t.Fatalf("error = %v, want empty path guidance", err)
+	}
+}
+
+func TestSQLiteUnsupportedRuntimeErrorNamesTrackedTail(t *testing.T) {
+	err := SQLiteUnsupportedRuntimeError(filepath.Join("tmp", "dev.db"))
+	if err == nil {
+		t.Fatal("SQLiteUnsupportedRuntimeError returned nil")
+	}
+	for _, want := range []string{"sqlite", "#1085-#1088", "tmp"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1084
Part of #1066

## Summary
- Adds `internal/store/backendselection` as the canonical runtime store backend and SQLite path resolver.
- Moves `swarm serve`, local foreground `swarm run` inherited serve options, `runServeRuntime`, `buildStores`, and the non-public fork runtime owner harness to consume typed backend selection instead of interpreting raw store-mode strings.
- Promotes the store backend selector/path contract into `platform-spec.yaml` and adds the #1066/#1084-#1089 watchlist mapping.

## Governing refs/context
- Issue #1084 and its approved gate: `runtime.store_backend_selection_and_local_sqlite_path_authority` first slice under #1066.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#engine.runtime_store_backend_selection` added in this PR because no exact governing spec section existed before this slice.
- Adjacent parent context: #1066 remains open for SQLite schema/runtime/session/delivery/trace/default-flip/docs/CI work split across #1085-#1089.

## Semantic migration
- New canonical owner: `internal/store/backendselection` for backend IDs, selector precedence, staged active default, and SQLite path resolution.
- Canonical backend IDs: `postgres`, `sqlite`.
- Canonical selector precedence: flag > environment > runtime config > rollout default.
- Canonical env/config: `SWARM_STORE_BACKEND`, `SWARM_SQLITE_PATH`, `store.backend`, `store.sqlite.path`.
- Old paths now invalid as owners: raw `StoreMode` interpretation in `buildStores`, `defaultServeOptions` as an independent default owner, Cobra/harness help saying only Postgres exists, and treating `SWARM_DB_*` / `PG*` as generic selector inputs.
- Production paths checked: `swarm serve`, `swarm run` local foreground via inherited serve options, `runServeRuntime`/`buildStoresForServe`, `buildStores`, `runForkRuntimeOwnerHarness`, runtime config/env loading.
- Migration completeness: complete for the approved selector/path child; #1066 parent remains open for SQLite runtime support and active default flip.

## Proof
- `go test ./...`