### PR TITLE
[agent-a][issue #1127] Promote LLM selection source authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1427,6 +1427,226 @@ func TestPlatformSpecLocalCLITestWorkspaceCLIAvailabilityPromoted(t *testing.T) 
 	}
 }
 
+func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing.T) {
+	var spec struct {
+		Engine struct {
+			AgentSessionManagement struct {
+				Selection struct {
+					PromotedBy           string            `yaml:"promoted_by"`
+					ImplementationStatus string            `yaml:"implementation_status"`
+					Owner                string            `yaml:"owner"`
+					BehaviorChildren     map[string]string `yaml:"behavior_children"`
+					CanonicalSelector    struct {
+						CLIFlag                          string   `yaml:"cli_flag"`
+						ConfigKey                        string   `yaml:"config_key"`
+						EnvVar                           string   `yaml:"env_var"`
+						DefaultBackendProfile            string   `yaml:"default_backend_profile"`
+						SourceOrder                      []string `yaml:"source_order"`
+						RetiredNonAuthoritativeSelectors []string `yaml:"retired_non_authoritative_selectors"`
+						Rules                            []string `yaml:"rules"`
+					} `yaml:"canonical_selector"`
+					BackendProfileIdentity struct {
+						ActiveBackendProfiles map[string]struct {
+							Provider                    string   `yaml:"provider"`
+							Transport                   string   `yaml:"transport"`
+							ProviderContractRuntimeMode string   `yaml:"provider_contract_runtime_mode"`
+							LegacyBackendIDs            []string `yaml:"legacy_backend_ids"`
+							CredentialSource            struct {
+								EnvVar   string `yaml:"env_var"`
+								Required bool   `yaml:"required"`
+							} `yaml:"credential_source"`
+							EndpointSource struct {
+								ConfigKey string `yaml:"config_key"`
+								EnvVar    string `yaml:"env_var"`
+								Rule      string `yaml:"rule"`
+							} `yaml:"endpoint_source"`
+						} `yaml:"active_backend_profiles"`
+						RejectedTargetNames map[string]string `yaml:"rejected_target_names"`
+					} `yaml:"backend_profile_identity"`
+					ModelAliasAuthority struct {
+						ContractField              string   `yaml:"contract_field"`
+						Replaces                   string   `yaml:"replaces"`
+						AliasConfigKey             string   `yaml:"alias_config_key"`
+						BuiltInAliases             []string `yaml:"built_in_aliases"`
+						AliasVocabularyDeclaration string   `yaml:"alias_vocabulary_declaration"`
+						ResolutionRule             string   `yaml:"resolution_rule"`
+						VerifyRule                 string   `yaml:"verify_rule"`
+						AuditRule                  string   `yaml:"audit_rule"`
+					} `yaml:"model_alias_authority"`
+					CredentialAndConfigPolicy struct {
+						SecretEnvSources              []string `yaml:"secret_env_sources"`
+						RuntimeConfigCanonicalFor     []string `yaml:"runtime_config_canonical_for"`
+						InfraConnectionOverridePolicy string   `yaml:"infra_connection_override_policy"`
+					} `yaml:"credential_and_config_policy"`
+					PersistenceRules []string `yaml:"persistence_rules"`
+					SplitBoundaries  []string `yaml:"split_boundaries"`
+				} `yaml:"llm_provider_selection_config_authority"`
+			} `yaml:"agent_session_management"`
+		} `yaml:"engine"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	authority := spec.Engine.AgentSessionManagement.Selection
+	if strings.TrimSpace(authority.PromotedBy) != "#1127" {
+		t.Fatalf("llm provider selection promoted_by = %q, want #1127", authority.PromotedBy)
+	}
+	if strings.TrimSpace(authority.ImplementationStatus) != "source_authority_promoted_behavior_split" {
+		t.Fatalf("llm provider selection implementation_status = %q", authority.ImplementationStatus)
+	}
+	if !strings.Contains(authority.Owner, "backend profile and model alias resolver") {
+		t.Fatalf("llm provider selection owner missing alias resolver: %s", authority.Owner)
+	}
+	for _, want := range []string{"#1128", "#1129", "#1130"} {
+		if !mapValueContains(authority.BehaviorChildren, want) {
+			t.Fatalf("behavior children missing %q: %#v", want, authority.BehaviorChildren)
+		}
+	}
+	selector := authority.CanonicalSelector
+	if selector.CLIFlag != "--backend" || selector.ConfigKey != "llm.backend" || selector.EnvVar != "" || selector.DefaultBackendProfile != "anthropic" {
+		t.Fatalf("selector = %#v, want --backend > llm.backend > default anthropic with no env selector", selector)
+	}
+	for _, want := range []string{"--backend", "runtime config llm.backend", "built-in default anthropic"} {
+		if !stringSliceContains(selector.SourceOrder, want) {
+			t.Fatalf("selector source order missing %q: %#v", want, selector.SourceOrder)
+		}
+	}
+	for _, want := range []string{"SWARM_LLM_BACKEND", "llm.runtime_mode", "SWARM_LLM_RUNTIME_MODE"} {
+		if !stringSliceContains(selector.RetiredNonAuthoritativeSelectors, want) {
+			t.Fatalf("retired selectors missing %q: %#v", want, selector.RetiredNonAuthoritativeSelectors)
+		}
+	}
+	if !joinedContains(selector.Rules, "Environment variables never select the backend profile") {
+		t.Fatalf("selector rules do not retire env backend selection: %#v", selector.Rules)
+	}
+	profiles := authority.BackendProfileIdentity.ActiveBackendProfiles
+	for _, oldID := range []string{"api", "cli_test"} {
+		if _, ok := profiles[oldID]; ok {
+			t.Fatalf("old backend id %q still active in source authority profiles: %#v", oldID, profiles)
+		}
+	}
+	if got := profiles["anthropic"]; got.Provider != "anthropic" || got.ProviderContractRuntimeMode != "api" || !stringSliceContains(got.LegacyBackendIDs, "api") {
+		t.Fatalf("anthropic profile = %#v", got)
+	}
+	if got := profiles["claude_cli"]; got.Provider != "claude" || got.ProviderContractRuntimeMode != "cli_test" || !stringSliceContains(got.LegacyBackendIDs, "cli_test") {
+		t.Fatalf("claude_cli profile = %#v", got)
+	}
+	if got := profiles["openai_compatible"]; got.Provider != "openai_compatible" || got.ProviderContractRuntimeMode != "openai_compatible" || got.EndpointSource.EnvVar != "" || !strings.Contains(got.EndpointSource.Rule, "#1128") {
+		t.Fatalf("openai_compatible profile = %#v", got)
+	}
+	if !strings.Contains(strings.ToLower(authority.BackendProfileIdentity.RejectedTargetNames["openai"]), "not active") {
+		t.Fatalf("openai rejected target missing design decision: %#v", authority.BackendProfileIdentity.RejectedTargetNames)
+	}
+	models := authority.ModelAliasAuthority
+	if models.ContractField != "model" || models.Replaces != "model_tier" || models.AliasConfigKey != "llm.models" {
+		t.Fatalf("model alias authority = %#v", models)
+	}
+	for _, want := range []string{"cheap", "regular", "frontier"} {
+		if !stringSliceContains(models.BuiltInAliases, want) {
+			t.Fatalf("model aliases missing %q: %#v", want, models.BuiltInAliases)
+		}
+	}
+	for _, want := range []string{"free-form", "well-formedness", "selected-backend", "write time", "MUST NOT reconstruct"} {
+		if !strings.Contains(models.AliasVocabularyDeclaration+models.ResolutionRule+models.VerifyRule+models.AuditRule, want) {
+			t.Fatalf("model alias authority missing %q:\n%#v", want, models)
+		}
+	}
+	for _, want := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_COMPATIBLE_API_KEY"} {
+		if !stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, want) {
+			t.Fatalf("secret env sources missing %q: %#v", want, authority.CredentialAndConfigPolicy.SecretEnvSources)
+		}
+	}
+	for _, want := range []string{"backend selection", "provider model alias maps"} {
+		if !stringSliceContains(authority.CredentialAndConfigPolicy.RuntimeConfigCanonicalFor, want) {
+			t.Fatalf("runtime config canonical list missing %q: %#v", want, authority.CredentialAndConfigPolicy.RuntimeConfigCanonicalFor)
+		}
+	}
+	for _, want := range []string{"anthropic", "claude_cli", "openai_compatible", "api and cli_test", "model_tier", "write time"} {
+		if !joinedContains(authority.PersistenceRules, want) {
+			t.Fatalf("persistence rules missing %q: %#v", want, authority.PersistenceRules)
+		}
+	}
+	for _, want := range []string{"#1127", "#1128", "#1129", "#1130", "MUST NOT change runtime"} {
+		if !joinedContains(authority.SplitBoundaries, want) {
+			t.Fatalf("split boundaries missing %q: %#v", want, authority.SplitBoundaries)
+		}
+	}
+}
+
+func TestRuntimeOperationsWatchlistMapsLLMProviderModelSelectionSourceAuthority(t *testing.T) {
+	var watchlist struct {
+		ActiveIssues []struct {
+			ID     int      `yaml:"id"`
+			MapsTo []string `yaml:"maps_to"`
+		} `yaml:"active_issues"`
+		Nodes []struct {
+			ID                    string   `yaml:"id"`
+			CanonicalOwners       []string `yaml:"canonical_owners"`
+			KnownManifestations   []string `yaml:"known_manifestations"`
+			RepresentativeIssues  []int    `yaml:"representative_issues"`
+			CommonFramingMistakes struct {
+				TooBroad  []string `yaml:"too_broad"`
+				TooNarrow []string `yaml:"too_narrow"`
+			} `yaml:"common_framing_mistakes"`
+		} `yaml:"nodes"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), "docs", "watchlists", "runtime-operations.yaml"))
+	if err != nil {
+		t.Fatalf("read runtime operations watchlist: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &watchlist); err != nil {
+		t.Fatalf("parse runtime operations watchlist: %v", err)
+	}
+	for _, issueID := range []int{1123, 1127, 1128, 1129, 1130} {
+		if !watchlistIssueMapsTo(watchlist.ActiveIssues, issueID, "llm_provider_selection_config_authority") {
+			t.Fatalf("issue %d does not map to llm_provider_selection_config_authority: %#v", issueID, watchlist.ActiveIssues)
+		}
+	}
+	var node struct {
+		ID                    string
+		CanonicalOwners       []string
+		KnownManifestations   []string
+		RepresentativeIssues  []int
+		CommonFramingMistakes struct {
+			TooBroad  []string `yaml:"too_broad"`
+			TooNarrow []string `yaml:"too_narrow"`
+		}
+	}
+	for _, candidate := range watchlist.Nodes {
+		if candidate.ID == "llm_provider_selection_config_authority" {
+			node.ID = candidate.ID
+			node.CanonicalOwners = candidate.CanonicalOwners
+			node.KnownManifestations = candidate.KnownManifestations
+			node.RepresentativeIssues = candidate.RepresentativeIssues
+			node.CommonFramingMistakes = candidate.CommonFramingMistakes
+			break
+		}
+	}
+	if node.ID == "" {
+		t.Fatalf("llm_provider_selection_config_authority node not found")
+	}
+	if !joinedContains(node.CanonicalOwners, "model alias resolver") {
+		t.Fatalf("watchlist canonical owners missing model alias resolver: %#v", node.CanonicalOwners)
+	}
+	for _, want := range []string{"#1127", "--backend", "anthropic", "claude_cli", "model_tier", "write time", "#1128", "#1129", "#1130"} {
+		if !joinedContains(node.KnownManifestations, want) {
+			t.Fatalf("watchlist known manifestations missing %q: %#v", want, node.KnownManifestations)
+		}
+	}
+	for _, issueID := range []int{1123, 1127, 1128, 1129, 1130} {
+		if !intSliceContains(node.RepresentativeIssues, issueID) {
+			t.Fatalf("representative issues missing %d: %#v", issueID, node.RepresentativeIssues)
+		}
+	}
+	if !joinedContains(node.CommonFramingMistakes.TooBroad, "#1128") || !joinedContains(node.CommonFramingMistakes.TooNarrow, "model alongside model_tier") {
+		t.Fatalf("watchlist framing mistakes do not guard #1127 split: %#v", node.CommonFramingMistakes)
+	}
+}
+
 func TestPlatformSpecContractPlatformSpecPathResolutionPromoted(t *testing.T) {
 	spec := loadCLIContractPlatformSpecPathResolutionSpec(t)
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
@@ -4951,6 +5171,40 @@ func loadCLIContractPlatformSpecPathResolutionSpec(t *testing.T) cliContractPlat
 func stringSliceContains(values []string, want string) bool {
 	for _, value := range values {
 		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinedContains(values []string, want string) bool {
+	return strings.Contains(strings.Join(values, "\n"), want)
+}
+
+func mapValueContains(values map[string]string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func intSliceContains(values []int, want int) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func watchlistIssueMapsTo(issues []struct {
+	ID     int      `yaml:"id"`
+	MapsTo []string `yaml:"maps_to"`
+}, issueID int, nodeID string) bool {
+	for _, issue := range issues {
+		if issue.ID == issueID && stringSliceContains(issue.MapsTo, nodeID) {
 			return true
 		}
 	}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2386,90 +2386,134 @@ engine:
       - Renaming cli_test is a separate compatibility/semantics decision.
       - Provider-selection UI is outside this adapter-contract slice.
     llm_provider_selection_config_authority:
-      description: Runtime LLM backend selection is profile-based. A backend profile id is the canonical selection and
-        persisted deployment value; it resolves to provider identity, transport/protocol mode, credential source, model-tier
-        mapping, and the provider adapter runtime mode consumed by internal/runtime/llm.ProviderContract. Provider identity
-        alone (for example anthropic/openai) and transport alone (for example api/cli/local) are not valid replacements for
-        the backend profile id.
-      owner: internal/runtime/llm/selection backend profile resolver
+      promoted_by: '#1127'
+      implementation_status: source_authority_promoted_behavior_split
+      description: Runtime LLM backend and authored model selection are provider-profile and model-alias based. A backend
+        profile id is the canonical operator/config/persisted deployment value; it resolves to provider identity, access
+        method/transport, credential source, alias-to-model resolution, and the provider adapter runtime mode consumed by
+        internal/runtime/llm.ProviderContract. Authored bundles declare one provider-agnostic model alias per agent. Runtime
+        readers consume write-time resolved backend/provider/model facts and MUST NOT reconstruct them from current config.
+      owner: internal/runtime/llm/selection backend profile and model alias resolver
+      behavior_children:
+        backend_selection_config_discovery: '#1128'
+        model_alias_runtime_migration: '#1129'
+        docs_config_secrets_cleanup: '#1130'
       canonical_selector:
+        cli_flag: --backend
         config_key: llm.backend
-        env_var: SWARM_LLM_BACKEND
-        default_backend_profile: api
+        env_var: null
+        default_backend_profile: anthropic
+        source_order:
+        - --backend
+        - runtime config llm.backend
+        - built-in default anthropic
         retired_non_authoritative_selectors:
+        - SWARM_LLM_BACKEND
         - llm.runtime_mode
         - SWARM_LLM_RUNTIME_MODE
         rules:
-        - Config and CLI env parsing may collect selector input, but they must consume the backend profile resolver rather
-          than independently interpreting provider identity, transport, credential, or model semantics.
-        - The platform must not infer backend profile from credential or model env presence. Missing selector input resolves
-          only through the documented default backend profile.
+        - Runtime config is canonical for non-secret LLM behavior.
+        - Environment variables never select the backend profile. Environment variables remain valid only for provider
+          secrets and pragmatic infra/connection overrides explicitly owned by their configuration sections.
+        - Commands that need runtime/operator config discover explicit --config first, config.yaml beside the running binary
+          when present second, and built-in/default config last.
+        - The platform must not infer backend profile from credential, endpoint, model, or tool-gateway env presence.
         - Unsupported backend profiles and retired selector fields fail closed.
-      active_backend_profiles:
-        api:
-          provider: anthropic
-          transport: api
-          provider_contract_runtime_mode: api
-          credential_source:
-            env_var: ANTHROPIC_API_KEY
-            required: true
-          model_tier_mapping:
-            default_model_config: llm.claude_api.default_model
-            low_cost_model_config: llm.claude_api.haiku_model
-            model_tier_source: agents.model_tier
-            throttle_degrade_rule: If the budget guard marks the actor entity throttled and the low-cost model is configured,
-              the API runtime uses the low-cost model for that turn.
-        cli_test:
-          provider: claude
-          transport: cli
-          provider_contract_runtime_mode: cli_test
-          credential_source:
-            env_var: CLAUDE_CODE_OAUTH_TOKEN
-            required: true
-          model_tier_mapping:
-            model_tier_source: agents.model_tier
-            accounting_model: CLI budget estimation records the configured model_tier string because the Claude CLI shipped
-              runtime does not expose exact model usage metadata in a stable non-interactive surface.
-        openai_compatible:
-          provider: openai_compatible
-          transport: api
-          provider_contract_runtime_mode: openai_compatible
-          protocol: Chat Completions-compatible HTTP JSON at /v1/chat/completions relative to the configured base URL.
-          credential_source:
-            env_var: OPENAI_COMPATIBLE_API_KEY
-            required: true
-          endpoint_source:
-            config_key: llm.openai_compatible.base_url
-            env_var: SWARM_OPENAI_COMPATIBLE_BASE_URL
-            required: true
-            rule: This is the API base URL, not the chat completions endpoint path; the runtime normalizes a root or /v1 base to exactly /v1/chat/completions.
-          model_tier_mapping:
-            default_model_config: llm.openai_compatible.default_model
-            default_model_env: SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL
-            low_cost_model_config: llm.openai_compatible.low_cost_model
-            low_cost_model_env: SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL
-            model_tier_source: agents.model_tier
-            throttle_degrade_rule: If the budget guard marks the actor entity throttled and the low-cost model is configured,
-              the OpenAI-compatible runtime uses the low-cost model for that turn.
-          proof_boundary: This profile proves one non-Anthropic Chat Completions-compatible HTTP provider path. It is not
-            an OpenAI Responses API provider, not an official-OpenAI-only provider identity, not OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM
-            closure, and not a provider matrix.
-      reserved_persisted_backend_profiles:
-        mock: Reserved persisted profile id for fixture replay. It is not a supported active runtime backend until a dedicated
-          provider/runtime owner lands.
-        local: Reserved persisted profile id for local model execution. It is not a supported active runtime backend until
-          a dedicated provider/runtime owner lands.
+      backend_profile_identity:
+        active_backend_profiles:
+          anthropic:
+            provider: anthropic
+            transport: api
+            provider_contract_runtime_mode: api
+            legacy_backend_ids:
+            - api
+            credential_source:
+              env_var: ANTHROPIC_API_KEY
+              required: true
+          claude_cli:
+            provider: claude
+            transport: cli
+            provider_contract_runtime_mode: cli_test
+            legacy_backend_ids:
+            - cli_test
+            credential_source:
+              env_var: CLAUDE_CODE_OAUTH_TOKEN
+              required: true
+          openai_compatible:
+            provider: openai_compatible
+            transport: api
+            provider_contract_runtime_mode: openai_compatible
+            protocol: Chat Completions-compatible HTTP JSON at /v1/chat/completions relative to the configured base URL.
+            legacy_backend_ids: []
+            credential_source:
+              env_var: OPENAI_COMPATIBLE_API_KEY
+              required: true
+            endpoint_source:
+              config_key: llm.openai_compatible.base_url
+              env_var: null
+              required: true
+              rule: "This is deployment configuration, not a secret. Runtime config is canonical; behavior migration decides any explicitly allowed connection-env override under #1128."
+            proof_boundary: This profile proves one non-Anthropic Chat Completions-compatible HTTP provider path. It remains
+              named openai_compatible and is not a native OpenAI Responses API provider, not an official-OpenAI-only provider
+              identity, not OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM closure, and not a provider matrix.
+        reserved_persisted_backend_profiles:
+          mock: Reserved persisted profile id for fixture replay. It is not a supported active runtime backend until a
+            dedicated provider/runtime owner lands.
+          local: Reserved persisted profile id for local model execution. It is not a supported active runtime backend until
+            a dedicated provider/runtime owner lands.
+        rejected_target_names:
+          openai: Not active for this authority because the shipped non-Anthropic proof is Chat Completions-compatible and
+            may front OpenRouter or local-compatible endpoints. Native OpenAI Responses requires a separate provider/protocol gate.
+      model_alias_authority:
+        contract_field: model
+        replaces: model_tier
+        alias_config_key: llm.models
+        built_in_aliases:
+        - cheap
+        - regular
+        - frontier
+        alias_vocabulary_declaration: none; aliases are free-form strings in bundles, with well-formedness checked by verify
+          and selected-backend resolution checked at boot.
+        resolution_rule: Resolution is deterministic and provider-scoped. The canonical input is (backend profile id, authored
+          model alias); the canonical output is the concrete provider model string plus resolved backend and provider identity.
+          Per-alias runtime config overrides built-in defaults; unresolved aliases fail closed before agent turns.
+        verify_rule: swarm verify validates the authored model field is present and well formed, but does not require deployment
+          credentials or provider-specific config. Deployment alias resolution is a boot/runtime validation responsibility.
+        audit_rule: Runtime audit writes authored model alias plus resolved backend profile, provider identity, and concrete
+          model at write time. Readers consume recorded values and MUST NOT reconstruct from current config.
+      credential_and_config_policy:
+        secret_env_sources:
+        - ANTHROPIC_API_KEY
+        - CLAUDE_CODE_OAUTH_TOKEN
+        - OPENAI_COMPATIBLE_API_KEY
+        - SWARM_TOOL_GATEWAY_TOKEN
+        - SWARM_API_TOKEN
+        - database password env/store sources
+        runtime_config_canonical_for:
+        - backend selection
+        - provider endpoint/base URLs
+        - provider model alias maps
+        - tool-gateway URLs and workspace/runtime behavior
+        - Claude CLI permission, output, timeout, and session behavior
+        infra_connection_override_policy: Config remains canonical; env overrides are allowed only for pragmatic infra/connection
+          values explicitly named by their owning config sections. This does not allow env-based backend selection.
       persistence_rules:
-      - agents.llm_backend stores the backend profile id, not provider identity and not transport mode.
+      - Target agents.llm_backend stores the provider-named backend profile ids anthropic, claude_cli, and openai_compatible.
+      - "Legacy persisted backend ids api and cli_test are non-authoritative after #1128/#1129 migration and must be explicitly backfilled to anthropic and claude_cli."
+      - "Authored model aliases replace model_tier as the bundle/source selector. Store/schema migration remains in #1129."
+      - Runtime manager/default materialization must persist the resolved backend profile id and model alias rather than
+        reusing config/runtime-mode strings.
+      - Runtime audit must persist resolved backend/provider/concrete model at write time, and readers must consume persisted
+        facts rather than re-resolving against current config.
       - Agent/session conversation scope remains owned by agent_sessions.runtime_mode and is orthogonal to llm_backend.
-      - Runtime manager/default materialization must persist the resolved backend profile id rather than reusing config/runtime
-        mode strings.
-      - Readers must consume persisted llm_backend as a backend profile id and fail closed on unknown values.
       split_boundaries:
+      - '#1127 is source-authority/spec/watchlist only and MUST NOT change runtime/config/store/verify/CLI behavior.'
+      - '#1128 owns backend selection/config discovery, --backend precedence, env selector retirement, and backend id migration.'
+      - '#1129 owns model_tier to model alias migration, boot/verify alias validation, runtime model resolution, and audit writes.'
+      - '#1130 owns docs/config/secrets/model-alias cleanup after behavior lands.'
       - Implementing OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other additional
         provider remains a separate provider implementation/parity gate.
-      - Renaming cli_test remains a separate compatibility/storage/spec migration.
-      - Provider UI and docs beyond the selector/config truth remain under the #983 parent tail.
+      - Native multi-backend-per-run remains deferred until a separate real user need is gated.
     conversation_modes:
       description: How the platform manages agent session context across invocations.
       modes:

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -81,6 +81,26 @@ active_issues:
     title: Canonicalize LLM provider selection/config authority
     maps_to:
       - llm_provider_selection_config_authority
+  - id: 1123
+    title: Model aliases in flow contracts, resolved per-provider; provider-named backends; env for secrets only
+    maps_to:
+      - llm_provider_selection_config_authority
+  - id: 1127
+    title: Promote LLM backend/model selection source authority
+    maps_to:
+      - llm_provider_selection_config_authority
+  - id: 1128
+    title: Backend selection/config discovery migration
+    maps_to:
+      - llm_provider_selection_config_authority
+  - id: 1129
+    title: model_tier to provider-resolved model aliases
+    maps_to:
+      - llm_provider_selection_config_authority
+  - id: 1130
+    title: Docs/config/secrets/model-alias documentation cleanup
+    maps_to:
+      - llm_provider_selection_config_authority
   - id: 1066
     title: Default to SQLite (Postgres as opt-in external DB) to minimize onboarding friction
     maps_to:
@@ -323,27 +343,40 @@ nodes:
     parent_class: runtime LLM provider abstraction not production-ready
     canonical_owners:
       - docs/specs/swarm-platform/platform/contracts/platform-spec.yaml llm_provider_selection_config_authority
-      - internal/runtime/llm/selection backend profile resolver
-    why_this_node_exists: LLM provider selection drifts when config, CLI env defaults, runtime factories, provider credentials, persisted llm_backend, and model-tier mapping each interpret backend identity independently
+      - internal/runtime/llm/selection backend profile and model alias resolver
+    why_this_node_exists: LLM provider/model selection drifts when config, CLI flags, env defaults, runtime factories,
+      provider credentials, persisted llm_backend, authored model aliases, and turn audit records each interpret backend
+      identity or model resolution independently
     known_manifestations:
-      - llm.backend and SWARM_LLM_BACKEND must be the only active selection inputs; retired llm.runtime_mode and SWARM_LLM_RUNTIME_MODE fail closed
-      - the backend profile id resolves provider identity, transport/protocol mode, credential source, provider-contract runtime mode, and model-tier mapping
-      - command defaults must not infer provider/backend selection from credential or model env presence
-      - RuntimeFactory, selected-fork runtime materialization, provider credential checks, AgentManager, store projection/hydration, and model selection must consume the same profile resolver
-      - agents.llm_backend stores a backend profile id; api, cli_test, and openai_compatible are active runtime profiles while mock and local are reserved persisted-only profiles
-      - openai_compatible closes the first non-Anthropic Chat Completions-compatible HTTP proof only; OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure, Vertex, vLLM, provider docs/sample config, and cli_test rename remain split tails
+      - '#1127 promotes the target authority: --backend > runtime config llm.backend > default anthropic; env never selects backend'
+      - target backend profile ids are anthropic, claude_cli, and openai_compatible; legacy api and cli_test require explicit migration/backfill before behavior flips
+      - openai_compatible intentionally remains the active profile name and is not renamed to openai until a separate provider/protocol gate promotes native OpenAI Responses or an official-only identity
+      - authored bundles target model, not model_tier; built-in aliases are cheap, regular, and frontier with provider-scoped resolution under llm.models
+      - runtime config is canonical for non-secret LLM behavior; env remains valid only for provider secrets and explicitly owned pragmatic infra/connection overrides
+      - RuntimeFactory, selected-fork runtime materialization, provider credential checks, AgentManager, store projection/hydration, boot/verify, model selection, budget/session audit, and read surfaces must consume the same profile/model alias resolver after behavior migrations
+      - runtime audit must write authored model alias plus resolved backend/profile/provider/concrete model at write time; readers must not reconstruct from current config
+      - '#1128 owns backend selection/config discovery migration; #1129 owns model_tier-to-model alias runtime/store/verify migration; #1130 owns docs/config/secrets cleanup after behavior lands'
+      - OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure, Vertex, vLLM, and native multi-backend-per-run remain separate provider/protocol gates
     representative_issues:
       - 983
       - 1062
       - 1070
+      - 1123
+      - 1127
+      - 1128
+      - 1129
+      - 1130
     common_framing_mistakes:
       too_broad:
         - implement OpenAI, OpenRouter, Ollama, Bedrock, or another provider in the selection-authority slice
-        - rename cli_test while defining profile semantics
+        - "implement #1128 and #1129 behavior in the #1127 source-authority slice"
+        - rename openai_compatible to openai while defining source authority
       too_narrow:
         - add one factory switch case
         - add one env var alias while keeping runtime_mode as semantic owner
-        - validate config without moving runtime/store/model consumers
+        - add --backend while SWARM_LLM_BACKEND or config readers remain independent selectors
+        - add model alongside model_tier instead of replacing the selector
+        - validate config without moving runtime/store/model/audit consumers
     current_action_pressure: active
   - id: runtime_store_backend_default_and_sqlite_portability
     title: Runtime Store Backend Default And SQLite Portability


### PR DESCRIPTION
## Summary

Closes #1127.
Part of #1123 and #983.

This PR promotes the merge-bearing source authority for LLM backend/model selection without changing runtime/API/CLI behavior. It updates `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority` and `docs/watchlists/runtime-operations.yaml#llm_provider_selection_config_authority`, then adds spec/watchlist regression tests.

## Governing Refs / Gate

- #1123 Pre-Implementation Coverage Audit: https://github.com/yazzaoui/Swarm/issues/1123#issuecomment-4557944317
- #1123 gate outcome: https://github.com/yazzaoui/Swarm/issues/1123#issuecomment-4558123848
- #1127 child scope: source-authority/spec/watchlist only; no runtime behavior change.
- Binding spec owner updated here: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`.
- Watchlist owner updated here: `docs/watchlists/runtime-operations.yaml#llm_provider_selection_config_authority`.

## Semantic Migration Record

- New canonical owner named by spec: `internal/runtime/llm/selection` backend profile and model alias resolver, backed by the platform spec authority.
- Old non-authoritative target paths now invalid for future behavior work: env backend selection (`SWARM_LLM_BACKEND`), transport backend IDs as new operator/config inputs (`api`, `cli_test`), authored `model_tier`, and reader-side reconstruction of resolved backend/provider/model from current config.
- Production paths checked for surviving old behavior: this PR intentionally does not change runtime/config/store/verify/CLI behavior; #1128 owns backend selection/config discovery migration, #1129 owns `model_tier` to `model` alias runtime/store/verify migration, and #1130 owns docs/config/secrets cleanup.
- Migration completion: source-authority/spec/watchlist migration is complete in this PR; behavior migration is explicitly incomplete and split.

## Proof

- `ruby -e 'require "yaml"; YAML.load_file("docs/specs/swarm-platform/platform/contracts/platform-spec.yaml"); YAML.load_file("docs/watchlists/runtime-operations.yaml"); puts "yaml ok"'` passes.
- `go test ./cmd/swarm -run 'TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted|TestRuntimeOperationsWatchlistMapsLLMProviderModelSelectionSourceAuthority' -count=1` passes.
- `go run ./cmd/swarm-openrpc-gen --check` passes: `api spec valid: methods=52 schemas=92 errors=32 mutating=19 subscriptions=4`.
- `go test ./cmd/swarm -count=1` fails because the local Colima Docker socket is unavailable for shared Postgres tests: `dial unix /Users/youmew/.colima/default/docker.sock: connect: no such file or directory`.
- `go test ./... -count=1` fails for the same local Docker/Postgres dependency across shared-Postgres packages; non-Docker packages reached in the run continued passing.