### PR TITLE
[agent-a][issue #1101] Deliver template instance node events

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -109,7 +109,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.PersistedRecipients = manifest.PersistedRecipients
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
 	plan.TargetFailure = manifest.TargetFailure
@@ -364,8 +364,12 @@ func internalDeliveryRoutesForPlan(evt events.Event, recipients, persisted []str
 	return events.NormalizeDeliveryRoutes(out)
 }
 
-func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	internalRecipients := filterOutAgentIDs(recipients, persisted)
+	if len(internalRecipients) == 0 {
 		return nil
 	}
 	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
@@ -373,18 +377,22 @@ func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscri
 		return nil
 	}
 	eventEntityID := strings.TrimSpace(evt.EntityID())
-	out := make([]events.DeliveryRoute, 0, len(routed))
+	routedNodeMatched := false
 	for _, subscriber := range routed {
 		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
 			continue
 		}
-		subscriberID := strings.TrimSpace(subscriber.ID)
-		if subscriberID == "" {
-			continue
-		}
+		routedNodeMatched = true
+		break
+	}
+	if !routedNodeMatched {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(internalRecipients))
+	for _, recipient := range internalRecipients {
 		out = append(out, events.DeliveryRoute{
 			SubscriberType: "node",
-			SubscriberID:   subscriberID,
+			SubscriberID:   recipient,
 			Target: events.RouteIdentity{
 				FlowInstance: flowInstance,
 				EntityID:     eventEntityID,

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"swarm/internal/events"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "swarm/internal/runtime/core/pinrouting"
 )
 
@@ -22,15 +23,20 @@ type deliveryRecipientCandidate struct {
 }
 
 type deliveryRouteResolver struct {
-	resolveRoutedSubscribers    func(string) []Subscriber
-	resolveSubscribedRecipients func(string) []deliveryRecipientCandidate
-	describeSubscribersForEvent func(string, []Subscriber) []PublishDiagnosticRecipient
+	resolveRoutedSubscribers            func(string) []Subscriber
+	resolveSubscribedRecipients         func(string) []deliveryRecipientCandidate
+	resolveRoutedNodeInternalRecipients func(events.Event, []Subscriber) []deliveryRecipientCandidate
+	describeSubscribersForEvent         func(string, []Subscriber) []PublishDiagnosticRecipient
 }
 
 func (r deliveryRouteResolver) Resolve(evt events.Event) deliveryRoutingResult {
 	routedRecipients := r.resolveRoutedSubscribers(string(evt.Type))
 	subscribedRecipients := r.resolveSubscribedRecipients(string(evt.Type))
-	recipients := normalizeDeliveryRecipientCandidates(append(routedSubscriberCandidates(routedRecipients), subscribedRecipients...))
+	routedCandidates := routedSubscriberCandidates(routedRecipients)
+	if r.resolveRoutedNodeInternalRecipients != nil {
+		routedCandidates = append(routedCandidates, r.resolveRoutedNodeInternalRecipients(evt, routedRecipients)...)
+	}
+	recipients := normalizeDeliveryRecipientCandidates(append(routedCandidates, subscribedRecipients...))
 	result := deliveryRoutingResult{
 		Recipients:           recipients,
 		RoutedRecipients:     routedRecipients,
@@ -103,6 +109,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.PersistedRecipients = manifest.PersistedRecipients
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
 	plan.TargetFailure = manifest.TargetFailure
@@ -166,9 +173,10 @@ func filteredRecipients(requested, allowed []string) []string {
 func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers:    eb.resolveRoutedSubscribers,
-			resolveSubscribedRecipients: eb.resolveSubscribedRecipientsForPlanning,
-			describeSubscribersForEvent: eb.describeSubscribersForEvent,
+			resolveRoutedSubscribers:            eb.resolveRoutedSubscribers,
+			resolveSubscribedRecipients:         eb.resolveSubscribedRecipientsForPlanning,
+			resolveRoutedNodeInternalRecipients: eb.resolveInternalRecipientsForRoutedNodePlanning,
+			describeSubscribersForEvent:         eb.describeSubscribersForEvent,
 		},
 		deliveryRecipientPolicy{
 			loadActiveAgentDescriptors: eb.activeAgentDescriptors,
@@ -354,6 +362,76 @@ func internalDeliveryRoutesForPlan(evt events.Event, recipients, persisted []str
 		}
 	}
 	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance == "" {
+		return nil
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	out := make([]events.DeliveryRoute, 0, len(routed))
+	for _, subscriber := range routed {
+		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
+			continue
+		}
+		subscriberID := strings.TrimSpace(subscriber.ID)
+		if subscriberID == "" {
+			continue
+		}
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   subscriberID,
+			Target: events.RouteIdentity{
+				FlowInstance: flowInstance,
+				EntityID:     eventEntityID,
+			},
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber) []string {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" {
+		return nil
+	}
+	out := []string{eventType}
+	for _, subscriber := range routed {
+		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
+			continue
+		}
+		instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+		if instancePath == "" || !strings.HasPrefix(eventType, instancePath+"/") {
+			continue
+		}
+		localEvent := strings.TrimPrefix(eventType, instancePath+"/")
+		staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(instancePath)
+		if localEvent == "" || staticScope == "" {
+			continue
+		}
+		out = append(out, staticScope+"/"+localEvent)
+	}
+	return uniqueStrings(out)
+}
+
+func routedNodeMatchesConcreteFlowInstanceEvent(evt events.Event, subscriber Subscriber) bool {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+		return false
+	}
+	instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if instancePath == "" || flowInstance == "" || instancePath != flowInstance {
+		return false
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	return eventType != "" && strings.HasPrefix(eventType, instancePath+"/")
 }
 
 func matchedInternalDeliveryTargets(evt events.Event, subscribers []Subscriber) []events.RouteIdentity {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -355,11 +355,11 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRou
 		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
 	}
 	if got := plan.DeliveryRoutes; len(got) != 1 {
-		t.Fatalf("delivery routes = %#v, want lifecycle-orchestrator route", got)
+		t.Fatalf("delivery routes = %#v, want workflow-runtime carrier route", got)
 	}
 	route := plan.DeliveryRoutes[0]
-	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
-		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator", route)
+	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
+		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
 	}
 	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
 		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -317,6 +317,58 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	}
 }
 
