### PR TITLE
[agent-a][issue #1125] Repair forkchat CLI accounting

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -9659,6 +9659,7 @@ cli_specification:
     - swarm conversations list
     - swarm conversation view
     - swarm conversation turn
+    - swarm forkchat new|resume|list|view|delete
     implemented_legacy_or_wrong_namespace: []
     retired_or_fail_closed:
     - swarm investigate
@@ -9671,7 +9672,6 @@ cli_specification:
     remaining_should_have_not_implemented:
     - swarm bundle list|show|agents|register|delete
     - swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
-    - swarm forkchat new|resume|list|view|delete
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
 api_specification:


### PR DESCRIPTION
## Summary

Closes #1125.

Repairs `platform-spec.yaml#cli_specification.parent_tail` so `swarm forkchat new|resume|list|view|delete` is counted as implemented instead of remaining not implemented. This is spec/accounting only; no runtime, API, CLI, OpenRPC, board, or watchlist behavior changed.

## Governing refs/context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.source_of_truth`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.catalog_accounting_model`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.forkchat`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.parent_tail`
- #1125 pre-audit and independent gate outcome: approved as first slice

## Semantic accounting migration

- Canonical owner: `platform-spec.yaml#cli_specification.command_catalog.forkchat`.
- Old invalid consumer path: `parent_tail.remaining_should_have_not_implemented` listed the implemented forkchat family as remaining.
- Production/proof surfaces checked for surviving old behavior: generated OpenRPC `conversation.fork*` method family and `swarm forkchat --help` subcommands.
- Migration complete: yes, for the approved forkchat parent-tail accounting class only. #735/#794 parent residuals remain for bundle and public `swarm fork`/`run.fork`.

## Validation

- YAML parse/assertion: `command_catalog.forkchat` remains implemented, forkchat is present in `implemented_v2_compliant`, and absent from `remaining_should_have_not_implemented`.
- OpenRPC method assertion: exactly `conversation.fork`, `conversation.fork_chat`, `conversation.fork_delete`, `conversation.fork_list`, `conversation.fork_view`.
- `go run ./cmd/swarm forkchat --help`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./cmd/swarm -run 'TestForkChat|TestCLIAPIConsumptionBoundary|TestPendingFork' -count=1`
- `go test ./...`