### PR TITLE
[agent-h][issue #1095] Add agent delivery diagnostics owner

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -13,6 +13,104 @@
   ],
   "methods": [
     {
+      "name": "agent.delivery_diagnostics",
+      "description": "Read the owner-backed per-agent delivery diagnostics slice for failed\ndeliveries and terminal dead-letter deliveries. This method is a\nseparate owner from agent.diagnose: AgentDiagnosis remains lean and must\nnot expose recent failures or dead letters. The API handler validates\nagent_id, list bounds, cursors, and unknown params, then consumes one\nnamed per-agent delivery diagnostics read owner. It must not locally\nreconstruct the shape from run.trace, run.diagnose, event.list,\nevent.get, event_receipts, dashboard helpers, CLI state, runtime memory,\nor EventBus data.\n\nFailed-delivery rows are sourced from canonical agent\nevent_deliveries rows with status failed. Dead-letter rows are sourced\nfrom canonical agent event_deliveries rows with status dead_letter and\nreconciled with event-scoped dead_letters records by original event id.\nA terminal dead-letter delivery without at least one matching\ndead_letters record is malformed owner data and must fail closed rather\nthan silently reporting a partial fact. Dead-letter records for events\nthat do not have a terminal delivery for this agent are not attributed to\nthis agent by this owner.\n\nDetail rows are ordered by the canonical delivery occurrence watermark\nDESC, then delivery_id DESC. The occurrence watermark is currently\nCOALESCE(event_deliveries.delivered_at, event_deliveries.created_at).\nfailure_cursor and dead_letter_cursor are independent opaque cursors\nover that ordering. failures_24h and dead_letters_24h are rolling\n24-hour counts over the same occurrence watermark. Detail lists return\nretained rows subject to store retention and explicit per-list limits.\nEmpty lists are represented as empty arrays.\n",
+      "params": [
+        {
+          "name": "agent_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "failure_limit",
+          "required": false,
+          "description": "Max failed-delivery detail rows to return.",
+          "schema": {
+            "default": 50,
+            "maximum": 200,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "failure_cursor",
+          "required": false,
+          "description": "Opaque cursor returned by failures_next_cursor for the next failed-delivery page.",
+          "schema": {
+            "$ref": "#/components/schemas/Cursor"
+          }
+        },
+        {
+          "name": "dead_letter_limit",
+          "required": false,
+          "description": "Max terminal dead-letter delivery detail rows to return.",
+          "schema": {
+            "default": 50,
+            "maximum": 200,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "dead_letter_cursor",
+          "required": false,
+          "description": "Opaque cursor returned by dead_letters_next_cursor for the next terminal dead-letter delivery page.",
+          "schema": {
+            "$ref": "#/components/schemas/Cursor"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/AgentDeliveryDiagnostics"
+        }
+      },
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Application error: AGENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "AGENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "agent_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "agent.diagnose",
       "description": "Read the owner-backed diagnosis slice for one agent. This method is\nlimited to agent identity/status refs, current/last conversation refs,\npending-delivery queue summary/detail evidence, and optional delivery\nlifecycle evidence. It may also return runtime_state.watchdog as a\nnarrow projection of the canonical active session watchdog descriptor,\nactive as selected active-session latest-turn refs, and\nlast_tool_outcome as compact selected active-session latest-turn\ncanonical tool-result evidence. active is omitted when no active live\nsession is selected or the selected session has no latest turn.\nactive.turn_id is required when active is present; active.task_id and\nactive.entity_id are omitted when empty or absent. active.entity_id is\nthe latest selected agent_turns.entity_id dispatch entity and must not\nfall back to the agent configured/effective entity, task target entity,\nrole-scoped current-entity tool context, dashboard projection,\nconversation API response, or stale session evidence.\nlast_tool_outcome is omitted when no active live session is selected,\nno latest turn exists, no canonical turn summary exists, or the\ncanonical summary has no tool result. last_tool_outcome.ok is the\nselected turn parse_ok value and is not a per-tool execution status;\nricher per-tool status, latency, completed_at, and error diagnostics\nremain split.\nruntime_state.watchdog is omitted when no active live session or no\nactive-session watchdog evidence exists, and malformed watchdog data\nfails closed. Queue details are paged with queue_limit and\nqueue_cursor, ordered by events.created_at ASC then events.event_id ASC.\nAgentPendingDelivery.enqueued_at uses the same timestamp owner as\noldest_pending_age_seconds. AgentPendingDelivery.attempts is the\ncanonical recorded retry counter from event_deliveries.retry_count, with\nno API-layer +1 or status arithmetic. The API handler consumes the\ncanonical agent diagnosis read owner directly, including its\nwatchdog-backed runtime_state sub-owner, selected-turn active sub-owner,\nand selected-turn last_tool_outcome sub-owner. It must not locally join\nconversation, run, trace, token, CLI, or dashboard owners, and it must\nnot expose the full runtime_state\nenum, top-level watchdog, run_id, bundle_version, actual in-flight\nactive work, configured/effective current entity, task target entity,\nrole-scoped current entity, token usage, recent failures, or dead\nletters.\n",
       "params": [
@@ -6221,6 +6319,170 @@
   ],
   "components": {
     "schemas": {
+      "AgentDeadLetterDelivery": {
+        "additionalProperties": false,
+        "properties": {
+          "dead_letter_records": {
+            "description": "Event-scoped dead-letter records reconciled to this terminal agent delivery through the original event id. A terminal dead-letter delivery without at least one matching record is malformed owner data and fails closed.",
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterRecord"
+            },
+            "type": "array"
+          },
+          "delivery_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "occurred_at": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "Canonical delivery occurrence watermark, currently COALESCE(event_deliveries.delivered_at, event_deliveries.created_at)."
+          },
+          "reason_code": {
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "status": {
+            "const": "dead_letter",
+            "description": "Terminal dead-letter delivery subfact from the canonical event_deliveries delivery status owner.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "delivery_id",
+          "event_id",
+          "event_name",
+          "status",
+          "retry_count",
+          "occurred_at",
+          "dead_letter_records"
+        ],
+        "type": "object"
+      },
+      "AgentDeliveryDiagnostics": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "dead_letters": {
+            "description": "Recent retained terminal dead-letter delivery rows for this agent, ordered by occurred_at DESC then delivery_id DESC.",
+            "items": {
+              "$ref": "#/components/schemas/AgentDeadLetterDelivery"
+            },
+            "type": "array"
+          },
+          "dead_letters_next_cursor": {
+            "$ref": "#/components/schemas/Cursor"
+          },
+          "failures": {
+            "description": "Recent retained failed delivery rows for this agent, ordered by occurred_at DESC then delivery_id DESC.",
+            "items": {
+              "$ref": "#/components/schemas/AgentDeliveryFailure"
+            },
+            "type": "array"
+          },
+          "failures_next_cursor": {
+            "$ref": "#/components/schemas/Cursor"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/AgentDeliveryDiagnosticsSummary"
+          }
+        },
+        "required": [
+          "agent_id",
+          "summary",
+          "failures",
+          "dead_letters"
+        ],
+        "type": "object"
+      },
+      "AgentDeliveryDiagnosticsSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "dead_letters_24h": {
+            "description": "Rolling 24-hour count of terminal dead-letter agent delivery rows using the same occurrence watermark as AgentDeadLetterDelivery.occurred_at.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "failures_24h": {
+            "description": "Rolling 24-hour count of failed agent delivery rows using the same occurrence watermark as AgentDeliveryFailure.occurred_at.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "failures_24h",
+          "dead_letters_24h"
+        ],
+        "type": "object"
+      },
+      "AgentDeliveryFailure": {
+        "additionalProperties": false,
+        "properties": {
+          "delivery_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "occurred_at": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "Canonical delivery occurrence watermark, currently COALESCE(event_deliveries.delivered_at, event_deliveries.created_at)."
+          },
+          "reason_code": {
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "run_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "status": {
+            "const": "failed",
+            "description": "Failed-delivery subfact from the canonical event_deliveries delivery status owner.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "delivery_id",
+          "event_id",
+          "event_name",
+          "status",
+          "retry_count",
+          "occurred_at"
+        ],
+        "type": "object"
+      },
       "AgentDeliveryLifecycle": {
         "additionalProperties": false,
         "properties": {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -11138,6 +11138,126 @@ api_specification:
             $ref: '#/components/schemas/AgentDiagnosisActive'
           last_tool_outcome:
             $ref: '#/components/schemas/AgentDiagnosisLastToolOutcome'
+      AgentDeliveryDiagnosticsSummary:
+        type: object
+        additionalProperties: false
+        required:
+        - failures_24h
+        - dead_letters_24h
+        properties:
+          failures_24h:
+            type: integer
+            minimum: 0
+            description: Rolling 24-hour count of failed agent delivery rows using the same occurrence watermark as AgentDeliveryFailure.occurred_at.
+          dead_letters_24h:
+            type: integer
+            minimum: 0
+            description: Rolling 24-hour count of terminal dead-letter agent delivery rows using the same occurrence watermark as AgentDeadLetterDelivery.occurred_at.
+      AgentDeliveryFailure:
+        type: object
+        additionalProperties: false
+        required:
+        - delivery_id
+        - event_id
+        - event_name
+        - status
+        - retry_count
+        - occurred_at
+        properties:
+          delivery_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_name:
+            type: string
+            minLength: 1
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          status:
+            type: string
+            const: failed
+            description: Failed-delivery subfact from the canonical event_deliveries delivery status owner.
+          reason_code:
+            type: string
+          last_error:
+            type: string
+          retry_count:
+            type: integer
+            minimum: 0
+          occurred_at:
+            $ref: '#/components/schemas/Timestamp'
+            description: Canonical delivery occurrence watermark, currently COALESCE(event_deliveries.delivered_at, event_deliveries.created_at).
+      AgentDeadLetterDelivery:
+        type: object
+        additionalProperties: false
+        required:
+        - delivery_id
+        - event_id
+        - event_name
+        - status
+        - retry_count
+        - occurred_at
+        - dead_letter_records
+        properties:
+          delivery_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_name:
+            type: string
+            minLength: 1
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          status:
+            type: string
+            const: dead_letter
+            description: Terminal dead-letter delivery subfact from the canonical event_deliveries delivery status owner.
+          reason_code:
+            type: string
+          last_error:
+            type: string
+          retry_count:
+            type: integer
+            minimum: 0
+          occurred_at:
+            $ref: '#/components/schemas/Timestamp'
+            description: Canonical delivery occurrence watermark, currently COALESCE(event_deliveries.delivered_at, event_deliveries.created_at).
+          dead_letter_records:
+            type: array
+            description: Event-scoped dead-letter records reconciled to this terminal agent delivery through the original event id. A terminal dead-letter delivery without at least one matching record is malformed owner data and fails closed.
+            items:
+              $ref: '#/components/schemas/DeadLetterRecord'
+      AgentDeliveryDiagnostics:
+        type: object
+        additionalProperties: false
+        required:
+        - agent_id
+        - summary
+        - failures
+        - dead_letters
+        properties:
+          agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          summary:
+            $ref: '#/components/schemas/AgentDeliveryDiagnosticsSummary'
+          failures:
+            type: array
+            description: Recent retained failed delivery rows for this agent, ordered by occurred_at DESC then delivery_id DESC.
+            items:
+              $ref: '#/components/schemas/AgentDeliveryFailure'
+          failures_next_cursor:
+            $ref: '#/components/schemas/Cursor'
+          dead_letters:
+            type: array
+            description: Recent retained terminal dead-letter delivery rows for this agent, ordered by occurred_at DESC then delivery_id DESC.
+            items:
+              $ref: '#/components/schemas/AgentDeadLetterDelivery'
+          dead_letters_next_cursor:
+            $ref: '#/components/schemas/Cursor'
       ConversationSummary:
         type: object
         additionalProperties: false
@@ -13495,6 +13615,79 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/AgentDiagnosis'
+      errors:
+      - AGENT_NOT_FOUND
+    agent.delivery_diagnostics:
+      tier: should_have
+      description: |
+        Read the owner-backed per-agent delivery diagnostics slice for failed
+        deliveries and terminal dead-letter deliveries. This method is a
+        separate owner from agent.diagnose: AgentDiagnosis remains lean and must
+        not expose recent failures or dead letters. The API handler validates
+        agent_id, list bounds, cursors, and unknown params, then consumes one
+        named per-agent delivery diagnostics read owner. It must not locally
+        reconstruct the shape from run.trace, run.diagnose, event.list,
+        event.get, event_receipts, dashboard helpers, CLI state, runtime memory,
+        or EventBus data.
+
+        Failed-delivery rows are sourced from canonical agent
+        event_deliveries rows with status failed. Dead-letter rows are sourced
+        from canonical agent event_deliveries rows with status dead_letter and
+        reconciled with event-scoped dead_letters records by original event id.
+        A terminal dead-letter delivery without at least one matching
+        dead_letters record is malformed owner data and must fail closed rather
+        than silently reporting a partial fact. Dead-letter records for events
+        that do not have a terminal delivery for this agent are not attributed to
+        this agent by this owner.
+
+        Detail rows are ordered by the canonical delivery occurrence watermark
+        DESC, then delivery_id DESC. The occurrence watermark is currently
+        COALESCE(event_deliveries.delivered_at, event_deliveries.created_at).
+        failure_cursor and dead_letter_cursor are independent opaque cursors
+        over that ordering. failures_24h and dead_letters_24h are rolling
+        24-hour counts over the same occurrence watermark. Detail lists return
+        retained rows subject to store retention and explicit per-list limits.
+        Empty lists are represented as empty arrays.
+      scope:
+        required:
+        - read:agents
+        - read:events
+      params:
+      - name: agent_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: failure_limit
+        required: false
+        description: Max failed-delivery detail rows to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 50
+      - name: failure_cursor
+        required: false
+        description: Opaque cursor returned by failures_next_cursor for the next failed-delivery page.
+        schema:
+          $ref: '#/components/schemas/Cursor'
+      - name: dead_letter_limit
+        required: false
+        description: Max terminal dead-letter delivery detail rows to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 50
+      - name: dead_letter_cursor
+        required: false
+        description: Opaque cursor returned by dead_letters_next_cursor for the next terminal dead-letter delivery page.
+        schema:
+          $ref: '#/components/schemas/Cursor'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/AgentDeliveryDiagnostics'
       errors:
       - AGENT_NOT_FOUND
     agent.send_directive:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,11 +16,11 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 48 {
-		t.Fatalf("method count = %d, want 48", report.MethodCount)
+	if report.MethodCount != 49 {
+		t.Fatalf("method count = %d, want 49", report.MethodCount)
 	}
-	if report.SchemaCount != 83 {
-		t.Fatalf("schema count = %d, want 83", report.SchemaCount)
+	if report.SchemaCount != 87 {
+		t.Fatalf("schema count = %d, want 87", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 31 {
 		t.Fatalf("error code count = %d, want 31", report.ErrorCodeCount)
@@ -66,11 +66,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 48 {
-		t.Fatalf("generated OpenRPC methods = %d, want 48", len(doc.Methods))
+	if len(doc.Methods) != 49 {
+		t.Fatalf("generated OpenRPC methods = %d, want 49", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 83 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 83", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 87 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 87", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 31 {
 		t.Fatalf("generated OpenRPC errors = %d, want 31", len(doc.Components.Errors))
@@ -93,6 +93,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := methods["agent.diagnose"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.diagnose")
 	}
+	if _, ok := methods["agent.delivery_diagnostics"]; !ok {
+		t.Fatal("generated OpenRPC missing agent.delivery_diagnostics")
+	}
 	for _, methodName := range []string{"conversation.fork", "conversation.fork_chat", "conversation.fork_list", "conversation.fork_view", "conversation.fork_delete"} {
 		if _, ok := methods[methodName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", methodName)
@@ -112,6 +115,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := doc.Components.Schemas["AgentDiagnosisLastToolOutcome"]; !ok {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisLastToolOutcome")
+	}
+	for _, schemaName := range []string{"AgentDeliveryDiagnostics", "AgentDeliveryDiagnosticsSummary", "AgentDeliveryFailure", "AgentDeadLetterDelivery"} {
+		if _, ok := doc.Components.Schemas[schemaName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", schemaName)
+		}
 	}
 	for _, schemaName := range []string{"MailboxDecisionSheet", "MailboxEntityContext", "MailboxDownstreamPreview"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 48 {
-		t.Fatalf("method count = %d, want 48", len(openRPCNames))
+	if len(openRPCNames) != 49 {
+		t.Fatalf("method count = %d, want 49", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 48 {
-		t.Fatalf("generated OpenRPC methods = %d, want 48", len(doc.Methods))
+	if len(doc.Methods) != 49 {
+		t.Fatalf("generated OpenRPC methods = %d, want 49", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -237,6 +237,7 @@ func readOnlyHTTPRuntimeMethods(t *testing.T, api *apispec.APISpecification, ope
 
 func approvedReadOnlyHTTPRuntimeMethods() []string {
 	return []string{
+		"agent.delivery_diagnostics",
 		"agent.diagnose",
 		"agent.get",
 		"agent.list",
@@ -266,6 +267,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 
 func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 	return map[string]readOnlyHTTPRuntimeFixture{
+		"agent.delivery_diagnostics":     {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "summary", "failures", "dead_letters"}},
 		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active", "last_tool_outcome"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
@@ -295,6 +297,16 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 
 func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 	return []readOnlyHTTPRuntimeErrorProbe{
+		{
+			Method: "agent.delivery_diagnostics",
+			Params: map[string]any{"agent_id": "missing"},
+			Code:   AgentNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.AgentConversations = &fakeAgentConversationReadStore{agentDeliveryDiagnosticsErr: store.ErrAgentNotFound}
+				return opts
+			},
+		},
 		{
 			Method: "agent.diagnose",
 			Params: map[string]any{"agent_id": "missing"},
@@ -597,6 +609,46 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 					},
 				},
 			},
+			agentDeliveryDiagnosticsResult: store.OperatorAgentDeliveryDiagnostics{
+				AgentID: "agent-1",
+				Summary: store.OperatorAgentDeliveryDiagnosticsSummary{
+					Failures24h:    1,
+					DeadLetters24h: 1,
+				},
+				Failures: []store.OperatorAgentDeliveryFailure{{
+					DeliveryID: "delivery-failed-1",
+					EventID:    "event-failed-1",
+					EventName:  "task.failed",
+					RunID:      runID,
+					EntityID:   "entity-1",
+					Status:     "failed",
+					ReasonCode: "handler_error",
+					LastError:  "boom",
+					RetryCount: 2,
+					OccurredAt: now.Add(-time.Minute),
+				}},
+				DeadLetters: []store.OperatorAgentDeadLetterDelivery{{
+					DeliveryID: "delivery-dead-1",
+					EventID:    "event-dead-1",
+					EventName:  "task.dead",
+					RunID:      runID,
+					EntityID:   "entity-1",
+					Status:     "dead_letter",
+					ReasonCode: "retry_exhausted",
+					LastError:  "terminal",
+					RetryCount: 3,
+					OccurredAt: now.Add(-2 * time.Minute),
+					DeadLetterRecords: []store.OperatorDeadLetterRecord{{
+						DeadLetterID: "dead-letter-1",
+						FailureType:  "retry_exhausted",
+						ErrorMessage: "terminal",
+						RetryCount:   3,
+						ChainDepth:   0,
+						HandlerNode:  "agent-1",
+						CreatedAt:    now.Add(-time.Minute),
+					}},
+				}},
+			},
 			listConversationsResult: store.OperatorConversationListResult{Conversations: []store.OperatorConversationSummary{{
 				SessionID:    sessionID,
 				AgentID:      "agent-1",
@@ -725,6 +777,32 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		}
 		if got := asMap(t, turns[0])["turn_index"]; got != float64(1) {
 			t.Fatalf("%s first turn_index = %#v, want 1", methodName, got)
+		}
+	}
+	if methodName == "agent.delivery_diagnostics" {
+		summary := asMap(t, result["summary"])
+		if summary["failures_24h"] != float64(1) || summary["dead_letters_24h"] != float64(1) {
+			t.Fatalf("agent.delivery_diagnostics summary = %#v", summary)
+		}
+		failures, ok := result["failures"].([]any)
+		if !ok || len(failures) != 1 {
+			t.Fatalf("agent.delivery_diagnostics failures = %#v", result["failures"])
+		}
+		failure := asMap(t, failures[0])
+		if failure["status"] != "failed" || failure["delivery_id"] != "delivery-failed-1" || failure["retry_count"] != float64(2) {
+			t.Fatalf("agent.delivery_diagnostics failure = %#v", failure)
+		}
+		deadLetters, ok := result["dead_letters"].([]any)
+		if !ok || len(deadLetters) != 1 {
+			t.Fatalf("agent.delivery_diagnostics dead_letters = %#v", result["dead_letters"])
+		}
+		deadLetter := asMap(t, deadLetters[0])
+		if deadLetter["status"] != "dead_letter" || deadLetter["delivery_id"] != "delivery-dead-1" || deadLetter["retry_count"] != float64(3) {
+			t.Fatalf("agent.delivery_diagnostics dead_letter = %#v", deadLetter)
+		}
+		records, ok := deadLetter["dead_letter_records"].([]any)
+		if !ok || len(records) != 1 || asMap(t, records[0])["dead_letter_id"] != "dead-letter-1" {
+			t.Fatalf("agent.delivery_diagnostics dead_letter_records = %#v", deadLetter["dead_letter_records"])
 		}
 	}
 	if methodName == "agent.diagnose" {

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -13,29 +13,33 @@ import (
 )
 
 type fakeAgentConversationReadStore struct {
-	listAgentsResult              store.OperatorAgentListResult
-	listAgentsErr                 error
-	agentResult                   store.OperatorAgentDetail
-	agentErr                      error
-	agentDiagnosisResult          store.OperatorAgentDiagnosis
-	agentDiagnosisErr             error
-	listConversationsResult       store.OperatorConversationListResult
-	listConversationsErr          error
-	conversationResult            store.OperatorConversationDetail
-	conversationErr               error
-	conversationTurnResult        store.OperatorConversationTurnDetail
-	conversationTurnErr           error
-	currentConversationResult     *store.OperatorConversationDetail
-	currentConversationErr        error
-	lastAgentList                 store.OperatorAgentListOptions
-	lastConversationList          store.OperatorConversationListOptions
-	lastAgentID                   string
-	lastAgentDiagnosisID          string
-	lastAgentDiagnosisOptions     store.OperatorAgentDiagnosisOptions
-	lastConversationSessionID     string
-	lastConversationTurnSessionID string
-	lastConversationTurnIndex     int
-	lastCurrentConversationFor    string
+	listAgentsResult                    store.OperatorAgentListResult
+	listAgentsErr                       error
+	agentResult                         store.OperatorAgentDetail
+	agentErr                            error
+	agentDiagnosisResult                store.OperatorAgentDiagnosis
+	agentDiagnosisErr                   error
+	agentDeliveryDiagnosticsResult      store.OperatorAgentDeliveryDiagnostics
+	agentDeliveryDiagnosticsErr         error
+	listConversationsResult             store.OperatorConversationListResult
+	listConversationsErr                error
+	conversationResult                  store.OperatorConversationDetail
+	conversationErr                     error
+	conversationTurnResult              store.OperatorConversationTurnDetail
+	conversationTurnErr                 error
+	currentConversationResult           *store.OperatorConversationDetail
+	currentConversationErr              error
+	lastAgentList                       store.OperatorAgentListOptions
+	lastConversationList                store.OperatorConversationListOptions
+	lastAgentID                         string
+	lastAgentDiagnosisID                string
+	lastAgentDiagnosisOptions           store.OperatorAgentDiagnosisOptions
+	lastAgentDeliveryDiagnosticsID      string
+	lastAgentDeliveryDiagnosticsOptions store.OperatorAgentDeliveryDiagnosticsOptions
+	lastConversationSessionID           string
+	lastConversationTurnSessionID       string
+	lastConversationTurnIndex           int
+	lastCurrentConversationFor          string
 }
 
 func (s *fakeAgentConversationReadStore) ListOperatorAgents(_ context.Context, opts store.OperatorAgentListOptions) (store.OperatorAgentListResult, error) {
@@ -52,6 +56,12 @@ func (s *fakeAgentConversationReadStore) LoadOperatorAgentDiagnosis(_ context.Co
 	s.lastAgentDiagnosisID = agentID
 	s.lastAgentDiagnosisOptions = opts
 	return s.agentDiagnosisResult, s.agentDiagnosisErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorAgentDeliveryDiagnostics(_ context.Context, agentID string, opts store.OperatorAgentDeliveryDiagnosticsOptions) (store.OperatorAgentDeliveryDiagnostics, error) {
+	s.lastAgentDeliveryDiagnosticsID = agentID
+	s.lastAgentDeliveryDiagnosticsOptions = opts
+	return s.agentDeliveryDiagnosticsResult, s.agentDeliveryDiagnosticsErr
 }
 
 func (s *fakeAgentConversationReadStore) ListOperatorConversations(_ context.Context, opts store.OperatorConversationListOptions) (store.OperatorConversationListResult, error) {
@@ -147,6 +157,48 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 					RecordedAt:    "2026-05-21T10:01:00Z",
 				},
 			},
+		},
+		agentDeliveryDiagnosticsResult: store.OperatorAgentDeliveryDiagnostics{
+			AgentID: "agent-1",
+			Summary: store.OperatorAgentDeliveryDiagnosticsSummary{
+				Failures24h:    1,
+				DeadLetters24h: 1,
+			},
+			Failures: []store.OperatorAgentDeliveryFailure{{
+				DeliveryID: "delivery-failed-1",
+				EventID:    "event-failed-1",
+				EventName:  "task.failed",
+				RunID:      "run-1",
+				EntityID:   "entity-1",
+				Status:     "failed",
+				ReasonCode: "handler_error",
+				LastError:  "boom",
+				RetryCount: 2,
+				OccurredAt: now.Add(-time.Minute),
+			}},
+			FailuresNextCursor: "failure-next",
+			DeadLetters: []store.OperatorAgentDeadLetterDelivery{{
+				DeliveryID: "delivery-dead-1",
+				EventID:    "event-dead-1",
+				EventName:  "task.dead",
+				RunID:      "run-1",
+				EntityID:   "entity-1",
+				Status:     "dead_letter",
+				ReasonCode: "retry_exhausted",
+				LastError:  "terminal",
+				RetryCount: 3,
+				OccurredAt: now.Add(-2 * time.Minute),
+				DeadLetterRecords: []store.OperatorDeadLetterRecord{{
+					DeadLetterID: "dead-letter-1",
+					FailureType:  "retry_exhausted",
+					ErrorMessage: "terminal",
+					RetryCount:   3,
+					ChainDepth:   0,
+					HandlerNode:  "agent-1",
+					CreatedAt:    now.Add(-time.Minute),
+				}},
+			}},
+			DeadLettersNextCursor: "dead-letter-next",
 		},
 		listConversationsResult: store.OperatorConversationListResult{
 			Conversations: []store.OperatorConversationSummary{{
@@ -279,6 +331,49 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		if _, ok := diagnosis[splitField]; ok {
 			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
 		}
+	}
+
+	deliveryDiagnostics := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent-delivery-diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"agent-1","failure_limit":1,"failure_cursor":"failure-cursor-1","dead_letter_limit":1,"dead_letter_cursor":"dead-letter-cursor-1"}}`)
+	if deliveryDiagnostics.Error != nil {
+		t.Fatalf("agent.delivery_diagnostics error = %#v", deliveryDiagnostics.Error)
+	}
+	if reads.lastAgentDeliveryDiagnosticsID != "agent-1" {
+		t.Fatalf("agent.delivery_diagnostics id = %q", reads.lastAgentDeliveryDiagnosticsID)
+	}
+	if reads.lastAgentDeliveryDiagnosticsOptions.FailureLimit != 1 || reads.lastAgentDeliveryDiagnosticsOptions.FailureCursor != "failure-cursor-1" ||
+		reads.lastAgentDeliveryDiagnosticsOptions.DeadLetterLimit != 1 || reads.lastAgentDeliveryDiagnosticsOptions.DeadLetterCursor != "dead-letter-cursor-1" {
+		t.Fatalf("agent.delivery_diagnostics options = %#v", reads.lastAgentDeliveryDiagnosticsOptions)
+	}
+	diagnostics := asMap(t, deliveryDiagnostics.Result)
+	if diagnostics["agent_id"] != "agent-1" {
+		t.Fatalf("agent.delivery_diagnostics agent_id = %#v", diagnostics["agent_id"])
+	}
+	summary := asMap(t, diagnostics["summary"])
+	if summary["failures_24h"] != float64(1) || summary["dead_letters_24h"] != float64(1) {
+		t.Fatalf("agent.delivery_diagnostics summary = %#v", summary)
+	}
+	failures, ok := diagnostics["failures"].([]any)
+	if !ok || len(failures) != 1 {
+		t.Fatalf("agent.delivery_diagnostics failures = %#v", diagnostics["failures"])
+	}
+	failure := asMap(t, failures[0])
+	if failure["delivery_id"] != "delivery-failed-1" || failure["status"] != "failed" || failure["retry_count"] != float64(2) {
+		t.Fatalf("agent.delivery_diagnostics failure = %#v", failure)
+	}
+	deadLetters, ok := diagnostics["dead_letters"].([]any)
+	if !ok || len(deadLetters) != 1 {
+		t.Fatalf("agent.delivery_diagnostics dead_letters = %#v", diagnostics["dead_letters"])
+	}
+	deadLetter := asMap(t, deadLetters[0])
+	if deadLetter["delivery_id"] != "delivery-dead-1" || deadLetter["status"] != "dead_letter" || deadLetter["retry_count"] != float64(3) {
+		t.Fatalf("agent.delivery_diagnostics dead_letter = %#v", deadLetter)
+	}
+	records, ok := deadLetter["dead_letter_records"].([]any)
+	if !ok || len(records) != 1 || asMap(t, records[0])["dead_letter_id"] != "dead-letter-1" {
+		t.Fatalf("agent.delivery_diagnostics dead_letter_records = %#v", deadLetter["dead_letter_records"])
+	}
+	if diagnostics["failures_next_cursor"] != "failure-next" || diagnostics["dead_letters_next_cursor"] != "dead-letter-next" {
+		t.Fatalf("agent.delivery_diagnostics cursors = %#v/%#v", diagnostics["failures_next_cursor"], diagnostics["dead_letters_next_cursor"])
 	}
 
 	listConversations := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"convs","method":"conversation.list","params":{"agent_id":"agent-1","run_id":"11111111-1111-1111-1111-111111111111","limit":10,"cursor":"abc"}}`)
@@ -563,6 +658,13 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 			wantApp: AgentNotFoundCode,
 		},
 		{
+			name:    "agent delivery diagnostics missing",
+			method:  "agent.delivery_diagnostics",
+			body:    `{"jsonrpc":"2.0","id":"agent-delivery-diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{agentDeliveryDiagnosticsErr: store.ErrAgentNotFound},
+			wantApp: AgentNotFoundCode,
+		},
+		{
 			name:    "conversation missing",
 			method:  "conversation.get",
 			body:    `{"jsonrpc":"2.0","id":"conv","method":"conversation.get","params":{"session_id":"missing"}}`,
@@ -639,6 +741,52 @@ func TestOperatorAgentDiagnoseFailsClosedOnMalformedOwnerData(t *testing.T) {
 		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
 	}
 	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.diagnose owner returned malformed result") {
+		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
+	}
+}
+
+func TestOperatorAgentDeliveryDiagnosticsFailsClosedOnMalformedOwnerData(t *testing.T) {
+	reads := &fakeAgentConversationReadStore{
+		agentDeliveryDiagnosticsResult: store.OperatorAgentDeliveryDiagnostics{
+			AgentID: "agent-1",
+			Summary: store.OperatorAgentDeliveryDiagnosticsSummary{
+				Failures24h:    1,
+				DeadLetters24h: 1,
+			},
+			Failures: []store.OperatorAgentDeliveryFailure{{
+				DeliveryID: "delivery-failed-1",
+				EventID:    "event-failed-1",
+				EventName:  "task.failed",
+				Status:     "failed",
+				RetryCount: 1,
+				OccurredAt: time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC),
+			}},
+			DeadLetters: []store.OperatorAgentDeadLetterDelivery{{
+				DeliveryID:        "delivery-dead-1",
+				EventID:           "event-dead-1",
+				EventName:         "task.dead",
+				Status:            "dead_letter",
+				RetryCount:        2,
+				OccurredAt:        time.Date(2026, 5, 21, 10, 1, 0, 0, time.UTC),
+				DeadLetterRecords: []store.OperatorDeadLetterRecord{},
+			}},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent-delivery-diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"agent-1"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.delivery_diagnostics returned success for malformed owner result")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.delivery_diagnostics owner returned malformed result") {
 		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
 	}
 }
@@ -816,4 +964,40 @@ func TestOperatorAgentDiagnoseRejectsBadQueueCursor(t *testing.T) {
 		t.Fatal("agent.diagnose returned success for invalid queue_cursor")
 	}
 	assertReadOnlyProbeInvalidParams(t, "agent.diagnose", resp, "queue_cursor")
+}
+
+func TestOperatorAgentDeliveryDiagnosticsRejectsLimits(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: &fakeAgentConversationReadStore{},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-delivery_diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"agent-1","failure_limit":0}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.delivery_diagnostics returned success for invalid failure_limit")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.delivery_diagnostics", resp, "failure_limit")
+
+	resp = rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-delivery_diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"agent-1","dead_letter_limit":0}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.delivery_diagnostics returned success for invalid dead_letter_limit")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.delivery_diagnostics", resp, "dead_letter_limit")
+}
+
+func TestOperatorAgentDeliveryDiagnosticsRejectsBadCursor(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: &fakeAgentConversationReadStore{agentDeliveryDiagnosticsErr: store.AgentDeliveryDiagnosticsCursorError{Field: "dead_letter_cursor"}},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-delivery_diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"agent-1","dead_letter_cursor":"bad"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.delivery_diagnostics returned success for invalid dead_letter_cursor")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.delivery_diagnostics", resp, "dead_letter_cursor")
 }

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -43,6 +43,7 @@ type AgentConversationReadStore interface {
 	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
 	LoadOperatorAgentDiagnosis(context.Context, string, store.OperatorAgentDiagnosisOptions) (store.OperatorAgentDiagnosis, error)
+	LoadOperatorAgentDeliveryDiagnostics(context.Context, string, store.OperatorAgentDeliveryDiagnosticsOptions) (store.OperatorAgentDeliveryDiagnostics, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
 	LoadOperatorConversationTurn(context.Context, string, int) (store.OperatorConversationTurnDetail, error)
@@ -340,6 +341,56 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			}
 			return result, nil
 		},
+		"agent.delivery_diagnostics": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			agentID, err := requiredStringParam(req.Params, "agent_id")
+			if err != nil {
+				return nil, err
+			}
+			failureLimit, err := boundedIntegerParam(req.Params, "failure_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
+			if err != nil {
+				return nil, err
+			}
+			deadLetterLimit, err := boundedIntegerParam(req.Params, "dead_letter_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
+			if err != nil {
+				return nil, err
+			}
+			failureCursor, _, err := optionalStringParam(req.Params, "failure_cursor")
+			if err != nil {
+				return nil, err
+			}
+			deadLetterCursor, _, err := optionalStringParam(req.Params, "dead_letter_cursor")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorAgentDeliveryDiagnostics(ctx, agentID, store.OperatorAgentDeliveryDiagnosticsOptions{
+				FailureLimit:     failureLimit,
+				FailureCursor:    failureCursor,
+				DeadLetterLimit:  deadLetterLimit,
+				DeadLetterCursor: deadLetterCursor,
+			})
+			if errors.Is(err, store.ErrAgentNotFound) {
+				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			var cursorErr store.AgentDeliveryDiagnosticsCursorError
+			if errors.As(err, &cursorErr) {
+				field := strings.TrimSpace(cursorErr.Field)
+				if field == "" {
+					field = "cursor"
+				}
+				return nil, NewInvalidParamsError(map[string]any{"field": field, "reason": "invalid agent.delivery_diagnostics cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if err := validateAgentDeliveryDiagnosticsResult(result); err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
 		"conversation.list": func(ctx context.Context, req Request) (any, error) {
 			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
 			if err != nil {
@@ -508,6 +559,102 @@ func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {
 		lastToolTurnID := strings.TrimSpace(item.LastToolOutcome.TurnID)
 		if activeTurnID != lastToolTurnID {
 			return fmt.Errorf("agent.diagnose owner returned malformed result: last_tool_outcome.turn_id %q must match active.turn_id %q", lastToolTurnID, activeTurnID)
+		}
+	}
+	return nil
+}
+
+func validateAgentDeliveryDiagnosticsResult(item store.OperatorAgentDeliveryDiagnostics) error {
+	if strings.TrimSpace(item.AgentID) == "" {
+		return fmt.Errorf("agent.delivery_diagnostics owner returned malformed result: agent_id is required")
+	}
+	if item.Summary.Failures24h < 0 {
+		return fmt.Errorf("agent.delivery_diagnostics owner returned malformed result: summary.failures_24h must be non-negative")
+	}
+	if item.Summary.DeadLetters24h < 0 {
+		return fmt.Errorf("agent.delivery_diagnostics owner returned malformed result: summary.dead_letters_24h must be non-negative")
+	}
+	if item.Failures == nil {
+		return fmt.Errorf("agent.delivery_diagnostics owner returned malformed result: failures must be an array")
+	}
+	for i, failure := range item.Failures {
+		if err := validateAgentDeliveryFailureResult(failure, i); err != nil {
+			return err
+		}
+	}
+	if item.DeadLetters == nil {
+		return fmt.Errorf("agent.delivery_diagnostics owner returned malformed result: dead_letters must be an array")
+	}
+	for i, deadLetter := range item.DeadLetters {
+		if err := validateAgentDeadLetterDeliveryResult(deadLetter, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAgentDeliveryFailureResult(item store.OperatorAgentDeliveryFailure, index int) error {
+	prefix := fmt.Sprintf("agent.delivery_diagnostics owner returned malformed result: failures[%d]", index)
+	if strings.TrimSpace(item.DeliveryID) == "" {
+		return fmt.Errorf("%s.delivery_id is required", prefix)
+	}
+	if strings.TrimSpace(item.EventID) == "" {
+		return fmt.Errorf("%s.event_id is required", prefix)
+	}
+	if strings.TrimSpace(item.EventName) == "" {
+		return fmt.Errorf("%s.event_name is required", prefix)
+	}
+	if strings.TrimSpace(item.Status) != "failed" {
+		return fmt.Errorf("%s.status must be failed", prefix)
+	}
+	if item.RetryCount < 0 {
+		return fmt.Errorf("%s.retry_count must be non-negative", prefix)
+	}
+	if item.OccurredAt.IsZero() {
+		return fmt.Errorf("%s.occurred_at is required", prefix)
+	}
+	return nil
+}
+
+func validateAgentDeadLetterDeliveryResult(item store.OperatorAgentDeadLetterDelivery, index int) error {
+	prefix := fmt.Sprintf("agent.delivery_diagnostics owner returned malformed result: dead_letters[%d]", index)
+	if strings.TrimSpace(item.DeliveryID) == "" {
+		return fmt.Errorf("%s.delivery_id is required", prefix)
+	}
+	if strings.TrimSpace(item.EventID) == "" {
+		return fmt.Errorf("%s.event_id is required", prefix)
+	}
+	if strings.TrimSpace(item.EventName) == "" {
+		return fmt.Errorf("%s.event_name is required", prefix)
+	}
+	if strings.TrimSpace(item.Status) != "dead_letter" {
+		return fmt.Errorf("%s.status must be dead_letter", prefix)
+	}
+	if item.RetryCount < 0 {
+		return fmt.Errorf("%s.retry_count must be non-negative", prefix)
+	}
+	if item.OccurredAt.IsZero() {
+		return fmt.Errorf("%s.occurred_at is required", prefix)
+	}
+	if len(item.DeadLetterRecords) == 0 {
+		return fmt.Errorf("%s.dead_letter_records must contain at least one record", prefix)
+	}
+	for i, record := range item.DeadLetterRecords {
+		recordPrefix := fmt.Sprintf("%s.dead_letter_records[%d]", prefix, i)
+		if strings.TrimSpace(record.DeadLetterID) == "" {
+			return fmt.Errorf("%s.dead_letter_id is required", recordPrefix)
+		}
+		if strings.TrimSpace(record.FailureType) == "" {
+			return fmt.Errorf("%s.failure_type is required", recordPrefix)
+		}
+		if record.RetryCount < 0 {
+			return fmt.Errorf("%s.retry_count must be non-negative", recordPrefix)
+		}
+		if record.ChainDepth < 0 {
+			return fmt.Errorf("%s.chain_depth must be non-negative", recordPrefix)
+		}
+		if record.CreatedAt.IsZero() {
+			return fmt.Errorf("%s.created_at is required", recordPrefix)
 		}
 	}
 	return nil

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -33,6 +33,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: agent.delivery_diagnostics
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorAgentDeliveryDiagnosticsFailsClosedOnMalformedOwnerData}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.get
     transport: http
     required_params: [agent_id]

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -322,8 +322,6 @@ type genericAgent struct {
 	OldestPendingAgeSec int               `json:"oldest_pending_age_sec,omitempty"`
 	LockOwner           string            `json:"lock_owner,omitempty"`
 	LockExpiresAt       string            `json:"lock_expires_at,omitempty"`
-	Failures24h         int               `json:"failures_24h,omitempty"`
-	DeadLetters24h      int               `json:"dead_letters_24h,omitempty"`
 	TurnCount           int               `json:"turn_count,omitempty"`
 	TurnLimit           int               `json:"turn_limit,omitempty"`
 	TotalTokens24h      int               `json:"total_tokens_24h,omitempty"`
@@ -1031,8 +1029,6 @@ func genericAgentFromOperatorSummary(row store.OperatorAgentSummary) genericAgen
 		OldestPendingAgeSec: row.OldestPendingAgeSec,
 		LockOwner:           strings.TrimSpace(row.LockOwner),
 		LockExpiresAt:       formatTime(row.LockExpiresAt),
-		Failures24h:         row.Failures24h,
-		DeadLetters24h:      row.DeadLetters24h,
 		TurnCount:           row.TurnCount,
 		TurnLimit:           row.TurnLimit,
 		NearBreaker:         row.NearBreaker,

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -100,7 +100,7 @@ func canonicalEventAndConversationCaps() store.StoreSchemaCapabilities {
 func canonicalAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -1785,7 +1785,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesCanonicalTurnSummary(t *testing.T)
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(turnBlocksPayload)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(turnBlocksPayload)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -1847,7 +1847,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutCanonicalTurnSummary
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"assistant_text","text":"stale fallback text"}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing canonical turn_summary for summary-bearing turn blocks") {
 		t.Fatalf("expected missing canonical summary to fail closed, got %v", err)
@@ -1880,7 +1880,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalTurnSummary(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":"bad"}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil {
 		t.Fatal("expected malformed canonical turn summary to fail")
@@ -1914,7 +1914,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsOnMalformedCanonicalLastToolResul
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "", nil, []byte(`{}`), 0, 0, "turn-1", "task-1", "", true, "", time.Now(), []byte(`[{"kind":"turn_summary","data":{"tool_results":[{"tool_name":"","tool_use_id":"toolu_1","output":{"status":"scheduled"}}]}}]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "latest canonical tool_result is missing tool_name") {
 		t.Fatalf("expected malformed canonical last_tool result error, got %v", err)
@@ -1954,7 +1954,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesOperatorProjectionAsCanonicalOwner
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, 0, 0, "turn-7", "task-7", "", false, "", time.Now(), []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-7", time.Now(), 7, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-7"}`), 2, 45, "turn-7", "task-7", "", false, "", time.Now(), []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -2015,7 +2015,7 @@ func TestSQLAgentReader_GetGenericAgent_UsesCanonicalLifecycleProjection(t *test
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 3, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -2067,7 +2067,7 @@ func TestSQLAgentReader_ListGenericAgents_DoesNotDeriveLifecycleFromActiveLeaseW
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	items, err := reader.ListGenericAgents(context.Background())
 	if err != nil {
@@ -2120,7 +2120,7 @@ func TestSQLAgentReader_GetGenericAgent_DoesNotDeriveLifecycleFromActiveLeaseWhe
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Now(), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	item, ok, err := reader.GetGenericAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -2301,7 +2301,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(canonicalAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	if _, err := reader.ListGenericAgents(context.Background()); err == nil || !strings.Contains(err.Error(), "missing agent lifecycle fact source") {
 		t.Fatalf("expected explicit lifecycle fact source error, got %v", err)
@@ -2409,12 +2409,6 @@ func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelec
 	wantOldestAge := factsByAgent["agent-1"].OldestPendingAgeSec
 	if diff := items[0].OldestPendingAgeSec - wantOldestAge; diff < -1 || diff > 1 {
 		t.Fatalf("oldest_pending_age_sec = %d, want %d canonical pending age (+/-1s)", items[0].OldestPendingAgeSec, wantOldestAge)
-	}
-	if items[0].Failures24h != 1 {
-		t.Fatalf("failures_24h = %d, want 1 failed delivery", items[0].Failures24h)
-	}
-	if items[0].DeadLetters24h != 1 {
-		t.Fatalf("dead_letters_24h = %d, want 1 dead-letter delivery", items[0].DeadLetters24h)
 	}
 	if items[0].State != "retrying" {
 		t.Fatalf("state = %q, want retrying", items[0].State)

--- a/internal/store/operator_agent_conversation_read_surface.go
+++ b/internal/store/operator_agent_conversation_read_surface.go
@@ -83,8 +83,6 @@ type OperatorAgentSummary struct {
 	OldestPendingAgeSec   int                                 `json:"-"`
 	LockOwner             string                              `json:"-"`
 	LockExpiresAt         time.Time                           `json:"-"`
-	Failures24h           int                                 `json:"-"`
-	DeadLetters24h        int                                 `json:"-"`
 	TurnCount             int                                 `json:"-"`
 	TurnLimit             int                                 `json:"-"`
 	NearBreaker           bool                                `json:"-"`
@@ -449,8 +447,6 @@ type operatorAgentProjection struct {
 	OldestPendingAgeSec int
 	LockOwner           string
 	LockExpiresAt       time.Time
-	Failures24h         int
-	DeadLetters24h      int
 	TurnCount           int
 	SessionID           string
 	SessionStartedAt    time.Time
@@ -1090,8 +1086,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			COALESCE(sess.runtime_state, '{}'::jsonb),
 			0,
 			0,
-			COALESCE(f.failures_24h, 0),
-			COALESCE(f.dead_letters_24h, 0),
 			COALESCE(latest_turn.turn_id, ''),
 			COALESCE(latest_turn.task_id, ''),
 			COALESCE(latest_turn.entity_id::text, ''),
@@ -1131,15 +1125,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			ORDER BY created_at DESC, turn_id DESC
 			LIMIT 1
 		) latest_turn ON true
-		LEFT JOIN LATERAL (
-			SELECT
-				COUNT(*) FILTER (WHERE status = 'failed')::int AS failures_24h,
-				COUNT(*) FILTER (WHERE status = 'dead_letter')::int AS dead_letters_24h
-			FROM event_deliveries
-			WHERE subscriber_type = 'agent'
-			  AND subscriber_id = a.agent_id
-			  AND COALESCE(delivered_at, created_at) >= now() - interval '24 hours'
-		) f ON true
 		WHERE a.status NOT IN ('terminated', 'ephemeral')
 		ORDER BY a.created_at ASC, a.agent_id ASC
 	`, latestTurnBlocksExpr), runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity)
@@ -1176,8 +1161,6 @@ func (r *OperatorAgentConversationReadSurface) loadAgentOperatorProjections(ctx 
 			&runtimeStateRaw,
 			&projection.PendingEvents,
 			&projection.OldestPendingAgeSec,
-			&projection.Failures24h,
-			&projection.DeadLetters24h,
 			&latestTurnID,
 			&latestTaskID,
 			&latestEntityID,
@@ -1267,8 +1250,6 @@ func operatorAgentSummaryFromPersisted(row runtimemanager.PersistedAgent, projec
 		OldestPendingAgeSec:   projection.OldestPendingAgeSec,
 		LockOwner:             strings.TrimSpace(projection.LockOwner),
 		LockExpiresAt:         projection.LockExpiresAt,
-		Failures24h:           projection.Failures24h,
-		DeadLetters24h:        projection.DeadLetters24h,
 		TurnCount:             projection.TurnCount,
 		TurnLimit:             maxStoreInt(turnLimit, 0),
 		SessionID:             strings.TrimSpace(projection.SessionID),

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -609,6 +609,57 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOw
 	}
 }
 
+func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsDoesNotRequireConversationOwners(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Role:             "researcher",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"diagnose"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	reader := NewOperatorAgentConversationReadSurface(db, fakeAgentConversationReadSource{
+		caps: StoreSchemaCapabilities{
+			Agents: SchemaFlavorCanonical,
+			Events: EventSchemaCapabilities{
+				Log:        SchemaFlavorCanonical,
+				LogRunID:   true,
+				Deliveries: SchemaFlavorCanonical,
+			},
+		},
+	}, 0)
+
+	result, err := reader.LoadOperatorAgentDeliveryDiagnostics(ctx, "agent-1", OperatorAgentDeliveryDiagnosticsOptions{})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDeliveryDiagnostics: %v", err)
+	}
+	if result.AgentID != "agent-1" {
+		t.Fatalf("agent_id = %q", result.AgentID)
+	}
+	if result.Summary.Failures24h != 0 || result.Summary.DeadLetters24h != 0 {
+		t.Fatalf("summary = %#v, want zero counts", result.Summary)
+	}
+	if len(result.Failures) != 0 || len(result.DeadLetters) != 0 {
+		t.Fatalf("diagnostics = failures %#v dead_letters %#v, want empty", result.Failures, result.DeadLetters)
+	}
+}
+
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsFailsClosedOnDeadLetterMismatch(t *testing.T) {
 	dsn, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
+	"swarm/internal/testutil"
 )
 
 type fakeConversationCapabilitySource struct {
@@ -90,7 +92,7 @@ func canonicalAgentConversationReadCaps() StoreSchemaCapabilities {
 func operatorAgentProjectionColumns() []string {
 	return []string{
 		"agent_id", "status", "session_id", "session_started_at", "turn_count", "lease_holder", "lease_expires_at", "runtime_state", "pending_count", "oldest_pending_age_sec",
-		"failures_24h", "dead_letters_24h", "turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
+		"turn_id", "task_id", "entity_id", "parse_ok", "error", "turn_created_at", "turn_blocks",
 	}
 }
 
@@ -297,7 +299,7 @@ func TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs(t *testing.
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, 0, 0, turnID, "task-1", "entity-1", false, "model error", turnCompletedAt, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{"provider_session_id":"provider-sess-1"}`), 0, 0, turnID, "task-1", "entity-1", false, "model error", turnCompletedAt, []byte(`[]`)))
 
 	detail, err := reader.LoadOperatorAgent(context.Background(), "agent-1")
 	if err != nil {
@@ -347,7 +349,7 @@ func TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease(t 
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 2, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	result, err := reader.ListOperatorAgents(context.Background(), OperatorAgentListOptions{})
 	if err != nil {
@@ -419,7 +421,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, 0, 0, turnID, "task-1", turnEntityID, true, "", turnCompletedAt, turnBlocks))
+			AddRow("agent-1", "active", sessionID, sessionStartedAt, 2, "", nil, runtimeState, 0, 0, turnID, "task-1", turnEntityID, true, "", turnCompletedAt, turnBlocks))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{QueueLimit: 1, QueueCursor: "cursor-1"})
 	if err != nil {
@@ -481,6 +483,187 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 	}
 }
 
+func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Role:             "researcher",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"diagnose"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	now := time.Now().UTC()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	failedNewEventID := uuid.NewString()
+	failedOldEventID := uuid.NewString()
+	deadEventID := uuid.NewString()
+	otherAgentEventID := uuid.NewString()
+	for _, event := range []struct {
+		id   string
+		name string
+	}{
+		{failedNewEventID, "task.failed.new"},
+		{failedOldEventID, "task.failed.old"},
+		{deadEventID, "task.dead"},
+		{otherAgentEventID, "task.other"},
+	} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, $3, $4::uuid, 'global', '{}'::jsonb, 'runtime', 'agent', $5
+			)
+		`, event.id, runID, event.name, entityID, now.Add(-10*time.Minute)); err != nil {
+			t.Fatalf("seed event %s: %v", event.name, err)
+		}
+	}
+	failedNewDeliveryID := uuid.NewString()
+	failedOldDeliveryID := uuid.NewString()
+	deadDeliveryID := uuid.NewString()
+	otherDeliveryID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, delivered_at, created_at
+		) VALUES
+			($1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-1', 'failed', 2, 'handler_error', 'new failure', $4, $8),
+			($5::uuid, $2::uuid, $6::uuid, 'agent', 'agent-1', 'failed', 1, 'handler_error', 'old failure', $7, $8),
+			($9::uuid, $2::uuid, $10::uuid, 'agent', 'agent-1', 'dead_letter', 3, 'retry_exhausted', 'terminal failure', $11, $8),
+			($12::uuid, $2::uuid, $13::uuid, 'agent', 'agent-2', 'failed', 1, 'handler_error', 'other agent', $4, $8)
+	`, failedNewDeliveryID, runID, failedNewEventID, now.Add(-1*time.Minute), failedOldDeliveryID, failedOldEventID, now.Add(-2*time.Minute), now.Add(-15*time.Minute), deadDeliveryID, deadEventID, now.Add(-3*time.Minute), otherDeliveryID, otherAgentEventID); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	deadLetterID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dead_letters (
+			dead_letter_id, original_event_id, original_event, original_payload, flow_instance,
+			failure_type, error_message, retry_count, chain_depth, handler_node, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'task.dead', '{}'::jsonb, 'flow/test',
+			'retry_exhausted', 'terminal failure', 3, 0, 'agent-1', $3
+		)
+	`, deadLetterID, deadEventID, now.Add(-2*time.Minute)); err != nil {
+		t.Fatalf("seed dead letter: %v", err)
+	}
+
+	first, err := pg.LoadOperatorAgentDeliveryDiagnostics(ctx, "agent-1", OperatorAgentDeliveryDiagnosticsOptions{
+		FailureLimit:    1,
+		DeadLetterLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDeliveryDiagnostics first page: %v", err)
+	}
+	if first.AgentID != "agent-1" {
+		t.Fatalf("agent_id = %q", first.AgentID)
+	}
+	if first.Summary.Failures24h != 2 || first.Summary.DeadLetters24h != 1 {
+		t.Fatalf("summary = %#v, want failures=2 dead_letters=1", first.Summary)
+	}
+	if len(first.Failures) != 1 || first.Failures[0].DeliveryID != failedNewDeliveryID || first.Failures[0].Status != "failed" {
+		t.Fatalf("first failures page = %#v", first.Failures)
+	}
+	if first.Failures[0].EventName != "task.failed.new" || first.Failures[0].RunID != runID || first.Failures[0].EntityID != entityID || first.Failures[0].RetryCount != 2 {
+		t.Fatalf("failure row = %#v", first.Failures[0])
+	}
+	if first.FailuresNextCursor == "" {
+		t.Fatal("failures_next_cursor empty, want second page")
+	}
+	if len(first.DeadLetters) != 1 || first.DeadLetters[0].DeliveryID != deadDeliveryID || first.DeadLetters[0].Status != "dead_letter" {
+		t.Fatalf("dead letters = %#v", first.DeadLetters)
+	}
+	if len(first.DeadLetters[0].DeadLetterRecords) != 1 || first.DeadLetters[0].DeadLetterRecords[0].DeadLetterID != deadLetterID {
+		t.Fatalf("dead letter records = %#v", first.DeadLetters[0].DeadLetterRecords)
+	}
+
+	second, err := pg.LoadOperatorAgentDeliveryDiagnostics(ctx, "agent-1", OperatorAgentDeliveryDiagnosticsOptions{
+		FailureLimit:  1,
+		FailureCursor: first.FailuresNextCursor,
+	})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentDeliveryDiagnostics second page: %v", err)
+	}
+	if len(second.Failures) != 1 || second.Failures[0].DeliveryID != failedOldDeliveryID {
+		t.Fatalf("second failures page = %#v", second.Failures)
+	}
+	if second.FailuresNextCursor != "" {
+		t.Fatalf("second failures_next_cursor = %q, want empty", second.FailuresNextCursor)
+	}
+}
+
+func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsFailsClosedOnDeadLetterMismatch(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Role:             "researcher",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"diagnose"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'task.dead', 'global', '{}'::jsonb, 'runtime', 'agent', now())
+	`, eventID, runID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, delivered_at, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-1', 'dead_letter', 1, now(), now()
+		)
+	`, deliveryID, runID, eventID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	_, err = pg.LoadOperatorAgentDeliveryDiagnostics(ctx, "agent-1", OperatorAgentDeliveryDiagnosticsOptions{})
+	if err == nil {
+		t.Fatal("LoadOperatorAgentDeliveryDiagnostics returned success for dead_letter delivery without record")
+	}
+	if !strings.Contains(err.Error(), "without a dead_letters record") {
+		t.Fatalf("error = %v, want dead_letters reconciliation failure", err)
+	}
+}
+
 func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -496,7 +679,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsAbsentLifecycle(t *testi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -631,7 +814,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisDoesNotDeriveStatusFromActive
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "lease-owner", time.Now().Add(time.Minute), []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -663,7 +846,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsActiveWithoutLatestTurn(
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -696,7 +879,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisOmitsEmptyActiveOptionalRefs(
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, 0, 0, turnID, "", "", true, "", time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC), []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{}`), 0, 0, turnID, "", "", true, "", time.Date(2026, 5, 12, 9, 5, 0, 0, time.UTC), []byte(`[]`)))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err != nil {
@@ -728,7 +911,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedRuntime
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "sess-1", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 0, "", nil, []byte(`{"watchdog":{"state":"stale","blocking_layer":"session_execution","action":"turn_long_running","outcome":"observed","recorded_at":"2026-05-12T09:05:00Z"}}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "decode latest agent session runtime_state") || !strings.Contains(err.Error(), "watchdog.state") {
@@ -757,7 +940,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisFailsClosedOnMalformedLifecyc
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 
 	_, err = reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if err == nil || !strings.Contains(err.Error(), "delivery_lifecycle.state") {
@@ -834,7 +1017,7 @@ func loadAgentDiagnosisWithLatestTurn(t *testing.T, turnID, taskID, entityID str
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a.*agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "11111111-1111-1111-1111-111111111111", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 1, "", nil, []byte(`{}`), 0, 0, 0, 0, turnID, taskID, entityID, parseOK, "", turnCompletedAt, turnBlocks))
+			AddRow("agent-1", "active", "11111111-1111-1111-1111-111111111111", time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC), 1, "", nil, []byte(`{}`), 0, 0, turnID, taskID, entityID, parseOK, "", turnCompletedAt, turnBlocks))
 
 	diagnosis, err := reader.LoadOperatorAgentDiagnosis(context.Background(), "agent-1", OperatorAgentDiagnosisOptions{})
 	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
@@ -861,7 +1044,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentUsesMostRecentActiveSessi
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", sessionID, now.Add(-time.Hour), 2, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()).
@@ -903,7 +1086,7 @@ func TestOperatorConversationReadSurfaceCurrentForAgentReturnsNullWithoutActiveL
 	mock.ExpectQuery("(?s)SELECT\\s+a\\.agent_id,.*FROM agents a").
 		WithArgs(runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorAgentProjectionColumns()).
-			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
+			AddRow("agent-1", "active", "", nil, 0, "", nil, []byte(`{}`), 0, 0, "", "", "", false, "", nil, []byte(`[]`)))
 	mock.ExpectQuery("(?s)SELECT\\s+session_id::text,\\s+agent_id,.*FROM agent_sessions.*status = 'active'.*ORDER BY updated_at DESC, created_at DESC, session_id ASC").
 		WithArgs("agent-1", runtimesessions.RuntimeModeSession, runtimesessions.RuntimeModeSessionPerEntity).
 		WillReturnRows(sqlmock.NewRows(operatorConversationDetailColumns()))

--- a/internal/store/operator_agent_delivery_diagnostics_read_surface.go
+++ b/internal/store/operator_agent_delivery_diagnostics_read_surface.go
@@ -1,0 +1,423 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultAgentDeliveryDiagnosticsLimit = 50
+	MaxAgentDeliveryDiagnosticsLimit     = 200
+)
+
+var ErrInvalidAgentDeliveryDiagnosticsCursor = errors.New("invalid agent delivery diagnostics cursor")
+
+type AgentDeliveryDiagnosticsCursorError struct {
+	Field string
+}
+
+func (e AgentDeliveryDiagnosticsCursorError) Error() string {
+	field := strings.TrimSpace(e.Field)
+	if field == "" {
+		field = "cursor"
+	}
+	return fmt.Sprintf("invalid agent delivery diagnostics %s", field)
+}
+
+func (e AgentDeliveryDiagnosticsCursorError) Unwrap() error {
+	return ErrInvalidAgentDeliveryDiagnosticsCursor
+}
+
+type OperatorAgentDeliveryDiagnosticsOptions struct {
+	FailureLimit     int
+	FailureCursor    string
+	DeadLetterLimit  int
+	DeadLetterCursor string
+}
+
+type OperatorAgentDeliveryDiagnostics struct {
+	AgentID               string                                  `json:"agent_id"`
+	Summary               OperatorAgentDeliveryDiagnosticsSummary `json:"summary"`
+	Failures              []OperatorAgentDeliveryFailure          `json:"failures"`
+	FailuresNextCursor    string                                  `json:"failures_next_cursor,omitempty"`
+	DeadLetters           []OperatorAgentDeadLetterDelivery       `json:"dead_letters"`
+	DeadLettersNextCursor string                                  `json:"dead_letters_next_cursor,omitempty"`
+}
+
+type OperatorAgentDeliveryDiagnosticsSummary struct {
+	Failures24h    int `json:"failures_24h"`
+	DeadLetters24h int `json:"dead_letters_24h"`
+}
+
+type OperatorAgentDeliveryFailure struct {
+	DeliveryID string    `json:"delivery_id"`
+	EventID    string    `json:"event_id"`
+	EventName  string    `json:"event_name"`
+	RunID      string    `json:"run_id,omitempty"`
+	EntityID   string    `json:"entity_id,omitempty"`
+	Status     string    `json:"status"`
+	ReasonCode string    `json:"reason_code,omitempty"`
+	LastError  string    `json:"last_error,omitempty"`
+	RetryCount int       `json:"retry_count"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+type OperatorAgentDeadLetterDelivery struct {
+	DeliveryID        string                     `json:"delivery_id"`
+	EventID           string                     `json:"event_id"`
+	EventName         string                     `json:"event_name"`
+	RunID             string                     `json:"run_id,omitempty"`
+	EntityID          string                     `json:"entity_id,omitempty"`
+	Status            string                     `json:"status"`
+	ReasonCode        string                     `json:"reason_code,omitempty"`
+	LastError         string                     `json:"last_error,omitempty"`
+	RetryCount        int                        `json:"retry_count"`
+	OccurredAt        time.Time                  `json:"occurred_at"`
+	DeadLetterRecords []OperatorDeadLetterRecord `json:"dead_letter_records"`
+}
+
+type agentDeliveryDiagnosticsCursor struct {
+	Kind       string `json:"kind"`
+	OccurredAt string `json:"occurred_at"`
+	DeliveryID string `json:"delivery_id"`
+}
+
+func (s *PostgresStore) LoadOperatorAgentDeliveryDiagnostics(ctx context.Context, agentID string, opts OperatorAgentDeliveryDiagnosticsOptions) (OperatorAgentDeliveryDiagnostics, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentDeliveryDiagnostics(ctx, agentID, opts)
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentDeliveryDiagnostics(ctx context.Context, agentID string, opts OperatorAgentDeliveryDiagnosticsOptions) (OperatorAgentDeliveryDiagnostics, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return OperatorAgentDeliveryDiagnostics{}, ErrAgentNotFound
+	}
+	if _, err := r.LoadOperatorAgent(ctx, agentID); err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+	if err := r.requireAgentDeliveryDiagnosticsCapabilities(ctx); err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+
+	opts = defaultOperatorAgentDeliveryDiagnosticsOptions(opts)
+	summary, err := r.loadAgentDeliveryDiagnosticsSummary(ctx, agentID)
+	if err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+	failures, failuresNext, err := r.listAgentDeliveryFailures(ctx, agentID, opts.FailureLimit, opts.FailureCursor)
+	if err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+	if err := r.assertAgentDeadLetterDeliveriesHaveRecords(ctx, agentID); err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+	deadLetters, deadLettersNext, err := r.listAgentDeadLetterDeliveries(ctx, agentID, opts.DeadLetterLimit, opts.DeadLetterCursor)
+	if err != nil {
+		return OperatorAgentDeliveryDiagnostics{}, err
+	}
+	result := OperatorAgentDeliveryDiagnostics{
+		AgentID:               agentID,
+		Summary:               summary,
+		Failures:              failures,
+		FailuresNextCursor:    failuresNext,
+		DeadLetters:           deadLetters,
+		DeadLettersNextCursor: deadLettersNext,
+	}
+	if result.Failures == nil {
+		result.Failures = []OperatorAgentDeliveryFailure{}
+	}
+	if result.DeadLetters == nil {
+		result.DeadLetters = []OperatorAgentDeadLetterDelivery{}
+	}
+	return result, nil
+}
+
+func defaultOperatorAgentDeliveryDiagnosticsOptions(opts OperatorAgentDeliveryDiagnosticsOptions) OperatorAgentDeliveryDiagnosticsOptions {
+	if opts.FailureLimit <= 0 {
+		opts.FailureLimit = DefaultAgentDeliveryDiagnosticsLimit
+	}
+	if opts.FailureLimit > MaxAgentDeliveryDiagnosticsLimit {
+		opts.FailureLimit = MaxAgentDeliveryDiagnosticsLimit
+	}
+	if opts.DeadLetterLimit <= 0 {
+		opts.DeadLetterLimit = DefaultAgentDeliveryDiagnosticsLimit
+	}
+	if opts.DeadLetterLimit > MaxAgentDeliveryDiagnosticsLimit {
+		opts.DeadLetterLimit = MaxAgentDeliveryDiagnosticsLimit
+	}
+	opts.FailureCursor = strings.TrimSpace(opts.FailureCursor)
+	opts.DeadLetterCursor = strings.TrimSpace(opts.DeadLetterCursor)
+	return opts
+}
+
+func (r *OperatorAgentConversationReadSurface) requireAgentDeliveryDiagnosticsCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("operator agent delivery diagnostics read owner requires postgres store")
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case caps.Events.Log != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	case !caps.Events.LogRunID:
+		return fmt.Errorf("agent delivery diagnostics read owner requires canonical events.run_id")
+	case caps.Events.Deliveries != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, r.db)
+	if err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"events": {
+			"event_id", "run_id", "event_name", "entity_id", "created_at",
+		},
+		"event_deliveries": {
+			"delivery_id", "event_id", "subscriber_type", "subscriber_id",
+			"status", "retry_count", "reason_code", "last_error", "delivered_at", "created_at",
+		},
+		"dead_letters": {
+			"dead_letter_id", "original_event_id", "failure_type", "error_message",
+			"retry_count", "chain_depth", "handler_node", "created_at",
+		},
+	}
+	for table, columns := range required {
+		if !catalog.hasColumns(table, columns...) {
+			return fmt.Errorf("agent delivery diagnostics read owner requires canonical %s columns: %s", table, strings.Join(columns, ", "))
+		}
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) loadAgentDeliveryDiagnosticsSummary(ctx context.Context, agentID string) (OperatorAgentDeliveryDiagnosticsSummary, error) {
+	var summary OperatorAgentDeliveryDiagnosticsSummary
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'failed')::int,
+			COUNT(*) FILTER (WHERE status = 'dead_letter')::int
+		FROM event_deliveries
+		WHERE subscriber_type = 'agent'
+		  AND subscriber_id = $1
+		  AND COALESCE(delivered_at, created_at) >= now() - interval '24 hours'
+	`, agentID).Scan(&summary.Failures24h, &summary.DeadLetters24h); err != nil {
+		return OperatorAgentDeliveryDiagnosticsSummary{}, fmt.Errorf("load agent delivery diagnostics summary: %w", err)
+	}
+	return summary, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) listAgentDeliveryFailures(ctx context.Context, agentID string, limit int, cursorRaw string) ([]OperatorAgentDeliveryFailure, string, error) {
+	cursorClause, args, err := agentDeliveryDiagnosticsCursorClause(agentID, cursorRaw, "agent.delivery_diagnostics.failures", "failure_cursor")
+	if err != nil {
+		return nil, "", err
+	}
+	args = append(args, limit+1)
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			d.delivery_id::text,
+			d.event_id::text,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.run_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.delivered_at, d.created_at) AS occurred_at
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		WHERE d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $1
+		  AND d.status = 'failed'
+		  %s
+		ORDER BY occurred_at DESC, d.delivery_id::text DESC
+		LIMIT $%d
+	`, cursorClause, len(args)), args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("list agent delivery failures: %w", err)
+	}
+	defer rows.Close()
+
+	out := []OperatorAgentDeliveryFailure{}
+	for rows.Next() {
+		var item OperatorAgentDeliveryFailure
+		if err := rows.Scan(
+			&item.DeliveryID,
+			&item.EventID,
+			&item.EventName,
+			&item.RunID,
+			&item.EntityID,
+			&item.ReasonCode,
+			&item.LastError,
+			&item.RetryCount,
+			&item.OccurredAt,
+		); err != nil {
+			return nil, "", fmt.Errorf("scan agent delivery failure: %w", err)
+		}
+		item.Status = "failed"
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("read agent delivery failures: %w", err)
+	}
+	nextCursor := ""
+	if len(out) > limit {
+		nextCursor = encodeAgentDeliveryDiagnosticsCursor("agent.delivery_diagnostics.failures", out[limit-1].OccurredAt, out[limit-1].DeliveryID)
+		out = out[:limit]
+	}
+	return out, nextCursor, nil
+}
+
+func (r *OperatorAgentConversationReadSurface) assertAgentDeadLetterDeliveriesHaveRecords(ctx context.Context, agentID string) error {
+	var deliveryID string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT d.delivery_id::text
+		FROM event_deliveries d
+		WHERE d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $1
+		  AND d.status = 'dead_letter'
+		  AND NOT EXISTS (
+		  	SELECT 1
+		  	FROM dead_letters dl
+		  	WHERE dl.original_event_id = d.event_id
+		  )
+		ORDER BY COALESCE(d.delivered_at, d.created_at) DESC, d.delivery_id::text DESC
+		LIMIT 1
+	`, agentID).Scan(&deliveryID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check agent dead-letter delivery reconciliation: %w", err)
+	}
+	return fmt.Errorf("agent delivery diagnostics owner found dead_letter delivery %s without a dead_letters record", deliveryID)
+}
+
+func (r *OperatorAgentConversationReadSurface) listAgentDeadLetterDeliveries(ctx context.Context, agentID string, limit int, cursorRaw string) ([]OperatorAgentDeadLetterDelivery, string, error) {
+	cursorClause, args, err := agentDeliveryDiagnosticsCursorClause(agentID, cursorRaw, "agent.delivery_diagnostics.dead_letters", "dead_letter_cursor")
+	if err != nil {
+		return nil, "", err
+	}
+	args = append(args, limit+1)
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			d.delivery_id::text,
+			d.event_id::text,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.run_id::text, ''),
+			COALESCE(e.entity_id::text, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.delivered_at, d.created_at) AS occurred_at,
+			COALESCE(jsonb_agg(jsonb_build_object(
+				'dead_letter_id', dl.dead_letter_id::text,
+				'failure_type', COALESCE(dl.failure_type, ''),
+				'error_message', COALESCE(dl.error_message, ''),
+				'retry_count', COALESCE(dl.retry_count, 0),
+				'chain_depth', COALESCE(dl.chain_depth, 0),
+				'handler_node', COALESCE(dl.handler_node, ''),
+				'created_at', dl.created_at
+			) ORDER BY dl.created_at ASC, dl.dead_letter_id::text ASC) FILTER (WHERE dl.dead_letter_id IS NOT NULL), '[]'::jsonb)
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		LEFT JOIN dead_letters dl ON dl.original_event_id = d.event_id
+		WHERE d.subscriber_type = 'agent'
+		  AND d.subscriber_id = $1
+		  AND d.status = 'dead_letter'
+		  %s
+		GROUP BY d.delivery_id, d.event_id, e.event_name, e.run_id, e.entity_id, d.reason_code, d.last_error, d.retry_count, d.delivered_at, d.created_at
+		ORDER BY occurred_at DESC, d.delivery_id::text DESC
+		LIMIT $%d
+	`, cursorClause, len(args)), args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("list agent dead-letter deliveries: %w", err)
+	}
+	defer rows.Close()
+
+	out := []OperatorAgentDeadLetterDelivery{}
+	for rows.Next() {
+		var (
+			item       OperatorAgentDeadLetterDelivery
+			recordsRaw []byte
+		)
+		if err := rows.Scan(
+			&item.DeliveryID,
+			&item.EventID,
+			&item.EventName,
+			&item.RunID,
+			&item.EntityID,
+			&item.ReasonCode,
+			&item.LastError,
+			&item.RetryCount,
+			&item.OccurredAt,
+			&recordsRaw,
+		); err != nil {
+			return nil, "", fmt.Errorf("scan agent dead-letter delivery: %w", err)
+		}
+		item.Status = "dead_letter"
+		if err := json.Unmarshal(recordsRaw, &item.DeadLetterRecords); err != nil {
+			return nil, "", fmt.Errorf("decode agent dead-letter records: %w", err)
+		}
+		if len(item.DeadLetterRecords) == 0 {
+			return nil, "", fmt.Errorf("agent delivery diagnostics owner returned dead_letter delivery %s without a dead_letters record", item.DeliveryID)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("read agent dead-letter deliveries: %w", err)
+	}
+	nextCursor := ""
+	if len(out) > limit {
+		nextCursor = encodeAgentDeliveryDiagnosticsCursor("agent.delivery_diagnostics.dead_letters", out[limit-1].OccurredAt, out[limit-1].DeliveryID)
+		out = out[:limit]
+	}
+	return out, nextCursor, nil
+}
+
+func agentDeliveryDiagnosticsCursorClause(agentID, rawCursor, kind, field string) (string, []any, error) {
+	args := []any{agentID}
+	rawCursor = strings.TrimSpace(rawCursor)
+	if rawCursor == "" {
+		return "", args, nil
+	}
+	cursor, err := decodeAgentDeliveryDiagnosticsCursor(rawCursor, kind, field)
+	if err != nil {
+		return "", nil, err
+	}
+	occurredAt, err := time.Parse(time.RFC3339Nano, cursor.OccurredAt)
+	if err != nil || strings.TrimSpace(cursor.DeliveryID) == "" {
+		return "", nil, AgentDeliveryDiagnosticsCursorError{Field: field}
+	}
+	args = append(args, occurredAt.UTC(), strings.TrimSpace(cursor.DeliveryID))
+	return fmt.Sprintf("AND (COALESCE(d.delivered_at, d.created_at) < $%d OR (COALESCE(d.delivered_at, d.created_at) = $%d AND d.delivery_id::text < $%d))", len(args)-1, len(args)-1, len(args)), args, nil
+}
+
+func encodeAgentDeliveryDiagnosticsCursor(kind string, occurredAt time.Time, deliveryID string) string {
+	raw, _ := json.Marshal(agentDeliveryDiagnosticsCursor{
+		Kind:       strings.TrimSpace(kind),
+		OccurredAt: occurredAt.UTC().Format(time.RFC3339Nano),
+		DeliveryID: strings.TrimSpace(deliveryID),
+	})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeAgentDeliveryDiagnosticsCursor(raw, kind, field string) (agentDeliveryDiagnosticsCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return agentDeliveryDiagnosticsCursor{}, AgentDeliveryDiagnosticsCursorError{Field: field}
+	}
+	var cursor agentDeliveryDiagnosticsCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return agentDeliveryDiagnosticsCursor{}, AgentDeliveryDiagnosticsCursorError{Field: field}
+	}
+	if strings.TrimSpace(cursor.Kind) != strings.TrimSpace(kind) {
+		return agentDeliveryDiagnosticsCursor{}, AgentDeliveryDiagnosticsCursorError{Field: field}
+	}
+	return cursor, nil
+}

--- a/internal/store/operator_agent_delivery_diagnostics_read_surface.go
+++ b/internal/store/operator_agent_delivery_diagnostics_read_surface.go
@@ -97,10 +97,10 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentDeliveryDiagnost
 	if agentID == "" {
 		return OperatorAgentDeliveryDiagnostics{}, ErrAgentNotFound
 	}
-	if _, err := r.LoadOperatorAgent(ctx, agentID); err != nil {
+	if err := r.requireAgentDeliveryDiagnosticsCapabilities(ctx); err != nil {
 		return OperatorAgentDeliveryDiagnostics{}, err
 	}
-	if err := r.requireAgentDeliveryDiagnosticsCapabilities(ctx); err != nil {
+	if err := r.ensureAgentDeliveryDiagnosticsAgentExists(ctx, agentID); err != nil {
 		return OperatorAgentDeliveryDiagnostics{}, err
 	}
 
@@ -164,6 +164,8 @@ func (r *OperatorAgentConversationReadSurface) requireAgentDeliveryDiagnosticsCa
 		return err
 	}
 	switch {
+	case caps.Agents != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("agents", caps.Agents)
 	case caps.Events.Log != SchemaFlavorCanonical:
 		return unsupportedSchemaCapability("events", caps.Events.Log)
 	case !caps.Events.LogRunID:
@@ -176,6 +178,9 @@ func (r *OperatorAgentConversationReadSurface) requireAgentDeliveryDiagnosticsCa
 		return err
 	}
 	required := map[string][]string{
+		"agents": {
+			"agent_id", "status",
+		},
 		"events": {
 			"event_id", "run_id", "event_name", "entity_id", "created_at",
 		},
@@ -192,6 +197,24 @@ func (r *OperatorAgentConversationReadSurface) requireAgentDeliveryDiagnosticsCa
 		if !catalog.hasColumns(table, columns...) {
 			return fmt.Errorf("agent delivery diagnostics read owner requires canonical %s columns: %s", table, strings.Join(columns, ", "))
 		}
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) ensureAgentDeliveryDiagnosticsAgentExists(ctx context.Context, agentID string) error {
+	var exists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM agents
+			WHERE agent_id = $1
+			  AND status NOT IN ('terminated', 'ephemeral')
+		)
+	`, agentID).Scan(&exists); err != nil {
+		return fmt.Errorf("load agent delivery diagnostics agent: %w", err)
+	}
+	if !exists {
+		return ErrAgentNotFound
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #1095
Part of #852

## Summary

Promotes the approved separate per-agent delivery diagnostics read owner and API surface:

- Adds `agent.delivery_diagnostics` / `AgentDeliveryDiagnostics` to tracked `platform-spec.yaml` and regenerates `openrpc.json`.
- Adds `/v1/rpc agent.delivery_diagnostics` handler validation and OpenRPC compliance/runtime proof coverage.
- Adds `LoadOperatorAgentDeliveryDiagnostics` as the canonical store owner for per-agent failed-delivery rows and terminal dead-letter delivery rows.
- Removes the dormant dashboard/helper `failures_24h` and `dead_letters_24h` projection fields from `OperatorAgentSummary` / `genericAgent` so they no longer act as an independent same-concept owner.

## Governing Refs / Context

Exact governing refs:

- `platform-spec.yaml` `agent.diagnose` / `AgentDiagnosis`: remains lean and does not gain recent failure/dead-letter fields.
- `platform-spec.yaml` new `agent.delivery_diagnostics` / `AgentDeliveryDiagnostics` contract.
- `platform-spec.yaml` event/dead-letter adjacent owners: `event_deliveries`, `dead_letters`, `event.list`, `event.get`, `run.trace`, `run.diagnose`.
- Issue #1095 pre-audit and gate outcome: `approved as first slice`, with the binding method/schema direction `agent.delivery_diagnostics` / `AgentDeliveryDiagnostics`.

## Semantic Migration

New canonical owner:

- Store: `LoadOperatorAgentDeliveryDiagnostics` / `OperatorAgentDeliveryDiagnostics`.
- API: `/v1/rpc agent.delivery_diagnostics`.
- Contract: `AgentDeliveryDiagnostics`, `AgentDeliveryDiagnosticsSummary`, `AgentDeliveryFailure`, `AgentDeadLetterDelivery`.

Old producer / reader / writer path now invalid:

- Dashboard/helper `OperatorAgentSummary.Failures24h` / `DeadLetters24h` and `genericAgent.failures_24h` / `dead_letters_24h` are removed as same-concept summary owners.
- Handler-local reconstruction from `run.trace`, `run.diagnose`, `event.list`, `event.get`, `event_receipts`, runtime memory, EventBus, CLI state, or dashboard helpers remains invalid.

Production paths checked for surviving old behavior:

- API handler registry and OpenRPC runtime probes.
- Store operator agent projection.
- Dashboard `genericAgent` projection/tests.
- `swarm agent diagnose` remains unchanged and does not expose split fields.

Migration status: complete for the approved #1095 API/read-owner slice. Parent #852 remains open for non-H/non-this-slice tails such as token usage rollups and richer runtime/tool diagnostics.

## Tests

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./internal/apiv1 -run 'TestPlatformAPISpecValidationCoverage|TestGeneratedOpenRPCArtifactMatchesPlatformSpec|TestRegistryMethodNamesMatchGeneratedOpenRPC|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorAgentConversationHandlersTypedErrors|TestOperatorAgentDeliveryDiagnostics|TestOpenRPCSuccessfulResultSchemas|TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod' -count=1`
- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnostics|TestOperatorAgent.*Diagnosis|Test.*Dead|Test.*Delivery|Test.*RunDebug|Test.*Observability|Test.*AgentLifecycle|TestEventReceipts|TestListPendingAgentDeliveryFacts' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLAgentReader.*(UsesOperatorProjectionAsCanonicalOwner|UsesCanonicalLifecycleProjection|AlignsBacklogWithCanonicalPendingSelector|LastTool|TurnSummary|FailsClosed)|TestHandler_AgentHandlersDoNotExposeUnsupportedMetricStubs|TestHandler_LegacyDashboardRoutesFailClosedWithoutAuthBoundary|TestHandler_DashboardRoutesFailClosedWhenAuthIsNotConfigured|TestHandler_OnlyHealthRouteIsMounted|TestHandler_LegacyDashboardRoutesFailClosed' -count=1`
- `go test ./cmd/swarm -run 'TestAgentDiagnose|TestCLIAPIResolverIncludesAgentCommands' -count=1`
- `go test ./...`

Note: full-suite proof required a test-only clock fixture repair in `conversation_fork_lifecycle_test.go`; the prior fixed `2026-05-25` fork timestamp had expired under the current 24h TTL.