+func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(string) []Subscriber {
+				return []Subscriber{{
+					ID:   "lifecycle-orchestrator",
+					Type: "node",
+					Path: "operating/inst-1",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate { return nil },
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "operating/inst-1/opco.product_initialization_requested",
+	}).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want [workflow-runtime]", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want lifecycle-orchestrator route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
+		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator", route)
+	}
+	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
+		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+}
+
 func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -335,6 +335,41 @@ func (eb *EventBus) resolveSubscribedRecipientsForPlanning(eventType string) []d
 	return normalizeDeliveryRecipientCandidates(recipients)
 }
 
+func (eb *EventBus) resolveInternalRecipientsForRoutedNodePlanning(evt events.Event, routed []Subscriber) []deliveryRecipientCandidate {
+	if eb == nil {
+		return nil
+	}
+	aliases := routedNodeInternalSubscriptionAliases(evt, routed)
+	if len(aliases) == 0 {
+		return nil
+	}
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	recipients := make([]deliveryRecipientCandidate, 0, len(eb.subscriptions))
+	for subscriberID, pats := range eb.subscriptions {
+		if eb.subscriptionKinds[subscriberID] != inMemorySubscriberInternal {
+			continue
+		}
+		for _, pat := range pats {
+			matched := false
+			for _, alias := range aliases {
+				if routeMatches(string(pat), alias) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				recipients = append(recipients, deliveryRecipientCandidate{
+					ID:                subscriberID,
+					PersistAsDelivery: false,
+				})
+				break
+			}
+		}
+	}
+	return normalizeDeliveryRecipientCandidates(recipients)
+}
+
 func (eb *EventBus) ResolveSubscribedRecipients(eventType string) []string {
 	return eb.resolveSubscribedRecipients(eventType)
 }

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -169,14 +169,28 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 
 	routes := store.routes[evt.ID]
 	if len(routes) != 1 {
-		t.Fatalf("persisted delivery routes = %#v, want one semantic node route", routes)
+		t.Fatalf("persisted delivery routes = %#v, want one workflow-runtime carrier route", routes)
 	}
 	route := routes[0]
-	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
-		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator", route)
+	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
+		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
 	}
 	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
 		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)
