### PR TITLE
[agent-e][issue #1017] Publish bundle read catalog APIs

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -358,6 +358,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Observability:      stores.Postgres,
 		Entities:           apiEntities,
 		AgentConversations: apiAgentConversations,
+		BundleCatalog:      stores.Postgres,
 		ConversationForks:  stores.Postgres,
 		ForkChatExecutor:   apiv1.NewLLMForkChatExecutor(forkChatLLM),
 		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -323,7 +323,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -399,7 +399,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -454,7 +454,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -514,7 +514,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -568,7 +568,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -626,7 +626,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -767,7 +767,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -893,7 +893,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1113,7 +1113,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1151,7 +1151,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1254,7 +1254,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1313,6 +1313,156 @@
           }
         }
       ]
+    },
+    {
+      "name": "bundle.agents",
+      "description": "Return definition-only agent catalog entries projected from the persisted bundle row identified by bundle_hash. This method must not read runtime agents, sessions, queues, diagnoses, active tasks, or status fields, and does not close strict duplicate-slug runtime identity work.\n",
+      "params": [
+        {
+          "name": "bundle_hash",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BundleAgentsResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32004,
+          "message": "Application error: BUNDLE_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  }
+                },
+                "required": [
+                  "bundle_hash"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bundle.get",
+      "description": "Read one persisted bundle catalog row by canonical bundle_hash. The result returns stored config, parsed projection, metadata, and data presence facts only; it does not expose runtime state or server-local filesystem paths.\n",
+      "params": [
+        {
+          "name": "bundle_hash",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BundleDetail"
+        }
+      },
+      "errors": [
+        {
+          "code": -32004,
+          "message": "Application error: BUNDLE_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  }
+                },
+                "required": [
+                  "bundle_hash"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bundle.list",
+      "description": "List persisted bundle catalog rows. This is a definition/catalog read over the bundles store owner, not runtime state. Results are ordered by newest ingested_at then bundle_hash and may be cursor-paginated.\n",
+      "params": [
+        {
+          "name": "limit",
+          "required": false,
+          "schema": {
+            "default": 50,
+            "maximum": 500,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Cursor"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BundleListResult"
+        }
+      }
     },
     {
       "name": "conversation.current_for_agent",
@@ -1417,7 +1567,7 @@
       },
       "errors": [
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1455,7 +1605,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1498,7 +1648,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1536,7 +1686,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1632,7 +1782,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1670,7 +1820,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1758,7 +1908,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1796,7 +1946,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1929,7 +2079,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1989,7 +2139,7 @@
       },
       "errors": [
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2066,7 +2216,7 @@
       },
       "errors": [
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2104,7 +2254,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2272,7 +2422,7 @@
       },
       "errors": [
         {
-          "code": -32004,
+          "code": -32005,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2405,7 +2555,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2627,7 +2777,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -2662,7 +2812,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2697,7 +2847,7 @@
           }
         },
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -2750,7 +2900,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2807,7 +2957,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -2865,7 +3015,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2903,7 +3053,7 @@
           }
         },
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2941,7 +3091,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -2983,7 +3133,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3082,7 +3232,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3120,7 +3270,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -3158,7 +3308,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -3213,7 +3363,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3273,7 +3423,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -3327,7 +3477,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3385,7 +3535,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3566,7 +3716,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3604,7 +3754,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3656,7 +3806,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -3698,7 +3848,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3793,7 +3943,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3831,7 +3981,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3883,7 +4033,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -3928,7 +4078,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4009,7 +4159,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4164,7 +4314,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4202,7 +4352,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4254,7 +4404,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4362,7 +4512,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4400,7 +4550,7 @@
           }
         },
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4442,7 +4592,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4523,7 +4673,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4592,7 +4742,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4733,7 +4883,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4771,7 +4921,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -4813,7 +4963,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4851,7 +5001,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5026,7 +5176,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -5061,7 +5211,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -5096,7 +5246,7 @@
           }
         },
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -5149,7 +5299,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5206,7 +5356,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5264,7 +5414,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5352,7 +5502,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5390,7 +5540,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5432,7 +5582,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5532,7 +5682,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5633,7 +5783,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5913,7 +6063,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -5951,7 +6101,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6032,7 +6182,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6063,7 +6213,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6144,7 +6294,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6175,7 +6325,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6823,6 +6973,116 @@
         "description": "Layer-of-the-system identifier when operational_state is \"stalled\".\nEmpty string when state is running or terminal. Source of truth:\nProjectRunOperationalStatus. Current owner emits:\n  \"\" (empty) — state is running or terminal\n  \"scoring_terminal_outcome\" — scoring entities have not reached\n    a terminal scoring outcome (shortlisted/marginal/rejected)\n  \"delivery_lifecycle\" — no active deliveries but events exist\nAdditional values may be added as the operator-state owner gains\nmore diagnostic semantics. Type stays string (not enum) for\nforward compatibility — additive owner extensions must not\nrequire a /v2/ bump.\n",
         "type": "string"
       },
+      "BundleAgentDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "conversation_mode": {
+            "type": "string"
+          },
+          "flow_instance": {
+            "description": "Persisted flow instance/catalog path when the definition is nested under a flow.",
+            "type": "string"
+          },
+          "llm_backend": {
+            "type": "string"
+          },
+          "model_tier": {
+            "type": "string"
+          },
+          "prompt_path": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "session_scope": {
+            "type": "string"
+          },
+          "subscriptions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_id"
+        ],
+        "type": "object"
+      },
+      "BundleAgentsResult": {
+        "additionalProperties": false,
+        "properties": {
+          "agents": {
+            "items": {
+              "$ref": "#/components/schemas/BundleAgentDefinition"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "agents"
+        ],
+        "type": "object"
+      },
+      "BundleDetail": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "bundle_hash": {
+            "$ref": "#/components/schemas/BundleHash"
+          },
+          "content_yaml": {
+            "description": "Persisted bundle config bytes for this catalog row.",
+            "type": "string"
+          },
+          "data_size_bytes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "has_data": {
+            "type": "boolean"
+          },
+          "ingested_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "parsed_json": {
+            "additionalProperties": true,
+            "description": "Persisted parsed projection for the bundle row.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "bundle_hash",
+          "content_yaml",
+          "parsed_json",
+          "metadata",
+          "agent_count",
+          "has_data",
+          "data_size_bytes",
+          "ingested_at"
+        ],
+        "type": "object"
+      },
       "BundleHash": {
         "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name. Until the canonical source-fact owner is promoted, runtime identity assertions that supply bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH.",
         "pattern": "^bundle-v1:sha256:[a-f0-9]{64}$",
@@ -6849,6 +7109,24 @@
         ],
         "type": "object"
       },
+      "BundleListResult": {
+        "additionalProperties": false,
+        "properties": {
+          "bundles": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSummary"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "$ref": "#/components/schemas/Cursor"
+          }
+        },
+        "required": [
+          "bundles"
+        ],
+        "type": "object"
+      },
       "BundleRef": {
         "additionalProperties": false,
         "description": "Deprecated legacy bundle reference accepted during the #1001 dual-accept transition. New callers use bundle_hash with BundleHash shape once canonical source facts are available. BundleRef carries the legacy sha256 fingerprint only and cannot be combined with bundle_hash; doing so fails closed with UNSUPPORTED_BUNDLE_HASH before runtime/store mutation.\n",
@@ -6859,6 +7137,44 @@
         },
         "required": [
           "fingerprint"
+        ],
+        "type": "object"
+      },
+      "BundleSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_count": {
+            "description": "Number of definition-only agents projected from the persisted bundle row.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "bundle_hash": {
+            "$ref": "#/components/schemas/BundleHash"
+          },
+          "data_size_bytes": {
+            "description": "Size of data_blob in bytes, or 0 when has_data is false.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "has_data": {
+            "description": "True when the persisted bundle row carries an auxiliary data_blob.",
+            "type": "boolean"
+          },
+          "ingested_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "bundle_hash",
+          "agent_count",
+          "has_data",
+          "data_size_bytes",
+          "metadata",
+          "ingested_at"
         ],
         "type": "object"
       },
@@ -8770,6 +9086,7 @@
           "admin:runs",
           "read:entities",
           "read:events",
+          "read:bundles",
           "read:mailbox",
           "approve:mailbox",
           "read:agents",
@@ -9167,8 +9484,46 @@
           "type": "object"
         }
       },
