### PR TITLE
[agent-c][issue #1100] Reconcile runtime external boot checks

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2979,8 +2979,9 @@ engine:
     - id: credential_key_exists
       severity: warning
       scope: global
-      trigger: A tool's credentials field or an MCP server's credentials_key references a credential key that does not exist
-        in the credential store (any tier). The tool may be unconfigured in this deployment.
+      trigger: A tool's credentials field, an MCP server's credentials_key, or policy.web_search_provider.credentials_key
+        references a credential key that does not exist in the credential store (any tier). The tool may be unconfigured in
+        this deployment.
       when: boot-only
     - id: agent_permission_validation
       severity: error
@@ -3525,11 +3526,13 @@ tool_model:
       docker: Environment variables (env tier). File store optionally mounted as a volume for builder access.
       production: Environment variables for secrets, or external secrets manager (Vault, AWS Secrets Manager) via a custom
         store tier implementation. The overlay model supports additional tiers — the platform resolves top-down.
-    contract_reference: Tools and MCP servers reference credentials by key name, never by value. The key name appears in
-      tools.yaml (credentials field) and policy.yaml (mcp_servers.*.credentials_key). The platform resolves the key to the
-      secret value at call time only.
-    boot_validation: At boot, the platform checks that every credential key referenced by tools and MCP servers exists in the
-      credential store (any tier). Missing keys log a warning — the tool may be unconfigured in this deployment.
+    contract_reference: Tools, MCP servers, and native web-search provider configuration reference credentials by key name,
+      never by value. The key name appears in tools.yaml (credentials field), policy.yaml (mcp_servers.*.credentials_key),
+      and policy.yaml (web_search_provider.credentials_key). The platform resolves the key to the secret value at call time
+      only.
+    boot_validation: At boot, the platform checks that every credential key referenced by tools, MCP servers, and native
+      web-search provider configuration exists in the credential store (any tier). Missing keys log a warning — the tool may
+      be unconfigured in this deployment.
     platform_guarantee: The platform never logs, indexes, or persists credential values in the event store, dead letters, or
       any platform table. Credentials exist only in the credential store and in-flight tool requests. The builder API never
       returns credential values after write — only metadata.

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -172,6 +172,10 @@ active_issues:
     title: Reconcile prompt_exists with canonical prompt resolution
     maps_to:
       - boot_check_definition_drift
+  - id: 1100
+    title: Gate credential and MCP external-resource checks
+    maps_to:
+      - boot_check_definition_drift
 nodes:
   - id: persisted_normal_run_completion_quiescence_owner
     title: Persisted Normal Run Completion/Quiescence Owner
@@ -272,6 +276,7 @@ nodes:
       - tool_resolution can drift when structural verifier scripts interpret only tools.yaml while Go bootverify consumes the merged runtime tool registry and MCP discovery boundary
       - required_agents_match can drift when spec, bootverify, runtime startup, verifier scripts, and catalog harness disagree on map-key role identity or required subscribes_to / emits coverage
       - prompt_exists can drift when spec, bootverify, verify.py, catalog harness, and prompt-derived checks use only prompts/{agent-id}.md while runtime resolves prompt_ref, entry id, mode variants, workspace-role, shard-parent, and bundle prompt-dir fallback
+      - credential_key_exists and mcp_server_reachable can drift when runtime-only external-resource checks are treated as structural verifier checks instead of consuming the credential store and MCP discovery owners
     representative_issues:
       - 447
       - 448
@@ -280,6 +285,7 @@ nodes:
       - 1065
       - 1072
       - 1082
+      - 1100
     common_framing_mistakes:
       too_broad:
         - all bootverify drift

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -12,7 +12,6 @@ import (
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/eventidentity"
-	runtimecredentials "swarm/internal/runtime/credentials"
 	"swarm/internal/runtime/flowdata"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -1131,79 +1130,6 @@ func (c *checkerContext) platformNamespace() []Finding {
 		return c.namespaceFindings[i].Location < c.namespaceFindings[j].Location
 	})
 	return c.namespaceFindings
-}
-
-func (c *checkerContext) credentials() []Finding {
-	if c.credentialLoaded {
-		return c.credentialFindings
-	}
-	c.credentialLoaded = true
-	if c.opts.Credentials == nil {
-		return nil
-	}
-	missing, err := runtimecredentials.MissingRequired(c.ctx, c.opts.Credentials, c.source)
-	if err != nil {
-		c.credentialFindings = append(c.credentialFindings, Finding{
-			CheckID:  "credential_key_exists",
-			Severity: "error",
-			Message:  strings.TrimSpace(err.Error()),
-			Location: "global",
-		})
-		return c.credentialFindings
-	}
-	for _, item := range missing {
-		requiredBy := make([]string, 0, len(item.RequiredBy))
-		for _, ref := range item.RequiredBy {
-			requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+" "+strings.TrimSpace(ref.Name))
-		}
-		c.credentialFindings = append(c.credentialFindings, Finding{
-			CheckID:  "credential_key_exists",
-			Severity: "warning",
-			Message:  fmtCredentialWarning(item.Key, requiredBy),
-			Location: item.Key,
-		})
-	}
-	return c.credentialFindings
-}
-
-func (c *checkerContext) mcp() []Finding {
-	if c.mcpLoaded {
-		return c.mcpFindings
-	}
-	c.mcpLoaded = true
-	for _, refreshErr := range c.mcpDiscoveryErrs() {
-		msg := strings.TrimSpace(refreshErr.Error())
-		c.mcpFindings = append(c.mcpFindings, Finding{
-			CheckID:  "mcp_server_reachable",
-			Severity: "warning",
-			Message:  msg,
-			Location: locationFromMessage(msg),
-		})
-	}
-	return c.mcpFindings
-}
-
-func (c *checkerContext) mcpDiscovered() map[string]runtimemcp.DiscoveredTool {
-	c.ensureMCPDiscovery()
-	return c.mcpDiscoveredTools
-}
-
-func (c *checkerContext) mcpDiscoveryErrs() []error {
-	c.ensureMCPDiscovery()
-	return c.mcpDiscoveryErrors
-}
-
-func (c *checkerContext) ensureMCPDiscovery() {
-	if c.mcpDiscoveryLoaded {
-		return
-	}
-	c.mcpDiscoveryLoaded = true
-	if !c.opts.CheckMCPReachable {
-		return
-	}
-	client := runtimemcp.NewClient(c.opts.Credentials)
-	c.mcpDiscoveryErrors = client.Refresh(c.ctx, c.source)
-	c.mcpDiscoveredTools = client.DiscoveredTools()
 }
 
 func promptFindingsForScope(bundle *runtimecontracts.WorkflowContractBundle, hasBundle bool, promptsDir, scopeLabel string, agents map[string]runtimecontracts.AgentRegistryEntry, source runtimecontracts.ContractItemSource, mode string) []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3,6 +3,7 @@ package bootverify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -173,6 +174,106 @@ func TestRun_MapsMissingContractMCPToolToToolResolutionWarning(t *testing.T) {
 
 	if !reportContains(report.Warnings(), "tool_resolution", "infra.missing") {
 		t.Fatalf("expected tool_resolution warning for undiscovered contract mcp tool, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_MapsMissingRuntimeExternalCredentialsToCredentialKeyExistsWarnings(t *testing.T) {
+	source := runtimeExternalResourceSource("http://127.0.0.1:1")
+
+	report := Run(context.Background(), source, Options{Credentials: bootverifyCredentialStore{}})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	for _, expected := range []string{
+		"credential sendgrid_api_key is missing (required by tool email_api)",
+		"credential infra_mcp_token is missing (required by mcp_server infra)",
+		"credential brave_search_api_key is missing (required by web_search_provider brave)",
+	} {
+		if !reportContains(report.Warnings(), "credential_key_exists", expected) {
+			t.Fatalf("expected credential_key_exists warning containing %q, got %#v", expected, report.Warnings())
+		}
+	}
+}
+
+func TestRun_SkipsCredentialKeyExistsWhenNoCredentialStoreIsSupplied(t *testing.T) {
+	source := runtimeExternalResourceSource("http://127.0.0.1:1")
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Warnings(), "credential_key_exists", "credential") {
+		t.Fatalf("expected no credential_key_exists warning without credential store, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_MapsCredentialStoreErrorsToCredentialKeyExistsError(t *testing.T) {
+	source := runtimeExternalResourceSource("http://127.0.0.1:1")
+
+	report := Run(context.Background(), source, Options{
+		Credentials: bootverifyCredentialStore{listErr: errors.New("credential store unavailable")},
+	})
+
+	if !reportContains(report.Errors(), "credential_key_exists", "credential store unavailable") {
+		t.Fatalf("expected credential_key_exists error for store failure, got %#v", report.Errors())
+	}
+}
+
+func TestRun_MapsMCPDiscoveryFailureToMCPServerReachableWarning(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		switch req["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req["id"],
+				"result": map[string]any{
+					"protocolVersion": "2025-03-26",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "infra", "version": "1.0.0"},
+				},
+			})
+		case "notifications/initialized":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "result": map[string]any{}})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req["id"],
+				"error": map[string]any{
+					"code":    -32000,
+					"message": "catalog unavailable",
+				},
+			})
+		default:
+			t.Fatalf("unexpected mcp method %v", req["method"])
+		}
+	}))
+	defer server.Close()
+	source := runtimeExternalResourceSource(server.URL)
+
+	report := Run(context.Background(), source, Options{CheckMCPReachable: true})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "mcp_server_reachable", "mcp server infra: catalog unavailable") {
+		t.Fatalf("expected mcp_server_reachable warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_SkipsMCPServerReachableWhenReachabilityCheckDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("MCP server should not be contacted when CheckMCPReachable is false")
+	}))
+	defer server.Close()
+	source := runtimeExternalResourceSource(server.URL)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Warnings(), "mcp_server_reachable", "mcp server") {
+		t.Fatalf("expected no mcp_server_reachable warning with disabled reachability check, got %#v", report.Warnings())
 	}
 }
 