+	}
+
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, replayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if len(live) != 1 || live[0] != "workflow-runtime" {
+		t.Fatalf("replay live recipients = %#v, want workflow-runtime", live)
+	}
+	if len(internal) != 1 || internal[0] != "workflow-runtime" {
+		t.Fatalf("replay internal recipients = %#v, want workflow-runtime", internal)
+	}
+	if len(replayRoutes) != 1 || replayRoutes[0].SubscriberID != "workflow-runtime" {
+		t.Fatalf("replay routes = %#v, want workflow-runtime carrier route", replayRoutes)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -7,7 +7,11 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	"swarm/internal/runtime/flowmodel"
 	"swarm/internal/runtime/replayclaim"
+	"swarm/internal/runtime/semanticview"
 )
 
 type targetRouteMemoryStore struct {
@@ -133,6 +137,49 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	assertTargetRouteDeliveries(t, ch, "ent-a", "ent-b")
 }
 
+func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	source := semanticview.Wrap(routedNodeTemplateBundle())
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got.FlowInstance() != "operating/inst-1" {
+			t.Fatalf("delivered flow instance = %q, want operating/inst-1", got.FlowInstance())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("workflow-runtime did not receive concrete routed node event")
+	}
+
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want one semantic node route", routes)
+	}
+	route := routes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
+		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator", route)
+	}
+	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
+		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)
+	}
+}
+
 func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntityIDs ...string) {
 	t.Helper()
 	seen := map[string]struct{}{}
@@ -155,5 +202,48 @@ func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntit
 		if _, ok := seen[want]; !ok {
 			t.Fatalf("missing target delivery for %q; saw %#v", want, seen)
 		}
+	}
+}
+
+func routedNodeTemplateBundle() *runtimecontracts.WorkflowContractBundle {
+	operating := runtimecontracts.FlowContractView{
+		Path:  "operating",
+		Paths: runtimecontracts.FlowContractPaths{ID: "operating", Flow: "operating"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			AutoEmitOnCreate: runtimecontracts.AutoEmitOnCreateContract{
+				Event: "opco.product_initialization_requested",
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"opco.product_initialization_requested": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"lifecycle-orchestrator": {
+				ID:            "lifecycle-orchestrator",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"opco.product_initialization_requested"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"opco.product_initialization_requested": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{operating}}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"operating": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"operating": {
+				Mode: "template",
+				AutoEmitOnCreate: runtimecontracts.AutoEmitOnCreateContract{
+					Event: "opco.product_initialization_requested",
+				},
+			},
+		},
 	}
 }

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -164,6 +164,63 @@ func TestEventBusRemoveNestedFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	}
 }
 