-      "ENTITY_NOT_FOUND": {
+      "BUNDLE_NOT_FOUND": {
         "code": -32004,
+        "message": "Application error: BUNDLE_NOT_FOUND",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "BUNDLE_NOT_FOUND",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                }
+              },
+              "required": [
+                "bundle_hash"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "ENTITY_NOT_FOUND": {
+        "code": -32005,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9206,7 +9561,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32005,
+        "code": -32006,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -9259,7 +9614,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32006,
+        "code": -32007,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9297,7 +9652,7 @@
         }
       },
       "EVENT_PUBLISH_FAILED": {
-        "code": -32007,
+        "code": -32008,
         "message": "Application error: EVENT_PUBLISH_FAILED",
         "data": {
           "additionalProperties": false,
@@ -9354,7 +9709,7 @@
         }
       },
       "EVENT_REPLAY_NOT_ELIGIBLE": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -9408,7 +9763,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -9446,7 +9801,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -9501,7 +9856,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -9561,7 +9916,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9599,7 +9954,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -9658,7 +10013,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -9703,7 +10058,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -9755,7 +10110,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -9797,7 +10152,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -9835,7 +10190,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -9873,7 +10228,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -9931,7 +10286,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9962,7 +10317,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -9993,7 +10348,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -10031,7 +10386,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -10069,7 +10424,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -10111,7 +10466,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10149,7 +10504,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -10191,7 +10546,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10229,7 +10584,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10272,7 +10627,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH": {