@@ -5487,6 +5588,74 @@ func reportContains(items []Finding, checkID, contains string) bool {
 		}
 	}
 	return false
+}
+
+type bootverifyCredentialStore struct {
+	values  map[string]string
+	listErr error
+	getErr  error
+}
+
+func (s bootverifyCredentialStore) Get(_ context.Context, key string) (string, bool, error) {
+	if s.getErr != nil {
+		return "", false, s.getErr
+	}
+	value, ok := s.values[strings.TrimSpace(key)]
+	return value, ok, nil
+}
+
+func (s bootverifyCredentialStore) Set(_ context.Context, key, value string) error {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	s.values[strings.TrimSpace(key)] = value
+	return nil
+}
+
+func (s bootverifyCredentialStore) List(_ context.Context) ([]string, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	out := make([]string, 0, len(s.values))
+	for key := range s.values {
+		out = append(out, strings.TrimSpace(key))
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s bootverifyCredentialStore) Delete(_ context.Context, key string) error {
+	delete(s.values, strings.TrimSpace(key))
+	return nil
+}
+
+func runtimeExternalResourceSource(mcpURL string) semanticview.Source {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"email_api": {Credentials: []string{"sendgrid_api_key"}},
+		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {
+				Value: map[string]any{
+					"infra": map[string]any{
+						"transport":       "http",
+						"url":             mcpURL,
+						"prefix":          "infra",
+						"credentials_key": "infra_mcp_token",
+					},
+				},
+			},
+			"web_search_provider": {
+				Value: map[string]any{
+					"provider":        "brave",
+					"credentials_key": "brave_search_api_key",
+				},
+			},
+		}},
+	}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	return semanticview.Wrap(bundle)
 }
 
 func firstBundleHandler(bundle *runtimecontracts.WorkflowContractBundle) (string, string, runtimecontracts.SystemNodeEventHandler, bool) {

--- a/internal/runtime/bootverify/runtime_external_resource_checks.go
+++ b/internal/runtime/bootverify/runtime_external_resource_checks.go
@@ -1,0 +1,81 @@
+package bootverify
+
+import (
+	"strings"
+
+	runtimecredentials "swarm/internal/runtime/credentials"
+	runtimemcp "swarm/internal/runtime/mcp"
+)
+
+func (c *checkerContext) credentials() []Finding {
+	if c.credentialLoaded {
+		return c.credentialFindings
+	}
+	c.credentialLoaded = true
+	if c.opts.Credentials == nil {
+		return nil
+	}
+	missing, err := runtimecredentials.MissingRequired(c.ctx, c.opts.Credentials, c.source)
+	if err != nil {
+		c.credentialFindings = append(c.credentialFindings, Finding{
+			CheckID:  "credential_key_exists",
+			Severity: "error",
+			Message:  strings.TrimSpace(err.Error()),
+			Location: "global",
+		})
+		return c.credentialFindings
+	}
+	for _, item := range missing {
+		requiredBy := make([]string, 0, len(item.RequiredBy))
+		for _, ref := range item.RequiredBy {
+			requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+" "+strings.TrimSpace(ref.Name))
+		}
+		c.credentialFindings = append(c.credentialFindings, Finding{
+			CheckID:  "credential_key_exists",
+			Severity: "warning",
+			Message:  fmtCredentialWarning(item.Key, requiredBy),
+			Location: item.Key,
+		})
+	}
+	return c.credentialFindings
+}
+
+func (c *checkerContext) mcp() []Finding {
+	if c.mcpLoaded {
+		return c.mcpFindings
+	}
+	c.mcpLoaded = true
+	for _, refreshErr := range c.mcpDiscoveryErrs() {
+		msg := strings.TrimSpace(refreshErr.Error())
+		c.mcpFindings = append(c.mcpFindings, Finding{
+			CheckID:  "mcp_server_reachable",
+			Severity: "warning",
+			Message:  msg,
+			Location: locationFromMessage(msg),
+		})
+	}
+	return c.mcpFindings
+}
+
+func (c *checkerContext) mcpDiscovered() map[string]runtimemcp.DiscoveredTool {
+	c.ensureMCPDiscovery()
+	return c.mcpDiscoveredTools
+}
+
+func (c *checkerContext) mcpDiscoveryErrs() []error {
+	c.ensureMCPDiscovery()
+	return c.mcpDiscoveryErrors
+}
+
+func (c *checkerContext) ensureMCPDiscovery() {
+	if c.mcpDiscoveryLoaded {
+		return
+	}
+	c.mcpDiscoveryLoaded = true
+	if !c.opts.CheckMCPReachable {
+		return
+	}
+	client := runtimemcp.NewClient(c.opts.Credentials)
+	c.mcpDiscoveryErrors = client.Refresh(c.ctx, c.source)
+	c.mcpDiscoveredTools = client.DiscoveredTools()
+}

