### PR TITLE
[agent-g][issue #1086] Add SQLite selected runtime store contracts

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -162,7 +162,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", opts.ConfigPath, "Optional path to Swarm runtime config")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
-	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (recognized but unsupported until #1085-#1088)")
+	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -83,6 +83,8 @@ type previousEnv struct {
 type storeBundle struct {
 	Postgres            *store.PostgresStore
 	SQLDB               *sql.DB
+	RuntimeSQLDB        *sql.DB
+	RuntimeBlocker      string
 	SchemaBootstrapper  store.SchemaBootstrapper
 	EventStore          runtimebus.EventStore
 	SessionRegistry     sessions.Registry
@@ -90,6 +92,7 @@ type storeBundle struct {
 	ManagerStore        runtimemanager.ManagerPersistence
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	MailboxStore        runtimetools.MailboxPersistence
+	MailboxAPIStore     apiv1.MailboxAPIStore
 	RuntimeIngressStore runtimeingress.Store
 	IdempotencyStore    apiv1.APIIdempotencyStore
 	TurnStore           runtimellm.TurnPersistence
@@ -97,7 +100,8 @@ type storeBundle struct {
 
 func (s storeBundle) runtimeStores() runtime.Stores {
 	return runtime.Stores{
-		SQLDB:               s.SQLDB,
+		SQLDB:               s.RuntimeSQLDB,
+		ConstructionBlocker: s.RuntimeBlocker,
 		EventStore:          s.EventStore,
 		SessionRegistry:     s.SessionRegistry,
 		ConversationStore:   s.ConversationStore,
@@ -366,7 +370,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		ConversationForks:  stores.Postgres,
 		ForkChatExecutor:   apiv1.NewLLMForkChatExecutor(forkChatLLM),
 		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},
-		Mailbox:            stores.Postgres,
+		Mailbox:            stores.MailboxAPIStore,
 		Idempotency:        stores.IdempotencyStore,
 		Events:             rt.Bus,
 		RunControl:         rt.RunControl,
@@ -1636,6 +1640,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		return storeBundle{
 			Postgres:            pg,
 			SQLDB:               pg.DB,
+			RuntimeSQLDB:        pg.DB,
 			SchemaBootstrapper:  pg,
 			EventStore:          pg,
 			SessionRegistry:     sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
@@ -1643,6 +1648,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ManagerStore:        pg,
 			ScheduleStore:       pg,
 			MailboxStore:        pg,
+			MailboxAPIStore:     pg,
 			RuntimeIngressStore: pg,
 			IdempotencyStore:    pg,
 			TurnStore:           pg,
@@ -1662,11 +1668,13 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		}
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
+			RuntimeBlocker:      "sqlite runtime construction is fail-closed until #1086 selected raw-SQL consumers (pipeline, budget, tool executor, runtime diagnostics) move to backend-neutral store owners",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
 			ManagerStore:        sqliteStore,
 			ScheduleStore:       sqliteStore,
 			MailboxStore:        sqliteStore,
+			MailboxAPIStore:     sqliteStore,
 			RuntimeIngressStore: sqliteStore,
 			IdempotencyStore:    sqliteStore,
 		}, nil

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -35,6 +35,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
+	runtimeingress "swarm/internal/runtime/ingress"
 	runtimellm "swarm/internal/runtime/llm"
 	llmselection "swarm/internal/runtime/llm/selection"
 	runtimemanager "swarm/internal/runtime/manager"
@@ -80,15 +81,18 @@ type previousEnv struct {
 }
 
 type storeBundle struct {
-	Postgres           *store.PostgresStore
-	SQLDB              *sql.DB
-	SchemaBootstrapper store.SchemaBootstrapper
-	EventStore         runtimebus.EventStore
-	SessionRegistry    sessions.Registry
-	ConversationStore  runtimellm.ConversationPersistence
-	ManagerStore       runtimemanager.ManagerPersistence
-	ScheduleStore      runtimepipeline.SchedulePersistence
-	TurnStore          runtimellm.TurnPersistence
+	Postgres            *store.PostgresStore
+	SQLDB               *sql.DB
+	SchemaBootstrapper  store.SchemaBootstrapper
+	EventStore          runtimebus.EventStore
+	SessionRegistry     sessions.Registry
+	ConversationStore   runtimellm.ConversationPersistence
+	ManagerStore        runtimemanager.ManagerPersistence
+	ScheduleStore       runtimepipeline.SchedulePersistence
+	MailboxStore        runtimetools.MailboxPersistence
+	RuntimeIngressStore runtimeingress.Store
+	IdempotencyStore    apiv1.APIIdempotencyStore
+	TurnStore           runtimellm.TurnPersistence
 }
 
 func (s storeBundle) runtimeStores() runtime.Stores {
@@ -100,7 +104,8 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ManagerStore:        s.ManagerStore,
 		ScheduleStore:       s.ScheduleStore,
 		StartupOwnership:    s.Postgres,
-		RuntimeIngressStore: s.Postgres,
+		MailboxStore:        s.MailboxStore,
+		RuntimeIngressStore: s.RuntimeIngressStore,
 		TurnStore:           s.TurnStore,
 	}
 }
@@ -362,7 +367,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		ForkChatExecutor:   apiv1.NewLLMForkChatExecutor(forkChatLLM),
 		AgentControl:       dashboardDynamicAgentControl{supervisor: supervisor},
 		Mailbox:            stores.Postgres,
-		Idempotency:        stores.Postgres,
+		Idempotency:        stores.IdempotencyStore,
 		Events:             rt.Bus,
 		RunControl:         rt.RunControl,
 		RuntimeIngress:     rt.RuntimeIngress,
@@ -651,7 +656,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	configPath := fs.String("config", "", "Optional path to Swarm runtime config")
 	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for fork planning or selected-contract execution")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
-	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), "Runtime store backend: postgres (active default) or sqlite (recognized but unsupported until #1085-#1088)")
+	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
 	runID := fs.String("run", "", "Source run ID to plan from")
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
@@ -840,7 +845,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 				ConversationStore: stores.ConversationStore,
 				TurnStore:         stores.TurnStore,
 				ScheduleStore:     stores.ScheduleStore,
-				MailboxStore:      stores.Postgres,
+				MailboxStore:      stores.MailboxStore,
 				Workspace:         workspaces,
 				Credentials:       credentialStore,
 			},
@@ -1629,18 +1634,42 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			return storeBundle{}, err
 		}
 		return storeBundle{
-			Postgres:           pg,
-			SQLDB:              pg.DB,
-			SchemaBootstrapper: pg,
-			EventStore:         pg,
-			SessionRegistry:    sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore:  pg,
-			ManagerStore:       pg,
-			ScheduleStore:      pg,
-			TurnStore:          pg,
+			Postgres:            pg,
+			SQLDB:               pg.DB,
+			SchemaBootstrapper:  pg,
+			EventStore:          pg,
+			SessionRegistry:     sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
+			ConversationStore:   pg,
+			ManagerStore:        pg,
+			ScheduleStore:       pg,
+			MailboxStore:        pg,
+			RuntimeIngressStore: pg,
+			IdempotencyStore:    pg,
+			TurnStore:           pg,
 		}, nil
 	case storebackend.BackendSQLite:
-		return storeBundle{}, storebackend.SQLiteUnsupportedRuntimeError(selection.SQLitePath)
+		sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)
+		if err != nil {
+			return storeBundle{}, err
+		}
+		if err := sqliteStore.Ping(ctx); err != nil {
+			_ = sqliteStore.Close()
+			return storeBundle{}, err
+		}
+		if _, err := sqliteStore.BindSchemaCapabilities(ctx); err != nil {
+			_ = sqliteStore.Close()
+			return storeBundle{}, err
+		}
+		return storeBundle{
+			SQLDB:               sqliteStore.DB,
+			SchemaBootstrapper:  sqliteStore,
+			EventStore:          sqliteStore,
+			ManagerStore:        sqliteStore,
+			ScheduleStore:       sqliteStore,
+			MailboxStore:        sqliteStore,
+			RuntimeIngressStore: sqliteStore,
+			IdempotencyStore:    sqliteStore,
+		}, nil
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)
 	}

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -181,11 +181,18 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil {
+	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
 		t.Fatalf("sqlite store bundle Postgres = %#v, want nil", stores.Postgres)
+	}
+	runtimeStores := stores.runtimeStores()
+	if runtimeStores.SQLDB != nil {
+		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
+	}
+	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1086 selected raw-SQL consumers") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want explicit #1086 raw-SQL split", runtimeStores.ConstructionBlocker)
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", path, err)

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -162,28 +162,33 @@ func TestServeHelpDocumentsStagedStoreBackends(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve --help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Runtime store backend", "postgres (active default)", "sqlite (recognized but unsupported until #1085-#1088)"} {
+	for _, want := range []string{"Runtime store backend", "postgres (active default)", "sqlite (selected core stores; default flip after #1088)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
 	}
 }
 
-func TestBuildStoresRejectsSQLiteBeforeRuntimeSupport(t *testing.T) {
+func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "dev.db")
-	_, err := buildStores(context.Background(), storebackend.Selection{
+	stores, err := buildStores(context.Background(), storebackend.Selection{
 		Backend:          storebackend.BackendSQLite,
 		BackendSource:    storebackend.SourceFlag,
 		SQLitePath:       path,
 		SQLitePathSource: storebackend.SourceRolloutDefault,
 	}, &config.Config{})
-	if err == nil {
-		t.Fatal("buildStores unexpectedly accepted sqlite before runtime support exists")
+	if err != nil {
+		t.Fatalf("buildStores(sqlite): %v", err)
 	}
-	for _, want := range []string{"SQLite runtime stores are not implemented yet", "#1085-#1088", path} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q missing %q", err.Error(), want)
-		}
+	t.Cleanup(func() { closeDB(stores.SQLDB) })
+	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil {
+		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
+	}
+	if stores.Postgres != nil {
+		t.Fatalf("sqlite store bundle Postgres = %#v, want nil", stores.Postgres)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", path, err)
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2109,10 +2109,11 @@ engine:
         status: active_supported_runtime_backend
         meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
       sqlite:
-        status: staged_selector_only_until_runtime_portability_lands
+        status: staged_selected_core_store_runtime_backend_until_default_flip
         meaning: >
-          Local/dev SQLite runtime store. #1084 may recognize this backend and resolve its path, but runtime store
-          construction must fail closed until the SQLite schema/store/session/delivery/trace children prove support.
+          Local/dev SQLite runtime store. Explicit sqlite selection may construct the selected core runtime store contracts
+          promoted by #1086, but SQLite remains staged until session/delivery/trace semantics and the public default flip
+          are separately proven.
     selector_precedence:
       source_order:
       - flag
@@ -2168,8 +2169,9 @@ engine:
     staged_runtime_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
-      Explicit sqlite selection is recognized as a canonical backend id but must fail closed before runtime store construction
-      until #1085-#1088 close the runtime portability tail.
+      Explicit sqlite selection is recognized as a canonical backend id. After #1086 it may construct selected core runtime
+      persistence stores, but surfaces split to #1087/#1088/#1089 must still fail closed or remain unavailable until their
+      owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2231,6 +2233,72 @@ engine:
     - "Session locking, event delivery/replay, and trace/read models remain split to #1087."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
+  runtime_core_persistence_store_contracts:
+    promoted_by: '#1086'
+    parent_tracker: '#1066'
+    canonical_owner: runtime.Stores selected persistence interfaces backed by internal/store.PostgresStore and internal/store.SQLiteRuntimeStore
+    description: >
+      Core runtime persistence selected for #1086 is owned by typed store contracts selected during runtime store construction.
+      CLI/runtime startup may keep raw database handles only for explicitly split surfaces, but selected core persistence
+      operations must be reachable through the runtime store bundle instead of treating Postgres-only construction as the
+      semantic owner. SQLite support at this layer is file-backed selected-store support only; it is not the public local/dev
+      default and does not promote production SQLite semantics.
+    backend_implementations:
+      postgres:
+        owner: internal/store.PostgresStore implementations consumed through selected runtime store interfaces
+        status: active_supported_runtime_backend
+      sqlite:
+        owner: internal/store.SQLiteRuntimeStore
+        status: staged_selected_core_store_backend
+        rules:
+        - Must be file-backed and use the canonical SQLite path selected by internal/store/backendselection.
+        - Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute.
+        - Must not silently replace missing unsupported sibling semantics with in-memory state.
+    selected_contracts:
+    - name: runtime_store_bundle_construction
+      owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
+      consumers:
+      - swarm serve explicit --store sqlite
+      - local foreground run startup through buildStores
+      - runtime.NewRuntime store dependency graph
+    - name: event_append_and_run_lifecycle_rows
+      owner: runtimebus.EventStore
+      sqlite_owner: internal/store.SQLiteRuntimeStore.AppendEvent
+      postgres_owner: internal/store.PostgresStore.AppendEvent
+      excludes:
+      - event delivery claim/retry/replay semantics owned by #1087
+    - name: manager_agent_and_entity_schema_rows
+      owner: runtimemanager.ManagerPersistence
+      sqlite_owner: internal/store.SQLiteRuntimeStore agent/entity schema methods
+      postgres_owner: internal/store.PostgresStore manager methods
+      excludes:
+      - pending delivery replay and receipt settlement semantics owned by #1087
+    - name: schedule_timer_rows
+      owner: runtimepipeline.SchedulePersistence
+      sqlite_owner: internal/store.SQLiteRuntimeStore schedule methods
+      postgres_owner: internal/store.PostgresStore schedule methods
+      excludes:
+      - cross-process timer claim/locking semantics owned by #1087
+    - name: mailbox_rows
+      owner: runtimetools.MailboxPersistence
+      sqlite_owner: internal/store.SQLiteRuntimeStore mailbox methods
+      postgres_owner: internal/store.PostgresStore mailbox methods
+    - name: runtime_ingress_and_run_control_rows
+      owner: runtimeingress.Store and runtimeruncontrol.Store
+      sqlite_owner: internal/store.SQLiteRuntimeStore ingress/run-control methods
+      postgres_owner: internal/store.PostgresStore ingress/run-control methods
+      excludes:
+      - delivery release/abandon and replay behavior owned by #1087
+    - name: api_idempotency_rows
+      owner: internal/store API idempotency persistence contract
+      sqlite_owner: internal/store.SQLiteRuntimeStore.WithAPIIdempotency
+      postgres_owner: internal/store.PostgresStore.WithAPIIdempotency
+      excludes:
+      - broad API delivery/replay/concurrency semantics owned by #1087
+    split_boundaries:
+    - "Session registry, startup ownership locks, event delivery claims/retry/replay, trace-stream/read/subscription semantics remain split to #1087."
+    - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
+    - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."
   agent_session_management:
     description: The platform manages agent sessions — the lifecycle of an agent from receiving an event to completing its
       response.

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2112,7 +2112,8 @@ engine:
         status: staged_selected_core_store_runtime_backend_until_default_flip
         meaning: >
           Local/dev SQLite runtime store. Explicit sqlite selection may construct the selected core runtime store contracts
-          promoted by #1086, but SQLite remains staged until session/delivery/trace semantics and the public default flip
+          promoted by #1086, but runtime boot must fail closed while selected-parent raw-SQL consumers still lack backend-neutral
+          owners. SQLite remains staged until session/delivery/trace semantics and the public default flip
           are separately proven.
     selector_precedence:
       source_order:
@@ -2254,6 +2255,8 @@ engine:
         - Must be file-backed and use the canonical SQLite path selected by internal/store/backendselection.
         - Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute.
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
+        - Must fail closed before runtime.NewRuntime construction whenever selected-parent consumers would otherwise reach raw
+          SQL/Postgres-only paths instead of a backend-neutral store owner.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2280,9 +2283,9 @@ engine:
       excludes:
       - cross-process timer claim/locking semantics owned by #1087
     - name: mailbox_rows
-      owner: runtimetools.MailboxPersistence
-      sqlite_owner: internal/store.SQLiteRuntimeStore mailbox methods
-      postgres_owner: internal/store.PostgresStore mailbox methods
+      owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
+      sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
+      postgres_owner: internal/store.PostgresStore mailbox and v1 mailbox API methods
     - name: runtime_ingress_and_run_control_rows
       owner: runtimeingress.Store and runtimeruncontrol.Store
       sqlite_owner: internal/store.SQLiteRuntimeStore ingress/run-control methods
@@ -2296,6 +2299,7 @@ engine:
       excludes:
       - broad API delivery/replay/concurrency semantics owned by #1087
     split_boundaries:
+    - "Runtime boot with explicit SQLite must remain fail-closed until raw SQL runtime consumers such as pipeline coordination, budget tracking, tool execution diagnostics, and runtime logging move to backend-neutral owners."
     - "Session registry, startup ownership locks, event delivery claims/retry/replay, trace-stream/read/subscription semantics remain split to #1087."
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -39,6 +39,7 @@ import (
 
 type Stores struct {
 	SQLDB               *sql.DB
+	ConstructionBlocker string
 	EventStore          runtimebus.EventStore
 	SessionRegistry     sessions.Registry
 	ConversationStore   llm.ConversationPersistence
@@ -288,6 +289,9 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 	}
 	if _, err := cfg.LLMBackendProfile(); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("runtime config validation failed: %w", err)
+	}
+	if blocker := strings.TrimSpace(stores.ConstructionBlocker); blocker != "" {
+		return validatedRuntimeDeps{}, fmt.Errorf("runtime store boundary is not construction-ready: %s", blocker)
 	}
 	if err := ensureWorkflowBootWiring(opts); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("workflow contract validation failed: %w", err)

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -120,6 +120,17 @@ func TestRuntimeDepsValidateOwnsRequiredBootInputs(t *testing.T) {
 				Options: RuntimeOptions{WorkflowModule: validModule},
 			},
 		},
+		{
+			name: "store boundary blocker",
+			deps: RuntimeDeps{
+				Config: &config.Config{},
+				Stores: Stores{
+					ConstructionBlocker: "sqlite selected runtime persistence remains blocked",
+				},
+				Options: RuntimeOptions{WorkflowModule: validModule},
+			},
+			errContains: "runtime store boundary is not construction-ready: sqlite selected runtime persistence remains blocked",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/store/mailbox.go
+++ b/internal/store/mailbox.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -395,7 +396,8 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 	out := make([]runtimetools.MailboxItem, 0)
 	for rows.Next() {
 		var it runtimetools.MailboxItem
-		var timeout sql.NullTime
+		var contextRaw any
+		var timeoutRaw any
 		if err := rows.Scan(
 			&it.ID,
 			&it.EventID,
@@ -405,18 +407,21 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 			&it.Priority,
 			&it.Status,
 			&it.Notified,
-			&it.Context,
+			&contextRaw,
 			&it.Summary,
-			&timeout,
+			&timeoutRaw,
 			&it.Decision,
 			&it.DecisionNotes,
 		); err != nil {
 			return nil, fmt.Errorf("scan mailbox item: %w", err)
 		}
+		it.Context = jsonRawMessageValue(contextRaw)
 		it.Priority = denormalizeMailboxSeverity(it.Priority)
 		it.Status = denormalizeMailboxStatus(it.Status, it.Decision)
-		if timeout.Valid {
-			it.TimeoutAt = timeout.Time
+		if timeout, ok, err := sqliteTimeValue(timeoutRaw); err != nil {
+			return nil, fmt.Errorf("scan mailbox timeout: %w", err)
+		} else if ok {
+			it.TimeoutAt = timeout
 		}
 		out = append(out, it)
 	}
@@ -424,6 +429,25 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 		return nil, fmt.Errorf("iterate mailbox items: %w", err)
 	}
 	return out, nil
+}
+
+func jsonRawMessageValue(raw any) json.RawMessage {
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case json.RawMessage:
+		return append(json.RawMessage(nil), v...)
+	case []byte:
+		return json.RawMessage(append([]byte(nil), v...))
+	case string:
+		return json.RawMessage([]byte(v))
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		return encoded
+	}
 }
 
 func normalizeMailboxSeverity(priority string) string {

--- a/internal/store/runtime_ingress_state.go
+++ b/internal/store/runtime_ingress_state.go
@@ -152,9 +152,15 @@ type runtimeIngressStateScanner interface {
 func scanRuntimeIngressState(row runtimeIngressStateScanner) (runtimeingress.State, error) {
 	var state runtimeingress.State
 	var status string
-	if err := row.Scan(&status, &state.Reason, &state.ControlledBy, &state.TransitionEventID, &state.UpdatedAt); err != nil {
+	var updatedAt any
+	if err := row.Scan(&status, &state.Reason, &state.ControlledBy, &state.TransitionEventID, &updatedAt); err != nil {
 		return runtimeingress.State{}, err
 	}
 	state.Status = runtimeingress.Status(strings.TrimSpace(status))
+	if at, ok, err := sqliteTimeValue(updatedAt); err != nil {
+		return runtimeingress.State{}, err
+	} else if ok {
+		state.UpdatedAt = at
+	}
 	return state, nil
 }

--- a/internal/store/sqlite_mailbox_v1.go
+++ b/internal/store/sqlite_mailbox_v1.go
@@ -1,0 +1,490 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+func (s *SQLiteRuntimeStore) ListV1MailboxItems(ctx context.Context, opts MailboxV1ListOptions) ([]MailboxV1Item, string, error) {
+	if s == nil || s.DB == nil {
+		return nil, "", fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return nil, "", unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return nil, "", err
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 200 {
+		opts.Limit = 200
+	}
+	cursor, err := decodeMailboxV1Cursor(opts.Cursor)
+	if err != nil {
+		return nil, "", err
+	}
+	where, args := sqliteMailboxV1ListWhere(opts, cursor)
+	args = append(args, opts.Limit+1)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			m.item_id,
+			m.item_type,
+			m.status,
+			COALESCE(m.decision, ''),
+			COALESCE(m.severity, 'normal'),
+			COALESCE(m.source_event_id, ''),
+			COALESCE(m.flow_instance, ''),
+			COALESCE(m.entity_id, ''),
+			COALESCE(m.payload, '{}'),
+			m.created_at,
+			m.decided_at,
+			COALESCE(m.decided_by, ''),
+			COALESCE(m.decision_notes, ''),
+			COALESCE(m.from_agent, ''),
+			COALESCE(e.run_id, '')
+		FROM mailbox m
+		LEFT JOIN events e ON e.event_id = m.source_event_id
+		`+where+`
+		ORDER BY m.created_at ASC, m.item_id ASC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("list sqlite v1 mailbox items: %w", err)
+	}
+	defer rows.Close()
+	rowItems, err := scanSQLiteMailboxV1Rows(rows)
+	if err != nil {
+		return nil, "", err
+	}
+	nextCursor := ""
+	if len(rowItems) > opts.Limit {
+		next := rowItems[opts.Limit-1]
+		nextCursor = encodeMailboxV1Cursor(next.CreatedAtTime, next.ID)
+		rowItems = rowItems[:opts.Limit]
+	}
+	items := make([]MailboxV1Item, 0, len(rowItems))
+	for _, row := range rowItems {
+		items = append(items, row.projectItem())
+	}
+	return items, nextCursor, nil
+}
+
+func (s *SQLiteRuntimeStore) GetV1MailboxItem(ctx context.Context, id string) (MailboxV1ItemDetail, error) {
+	if s == nil || s.DB == nil {
+		return MailboxV1ItemDetail{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return MailboxV1ItemDetail{}, unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if strings.TrimSpace(id) == "" {
+		return MailboxV1ItemDetail{}, ErrMailboxV1NotFound
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	row, err := s.loadSQLiteMailboxV1Row(ctx, id)
+	if err != nil {
+		return MailboxV1ItemDetail{}, err
+	}
+	return row.projectDetail(), nil
+}
+
+func (s *SQLiteRuntimeStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1DecisionRequest) (MailboxV1DecisionOutcome, error) {
+	if s == nil || s.DB == nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return MailboxV1DecisionOutcome{}, unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	if input.Now.IsZero() {
+		input.Now = time.Now().UTC()
+	}
+	input.Now = input.Now.UTC()
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+
+	action := strings.TrimSpace(strings.ToLower(input.Action))
+	switch action {
+	case "approve", "approved":
+		action = "approved"
+	case "reject", "rejected":
+		action = "rejected"
+	case "defer", "deferred":
+		action = "deferred"
+	default:
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("unsupported mailbox decision action %q", input.Action)
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("begin sqlite v1 mailbox decision tx: %w", err)
+	}
+	postCommitActions := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	idempotencyReq, hasIdempotency, err := prepareMailboxV1IdempotencyRequest(input)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if hasIdempotency {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, idempotencyReq.Now.UTC()); err != nil {
+			return MailboxV1DecisionOutcome{}, fmt.Errorf("purge expired sqlite api idempotency: %w", err)
+		}
+		existing, ok, err := sqliteLoadAPIIdempotency(ctx, tx, idempotencyReq)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		if ok {
+			if existing.RequestHash != idempotencyReq.RequestHash {
+				return MailboxV1DecisionOutcome{}, &APIIdempotencyConflictError{
+					OriginalRequestHash:    existing.RequestHash,
+					ConflictingRequestHash: idempotencyReq.RequestHash,
+					Method:                 idempotencyReq.Method,
+					ResourceID:             existing.ResourceID,
+				}
+			}
+			var result MailboxV1DecisionResult
+			if err := json.Unmarshal(existing.Response, &result); err != nil {
+				return MailboxV1DecisionOutcome{}, fmt.Errorf("decode sqlite api idempotency mailbox response: %w", err)
+			}
+			if err := normalizeSQLiteMailboxV1DecisionReplayResult(ctx, tx, &result); err != nil {
+				return MailboxV1DecisionOutcome{}, err
+			}
+			if err := tx.Commit(); err != nil {
+				return MailboxV1DecisionOutcome{}, fmt.Errorf("commit sqlite v1 mailbox idempotency replay tx: %w", err)
+			}
+			committed = true
+			return MailboxV1DecisionOutcome{Result: result, Replayed: true}, nil
+		}
+	}
+	if action == "deferred" && !input.DeferUntil.After(input.Now) {
+		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
+	}
+
+	row, err := s.loadSQLiteMailboxV1RowTx(ctx, tx, input.MailboxID)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, err
+	}
+	if row.Status != "pending" {
+		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
+			MailboxID:        row.ID,
+			ExistingDecision: row.existingDecision(),
+			DecidedAt:        row.decisionTime(input.Now),
+		}
+	}
+	if action == "approved" && strings.TrimSpace(input.ApprovalEventType) == "" {
+		return MailboxV1DecisionOutcome{}, &MailboxV1ApprovalRouteError{MailboxID: row.ID, ItemType: row.Type}
+	}
+
+	decisionID := uuid.NewString()
+	outcome := MailboxV1DecisionOutcome{
+		Result: MailboxV1DecisionResult{
+			OK:                true,
+			MailboxDecisionID: decisionID,
+			Status:            mailboxV1APIStatus("decided", action),
+		},
+	}
+	var expiresAt any
+	notes := strings.TrimSpace(input.Reason)
+	if action == "deferred" {
+		expiresAt = input.DeferUntil.UTC()
+		if notes == "" {
+			notes = "Deferred until " + input.DeferUntil.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	if action == "approved" {
+		eventID := uuid.NewString()
+		evt, err := row.approvalEvent(eventID, decisionID, strings.TrimSpace(input.ApprovalEventType), input.ActorTokenID, input.DecisionPayload, input.Now)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		subscribers := append([]string(nil), input.ApprovalEventSubscribers...)
+		if subscribers == nil {
+			subscribers = []string{}
+		}
+		subscriberSource := strings.TrimSpace(input.ApprovalEventSubscriberSource)
+		if subscriberSource == "" {
+			subscriberSource = "unavailable"
+		}
+		outcome.Result.DownstreamEventID = eventID
+		outcome.Result.DownstreamEventName = strings.TrimSpace(input.ApprovalEventType)
+		outcome.Result.DownstreamSubscribers = &subscribers
+		outcome.Result.DownstreamSubscriberSource = subscriberSource
+		outcome.ApprovalEvent = &evt
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE mailbox
+		SET status = 'decided',
+		    decision = ?,
+		    decision_notes = NULLIF(?, ''),
+		    decided_by = NULLIF(?, ''),
+		    decided_at = ?,
+		    expires_at = COALESCE(?, expires_at)
+		WHERE item_id = ?
+		  AND status = 'pending'
+	`, action, notes, strings.TrimSpace(input.ActorTokenID), input.Now, expiresAt, row.ID)
+	if err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("decide sqlite v1 mailbox item: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		latest, latestErr := s.loadSQLiteMailboxV1RowTx(ctx, tx, row.ID)
+		if latestErr != nil {
+			return MailboxV1DecisionOutcome{}, latestErr
+		}
+		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
+			MailboxID:        latest.ID,
+			ExistingDecision: latest.existingDecision(),
+			DecidedAt:        latest.decisionTime(input.Now),
+		}
+	}
+	if outcome.ApprovalEvent != nil {
+		publishTx := input.ApprovalEventTx
+		if publishTx == nil {
+			publishTx = s.appendSQLiteMailboxV1ApprovalEventTx
+		}
+		if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
+			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish sqlite v1 mailbox approval event: %w", err)
+		}
+	}
+	if hasIdempotency {
+		raw, err := json.Marshal(outcome.Result)
+		if err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+		if err := sqliteStoreAPIIdempotency(ctx, tx, idempotencyReq, APIIdempotencyCompletion{
+			ResourceID: row.ID,
+			Response:   raw,
+		}); err != nil {
+			return MailboxV1DecisionOutcome{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MailboxV1DecisionOutcome{}, fmt.Errorf("commit sqlite v1 mailbox decision tx: %w", err)
+	}
+	committed = true
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	return outcome, nil
+}
+
+func sqliteMailboxV1ListWhere(opts MailboxV1ListOptions, cursor mailboxV1Cursor) (string, []any) {
+	clauses := []string{"1=1"}
+	args := []any{}
+	add := func(clause string, value any) {
+		args = append(args, value)
+		clauses = append(clauses, clause)
+	}
+	switch strings.TrimSpace(strings.ToLower(opts.Status)) {
+	case "":
+	case "pending":
+		clauses = append(clauses, "m.status = 'pending'")
+	case "decided":
+		clauses = append(clauses, "m.status = 'decided' AND COALESCE(m.decision, '') <> 'deferred'")
+	case "expired":
+		clauses = append(clauses, "m.status = 'expired'")
+	case "deferred":
+		clauses = append(clauses, "m.status = 'decided' AND COALESCE(m.decision, '') = 'deferred'")
+	default:
+		clauses = append(clauses, "false")
+	}
+	if runID := strings.TrimSpace(opts.RunID); runID != "" {
+		add("e.run_id = ?", runID)
+	}
+	if entityID := strings.TrimSpace(opts.EntityID); entityID != "" {
+		add("m.entity_id = ?", entityID)
+	}
+	if itemType := strings.TrimSpace(opts.Type); itemType != "" {
+		add("m.item_type = ?", itemType)
+	}
+	if priority := mailboxV1SeverityForPriority(opts.Priority); priority != "" {
+		add("COALESCE(m.severity, 'normal') = ?", priority)
+	}
+	if !cursor.CreatedAt.IsZero() {
+		args = append(args, cursor.CreatedAt.UTC(), cursor.CreatedAt.UTC(), strings.TrimSpace(cursor.MailboxID))
+		clauses = append(clauses, "(m.created_at > ? OR (m.created_at = ? AND m.item_id > ?))")
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func (s *SQLiteRuntimeStore) loadSQLiteMailboxV1Row(ctx context.Context, id string) (mailboxV1Row, error) {
+	return s.loadSQLiteMailboxV1RowTx(ctx, nil, id)
+}
+
+func (s *SQLiteRuntimeStore) loadSQLiteMailboxV1RowTx(ctx context.Context, tx *sql.Tx, id string) (mailboxV1Row, error) {
+	var q mailboxV1RowQueryer = s.DB
+	if tx != nil {
+		q = tx
+	}
+	rows, err := q.QueryContext(ctx, `
+		SELECT
+			m.item_id,
+			m.item_type,
+			m.status,
+			COALESCE(m.decision, ''),
+			COALESCE(m.severity, 'normal'),
+			COALESCE(m.source_event_id, ''),
+			COALESCE(m.flow_instance, ''),
+			COALESCE(m.entity_id, ''),
+			COALESCE(m.payload, '{}'),
+			m.created_at,
+			m.decided_at,
+			COALESCE(m.decided_by, ''),
+			COALESCE(m.decision_notes, ''),
+			COALESCE(m.from_agent, ''),
+			COALESCE(e.run_id, '')
+		FROM mailbox m
+		LEFT JOIN events e ON e.event_id = m.source_event_id
+		WHERE m.item_id = ?
+	`, strings.TrimSpace(id))
+	if err != nil {
+		return mailboxV1Row{}, fmt.Errorf("load sqlite v1 mailbox item: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanSQLiteMailboxV1Rows(rows)
+	if err != nil {
+		return mailboxV1Row{}, err
+	}
+	if len(items) == 0 {
+		return mailboxV1Row{}, ErrMailboxV1NotFound
+	}
+	return items[0], nil
+}
+
+func scanSQLiteMailboxV1Rows(rows *sql.Rows) ([]mailboxV1Row, error) {
+	out := make([]mailboxV1Row, 0)
+	for rows.Next() {
+		var row mailboxV1Row
+		var payloadRaw any
+		var createdAtRaw any
+		var decidedAtRaw any
+		if err := rows.Scan(
+			&row.ID,
+			&row.Type,
+			&row.Status,
+			&row.Decision,
+			&row.Priority,
+			&row.SourceEventID,
+			&row.FlowInstance,
+			&row.EntityID,
+			&payloadRaw,
+			&createdAtRaw,
+			&decidedAtRaw,
+			&row.DecidedBy,
+			&row.DecisionNotes,
+			&row.FromAgent,
+			&row.RunID,
+		); err != nil {
+			return nil, fmt.Errorf("scan sqlite v1 mailbox item: %w", err)
+		}
+		row.RawPayload = jsonRawMessageValue(payloadRaw)
+		row.Payload = map[string]any{}
+		if len(row.RawPayload) > 0 {
+			_ = json.Unmarshal(row.RawPayload, &row.Payload)
+		}
+		if row.Payload == nil {
+			row.Payload = map[string]any{}
+		}
+		if at, ok, err := sqliteTimeValue(createdAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite v1 mailbox created_at: %w", err)
+		} else if ok {
+			row.CreatedAtTime = at
+		}
+		if at, ok, err := sqliteTimeValue(decidedAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite v1 mailbox decided_at: %w", err)
+		} else if ok {
+			row.DecidedAt = sql.NullTime{Time: at, Valid: true}
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sqlite v1 mailbox items: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) appendSQLiteMailboxV1ApprovalEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	return s.AppendEventTx(ctx, tx, evt)
+}
+
+func sqliteStoreAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest, completion APIIdempotencyCompletion) error {
+	_, err := q.ExecContext(ctx, `
+		INSERT INTO api_idempotency (
+			method, actor_token_id, idempotency_key, request_hash,
+			resource_id, response, created_at, expires_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.RequestHash, strings.TrimSpace(completion.ResourceID), string(completion.Response), req.Now.UTC(), req.Now.Add(req.TTL).UTC())
+	if err != nil {
+		return fmt.Errorf("store sqlite api idempotency response: %w", err)
+	}
+	return nil
+}
+
+func normalizeSQLiteMailboxV1DecisionReplayResult(ctx context.Context, q execQueryer, result *MailboxV1DecisionResult) error {
+	if result == nil || strings.TrimSpace(result.DownstreamEventID) == "" {
+		return nil
+	}
+	if strings.TrimSpace(result.DownstreamEventName) == "" {
+		eventName, err := loadSQLiteMailboxV1DecisionReplayEventName(ctx, q, result.DownstreamEventID)
+		if err != nil {
+			return err
+		}
+		result.DownstreamEventName = eventName
+	}
+	if result.DownstreamSubscribers == nil {
+		subscribers := []string{}
+		result.DownstreamSubscribers = &subscribers
+	}
+	if strings.TrimSpace(result.DownstreamSubscriberSource) == "" {
+		result.DownstreamSubscriberSource = "unavailable"
+	}
+	return nil
+}
+
+func loadSQLiteMailboxV1DecisionReplayEventName(ctx context.Context, q execQueryer, eventID string) (string, error) {
+	var eventName string
+	err := q.QueryRowContext(ctx, `
+		SELECT event_name
+		FROM events
+		WHERE event_id = ?
+	`, strings.TrimSpace(eventID)).Scan(&eventName)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", fmt.Errorf("load sqlite mailbox idempotency replay event name: event %s not found", strings.TrimSpace(eventID))
+	case err != nil:
+		return "", fmt.Errorf("load sqlite mailbox idempotency replay event name: %w", err)
+	}
+	eventName = strings.TrimSpace(eventName)
+	if eventName == "" {
+		return "", fmt.Errorf("load sqlite mailbox idempotency replay event name: event %s has empty event_name", strings.TrimSpace(eventID))
+	}
+	return eventName, nil
+}

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -1,0 +1,691 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
+	runtimeingress "swarm/internal/runtime/ingress"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+	runtimeruncontrol "swarm/internal/runtime/runcontrol"
+	runtimesessions "swarm/internal/runtime/sessions"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+// SQLiteRuntimeStore is the file-backed SQLite implementation of the selected
+// #1086 runtime persistence contracts. Session locking, delivery replay, and
+// trace streaming stay split to #1087.
+type SQLiteRuntimeStore struct {
+	*SQLiteSchemaStore
+
+	eventPayloadValidator EventPayloadValidator
+}
+
+var _ SchemaBootstrapper = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.EventStore = (*SQLiteRuntimeStore)(nil)
+var _ runtimemanager.ManagerPersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimepipeline.SchedulePersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimetools.MailboxPersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimeingress.Store = (*SQLiteRuntimeStore)(nil)
+var _ runtimeruncontrol.Store = (*SQLiteRuntimeStore)(nil)
+var _ runtimereplayclaim.Participation = (*SQLiteRuntimeStore)(nil)
+
+func NewSQLiteRuntimeStore(path string) (*SQLiteRuntimeStore, error) {
+	schemaStore, err := NewSQLiteSchemaStore(path)
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteRuntimeStore{SQLiteSchemaStore: schemaStore}, nil
+}
+
+func (s *SQLiteRuntimeStore) schemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
+	if s == nil || s.DB == nil {
+		return StoreSchemaCapabilities{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	return s.ResolveSchemaCapabilities(ctx)
+}
+
+func (*SQLiteRuntimeStore) SupportsPersistedReplay() bool { return false }
+
+func (s *SQLiteRuntimeStore) SetEventPayloadValidator(validator func(eventType string, payload []byte) error) {
+	if s == nil {
+		return
+	}
+	s.eventPayloadValidator = EventPayloadValidator(validator)
+}
+
+func (s *SQLiteRuntimeStore) validateEventPayload(eventType string, payload []byte) error {
+	if s == nil || s.eventPayloadValidator == nil {
+		return nil
+	}
+	if err := s.eventPayloadValidator(strings.TrimSpace(eventType), payload); err != nil {
+		return fmt.Errorf("validate event payload: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) CanonicalRuntimeLogCapability(ctx context.Context) (bool, bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, false, err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return false, false, nil
+	}
+	return true, caps.Events.LogRunID, nil
+}
+
+func (s *SQLiteRuntimeStore) CanonicalEventReceiptsCapability(ctx context.Context) (bool, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+	return caps.Events.Log == SchemaFlavorCanonical && caps.Events.Receipts == SchemaFlavorCanonical, nil
+}
+
+func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt, err := eventStorageEnvelope(evt)
+	if err != nil {
+		return err
+	}
+	if err := s.validateEventPayload(name, payload); err != nil {
+		return err
+	}
+	sourceRoute, targetRoute, targetSet := eventRouteStorageEnvelope(evt)
+	if eventHasRouteIdentity(evt) && !caps.Events.LogRouteIdentity {
+		return fmt.Errorf("events source_route/target_route/target_set columns required for routed event")
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite event tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if caps.Events.LogRunID {
+		if err := sqliteEnsureRunRow(ctx, tx, runID, id, name, createdAt); err != nil {
+			return err
+		}
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
+			scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id, sqliteNullUUID(runID), name, sqliteNullUUID(entityID), sqliteNullString(flowInstance), string(sourceRoute), string(targetRoute), string(targetSet),
+		scope, string(payload), chainDepth, sqliteNullString(producedBy), producedByType, sqliteNullUUID(sourceEventID), createdAt.UTC())
+	if err != nil {
+		return fmt.Errorf("append sqlite event: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite event tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" || len(agentIDs) == 0 {
+		return nil
+	}
+	var runID sql.NullString
+	if err := s.DB.QueryRowContext(ctx, `SELECT run_id FROM events WHERE event_id = ?`, eventID).Scan(&runID); err != nil {
+		return fmt.Errorf("load event run for sqlite delivery manifest: %w", err)
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite delivery manifest tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, agentID := range agentIDs {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, created_at
+			)
+			VALUES (?, ?, ?, 'agent', ?, '{}', 'pending', ?)
+		`, uuid.NewString(), sqliteNullString(runID.String), eventID, agentID, time.Now().UTC()); err != nil {
+			return fmt.Errorf("insert sqlite event delivery: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite delivery manifest tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil, runtimereplayclaim.ErrAuthoritativeRecipientManifestUnavailable
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT subscriber_id
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		ORDER BY created_at ASC, subscriber_id ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite delivery recipients: %w", err)
+	}
+	defer rows.Close()
+	out := make([]string, 0)
+	for rows.Next() {
+		var recipient string
+		if err := rows.Scan(&recipient); err != nil {
+			return nil, fmt.Errorf("scan sqlite delivery recipient: %w", err)
+		}
+		out = append(out, strings.TrimSpace(recipient))
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteRuntimeStore) UpsertAgent(ctx context.Context, rec runtimemanager.PersistedAgent) error {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Agents != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agents", caps.Agents)
+	}
+	if rec.Config.ID == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	rec.Config.NormalizeEntityID()
+	rec.Config.NormalizeRuntimeDescriptor()
+	if _, err := runtimesessions.ValidateAgentSessionScopeConfig(rec.Config); err != nil {
+		return fmt.Errorf("invalid agent session scope: %w", err)
+	}
+	projection, err := projectPersistedAgentConfig(rec.Config, rec.ParentAgentID)
+	if err != nil {
+		return err
+	}
+	startedAt := rec.StartedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	_, err = s.DB.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, flow_instance, role, model_tier, llm_backend, conversation_mode,
+			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
+			runtime_descriptor, status, turn_count, last_active_at, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+		ON CONFLICT(agent_id) DO UPDATE SET
+			flow_instance = excluded.flow_instance,
+			role = excluded.role,
+			model_tier = excluded.model_tier,
+			llm_backend = excluded.llm_backend,
+			conversation_mode = excluded.conversation_mode,
+			parent_agent_id = excluded.parent_agent_id,
+			entity_id = excluded.entity_id,
+			config = excluded.config,
+			subscriptions = excluded.subscriptions,
+			emit_events = excluded.emit_events,
+			tools = excluded.tools,
+			permissions = excluded.permissions,
+			runtime_descriptor = excluded.runtime_descriptor,
+			status = excluded.status,
+			last_active_at = excluded.last_active_at
+	`, projection.AgentID, sqliteNullString(projection.FlowInstance), projection.Role, projection.ModelTier, projection.LLMBackend, projection.ConversationMode,
+		sqliteNullString(projection.ParentAgentID), sqliteNullUUID(projection.EntityID), string(projection.ConfigJSON), string(projection.SubscriptionsJSON),
+		string(projection.EmitEventsJSON), string(projection.ToolsJSON), string(projection.PermissionsJSON), string(projection.RuntimeDescriptor),
+		agentPersistedStatus(rec.Status), time.Now().UTC(), startedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("upsert sqlite agent: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT agent_id, COALESCE(flow_instance, ''), role, model_tier, llm_backend, conversation_mode,
+		       COALESCE(parent_agent_id, ''), COALESCE(entity_id, ''), config, COALESCE(runtime_descriptor, '{}'),
+		       COALESCE(subscriptions, '[]'), COALESCE(emit_events, '[]'), COALESCE(tools, '[]'), COALESCE(permissions, '[]'),
+		       COALESCE(status, 'active'), COALESCE(created_at, CURRENT_TIMESTAMP)
+		FROM agents
+		WHERE status NOT IN ('terminated', 'ephemeral')
+		ORDER BY created_at ASC, agent_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite agents: %w", err)
+	}
+	defer rows.Close()
+	out := make([]runtimemanager.PersistedAgent, 0)
+	for rows.Next() {
+		var rec runtimemanager.PersistedAgent
+		var row persistedAgentProjection
+		var startedAt any
+		if err := rows.Scan(&row.AgentID, &row.FlowInstance, &row.Role, &row.ModelTier, &row.LLMBackend, &row.ConversationMode,
+			&row.ParentAgentID, &row.EntityID, &row.ConfigJSON, &row.RuntimeDescriptor, &row.SubscriptionsJSON, &row.EmitEventsJSON,
+			&row.ToolsJSON, &row.PermissionsJSON, &rec.Status, &startedAt); err != nil {
+			return nil, fmt.Errorf("scan sqlite agent: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(startedAt); err != nil {
+			return nil, fmt.Errorf("scan sqlite agent created_at: %w", err)
+		} else if ok {
+			rec.StartedAt = at
+		}
+		cfg, err := hydratePersistedAgentConfig(row)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate sqlite agent row %s: %w", strings.TrimSpace(row.AgentID), err)
+		}
+		rec.ParentAgentID = row.ParentAgentID
+		rec.Config = cfg
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteRuntimeStore) MarkAgentTerminated(ctx context.Context, agentID string) error {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return fmt.Errorf("agent_id is required")
+	}
+	_, err := s.DB.ExecContext(ctx, `
+		UPDATE agents
+		SET status = 'terminated',
+		    last_active_at = ?
+		WHERE agent_id = ?
+	`, time.Now().UTC(), agentID)
+	if err != nil {
+		return fmt.Errorf("mark sqlite agent terminated: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) EnsureEntitySchema(ctx context.Context, entityID string) error {
+	if strings.TrimSpace(entityID) == "" {
+		return fmt.Errorf("entity_id is required")
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(entityID)); err != nil {
+		return nil
+	}
+	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	if err != nil {
+		return fmt.Errorf("lookup sqlite entity schema identity: %w", err)
+	}
+	var exists int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM entity_state
+		WHERE run_id = ?
+		  AND entity_id = ?
+	`, identity.RunID, identity.EntityID).Scan(&exists); err != nil {
+		return fmt.Errorf("lookup sqlite entity schema row: %w", err)
+	}
+	if exists == 0 {
+		return fmt.Errorf("lookup sqlite entity schema row: sql: no rows in result set")
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
+	return fmt.Errorf("sqlite event receipt delivery semantics are split to #1087")
+}
+
+func (s *SQLiteRuntimeStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+
+func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+	return nil, nil
+}
+
+func (s *SQLiteRuntimeStore) EnsureRuntimeIngressState(ctx context.Context, now time.Time) (runtimeingress.State, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if _, err := s.DB.ExecContext(ctx, `
+		INSERT OR IGNORE INTO runtime_ingress_state (id, status, controlled_by, updated_at)
+		VALUES (1, 'running', 'runtime', ?)
+	`, now.UTC()); err != nil {
+		return runtimeingress.State{}, fmt.Errorf("ensure sqlite runtime ingress state: %w", err)
+	}
+	return s.LoadRuntimeIngressState(ctx)
+}
+
+func (s *SQLiteRuntimeStore) LoadRuntimeIngressState(ctx context.Context) (runtimeingress.State, error) {
+	state, err := scanRuntimeIngressState(s.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id, ''), updated_at
+		FROM runtime_ingress_state
+		WHERE id = 1
+	`))
+	if err == sql.ErrNoRows {
+		return runtimeingress.State{}, fmt.Errorf("runtime ingress state is not initialized")
+	}
+	if err != nil {
+		return runtimeingress.State{}, fmt.Errorf("load sqlite runtime ingress state: %w", err)
+	}
+	return state, nil
+}
+
+func (s *SQLiteRuntimeStore) TransitionRuntimeIngressState(ctx context.Context, target runtimeingress.Status, reason, controlledBy string, now time.Time) (runtimeingress.State, bool, error) {
+	if target != runtimeingress.StatusRunning && target != runtimeingress.StatusPaused {
+		return runtimeingress.State{}, false, fmt.Errorf("unsupported runtime ingress status: %s", target)
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if _, err := s.EnsureRuntimeIngressState(ctx, now); err != nil {
+		return runtimeingress.State{}, false, err
+	}
+	current, err := s.LoadRuntimeIngressState(ctx)
+	if err != nil {
+		return runtimeingress.State{}, false, err
+	}
+	if current.Status == target {
+		return current, false, nil
+	}
+	if controlledBy = strings.TrimSpace(controlledBy); controlledBy == "" {
+		controlledBy = "runtime"
+	}
+	_, err = s.DB.ExecContext(ctx, `
+		UPDATE runtime_ingress_state
+		SET status = ?, reason = ?, controlled_by = ?, transition_event_id = NULL, updated_at = ?
+		WHERE id = 1
+	`, string(target), sqliteNullString(reason), controlledBy, now.UTC())
+	if err != nil {
+		return runtimeingress.State{}, false, fmt.Errorf("update sqlite runtime ingress state: %w", err)
+	}
+	state, err := s.LoadRuntimeIngressState(ctx)
+	return state, true, err
+}
+
+func (s *SQLiteRuntimeStore) SetRuntimeIngressTransitionEvent(ctx context.Context, target runtimeingress.Status, eventID string, transitionAt time.Time) (bool, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return false, nil
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE runtime_ingress_state
+		SET transition_event_id = ?, updated_at = ?
+		WHERE id = 1
+		  AND status = ?
+		  AND updated_at = ?
+	`, eventID, transitionAt.UTC(), string(target), transitionAt.UTC())
+	if err != nil {
+		return false, fmt.Errorf("set sqlite runtime ingress transition event: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	return rows > 0, err
+}
+
+func (s *SQLiteRuntimeStore) StopRunControl(ctx context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	return s.sqliteRunControlTransition(ctx, req, "stop")
+}
+
+func (s *SQLiteRuntimeStore) PauseRunControl(ctx context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	return s.sqliteRunControlTransition(ctx, req, "pause")
+}
+
+func (s *SQLiteRuntimeStore) ContinueRunControl(ctx context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	return s.sqliteRunControlTransition(ctx, req, "continue")
+}
+
+func (s *SQLiteRuntimeStore) RunDispatchBlocked(ctx context.Context, runID string) (bool, error) {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return false, nil
+	}
+	var blocked bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM run_control_state
+			WHERE run_id = ? AND control_status IN ('paused', 'stopped')
+		)
+	`, runID).Scan(&blocked); err != nil {
+		return false, fmt.Errorf("load sqlite run dispatch control state: %w", err)
+	}
+	return blocked, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunControlTransition(ctx context.Context, req runtimeruncontrol.TransitionRequest, action string) (runtimeruncontrol.State, error) {
+	runID := nullUUIDString(req.RunID)
+	if runID == "" {
+		return runtimeruncontrol.State{}, fmt.Errorf("run_id is required")
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+	if req.Reason = strings.TrimSpace(req.Reason); req.Reason == "" {
+		req.Reason = "operator_request"
+	}
+	if req.ControlledBy = strings.TrimSpace(req.ControlledBy); req.ControlledBy == "" {
+		req.ControlledBy = "api.v1"
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("begin sqlite run control transition: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	state, err := sqliteLoadRunControlState(ctx, tx, runID)
+	if err != nil {
+		return runtimeruncontrol.State{}, err
+	}
+	switch action {
+	case "pause":
+		state, err = sqlitePauseRunControl(ctx, tx, state, req)
+	case "continue":
+		state, err = sqliteContinueRunControl(ctx, tx, state, req)
+	case "stop":
+		state, err = sqliteStopRunControl(ctx, tx, state, req)
+	default:
+		err = fmt.Errorf("unsupported run control action %q", action)
+	}
+	if err != nil {
+		return runtimeruncontrol.State{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("commit sqlite run control transition: %w", err)
+	}
+	committed = true
+	return state, nil
+}
+
+func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdempotencyRequest, execute func(context.Context) (APIIdempotencyCompletion, error)) (APIIdempotencyCompletion, bool, error) {
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		completion, err := execute(ctx)
+		return completion, false, err
+	}
+	if execute == nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency executor is required")
+	}
+	req.Method = strings.TrimSpace(req.Method)
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	req.RequestHash = strings.TrimSpace(req.RequestHash)
+	if req.Method == "" || req.ActorTokenID == "" || req.RequestHash == "" {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("method, actor token id, and request hash are required")
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+	if req.TTL <= 0 {
+		req.TTL = 24 * time.Hour
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("begin sqlite api idempotency tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, req.Now.UTC()); err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("purge expired sqlite api idempotency: %w", err)
+	}
+	existing, ok, err := sqliteLoadAPIIdempotency(ctx, tx, req)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	if ok {
+		if existing.RequestHash != req.RequestHash {
+			return APIIdempotencyCompletion{}, false, &APIIdempotencyConflictError{
+				OriginalRequestHash:    existing.RequestHash,
+				ConflictingRequestHash: req.RequestHash,
+				Method:                 req.Method,
+				ResourceID:             existing.ResourceID,
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return APIIdempotencyCompletion{}, false, fmt.Errorf("commit sqlite api idempotency replay: %w", err)
+		}
+		committed = true
+		return APIIdempotencyCompletion{ResourceID: existing.ResourceID, Response: existing.Response}, true, nil
+	}
+	completion, err := execute(ctx)
+	if err != nil {
+		return APIIdempotencyCompletion{}, false, err
+	}
+	if len(completion.Response) == 0 {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency response is required")
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO api_idempotency (method, actor_token_id, idempotency_key, request_hash, resource_id, response, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.RequestHash, strings.TrimSpace(completion.ResourceID), string(completion.Response), req.Now.UTC(), req.Now.Add(req.TTL).UTC()); err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("store sqlite api idempotency response: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("commit sqlite api idempotency tx: %w", err)
+	}
+	committed = true
+	return completion, false, nil
+}
+
+func sqliteLoadAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {
+	var record apiIdempotencyRecord
+	var response []byte
+	err := q.QueryRowContext(ctx, `
+		SELECT request_hash, resource_id, response
+		FROM api_idempotency
+		WHERE method = ? AND actor_token_id = ? AND idempotency_key = ? AND expires_at > ?
+	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.Now.UTC()).Scan(&record.RequestHash, &record.ResourceID, &response)
+	if err == sql.ErrNoRows {
+		return apiIdempotencyRecord{}, false, nil
+	}
+	if err != nil {
+		return apiIdempotencyRecord{}, false, fmt.Errorf("load sqlite api idempotency response: %w", err)
+	}
+	record.Response = json.RawMessage(response)
+	return record, true, nil
+}
+
+func sqliteEnsureRunRow(ctx context.Context, tx *sql.Tx, runID, triggerEventID, triggerEventType string, now time.Time) error {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO runs (run_id, status, bundle_source, trigger_event_id, trigger_event_type, started_at)
+		VALUES (?, 'running', 'legacy', ?, ?, ?)
+	`, runID, sqliteNullUUID(triggerEventID), sqliteNullString(triggerEventType), now.UTC())
+	if err != nil {
+		return fmt.Errorf("ensure sqlite run row: %w", err)
+	}
+	return nil
+}
+
+func sqliteNullString(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	return raw
+}
+
+func sqliteNullUUID(raw string) any {
+	raw = nullUUIDString(raw)
+	if raw == "" {
+		return nil
+	}
+	return raw
+}
+
+func sqliteTimeValue(raw any) (time.Time, bool, error) {
+	switch v := raw.(type) {
+	case nil:
+		return time.Time{}, false, nil
+	case time.Time:
+		if v.IsZero() {
+			return time.Time{}, false, nil
+		}
+		return v.UTC(), true, nil
+	case string:
+		return parseSQLiteTimeString(v)
+	case []byte:
+		return parseSQLiteTimeString(string(v))
+	default:
+		return time.Time{}, false, fmt.Errorf("unsupported sqlite time value %T", raw)
+	}
+}
+
+func parseSQLiteTimeString(raw string) (time.Time, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+	}
+	var lastErr error
+	for _, layout := range formats {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return parsed.UTC(), true, nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, false, fmt.Errorf("parse sqlite time %q: %w", raw, lastErr)
+}

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -356,11 +356,11 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(context.Context, string, string,
 }
 
 func (s *SQLiteRuntimeStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
-	return nil, nil
+	return nil, fmt.Errorf("sqlite event backlog replay queries are split to #1087")
 }
 
 func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
-	return nil, nil
+	return nil, fmt.Errorf("sqlite event backlog replay queries are split to #1087")
 }
 
 func (s *SQLiteRuntimeStore) EnsureRuntimeIngressState(ctx context.Context, now time.Time) (runtimeingress.State, error) {

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -93,6 +93,17 @@ func (s *SQLiteRuntimeStore) CanonicalEventReceiptsCapability(ctx context.Contex
 }
 
 func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) error {
+	return s.AppendEventTx(ctx, nil, evt)
+}
+
+func (s *SQLiteRuntimeStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite runtime store is required")
+	}
+	return s.DB.BeginTx(ctx, nil)
+}
+
+func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -111,13 +122,16 @@ func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) 
 	if eventHasRouteIdentity(evt) && !caps.Events.LogRouteIdentity {
 		return fmt.Errorf("events source_route/target_route/target_set columns required for routed event")
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite event tx: %w", err)
+	ownedTx := tx == nil
+	if ownedTx {
+		tx, err = s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin sqlite event tx: %w", err)
+		}
 	}
 	committed := false
 	defer func() {
-		if !committed {
+		if ownedTx && !committed {
 			_ = tx.Rollback()
 		}
 	}()
@@ -137,29 +151,39 @@ func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) 
 	if err != nil {
 		return fmt.Errorf("append sqlite event: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite event tx: %w", err)
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite event tx: %w", err)
+		}
+		committed = true
 	}
-	committed = true
 	return nil
 }
 
 func (s *SQLiteRuntimeStore) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	return s.InsertEventDeliveriesTx(ctx, nil, eventID, agentIDs)
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveriesTx(ctx context.Context, tx *sql.Tx, eventID string, agentIDs []string) error {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" || len(agentIDs) == 0 {
 		return nil
 	}
 	var runID sql.NullString
-	if err := s.DB.QueryRowContext(ctx, `SELECT run_id FROM events WHERE event_id = ?`, eventID).Scan(&runID); err != nil {
+	if err := chooseRowQueryer(s.DB, tx).QueryRowContext(ctx, `SELECT run_id FROM events WHERE event_id = ?`, eventID).Scan(&runID); err != nil {
 		return fmt.Errorf("load event run for sqlite delivery manifest: %w", err)
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite delivery manifest tx: %w", err)
+	ownedTx := tx == nil
+	var err error
+	if ownedTx {
+		tx, err = s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin sqlite delivery manifest tx: %w", err)
+		}
 	}
 	committed := false
 	defer func() {
-		if !committed {
+		if ownedTx && !committed {
 			_ = tx.Rollback()
 		}
 	}()
@@ -177,11 +201,17 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveries(ctx context.Context, eventID 
 			return fmt.Errorf("insert sqlite event delivery: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite delivery manifest tx: %w", err)
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite delivery manifest tx: %w", err)
+		}
+		committed = true
 	}
-	committed = true
 	return nil
+}
+
+func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(context.Context, *sql.Tx, string, string, string) error {
+	return fmt.Errorf("sqlite pipeline receipt persistence is split to #1087")
 }
 
 func (s *SQLiteRuntimeStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -1,0 +1,477 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimeruncontrol "swarm/internal/runtime/runcontrol"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+func (s *SQLiteRuntimeStore) InsertMailboxItem(ctx context.Context, item runtimetools.MailboxItem) (string, error) {
+	if strings.TrimSpace(item.Type) == "" {
+		return "", fmt.Errorf("mailbox item type is required")
+	}
+	if strings.TrimSpace(item.ID) == "" {
+		item.ID = uuid.NewString()
+	}
+	if strings.TrimSpace(item.Priority) == "" {
+		item.Priority = "normal"
+	}
+	if strings.TrimSpace(item.Status) == "" {
+		item.Status = "pending"
+	}
+	if len(item.Context) == 0 {
+		item.Context = []byte("{}")
+	}
+	scope := "global"
+	if entityID := coalesceMailboxEntityID(item); entityID != "" {
+		scope = "entity"
+	}
+	status, decision := mailboxStateForStoredStatus(item.Status, item.Decision)
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO mailbox (
+			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+			from_agent, severity, summary, payload, status, decision, decision_notes,
+			notified, expires_at, created_at
+		)
+		VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, item.ID, sqliteNullUUID(coalesceMailboxEntityID(item)), scope, item.Type, sqliteNullUUID(item.EventID),
+		sqliteNullString(item.FromAgent), normalizeMailboxSeverity(item.Priority), sqliteNullString(item.Summary), string(item.Context),
+		status, sqliteNullString(decision), sqliteNullString(item.DecisionNotes), item.Notified, sqliteNullTime(item.TimeoutAt), time.Now().UTC())
+	if err != nil {
+		return "", fmt.Errorf("insert sqlite mailbox item: %w", err)
+	}
+	return item.ID, nil
+}
+
+func (s *SQLiteRuntimeStore) ListMailboxItems(ctx context.Context, status string, limit int) ([]runtimetools.MailboxItem, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if strings.TrimSpace(status) == "" {
+		status = "pending"
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return nil, err
+	}
+	rows, err := s.DB.QueryContext(ctx, sqliteMailboxSelectSQL(`status = ?`)+` ORDER BY created_at ASC LIMIT ?`, status, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite mailbox items: %w", err)
+	}
+	defer rows.Close()
+	return scanSpecMailboxItems(rows)
+}
+
+func (s *SQLiteRuntimeStore) CountMailboxItems(ctx context.Context, status string) (int, error) {
+	if strings.TrimSpace(status) == "" {
+		status = "pending"
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return 0, err
+	}
+	var n int
+	if err := s.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE status = ?`, status).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count sqlite mailbox items: %w", err)
+	}
+	return n, nil
+}
+
+func (s *SQLiteRuntimeStore) GetMailboxItem(ctx context.Context, id string) (runtimetools.MailboxItem, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return runtimetools.MailboxItem{}, fmt.Errorf("mailbox id is required")
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return runtimetools.MailboxItem{}, err
+	}
+	rows, err := s.DB.QueryContext(ctx, sqliteMailboxSelectSQL(`item_id = ?`), id)
+	if err != nil {
+		return runtimetools.MailboxItem{}, fmt.Errorf("get sqlite mailbox item: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanSpecMailboxItems(rows)
+	if err != nil {
+		return runtimetools.MailboxItem{}, err
+	}
+	if len(items) == 0 {
+		return runtimetools.MailboxItem{}, fmt.Errorf("mailbox item not found: %s", id)
+	}
+	return items[0], nil
+}
+
+func (s *SQLiteRuntimeStore) DecideMailboxItem(ctx context.Context, id, status, decision, notes string) error {
+	id = strings.TrimSpace(id)
+	if id == "" || strings.TrimSpace(status) == "" || strings.TrimSpace(decision) == "" {
+		return fmt.Errorf("mailbox id, status, and decision are required")
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return err
+	}
+	rowStatus, rowDecision := mailboxDecisionState(status, decision)
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE mailbox
+		SET status = ?, decision = ?, decision_notes = ?, decided_at = ?
+		WHERE item_id = ? AND status = 'pending'
+	`, rowStatus, rowDecision, sqliteNullString(notes), time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("decide sqlite mailbox item: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("mailbox item is not pending or not found: %s", id)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ExpireMailboxItems(ctx context.Context, limit int) ([]runtimetools.MailboxItem, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	rows, err := s.DB.QueryContext(ctx, sqliteMailboxSelectSQL(`status = 'pending' AND expires_at IS NOT NULL AND expires_at <= ?`)+` ORDER BY expires_at ASC LIMIT ?`, time.Now().UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("query expiring sqlite mailbox items: %w", err)
+	}
+	items, err := scanSpecMailboxItems(rows)
+	rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	for i, item := range items {
+		if _, err := s.DB.ExecContext(ctx, `
+			UPDATE mailbox
+			SET status = 'expired',
+			    decision = COALESCE(NULLIF(decision, ''), ''),
+			    decision_notes = COALESCE(NULLIF(decision_notes, ''), 'Timed out without human decision'),
+			    decided_at = COALESCE(decided_at, ?)
+			WHERE item_id = ? AND status = 'pending'
+		`, now, item.ID); err != nil {
+			return nil, fmt.Errorf("expire sqlite mailbox item: %w", err)
+		}
+		items[i].Status = "expired"
+		if strings.TrimSpace(items[i].DecisionNotes) == "" {
+			items[i].DecisionNotes = "Timed out without human decision"
+		}
+	}
+	return items, nil
+}
+
+func (s *SQLiteRuntimeStore) ListUnnotifiedCriticalMailboxItems(ctx context.Context, limit int) ([]runtimetools.MailboxItem, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if _, err := s.ExpireMailboxItems(ctx, 200); err != nil {
+		return nil, err
+	}
+	rows, err := s.DB.QueryContext(ctx, sqliteMailboxSelectSQL(`status = 'pending' AND severity = 'critical' AND COALESCE(notified, false) = false`)+` ORDER BY created_at ASC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite unnotified critical mailbox items: %w", err)
+	}
+	defer rows.Close()
+	return scanSpecMailboxItems(rows)
+}
+
+func (s *SQLiteRuntimeStore) MarkMailboxItemNotified(ctx context.Context, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("mailbox id is required")
+	}
+	if _, err := s.DB.ExecContext(ctx, `UPDATE mailbox SET notified = true WHERE item_id = ?`, id); err != nil {
+		return fmt.Errorf("mark sqlite mailbox item notified: %w", err)
+	}
+	return nil
+}
+
+func sqliteMailboxSelectSQL(where string) string {
+	return `
+		SELECT item_id, COALESCE(source_event_id, ''), COALESCE(entity_id, ''), COALESCE(from_agent, ''),
+		       item_type, COALESCE(severity, 'normal'), status, COALESCE(notified, false),
+		       COALESCE(payload, '{}'), COALESCE(summary, ''), expires_at,
+		       COALESCE(decision, ''), COALESCE(decision_notes, '')
+		FROM mailbox
+		WHERE ` + where
+}
+
+func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.Schedule) error {
+	if strings.TrimSpace(sc.AgentID) == "" || strings.TrimSpace(sc.EventType) == "" {
+		return fmt.Errorf("agent_id and event_type are required")
+	}
+	if strings.TrimSpace(sc.Mode) == "" {
+		sc.Mode = "once"
+	}
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	if err := s.CancelScheduleExact(ctx, sc); err != nil {
+		return err
+	}
+	fireAt := sc.At
+	if fireAt.IsZero() {
+		fireAt = time.Now().UTC()
+	}
+	recurring := strings.EqualFold(strings.TrimSpace(sc.Mode), "cron")
+	taskType := "timer"
+	if recurring {
+		taskType = "scheduled_task"
+		if sc.EntityID == "" {
+			taskType = "global_recurring"
+		}
+	}
+	timerName := strings.TrimSpace(sc.TaskID)
+	if timerName == "" {
+		timerName = strings.TrimSpace(sc.EventType)
+	}
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+			fire_at, recurring, recurrence_cron, owner_agent, task_type, status, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+	`, uuid.NewString(), sqliteNullUUID(sc.RunID), timerName, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance),
+		sc.EventType, string(persistedSchedulePayload(sc)), fireAt.UTC(), recurring, sqliteNullString(sc.Cron), sc.AgentID, taskType, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("insert sqlite timer: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) CancelScheduleExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	_, err := s.DB.ExecContext(ctx, `
+		UPDATE timers
+		SET status = 'cancelled'
+		WHERE COALESCE(run_id, '') = COALESCE(?, '')
+		  AND owner_agent = ?
+		  AND fire_event = ?
+		  AND COALESCE(entity_id, '') = COALESCE(?, '')
+		  AND COALESCE(flow_instance, '') = COALESCE(?, '')
+		  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
+		  AND status = 'active'
+	`, sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
+	if err != nil {
+		return fmt.Errorf("cancel sqlite timer exact: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) CancelScheduleExactTerminal(ctx context.Context, sc runtimepipeline.Schedule) error {
+	return s.CancelScheduleExact(ctx, sc)
+}
+
+func (s *SQLiteRuntimeStore) LoadActiveSchedules(ctx context.Context) ([]runtimepipeline.Schedule, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(run_id, ''), COALESCE(owner_agent, ''), fire_event, COALESCE(recurrence_cron, ''),
+		       fire_at, COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(fire_payload, '{}')
+		FROM timers
+		WHERE status = 'active'
+		ORDER BY fire_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("load sqlite active schedules: %w", err)
+	}
+	defer rows.Close()
+	out := make([]runtimepipeline.Schedule, 0)
+	for rows.Next() {
+		var sc runtimepipeline.Schedule
+		var fireAt any
+		var payload any
+		if err := rows.Scan(&sc.RunID, &sc.AgentID, &sc.EventType, &sc.Cron, &fireAt, &sc.EntityID, &sc.FlowInstance, &payload); err != nil {
+			return nil, fmt.Errorf("scan sqlite schedule: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(fireAt); err != nil {
+			return nil, fmt.Errorf("scan sqlite schedule fire_at: %w", err)
+		} else if ok {
+			sc.At = at
+		}
+		sc.Payload = jsonRawMessageValue(payload)
+		if strings.TrimSpace(sc.Cron) != "" {
+			sc.Mode = "cron"
+		} else {
+			sc.Mode = "once"
+		}
+		sc.TaskID = scheduleTaskIDFromPayload(sc.Payload)
+		out = append(out, sc)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteRuntimeStore) MarkScheduleFiredExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	_, err := s.DB.ExecContext(ctx, `
+		UPDATE timers
+		SET status = 'fired', fired_at = ?
+		WHERE COALESCE(run_id, '') = COALESCE(?, '')
+		  AND owner_agent = ?
+		  AND fire_event = ?
+		  AND COALESCE(entity_id, '') = COALESCE(?, '')
+		  AND COALESCE(flow_instance, '') = COALESCE(?, '')
+		  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
+		  AND status = 'active'
+	`, time.Now().UTC(), sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
+	if err != nil {
+		return fmt.Errorf("mark sqlite timer fired exact: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) CompleteScheduleFireExact(ctx context.Context, sc runtimepipeline.Schedule) error {
+	return s.MarkScheduleFiredExact(ctx, sc)
+}
+
+func (s *SQLiteRuntimeStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
+	return true, nil
+}
+
+func (s *SQLiteRuntimeStore) ReleaseSchedule(context.Context, runtimepipeline.Schedule) error {
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ReleaseScheduleClaims(context.Context) error {
+	return nil
+}
+
+func scheduleTaskIDFromPayload(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil || decoded == nil {
+		return ""
+	}
+	raw, ok := decoded["__schedule_task_id"]
+	if !ok || raw == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
+}
+
+func sqliteNullTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+func sqliteLoadRunControlState(ctx context.Context, tx *sql.Tx, runID string) (runtimeruncontrol.State, error) {
+	var state runtimeruncontrol.State
+	var controlStatus, reason, controlledBy sql.NullString
+	var updatedAt any
+	err := tx.QueryRowContext(ctx, `
+		SELECT r.run_id, COALESCE(r.status, ''), COALESCE(rc.control_status, ''),
+		       COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, ''), rc.updated_at
+		FROM runs r
+		LEFT JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = ?
+	`, runID).Scan(&state.RunID, &state.Status, &controlStatus, &reason, &controlledBy, &updatedAt)
+	if err == sql.ErrNoRows {
+		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrRunNotFound, RunID: runID}
+	}
+	if err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("load sqlite run control state: %w", err)
+	}
+	state.ControlStatus = strings.TrimSpace(controlStatus.String)
+	state.Reason = strings.TrimSpace(reason.String)
+	state.ControlledBy = strings.TrimSpace(controlledBy.String)
+	if at, ok, err := sqliteTimeValue(updatedAt); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("scan sqlite run control updated_at: %w", err)
+	} else if ok {
+		state.UpdatedAt = at
+	}
+	return state, nil
+}
+
+func sqlitePauseRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontrol.State, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	switch state.Status {
+	case "running":
+	case "paused":
+		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrAlreadyPaused, RunID: state.RunID, CurrentStatus: state.Status}
+	case "completed", "failed", "cancelled", "forked":
+		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrAlreadyTerminal, RunID: state.RunID, CurrentStatus: state.Status}
+	default:
+		return runtimeruncontrol.State{}, fmt.Errorf("unsupported run status %q", state.Status)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET status = 'paused' WHERE run_id = ? AND status = 'running'`, state.RunID); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("pause sqlite run: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES (?, 'paused', ?, ?, ?, ?, NULL)
+		ON CONFLICT(run_id) DO UPDATE SET
+			control_status = 'paused', reason = excluded.reason, controlled_by = excluded.controlled_by,
+			updated_at = excluded.updated_at, paused_at = COALESCE(run_control_state.paused_at, excluded.paused_at),
+			stopped_at = NULL
+	`, state.RunID, sqliteNullString(req.Reason), req.ControlledBy, req.Now.UTC(), req.Now.UTC()); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("persist sqlite run pause control state: %w", err)
+	}
+	state.Status = "paused"
+	state.ControlStatus = "paused"
+	state.Reason = req.Reason
+	state.ControlledBy = req.ControlledBy
+	state.UpdatedAt = req.Now.UTC()
+	return state, nil
+}
+
+func sqliteContinueRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontrol.State, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	if state.Status != "paused" {
+		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrNotPaused, RunID: state.RunID, CurrentStatus: state.Status}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET status = 'running' WHERE run_id = ? AND status = 'paused'`, state.RunID); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("continue sqlite run: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES (?, 'running', ?, ?, ?, NULL, NULL)
+		ON CONFLICT(run_id) DO UPDATE SET
+			control_status = 'running', reason = excluded.reason, controlled_by = excluded.controlled_by,
+			updated_at = excluded.updated_at, stopped_at = NULL
+	`, state.RunID, sqliteNullString(req.Reason), req.ControlledBy, req.Now.UTC()); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("persist sqlite run continue control state: %w", err)
+	}
+	state.Status = "running"
+	state.ControlStatus = "running"
+	state.Reason = req.Reason
+	state.ControlledBy = req.ControlledBy
+	state.UpdatedAt = req.Now.UTC()
+	return state, nil
+}
+
+func sqliteStopRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontrol.State, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	switch state.Status {
+	case "running", "paused":
+	case "completed", "failed", "cancelled", "forked":
+		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrAlreadyTerminal, RunID: state.RunID, CurrentStatus: state.Status}
+	default:
+		return runtimeruncontrol.State{}, fmt.Errorf("unsupported run status %q", state.Status)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET status = 'cancelled', ended_at = COALESCE(ended_at, ?) WHERE run_id = ?`, req.Now.UTC(), state.RunID); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("stop sqlite run: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES (?, 'stopped', ?, ?, ?, NULL, ?)
+		ON CONFLICT(run_id) DO UPDATE SET
+			control_status = 'stopped', reason = excluded.reason, controlled_by = excluded.controlled_by,
+			updated_at = excluded.updated_at, stopped_at = excluded.stopped_at
+	`, state.RunID, sqliteNullString(req.Reason), req.ControlledBy, req.Now.UTC(), req.Now.UTC()); err != nil {
+		return runtimeruncontrol.State{}, fmt.Errorf("persist sqlite run stop control state: %w", err)
+	}
+	state.Status = "cancelled"
+	state.ControlStatus = "stopped"
+	state.Reason = req.Reason
+	state.ControlledBy = req.ControlledBy
+	state.UpdatedAt = req.Now.UTC()
+	return state, nil
+}

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -331,8 +331,29 @@ func (s *SQLiteRuntimeStore) CompleteScheduleFireExact(ctx context.Context, sc r
 	return s.MarkScheduleFiredExact(ctx, sc)
 }
 
-func (s *SQLiteRuntimeStore) ClaimSchedule(context.Context, runtimepipeline.Schedule) (bool, error) {
-	return true, nil
+func (s *SQLiteRuntimeStore) ClaimSchedule(ctx context.Context, sc runtimepipeline.Schedule) (bool, error) {
+	sc = scheduleWithContextRunID(ctx, sc)
+	sc.NormalizeRunID()
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
+	var active bool
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE COALESCE(run_id, '') = COALESCE(?, '')
+			  AND owner_agent = ?
+			  AND fire_event = ?
+			  AND COALESCE(entity_id, '') = COALESCE(?, '')
+			  AND COALESCE(flow_instance, '') = COALESCE(?, '')
+			  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
+			  AND status = 'active'
+		)
+	`, sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID)).Scan(&active)
+	if err != nil {
+		return false, fmt.Errorf("claim sqlite schedule ownership: %w", err)
+	}
+	return active, nil
 }
 
 func (s *SQLiteRuntimeStore) ReleaseSchedule(context.Context, runtimepipeline.Schedule) error {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1,0 +1,261 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimeingress "swarm/internal/runtime/ingress"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimeruncontrol "swarm/internal/runtime/runcontrol"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+
+	evtID := uuid.NewString()
+	evt := events.Event{
+		ID:          evtID,
+		RunID:       runID,
+		Type:        events.EventType("test.started"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"ok":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := store.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := store.InsertEventDeliveries(ctx, evtID, []string{"agent-1"}); err != nil {
+		t.Fatalf("InsertEventDeliveries: %v", err)
+	}
+	recipients, err := store.ListEventDeliveryRecipients(ctx, evtID)
+	if err != nil {
+		t.Fatalf("ListEventDeliveryRecipients: %v", err)
+	}
+	if len(recipients) != 1 || recipients[0] != "agent-1" {
+		t.Fatalf("recipients = %#v, want agent-1", recipients)
+	}
+
+	if err := store.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Role:             "operator",
+			Mode:             "global",
+			ModelTier:        "generic",
+			LLMBackend:       "api",
+			ConversationMode: "task",
+			Config:           json.RawMessage(`{"system_prompt":"You are an operator.","tools":[]}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	agents, err := store.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Config.ID != "agent-1" {
+		t.Fatalf("agents = %#v, want persisted agent-1", agents)
+	}
+
+	entityID := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (?, ?, 'test-flow', 'test_entity', 'test', 'Test Entity', 'active',
+			'{}', '{"score":1}', '{}', 1, ?, ?, ?)
+	`, runID, entityID, time.Now().UTC(), time.Now().UTC(), time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite entity_state: %v", err)
+	}
+	if err := store.EnsureEntitySchema(ctx, entityID); err != nil {
+		t.Fatalf("EnsureEntitySchema: %v", err)
+	}
+
+	itemID, err := store.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   evtID,
+		EntityID:  entityID,
+		FromAgent: "agent-1",
+		Type:      "human_task",
+		Priority:  "critical",
+		Status:    "pending",
+		Summary:   "needs decision",
+		Context:   json.RawMessage(`{"reason":"test"}`),
+	})
+	if err != nil {
+		t.Fatalf("InsertMailboxItem: %v", err)
+	}
+	count, err := store.CountMailboxItems(ctx, "pending")
+	if err != nil {
+		t.Fatalf("CountMailboxItems: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("pending mailbox count = %d, want 1", count)
+	}
+	if err := store.DecideMailboxItem(ctx, itemID, "decided", "approved", "ok"); err != nil {
+		t.Fatalf("DecideMailboxItem: %v", err)
+	}
+	item, err := store.GetMailboxItem(ctx, itemID)
+	if err != nil {
+		t.Fatalf("GetMailboxItem: %v", err)
+	}
+	if item.Status != "decided" || item.Decision != "approved" {
+		t.Fatalf("mailbox item status=%q decision=%q, want decided/approved", item.Status, item.Decision)
+	}
+
+	schedule := runtimepipeline.Schedule{
+		RunID:        runID,
+		AgentID:      "agent-1",
+		EventType:    "timer.fired",
+		Mode:         "once",
+		At:           time.Now().UTC().Add(time.Hour),
+		EntityID:     entityID,
+		FlowInstance: "test-flow",
+		TaskID:       "task-1",
+		Payload:      json.RawMessage(`{"__schedule_task_id":"task-1"}`),
+	}
+	if err := store.UpsertSchedule(ctx, schedule); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+	schedules, err := store.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules: %v", err)
+	}
+	if len(schedules) != 1 || schedules[0].TaskID != "task-1" {
+		t.Fatalf("active schedules = %#v, want task-1", schedules)
+	}
+	if err := store.MarkScheduleFiredExact(ctx, schedule); err != nil {
+		t.Fatalf("MarkScheduleFiredExact: %v", err)
+	}
+	schedules, err = store.LoadActiveSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadActiveSchedules after fire: %v", err)
+	}
+	if len(schedules) != 0 {
+		t.Fatalf("active schedules after fire = %#v, want empty", schedules)
+	}
+
+	ingressState, err := store.EnsureRuntimeIngressState(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("EnsureRuntimeIngressState: %v", err)
+	}
+	if ingressState.Status != runtimeingress.StatusRunning {
+		t.Fatalf("ingress status = %s, want running", ingressState.Status)
+	}
+	pausedIngress, changed, err := store.TransitionRuntimeIngressState(ctx, runtimeingress.StatusPaused, "test", "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("TransitionRuntimeIngressState(paused): %v", err)
+	}
+	if !changed || pausedIngress.Status != runtimeingress.StatusPaused {
+		t.Fatalf("paused ingress state=%+v changed=%v, want paused changed", pausedIngress, changed)
+	}
+
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_source, started_at)
+		VALUES (?, 'running', 'legacy', ?)
+		ON CONFLICT(run_id) DO UPDATE SET status = 'running'
+	`, runID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite run row: %v", err)
+	}
+	pausedRun, err := store.PauseRunControl(ctx, runtimeruncontrol.TransitionRequest{RunID: runID, Reason: "pause", ControlledBy: "operator", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("PauseRunControl: %v", err)
+	}
+	if pausedRun.Status != "paused" || pausedRun.ControlStatus != "paused" {
+		t.Fatalf("paused run state = %+v, want paused", pausedRun)
+	}
+	blocked, err := store.RunDispatchBlocked(ctx, runID)
+	if err != nil {
+		t.Fatalf("RunDispatchBlocked: %v", err)
+	}
+	if !blocked {
+		t.Fatal("RunDispatchBlocked = false, want true for paused run")
+	}
+	runningRun, err := store.ContinueRunControl(ctx, runtimeruncontrol.TransitionRequest{RunID: runID, Reason: "continue", ControlledBy: "operator", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("ContinueRunControl: %v", err)
+	}
+	if runningRun.Status != "running" {
+		t.Fatalf("continued run state = %+v, want running", runningRun)
+	}
+	stoppedRun, err := store.StopRunControl(ctx, runtimeruncontrol.TransitionRequest{RunID: runID, Reason: "stop", ControlledBy: "operator", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("StopRunControl: %v", err)
+	}
+	if stoppedRun.Status != "cancelled" || stoppedRun.ControlStatus != "stopped" {
+		t.Fatalf("stopped run state = %+v, want cancelled/stopped", stoppedRun)
+	}
+
+	req := APIIdempotencyRequest{
+		Method:         "mailbox.decide",
+		ActorTokenID:   "token-1",
+		IdempotencyKey: "idem-1",
+		RequestHash:    "hash-1",
+		Now:            time.Now().UTC(),
+	}
+	first, replayed, err := store.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		return APIIdempotencyCompletion{ResourceID: itemID, Response: json.RawMessage(`{"ok":true}`)}, nil
+	})
+	if err != nil {
+		t.Fatalf("WithAPIIdempotency first: %v", err)
+	}
+	if replayed || first.ResourceID != itemID {
+		t.Fatalf("first idempotency completion=%+v replayed=%v, want new item", first, replayed)
+	}
+	second, replayed, err := store.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		return APIIdempotencyCompletion{ResourceID: "wrong", Response: json.RawMessage(`{"ok":false}`)}, nil
+	})
+	if err != nil {
+		t.Fatalf("WithAPIIdempotency replay: %v", err)
+	}
+	if !replayed || second.ResourceID != itemID {
+		t.Fatalf("second idempotency completion=%+v replayed=%v, want replayed item", second, replayed)
+	}
+	req.RequestHash = "hash-2"
+	_, _, err = store.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		return APIIdempotencyCompletion{ResourceID: "wrong", Response: json.RawMessage(`{"ok":false}`)}, nil
+	})
+	if !errors.Is(err, ErrAPIIdempotencyConflict) {
+		t.Fatalf("idempotency conflict err = %v, want ErrAPIIdempotencyConflict", err)
+	}
+}
+
+func newBootstrappedSQLiteRuntimeStoreForTest(t *testing.T) *SQLiteRuntimeStore {
+	t.Helper()
+	spec := loadPlatformSpecForSQLiteSchemaTest(t)
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	store, err := NewSQLiteRuntimeStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("close sqlite runtime store: %v", err)
+		}
+	})
+	if err := store.EnsureSchemaTables(context.Background(), plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", dbPath, err)
+	}
+	return store
+}

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -231,6 +232,73 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	})
 	if !errors.Is(err, ErrAPIIdempotencyConflict) {
 		t.Fatalf("idempotency conflict err = %v, want ErrAPIIdempotencyConflict", err)
+	}
+}
+
+func TestSQLiteRuntimeStoreReplayBacklogQueriesFailClosed(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+
+	if _, err := store.ListPendingEventsForAgent(ctx, "agent-1", time.Now().Add(-time.Hour), 10); err == nil || !strings.Contains(err.Error(), "split to #1087") {
+		t.Fatalf("ListPendingEventsForAgent error = %v, want explicit #1087 split", err)
+	}
+	if _, err := store.ListPendingSubscribedEvents(ctx, "agent-1", []events.EventType{"test.*"}, time.Now().Add(-time.Hour), 10); err == nil || !strings.Contains(err.Error(), "split to #1087") {
+		t.Fatalf("ListPendingSubscribedEvents error = %v, want explicit #1087 split", err)
+	}
+}
+
+func TestSQLiteRuntimeStoreClaimScheduleRequiresActiveRow(t *testing.T) {
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_source, started_at)
+		VALUES (?, 'running', 'legacy', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite run row: %v", err)
+	}
+	schedule := runtimepipeline.Schedule{
+		RunID:     runID,
+		AgentID:   "agent-1",
+		EventType: "timer.fired",
+		Mode:      "once",
+		At:        time.Now().UTC().Add(time.Hour),
+		TaskID:    "task-claim",
+		Payload:   json.RawMessage(`{"__schedule_task_id":"task-claim"}`),
+	}
+
+	if err := store.UpsertSchedule(ctx, schedule); err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+	claimed, err := store.ClaimSchedule(ctx, schedule)
+	if err != nil {
+		t.Fatalf("ClaimSchedule active: %v", err)
+	}
+	if !claimed {
+		t.Fatal("ClaimSchedule active = false, want true")
+	}
+	if err := store.CancelScheduleExact(ctx, schedule); err != nil {
+		t.Fatalf("CancelScheduleExact: %v", err)
+	}
+	claimed, err = store.ClaimSchedule(ctx, schedule)
+	if err != nil {
+		t.Fatalf("ClaimSchedule cancelled: %v", err)
+	}
+	if claimed {
+		t.Fatal("ClaimSchedule cancelled = true, want false")
+	}
+	if err := store.UpsertSchedule(ctx, schedule); err != nil {
+		t.Fatalf("UpsertSchedule after cancel: %v", err)
+	}
+	if err := store.MarkScheduleFiredExact(ctx, schedule); err != nil {
+		t.Fatalf("MarkScheduleFiredExact: %v", err)
+	}
+	claimed, err = store.ClaimSchedule(ctx, schedule)
+	if err != nil {
+		t.Fatalf("ClaimSchedule fired: %v", err)
+	}
+	if claimed {
+		t.Fatal("ClaimSchedule fired = true, want false")
 	}
 }
 

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -247,6 +247,108 @@ func TestSQLiteRuntimeStoreReplayBacklogQueriesFailClosed(t *testing.T) {
 	}
 }
 
+func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	eventID := uuid.NewString()
+	if err := store.AppendEvent(ctx, events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("mailbox.requested"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"request":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent source: %v", err)
+	}
+	entityID := uuid.NewString()
+	itemID, err := store.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EventID:   eventID,
+		EntityID:  entityID,
+		FromAgent: "agent-1",
+		Type:      "approval",
+		Priority:  "critical",
+		Status:    "pending",
+		Summary:   "approve test",
+		Context:   json.RawMessage(`{"thing":"test"}`),
+	})
+	if err != nil {
+		t.Fatalf("InsertMailboxItem: %v", err)
+	}
+
+	items, nextCursor, err := store.ListV1MailboxItems(ctx, MailboxV1ListOptions{Status: "pending", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListV1MailboxItems: %v", err)
+	}
+	if nextCursor != "" || len(items) != 1 {
+		t.Fatalf("ListV1MailboxItems len=%d next=%q, want one item no cursor", len(items), nextCursor)
+	}
+	if items[0].MailboxID != itemID || items[0].SourceRunID != runID || items[0].Status != "pending" {
+		t.Fatalf("listed item = %+v, want pending item for run %s", items[0], runID)
+	}
+	detail, err := store.GetV1MailboxItem(ctx, itemID)
+	if err != nil {
+		t.Fatalf("GetV1MailboxItem: %v", err)
+	}
+	if detail.Item.MailboxID != itemID || detail.Payload["thing"] != "test" {
+		t.Fatalf("detail = %+v, want item payload", detail)
+	}
+
+	now := time.Now().UTC()
+	req := MailboxV1DecisionRequest{
+		MailboxID:                     itemID,
+		Action:                        "approved",
+		ActorTokenID:                  "token-1",
+		DecisionPayload:               json.RawMessage(`{"approved":true}`),
+		Now:                           now,
+		ApprovalEventType:             "mailbox.item_decided",
+		ApprovalEventSubscribers:      []string{"agent-2"},
+		ApprovalEventSubscriberSource: "test",
+		Idempotency: &APIIdempotencyRequest{
+			Method:         "mailbox.approve",
+			ActorTokenID:   "token-1",
+			IdempotencyKey: "idem-mailbox",
+			RequestHash:    "hash-1",
+			Now:            now,
+		},
+	}
+	outcome, err := store.DecideV1MailboxItem(ctx, req)
+	if err != nil {
+		t.Fatalf("DecideV1MailboxItem approve: %v", err)
+	}
+	if !outcome.Result.OK || outcome.Result.Status != "decided" || outcome.Result.DownstreamEventName != "mailbox.item_decided" {
+		t.Fatalf("approval outcome = %+v, want decided downstream event", outcome.Result)
+	}
+	var eventName string
+	if err := store.DB.QueryRowContext(ctx, `SELECT event_name FROM events WHERE event_id = ?`, outcome.Result.DownstreamEventID).Scan(&eventName); err != nil {
+		t.Fatalf("load downstream event: %v", err)
+	}
+	if eventName != "mailbox.item_decided" {
+		t.Fatalf("downstream event_name = %q, want mailbox.item_decided", eventName)
+	}
+	decided, err := store.GetV1MailboxItem(ctx, itemID)
+	if err != nil {
+		t.Fatalf("GetV1MailboxItem decided: %v", err)
+	}
+	if decided.Item.Status != "decided" || decided.Item.Decision != "approved" {
+		t.Fatalf("decided item = %+v, want approved decision", decided.Item)
+	}
+	replayed, err := store.DecideV1MailboxItem(ctx, req)
+	if err != nil {
+		t.Fatalf("DecideV1MailboxItem replay: %v", err)
+	}
+	if !replayed.Replayed || replayed.Result.DownstreamEventID != outcome.Result.DownstreamEventID {
+		t.Fatalf("replayed outcome = %+v, want idempotent replay of %s", replayed, outcome.Result.DownstreamEventID)
+	}
+	req.Idempotency.RequestHash = "hash-2"
+	_, err = store.DecideV1MailboxItem(ctx, req)
+	if !errors.Is(err, ErrAPIIdempotencyConflict) {
+		t.Fatalf("DecideV1MailboxItem conflict error = %v, want ErrAPIIdempotencyConflict", err)
+	}
+}
+
 func TestSQLiteRuntimeStoreClaimScheduleRequiresActiveRow(t *testing.T) {
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	runID := uuid.NewString()


### PR DESCRIPTION
## Summary

Part of #1086.

Implements the selected SQLite runtime store contract slice approved for the #1086 first-slice gate:

- adds `internal/store.SQLiteRuntimeStore` for file-backed SQLite selected runtime persistence
- wires explicit `--store sqlite` construction through the selected store bundle for event, manager, schedule, mailbox, runtime ingress/run-control, and API idempotency owners
- fails closed before `runtime.NewRuntime` construction when explicit SQLite would otherwise reach selected-parent raw `*sql.DB` / Postgres-shaped runtime consumers
- wires the v1 operator mailbox API through the selected `apiv1.MailboxAPIStore` owner and adds the SQLite implementation for list/get/decide
- preserves Postgres as the active no-selection default and explicit production backend
- updates `platform-spec.yaml` with `engine.runtime_core_persistence_store_contracts`

## Governing refs/context

Binding spec sections:

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `engine.runtime_store_backend_selection`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `engine.runtime_store_schema_dialect_bootstrap`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `engine.runtime_core_persistence_store_contracts`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` `platform_tables.tables`

Binding issue/gate context:

- #1086 Pre-Implementation Coverage Audit
- #1086 gate outcome: `approved as first slice`
- parent #1066 remains open
- #1087/#1088/#1089 remain split tails

## Semantic migration

New canonical owners:

- `runtime.Stores` selected persistence interfaces backed by `internal/store.PostgresStore` and `internal/store.SQLiteRuntimeStore`
- `runtime.Stores.ConstructionBlocker` for fail-closed runtime construction when selected store consumers are not backend-neutral yet
- `apiv1.MailboxAPIStore` for v1 operator mailbox list/get/decision persistence

Old producer/reader/writer paths now invalid for this selected slice:

- explicit SQLite selection failing before runtime store construction
- explicit SQLite passing its raw `SQLDB` into `runtime.NewRuntime` while raw-SQL runtime consumers remain live
- selected mailbox/runtime-ingress/API-idempotency wiring hard-coded to `PostgresStore`
- runtime store help text describing SQLite as fully unsupported until #1085-#1088

Production paths checked for surviving old behavior:

- explicit Postgres store construction still builds the Postgres-backed selected interfaces and passes raw `SQLDB` for the active Postgres backend
- no-selection default remains Postgres
- explicit SQLite constructs selected stores, but runtime boot fails closed before raw-SQL runtime consumers
- split API/read/reset/session/delivery/trace surfaces still remain Postgres-owned or unavailable under their existing owner chain

Migration completeness:

- complete for the selected store construction, selected mailbox API ownership, SQLite selected store methods, and fail-closed runtime construction boundary in this PR
- not a full SQLite runtime boot/default/parity migration
- parent #1066 remains open for #1087/#1088/#1089

## Proof

- `go test ./...`
- `go test ./internal/store -run 'TestSQLiteRuntimeStore(V1MailboxAPISelectedOwner|ReplayBacklogQueriesFailClosed|ClaimScheduleRequiresActiveRow|SelectedCoreContracts)'`
- `go test ./cmd/swarm -run TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore`
- `go test ./internal/runtime -run TestRuntimeDepsValidateOwnsRequiredBootInputs`