-        "code": -32029,
+        "code": -32030,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
         "data": {
           "additionalProperties": false,
@@ -10307,7 +10662,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32030,
+        "code": -32031,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5336,15 +5336,17 @@ multi_bundle_persistence:
     only. Runtime, API handler, CLI implementation, database migration, and generated OpenRPC publication remain separately
     gated implementation work unless a later PR explicitly promotes and proves them.
   generated_artifact_policy:
-    current_openrpc_status: unchanged
+    current_openrpc_status: bundle_read_catalog_methods_published
     rule: >
       Generated openrpc.json is derived from api_specification.method_catalog and must continue to match the currently
-      registered /v1/rpc handler set. Multi-bundle methods described here are source authority but are not added to
-      method_catalog/OpenRPC until their API/runtime handlers are implemented and registered in the same gated PR.
+      registered /v1/rpc handler set. The read-only bundle.list, bundle.get, and bundle.agents catalog methods are now
+      published because their handlers and store owner are implemented in the same gated PR. Mutating bundle.register,
+      destructive bundle.delete, and run.fork remain source authority only until their API/runtime handlers are implemented
+      and registered in a later gated PR.
     proof_expectation: >
-      Source-authority promotion proof must verify that run.fork and bundle.* are not silently published in generated
-      OpenRPC without implementation, and that future implementation PRs promote matching method_catalog entries and
-      generated artifacts together.
+      Source-authority promotion proof must verify that run.fork, bundle.register, and bundle.delete are not silently
+      published in generated OpenRPC without implementation, and that future implementation PRs promote matching
+      method_catalog entries and generated artifacts together.
   bundle_identity:
     canonical_name: bundle_hash
     format: 'bundle-v1:sha256:<64 lowercase hex>'
@@ -5595,7 +5597,7 @@ multi_bundle_persistence:
         - containers_stopped
         - dry_run
   api_surface:
-    publication_status: source_authority_not_generated_openrpc_until_runtime_api_implementation
+    publication_status: partial_read_catalog_generated_openrpc
     command_transport_owner: api_specification
     bundle_methods_planned:
       bundle.list:
@@ -9633,12 +9635,14 @@ api_specification:
       downgraded to backlog before it can be used as implementation authority.
   multi_bundle_publication_boundary:
     owner: multi_bundle_persistence.api_surface
-    status: source_authority_not_method_catalog
+    status: partial_bundle_read_catalog_method_catalog
     rule: >
       #1012 promotes the multi-bundle API contract as source authority, including bundle.* methods, run.fork, bundle_hash
-      filters, and bundle_hash create-new-work params. These methods and shapes are not in method_catalog/OpenRPC until
-      a later gated API/runtime implementation PR registers handlers and regenerates openrpc.json/proof artifacts in the
-      same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or #1038 prose as API authority after #1012.
+      filters, and bundle_hash create-new-work params. The read-only bundle.list, bundle.get, and bundle.agents methods are
+      now in method_catalog/OpenRPC with matching handlers and proof. Remaining multi-bundle methods and shapes are not in
+      method_catalog/OpenRPC until a later gated API/runtime implementation PR registers handlers and regenerates
+      openrpc.json/proof artifacts in the same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or #1038
+      prose as API authority after #1012.
     blocked_children:
       run_fork_api_runtime_cli: '#989'
       multi_bundle_cli_inventory: '#1023'
@@ -10013,6 +10017,7 @@ api_specification:
       - admin:runs
       - read:entities
       - read:events
+      - read:bundles
       - read:mailbox
       - approve:mailbox
       - read:agents
@@ -10111,6 +10116,7 @@ api_specification:
         - admin:runs
         - read:entities
         - read:events
+        - read:bundles
         - read:mailbox
         - approve:mailbox
         - read:agents
@@ -10151,6 +10157,125 @@ api_specification:
             type: string
           fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
+      BundleSummary:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        - agent_count
+        - has_data
+        - data_size_bytes
+        - metadata
+        - ingested_at
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          agent_count:
+            type: integer
+            minimum: 0
+            description: Number of definition-only agents projected from the persisted bundle row.
+          has_data:
+            type: boolean
+            description: True when the persisted bundle row carries an auxiliary data_blob.
+          data_size_bytes:
+            type: integer
+            minimum: 0
+            description: Size of data_blob in bytes, or 0 when has_data is false.
+          metadata:
+            type: object
+            additionalProperties: true
+          ingested_at:
+            $ref: '#/components/schemas/Timestamp'
+      BundleListResult:
+        type: object
+        additionalProperties: false
+        required:
+        - bundles
+        properties:
+          bundles:
+            type: array
+            items:
+              $ref: '#/components/schemas/BundleSummary'
+          next_cursor:
+            $ref: '#/components/schemas/Cursor'
+      BundleDetail:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        - content_yaml
+        - parsed_json
+        - metadata
+        - agent_count
+        - has_data
+        - data_size_bytes
+        - ingested_at
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          content_yaml:
+            type: string
+            description: Persisted bundle config bytes for this catalog row.
+          parsed_json:
+            type: object
+            additionalProperties: true
+            description: Persisted parsed projection for the bundle row.
+          metadata:
+            type: object
+            additionalProperties: true
+          agent_count:
+            type: integer
+            minimum: 0
+          has_data:
+            type: boolean
+          data_size_bytes:
+            type: integer
+            minimum: 0
+          ingested_at:
+            $ref: '#/components/schemas/Timestamp'
+      BundleAgentDefinition:
+        type: object
+        additionalProperties: false
+        required:
+        - agent_id
+        properties:
+          agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          flow_instance:
+            type: string
+            description: Persisted flow instance/catalog path when the definition is nested under a flow.
+          role:
+            type: string
+          type:
+            type: string
+          model_tier:
+            type: string
+          llm_backend:
+            type: string
+          conversation_mode:
+            type: string
+          session_scope:
+            type: string
+          prompt_path:
+            type: string
+          subscriptions:
+            type: array
+            items:
+              type: string
+          tools:
+            type: array
+            items:
+              type: string
+      BundleAgentsResult:
+        type: object
+        additionalProperties: false
+        required:
+        - agents
+        properties:
+          agents:
+            type: array
+            items:
+              $ref: '#/components/schemas/BundleAgentDefinition'
       HealthCheckResult:
         type: object
         additionalProperties: false
@@ -12160,6 +12285,14 @@ api_specification:
             $ref: '#/components/schemas/Sha256Fingerprint'
           boot_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
+      BUNDLE_NOT_FOUND:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
       UNSUPPORTED_BUNDLE_HASH:
         type: object
         additionalProperties: false
@@ -12591,6 +12724,73 @@ api_specification:
         schema:
           $ref: '#/components/schemas/HealthCheckResult'
       errors: []
+    bundle.list:
+      tier: should_have
+      description: >
+        List persisted bundle catalog rows. This is a definition/catalog read over the bundles store owner, not runtime
+        state. Results are ordered by newest ingested_at then bundle_hash and may be cursor-paginated.
+      scope:
+        required:
+        - read:bundles
+      params:
+      - name: limit
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 500
+          default: 50
+      - name: cursor
+        required: false
+        schema:
+          $ref: '#/components/schemas/Cursor'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleListResult'
+      errors: []
+    bundle.get:
+      tier: should_have
+      description: >
+        Read one persisted bundle catalog row by canonical bundle_hash. The result returns stored config, parsed projection,
+        metadata, and data presence facts only; it does not expose runtime state or server-local filesystem paths.
+      scope:
+        required:
+        - read:bundles
+      params:
+      - name: bundle_hash
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleHash'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleDetail'
+      errors:
+      - BUNDLE_NOT_FOUND
+    bundle.agents:
+      tier: should_have
+      description: >
+        Return definition-only agent catalog entries projected from the persisted bundle row identified by bundle_hash. This
+        method must not read runtime agents, sessions, queues, diagnoses, active tasks, or status fields, and does not close
+        strict duplicate-slug runtime identity work.
+      scope:
+        required:
+        - read:bundles
+      params:
+      - name: bundle_hash
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleHash'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleAgentsResult'
+      errors:
+      - BUNDLE_NOT_FOUND
     health.subscribe:
       tier: should_have
       description: WebSocket heartbeat subscription. Notifications carry the same shape as health.check returns.
@@ -14475,8 +14675,9 @@ api_specification:
       rationale: >
         Legacy dynamic bundle.open/reload/close remains deferred and is not the multi-bundle public API. #1012 promotes the
         authoritative multi-bundle source model under multi_bundle_persistence, with planned bundle.list/get/agents/register/delete,
-        run.fork, and bundle_hash create-new-work semantics. Those planned methods are intentionally not added to
-        method_catalog/OpenRPC until their gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
+        run.fork, and bundle_hash create-new-work semantics. The read-only bundle.list/get/agents catalog methods are now
+        published in method_catalog/OpenRPC with handlers; bundle.register/delete and run.fork remain withheld until their
+        gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
         language is migration evidence only after the #1001 bundle_hash decision.
     verify:
       methods:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,14 +16,14 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 49 {
-		t.Fatalf("method count = %d, want 49", report.MethodCount)
+	if report.MethodCount != 52 {
+		t.Fatalf("method count = %d, want 52", report.MethodCount)
 	}
-	if report.SchemaCount != 87 {
-		t.Fatalf("schema count = %d, want 87", report.SchemaCount)
+	if report.SchemaCount != 92 {
+		t.Fatalf("schema count = %d, want 92", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 31 {
-		t.Fatalf("error code count = %d, want 31", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 32 {
+		t.Fatalf("error code count = %d, want 32", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 19 {
 		t.Fatalf("mutating method count = %d, want 19", report.MutatingMethodCount)
@@ -66,14 +66,14 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 49 {
-		t.Fatalf("generated OpenRPC methods = %d, want 49", len(doc.Methods))
+	if len(doc.Methods) != 52 {
+		t.Fatalf("generated OpenRPC methods = %d, want 52", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 87 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 87", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 92 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 92", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 31 {
-		t.Fatalf("generated OpenRPC errors = %d, want 31", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 32 {
+		t.Fatalf("generated OpenRPC errors = %d, want 32", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
@@ -95,6 +95,16 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["agent.delivery_diagnostics"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.delivery_diagnostics")
+	}
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents"} {
+		if _, ok := methods[methodName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", methodName)
+		}
+	}
+	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult"} {
+		if _, ok := doc.Components.Schemas[schemaName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", schemaName)
+		}
 	}
 	for _, methodName := range []string{"conversation.fork", "conversation.fork_chat", "conversation.fork_list", "conversation.fork_view", "conversation.fork_delete"} {
 		if _, ok := methods[methodName]; !ok {
@@ -239,7 +249,7 @@ func TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints(t *testin
 	}
 }
 
-func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *testing.T) {
+func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadMethods(t *testing.T) {
 	root := loadPlatformSpecYAMLNode(t)
 	multi := mustMappingValue(t, root, "multi_bundle_persistence")
 	assertScalarValue(t, mustMappingValue(t, multi, "status"), "promoted_source_authority_no_runtime_behavior")
@@ -248,9 +258,10 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
 
 	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
-	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "unchanged")
-	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "not added to")
-	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "until their API/runtime handlers are implemented")
+	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_methods_published")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.list")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.register")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "later gated PR")
 
 	identity := mustMappingValue(t, multi, "bundle_identity")
 	assertScalarValue(t, mustMappingValue(t, identity, "canonical_name"), "bundle_hash")
@@ -299,7 +310,7 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	}
 
 	apiSurface := mustMappingValue(t, multi, "api_surface")
-	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "source_authority_not_generated_openrpc_until_runtime_api_implementation")
+	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "partial_read_catalog_generated_openrpc")
 
 	bundleDelete := mustMappingValue(t, multi, "bundle_delete")
 	phaseFive := mustMappingValue(t, bundleDelete, "phase_5_atomicity")
@@ -387,7 +398,7 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	}
 
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
-	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "source_authority_not_method_catalog")
+	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_method_catalog")
 
 	for _, relPath := range []string{
 		filepath.Join("cmd", "swarm", "cli.go"),
@@ -412,7 +423,12 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	}
 
 	api := loadRepoAPISpec(t)
-	for _, methodName := range []string{"run.fork", "bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete"} {
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents"} {
+		if _, ok := api.MethodCatalog[methodName]; !ok {
+			t.Fatalf("%s must be in live method_catalog after read-only bundle catalog implementation lands", methodName)
+		}
+	}
+	for _, methodName := range []string{"run.fork", "bundle.register", "bundle.delete"} {
 		if _, ok := api.MethodCatalog[methodName]; ok {
 			t.Fatalf("%s must not be in live method_catalog until handler implementation lands", methodName)
 		}
@@ -427,7 +443,7 @@ func TestMultiBundleSourceAuthorityStaysOutOfLiveOpenRPCUntilImplemented(t *test
 	}
 	for _, method := range doc.Methods {
 		switch method.Name {
-		case "run.fork", "bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete":
+		case "run.fork", "bundle.register", "bundle.delete":
 			t.Fatalf("%s must not be published in generated OpenRPC until implementation lands", method.Name)
 		}
 	}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 49 {
-		t.Fatalf("method count = %d, want 49", len(openRPCNames))
+	if len(openRPCNames) != 52 {
+		t.Fatalf("method count = %d, want 52", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")
@@ -457,6 +457,133 @@ func TestOperatorReadHandlersRunListRejectsInvalidFilters(t *testing.T) {
 	}
 }
 
+func TestOperatorBundleCatalogHandlersExposeStoreOwner(t *testing.T) {
+	now := time.Unix(1700000100, 0).UTC()
+	bundleHash := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	catalog := &fakeBundleCatalogReadStore{
+		listResult: store.BundleCatalogListResult{
+			Bundles: []store.BundleCatalogSummary{{
+				BundleHash:    bundleHash,
+				AgentCount:    1,
+				HasData:       true,
+				DataSizeBytes: 4,
+				Metadata:      map[string]any{"source": "test"},
+				IngestedAt:    now,
+			}},
+			NextCursor: "cursor-2",
+		},
+		details: map[string]store.BundleCatalogDetail{
+			bundleHash: {
+				BundleHash:    bundleHash,
+				ContentYAML:   "name: test",
+				ParsedJSON:    map[string]any{"agents": map[string]any{}},
+				Metadata:      map[string]any{"source": "test"},
+				AgentCount:    1,
+				HasData:       true,
+				DataSizeBytes: 4,
+				IngestedAt:    now,
+			},
+		},
+		agents: map[string]store.BundleCatalogAgentsResult{
+			bundleHash: {
+				Agents: []store.BundleCatalogAgentDefinition{{
+					AgentID:          "researcher",
+					Role:             "research",
+					Type:             "managed",
+					ModelTier:        "haiku",
+					LLMBackend:       "claude",
+					ConversationMode: "session",
+					SessionScope:     "flow",
+					PromptPath:       "prompts/researcher.md",
+					Subscriptions:    []string{"scan.requested"},
+					Tools:            []string{"web_search"},
+				}},
+			},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:         func() bool { return true },
+			Database:      fakePinger{err: nil},
+			BundleCatalog: catalog,
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"bundle.list","params":{"limit":1,"cursor":"cursor-1"}}`)
+	if list.Error != nil {
+		t.Fatalf("bundle.list error = %#v", list.Error)
+	}
+	if catalog.lastList.Limit != 1 || catalog.lastList.Cursor != "cursor-1" {
+		t.Fatalf("bundle.list opts = %#v", catalog.lastList)
+	}
+	listResult := asMap(t, list.Result)
+	if listResult["next_cursor"] != "cursor-2" {
+		t.Fatalf("bundle.list next_cursor = %#v", listResult["next_cursor"])
+	}
+	bundles, ok := listResult["bundles"].([]any)
+	if !ok || len(bundles) != 1 {
+		t.Fatalf("bundle.list bundles = %#v", listResult["bundles"])
+	}
+	if asMap(t, bundles[0])["bundle_hash"] != bundleHash {
+		t.Fatalf("bundle.list bundle row = %#v", bundles[0])
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"bundle.get","params":{"bundle_hash":"`+bundleHash+`"}}`)
+	if get.Error != nil {
+		t.Fatalf("bundle.get error = %#v", get.Error)
+	}
+	if got := asMap(t, get.Result)["bundle_hash"]; got != bundleHash {
+		t.Fatalf("bundle.get bundle_hash = %#v", got)
+	}
+
+	agents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agents","method":"bundle.agents","params":{"bundle_hash":"`+bundleHash+`"}}`)
+	if agents.Error != nil {
+		t.Fatalf("bundle.agents error = %#v", agents.Error)
+	}
+	agentRows := asMap(t, agents.Result)["agents"].([]any)
+	agent := asMap(t, agentRows[0])
+	if agent["agent_id"] != "researcher" || agent["model_tier"] != "haiku" {
+		t.Fatalf("bundle.agents row = %#v", agent)
+	}
+	for _, runtimeKey := range []string{"status", "runtime_state", "queue", "active", "session_id"} {
+		if _, ok := agent[runtimeKey]; ok {
+			t.Fatalf("bundle.agents leaked runtime key %q: %#v", runtimeKey, agent)
+		}
+	}
+}
+
+func TestOperatorBundleCatalogHandlersErrors(t *testing.T) {
+	bundleHash := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			BundleCatalog: &fakeBundleCatalogReadStore{
+				missing: map[string]bool{bundleHash: true},
+				listErr: store.ErrInvalidBundleCatalogCursor,
+			},
+		}),
+	})
+
+	badHash := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"bad","method":"bundle.get","params":{"bundle_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`)
+	if badHash.Error == nil || badHash.Error.Code != codeInvalidParams {
+		t.Fatalf("bundle.get invalid hash error = %#v, want invalid params", badHash.Error)
+	}
+
+	missing := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"missing","method":"bundle.get","params":{"bundle_hash":"`+bundleHash+`"}}`)
+	if missing.Error == nil {
+		t.Fatal("bundle.get missing error = nil, want BUNDLE_NOT_FOUND")
+	}
+	if data := asMap(t, missing.Error.Data); data["code"] != BundleNotFoundCode {
+		t.Fatalf("bundle.get missing error data = %#v", data)
+	}
+
+	badCursor := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"cursor","method":"bundle.list","params":{"cursor":"bad"}}`)
+	if badCursor.Error == nil || badCursor.Error.Code != codeInvalidParams {
+		t.Fatalf("bundle.list invalid cursor error = %#v, want invalid params", badCursor.Error)
+	}
+}
+
 func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {
 	t.Helper()
 	rec := httptest.NewRecorder()
@@ -521,6 +648,47 @@ func (s *fakeRunReadStore) LoadRunDebugReport(_ context.Context, runID string, _
 	}
 	return report, nil
 }
+
+type fakeBundleCatalogReadStore struct {
+	listResult store.BundleCatalogListResult
+	listErr    error
+	lastList   store.BundleCatalogListOptions
+	details    map[string]store.BundleCatalogDetail
+	agents     map[string]store.BundleCatalogAgentsResult
+	missing    map[string]bool
+}
+
+func (s *fakeBundleCatalogReadStore) ListBundleCatalog(_ context.Context, opts store.BundleCatalogListOptions) (store.BundleCatalogListResult, error) {
+	s.lastList = opts
+	if s.listErr != nil {
+		return store.BundleCatalogListResult{}, s.listErr
+	}
+	return s.listResult, nil
+}
+
+func (s *fakeBundleCatalogReadStore) LoadBundleCatalog(_ context.Context, bundleHash string) (store.BundleCatalogDetail, error) {
+	if s.missing[bundleHash] {
+		return store.BundleCatalogDetail{}, store.ErrBundleNotFound
+	}
+	detail, ok := s.details[bundleHash]
+	if !ok {
+		return store.BundleCatalogDetail{}, store.ErrBundleNotFound
+	}
+	return detail, nil
+}
+
+func (s *fakeBundleCatalogReadStore) ListBundleCatalogAgents(_ context.Context, bundleHash string) (store.BundleCatalogAgentsResult, error) {
+	if s.missing[bundleHash] {
+		return store.BundleCatalogAgentsResult{}, store.ErrBundleNotFound
+	}
+	result, ok := s.agents[bundleHash]
+	if !ok {
+		return store.BundleCatalogAgentsResult{}, store.ErrBundleNotFound
+	}
+	return result, nil
+}
+
+var _ BundleCatalogReadStore = (*fakeBundleCatalogReadStore)(nil)
 
 func testHandler(t *testing.T, opts Options) *Handler {
 	t.Helper()

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 49 {
-		t.Fatalf("generated OpenRPC methods = %d, want 49", len(doc.Methods))
+	if len(doc.Methods) != 52 {
+		t.Fatalf("generated OpenRPC methods = %d, want 52", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 const readOnlyRuntimeProbeTestName = "TestOpenRPCReadOnlyHTTPRuntimeProbes"
+const readOnlyProbeBundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const readOnlyProbeMissingBundleHash = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 func TestOpenRPCReadOnlyHTTPRuntimeProbes(t *testing.T) {
 	root := repoRoot(t)
@@ -241,6 +243,9 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 		"agent.diagnose",
 		"agent.get",
 		"agent.list",
+		"bundle.agents",
+		"bundle.get",
+		"bundle.list",
 		"conversation.current_for_agent",
 		"conversation.fork_list",
 		"conversation.fork_view",
@@ -271,6 +276,9 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active", "last_tool_outcome"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
+		"bundle.agents":                  {Params: map[string]any{"bundle_hash": readOnlyProbeBundleHash}, ResultKeys: []string{"agents"}},
+		"bundle.get":                     {Params: map[string]any{"bundle_hash": readOnlyProbeBundleHash}, ResultKeys: []string{"bundle_hash", "content_yaml", "parsed_json", "metadata", "agent_count", "has_data", "data_size_bytes", "ingested_at"}},
+		"bundle.list":                    {Params: map[string]any{}, ResultKeys: []string{"bundles"}},
 		"conversation.current_for_agent": {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"conversation", "turns"}},
 		"conversation.fork_list":         {Params: map[string]any{}, ResultKeys: []string{"forks"}},
 		"conversation.fork_view":         {Params: map[string]any{"fork_id": "00000000-0000-0000-0000-000000000301"}, ResultKeys: []string{"fork_id", "source_session_id", "source_agent_id", "fork_point", "created_by", "created_at", "expires_at", "state", "turns"}},
@@ -324,6 +332,26 @@ func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 			Options: func(t *testing.T) OperatorReadOptions {
 				opts := readOnlyRuntimeProbeOptions(t)
 				opts.AgentConversations = &fakeAgentConversationReadStore{agentErr: store.ErrAgentNotFound}
+				return opts
+			},
+		},
+		{
+			Method: "bundle.agents",
+			Params: map[string]any{"bundle_hash": readOnlyProbeMissingBundleHash},
+			Code:   BundleNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.BundleCatalog = &fakeBundleCatalogReadStore{missing: map[string]bool{readOnlyProbeMissingBundleHash: true}}
+				return opts
+			},
+		},
+		{
+			Method: "bundle.get",
+			Params: map[string]any{"bundle_hash": readOnlyProbeMissingBundleHash},
+			Code:   BundleNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.BundleCatalog = &fakeBundleCatalogReadStore{missing: map[string]bool{readOnlyProbeMissingBundleHash: true}}
 				return opts
 			},
 		},
@@ -550,6 +578,43 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 				},
 			},
 			aggregate: store.OperatorEntityAggregateResult{Counts: map[string]int{"collecting": 1}},
+		},
+		BundleCatalog: &fakeBundleCatalogReadStore{
+			listResult: store.BundleCatalogListResult{Bundles: []store.BundleCatalogSummary{{
+				BundleHash:    readOnlyProbeBundleHash,
+				AgentCount:    1,
+				HasData:       false,
+				DataSizeBytes: 0,
+				Metadata:      map[string]any{"source": "probe"},
+				IngestedAt:    now,
+			}}},
+			details: map[string]store.BundleCatalogDetail{
+				readOnlyProbeBundleHash: {
+					BundleHash:    readOnlyProbeBundleHash,
+					ContentYAML:   "name: probe",
+					ParsedJSON:    map[string]any{"agents": map[string]any{}},
+					Metadata:      map[string]any{"source": "probe"},
+					AgentCount:    1,
+					HasData:       false,
+					DataSizeBytes: 0,
+					IngestedAt:    now,
+				},
+			},
+			agents: map[string]store.BundleCatalogAgentsResult{
+				readOnlyProbeBundleHash: {
+					Agents: []store.BundleCatalogAgentDefinition{{
+						AgentID:          "researcher",
+						Role:             "research",
+						Type:             "managed",
+						ModelTier:        "haiku",
+						LLMBackend:       "claude",
+						ConversationMode: "session",
+						SessionScope:     "flow",
+						Subscriptions:    []string{"scan.requested"},
+						Tools:            []string{"web_search"},
+					}},
+				},
+			},
 		},
 		AgentConversations: &fakeAgentConversationReadStore{
 			listAgentsResult: store.OperatorAgentListResult{Agents: []store.OperatorAgentSummary{{
@@ -854,6 +919,18 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 			}
 			if subscribers, ok := downstream["subscribers"].([]any); !ok || len(subscribers) != 0 {
 				t.Fatalf("mailbox.get decision_sheet.downstream_preview.subscribers = %#v", downstream["subscribers"])
+			}
+		}
+	}
+	if methodName == "bundle.agents" {
+		agents, ok := result["agents"].([]any)
+		if !ok || len(agents) != 1 {
+			t.Fatalf("bundle.agents agents = %#v, want one definition", result["agents"])
+		}
+		agent := asMap(t, agents[0])
+		for _, runtimeKey := range []string{"status", "runtime_state", "queue", "active", "session_id"} {
+			if _, ok := agent[runtimeKey]; ok {
+				t.Fatalf("bundle.agents leaked runtime field %q: %#v", runtimeKey, agent)
 			}
 		}
 	}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -50,6 +50,12 @@ type AgentConversationReadStore interface {
 	LoadCurrentOperatorConversationForAgent(context.Context, string) (*store.OperatorConversationDetail, error)
 }
 
+type BundleCatalogReadStore interface {
+	ListBundleCatalog(context.Context, store.BundleCatalogListOptions) (store.BundleCatalogListResult, error)
+	LoadBundleCatalog(context.Context, string) (store.BundleCatalogDetail, error)
+	ListBundleCatalogAgents(context.Context, string) (store.BundleCatalogAgentsResult, error)
+}
+
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
@@ -58,6 +64,7 @@ type OperatorReadOptions struct {
 	Observability         ObservabilityReadStore
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
+	BundleCatalog         BundleCatalogReadStore
 	ConversationForks     ConversationForkLifecycleStore
 	ForkChatExecutor      ForkChatExecutor
 	AgentControl          AgentControlController
@@ -231,6 +238,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorAgentConversationHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorBundleCatalogHandlers(opts) {
+		handlers[name] = handler
+	}
 	for name, handler := range OperatorConversationForkHandlers(opts) {
 		handlers[name] = handler
 	}
@@ -266,6 +276,75 @@ func requireAgentConversationReadStore(reads AgentConversationReadStore) (AgentC
 		return nil, fmt.Errorf("agent/conversation read store is required")
 	}
 	return reads, nil
+}
+
+func requireBundleCatalogReadStore(reads BundleCatalogReadStore) (BundleCatalogReadStore, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("bundle catalog read store is required")
+	}
+	return reads, nil
+}
+
+func OperatorBundleCatalogHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.BundleCatalog == nil {
+		return nil
+	}
+	return map[string]MethodHandler{
+		"bundle.list": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireBundleCatalogReadStore(opts.BundleCatalog)
+			if err != nil {
+				return nil, err
+			}
+			listOpts, err := bundleCatalogListOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListBundleCatalog(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidBundleCatalogCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid bundle catalog cursor"})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"bundle.get": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireBundleCatalogReadStore(opts.BundleCatalog)
+			if err != nil {
+				return nil, err
+			}
+			bundleHash, err := requiredBundleHashParam(req.Params, "bundle_hash")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadBundleCatalog(ctx, bundleHash)
+			if errors.Is(err, store.ErrBundleNotFound) {
+				return nil, NewApplicationError(BundleNotFoundCode, false, map[string]any{"bundle_hash": bundleHash})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+		"bundle.agents": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireBundleCatalogReadStore(opts.BundleCatalog)
+			if err != nil {
+				return nil, err
+			}
+			bundleHash, err := requiredBundleHashParam(req.Params, "bundle_hash")
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.ListBundleCatalogAgents(ctx, bundleHash)
+			if errors.Is(err, store.ErrBundleNotFound) {
+				return nil, NewApplicationError(BundleNotFoundCode, false, map[string]any{"bundle_hash": bundleHash})
+			}
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	}
 }
 
 func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -1321,6 +1400,29 @@ func runHeaderListOptionsFromParams(params map[string]any) (store.RunHeaderListO
 		return store.RunHeaderListOptions{}, err
 	}
 	return out, nil
+}
+
+func bundleCatalogListOptionsFromParams(params map[string]any) (store.BundleCatalogListOptions, error) {
+	out := store.BundleCatalogListOptions{}
+	var err error
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.BundleCatalogListOptions{}, err
+	}
+	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 500); err != nil {
+		return store.BundleCatalogListOptions{}, err
+	}
+	return out, nil
+}
+
+func requiredBundleHashParam(params map[string]any, name string) (string, error) {
+	value, err := requiredStringParam(params, name)
+	if err != nil {
+		return "", err
+	}
+	if !bundleHashPattern.MatchString(value) {
+		return "", NewInvalidParamsError(map[string]any{"field": name, "reason": "must be bundle-v1:sha256:<64 lowercase hex>"})
+	}
+	return value, nil
 }
 
 func optionalBundleHashParam(params map[string]any, name string) (string, error) {

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -13,6 +13,7 @@ import (
 const (
 	MethodUnavailableCode                = "METHOD_UNAVAILABLE"
 	BundleMismatchCode                   = "BUNDLE_MISMATCH"
+	BundleNotFoundCode                   = "BUNDLE_NOT_FOUND"
 	UnsupportedBundleHashCode            = "UNSUPPORTED_BUNDLE_HASH"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"
 	EventNotDeclaredCode                 = "EVENT_NOT_DECLARED"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -138,6 +138,51 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: bundle.agents
+    transport: http
+    required_params: [bundle_hash]
+    declared_errors: [BUNDLE_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
+  - method: bundle.get
+    transport: http
+    required_params: [bundle_hash]
+    declared_errors: [BUNDLE_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
+  - method: bundle.list
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.current_for_agent
     transport: http
     required_params: [agent_id]

--- a/internal/store/bundle_catalog_read_surface.go
+++ b/internal/store/bundle_catalog_read_surface.go
@@ -1,0 +1,561 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type BundleCatalogListOptions struct {
+	Limit  int
+	Cursor string
+}
+
+type BundleCatalogListResult struct {
+	Bundles    []BundleCatalogSummary `json:"bundles"`
+	NextCursor string                 `json:"next_cursor,omitempty"`
+}
+
+type BundleCatalogSummary struct {
+	BundleHash    string         `json:"bundle_hash"`
+	AgentCount    int            `json:"agent_count"`
+	HasData       bool           `json:"has_data"`
+	DataSizeBytes int64          `json:"data_size_bytes"`
+	Metadata      map[string]any `json:"metadata"`
+	IngestedAt    time.Time      `json:"ingested_at"`
+}
+
+type BundleCatalogDetail struct {
+	BundleHash    string         `json:"bundle_hash"`
+	ContentYAML   string         `json:"content_yaml"`
+	ParsedJSON    map[string]any `json:"parsed_json"`
+	Metadata      map[string]any `json:"metadata"`
+	AgentCount    int            `json:"agent_count"`
+	HasData       bool           `json:"has_data"`
+	DataSizeBytes int64          `json:"data_size_bytes"`
+	IngestedAt    time.Time      `json:"ingested_at"`
+}
+
+type BundleCatalogAgentsResult struct {
+	Agents []BundleCatalogAgentDefinition `json:"agents"`
+}
+
+type BundleCatalogAgentDefinition struct {
+	AgentID          string   `json:"agent_id"`
+	FlowInstance     string   `json:"flow_instance,omitempty"`
+	Role             string   `json:"role,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	ModelTier        string   `json:"model_tier,omitempty"`
+	LLMBackend       string   `json:"llm_backend,omitempty"`
+	ConversationMode string   `json:"conversation_mode,omitempty"`
+	SessionScope     string   `json:"session_scope,omitempty"`
+	PromptPath       string   `json:"prompt_path,omitempty"`
+	Subscriptions    []string `json:"subscriptions,omitempty"`
+	Tools            []string `json:"tools,omitempty"`
+}
+
+type bundleCatalogCursor struct {
+	IngestedAt string `json:"ingested_at"`
+	BundleHash string `json:"bundle_hash"`
+}
+
+type bundleCatalogRow struct {
+	BundleHash    string
+	ContentYAML   string
+	ParsedJSONRaw []byte
+	MetadataRaw   []byte
+	HasData       bool
+	DataSizeBytes int64
+	IngestedAt    time.Time
+}
+
+func defaultBundleCatalogListOptions(opts BundleCatalogListOptions) BundleCatalogListOptions {
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts
+}
+
+func (s *PostgresStore) requireBundleCatalogCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if catalog.hasColumns("bundles", "bundle_hash", "content_yaml", "parsed_json", "data_blob", "metadata", "ingested_at") {
+		return nil
+	}
+	return fmt.Errorf("bundle catalog read surface requires bundles columns [bundle_hash content_yaml parsed_json data_blob metadata ingested_at]")
+}
+
+func (s *PostgresStore) ListBundleCatalog(ctx context.Context, opts BundleCatalogListOptions) (BundleCatalogListResult, error) {
+	if err := s.requireBundleCatalogCapabilities(ctx); err != nil {
+		return BundleCatalogListResult{}, err
+	}
+	opts = defaultBundleCatalogListOptions(opts)
+	args := make([]any, 0, 3)
+	where := []string{"TRUE"}
+	if opts.Cursor != "" {
+		ingestedAt, bundleHash, err := decodeBundleCatalogCursor(opts.Cursor)
+		if err != nil {
+			return BundleCatalogListResult{}, err
+		}
+		args = append(args, ingestedAt.UTC(), bundleHash)
+		where = append(where, fmt.Sprintf("(ingested_at < $%d OR (ingested_at = $%d AND bundle_hash < $%d))", len(args)-1, len(args)-1, len(args)))
+	}
+	args = append(args, opts.Limit+1)
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			bundle_hash,
+			content_yaml,
+			COALESCE(parsed_json, '{}'::jsonb),
+			COALESCE(metadata, '{}'::jsonb),
+			data_blob IS NOT NULL,
+			COALESCE(octet_length(data_blob), 0)::bigint,
+			ingested_at
+		FROM bundles
+		WHERE %s
+		ORDER BY ingested_at DESC, bundle_hash DESC
+		LIMIT $%d
+	`, strings.Join(where, " AND "), len(args)), args...)
+	if err != nil {
+		return BundleCatalogListResult{}, fmt.Errorf("list bundle catalog: %w", err)
+	}
+	defer rows.Close()
+
+	bundles := make([]BundleCatalogSummary, 0, opts.Limit)
+	for rows.Next() {
+		row, err := scanBundleCatalogRow(rows)
+		if err != nil {
+			return BundleCatalogListResult{}, err
+		}
+		detail, err := row.toDetail()
+		if err != nil {
+			return BundleCatalogListResult{}, err
+		}
+		bundles = append(bundles, BundleCatalogSummary{
+			BundleHash:    detail.BundleHash,
+			AgentCount:    detail.AgentCount,
+			HasData:       detail.HasData,
+			DataSizeBytes: detail.DataSizeBytes,
+			Metadata:      detail.Metadata,
+			IngestedAt:    detail.IngestedAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return BundleCatalogListResult{}, fmt.Errorf("read bundle catalog: %w", err)
+	}
+
+	nextCursor := ""
+	if len(bundles) > opts.Limit {
+		bundles = bundles[:opts.Limit]
+		nextCursor = encodeBundleCatalogCursor(bundles[len(bundles)-1])
+	}
+	if bundles == nil {
+		bundles = []BundleCatalogSummary{}
+	}
+	return BundleCatalogListResult{Bundles: bundles, NextCursor: nextCursor}, nil
+}
+
+func (s *PostgresStore) LoadBundleCatalog(ctx context.Context, bundleHash string) (BundleCatalogDetail, error) {
+	if err := s.requireBundleCatalogCapabilities(ctx); err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	bundleHash = strings.TrimSpace(bundleHash)
+	if bundleHash == "" {
+		return BundleCatalogDetail{}, ErrBundleNotFound
+	}
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT
+			bundle_hash,
+			content_yaml,
+			COALESCE(parsed_json, '{}'::jsonb),
+			COALESCE(metadata, '{}'::jsonb),
+			data_blob IS NOT NULL,
+			COALESCE(octet_length(data_blob), 0)::bigint,
+			ingested_at
+		FROM bundles
+		WHERE bundle_hash = $1
+	`, bundleHash)
+	scanned, err := scanBundleCatalogRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BundleCatalogDetail{}, ErrBundleNotFound
+	}
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	return scanned.toDetail()
+}
+
+func (s *PostgresStore) ListBundleCatalogAgents(ctx context.Context, bundleHash string) (BundleCatalogAgentsResult, error) {
+	detail, err := s.LoadBundleCatalog(ctx, bundleHash)
+	if err != nil {
+		return BundleCatalogAgentsResult{}, err
+	}
+	agents, err := projectBundleCatalogAgents(detail.ParsedJSON, detail.ContentYAML)
+	if err != nil {
+		return BundleCatalogAgentsResult{}, err
+	}
+	if agents == nil {
+		agents = []BundleCatalogAgentDefinition{}
+	}
+	return BundleCatalogAgentsResult{Agents: agents}, nil
+}
+
+type bundleCatalogScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanBundleCatalogRow(row bundleCatalogScanner) (bundleCatalogRow, error) {
+	var out bundleCatalogRow
+	if err := row.Scan(
+		&out.BundleHash,
+		&out.ContentYAML,
+		&out.ParsedJSONRaw,
+		&out.MetadataRaw,
+		&out.HasData,
+		&out.DataSizeBytes,
+		&out.IngestedAt,
+	); err != nil {
+		return bundleCatalogRow{}, err
+	}
+	out.BundleHash = strings.TrimSpace(out.BundleHash)
+	out.IngestedAt = out.IngestedAt.UTC()
+	return out, nil
+}
+
+func (r bundleCatalogRow) toDetail() (BundleCatalogDetail, error) {
+	parsed, err := decodeBundleCatalogJSONMap(r.ParsedJSONRaw, "parsed_json")
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	metadata, err := decodeBundleCatalogJSONMap(r.MetadataRaw, "metadata")
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	agents, err := projectBundleCatalogAgents(parsed, r.ContentYAML)
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	return BundleCatalogDetail{
+		BundleHash:    r.BundleHash,
+		ContentYAML:   r.ContentYAML,
+		ParsedJSON:    parsed,
+		Metadata:      metadata,
+		AgentCount:    len(agents),
+		HasData:       r.HasData,
+		DataSizeBytes: r.DataSizeBytes,
+		IngestedAt:    r.IngestedAt,
+	}, nil
+}
+
+func decodeBundleCatalogJSONMap(raw []byte, field string) (map[string]any, error) {
+	raw = []byte(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 || string(raw) == "null" {
+		return map[string]any{}, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("bundle catalog %s must be a JSON object: %w", field, err)
+	}
+	if out == nil {
+		out = map[string]any{}
+	}
+	return out, nil
+}
+
+func encodeBundleCatalogCursor(summary BundleCatalogSummary) string {
+	raw, _ := json.Marshal(bundleCatalogCursor{
+		IngestedAt: summary.IngestedAt.UTC().Format(time.RFC3339Nano),
+		BundleHash: strings.TrimSpace(summary.BundleHash),
+	})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeBundleCatalogCursor(cursor string) (time.Time, string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(cursor))
+	if err != nil {
+		return time.Time{}, "", ErrInvalidBundleCatalogCursor
+	}
+	var decoded bundleCatalogCursor
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return time.Time{}, "", ErrInvalidBundleCatalogCursor
+	}
+	ingestedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(decoded.IngestedAt))
+	if err != nil {
+		return time.Time{}, "", ErrInvalidBundleCatalogCursor
+	}
+	bundleHash := strings.TrimSpace(decoded.BundleHash)
+	if bundleHash == "" {
+		return time.Time{}, "", ErrInvalidBundleCatalogCursor
+	}
+	return ingestedAt.UTC(), bundleHash, nil
+}
+
+func projectBundleCatalogAgents(parsed map[string]any, contentYAML string) ([]BundleCatalogAgentDefinition, error) {
+	if len(parsed) > 0 {
+		agents, found, err := extractBundleCatalogAgents(parsed)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return agents, nil
+		}
+	}
+	contentYAML = strings.TrimSpace(contentYAML)
+	if contentYAML == "" {
+		return []BundleCatalogAgentDefinition{}, nil
+	}
+	var decoded any
+	if err := yaml.Unmarshal([]byte(contentYAML), &decoded); err != nil {
+		return nil, fmt.Errorf("bundle catalog content_yaml projection failed: %w", err)
+	}
+	root, ok := normalizeBundleYAMLValue(decoded).(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("bundle catalog content_yaml projection failed: root must be an object")
+	}
+	agents, _, err := extractBundleCatalogAgents(root)
+	if err != nil {
+		return nil, err
+	}
+	return agents, nil
+}
+
+func extractBundleCatalogAgents(root map[string]any) ([]BundleCatalogAgentDefinition, bool, error) {
+	var out []BundleCatalogAgentDefinition
+	found := false
+	if raw, ok := root["agents"]; ok {
+		found = true
+		agents, err := extractBundleCatalogAgentCollection(raw, "")
+		if err != nil {
+			return nil, true, err
+		}
+		out = append(out, agents...)
+	}
+	if raw, ok := root["flows"]; ok {
+		found = true
+		flowAgents, err := extractBundleCatalogFlowAgents(raw)
+		if err != nil {
+			return nil, true, err
+		}
+		out = append(out, flowAgents...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].FlowInstance != out[j].FlowInstance {
+			return out[i].FlowInstance < out[j].FlowInstance
+		}
+		return out[i].AgentID < out[j].AgentID
+	})
+	if out == nil {
+		out = []BundleCatalogAgentDefinition{}
+	}
+	return out, found, nil
+}
+
+func extractBundleCatalogFlowAgents(raw any) ([]BundleCatalogAgentDefinition, error) {
+	switch flows := raw.(type) {
+	case map[string]any:
+		names := make([]string, 0, len(flows))
+		for name := range flows {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		var out []BundleCatalogAgentDefinition
+		for _, name := range names {
+			flow, ok := flows[name].(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("bundle catalog agents projection failed: flows.%s must be an object", name)
+			}
+			rawAgents, ok := flow["agents"]
+			if !ok {
+				continue
+			}
+			agents, err := extractBundleCatalogAgentCollection(rawAgents, name)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, agents...)
+		}
+		return out, nil
+	case []any:
+		var out []BundleCatalogAgentDefinition
+		for i, item := range flows {
+			flow, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("bundle catalog agents projection failed: flows[%d] must be an object", i)
+			}
+			rawAgents, ok := flow["agents"]
+			if !ok {
+				continue
+			}
+			flowInstance := stringFromMap(flow, "flow_instance")
+			agents, err := extractBundleCatalogAgentCollection(rawAgents, flowInstance)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, agents...)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("bundle catalog agents projection failed: flows must be an object or array")
+	}
+}
+
+func extractBundleCatalogAgentCollection(raw any, flowInstance string) ([]BundleCatalogAgentDefinition, error) {
+	switch agents := raw.(type) {
+	case map[string]any:
+		names := make([]string, 0, len(agents))
+		for name := range agents {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out := make([]BundleCatalogAgentDefinition, 0, len(names))
+		for _, name := range names {
+			def, ok := agents[name].(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("bundle catalog agents projection failed: agents.%s must be an object", name)
+			}
+			agent, err := projectBundleCatalogAgentDefinition(name, flowInstance, def)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, agent)
+		}
+		return out, nil
+	case []any:
+		out := make([]BundleCatalogAgentDefinition, 0, len(agents))
+		for i, item := range agents {
+			def, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("bundle catalog agents projection failed: agents[%d] must be an object", i)
+			}
+			agent, err := projectBundleCatalogAgentDefinition("", flowInstance, def)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, agent)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("bundle catalog agents projection failed: agents must be an object or array")
+	}
+}
+
+func projectBundleCatalogAgentDefinition(agentID, flowInstance string, def map[string]any) (BundleCatalogAgentDefinition, error) {
+	for key := range def {
+		if bundleCatalogRuntimeAgentFields[key] {
+			return BundleCatalogAgentDefinition{}, fmt.Errorf("bundle catalog agents projection failed: runtime field %q is not allowed", key)
+		}
+	}
+	if agentID == "" {
+		agentID = stringFromMap(def, "agent_id")
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return BundleCatalogAgentDefinition{}, fmt.Errorf("bundle catalog agents projection failed: agent_id is required")
+	}
+	if flowInstance == "" {
+		flowInstance = stringFromMap(def, "flow_instance")
+	}
+	subscriptions, err := optionalStringListFromMap(def, "subscriptions")
+	if err != nil {
+		return BundleCatalogAgentDefinition{}, err
+	}
+	tools, err := optionalStringListFromMap(def, "tools")
+	if err != nil {
+		return BundleCatalogAgentDefinition{}, err
+	}
+	return BundleCatalogAgentDefinition{
+		AgentID:          agentID,
+		FlowInstance:     strings.TrimSpace(flowInstance),
+		Role:             stringFromMap(def, "role"),
+		Type:             stringFromMap(def, "type"),
+		ModelTier:        stringFromMap(def, "model_tier"),
+		LLMBackend:       stringFromMap(def, "llm_backend"),
+		ConversationMode: stringFromMap(def, "conversation_mode"),
+		SessionScope:     stringFromMap(def, "session_scope"),
+		PromptPath:       stringFromMap(def, "prompt_path"),
+		Subscriptions:    subscriptions,
+		Tools:            tools,
+	}, nil
+}
+
+var bundleCatalogRuntimeAgentFields = map[string]bool{
+	"status":                     true,
+	"runtime_state":              true,
+	"queue":                      true,
+	"active":                     true,
+	"last_tool_outcome":          true,
+	"session_id":                 true,
+	"turn_id":                    true,
+	"task_id":                    true,
+	"pending_deliveries":         true,
+	"delivery_lifecycle":         true,
+	"watchdog":                   true,
+	"oldest_pending_age_seconds": true,
+}
+
+func stringFromMap(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func optionalStringListFromMap(values map[string]any, key string) ([]string, error) {
+	raw, ok := values[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("bundle catalog agents projection failed: %s must be an array of strings", key)
+	}
+	out := make([]string, 0, len(items))
+	for i, item := range items {
+		text, ok := item.(string)
+		text = strings.TrimSpace(text)
+		if !ok || text == "" {
+			return nil, fmt.Errorf("bundle catalog agents projection failed: %s[%d] must be a non-empty string", key, i)
+		}
+		out = append(out, text)
+	}
+	return out, nil
+}
+
+func normalizeBundleYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[strings.TrimSpace(key)] = normalizeBundleYAMLValue(item)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[strings.TrimSpace(fmt.Sprint(key))] = normalizeBundleYAMLValue(item)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeBundleYAMLValue(item))
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/testutil"
+)
+
+func TestBundleCatalogReadSurfaceListGetAgentsAndCursor(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	olderHash := "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	newerHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	now := time.Unix(1700000000, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, data_blob, metadata, ingested_at)
+		VALUES
+			($1, $2, $3::jsonb, NULL, $4::jsonb, $5),
+			($6, $7, $8::jsonb, $9::bytea, $10::jsonb, $11)
+	`, olderHash, `
+agents:
+  researcher:
+    role: research
+    type: managed
+`, `{}`, `{"source":"older"}`, now.Add(-time.Hour),
+		newerHash, `name: newer`, `{
+			"agents": {
+				"researcher": {
+					"role": "research",
+					"type": "managed",
+					"model_tier": "haiku",
+					"llm_backend": "claude",
+					"conversation_mode": "session",
+					"session_scope": "flow",
+					"prompt_path": "prompts/researcher.md",
+					"subscriptions": ["scan.requested"],
+					"tools": ["web_search"]
+				}
+			},
+			"flows": {
+				"review/primary": {
+					"agents": {
+						"reviewer": {
+							"role": "review",
+							"type": "managed"
+						}
+					}
+				}
+			}
+		}`, []byte("blob"), `{"source":"newer"}`, now); err != nil {
+		t.Fatalf("seed bundles: %v", err)
+	}
+
+	first, err := pg.ListBundleCatalog(ctx, BundleCatalogListOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("ListBundleCatalog first: %v", err)
+	}
+	if len(first.Bundles) != 1 || first.Bundles[0].BundleHash != newerHash {
+		t.Fatalf("first page = %#v, want newest bundle", first.Bundles)
+	}
+	if first.Bundles[0].AgentCount != 2 || !first.Bundles[0].HasData || first.Bundles[0].DataSizeBytes != 4 {
+		t.Fatalf("newer summary = %#v", first.Bundles[0])
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first page cursor empty")
+	}
+
+	second, err := pg.ListBundleCatalog(ctx, BundleCatalogListOptions{Limit: 1, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatalf("ListBundleCatalog second: %v", err)
+	}
+	if len(second.Bundles) != 1 || second.Bundles[0].BundleHash != olderHash || second.NextCursor != "" {
+		t.Fatalf("second page = %#v cursor=%q, want older only", second.Bundles, second.NextCursor)
+	}
+	if second.Bundles[0].AgentCount != 1 || second.Bundles[0].HasData {
+		t.Fatalf("older summary = %#v", second.Bundles[0])
+	}
+
+	detail, err := pg.LoadBundleCatalog(ctx, newerHash)
+	if err != nil {
+		t.Fatalf("LoadBundleCatalog: %v", err)
+	}
+	if detail.BundleHash != newerHash || detail.Metadata["source"] != "newer" || detail.AgentCount != 2 || !detail.HasData {
+		t.Fatalf("detail = %#v", detail)
+	}
+
+	agents, err := pg.ListBundleCatalogAgents(ctx, newerHash)
+	if err != nil {
+		t.Fatalf("ListBundleCatalogAgents: %v", err)
+	}
+	if len(agents.Agents) != 2 {
+		t.Fatalf("agents = %#v, want two definitions", agents.Agents)
+	}
+	if agents.Agents[0].AgentID != "researcher" || agents.Agents[0].FlowInstance != "" || agents.Agents[0].ModelTier != "haiku" {
+		t.Fatalf("root agent = %#v", agents.Agents[0])
+	}
+	if agents.Agents[1].AgentID != "reviewer" || agents.Agents[1].FlowInstance != "review/primary" {
+		t.Fatalf("flow agent = %#v", agents.Agents[1])
+	}
+}
+
+func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	missingHash := "bundle-v1:sha256:9999999999999999999999999999999999999999999999999999999999999999"
+	if _, err := pg.LoadBundleCatalog(ctx, missingHash); !errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("LoadBundleCatalog missing error = %v, want ErrBundleNotFound", err)
+	}
+	if _, err := pg.ListBundleCatalog(ctx, BundleCatalogListOptions{Cursor: "not-a-cursor"}); !errors.Is(err, ErrInvalidBundleCatalogCursor) {
+		t.Fatalf("ListBundleCatalog invalid cursor error = %v, want ErrInvalidBundleCatalogCursor", err)
+	}
+
+	badHash := "bundle-v1:sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: bad', $2::jsonb)
+	`, badHash, `{"agents":{"bad":{"status":"running"}}}`); err != nil {
+		t.Fatalf("seed malformed bundle: %v", err)
+	}
+	_, err := pg.ListBundleCatalogAgents(ctx, badHash)
+	if err == nil || !strings.Contains(err.Error(), "runtime field") {
+		t.Fatalf("ListBundleCatalogAgents malformed error = %v, want runtime field rejection", err)
+	}
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -8,6 +8,10 @@ var ErrRunNotFound = errors.New("store: run not found")
 
 var ErrInvalidRunListCursor = errors.New("store: invalid run list cursor")
 
+var ErrBundleNotFound = errors.New("store: bundle not found")
+
+var ErrInvalidBundleCatalogCursor = errors.New("store: invalid bundle catalog cursor")
+
 var ErrEventNotFound = errors.New("store: event not found")
 
 var ErrInvalidObservabilityCursor = errors.New("store: invalid observability cursor")


### PR DESCRIPTION
## Summary

Part of #1017.

Publishes the approved read-only bundle catalog API slice:
- `bundle.list`
- `bundle.get(bundle_hash)`
- definition-only `bundle.agents(bundle_hash)`

Adds a store-owned bundle catalog read projection over `bundles`, wires `/v1/rpc` handlers through that owner, updates `platform-spec.yaml`, regenerates OpenRPC, and adds compliance/runtime/store proof. `bundle.register`, `bundle.delete`, CLI bundle commands, RuntimeContextManager, and runtime agent-state fields remain split per the #1017 gate.

## Governing Refs

- #1017 pre-audit: https://github.com/yazzaoui/Swarm/issues/1017#issuecomment-4545505447
- #1017 gate: https://github.com/yazzaoui/Swarm/issues/1017#issuecomment-4545609703
- `platform-spec.yaml#multi_bundle_persistence.api_surface`
- `platform-spec.yaml#api_specification.method_catalog`
- `platform-spec.yaml#platform_tables.tables.bundles`
- generated `docs/specs/swarm-platform/platform/contracts/openrpc.json`
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`

## Semantic Migration

- New canonical owner: `internal/store` bundle catalog read surface over `bundles` for list/get/definition-agent projection.
- Public consumers moved to that owner: `/v1/rpc bundle.list`, `bundle.get`, and `bundle.agents` via `internal/apiv1.OperatorBundleCatalogHandlers` and `cmd/swarm` serve wiring.
- Old invalid paths: handler-local raw SQL, runtime `agents`/sessions/diagnoses/queues/status as a `bundle.agents` source, generated OpenRPC absence for implemented read methods, and legacy `BundleFingerprint` for `bundle.register` or canonical bundle_hash generation.
- Production paths checked for surviving old behavior: OpenRPC method catalog, apispec validation, compliance matrix, read-only runtime probes, handler registry, store reader tests, and runtime handler wiring.
- Migration is complete for the approved read-only bundle catalog class only. `bundle.register` remains blocked on #979 canonical v1 hash work and is intentionally not published.

## Proof

Passed:
- `go test ./internal/store -run 'BundleCatalog|SchemaDDL' -count=1`
- `go test ./internal/apiv1 -run 'BundleCatalog|ReadOnly|Compliance|ResultSchemas|RegistryMethodNames|HandlerHTTPJSONRPCEnvelope' -count=1`
- `go test ./internal/apispec -run 'PlatformAPISpec|GeneratedOpenRPC|MultiBundle|BundleIdentity' -count=1`
- `go test ./internal/store -run 'BundleCatalog' -count=1 && go test ./internal/apiv1 -run 'BundleCatalog|ReadOnly|Compliance|ResultSchemas|RegistryMethodNames' -count=1 && go test ./internal/apispec -run 'PlatformAPISpec|GeneratedOpenRPC|MultiBundle' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check` (`methods=51 schemas=88 errors=32 mutating=19 subscriptions=4`)
- `git diff --check`

Full suite:
- `go test ./...` fails in unrelated `swarm/internal/store` test `TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete`: the test uses fixed expiry `2026-05-26T12:00:00Z`; on current date `2026-05-26`, `LoadOperatorConversationFork` returns state `expired` while the test expects `active`. Re-running that single test reproduces the same failure. This PR does not touch conversation-fork code.