--- a/internal/runtime/credentials/store_test.go
+++ b/internal/runtime/credentials/store_test.go
@@ -67,7 +67,7 @@ func TestOverlayStore_EnvOverridesFile(t *testing.T) {
 	}
 }
 
-func TestListDescriptors_IndexesToolsAndMCPServers(t *testing.T) {
+func TestListDescriptors_IndexesToolsMCPServersAndWebSearchProvider(t *testing.T) {
 	ctx := context.Background()
 	fileStore, err := NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
 	if err != nil {
@@ -90,14 +90,20 @@ func TestListDescriptors_IndexesToolsAndMCPServers(t *testing.T) {
 					},
 				},
 			},
+			"web_search_provider": {
+				Value: map[string]any{
+					"provider":        "brave",
+					"credentials_key": "brave_search_api_key",
+				},
+			},
 		}},
 	})
 	items, err := ListDescriptors(ctx, store, source)
 	if err != nil {
 		t.Fatalf("ListDescriptors: %v", err)
 	}
-	if len(items) != 2 {
-		t.Fatalf("expected 2 credential descriptors, got %d", len(items))
+	if len(items) != 3 {
+		t.Fatalf("expected 3 credential descriptors, got %d", len(items))
 	}
 	byKey := map[string]Descriptor{}
 	for _, item := range items {
@@ -108,6 +114,9 @@ func TestListDescriptors_IndexesToolsAndMCPServers(t *testing.T) {
 	}
 	if got := byKey["infra_mcp_token"]; got.Present || len(got.RequiredBy) != 1 || got.RequiredBy[0].Kind != "mcp_server" || got.RequiredBy[0].Name != "infra" {
 		t.Fatalf("infra descriptor = %+v", got)
+	}
+	if got := byKey["brave_search_api_key"]; got.Present || len(got.RequiredBy) != 1 || got.RequiredBy[0].Kind != "web_search_provider" || got.RequiredBy[0].Name != "brave" {
+		t.Fatalf("web search descriptor = %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- moves `credential_key_exists` and `mcp_server_reachable` into the runtime external-resource bootverify boundary
- preserves credential existence through `runtimecredentials.MissingRequired` and MCP reachability through `runtimemcp.Client.Refresh`
- adds direct proof for missing tool, MCP-server, and web-search credentials, credential-store errors, disabled credential-store behavior, MCP discovery failure, and disabled MCP reachability
- aligns `platform-spec.yaml` and the semantic correctness watchlist with the approved #1100 boundary

Closes #1100
Part of #126

## Governing refs / context
- #1100 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/1100#issuecomment-4539902170
- #1100 independent gate: https://github.com/yazzaoui/Swarm/issues/1100#issuecomment-4545199201
- `platform-spec.yaml` `engine.boot_verification.checks.credential_key_exists`
- `platform-spec.yaml` `engine.boot_verification.checks.mcp_server_reachable`
- `platform-spec.yaml` `tool_model.credential_store.boot_validation`
- `platform-spec.yaml` `tool_model.mcp_client.registration`, `boot_sequence`, and `lifecycle`
- `docs/specs/swarm-platform/verify.py` skipped runtime-only behavior for credential and MCP checks

## Semantic migration
- New canonical bootverify boundary: `internal/runtime/bootverify/runtime_external_resource_checks.go`
- Canonical credential owner remains: `internal/runtime/credentials.MissingRequired`, `BuildRequirementIndex`, `ListDescriptors`, and credential `Store` / `Inspector`
- Canonical MCP owner remains: `internal/runtime/mcp.Client.Refresh`, `parseServerConfigs`, `discoverServerTools`, and `DiscoveredTools`
- Old producer / reader / writer path now invalid: local runtime-external-resource check implementation embedded in monolithic `internal/runtime/bootverify/checks.go`
- Production paths checked for surviving old behavior: Go bootverify registry, runtime startup validation wiring, runtime duplicate credential warning consumer, runtime MCP client discovery, `verify.py` structural skipped surface, and watchlist mapping
- Migration complete for the approved #1100 child. Parent #126 remains open for separate sibling bootverify tails.

## Tests
- `go test ./internal/runtime/bootverify -run 'TestRun_MapsMissingRuntimeExternalCredentialsToCredentialKeyExistsWarnings|TestRun_SkipsCredentialKeyExistsWhenNoCredentialStoreIsSupplied|TestRun_MapsCredentialStoreErrorsToCredentialKeyExistsError|TestRun_MapsMCPDiscoveryFailureToMCPServerReachableWarning|TestRun_SkipsMCPServerReachableWhenReachabilityCheckDisabled|TestRun_MapsMissingDiscoveredMCPToolToToolResolutionWarning|TestRun_MapsMissingContractMCPToolToToolResolutionWarning' -count=1`
- `go test ./internal/runtime/credentials -run 'TestListDescriptors_IndexesToolsMCPServersAndWebSearchProvider|TestOverlayStore_EnvOverridesFile|TestFileStore_SetGetDeleteInspect' -count=1`
- `go test ./internal/runtime/mcp -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/credentials ./internal/runtime/mcp ./internal/runtime ./internal/runtime/cataloge2e -count=1`
- `python3 docs/specs/swarm-platform/verify.py tests/tier8-boot-verification/test-boot-success | rg "credential_key_exists|mcp_server_reachable|structural verifier subset|SUMMARY"`
- `go test ./...` currently fails in `internal/store` on `TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete`; verified the same failure reproduces on clean `origin/master` at `9f4c111b`, with the test fork loaded as `expired` after its fixed 2026-05-26 12:00 UTC expiry.
