### PR TITLE
[agent-c][issue #1105] Fix conversation fork lifecycle clock

### DIFF
--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -15,7 +15,7 @@ func TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete(t *test
 	_, db, _ := testutil.StartPostgres(t)
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
-	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	now := activeConversationForkTestClock()
 	source := seedConversationForkSource(t, db, now)
 
 	created, err := s.CreateOperatorConversationFork(ctx, ConversationForkCreateRequest{
@@ -131,6 +131,10 @@ func TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete(t *test
 	if normalSessionRows != 0 {
 		t.Fatalf("fork lifecycle leaked into agent_sessions rows = %d", normalSessionRows)
 	}
+}
+
+func activeConversationForkTestClock() time.Time {
+	return time.Now().UTC().Truncate(time.Second)
 }
 
 func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testing.T) {


### PR DESCRIPTION
## Summary
- makes `TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete` derive its fixture clock from the test start time
- keeps the change test-only; production lifecycle state still uses the existing `LoadOperatorConversationFork` real-time state calculation
- removes the hard-coded 2026-05-26 12:00 UTC expiry that made the test fail after that date

Closes #1105

## Tests
- Reproduced before fix: `go test ./internal/store -run TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete -count=1`
- `go test ./internal/store -run TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete -count=1`
- `go test ./internal/store -count=1`
- `go test ./...`