+func TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryPlanning(t *testing.T) {
+	operating := runtimecontracts.FlowContractView{
+		Path:  "operating",
+		Paths: runtimecontracts.FlowContractPaths{ID: "operating", Flow: "operating"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			AutoEmitOnCreate: runtimecontracts.AutoEmitOnCreateContract{
+				Event: "opco.product_initialization_requested",
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"opco.product_initialization_requested": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"lifecycle-orchestrator": {
+				ID:            "lifecycle-orchestrator",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"opco.product_initialization_requested"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"opco.product_initialization_requested": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{operating}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"operating": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"operating": {
+				Mode: "template",
+				AutoEmitOnCreate: runtimecontracts.AutoEmitOnCreateContract{
+					Event: "opco.product_initialization_requested",
+				},
+			},
+		},
+	}
+	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	got := rt.Resolve("operating/inst-1/opco.product_initialization_requested")
+	if len(got) != 1 {
+		t.Fatalf("resolved subscribers = %#v, want one lifecycle-orchestrator route", got)
+	}
+	if got[0].ID != "lifecycle-orchestrator" || got[0].Type != "node" || got[0].Path != "operating/inst-1" {
+		t.Fatalf("resolved subscriber = %#v, want node lifecycle-orchestrator at operating/inst-1", got[0])
+	}
+}
+
 func TestDeriveRouteTable_InputPinsAutoWireFromProducerOutput(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -230,7 +230,7 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	if trigger == "" {
 		return false, nil
 	}
-	handler, ok := source.NodeEventHandler(nodeID, trigger)
+	handler, ok := workflowNodeEventHandlerForDelivery(source, nodeID, evt)
 	if !ok && isAccumulationTimeoutEvent(events.EventType(trigger)) {
 		bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload))
 		if bucketOK && strings.TrimSpace(bucket.NodeID) == nodeID {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"swarm/internal/events"
@@ -269,6 +270,70 @@ pins:
 	}
 }
 
+func TestTemplateInstanceSystemNodeDeliveryLocalizesConcreteEventToHandlerKey(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+auto_emit_on_create:
+  event: opco.product_initialization_requested
+`,
+		"flows/operating/events.yaml": `opco.product_initialization_requested:
+  entity_id: string
+opco.ceo_ready:
+  entity_id: string
+`,
+		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
+  id: lifecycle-orchestrator
+  execution_type: system_node
+  subscribes_to: [opco.product_initialization_requested]
+  produces: [opco.ceo_ready]
+  event_handlers:
+    opco.product_initialization_requested:
+      emit: opco.ceo_ready
+`,
+	})
+	evt := (events.Event{
+		Type:    events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		Payload: []byte(`{"entity_id":"ent-operating"}`),
+	}).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+	if _, ok := source.NodeEventHandler("lifecycle-orchestrator", string(evt.Type)); ok {
+		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
+	}
+	if _, ok := workflowNodeEventHandlerForDelivery(source, "lifecycle-orchestrator", evt); !ok {
+		t.Fatal("expected concrete instance event to resolve to local lifecycle-orchestrator handler")
+	}
+
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module:         staticSemanticWorkflowModule{source: source},
+	}
+	handled, err := pc.executeNodeHandlerPlanResult(context.Background(), "lifecycle-orchestrator", evt)
+	if err != nil {
+		t.Fatalf("executeNodeHandlerPlanResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("executeNodeHandlerPlanResult handled = false, want true")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("published count = %d, want 1", got)
+	}
+	if got := string(bus.publishedEvent(0).Type); got != "operating/opco.ceo_ready" {
+		t.Fatalf("published event type = %q, want operating/opco.ceo_ready", got)
+	}
+}
+
 func loadWorkflowFixtureSource(t *testing.T, fixture string) semanticview.Source {
 	t.Helper()
 	return semanticview.Wrap(loadWorkflowFixtureBundle(t, fixture))
@@ -288,6 +353,11 @@ func loadWorkflowFixtureBundle(t *testing.T, fixture string) *runtimecontracts.W
 
 func loadWorkflowTempSource(t *testing.T, files map[string]string) semanticview.Source {
 	t.Helper()
+	return semanticview.Wrap(loadWorkflowTempBundle(t, files))
+}
+
+func loadWorkflowTempBundle(t *testing.T, files map[string]string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
 	root := t.TempDir()
 	for rel, body := range files {
 		path := filepath.Join(root, rel)
@@ -304,7 +374,7 @@ func loadWorkflowTempSource(t *testing.T, files map[string]string) semanticview.
 	if err != nil {
 		t.Fatalf("load temp bundle: %v", err)
 	}
-	return semanticview.Wrap(bundle)
+	return bundle
 }
 
 type staticSemanticWorkflowModule struct {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -101,6 +101,132 @@ func workflowNodeEventPolicy(nodes []WorkflowNode, nodeID, eventType string) (Wo
 	return WorkflowEventPolicy{}, false
 }
 
+func workflowNodeEventHandlerForDelivery(source semanticview.Source, nodeID string, evt events.Event) (runtimecontracts.SystemNodeEventHandler, bool) {
+	if source == nil {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
+	rawEventType := eventidentity.Normalize(string(evt.Type))
+	if rawEventType == "" {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
+	if handler, ok := source.NodeEventHandler(nodeID, rawEventType); ok {
+		return handler, true
+	}
+	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
+	if localizedEventType == "" || localizedEventType == rawEventType {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
+	return source.NodeEventHandler(nodeID, localizedEventType)
+}
+
+func workflowNodeConcreteInstanceLocalEventType(source semanticview.Source, nodeID string, evt events.Event) string {
+	if source == nil {
+		return ""
+	}
+	rawEventType := eventidentity.Normalize(string(evt.Type))
+	if rawEventType == "" || !strings.Contains(rawEventType, "/") {
+		return ""
+	}
+	flowID := workflowNodeFlowID(source, nodeID)
+	if flowID == "" {
+		return ""
+	}
+	staticFlowPath := eventidentity.Normalize(source.FlowPath(flowID))
+	if staticFlowPath == "" {
+		staticFlowPath = flowID
+	}
+	if !eventTypeBelongsToNodeStaticFlow(rawEventType, staticFlowPath) {
+		return ""
+	}
+	handlerKeys := workflowNodeHandlerEventKeys(source, nodeID)
+	if len(handlerKeys) == 0 {
+		return ""
+	}
+	for _, flowInstance := range workflowNodeConcreteReceiverScopes(evt) {
+		if flowInstance == "" || !strings.HasPrefix(flowInstance, staticFlowPath+"/") {
+			continue
+		}
+		if !strings.HasPrefix(rawEventType, flowInstance+"/") {
+			continue
+		}
+		localized := eventidentity.LocalizeForFlow(flowInstance, handlerKeys, rawEventType)
+		if workflowNodeHasHandlerEventKey(handlerKeys, localized) {
+			return localized
+		}
+	}
+	remainder := strings.TrimPrefix(rawEventType, staticFlowPath+"/")
+	if !strings.Contains(remainder, "/") {
+		return ""
+	}
+	for _, key := range handlerKeys {
+		key = eventidentity.Normalize(key)
+		if key != "" && strings.HasSuffix(rawEventType, "/"+key) {
+			return key
+		}
+	}
+	return ""
+}
+
+func eventTypeBelongsToNodeStaticFlow(eventType, staticFlowPath string) bool {
+	eventType = eventidentity.Normalize(eventType)
+	staticFlowPath = eventidentity.Normalize(staticFlowPath)
+	if eventType == "" || staticFlowPath == "" {
+		return false
+	}
+	return eventType == staticFlowPath || strings.HasPrefix(eventType, staticFlowPath+"/")
+}
+
+func workflowNodeConcreteReceiverScopes(evt events.Event) []string {
+	out := make([]string, 0, 2)
+	appendScope := func(value string) {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range out {
+			if existing == value {
+				return
+			}
+		}
+		out = append(out, value)
+	}
+	appendScope(evt.TargetRoute().FlowInstance)
+	appendScope(evt.FlowInstance())
+	return out
+}
+
+func workflowNodeHandlerEventKeys(source semanticview.Source, nodeID string) []string {
+	if source == nil {
+		return nil
+	}
+	handlers := source.NodeEventHandlers(nodeID)
+	if len(handlers) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(handlers))
+	for key := range handlers {
+		key = eventidentity.Normalize(key)
+		if key != "" {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func workflowNodeHasHandlerEventKey(keys []string, eventType string) bool {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	for _, key := range keys {
+		if key == eventType {
+			return true
+		}
+	}
+	return false
+}
+
 func LoadWorkflowNodes(source semanticview.Source) ([]WorkflowNode, error) {
 	if source == nil {
 		return nil, ErrContractBundleNil

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -1,0 +1,221 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+const templateInstanceDeliveryRunID = "99999999-9999-4999-8999-999999999901"
+
+func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceDeliveryFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module: module,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	subscribed := make(chan struct{}, 1)
+	pc.SetTestSubscribeHook(func() { subscribed <- struct{}{} })
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	go pc.Run(runCtx)
+	select {
+	case <-subscribed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow runtime did not subscribe")
+	}
+	if err := bus.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	eventID := "99999999-9999-4999-8999-999999999902"
+	evt := (events.Event{
+		ID:        eventID,
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		Payload:   []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("11111111-1111-4111-8111-111111111111").WithFlowInstance("operating/inst-1")
+	if err := bus.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
+	`, 1, eventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 1, eventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, eventID)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM events
+		WHERE event_name = 'operating/opco.ceo_ready'
+	`, 1)
+}
+
+type runtimeTestWorkflowModule struct {
+	source       semanticview.Source
+	workflow     *runtimepipeline.WorkflowDefinition
+	workflowNode []runtimepipeline.WorkflowNode
+	guards       runtimepipeline.GuardRegistry
+	actions      runtimepipeline.ActionRegistry
+}
+
+func newRuntimeTestWorkflowModule(t *testing.T, source semanticview.Source) runtimepipeline.WorkflowModule {
+	t.Helper()
+	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	return &runtimeTestWorkflowModule{
+		source:       source,
+		workflow:     workflow,
+		workflowNode: nodes,
+		guards:       runtimepipeline.NewContractGuardRegistry(source),
+		actions:      runtimepipeline.NewContractActionRegistry(source),
+	}
+}
+
+func (m *runtimeTestWorkflowModule) SemanticSource() semanticview.Source { return m.source }
+func (m *runtimeTestWorkflowModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return m.workflow
+}
+func (m *runtimeTestWorkflowModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.workflowNode...)
+}
+func (m *runtimeTestWorkflowModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guards
+}
+func (m *runtimeTestWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actions
+}
+
+func loadRuntimeTempBundle(t *testing.T, files map[string]string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	platformSpec := filepath.Join(repoRoot, "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
+	if err != nil {
+		t.Fatalf("load temp bundle: %v", err)
+	}
+	return bundle
+}
+
+func templateInstanceDeliveryFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+auto_emit_on_create:
+  event: opco.product_initialization_requested
+`,
+		"flows/operating/events.yaml": `opco.product_initialization_requested:
+  entity_id: string
+opco.ceo_ready:
+  entity_id: string
+`,
+		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
+  id: lifecycle-orchestrator
+  execution_type: system_node
+  subscribes_to: [opco.product_initialization_requested]
+  produces: [opco.ceo_ready]
+  event_handlers:
+    opco.product_initialization_requested:
+      emit: opco.ceo_ready
+`,
+	}
+}
+
+func seedRuntimeTestRun(t *testing.T, db *sql.DB) context.Context {
+	t.Helper()
+	ctx := runtimecorrelation.WithRunID(context.Background(), templateInstanceDeliveryRunID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, templateInstanceDeliveryRunID); err != nil {
+		t.Fatalf("seed runtime test run: %v", err)
+	}
+	return ctx
+}
+
+func waitRuntimeDBCount(t *testing.T, ctx context.Context, db *sql.DB, query string, want int, args ...any) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var got int
+		if err := db.QueryRowContext(ctx, query, args...).Scan(&got); err != nil {
+			t.Fatalf("query count: %v", err)
+		}
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("count = %d, want %d for query %s", got, want, strings.TrimSpace(query))
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func assertRuntimeDBCount(t *testing.T, ctx context.Context, db *sql.DB, query string, want int, args ...any) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&got); err != nil {
+		t.Fatalf("query count: %v", err)
+	}
+	if got != want {
+		t.Fatalf("count = %d, want %d for query %s", got, want, strings.TrimSpace(query))
+	}
+}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -71,6 +71,10 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 	`, 1, eventID)
 	assertRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 1, eventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
 	`, 1, eventID)
 	assertRuntimeDBCount(t, ctx, db, `

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -141,7 +141,7 @@ func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testi
 	_, db, _ := testutil.StartPostgres(t)
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
-	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	now := activeConversationForkTestClock()
 	source := seedConversationForkSource(t, db, now)
 
 	_, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
@@ -186,7 +186,7 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 	_, db, _ := testutil.StartPostgres(t)
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
-	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	now := activeConversationForkTestClock()
 	source := seedConversationForkSource(t, db, now)
 	entityID := uuid.NewString()
 


### PR DESCRIPTION
Closes #1101

## Governing refs / context
- Approved pre-audit and gate: #1101, including `runtime.template_instance_auto_emit_system_node_delivery_localization` as the binding child class.
- `platform-spec.yaml` refs: `event_identity_resolution.handler_lookup_localizes`, `dynamic_instance_lifecycle`, and event-loop `resolve_subscribers` semantics.
- Gate conditions preserved: no `auto_emit_on_create` special-case, no input-pin requirement, `__runtime_replay_scope__` remains replay evidence only, and workflow-runtime remains the single execution carrier for concrete routed system-node events.

## Semantic migration
- New canonical owner for the chosen slice: route-table materialization remains the concrete subscriber source; delivery planning now maps no-target concrete routed node subscribers to `workflow-runtime` carrier delivery routes with the concrete flow-instance target; pipeline handler lookup localizes concrete instance event names to the receiver node's local handler key and handler completion writes/settles the semantic node delivery/receipt evidence.
- Old invalid paths: route-table node subscribers can no longer be treated as diagnostic-only/dropped during no-target delivery planning; raw bundle handler lookup alone is no longer authoritative for concrete template-instance receiver paths; replay-scope delivery rows are not handler-execution proof; semantic node IDs are not used as in-memory delivery carrier IDs.
- Production paths checked for surviving old behavior: template instance route-table derivation, bus publish/delivery planning, committed replay recipient reconstruction, pipeline system-node dispatch, static system-node delivery, routed agent delivery, replay marker separation, and duplicate create fail-closed behavior.
- Migration completeness: complete for the approved child class. Broader delivery/replay ownership and selected-contract/fork/historical replay tails remain outside this PR.

## Notes
- Includes a separate test-only clock stabilization for `internal/store` conversation fork lifecycle tests; the fixed fixture expiry crossed the current date during the required `go test ./...` run and is non-closure-bearing for #1101.

## Verification
- `go test ./internal/runtime -run TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime -run 'TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute|TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute|TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryPlanning|TestTemplateInstanceSystemNodeDeliveryLocalizesConcreteEventToHandlerKey|TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|TestActivateFlowInstanceRejectsDuplicateInstanceIDBeforeSideEffects' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete|TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation|TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors' -count=1`
- `go test ./...`