### PR TITLE
[agent-g][issue #1087] Stage SQLite typed runtime stores

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -45,6 +45,7 @@ import (
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
+	runtimestartupownership "swarm/internal/runtime/startupownership"
 	runtimestartuprecovery "swarm/internal/runtime/startuprecovery"
 	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
@@ -126,9 +127,11 @@ type storeBundle struct {
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	MailboxStore        runtimetools.MailboxPersistence
 	MailboxAPIStore     apiv1.MailboxAPIStore
+	ObservabilityStore  apiv1.ObservabilityReadStore
 	RuntimeIngressStore runtimeingress.Store
 	IdempotencyStore    apiv1.APIIdempotencyStore
 	TurnStore           runtimellm.TurnPersistence
+	StartupOwnership    runtimestartupownership.Store
 }
 
 func (s storeBundle) runtimeStores() runtime.Stores {
@@ -140,7 +143,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ConversationStore:   s.ConversationStore,
 		ManagerStore:        s.ManagerStore,
 		ScheduleStore:       s.ScheduleStore,
-		StartupOwnership:    s.Postgres,
+		StartupOwnership:    s.StartupOwnership,
 		MailboxStore:        s.MailboxStore,
 		RuntimeIngressStore: s.RuntimeIngressStore,
 		TurnStore:           s.TurnStore,
@@ -411,9 +414,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	var apiEntities apiv1.EntityReadStore
 	var apiAgentConversations apiv1.AgentConversationReadStore
+	apiObservability := stores.ObservabilityStore
 	if stores.Postgres != nil {
 		apiEntities = stores.Postgres
 		apiAgentConversations = stores.Postgres
+		apiObservability = stores.Postgres
 	}
 	resetPlanner := runtimedestructivereset.InventoryPlanner{
 		Reader: runtimedestructivereset.CompositeInventoryReader{
@@ -427,7 +432,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		},
 		Database:            stores.Postgres,
 		Runs:                stores.Postgres,
-		Observability:       stores.Postgres,
+		Observability:       apiObservability,
 		Entities:            apiEntities,
 		AgentConversations:  apiAgentConversations,
 		BundleCatalog:       stores.Postgres,
@@ -1837,9 +1842,11 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ScheduleStore:       pg,
 			MailboxStore:        pg,
 			MailboxAPIStore:     pg,
+			ObservabilityStore:  pg,
 			RuntimeIngressStore: pg,
 			IdempotencyStore:    pg,
 			TurnStore:           pg,
+			StartupOwnership:    pg,
 		}, nil
 	case storebackend.BackendSQLite:
 		sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)
@@ -1854,17 +1861,22 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			_ = sqliteStore.Close()
 			return storeBundle{}, err
 		}
+		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction is fail-closed until #1086 selected raw-SQL consumers (pipeline, budget, tool executor, runtime diagnostics) move to backend-neutral store owners",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
+			SessionRegistry:     sqliteStore,
+			ConversationStore:   sqliteStore,
 			ManagerStore:        sqliteStore,
 			ScheduleStore:       sqliteStore,
 			MailboxStore:        sqliteStore,
 			MailboxAPIStore:     sqliteStore,
+			ObservabilityStore:  sqliteStore,
 			RuntimeIngressStore: sqliteStore,
 			IdempotencyStore:    sqliteStore,
+			TurnStore:           sqliteStore,
+			StartupOwnership:    sqliteStore,
 		}, nil
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1864,6 +1864,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
+			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (pipeline coordination/background nodes, budget tracking/spend ledger, tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
 			SessionRegistry:     sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -9,15 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
-	platformcontracts "swarm/docs/specs/swarm-platform/platform/contracts"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
-	runtimecontracts "swarm/internal/runtime/contracts"
-	runtimellm "swarm/internal/runtime/llm"
-	runtimepipeline "swarm/internal/runtime/pipeline"
-	"swarm/internal/runtime/semanticview"
-	"swarm/internal/store"
 	storebackend "swarm/internal/store/backendselection"
 )
 
@@ -198,15 +191,15 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
 	}
-	if runtimeStores.ConstructionBlocker != "" {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want construction-ready typed SQLite owners", runtimeStores.ConstructionBlocker)
+	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 gate-promoted raw-SQL consumers") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1087 raw-SQL consumer fail-closed blocker", runtimeStores.ConstructionBlocker)
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", path, err)
 	}
 }
 
-func TestBuildStoresSQLiteRuntimeStartsThroughTypedStoreOwners(t *testing.T) {
+func TestBuildStoresSQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "dev.db")
 	stores, err := buildStores(ctx, storebackend.Selection{
@@ -219,55 +212,17 @@ func TestBuildStoresSQLiteRuntimeStartsThroughTypedStoreOwners(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	bundle := &runtimecontracts.WorkflowContractBundle{}
-	bundle.Platform.Platform.Name = "swarm"
-	bundle.Platform.Platform.Version = "test"
-	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platformcontracts.PlatformSpecYAML(), &platformSpec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
-	plans, err := store.GeneratePlatformTableDDLs(platformSpec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := stores.SchemaBootstrapper.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables(sqlite): %v", err)
-	}
-	if _, err := stores.SchemaBootstrapper.ResolveSchemaCapabilities(ctx); err != nil {
-		t.Fatalf("ResolveSchemaCapabilities(sqlite): %v", err)
-	}
-	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{
-		Config: &config.Config{},
-		Stores: stores.runtimeStores(),
-		Options: runtime.RuntimeOptions{
-			WorkflowModule: sqliteRuntimeStartupTestModule{source: semanticview.Wrap(bundle)},
-			LLMRuntime:     runtimellm.NoopRuntime{},
-			SelfCheck:      true,
-		},
+	_, err = runtime.NewRuntime(ctx, runtime.RuntimeDeps{
+		Config:  &config.Config{},
+		Stores:  stores.runtimeStores(),
+		Options: runtime.RuntimeOptions{SelfCheck: true},
 	})
-	if err != nil {
-		t.Fatalf("NewRuntime(sqlite): %v", err)
+	if err == nil {
+		t.Fatal("NewRuntime(sqlite) succeeded, want fail-closed blocker while #1087 raw-SQL consumers remain unsplit")
 	}
-	if err := rt.Start(ctx); err != nil {
-		t.Fatalf("Runtime.Start(sqlite): %v", err)
+	if !strings.Contains(err.Error(), "#1087 gate-promoted raw-SQL consumers") {
+		t.Fatalf("NewRuntime(sqlite) error = %v, want #1087 raw-SQL consumer blocker", err)
 	}
-	if err := rt.Shutdown(); err != nil {
-		t.Fatalf("Runtime.Shutdown(sqlite): %v", err)
-	}
-}
-
-type sqliteRuntimeStartupTestModule struct {
-	source semanticview.Source
-}
-
-func (s sqliteRuntimeStartupTestModule) SemanticSource() semanticview.Source { return s.source }
-func (sqliteRuntimeStartupTestModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
-	return nil
-}
-func (sqliteRuntimeStartupTestModule) WorkflowNodes() []runtimepipeline.WorkflowNode { return nil }
-func (sqliteRuntimeStartupTestModule) GuardRegistry() runtimepipeline.GuardRegistry  { return nil }
-func (sqliteRuntimeStartupTestModule) ActionRegistry() runtimepipeline.ActionRegistry {
-	return nil
 }
 
 func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath string) string {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -9,8 +9,15 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+	platformcontracts "swarm/docs/specs/swarm-platform/platform/contracts"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimellm "swarm/internal/runtime/llm"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
 	storebackend "swarm/internal/store/backendselection"
 )
 
@@ -181,7 +188,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil {
+	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -191,12 +198,76 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
 	}
-	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1086 selected raw-SQL consumers") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want explicit #1086 raw-SQL split", runtimeStores.ConstructionBlocker)
+	if runtimeStores.ConstructionBlocker != "" {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want construction-ready typed SQLite owners", runtimeStores.ConstructionBlocker)
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", path, err)
 	}
+}
+
+func TestBuildStoresSQLiteRuntimeStartsThroughTypedStoreOwners(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "dev.db")
+	stores, err := buildStores(ctx, storebackend.Selection{
+		Backend:          storebackend.BackendSQLite,
+		BackendSource:    storebackend.SourceFlag,
+		SQLitePath:       path,
+		SQLitePathSource: storebackend.SourceRolloutDefault,
+	}, &config.Config{})
+	if err != nil {
+		t.Fatalf("buildStores(sqlite): %v", err)
+	}
+	t.Cleanup(func() { closeDB(stores.SQLDB) })
+	bundle := &runtimecontracts.WorkflowContractBundle{}
+	bundle.Platform.Platform.Name = "swarm"
+	bundle.Platform.Platform.Version = "test"
+	var platformSpec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platformcontracts.PlatformSpecYAML(), &platformSpec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := store.GeneratePlatformTableDDLs(platformSpec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if err := stores.SchemaBootstrapper.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables(sqlite): %v", err)
+	}
+	if _, err := stores.SchemaBootstrapper.ResolveSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("ResolveSchemaCapabilities(sqlite): %v", err)
+	}
+	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{
+		Config: &config.Config{},
+		Stores: stores.runtimeStores(),
+		Options: runtime.RuntimeOptions{
+			WorkflowModule: sqliteRuntimeStartupTestModule{source: semanticview.Wrap(bundle)},
+			LLMRuntime:     runtimellm.NoopRuntime{},
+			SelfCheck:      true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime(sqlite): %v", err)
+	}
+	if err := rt.Start(ctx); err != nil {
+		t.Fatalf("Runtime.Start(sqlite): %v", err)
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Runtime.Shutdown(sqlite): %v", err)
+	}
+}
+
+type sqliteRuntimeStartupTestModule struct {
+	source semanticview.Source
+}
+
+func (s sqliteRuntimeStartupTestModule) SemanticSource() semanticview.Source { return s.source }
+func (sqliteRuntimeStartupTestModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return nil
+}
+func (sqliteRuntimeStartupTestModule) WorkflowNodes() []runtimepipeline.WorkflowNode { return nil }
+func (sqliteRuntimeStartupTestModule) GuardRegistry() runtimepipeline.GuardRegistry  { return nil }
+func (sqliteRuntimeStartupTestModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return nil
 }
 
 func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath string) string {

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2109,12 +2109,13 @@ engine:
         status: active_supported_runtime_backend
         meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
       sqlite:
-        status: explicit_local_runtime_backend_until_default_flip
+        status: explicit_local_store_backend_until_runtime_construction_gate
         meaning: >
-          Local/dev SQLite runtime store. Explicit sqlite selection may construct the selected core runtime store contracts
-          promoted by #1086 plus the local-runtime session, startup ownership, delivery/replay, conversation/turn, and
-          observability semantics promoted by #1087. SQLite remains staged until the public default flip is separately
-          proven by #1088; it does not promote production multi-writer SQLite semantics.
+          Local/dev SQLite runtime store selection. Explicit sqlite selection may construct the selected typed SQLite store
+          owners promoted by #1086 and staged by #1087, but runtime boot remains fail-closed while the #1087 gate-promoted
+          raw-SQL runtime consumers are not migrated to backend-neutral owners or explicitly split by lead-approved tracker
+          repair. SQLite remains staged until the public default flip is separately proven by #1088; it does not promote
+          production multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2170,9 +2171,10 @@ engine:
     staged_runtime_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
-      Explicit sqlite selection is recognized as a canonical backend id. After #1087 it may construct the explicit local
-      runtime through typed SQLite store owners without passing a raw runtime SQL handle into Postgres-only runtime
-      consumers. Surfaces split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
+      Explicit sqlite selection is recognized as a canonical backend id. It may construct the selected typed SQLite store
+      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers, but runtime.NewRuntime must
+      continue to fail closed until the #1087 raw-SQL consumer blocker is migrated or receives explicit split/tracker
+      approval. Surfaces split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2186,6 +2188,7 @@ engine:
     split_boundaries:
     - "SQLite dialect/schema/bootstrap remains split to #1085."
     - "Backend-neutral core runtime persistence stores remain split to #1086."
+    - "SQLite runtime construction remains blocked by #1087 until gate-promoted raw-SQL runtime consumers are migrated or explicitly split."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
@@ -2230,7 +2233,7 @@ engine:
         portability remains split until #1086/#1087.
     split_boundaries:
     - "Core runtime store method portability remains split to #1086."
-    - "Explicit SQLite local-runtime session locking, event delivery/replay, and trace/read model semantics are promoted by #1087."
+    - "Explicit SQLite local-runtime session locking, event delivery/replay, and trace/read model semantics remain staged under #1087 and do not unblock runtime construction until the raw-SQL consumer blocker is resolved or explicitly split."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_core_persistence_store_contracts:
@@ -2249,16 +2252,19 @@ engine:
         status: active_supported_runtime_backend
       sqlite:
         owner: internal/store.SQLiteRuntimeStore
-        status: explicit_local_runtime_backend
+        status: staged_selected_core_store_backend
         rules:
         - Must be file-backed and use the canonical SQLite path selected by internal/store/backendselection.
         - "Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute."
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
         - >
-          Must construct the explicit local runtime through typed SQLite store owners for the #1087 session, startup ownership,
-          delivery/replay, conversation/turn, and observability semantics.
-        - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers; those consumers remain inactive or split
-          unless/until they gain backend-neutral owners for SQLite.
+          May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
+          and observability semantics, but must not be treated as a construction-ready runtime backend while the #1087
+          raw-SQL consumer blocker remains unresolved.
+        - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
+        - Must keep runtime construction fail-closed until pipeline coordination/background nodes, budget tracking/spend
+          ledger, tool-executor entity/human-task persistence and diagnostics, and runtime diagnostics/logging either gain
+          backend-neutral owners for SQLite or receive explicit lead-approved split/tracker repair.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2333,14 +2339,14 @@ engine:
       scope: >
         SQLite exposes persisted local-runtime event, delivery, session, turn, and log rows through the same API read owner.
         Cursor-rich production read semantics remain Postgres-owned unless separately promoted for SQLite.
-    raw_sql_runtime_consumer_disposition_after_1087:
+    raw_sql_runtime_consumer_blocker_for_sqlite:
       runtime_sql_handle_for_sqlite: omitted
       rule: >
-        Explicit SQLite runtime construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are
-        not accidentally treated as SQLite owners. Pipeline coordination/background nodes, budget tracking/spend ledger,
-        tool-executor SQL diagnostics/entity helpers, and SQL runtime logging are not allowed to consume SQLite through
-        a raw *sql.DB path. Their SQLite behavior is either represented by the typed store owners above or remains inactive
-        for the explicit local-dev runtime until a future backend-neutral owner is promoted.
+        Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
+        accidentally treated as SQLite owners. Because pipeline coordination/background nodes, budget tracking/spend ledger,
+        tool-executor SQL diagnostics/entity helpers, and SQL runtime logging are still gate-promoted #1087 consumers,
+        runtime.NewRuntime must fail closed for SQLite until those consumers move to backend-neutral store owners or receive
+        explicit lead-approved split/tracker repair.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2109,12 +2109,12 @@ engine:
         status: active_supported_runtime_backend
         meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
       sqlite:
-        status: staged_selected_core_store_runtime_backend_until_default_flip
+        status: explicit_local_runtime_backend_until_default_flip
         meaning: >
           Local/dev SQLite runtime store. Explicit sqlite selection may construct the selected core runtime store contracts
-          promoted by #1086, but runtime boot must fail closed while selected-parent raw-SQL consumers still lack backend-neutral
-          owners. SQLite remains staged until session/delivery/trace semantics and the public default flip
-          are separately proven.
+          promoted by #1086 plus the local-runtime session, startup ownership, delivery/replay, conversation/turn, and
+          observability semantics promoted by #1087. SQLite remains staged until the public default flip is separately
+          proven by #1088; it does not promote production multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2170,9 +2170,9 @@ engine:
     staged_runtime_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
-      Explicit sqlite selection is recognized as a canonical backend id. After #1086 it may construct selected core runtime
-      persistence stores, but surfaces split to #1087/#1088/#1089 must still fail closed or remain unavailable until their
-      owning children land.
+      Explicit sqlite selection is recognized as a canonical backend id. After #1087 it may construct the explicit local
+      runtime through typed SQLite store owners without passing a raw runtime SQL handle into Postgres-only runtime
+      consumers. Surfaces split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2186,7 +2186,6 @@ engine:
     split_boundaries:
     - "SQLite dialect/schema/bootstrap remains split to #1085."
     - "Backend-neutral core runtime persistence stores remain split to #1086."
-    - "SQLite sessions, locking, delivery, replay, and trace-stream semantics remain split to #1087."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
@@ -2207,7 +2206,7 @@ engine:
         - Postgres bootstrap may use pgcrypto, Postgres compatibility migrations, Postgres DDL execution, and Postgres
           catalog inspection.
       sqlite:
-        status: schema_bootstrap_only_until_runtime_portability_lands
+        status: explicit_local_runtime_schema_bootstrap
         owner: internal/store.SQLiteSchemaStore and SQLite dialect translation
         rules:
         - SQLite schema bootstrap must be file-backed and must not silently use an in-memory database.
@@ -2231,7 +2230,7 @@ engine:
         portability remains split until #1086/#1087.
     split_boundaries:
     - "Core runtime store method portability remains split to #1086."
-    - "Session locking, event delivery/replay, and trace/read models remain split to #1087."
+    - "Explicit SQLite local-runtime session locking, event delivery/replay, and trace/read model semantics are promoted by #1087."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_core_persistence_store_contracts:
@@ -2250,13 +2249,16 @@ engine:
         status: active_supported_runtime_backend
       sqlite:
         owner: internal/store.SQLiteRuntimeStore
-        status: staged_selected_core_store_backend
+        status: explicit_local_runtime_backend
         rules:
         - Must be file-backed and use the canonical SQLite path selected by internal/store/backendselection.
-        - Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute.
+        - "Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute."
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
-        - Must fail closed before runtime.NewRuntime construction whenever selected-parent consumers would otherwise reach raw
-          SQL/Postgres-only paths instead of a backend-neutral store owner.
+        - >
+          Must construct the explicit local runtime through typed SQLite store owners for the #1087 session, startup ownership,
+          delivery/replay, conversation/turn, and observability semantics.
+        - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers; those consumers remain inactive or split
+          unless/until they gain backend-neutral owners for SQLite.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2298,11 +2300,52 @@ engine:
       postgres_owner: internal/store.PostgresStore.WithAPIIdempotency
       excludes:
       - broad API delivery/replay/concurrency semantics owned by #1087
+    - name: runtime_session_registry_rows
+      owner: internal/runtime/sessions.Registry
+      sqlite_owner: internal/store.SQLiteRuntimeStore session registry methods
+      postgres_owner: internal/runtime/sessions.PostgresRegistry through internal/store.PostgresStore database
+      scope: >
+        SQLite provides persisted local-dev session leases and process-local serialization. Postgres remains authoritative
+        for production concurrency and cross-process session fencing.
+    - name: runtime_startup_ownership
+      owner: internal/runtime/startupownership.Store
+      sqlite_owner: internal/store.SQLiteRuntimeStore process-local startup ownership lease
+      postgres_owner: internal/store.PostgresStore advisory-lock startup ownership
+      scope: >
+        SQLite startup ownership prevents competing runtimes inside the local process boundary. It is not a production
+        multi-writer lock substitute.
+    - name: event_delivery_receipt_and_replay_rows
+      owner: runtimebus.EventStore, runtimebus.TransactionalEventStore, runtimemanager.ManagerPersistence, and runtimereplayclaim committed replay contracts
+      sqlite_owner: internal/store.SQLiteRuntimeStore delivery, receipt, pipeline receipt, committed replay scope, and replay-claim methods
+      postgres_owner: internal/store.PostgresStore delivery, receipt, pipeline receipt, committed replay scope, and replay-claim methods
+      scope: >
+        SQLite supports local-dev delivery, receipt settlement, pending/backlog replay, and process-local replay claims over
+        persisted rows. Postgres remains the production owner for cross-runtime claims and transaction/fencing semantics.
+    - name: llm_conversation_and_turn_rows
+      owner: internal/runtime/llm TurnPersistence and ConversationPersistence
+      sqlite_owner: internal/store.SQLiteRuntimeStore conversation and agent turn methods
+      postgres_owner: internal/store.PostgresStore conversation and agent turn methods
+      scope: SQLite persists local-runtime conversation state and turns for the selected backend.
+    - name: operator_trace_event_log_read_rows
+      owner: apiv1.ObservabilityReadStore and v1 run.trace, event.subscribe, runtime.logs/runtime.subscribe_logs surfaces
+      sqlite_owner: internal/store.SQLiteRuntimeStore observability read methods
+      postgres_owner: internal/store.PostgresStore observability read methods
+      scope: >
+        SQLite exposes persisted local-runtime event, delivery, session, turn, and log rows through the same API read owner.
+        Cursor-rich production read semantics remain Postgres-owned unless separately promoted for SQLite.
+    raw_sql_runtime_consumer_disposition_after_1087:
+      runtime_sql_handle_for_sqlite: omitted
+      rule: >
+        Explicit SQLite runtime construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are
+        not accidentally treated as SQLite owners. Pipeline coordination/background nodes, budget tracking/spend ledger,
+        tool-executor SQL diagnostics/entity helpers, and SQL runtime logging are not allowed to consume SQLite through
+        a raw *sql.DB path. Their SQLite behavior is either represented by the typed store owners above or remains inactive
+        for the explicit local-dev runtime until a future backend-neutral owner is promoted.
     split_boundaries:
-    - "Runtime boot with explicit SQLite must remain fail-closed until raw SQL runtime consumers such as pipeline coordination, budget tracking, tool execution diagnostics, and runtime logging move to backend-neutral owners."
-    - "Session registry, startup ownership locks, event delivery claims/retry/replay, trace-stream/read/subscription semantics remain split to #1087."
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."
+    - "Production multi-writer SQLite concurrency semantics are not promoted by #1087."
+    - "Additional raw-SQL runtime feature parity for SQLite requires a separately gated backend-neutral owner before use."
   agent_session_management:
     description: The platform manages agent sessions — the lifecycle of an agent from receiving an event to completing its
       response.

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -1,0 +1,155 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	platformcontracts "swarm/docs/specs/swarm-platform/platform/contracts"
+	"swarm/internal/events"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	storepkg "swarm/internal/store"
+)
+
+func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSQLiteObservabilitySurfaceFixture(t, ctx)
+	readOpts := OperatorReadOptions{
+		Now:           func() time.Time { return fixture.now.Add(time.Minute) },
+		Observability: fixture.store,
+	}
+	handler := testHandler(t, Options{
+		AuthTokens:    []string{testToken},
+		Handlers:      OperatorReadHandlers(readOpts),
+		Subscriptions: OperatorSubscriptions(readOpts, SubscriptionRuntimeOptions{PollInterval: time.Hour, QueueSize: 4}),
+	})
+
+	trace := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"trace","method":"run.trace","params":{"run_id":%q,"filter":{"event_name":["trace.visible"]},"limit":10}}`, fixture.runID))
+	if trace.Error != nil {
+		t.Fatalf("run.trace error = %#v", trace.Error)
+	}
+	if rows, _ := asMap(t, trace.Result)["trace"].([]any); len(rows) != 1 || asMap(t, rows[0])["event_id"] != fixture.eventID {
+		t.Fatalf("run.trace rows = %#v, want event %s", asMap(t, trace.Result)["trace"], fixture.eventID)
+	}
+
+	logs := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":%q,"component":"scheduler","level":"warn","limit":10}}`, fixture.runID))
+	if logs.Error != nil {
+		t.Fatalf("runtime.logs error = %#v", logs.Error)
+	}
+	if rows, _ := asMap(t, logs.Result)["logs"].([]any); len(rows) != 1 || asMap(t, rows[0])["log_id"] != fixture.logID {
+		t.Fatalf("runtime.logs rows = %#v, want log %s", asMap(t, logs.Result)["logs"], fixture.logID)
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	assertSQLiteSubscriptionNotification(t, server.URL, "event.subscribe", map[string]any{
+		"filter": map[string]any{
+			"run_id":     fixture.runID,
+			"event_name": "trace.visible",
+		},
+		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, "event_id", fixture.eventID)
+	assertSQLiteSubscriptionNotification(t, server.URL, "run.subscribe_trace", map[string]any{
+		"run_id":       fixture.runID,
+		"filter":       map[string]any{"event_name": []any{"trace.visible"}},
+		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, "event_id", fixture.eventID)
+	assertSQLiteSubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
+		"run_id":       fixture.runID,
+		"component":    "scheduler",
+		"level":        "warn",
+		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, "log_id", fixture.logID)
+}
+
+type sqliteObservabilitySurfaceFixture struct {
+	store   *storepkg.SQLiteRuntimeStore
+	runID   string
+	eventID string
+	logID   string
+	now     time.Time
+}
+
+func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sqliteObservabilitySurfaceFixture {
+	t.Helper()
+	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() { _ = sqliteStore.Close() })
+
+	var platformSpec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platformcontracts.PlatformSpecYAML(), &platformSpec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+
+	now := time.Unix(1700002000, 0).UTC()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	if err := sqliteStore.PersistEventWithDeliveries(ctx, events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("trace.visible"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"trace":true}`),
+		CreatedAt:   now,
+	}, []string{"agent-1"}); err != nil {
+		t.Fatalf("PersistEventWithDeliveries: %v", err)
+	}
+	if err := sqliteStore.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", "session-1"); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
+	}
+
+	logID := uuid.NewString()
+	if err := sqliteStore.AppendEvent(ctx, events.Event{
+		ID:          logID,
+		RunID:       runID,
+		Type:        events.EventType("platform.runtime_log"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","session_id":"session-1"}}`),
+		CreatedAt:   now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("AppendEvent runtime log: %v", err)
+	}
+
+	return sqliteObservabilitySurfaceFixture{
+		store:   sqliteStore,
+		runID:   runID,
+		eventID: eventID,
+		logID:   logID,
+		now:     now,
+	}
+}
+
+func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string, params map[string]any, key, want string) {
+	t.Helper()
+	conn := dialTestWS(t, serverURL)
+	defer conn.Close()
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      method + "-sqlite",
+		"method":  method,
+		"params":  params,
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("%s error = %#v", method, subscribe.Error)
+	}
+	notification := readWSNotification(t, conn)
+	if got := asMap(t, notification.Params.Result)[key]; got != want {
+		t.Fatalf("%s notification %s = %#v, want %s", method, key, got, want)
+	}
+}

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,12 +23,20 @@ import (
 )
 
 // SQLiteRuntimeStore is the file-backed SQLite implementation of the selected
-// #1086 runtime persistence contracts. Session locking, delivery replay, and
-// trace streaming stay split to #1087.
+// runtime persistence contracts. SQLite is a local-dev backend: process-local
+// mutexes provide startup/session serialization while persisted rows remain the
+// canonical state consumed by the runtime.
 type SQLiteRuntimeStore struct {
 	*SQLiteSchemaStore
 
 	eventPayloadValidator EventPayloadValidator
+	startupMu             sync.Mutex
+	sessionMu             sync.Mutex
+	replayMu              sync.Mutex
+	startupOwner          string
+	replayClaims          map[string]struct{}
+	sessionLockTTL        time.Duration
+	nowFn                 func() time.Time
 }
 
 var _ SchemaBootstrapper = (*SQLiteRuntimeStore)(nil)
@@ -44,7 +53,12 @@ func NewSQLiteRuntimeStore(path string) (*SQLiteRuntimeStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRuntimeStore{SQLiteSchemaStore: schemaStore}, nil
+	return &SQLiteRuntimeStore{
+		SQLiteSchemaStore: schemaStore,
+		replayClaims:      map[string]struct{}{},
+		sessionLockTTL:    120 * time.Second,
+		nowFn:             time.Now,
+	}, nil
 }
 
 func (s *SQLiteRuntimeStore) schemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error) {
@@ -54,7 +68,24 @@ func (s *SQLiteRuntimeStore) schemaCapabilities(ctx context.Context) (StoreSchem
 	return s.ResolveSchemaCapabilities(ctx)
 }
 
-func (*SQLiteRuntimeStore) SupportsPersistedReplay() bool { return false }
+func (*SQLiteRuntimeStore) SupportsPersistedReplay() bool { return true }
+
+func (s *SQLiteRuntimeStore) SetSessionLockTTL(ttl time.Duration) {
+	if s == nil {
+		return
+	}
+	if ttl <= 0 {
+		ttl = 120 * time.Second
+	}
+	s.sessionLockTTL = ttl
+}
+
+func (s *SQLiteRuntimeStore) now() time.Time {
+	if s == nil || s.nowFn == nil {
+		return time.Now().UTC()
+	}
+	return s.nowFn().UTC()
+}
 
 func (s *SQLiteRuntimeStore) SetEventPayloadValidator(validator func(eventType string, payload []byte) error) {
 	if s == nil {
@@ -208,10 +239,6 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveriesTx(ctx context.Context, tx *sq
 		committed = true
 	}
 	return nil
-}
-
-func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(context.Context, *sql.Tx, string, string, string) error {
-	return fmt.Errorf("sqlite pipeline receipt persistence is split to #1087")
 }
 
 func (s *SQLiteRuntimeStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {
@@ -379,18 +406,6 @@ func (s *SQLiteRuntimeStore) EnsureEntitySchema(ctx context.Context, entityID st
 		return fmt.Errorf("lookup sqlite entity schema row: sql: no rows in result set")
 	}
 	return nil
-}
-
-func (s *SQLiteRuntimeStore) UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, string) error {
-	return fmt.Errorf("sqlite event receipt delivery semantics are split to #1087")
-}
-
-func (s *SQLiteRuntimeStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
-	return nil, fmt.Errorf("sqlite event backlog replay queries are split to #1087")
-}
-
-func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
-	return nil, fmt.Errorf("sqlite event backlog replay queries are split to #1087")
 }
 
 func (s *SQLiteRuntimeStore) EnsureRuntimeIngressState(ctx context.Context, now time.Time) (runtimeingress.State, error) {

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -1,0 +1,907 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	"swarm/internal/runtime/core/eventidentity"
+	runtimeownership "swarm/internal/runtime/core/ownership"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
+)
+
+type sqliteReplayLease struct {
+	store   *SQLiteRuntimeStore
+	eventID string
+}
+
+func (s *SQLiteRuntimeStore) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return s.UpsertPipelineReceiptTx(ctx, nil, eventID, status, errText)
+}
+
+func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	status = strings.TrimSpace(strings.ToLower(status))
+	if status == "" {
+		status = "processed"
+	}
+	if strings.TrimSpace(errText) != "" && status == "processed" {
+		status = "error"
+	}
+	reasonCode := pipelineReceiptReasonCode(status, errText)
+	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects(status, reasonCode, errText))
+	if err != nil {
+		return fmt.Errorf("marshal sqlite pipeline receipt side effects: %w", err)
+	}
+	outcome := mapPipelineStatusToOutcome(status)
+	exec := s.DB.ExecContext
+	if tx != nil {
+		exec = tx.ExecContext
+	}
+	_, err = exec(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			?, e.event_id, 'platform', 'pipeline', e.entity_id, e.flow_instance,
+			?, ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			outcome = excluded.outcome,
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), outcome, sqliteNullString(reasonCode), string(sideEffects), s.now(), eventID)
+	if err != nil {
+		return fmt.Errorf("upsert sqlite pipeline receipt: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	return s.InsertEventDeliveriesWithTargetsTx(ctx, nil, eventID, agentIDs, deliveryTargets)
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveriesWithTargetsTx(ctx context.Context, tx *sql.Tx, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	routes := make([]events.DeliveryRoute, 0, len(agentIDs))
+	for _, agentID := range agentIDs {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		routes = append(routes, events.DeliveryRoute{
+			SubscriberType: "agent",
+			SubscriberID:   agentID,
+			Target:         deliveryTargets[agentID],
+		})
+	}
+	return s.InsertEventDeliveryRoutesTx(ctx, tx, eventID, routes)
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveryRoutes(ctx context.Context, eventID string, deliveryRoutes []events.DeliveryRoute) error {
+	return s.InsertEventDeliveryRoutesTx(ctx, nil, eventID, deliveryRoutes)
+}
+
+func (s *SQLiteRuntimeStore) InsertEventDeliveryRoutesTx(ctx context.Context, tx *sql.Tx, eventID string, deliveryRoutes []events.DeliveryRoute) error {
+	eventID = strings.TrimSpace(eventID)
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if eventID == "" || len(deliveryRoutes) == 0 {
+		return nil
+	}
+	var runID sql.NullString
+	if err := chooseRowQueryer(s.DB, tx).QueryRowContext(ctx, `SELECT run_id FROM events WHERE event_id = ?`, eventID).Scan(&runID); err != nil {
+		return fmt.Errorf("load event run for sqlite delivery routes: %w", err)
+	}
+	ownedTx := tx == nil
+	var err error
+	if ownedTx {
+		tx, err = s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin sqlite delivery routes tx: %w", err)
+		}
+	}
+	committed := false
+	defer func() {
+		if ownedTx && !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, route := range deliveryRoutes {
+		route = route.Normalized()
+		if route.SubscriberType == "" || route.SubscriberID == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route,
+				status, reason_code, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+		`, uuid.NewString(), sqliteNullString(runID.String), eventID, route.SubscriberType, route.SubscriberID,
+			string(routeIdentityJSON(route.Target)), deliveryRouteReasonCode(route), s.now()); err != nil {
+			return fmt.Errorf("insert sqlite event delivery route (%s=%s): %w", route.SubscriberType, route.SubscriberID, err)
+		}
+	}
+	if ownedTx {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite delivery routes tx: %w", err)
+		}
+		committed = true
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) PersistEventWithDeliveries(ctx context.Context, evt events.Event, agentIDs []string) error {
+	return s.PersistEventWithDeliveriesAndScope(ctx, evt, agentIDs, runtimereplayclaim.CommittedReplayScopeSubscribed)
+}
+
+func (s *SQLiteRuntimeStore) PersistEventWithDeliveriesAndScope(ctx context.Context, evt events.Event, agentIDs []string, scope runtimereplayclaim.CommittedReplayScope) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite event/delivery tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+	if err := s.InsertEventDeliveriesTx(ctx, tx, evt.ID, agentIDs); err != nil {
+		return err
+	}
+	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID, scope); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite event/delivery tx: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRoutesAndScope(ctx context.Context, evt events.Event, agentIDs []string, deliveryTargets map[string]events.RouteIdentity, scope runtimereplayclaim.CommittedReplayScope) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite event/routes tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+	if err := s.InsertEventDeliveriesWithTargetsTx(ctx, tx, evt.ID, agentIDs, deliveryTargets); err != nil {
+		return err
+	}
+	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID, scope); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite event/routes tx: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRouteSetAndScope(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite event/route-set tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+	if err := s.InsertEventDeliveryRoutesTx(ctx, tx, evt.ID, deliveryRoutes); err != nil {
+		return err
+	}
+	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID, scope); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite event/route-set tx: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	return s.UpsertCommittedReplayScopeTx(ctx, nil, eventID, scope)
+}
+
+func (s *SQLiteRuntimeStore) UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil
+	}
+	reasonCode, err := committedReplayScopeReasonCode(scope)
+	if err != nil {
+		return err
+	}
+	exec := s.DB.ExecContext
+	if tx != nil {
+		exec = tx.ExecContext
+	}
+	now := s.now()
+	res, err := exec(ctx, `
+		UPDATE event_deliveries
+		SET reason_code = ?,
+		    status = 'delivered',
+		    delivered_at = ?
+		WHERE event_id = ?
+		  AND subscriber_type = ?
+		  AND subscriber_id = ?
+	`, reasonCode, now, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	if err != nil {
+		return fmt.Errorf("update sqlite committed replay scope: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows > 0 {
+		return nil
+	}
+	_, err = exec(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
+			status, reason_code, delivered_at, created_at
+		)
+		SELECT ?, e.run_id, e.event_id, ?, ?, 'delivered', ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+	`, uuid.NewString(), replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, reasonCode, now, now, eventID)
+	if err != nil {
+		return fmt.Errorf("insert sqlite committed replay scope: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) LoadCommittedReplayScope(ctx context.Context, eventID string) (runtimereplayclaim.CommittedReplayScope, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	var reasonCode string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = ?
+		  AND subscriber_id = ?
+		ORDER BY created_at DESC, delivery_id DESC
+		LIMIT 1
+	`, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID).Scan(&reasonCode)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	case err != nil:
+		return "", fmt.Errorf("load sqlite committed replay scope: %w", err)
+	}
+	scope, ok := committedReplayScopeFromReasonCode(reasonCode)
+	if !ok {
+		return "", fmt.Errorf("load sqlite committed replay scope: unrecognized reason_code %q", strings.TrimSpace(reasonCode))
+	}
+	return scope, nil
+}
+
+func (s *SQLiteRuntimeStore) ListEventDeliveryTargets(ctx context.Context, eventID string) (map[string]events.RouteIdentity, error) {
+	routes, err := s.ListEventDeliveryRoutes(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]events.RouteIdentity{}
+	for _, route := range routes {
+		if route.SubscriberType == "agent" && !route.Target.Empty() {
+			out[route.SubscriberID] = route.Target
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ListEventDeliveryRoutes(ctx context.Context, eventID string) ([]events.DeliveryRoute, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil, nil
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT subscriber_type, subscriber_id, COALESCE(delivery_target_route, '{}')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND NOT (subscriber_type = ? AND subscriber_id = ?)
+		ORDER BY created_at ASC, delivery_id ASC
+	`, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	if err != nil {
+		return nil, fmt.Errorf("list sqlite event delivery routes: %w", err)
+	}
+	defer rows.Close()
+	out := make([]events.DeliveryRoute, 0, 8)
+	for rows.Next() {
+		var route events.DeliveryRoute
+		var raw json.RawMessage
+		if err := rows.Scan(&route.SubscriberType, &route.SubscriberID, &raw); err != nil {
+			return nil, fmt.Errorf("scan sqlite event delivery route: %w", err)
+		}
+		route.Target = decodeRouteIdentityJSON(raw)
+		out = append(out, route)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite event delivery routes: %w", err)
+	}
+	return events.NormalizeDeliveryRoutes(out), nil
+}
+
+func (s *SQLiteRuntimeStore) ListEventsMissingPipelineReceipt(ctx context.Context, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if since.IsZero() {
+		since = time.Now().Add(-24 * time.Hour)
+	}
+	return s.listSQLiteEventsMissingPipelineReceipt(ctx, "e.created_at >= ?", []any{since.UTC()}, limit)
+}
+
+func (s *SQLiteRuntimeStore) ListEventsMissingPipelineReceiptForRun(ctx context.Context, runID string, since time.Time, limit int) ([]events.PersistedReplayEvent, error) {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	if since.IsZero() {
+		since = time.Now().Add(-24 * time.Hour)
+	}
+	return s.listSQLiteEventsMissingPipelineReceipt(ctx, "e.run_id = ? AND e.created_at >= ?", []any{runID, since.UTC()}, limit)
+}
+
+func (s *SQLiteRuntimeStore) listSQLiteEventsMissingPipelineReceipt(ctx context.Context, where string, args []any, limit int) ([]events.PersistedReplayEvent, error) {
+	args = append(append([]any{}, args...), limit)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id,
+			COALESCE(e.run_id, ''),
+			e.event_name,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.entity_id, ''),
+			COALESCE(e.flow_instance, ''),
+			COALESCE(e.scope, 'global'),
+			e.payload,
+			e.created_at,
+			COALESCE(e.source_event_id, ''),
+			COALESCE(e.source_route, '{}'),
+			COALESCE(e.target_route, '{}'),
+			COALESCE(e.target_set, '[]')
+		FROM events e
+		LEFT JOIN event_receipts r
+			ON r.event_id = e.event_id
+			AND r.subscriber_type = 'platform'
+			AND r.subscriber_id = 'pipeline'
+		WHERE r.event_id IS NULL
+		  AND `+where+`
+		ORDER BY e.created_at ASC, e.event_id ASC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list sqlite events missing pipeline receipt: %w", err)
+	}
+	defer rows.Close()
+	out := make([]events.PersistedReplayEvent, 0, limit)
+	for rows.Next() {
+		var evt events.Event
+		var entityID, flowInstance, scope string
+		var payloadRaw, createdAtRaw, sourceRouteRaw, targetRouteRaw, targetSetRaw any
+		if err := rows.Scan(
+			&evt.ID,
+			&evt.RunID,
+			&evt.Type,
+			&evt.SourceAgent,
+			&entityID,
+			&flowInstance,
+			&scope,
+			&payloadRaw,
+			&createdAtRaw,
+			&evt.ParentEventID,
+			&sourceRouteRaw,
+			&targetRouteRaw,
+			&targetSetRaw,
+		); err != nil {
+			return nil, fmt.Errorf("scan sqlite missing pipeline receipt event: %w", err)
+		}
+		evt.Payload = sqliteJSONRawMessage(payloadRaw)
+		if createdAt, ok, err := sqliteTimeValue(createdAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite missing pipeline receipt created_at: %w", err)
+		} else if ok {
+			evt.CreatedAt = createdAt
+		}
+		sourceRoute := sqliteJSONRawMessage(sourceRouteRaw)
+		targetRoute := sqliteJSONRawMessage(targetRouteRaw)
+		targetSet := sqliteJSONRawMessage(targetSetRaw)
+		evt = evt.WithEnvelope(eventEnvelopeFromStorage(entityID, flowInstance, scope, sourceRoute, targetRoute, targetSet))
+		record := events.PersistedReplayEvent{Event: evt}
+		if strings.TrimSpace(evt.RunID) == "" {
+			record.ReplayError = "missing canonical run_id"
+		}
+		out = append(out, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite missing pipeline receipt events: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ClaimPipelineReplay(ctx context.Context, eventID string) (runtimeownership.Lease, bool, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil, false, fmt.Errorf("event_id is required")
+	}
+	var pending bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events e
+			LEFT JOIN event_receipts r
+				ON r.event_id = e.event_id
+				AND r.subscriber_type = 'platform'
+				AND r.subscriber_id = 'pipeline'
+			WHERE e.event_id = ?
+			  AND r.event_id IS NULL
+		)
+	`, eventID).Scan(&pending); err != nil {
+		return nil, false, fmt.Errorf("claim sqlite pipeline replay: %w", err)
+	}
+	if !pending {
+		return nil, false, nil
+	}
+	s.replayMu.Lock()
+	if s.replayClaims == nil {
+		s.replayClaims = map[string]struct{}{}
+	}
+	if _, exists := s.replayClaims[eventID]; exists {
+		s.replayMu.Unlock()
+		return nil, false, nil
+	}
+	s.replayClaims[eventID] = struct{}{}
+	s.replayMu.Unlock()
+	return &sqliteReplayLease{store: s, eventID: eventID}, true, nil
+}
+
+func (l *sqliteReplayLease) Release(context.Context) error {
+	if l == nil || l.store == nil {
+		return nil
+	}
+	l.store.replayMu.Lock()
+	delete(l.store.replayClaims, strings.TrimSpace(l.eventID))
+	l.store.replayMu.Unlock()
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, eventID, agentID, sessionID string) error {
+	eventID = strings.TrimSpace(eventID)
+	agentID = strings.TrimSpace(agentID)
+	if eventID == "" || agentID == "" {
+		return fmt.Errorf("mark sqlite event delivery in progress: eventID and agentID required")
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'in_progress',
+		    active_session_id = ?,
+		    started_at = COALESCE(started_at, ?)
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+		  AND status IN ('pending', 'failed', 'in_progress')
+	`, sqliteNullUUID(sessionID), s.now(), eventID, agentID)
+	if err != nil {
+		return fmt.Errorf("mark sqlite event delivery in progress: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("mark sqlite event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, agentID string, status runtimemanager.ReceiptStatus, errText string) error {
+	eventID = strings.TrimSpace(eventID)
+	agentID = strings.TrimSpace(agentID)
+	if eventID == "" || agentID == "" {
+		return fmt.Errorf("upsert sqlite event receipt: eventID and agentID required")
+	}
+	if status == "" {
+		return fmt.Errorf("upsert sqlite event receipt: status required")
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite event receipt tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	delivery, err := s.sqliteLockAgentDeliveryTx(ctx, tx, eventID, agentID)
+	if err != nil {
+		return err
+	}
+	if !delivery.found {
+		return fmt.Errorf("upsert sqlite event receipt: delivery row required for event %s agent %s", eventID, agentID)
+	}
+	state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
+	now := s.now()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = ?,
+		    retry_count = ?,
+		    reason_code = ?,
+		    last_error = ?,
+		    delivered_at = ?
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+	`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), sqliteNullString(state.errorText), now, eventID, agentID); err != nil {
+		return fmt.Errorf("update sqlite event delivery receipt state: %w", err)
+	}
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
+	if err != nil {
+		return fmt.Errorf("marshal sqlite agent receipt side effects: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		VALUES (?, ?, 'agent', ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			outcome = excluded.outcome,
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), eventID, agentID, sqliteNullUUID(delivery.entityID), sqliteNullString(delivery.flowInstance),
+		mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), string(sideEffects), now); err != nil {
+		return fmt.Errorf("upsert sqlite event receipt row: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite event receipt tx: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
+	eventID = strings.TrimSpace(eventID)
+	agentID = strings.TrimSpace(agentID)
+	if eventID == "" || agentID == "" {
+		return runtimemanager.EventReceipt{}, false, fmt.Errorf("event_id and agent_id are required")
+	}
+	var rec runtimemanager.EventReceipt
+	var outcome string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT event_id, subscriber_id, outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+	`, eventID, agentID).Scan(&rec.EventID, &rec.AgentID, &outcome, &rec.Error)
+	if errors.Is(err, sql.ErrNoRows) {
+		return runtimemanager.EventReceipt{}, false, nil
+	}
+	if err != nil {
+		return runtimemanager.EventReceipt{}, false, fmt.Errorf("get sqlite event receipt: %w", err)
+	}
+	rec.Status = mapOutcomeToManagerReceiptStatus(outcome)
+	return rec, true, nil
+}
+
+func (s *SQLiteRuntimeStore) ListPendingEventsForAgent(ctx context.Context, agentID string, since time.Time, limit int) ([]events.Event, error) {
+	if strings.TrimSpace(agentID) == "" {
+		return nil, nil
+	}
+	page, err := s.ListPendingAgentDeliveryDetails(ctx, PendingAgentDeliveryListOptions{
+		AgentID: strings.TrimSpace(agentID),
+		Since:   since,
+		Limit:   limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]events.Event, 0, len(page.PendingDeliveries))
+	for _, detail := range page.PendingDeliveries {
+		out = append(out, detail.Event)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(ctx context.Context, agentID string, subscriptions []events.EventType, since time.Time, limit int) ([]events.Event, error) {
+	if strings.TrimSpace(agentID) == "" || len(subscriptions) == 0 {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	if since.IsZero() {
+		since = time.Now().Add(-30 * 24 * time.Hour)
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id,
+			COALESCE(e.run_id, ''),
+			e.event_name,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.entity_id, ''),
+			COALESCE(e.flow_instance, ''),
+			COALESCE(e.scope, 'global'),
+			e.payload,
+			e.created_at,
+			COALESCE(e.source_event_id, '')
+		FROM events e
+		LEFT JOIN event_deliveries d
+			ON d.event_id = e.event_id
+			AND d.subscriber_type = 'agent'
+			AND d.subscriber_id = ?
+		LEFT JOIN event_receipts r
+			ON r.event_id = e.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = ?
+		WHERE e.created_at >= ?
+		  AND d.delivery_id IS NULL
+		  AND r.event_id IS NULL
+		ORDER BY e.created_at ASC, e.event_id ASC
+		LIMIT ?
+	`, strings.TrimSpace(agentID), strings.TrimSpace(agentID), since.UTC(), limit*4)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite pending subscribed events: %w", err)
+	}
+	defer rows.Close()
+	out := make([]events.Event, 0, limit)
+	for rows.Next() {
+		var evt events.Event
+		var entityID, flowInstance, scope string
+		var payloadRaw, createdAtRaw any
+		if err := rows.Scan(&evt.ID, &evt.RunID, &evt.Type, &evt.SourceAgent, &entityID, &flowInstance, &scope, &payloadRaw, &createdAtRaw, &evt.ParentEventID); err != nil {
+			return nil, fmt.Errorf("scan sqlite pending subscribed event: %w", err)
+		}
+		evt.Payload = sqliteJSONRawMessage(payloadRaw)
+		if createdAt, ok, err := sqliteTimeValue(createdAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite pending subscribed event created_at: %w", err)
+		} else if ok {
+			evt.CreatedAt = createdAt
+		}
+		if !eventMatchesAnyPattern(evt.Type, subscriptions) {
+			continue
+		}
+		out = append(out, evt.WithEnvelope(events.EventEnvelope{EntityID: entityID, FlowInstance: flowInstance, Scope: events.EventScope(scope)}))
+		if len(out) >= limit {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite pending subscribed events: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ListPendingAgentDeliveryFacts(ctx context.Context, agentIDs []string, since time.Time) (map[string]PendingAgentDeliveryFacts, error) {
+	normalized := normalizePendingAgentIDs(agentIDs)
+	out := make(map[string]PendingAgentDeliveryFacts, len(normalized))
+	for _, agentID := range normalized {
+		out[agentID] = PendingAgentDeliveryFacts{}
+	}
+	if len(normalized) == 0 {
+		return out, nil
+	}
+	records, err := s.listSQLitePendingAgentDeliveryRecords(ctx, normalized, since)
+	if err != nil {
+		return nil, err
+	}
+	grouped := make(map[string][]pendingAgentDeliveryRecord, len(normalized))
+	for _, record := range records {
+		grouped[record.AgentID] = append(grouped[record.AgentID], record)
+	}
+	now := s.now()
+	for _, agentID := range normalized {
+		out[agentID] = pendingAgentDeliveryFactsFromRecords(grouped[agentID], now)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ListPendingAgentDeliveryDetails(ctx context.Context, opts PendingAgentDeliveryListOptions) (PendingAgentDeliveryPage, error) {
+	opts.AgentID = strings.TrimSpace(opts.AgentID)
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.AgentID == "" {
+		return PendingAgentDeliveryPage{PendingDeliveries: []PendingAgentDeliveryDetail{}}, nil
+	}
+	if opts.Limit == 0 {
+		opts.Limit = DefaultPendingAgentDeliveryDetailLimit
+	}
+	if opts.Limit < 0 || opts.Limit > MaxPendingAgentDeliveryDetailLimit {
+		return PendingAgentDeliveryPage{}, fmt.Errorf("pending agent delivery detail limit must be from 1 to %d", MaxPendingAgentDeliveryDetailLimit)
+	}
+	var cursor *pendingAgentDeliveryCursorPosition
+	if opts.Cursor != "" {
+		decoded, err := decodePendingAgentDeliveryCursor(opts.Cursor)
+		if err != nil {
+			return PendingAgentDeliveryPage{}, err
+		}
+		cursor = &decoded
+	}
+	records, err := s.listSQLitePendingAgentDeliveryRecords(ctx, []string{opts.AgentID}, opts.Since)
+	if err != nil {
+		return PendingAgentDeliveryPage{}, err
+	}
+	return pendingAgentDeliveryPageFromRecords(records, s.now(), opts.Limit, cursor)
+}
+
+func (s *SQLiteRuntimeStore) listSQLitePendingAgentDeliveryRecords(ctx context.Context, agentIDs []string, since time.Time) ([]pendingAgentDeliveryRecord, error) {
+	if len(agentIDs) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(agentIDs)+1)
+	placeholders := make([]string, 0, len(agentIDs))
+	for _, agentID := range agentIDs {
+		placeholders = append(placeholders, "?")
+		args = append(args, agentID)
+	}
+	sinceClause := ""
+	if !since.IsZero() {
+		sinceClause = "AND e.created_at >= ?"
+		args = append(args, since.UTC())
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			d.subscriber_id,
+			e.event_id,
+			COALESCE(e.run_id, ''),
+			e.event_name,
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.entity_id, ''),
+			COALESCE(e.flow_instance, ''),
+			COALESCE(e.scope, 'global'),
+			e.payload,
+			e.created_at,
+			COALESCE(e.source_event_id, ''),
+			1,
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			d.created_at,
+			d.delivered_at,
+			CASE WHEN r.event_id IS NULL THEN 0 ELSE 1 END
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		LEFT JOIN event_receipts r
+			ON r.event_id = d.event_id
+			AND r.subscriber_type = 'agent'
+			AND r.subscriber_id = d.subscriber_id
+		WHERE d.subscriber_type = 'agent'
+		  AND d.subscriber_id IN (`+strings.Join(placeholders, ",")+`)
+		  `+sinceClause+`
+		ORDER BY d.subscriber_id ASC, e.created_at ASC, e.event_id ASC
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite pending agent delivery records: %w", err)
+	}
+	defer rows.Close()
+	out := make([]pendingAgentDeliveryRecord, 0)
+	for rows.Next() {
+		var (
+			record                 pendingAgentDeliveryRecord
+			entityID, flowInstance string
+			scope                  string
+			payloadRaw             any
+			eventCreatedRaw        any
+			deliveryCreatedRaw     any
+			deliveryDeliveredRaw   any
+		)
+		if err := rows.Scan(
+			&record.AgentID,
+			&record.Event.ID,
+			&record.Event.RunID,
+			&record.Event.Type,
+			&record.Event.SourceAgent,
+			&entityID,
+			&flowInstance,
+			&scope,
+			&payloadRaw,
+			&eventCreatedRaw,
+			&record.Event.ParentEventID,
+			&record.DeliveryFound,
+			&record.DeliveryStatus,
+			&record.DeliveryRetryCount,
+			&deliveryCreatedRaw,
+			&deliveryDeliveredRaw,
+			&record.ReceiptFound,
+		); err != nil {
+			return nil, fmt.Errorf("scan pending agent delivery record: %w", err)
+		}
+		eventCreatedAt, ok, err := sqliteTimeValue(eventCreatedRaw)
+		if err != nil {
+			return nil, fmt.Errorf("scan pending agent event created_at: %w", err)
+		}
+		if ok {
+			record.Event.CreatedAt = eventCreatedAt
+		}
+		deliveryCreatedAt, ok, err := sqliteTimeValue(deliveryCreatedRaw)
+		if err != nil {
+			return nil, fmt.Errorf("scan pending agent delivery created_at: %w", err)
+		}
+		if ok {
+			record.DeliveryCreatedAt = deliveryCreatedAt
+		}
+		deliveryDeliveredAt, ok, err := sqliteTimeValue(deliveryDeliveredRaw)
+		if err != nil {
+			return nil, fmt.Errorf("scan pending agent delivery delivered_at: %w", err)
+		}
+		if ok {
+			record.DeliveryDeliveredAt = sql.NullTime{Time: deliveryDeliveredAt, Valid: true}
+		}
+		record.AgentID = strings.TrimSpace(record.AgentID)
+		record.Event.Payload = sqliteJSONRawMessage(payloadRaw)
+		record.Event = record.Event.WithEnvelope(events.EventEnvelope{
+			EntityID:     entityID,
+			FlowInstance: flowInstance,
+			Scope:        events.EventScope(scope),
+		})
+		out = append(out, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read pending agent delivery records: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteLockAgentDeliveryTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (lockedAgentDelivery, error) {
+	var delivery lockedAgentDelivery
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id, ''),
+			COALESCE(e.entity_id, ''),
+			COALESCE(e.flow_instance, '')
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		WHERE d.event_id = ?
+		  AND d.subscriber_type = 'agent'
+		  AND d.subscriber_id = ?
+	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return lockedAgentDelivery{}, nil
+	case err != nil:
+		return lockedAgentDelivery{}, fmt.Errorf("lock sqlite event delivery row: %w", err)
+	default:
+		delivery.found = true
+		return delivery, nil
+	}
+}
+
+func eventMatchesAnyPattern(eventType events.EventType, subscriptions []events.EventType) bool {
+	name := strings.TrimSpace(string(eventType))
+	if name == "" {
+		return false
+	}
+	for _, subscription := range subscriptions {
+		if eventidentity.MatchPattern(strings.TrimSpace(string(subscription)), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func sqliteJSONRawMessage(raw any) json.RawMessage {
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case json.RawMessage:
+		return append(json.RawMessage(nil), v...)
+	case []byte:
+		return json.RawMessage(append([]byte(nil), v...))
+	case string:
+		return json.RawMessage(v)
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		return encoded
+	}
+}

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -572,15 +572,35 @@ func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agent
 	if eventID == "" || agentID == "" {
 		return runtimemanager.EventReceipt{}, false, fmt.Errorf("event_id and agent_id are required")
 	}
-	var rec runtimemanager.EventReceipt
-	var outcome string
+	var (
+		rec          runtimemanager.EventReceipt
+		outcome      string
+		sideEffects  any
+		delivery     string
+		deliveryErr  string
+		deliverySeen int
+		retryCount   sql.NullInt64
+	)
 	err := s.DB.QueryRowContext(ctx, `
-		SELECT event_id, subscriber_id, outcome, COALESCE(reason_code, '')
-		FROM event_receipts
-		WHERE event_id = ?
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = ?
-	`, eventID, agentID).Scan(&rec.EventID, &rec.AgentID, &outcome, &rec.Error)
+		SELECT
+			r.event_id,
+			r.subscriber_id,
+			r.outcome,
+			COALESCE(r.reason_code, ''),
+			COALESCE(r.side_effects, '{}'),
+			COALESCE(d.status, ''),
+			COALESCE(d.last_error, ''),
+			d.retry_count,
+			CASE WHEN d.delivery_id IS NULL THEN 0 ELSE 1 END
+		FROM event_receipts r
+		LEFT JOIN event_deliveries d
+			ON d.event_id = r.event_id
+			AND d.subscriber_type = 'agent'
+			AND d.subscriber_id = r.subscriber_id
+		WHERE r.event_id = ?
+		  AND r.subscriber_type = 'agent'
+		  AND r.subscriber_id = ?
+	`, eventID, agentID).Scan(&rec.EventID, &rec.AgentID, &outcome, &rec.Error, &sideEffects, &delivery, &deliveryErr, &retryCount, &deliverySeen)
 	if errors.Is(err, sql.ErrNoRows) {
 		return runtimemanager.EventReceipt{}, false, nil
 	}
@@ -588,6 +608,30 @@ func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agent
 		return runtimemanager.EventReceipt{}, false, fmt.Errorf("get sqlite event receipt: %w", err)
 	}
 	rec.Status = mapOutcomeToManagerReceiptStatus(outcome)
+	if raw := sqliteJSONRawMessage(sideEffects); len(raw) > 0 {
+		payload, err := decodeAgentReceiptSideEffects(raw)
+		if err != nil {
+			return runtimemanager.EventReceipt{}, false, fmt.Errorf("decode sqlite event receipt side effects: %w", err)
+		}
+		rec.Status = payload.ManagerStatus
+		rec.RetryCount = payload.RetryCount
+		rec.Error = payload.Error
+	}
+	if deliverySeen != 0 {
+		mappedStatus, override, err := terminalManagerReceiptStatusFromDelivery(delivery)
+		if err != nil {
+			return runtimemanager.EventReceipt{}, false, fmt.Errorf("get sqlite event receipt: %w", err)
+		}
+		if override {
+			rec.Status = mappedStatus
+			if retryCount.Valid {
+				rec.RetryCount = int(retryCount.Int64)
+			}
+			if strings.TrimSpace(deliveryErr) != "" {
+				rec.Error = strings.TrimSpace(deliveryErr)
+			}
+		}
+	}
 	return rec, true, nil
 }
 
@@ -611,7 +655,8 @@ func (s *SQLiteRuntimeStore) ListPendingEventsForAgent(ctx context.Context, agen
 }
 
 func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(ctx context.Context, agentID string, subscriptions []events.EventType, since time.Time, limit int) ([]events.Event, error) {
-	if strings.TrimSpace(agentID) == "" || len(subscriptions) == 0 {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" || len(subscriptions) == 0 {
 		return nil, nil
 	}
 	if limit <= 0 {
@@ -631,7 +676,13 @@ func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(ctx context.Context, ag
 			COALESCE(e.scope, 'global'),
 			e.payload,
 			e.created_at,
-			COALESCE(e.source_event_id, '')
+			COALESCE(e.source_event_id, ''),
+			CASE WHEN d.delivery_id IS NULL THEN 0 ELSE 1 END,
+			COALESCE(d.status, ''),
+			COALESCE(d.retry_count, 0),
+			COALESCE(d.created_at, e.created_at),
+			d.delivered_at,
+			CASE WHEN r.event_id IS NULL THEN 0 ELSE 1 END
 		FROM events e
 		LEFT JOIN event_deliveries d
 			ON d.event_id = e.event_id
@@ -642,21 +693,45 @@ func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(ctx context.Context, ag
 			AND r.subscriber_type = 'agent'
 			AND r.subscriber_id = ?
 		WHERE e.created_at >= ?
-		  AND d.delivery_id IS NULL
-		  AND r.event_id IS NULL
+		  AND EXISTS (
+				SELECT 1
+				FROM event_deliveries d_me
+				WHERE d_me.event_id = e.event_id
+				  AND d_me.subscriber_type = 'agent'
+				  AND d_me.subscriber_id = ?
+			)
 		ORDER BY e.created_at ASC, e.event_id ASC
-		LIMIT ?
-	`, strings.TrimSpace(agentID), strings.TrimSpace(agentID), since.UTC(), limit*4)
+	`, agentID, agentID, since.UTC(), agentID)
 	if err != nil {
 		return nil, fmt.Errorf("query sqlite pending subscribed events: %w", err)
 	}
 	defer rows.Close()
 	out := make([]events.Event, 0, limit)
+	now := s.now()
 	for rows.Next() {
 		var evt events.Event
 		var entityID, flowInstance, scope string
-		var payloadRaw, createdAtRaw any
-		if err := rows.Scan(&evt.ID, &evt.RunID, &evt.Type, &evt.SourceAgent, &entityID, &flowInstance, &scope, &payloadRaw, &createdAtRaw, &evt.ParentEventID); err != nil {
+		var payloadRaw, createdAtRaw, deliveryCreatedAtRaw, deliveryDeliveredAtRaw any
+		var deliveryFound, receiptFound int
+		record := pendingAgentDeliveryRecord{AgentID: agentID}
+		if err := rows.Scan(
+			&evt.ID,
+			&evt.RunID,
+			&evt.Type,
+			&evt.SourceAgent,
+			&entityID,
+			&flowInstance,
+			&scope,
+			&payloadRaw,
+			&createdAtRaw,
+			&evt.ParentEventID,
+			&deliveryFound,
+			&record.DeliveryStatus,
+			&record.DeliveryRetryCount,
+			&deliveryCreatedAtRaw,
+			&deliveryDeliveredAtRaw,
+			&receiptFound,
+		); err != nil {
 			return nil, fmt.Errorf("scan sqlite pending subscribed event: %w", err)
 		}
 		evt.Payload = sqliteJSONRawMessage(payloadRaw)
@@ -665,10 +740,26 @@ func (s *SQLiteRuntimeStore) ListPendingSubscribedEvents(ctx context.Context, ag
 		} else if ok {
 			evt.CreatedAt = createdAt
 		}
+		if deliveryCreatedAt, ok, err := sqliteTimeValue(deliveryCreatedAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite pending subscribed delivery created_at: %w", err)
+		} else if ok {
+			record.DeliveryCreatedAt = deliveryCreatedAt
+		}
+		if deliveryDeliveredAt, ok, err := sqliteTimeValue(deliveryDeliveredAtRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite pending subscribed delivery delivered_at: %w", err)
+		} else if ok {
+			record.DeliveryDeliveredAt = sql.NullTime{Time: deliveryDeliveredAt, Valid: true}
+		}
+		record.DeliveryFound = deliveryFound != 0
+		record.ReceiptFound = receiptFound != 0
+		record.Event = evt.WithEnvelope(events.EventEnvelope{EntityID: entityID, FlowInstance: flowInstance, Scope: events.EventScope(scope)})
+		if !record.isPending(now) {
+			continue
+		}
 		if !eventMatchesAnyPattern(evt.Type, subscriptions) {
 			continue
 		}
-		out = append(out, evt.WithEnvelope(events.EventEnvelope{EntityID: entityID, FlowInstance: flowInstance, Scope: events.EventScope(scope)}))
+		out = append(out, record.Event)
 		if len(out) >= limit {
 			break
 		}

--- a/internal/store/sqlite_runtime_llm.go
+++ b/internal/store/sqlite_runtime_llm.go
@@ -1,0 +1,368 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimellm "swarm/internal/runtime/llm"
+	runtimesessions "swarm/internal/runtime/sessions"
+)
+
+func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
+	if strings.TrimSpace(rec.AgentID) == "" || strings.TrimSpace(rec.RuntimeMode) == "" || strings.TrimSpace(rec.SessionID) == "" {
+		return fmt.Errorf("agent_id, runtime_mode, and session_id are required")
+	}
+	mode := runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode)
+	if mode == "" {
+		return fmt.Errorf("runtime_mode is required")
+	}
+	if rec.Latency < 0 {
+		rec.Latency = 0
+	}
+	if rec.RetryCount < 0 {
+		rec.RetryCount = 0
+	}
+	reqPayload := normalizeJSONPayload(rec.RequestPayload)
+	respPayload := normalizeJSONPayload(rec.ResponseRaw)
+	toolCallsPayload := normalizeJSONArray(rec.ToolCalls)
+	availableToolsPayload := normalizeJSONArray(rec.AvailableTools)
+	emittedEventsPayload := normalizeJSONArray(rec.EmittedEvents)
+	mcpServersPayload := normalizeJSONObject(rec.MCPServers)
+	mcpToolsListedPayload := normalizeJSONArray(rec.MCPToolsListed)
+	mcpToolsVisiblePayload := normalizeJSONArray(rec.MCPToolsVisible)
+	rec = runtimellm.CanonicalizeTurnForPersistence(rec)
+	if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocks(rec.TurnBlocks); err != nil {
+		return fmt.Errorf("validate canonical runtime_log turn_blocks: %w", err)
+	}
+	turnBlocksPayload := normalizeJSONArray(rec.TurnBlocks)
+	latencyMS := int(rec.Latency / time.Millisecond)
+	runID := nullUUIDString(rec.RunID)
+	now := s.now()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("append sqlite agent turn begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := sqliteEnsureRunRow(ctx, tx, runID, rec.TriggerEventID, rec.TriggerEventType, now); err != nil {
+		return err
+	}
+	if mode.IsStateless() {
+		if err := s.ensureSQLiteTaskConversationAuditRowTx(ctx, tx, rec, now); err != nil {
+			return err
+		}
+	} else {
+		res, err := tx.ExecContext(ctx, `
+			UPDATE agent_sessions
+			SET run_id = COALESCE(?, run_id),
+			    updated_at = ?
+			WHERE agent_id = ?
+			  AND runtime_mode = ?
+			  AND session_id = ?
+			  AND status = 'active'
+		`, sqliteNullUUID(runID), now, strings.TrimSpace(rec.AgentID), mode.String(), strings.TrimSpace(rec.SessionID))
+		if err != nil {
+			return fmt.Errorf("append sqlite agent turn update session: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, mode.String(), rec.SessionID)
+		}
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+			request_payload, response_payload, turn_blocks, parse_ok, latency_ms, retry_count, error, created_at
+		) VALUES (
+			?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?,
+			?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?
+		)
+	`, uuid.NewString(), sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), strings.TrimSpace(rec.SessionID),
+		mode.String(), sqliteNullString(rec.ScopeKey), sqliteNullUUID(rec.EntityID), sqliteNullUUID(rec.TriggerEventID),
+		sqliteNullString(rec.TriggerEventType), sqliteNullString(rec.TaskID), availableToolsPayload, toolCallsPayload,
+		emittedEventsPayload, mcpServersPayload, mcpToolsListedPayload, mcpToolsVisiblePayload,
+		sqliteNullString(reqPayload), sqliteNullString(respPayload), turnBlocksPayload, rec.ParseOK, latencyMS,
+		rec.RetryCount, sqliteNullString(rec.Error), now)
+	if err != nil {
+		return fmt.Errorf("insert sqlite agent turn: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("append sqlite agent turn commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtimellm.ConversationRecord) error {
+	agentID := strings.TrimSpace(rec.AgentID)
+	if agentID == "" {
+		return fmt.Errorf("agent_id is required")
+	}
+	mode, err := runtimesessions.ParseConversationRuntimeMode(rec.Mode)
+	if err != nil {
+		return err
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, mode, runtimesessions.NormalizeSessionScope(rec.SessionScope), rec.ScopeKey)
+	if err != nil {
+		return err
+	}
+	status := strings.TrimSpace(strings.ToLower(rec.Status))
+	if status == "" {
+		status = "active"
+	}
+	msgJSON, runtimeStatePatch, err := sqliteConversationPayloads(rec)
+	if err != nil {
+		return err
+	}
+	sessionID := strings.TrimSpace(rec.SessionID)
+	if sessionID == "" {
+		sessionID = uuid.NewString()
+	}
+	runID := nullUUIDString(rec.RunID)
+	now := s.now()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("upsert sqlite conversation begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := sqliteEnsureRunRow(ctx, tx, runID, "", "", now); err != nil {
+		return err
+	}
+	if resolved.Stateless {
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO agent_conversation_audits (
+				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+			) VALUES (
+				?, ?, ?, ?, ?, ?, ?,
+				?, ?, ?, ?, ?, ?, ?
+			)
+			ON CONFLICT(session_id) DO UPDATE SET
+				run_id = COALESCE(excluded.run_id, agent_conversation_audits.run_id),
+				agent_id = excluded.agent_id,
+				entity_id = excluded.entity_id,
+				flow_instance = excluded.flow_instance,
+				scope_key = excluded.scope_key,
+				scope = excluded.scope,
+				conversation = excluded.conversation,
+				turn_count = excluded.turn_count,
+				runtime_mode = excluded.runtime_mode,
+				runtime_state = json_patch(COALESCE(agent_conversation_audits.runtime_state, '{}'), excluded.runtime_state),
+				status = excluded.status,
+				updated_at = excluded.updated_at
+		`, sessionID, sqliteNullUUID(runID), agentID, sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+			sqliteNullString(resolved.ScopeKey), resolved.Scope.String(), string(msgJSON), rec.TurnCount, mode.String(),
+			runtimeStatePatch, status, now, now)
+		if err != nil {
+			return fmt.Errorf("upsert sqlite task conversation audit: %w", err)
+		}
+	} else {
+		if strings.TrimSpace(rec.SessionID) == "" {
+			return fmt.Errorf("session_id is required for live session conversation persistence")
+		}
+		res, err := tx.ExecContext(ctx, `
+			UPDATE agent_sessions
+			SET conversation = ?,
+			    turn_count = ?,
+			    runtime_state = json_patch(COALESCE(runtime_state, '{}'), ?),
+			    run_id = COALESCE(?, run_id),
+			    updated_at = ?
+			WHERE session_id = ?
+			  AND agent_id = ?
+			  AND scope_key = ?
+			  AND runtime_mode = ?
+			  AND status = 'active'
+		`, string(msgJSON), rec.TurnCount, runtimeStatePatch, sqliteNullUUID(runID), now,
+			strings.TrimSpace(rec.SessionID), agentID, resolved.ScopeKey, mode.String())
+		if err != nil {
+			return fmt.Errorf("update sqlite live conversation: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, rec.SessionID, mode.String(), resolved.ScopeKey)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("upsert sqlite conversation commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) LoadActiveConversation(ctx context.Context, agentID, mode, sessionScope, scopeKey string) (runtimellm.ConversationRecord, bool, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return runtimellm.ConversationRecord{}, false, fmt.Errorf("agent_id is required")
+	}
+	resolvedMode, err := runtimesessions.ParseConversationRuntimeMode(mode)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, resolvedMode, runtimesessions.NormalizeSessionScope(sessionScope), scopeKey)
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, err
+	}
+	if resolved.Stateless {
+		return runtimellm.ConversationRecord{}, false, nil
+	}
+	var rec runtimellm.ConversationRecord
+	rec.AgentID = agentID
+	rec.Mode = resolvedMode.String()
+	rec.SessionScope = resolved.Scope.String()
+	var rawMessages, runtimeStateRaw any
+	err = s.DB.QueryRowContext(ctx, `
+		SELECT session_id, scope_key, COALESCE(conversation, '[]'), COALESCE(runtime_state, '{}'), COALESCE(turn_count, 0), COALESCE(status, 'active')
+		FROM agent_sessions
+		WHERE agent_id = ?
+		  AND runtime_mode = ?
+		  AND scope_key = ?
+		  AND status = 'active'
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`, agentID, resolvedMode.String(), resolved.ScopeKey).Scan(&rec.SessionID, &rec.ScopeKey, &rawMessages, &runtimeStateRaw, &rec.TurnCount, &rec.Status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return runtimellm.ConversationRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, fmt.Errorf("load sqlite active conversation: %w", err)
+	}
+	runtimeState, err := DecodeConversationRuntimeStateDescriptor(sqliteJSONRawMessage(runtimeStateRaw))
+	if err != nil {
+		return runtimellm.ConversationRecord{}, false, fmt.Errorf("decode sqlite conversation runtime_state: %w", err)
+	}
+	rec.Summary = runtimeState.Summary
+	rec.RetryReason = runtimeState.RetryReason
+	rec.RetriesFromSessionID = runtimeState.RetriesFromSessionID
+	if runtimeState.Watchdog != nil {
+		rec.Watchdog = &runtimellm.ConversationWatchdog{
+			State:         runtimeState.Watchdog.State,
+			BlockingLayer: runtimeState.Watchdog.BlockingLayer,
+			Action:        runtimeState.Watchdog.Action,
+			Outcome:       runtimeState.Watchdog.Outcome,
+			LastOutputAt:  runtimeState.Watchdog.LastOutputAt,
+			RecordedAt:    runtimeState.Watchdog.RecordedAt,
+		}
+	}
+	if raw := sqliteJSONRawMessage(rawMessages); len(raw) > 0 {
+		var msgs []runtimellm.Message
+		if json.Unmarshal(raw, &msgs) == nil {
+			rec.Messages = msgs
+		}
+	}
+	return rec, true, nil
+}
+
+func (s *SQLiteRuntimeStore) UpdateLiveSessionWatchdog(ctx context.Context, update runtimellm.ConversationWatchdogUpdate) error {
+	agentID := strings.TrimSpace(update.AgentID)
+	sessionID := strings.TrimSpace(update.SessionID)
+	if agentID == "" || sessionID == "" {
+		return fmt.Errorf("agent_id and session_id are required")
+	}
+	mode, err := runtimesessions.ParseConversationRuntimeMode(update.Mode)
+	if err != nil {
+		return err
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, mode, runtimesessions.NormalizeSessionScope(update.SessionScope), update.ScopeKey)
+	if err != nil {
+		return err
+	}
+	if resolved.Stateless {
+		return fmt.Errorf("live session watchdog updates require session runtime mode")
+	}
+	if update.Watchdog == nil {
+		return fmt.Errorf("watchdog is required")
+	}
+	patch, err := marshalConversationRuntimeStatePatch(nil, update.Watchdog)
+	if err != nil {
+		return fmt.Errorf("marshal sqlite live session watchdog patch: %w", err)
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = json_patch(COALESCE(runtime_state, '{}'), ?),
+		    updated_at = ?
+		WHERE session_id = ?
+		  AND agent_id = ?
+		  AND scope_key = ?
+		  AND runtime_mode = ?
+		  AND status = 'active'
+	`, patch, s.now(), sessionID, agentID, resolved.ScopeKey, mode.String())
+	if err != nil {
+		return fmt.Errorf("update sqlite live session watchdog: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, sessionID, mode.String(), resolved.ScopeKey)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ensureSQLiteTaskConversationAuditRowTx(ctx context.Context, tx *sql.Tx, rec runtimellm.AgentTurnRecord, now time.Time) error {
+	sessionID := strings.TrimSpace(rec.SessionID)
+	if sessionID == "" {
+		return fmt.Errorf("task conversation audit session_id is required")
+	}
+	runID := nullUUIDString(rec.RunID)
+	scopeKey := strings.TrimSpace(rec.ScopeKey)
+	scope := "global"
+	if strings.TrimSpace(rec.EntityID) != "" {
+		scope = "entity"
+		if scopeKey == "" {
+			scopeKey = strings.TrimSpace(rec.EntityID)
+		}
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES (
+			?, ?, ?, ?, ?, ?, ?,
+			'[]', 0, 'task', '{}', 'active', ?, ?
+		)
+		ON CONFLICT(session_id) DO UPDATE SET
+			run_id = COALESCE(agent_conversation_audits.run_id, excluded.run_id),
+			updated_at = excluded.updated_at
+	`, sessionID, sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), sqliteNullUUID(rec.EntityID), nil,
+		sqliteNullString(scopeKey), scope, now, now)
+	if err != nil {
+		return fmt.Errorf("ensure sqlite task conversation audit row: %w", err)
+	}
+	return nil
+}
+
+func sqliteConversationPayloads(rec runtimellm.ConversationRecord) ([]byte, string, error) {
+	msgs := make([]runtimellm.Message, 0, len(rec.Messages))
+	for _, m := range rec.Messages {
+		msgs = append(msgs, runtimellm.Message{
+			Role:    strings.TrimSpace(m.Role),
+			Content: strings.ToValidUTF8(m.Content, "\uFFFD"),
+		})
+	}
+	msgJSON, err := json.Marshal(msgs)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal sqlite conversation messages: %w", err)
+	}
+	summary := strings.ToValidUTF8(rec.Summary, "\uFFFD")
+	runtimeStatePatch, err := marshalConversationRuntimeStatePatch(&summary, rec.Watchdog)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal sqlite conversation runtime_state patch: %w", err)
+	}
+	return msgJSON, runtimeStatePatch, nil
+}

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -1,0 +1,416 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, string, error) {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return nil, "", ErrRunNotFound
+	}
+	if opts.Cursor != "" {
+		return nil, "", ErrInvalidObservabilityCursor
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM runs WHERE run_id = ?)`, runID).Scan(&exists); err != nil {
+		return nil, "", fmt.Errorf("load sqlite run trace run existence: %w", err)
+	}
+	if !exists {
+		return nil, "", ErrRunNotFound
+	}
+	opts = defaultRunDebugTraceQueryOptions(opts)
+	where := []string{"e.run_id = ?", "NOT (COALESCE(d.subscriber_type, '') = ? AND COALESCE(d.subscriber_id, '') = ?)"}
+	args := []any{runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID}
+	if opts.Since != nil {
+		where = append(where, "e.created_at >= ?")
+		args = append(args, opts.Since.UTC())
+	}
+	if opts.Until != nil {
+		where = append(where, "e.created_at <= ?")
+		args = append(args, opts.Until.UTC())
+	}
+	appendIn := func(column string, values []string) {
+		if len(values) == 0 {
+			return
+		}
+		placeholders := make([]string, 0, len(values))
+		for _, value := range values {
+			placeholders = append(placeholders, "?")
+			args = append(args, value)
+		}
+		where = append(where, column+" IN ("+strings.Join(placeholders, ",")+")")
+	}
+	appendIn("e.event_name", opts.Filter.EventNames)
+	appendIn("COALESCE(e.entity_id, '')", opts.Filter.EntityIDs)
+	appendIn("COALESCE(d.status, '')", opts.Filter.DeliveryStatuses)
+	appendIn("COALESCE(d.subscriber_id, '')", opts.Filter.SubscriberIDs)
+	appendIn("COALESCE(d.subscriber_type, '')", opts.Filter.SubscriberTypes)
+	args = append(args, opts.Limit)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id, e.event_name, COALESCE(e.source_event_id, ''), COALESCE(e.entity_id, ''),
+			COALESCE(e.produced_by, ''), COALESCE(e.produced_by_type, ''), e.created_at,
+			COALESCE(d.delivery_id, ''), COALESCE(d.subscriber_type, ''), COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''), COALESCE(d.reason_code, ''), COALESCE(d.active_session_id, ''),
+			d.created_at, d.started_at, d.delivered_at,
+			COALESCE(ses.session_id, ''), COALESCE(ses.scope, ''), COALESCE(ses.runtime_mode, ''),
+			COALESCE(ses.status, ''), ses.updated_at,
+			COALESCE(t.turn_id, ''), COALESCE(t.trigger_event_id, ''), COALESCE(t.trigger_event_type, ''),
+			COALESCE(t.runtime_mode, ''), COALESCE(t.scope_key, ''), COALESCE(t.entity_id, ''),
+			COALESCE(t.task_id, ''), COALESCE(t.parse_ok, 0), COALESCE(t.retry_count, 0),
+			COALESCE(t.error, ''), t.created_at
+		FROM events e
+		LEFT JOIN event_deliveries d ON d.event_id = e.event_id
+		LEFT JOIN agent_sessions ses ON ses.session_id = d.active_session_id
+		LEFT JOIN agent_turns t ON t.trigger_event_id = e.event_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY e.created_at ASC, e.event_id ASC, d.created_at ASC, d.delivery_id ASC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("query sqlite run trace: %w", err)
+	}
+	defer rows.Close()
+	out := make([]RunDebugTraceRow, 0, opts.Limit)
+	for rows.Next() {
+		var row RunDebugTraceRow
+		var eventCreatedRaw, deliveryCreatedRaw, deliveryStartedRaw, deliveryDeliveredRaw, sessionUpdatedRaw, turnCreatedRaw any
+		if err := rows.Scan(
+			&row.EventID, &row.EventName, &row.SourceEventID, &row.EntityID,
+			&row.EventSource, &row.EventSourceType, &eventCreatedRaw,
+			&row.DeliveryID, &row.SubscriberType, &row.SubscriberID,
+			&row.DeliveryStatus, &row.DeliveryReasonCode, &row.ActiveSessionID,
+			&deliveryCreatedRaw, &deliveryStartedRaw, &deliveryDeliveredRaw,
+			&row.SessionID, &row.SessionKind, &row.SessionRuntimeMode,
+			&row.SessionStatus, &sessionUpdatedRaw,
+			&row.TurnID, &row.TurnTriggerEventID, &row.TurnTriggerEventType,
+			&row.TurnRuntimeMode, &row.TurnScopeKey, &row.TurnEntityID,
+			&row.TurnTaskID, &row.TurnParseOK, &row.TurnRetryCount,
+			&row.TurnError, &turnCreatedRaw,
+		); err != nil {
+			return nil, "", fmt.Errorf("scan sqlite run trace: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(eventCreatedRaw); err != nil {
+			return nil, "", err
+		} else if ok {
+			row.EventCreatedAt = at
+		}
+		row.DeliveryCreatedAt = sqliteTraceTimePtr(deliveryCreatedRaw)
+		row.DeliveryStartedAt = sqliteTraceTimePtr(deliveryStartedRaw)
+		row.DeliveryDeliveredAt = sqliteTraceTimePtr(deliveryDeliveredRaw)
+		row.SessionUpdatedAt = sqliteTraceTimePtr(sessionUpdatedRaw)
+		row.TurnCreatedAt = sqliteTraceTimePtr(turnCreatedRaw)
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("read sqlite run trace: %w", err)
+	}
+	return out, "", nil
+}
+
+func (s *SQLiteRuntimeStore) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {
+	if opts.Cursor != "" {
+		return OperatorEventListResult{}, ErrInvalidObservabilityCursor
+	}
+	opts = defaultOperatorEventListOptions(opts)
+	where := []string{"1=1"}
+	args := []any{}
+	if opts.Filter.RunID != "" {
+		where = append(where, "e.run_id = ?")
+		args = append(args, nullUUIDString(opts.Filter.RunID))
+	}
+	if opts.Filter.EventName != "" {
+		where = append(where, "e.event_name = ?")
+		args = append(args, opts.Filter.EventName)
+	}
+	if opts.Filter.EntityID != "" {
+		where = append(where, "COALESCE(e.entity_id, '') = ?")
+		args = append(args, nullUUIDString(opts.Filter.EntityID))
+	}
+	if opts.Source != "" {
+		where = append(where, "COALESCE(e.produced_by, '') = ?")
+		args = append(args, opts.Source)
+	}
+	if opts.Since != nil {
+		where = append(where, "e.created_at >= ?")
+		args = append(args, opts.Since.UTC())
+	}
+	if opts.Until != nil {
+		where = append(where, "e.created_at <= ?")
+		args = append(args, opts.Until.UTC())
+	}
+	if opts.ExcludeRuntimeLogs {
+		where = append(where, "e.event_name <> 'platform.runtime_log'")
+	}
+	if opts.Filter.DeliveryStatus != "" || opts.Filter.SubscriberID != "" || opts.Filter.SubscriberType != "" || opts.Filter.ReasonCode != "" {
+		where = append(where, `EXISTS (
+			SELECT 1 FROM event_deliveries d
+			WHERE d.event_id = e.event_id
+			  AND (? = '' OR d.status = ?)
+			  AND (? = '' OR d.subscriber_id = ?)
+			  AND (? = '' OR d.subscriber_type = ?)
+			  AND (? = '' OR COALESCE(d.reason_code, '') = ?)
+		)`)
+		args = append(args,
+			opts.Filter.DeliveryStatus, opts.Filter.DeliveryStatus,
+			opts.Filter.SubscriberID, opts.Filter.SubscriberID,
+			opts.Filter.SubscriberType, opts.Filter.SubscriberType,
+			opts.Filter.ReasonCode, opts.Filter.ReasonCode,
+		)
+	}
+	order := "DESC"
+	if strings.EqualFold(opts.Order, "asc") {
+		order = "ASC"
+	}
+	args = append(args, opts.Limit)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT e.event_id
+		FROM events e
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY e.created_at `+order+`, e.event_id `+order+`
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return OperatorEventListResult{}, fmt.Errorf("query sqlite operator events: %w", err)
+	}
+	defer rows.Close()
+	result := OperatorEventListResult{Events: []OperatorEventFull{}}
+	for rows.Next() {
+		var eventID string
+		if err := rows.Scan(&eventID); err != nil {
+			return OperatorEventListResult{}, fmt.Errorf("scan sqlite operator event id: %w", err)
+		}
+		full, err := s.LoadOperatorEvent(ctx, eventID)
+		if err != nil {
+			return OperatorEventListResult{}, err
+		}
+		result.Events = append(result.Events, full)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEventListResult{}, fmt.Errorf("read sqlite operator events: %w", err)
+	}
+	return result, nil
+}
+
+func (s *SQLiteRuntimeStore) LoadOperatorEvent(ctx context.Context, eventID string) (OperatorEventFull, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return OperatorEventFull{}, ErrEventNotFound
+	}
+	var event OperatorEventFull
+	var payloadRaw, createdRaw any
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT event_id, event_name, COALESCE(entity_id, ''), COALESCE(run_id, ''), COALESCE(source_event_id, ''),
+		       created_at, COALESCE(produced_by, ''), payload
+		FROM events
+		WHERE event_id = ?
+	`, eventID).Scan(&event.EventID, &event.EventName, &event.EntityID, &event.RunID, &event.SourceEventID, &createdRaw, &event.Source, &payloadRaw)
+	if err == sql.ErrNoRows {
+		return OperatorEventFull{}, ErrEventNotFound
+	}
+	if err != nil {
+		return OperatorEventFull{}, fmt.Errorf("load sqlite operator event: %w", err)
+	}
+	if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
+		return OperatorEventFull{}, err
+	} else if ok {
+		event.CreatedAt = at
+	}
+	event.Payload = map[string]any{}
+	_ = json.Unmarshal(sqliteJSONRawMessage(payloadRaw), &event.Payload)
+	deliveries, err := s.sqliteOperatorEventDeliveries(ctx, eventID)
+	if err != nil {
+		return OperatorEventFull{}, err
+	}
+	event.Deliveries = deliveries
+	event.DeadLetters = []OperatorDeadLetterRecord{}
+	return event, nil
+}
+
+func (s *SQLiteRuntimeStore) ListOperatorRuntimeLogs(ctx context.Context, opts OperatorRuntimeLogListOptions) (OperatorRuntimeLogListResult, error) {
+	if opts.Cursor != "" {
+		return OperatorRuntimeLogListResult{}, ErrInvalidObservabilityCursor
+	}
+	opts = defaultOperatorRuntimeLogListOptions(opts)
+	where := []string{"event_name = 'platform.runtime_log'"}
+	args := []any{}
+	if opts.RunID != "" {
+		where = append(where, "run_id = ?")
+		args = append(args, nullUUIDString(opts.RunID))
+	}
+	if opts.EntityID != "" {
+		where = append(where, "COALESCE(entity_id, '') = ?")
+		args = append(args, nullUUIDString(opts.EntityID))
+	}
+	if opts.Level != "" {
+		where = append(where, "json_extract(payload, '$.log_level') = ?")
+		args = append(args, strings.ToLower(opts.Level))
+	}
+	if opts.Component != "" {
+		where = append(where, "json_extract(payload, '$.details.component') = ?")
+		args = append(args, opts.Component)
+	}
+	if opts.SessionID != "" {
+		where = append(where, "json_extract(payload, '$.details.session_id') = ?")
+		args = append(args, opts.SessionID)
+	}
+	if opts.Since != nil {
+		where = append(where, "created_at >= ?")
+		args = append(args, opts.Since.UTC())
+	}
+	if opts.Until != nil {
+		where = append(where, "created_at <= ?")
+		args = append(args, opts.Until.UTC())
+	}
+	order := "DESC"
+	if strings.EqualFold(opts.Order, "asc") {
+		order = "ASC"
+	}
+	args = append(args, opts.Limit)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT event_id, created_at, COALESCE(run_id, ''), COALESCE(entity_id, ''), payload
+		FROM events
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY created_at `+order+`, event_id `+order+`
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return OperatorRuntimeLogListResult{}, fmt.Errorf("query sqlite runtime logs: %w", err)
+	}
+	defer rows.Close()
+	result := OperatorRuntimeLogListResult{Logs: []OperatorRuntimeLogEntry{}}
+	for rows.Next() {
+		var log OperatorRuntimeLogEntry
+		var createdRaw, payloadRaw any
+		if err := rows.Scan(&log.LogID, &createdRaw, &log.RunID, &log.EntityID, &payloadRaw); err != nil {
+			return OperatorRuntimeLogListResult{}, fmt.Errorf("scan sqlite runtime log: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
+			return OperatorRuntimeLogListResult{}, err
+		} else if ok {
+			log.TS = at
+		}
+		applySQLiteRuntimeLogPayload(&log, sqliteJSONRawMessage(payloadRaw))
+		result.Logs = append(result.Logs, log)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorRuntimeLogListResult{}, fmt.Errorf("read sqlite runtime logs: %w", err)
+	}
+	return result, nil
+}
+
+func (s *SQLiteRuntimeStore) ListOperatorRuntimeIncidents(ctx context.Context, opts OperatorRuntimeIncidentListOptions) (OperatorRuntimeIncidentListResult, error) {
+	logs, err := s.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		Component: opts.Component,
+		Level:     coalesceRuntimeIncidentLevel(opts.Level),
+		Limit:     opts.Limit,
+	})
+	if err != nil {
+		return OperatorRuntimeIncidentListResult{}, err
+	}
+	result := OperatorRuntimeIncidentListResult{Incidents: []OperatorRuntimeIncident{}}
+	for _, log := range logs.Logs {
+		result.Incidents = append(result.Incidents, OperatorRuntimeIncident{
+			IncidentID:    log.LogID,
+			FirstSeen:     log.TS,
+			LastSeen:      log.TS,
+			Count:         1,
+			Level:         log.Level,
+			Component:     log.Component,
+			ErrorCode:     log.ErrorCode,
+			SampleMessage: log.Message,
+			SampleLogIDs:  []string{log.LogID},
+		})
+	}
+	return result, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteOperatorEventDeliveries(ctx context.Context, eventID string) ([]OperatorEventDelivery, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT delivery_id, subscriber_type, subscriber_id, COALESCE(active_session_id, ''),
+		       status, COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(retry_count, 0)
+		FROM event_deliveries
+		WHERE event_id = ?
+		ORDER BY created_at ASC, delivery_id ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite operator event deliveries: %w", err)
+	}
+	defer rows.Close()
+	out := []OperatorEventDelivery{}
+	for rows.Next() {
+		var delivery OperatorEventDelivery
+		if err := rows.Scan(&delivery.DeliveryID, &delivery.SubscriberType, &delivery.SubscriberID, &delivery.SessionID, &delivery.Status, &delivery.ReasonCode, &delivery.LastError, &delivery.RetryCount); err != nil {
+			return nil, fmt.Errorf("scan sqlite operator event delivery: %w", err)
+		}
+		out = append(out, delivery)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite operator event deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func sqliteTraceTimePtr(raw any) *time.Time {
+	at, ok, err := sqliteTimeValue(raw)
+	if err != nil || !ok {
+		return nil
+	}
+	return &at
+}
+
+func applySQLiteRuntimeLogPayload(log *OperatorRuntimeLogEntry, raw json.RawMessage) {
+	if log == nil {
+		return
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		payload = map[string]any{}
+	}
+	log.Level = strings.TrimSpace(sqliteObservabilityString(payload["log_level"]))
+	if log.Level == "" {
+		log.Level = "info"
+	}
+	log.Message = strings.TrimSpace(sqliteObservabilityString(payload["message"]))
+	details, _ := payload["details"].(map[string]any)
+	if details == nil {
+		details = map[string]any{}
+	}
+	log.Details = details
+	log.Component = strings.TrimSpace(sqliteObservabilityString(details["component"]))
+	log.Source = strings.TrimSpace(sqliteObservabilityString(details["source"]))
+	log.SessionID = strings.TrimSpace(sqliteObservabilityString(details["session_id"]))
+	log.ErrorCode = strings.TrimSpace(sqliteObservabilityString(details["error_code"]))
+	if log.Message == "" {
+		log.Message = strings.TrimSpace(sqliteObservabilityString(details["message"]))
+	}
+}
+
+func coalesceRuntimeIncidentLevel(level string) string {
+	level = strings.TrimSpace(strings.ToLower(level))
+	if level != "" {
+		return level
+	}
+	return "error"
+}
+
+func sqliteObservabilityString(v any) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(typed)
+	}
+}

--- a/internal/store/sqlite_runtime_sessions.go
+++ b/internal/store/sqlite_runtime_sessions.go
@@ -1,0 +1,505 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimesessions "swarm/internal/runtime/sessions"
+	runtimestartupownership "swarm/internal/runtime/startupownership"
+)
+
+type sqliteRuntimeStartupLease struct {
+	store *SQLiteRuntimeStore
+	owner string
+}
+
+func (s *SQLiteRuntimeStore) AcquireRuntimeStartupOwnership(ctx context.Context, ownerID string) (runtimestartupownership.Lease, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil, fmt.Errorf("runtime owner id is required")
+	}
+	s.startupMu.Lock()
+	defer s.startupMu.Unlock()
+	if s.startupOwner != "" && s.startupOwner != ownerID {
+		return nil, fmt.Errorf("sqlite local runtime store already owned by another runtime instance")
+	}
+	s.startupOwner = ownerID
+	return &sqliteRuntimeStartupLease{store: s, owner: ownerID}, nil
+}
+
+func (l *sqliteRuntimeStartupLease) Release(context.Context) error {
+	if l == nil || l.store == nil {
+		return nil
+	}
+	l.store.startupMu.Lock()
+	defer l.store.startupMu.Unlock()
+	if strings.TrimSpace(l.store.startupOwner) == strings.TrimSpace(l.owner) {
+		l.store.startupOwner = ""
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) Acquire(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, lockOwner, scopeKey string) (*runtimesessions.Lease, error) {
+	if strings.TrimSpace(agentID) == "" || runtimeMode == "" || strings.TrimSpace(lockOwner) == "" {
+		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
+	}
+
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin sqlite session acquire tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rec, found, err := sqliteLoadLiveSession(ctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+	now := s.now()
+	expires := now.Add(s.sessionLockTTL)
+	if !found {
+		sessionID := uuid.NewString()
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO agent_sessions (
+				session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state,
+				lease_holder, lease_expires_at, status, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, '{}', ?, ?, 'active', ?, ?)
+		`, sessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+			resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), strings.TrimSpace(lockOwner), expires, now, now); err != nil {
+			return nil, fmt.Errorf("insert sqlite session row: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit sqlite session acquire new: %w", err)
+		}
+		committed = true
+		return &runtimesessions.Lease{
+			SessionID:    sessionID,
+			AgentID:      strings.TrimSpace(agentID),
+			RuntimeMode:  resolved.RuntimeMode,
+			SessionScope: resolved.Scope,
+			LockOwner:    strings.TrimSpace(lockOwner),
+			ScopeKey:     resolved.ScopeKey,
+			ExpiresAt:    expires,
+		}, nil
+	}
+	if strings.TrimSpace(rec.status) == "suspended" {
+		return nil, runtimesessions.ErrSessionSuspended
+	}
+	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
+		return nil, runtimesessions.ErrSessionLeased
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET lease_holder = ?, lease_expires_at = ?, updated_at = ?
+		WHERE session_id = ?
+	`, strings.TrimSpace(lockOwner), expires, now, rec.sessionID); err != nil {
+		return nil, fmt.Errorf("update sqlite session lease: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit sqlite session acquire existing: %w", err)
+	}
+	committed = true
+	return &runtimesessions.Lease{
+		SessionID:            rec.sessionID,
+		ProviderSessionID:    rec.providerSessionID,
+		AgentID:              strings.TrimSpace(agentID),
+		RuntimeMode:          resolved.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          rec.retryReason,
+		RetriesFromSessionID: rec.retriesFromSessionID,
+		LockOwner:            strings.TrimSpace(lockOwner),
+		ScopeKey:             resolved.ScopeKey,
+		ExpiresAt:            expires,
+	}, nil
+}
+
+func (s *SQLiteRuntimeStore) Release(ctx context.Context, lease *runtimesessions.Lease) error {
+	if lease == nil {
+		return errors.New("nil lease")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE agent_id = ?
+		  AND runtime_mode = ?
+		  AND session_id = ?
+		  AND scope_key = ?
+		  AND lease_holder = ?
+		  AND status = 'active'
+	`, s.now(), strings.TrimSpace(lease.AgentID), lease.RuntimeMode.String(), strings.TrimSpace(lease.SessionID), strings.TrimSpace(lease.ScopeKey), strings.TrimSpace(lease.LockOwner))
+	if err != nil {
+		return fmt.Errorf("release sqlite session lease: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("no active lease to release for agent=%s session=%s", lease.AgentID, lease.SessionID)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) Rotate(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, lockOwner string, rotation runtimesessions.RotationMetadata, scopeKey string) (*runtimesessions.Lease, error) {
+	if strings.TrimSpace(agentID) == "" || runtimeMode == "" || strings.TrimSpace(lockOwner) == "" {
+		return nil, errors.New("agentID, runtimeMode, and lockOwner are required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Stateless {
+		return nil, errors.New("task-scoped sessions are stateless")
+	}
+
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin sqlite session rotate tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	rec, found, err := sqliteLoadActiveSession(ctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("no active session to rotate for agent=%s", strings.TrimSpace(agentID))
+	}
+	now := s.now()
+	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
+		return nil, runtimesessions.ErrSessionLeased
+	}
+	retryReason := strings.TrimSpace(rotation.RetryReason)
+	terminationReason := rotation.TerminationReason
+	if terminationReason == "" {
+		terminationReason = runtimesessions.TerminationReasonContaminated
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET status = 'terminated',
+		    termination_reason = ?,
+		    termination_detail = ?,
+		    terminated_at = COALESCE(terminated_at, ?),
+		    successor_session_id = NULL,
+		    lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE session_id = ?
+		  AND status = 'active'
+	`, terminationReason.String(), sqliteNullString(retryReason), now, now, rec.sessionID); err != nil {
+		return nil, fmt.Errorf("terminate sqlite rotated session row: %w", err)
+	}
+	newSessionID := uuid.NewString()
+	expires := now.Add(s.sessionLockTTL)
+	runtimeState := sqliteSessionRuntimeStateJSON(strings.TrimSpace(rotation.CheckpointSummary), retryReason, rec.sessionID)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status,
+			created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, ?, ?, ?, 'active', ?, ?)
+	`, newSessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+		resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), runtimeState, strings.TrimSpace(lockOwner), expires, now, now); err != nil {
+		return nil, fmt.Errorf("insert sqlite rotated successor session row: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET successor_session_id = ?, updated_at = ?
+		WHERE session_id = ?
+		  AND status = 'terminated'
+	`, newSessionID, now, rec.sessionID); err != nil {
+		return nil, fmt.Errorf("link sqlite rotated successor session row: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit sqlite session rotate: %w", err)
+	}
+	committed = true
+	return &runtimesessions.Lease{
+		SessionID:            newSessionID,
+		AgentID:              strings.TrimSpace(agentID),
+		RuntimeMode:          resolved.RuntimeMode,
+		SessionScope:         resolved.Scope,
+		RetryReason:          retryReason,
+		RetriesFromSessionID: rec.sessionID,
+		LockOwner:            strings.TrimSpace(lockOwner),
+		ScopeKey:             resolved.ScopeKey,
+		ExpiresAt:            expires,
+	}, nil
+}
+
+func (s *SQLiteRuntimeStore) IncrementTurn(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, sessionID, scopeKey string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
+	if err != nil {
+		return err
+	}
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET turn_count = turn_count + 1,
+		    updated_at = ?
+		WHERE agent_id = ?
+		  AND runtime_mode = ?
+		  AND session_id = ?
+		  AND scope_key = ?
+		  AND status = 'active'
+	`, s.now(), strings.TrimSpace(agentID), resolved.RuntimeMode.String(), strings.TrimSpace(sessionID), resolved.ScopeKey)
+	if err != nil {
+		return fmt.Errorf("increment sqlite session turn: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("session not found for turn increment: agent=%s runtime=%s scope=%s session=%s", agentID, runtimeMode, scopeKey, sessionID)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) AdoptSessionID(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, lockOwner, newSessionID, scopeKey string) error {
+	agentID = strings.TrimSpace(agentID)
+	lockOwner = strings.TrimSpace(lockOwner)
+	newSessionID = strings.TrimSpace(newSessionID)
+	if agentID == "" || runtimeMode == "" || lockOwner == "" || newSessionID == "" {
+		return errors.New("agentID, runtimeMode, lockOwner, and newSessionID are required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolved, err := runtimesessions.ResolveScope(ctx, runtimeMode, sessionScope, scopeKey)
+	if err != nil {
+		return err
+	}
+	if resolved.Stateless {
+		return nil
+	}
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite adopt session id tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	rec, found, err := sqliteLoadActiveSession(ctx, tx, agentID, resolved.RuntimeMode, resolved.ScopeKey)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("no active session to adopt for agent=%s", agentID)
+	}
+	now := s.now()
+	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != lockOwner {
+		return runtimesessions.ErrSessionLeased
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET runtime_state = json_set(COALESCE(runtime_state, '{}'), '$.provider_session_id', ?),
+		    lease_holder = ?,
+		    lease_expires_at = ?,
+		    updated_at = ?
+		WHERE session_id = ?
+	`, newSessionID, lockOwner, now.Add(s.sessionLockTTL), now, rec.sessionID); err != nil {
+		return fmt.Errorf("update sqlite provider session id: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite adopt session id: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, metadata runtimesessions.ResetMetadata) (runtimesessions.ResetSummary, error) {
+	if s == nil || s.DB == nil {
+		return runtimesessions.ResetSummary{}, nil
+	}
+	source := strings.TrimSpace(metadata.Source)
+	now := s.now()
+	args := []any{runtimesessions.TerminationReasonOrphaned.String(), sqliteNullString(source), now, now}
+	where := "status IN ('active', 'suspended') AND runtime_mode IN ('session', 'session_per_entity')"
+	if runtimeMode == runtimesessions.RuntimeModeTask {
+		return runtimesessions.ResetSummary{}, nil
+	}
+	if runtimeMode != "" {
+		where += " AND runtime_mode = ?"
+		args = append(args, runtimeMode.String())
+	}
+	rows, err := s.DB.Query(`
+		SELECT session_id, agent_id, scope_key, runtime_mode, status
+		FROM agent_sessions
+		WHERE `+where+`
+		ORDER BY agent_id ASC, scope_key ASC, session_id ASC
+	`, args[4:]...)
+	if err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("list sqlite sessions for reset: %w", err)
+	}
+	defer rows.Close()
+	summary := runtimesessions.ResetSummary{}
+	for rows.Next() {
+		var d runtimesessions.ResetDisposition
+		if err := rows.Scan(&d.SessionID, &d.AgentID, &d.ScopeKey, &d.RuntimeMode, &d.PreviousStatus); err != nil {
+			return runtimesessions.ResetSummary{}, fmt.Errorf("scan sqlite session reset summary: %w", err)
+		}
+		d.TerminationReason = runtimesessions.TerminationReasonOrphaned.String()
+		d.TerminationDetail = source
+		summary.OrphanedSessions = append(summary.OrphanedSessions, d)
+	}
+	if err := rows.Err(); err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("read sqlite session reset summary: %w", err)
+	}
+	updateArgs := append([]any{}, args...)
+	if _, err := s.DB.Exec(`
+		UPDATE agent_sessions
+		SET status = 'terminated',
+		    termination_reason = ?,
+		    termination_detail = ?,
+		    terminated_at = COALESCE(terminated_at, ?),
+		    lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE `+where, updateArgs...); err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("reset sqlite sessions: %w", err)
+	}
+	return summary, nil
+}
+
+func (s *SQLiteRuntimeStore) SetNowFnForTest(nowFn func() time.Time) {
+	if s == nil {
+		return
+	}
+	if nowFn == nil {
+		s.nowFn = time.Now
+		return
+	}
+	s.nowFn = nowFn
+}
+
+func (s *SQLiteRuntimeStore) ScopeKeyEnabledForTest() bool { return true }
+
+type sqliteSessionRow struct {
+	sessionID            string
+	status               string
+	providerSessionID    string
+	retryReason          string
+	retriesFromSessionID string
+	leaseHolder          string
+	leaseExpiresAt       time.Time
+}
+
+func sqliteLoadLiveSession(ctx context.Context, q rowQueryer, agentID string, runtimeMode runtimesessions.RuntimeMode, scopeKey string) (sqliteSessionRow, bool, error) {
+	return sqliteLoadSession(ctx, q, agentID, runtimeMode, scopeKey, "status IN ('active', 'suspended')")
+}
+
+func sqliteLoadActiveSession(ctx context.Context, q rowQueryer, agentID string, runtimeMode runtimesessions.RuntimeMode, scopeKey string) (sqliteSessionRow, bool, error) {
+	return sqliteLoadSession(ctx, q, agentID, runtimeMode, scopeKey, "status = 'active'")
+}
+
+func sqliteLoadSession(ctx context.Context, q rowQueryer, agentID string, runtimeMode runtimesessions.RuntimeMode, scopeKey, statusPredicate string) (sqliteSessionRow, bool, error) {
+	var rec sqliteSessionRow
+	var leaseExpiresRaw any
+	err := q.QueryRowContext(ctx, `
+		SELECT
+			session_id,
+			status,
+			COALESCE(json_extract(runtime_state, '$.provider_session_id'), ''),
+			COALESCE(json_extract(runtime_state, '$.retry_reason'), ''),
+			COALESCE(json_extract(runtime_state, '$.retries_from_session_id'), ''),
+			COALESCE(lease_holder, ''),
+			lease_expires_at
+		FROM agent_sessions
+		WHERE agent_id = ?
+		  AND scope_key = ?
+		  AND runtime_mode = ?
+		  AND `+statusPredicate+`
+		ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END, created_at DESC
+		LIMIT 1
+	`, agentID, scopeKey, runtimeMode.String()).Scan(
+		&rec.sessionID,
+		&rec.status,
+		&rec.providerSessionID,
+		&rec.retryReason,
+		&rec.retriesFromSessionID,
+		&rec.leaseHolder,
+		&leaseExpiresRaw,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sqliteSessionRow{}, false, nil
+	}
+	if err != nil {
+		return sqliteSessionRow{}, false, fmt.Errorf("load sqlite session row: %w", err)
+	}
+	if at, ok, err := sqliteTimeValue(leaseExpiresRaw); err != nil {
+		return sqliteSessionRow{}, false, fmt.Errorf("scan sqlite session lease expiry: %w", err)
+	} else if ok {
+		rec.leaseExpiresAt = at
+	}
+	rec.sessionID = strings.TrimSpace(rec.sessionID)
+	rec.status = strings.TrimSpace(rec.status)
+	rec.providerSessionID = strings.TrimSpace(rec.providerSessionID)
+	rec.retryReason = strings.TrimSpace(rec.retryReason)
+	rec.retriesFromSessionID = strings.TrimSpace(rec.retriesFromSessionID)
+	rec.leaseHolder = strings.TrimSpace(rec.leaseHolder)
+	return rec, true, nil
+}
+
+func sqliteSessionRuntimeStateJSON(summary, retryReason, retriesFromSessionID string) string {
+	parts := make([]string, 0, 3)
+	if summary = strings.TrimSpace(summary); summary != "" {
+		parts = append(parts, fmt.Sprintf("%q:%q", "summary", summary))
+	}
+	if retryReason = strings.TrimSpace(retryReason); retryReason != "" {
+		parts = append(parts, fmt.Sprintf("%q:%q", "retry_reason", retryReason))
+	}
+	if retriesFromSessionID = strings.TrimSpace(retriesFromSessionID); retriesFromSessionID != "" {
+		parts = append(parts, fmt.Sprintf("%q:%q", "retries_from_session_id", retriesFromSessionID))
+	}
+	if len(parts) == 0 {
+		return "{}"
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -276,10 +276,20 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	if err := store.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", uuid.NewString()); err != nil {
 		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
 	}
+	if err := store.UpsertEventReceipt(ctx, eventID, "agent-1", runtimemanager.ReceiptStatusError, "boom"); err != nil {
+		t.Fatalf("UpsertEventReceipt retryable error: %v", err)
+	}
+	receipt, ok, err := store.GetEventReceipt(ctx, eventID, "agent-1")
+	if err != nil {
+		t.Fatalf("GetEventReceipt retryable error: %v", err)
+	}
+	if !ok || receipt.Status != runtimemanager.ReceiptStatusError || receipt.RetryCount != 1 || receipt.Error != "boom" {
+		t.Fatalf("retryable receipt = %+v ok=%v, want error retry_count=1 boom", receipt, ok)
+	}
 	if err := store.UpsertEventReceipt(ctx, eventID, "agent-1", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
 		t.Fatalf("UpsertEventReceipt: %v", err)
 	}
-	receipt, ok, err := store.GetEventReceipt(ctx, eventID, "agent-1")
+	receipt, ok, err = store.GetEventReceipt(ctx, eventID, "agent-1")
 	if err != nil {
 		t.Fatalf("GetEventReceipt: %v", err)
 	}
@@ -325,24 +335,40 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 		t.Fatalf("missing pipeline receipts after receipt = %#v, want none", missing)
 	}
 
-	subEventID := uuid.NewString()
-	subEvt := events.Event{
-		ID:          subEventID,
-		RunID:       runID,
-		Type:        events.EventType("subscription.visible"),
-		SourceAgent: "runtime",
-		Payload:     json.RawMessage(`{"subscription":true}`),
-		CreatedAt:   now.Add(time.Second),
+	subSelfID := uuid.NewString()
+	subOtherID := uuid.NewString()
+	subNoDeliveryID := uuid.NewString()
+	subEvt := func(id string, offset time.Duration) events.Event {
+		return events.Event{
+			ID:          id,
+			RunID:       runID,
+			Type:        events.EventType("subscription.visible"),
+			SourceAgent: "runtime",
+			Payload:     json.RawMessage(`{"subscription":true}`),
+			CreatedAt:   now.Add(offset),
+		}
 	}
-	if err := store.AppendEvent(ctx, subEvt); err != nil {
-		t.Fatalf("AppendEvent subscription: %v", err)
+	if err := store.AppendEvent(ctx, subEvt(subSelfID, time.Second)); err != nil {
+		t.Fatalf("AppendEvent subscription self: %v", err)
+	}
+	if err := store.InsertEventDeliveries(ctx, subSelfID, []string{"agent-2"}); err != nil {
+		t.Fatalf("InsertEventDeliveries subscription self: %v", err)
+	}
+	if err := store.AppendEvent(ctx, subEvt(subOtherID, 2*time.Second)); err != nil {
+		t.Fatalf("AppendEvent subscription other: %v", err)
+	}
+	if err := store.InsertEventDeliveries(ctx, subOtherID, []string{"agent-1"}); err != nil {
+		t.Fatalf("InsertEventDeliveries subscription other: %v", err)
+	}
+	if err := store.AppendEvent(ctx, subEvt(subNoDeliveryID, 3*time.Second)); err != nil {
+		t.Fatalf("AppendEvent subscription no delivery: %v", err)
 	}
 	subscribed, err := store.ListPendingSubscribedEvents(ctx, "agent-2", []events.EventType{"subscription.*"}, now.Add(-time.Minute), 10)
 	if err != nil {
 		t.Fatalf("ListPendingSubscribedEvents: %v", err)
 	}
-	if len(subscribed) != 1 || subscribed[0].ID != subEventID {
-		t.Fatalf("subscribed pending events = %#v, want %s", subscribed, subEventID)
+	if len(subscribed) != 1 || subscribed[0].ID != subSelfID {
+		t.Fatalf("subscribed pending events = %#v, want only direct self %s", subscribed, subSelfID)
 	}
 }
 

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,9 +14,12 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimeingress "swarm/internal/runtime/ingress"
+	runtimellm "swarm/internal/runtime/llm"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	runtimeruncontrol "swarm/internal/runtime/runcontrol"
+	runtimesessions "swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
 )
 
@@ -235,16 +237,269 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	}
 }
 
-func TestSQLiteRuntimeStoreReplayBacklogQueriesFailClosed(t *testing.T) {
+func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	now := time.Now().UTC()
+	store.SetNowFnForTest(func() time.Time { return now })
 
-	if _, err := store.ListPendingEventsForAgent(ctx, "agent-1", time.Now().Add(-time.Hour), 10); err == nil || !strings.Contains(err.Error(), "split to #1087") {
-		t.Fatalf("ListPendingEventsForAgent error = %v, want explicit #1087 split", err)
+	eventID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("test.delivery_requested"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"delivery":true}`),
+		CreatedAt:   now,
 	}
-	if _, err := store.ListPendingSubscribedEvents(ctx, "agent-1", []events.EventType{"test.*"}, time.Now().Add(-time.Hour), 10); err == nil || !strings.Contains(err.Error(), "split to #1087") {
-		t.Fatalf("ListPendingSubscribedEvents error = %v, want explicit #1087 split", err)
+	if err := store.PersistEventWithDeliveriesAndScope(ctx, evt, []string{"agent-1"}, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+		t.Fatalf("PersistEventWithDeliveriesAndScope: %v", err)
 	}
+
+	scope, err := store.LoadCommittedReplayScope(ctx, eventID)
+	if err != nil {
+		t.Fatalf("LoadCommittedReplayScope: %v", err)
+	}
+	if scope != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", scope)
+	}
+
+	pending, err := store.ListPendingEventsForAgent(ctx, "agent-1", now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != eventID {
+		t.Fatalf("pending events = %#v, want %s", pending, eventID)
+	}
+	if err := store.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", uuid.NewString()); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
+	}
+	if err := store.UpsertEventReceipt(ctx, eventID, "agent-1", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("UpsertEventReceipt: %v", err)
+	}
+	receipt, ok, err := store.GetEventReceipt(ctx, eventID, "agent-1")
+	if err != nil {
+		t.Fatalf("GetEventReceipt: %v", err)
+	}
+	if !ok || receipt.Status != runtimemanager.ReceiptStatusProcessed {
+		t.Fatalf("receipt = %+v ok=%v, want processed", receipt, ok)
+	}
+	pending, err = store.ListPendingEventsForAgent(ctx, "agent-1", now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListPendingEventsForAgent after receipt: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending events after receipt = %#v, want none", pending)
+	}
+
+	missing, err := store.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun: %v", err)
+	}
+	if len(missing) != 1 || missing[0].Event.ID != eventID {
+		t.Fatalf("missing pipeline receipts = %#v, want %s", missing, eventID)
+	}
+	lease, claimed, err := store.ClaimPipelineReplay(ctx, eventID)
+	if err != nil {
+		t.Fatalf("ClaimPipelineReplay: %v", err)
+	}
+	if !claimed || lease == nil {
+		t.Fatalf("ClaimPipelineReplay claimed=%v lease=%#v, want claim", claimed, lease)
+	}
+	if _, claimedAgain, err := store.ClaimPipelineReplay(ctx, eventID); err != nil || claimedAgain {
+		t.Fatalf("second ClaimPipelineReplay claimed=%v err=%v, want busy/no claim", claimedAgain, err)
+	}
+	if err := lease.Release(ctx); err != nil {
+		t.Fatalf("release replay claim: %v", err)
+	}
+	if err := store.UpsertPipelineReceipt(ctx, eventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	missing, err = store.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun after receipt: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing pipeline receipts after receipt = %#v, want none", missing)
+	}
+
+	subEventID := uuid.NewString()
+	subEvt := events.Event{
+		ID:          subEventID,
+		RunID:       runID,
+		Type:        events.EventType("subscription.visible"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"subscription":true}`),
+		CreatedAt:   now.Add(time.Second),
+	}
+	if err := store.AppendEvent(ctx, subEvt); err != nil {
+		t.Fatalf("AppendEvent subscription: %v", err)
+	}
+	subscribed, err := store.ListPendingSubscribedEvents(ctx, "agent-2", []events.EventType{"subscription.*"}, now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListPendingSubscribedEvents: %v", err)
+	}
+	if len(subscribed) != 1 || subscribed[0].ID != subEventID {
+		t.Fatalf("subscribed pending events = %#v, want %s", subscribed, subEventID)
+	}
+}
+
+func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Now().UTC()
+	store.SetNowFnForTest(func() time.Time { return now })
+
+	if err := store.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:                    "agent-1",
+			Role:                  "operator",
+			Mode:                  "global",
+			ModelTier:             "generic",
+			LLMBackend:            "api",
+			ConversationMode:      "session",
+			SessionScope:          "global",
+			SessionScopeAuthority: runtimeactors.SessionScopeAuthorityPlatformInternal,
+			Config:                json.RawMessage(`{"system_prompt":"test","tools":[]}`),
+		},
+		Status:    "active",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	startupLease, err := store.AcquireRuntimeStartupOwnership(ctx, "runtime-1")
+	if err != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership first: %v", err)
+	}
+	if _, err := store.AcquireRuntimeStartupOwnership(ctx, "runtime-2"); err == nil {
+		t.Fatal("AcquireRuntimeStartupOwnership second unexpectedly succeeded")
+	}
+	if err := startupLease.Release(ctx); err != nil {
+		t.Fatalf("release startup lease: %v", err)
+	}
+	successorStartupLease, err := store.AcquireRuntimeStartupOwnership(ctx, "runtime-2")
+	if err != nil {
+		t.Fatalf("AcquireRuntimeStartupOwnership after release: %v", err)
+	}
+	if err := successorStartupLease.Release(ctx); err != nil {
+		t.Fatalf("release successor startup lease: %v", err)
+	}
+
+	lease, err := store.Acquire(ctx, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "owner-1", "")
+	if err != nil {
+		t.Fatalf("Acquire session: %v", err)
+	}
+	if lease.ScopeKey != "global" {
+		t.Fatalf("session scope key = %q, want global", lease.ScopeKey)
+	}
+	if _, err := store.Acquire(ctx, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "owner-2", ""); !errors.Is(err, runtimesessions.ErrSessionLeased) {
+		t.Fatalf("competing Acquire error = %v, want ErrSessionLeased", err)
+	}
+	if err := store.AdoptSessionID(ctx, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "owner-1", "provider-session-1", "global"); err != nil {
+		t.Fatalf("AdoptSessionID: %v", err)
+	}
+	if err := store.IncrementTurn(ctx, "agent-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, lease.SessionID, "global"); err != nil {
+		t.Fatalf("IncrementTurn: %v", err)
+	}
+	if err := store.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    lease.SessionID,
+		AgentID:      "agent-1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Messages:     []runtimellm.Message{{Role: "user", Content: "hello"}},
+		Summary:      "greeting",
+		TurnCount:    1,
+		Status:       "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation: %v", err)
+	}
+	conversation, ok, err := store.LoadActiveConversation(ctx, "agent-1", "session", "global", "global")
+	if err != nil {
+		t.Fatalf("LoadActiveConversation: %v", err)
+	}
+	if !ok || conversation.Summary != "greeting" || len(conversation.Messages) != 1 {
+		t.Fatalf("conversation = %+v ok=%v, want persisted greeting", conversation, ok)
+	}
+
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	eventID := uuid.NewString()
+	if err := store.PersistEventWithDeliveries(ctx, events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("trace.visible"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"trace":true}`),
+		CreatedAt:   now,
+	}, []string{"agent-1"}); err != nil {
+		t.Fatalf("PersistEventWithDeliveries trace event: %v", err)
+	}
+	if err := store.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", lease.SessionID); err != nil {
+		t.Fatalf("MarkEventDeliveryInProgress trace event: %v", err)
+	}
+	if err := store.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:          "agent-1",
+		RuntimeMode:      "session",
+		SessionID:        lease.SessionID,
+		ScopeKey:         "global",
+		RunID:            runID,
+		TriggerEventID:   eventID,
+		TriggerEventType: "trace.visible",
+		RequestPayload:   []byte(`{"prompt":"hello"}`),
+		ResponseRaw:      []byte(`{"content":"ok"}`),
+		ParseOK:          true,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn: %v", err)
+	}
+	trace, _, err := store.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage: %v", err)
+	}
+	if len(trace) != 1 || trace[0].EventID != eventID || trace[0].SessionID != lease.SessionID || trace[0].TurnTriggerEventID != eventID {
+		t.Fatalf("trace = %#v, want event/session/turn visibility", trace)
+	}
+	eventsPage, err := store.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListOperatorEvents: %v", err)
+	}
+	if len(eventsPage.Events) != 1 || eventsPage.Events[0].EventID != eventID || !operatorDeliveriesContain(eventsPage.Events[0].Deliveries, "agent", "agent-1") {
+		t.Fatalf("events page = %#v, want event with delivery", eventsPage)
+	}
+
+	logID := uuid.NewString()
+	if err := store.AppendEvent(ctx, events.Event{
+		ID:          logID,
+		RunID:       runID,
+		Type:        events.EventType("platform.runtime_log"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","session_id":"` + lease.SessionID + `"}}`),
+		CreatedAt:   now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("AppendEvent runtime log: %v", err)
+	}
+	logs, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{RunID: runID, Level: "warn", Component: "scheduler", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs: %v", err)
+	}
+	if len(logs.Logs) != 1 || logs.Logs[0].LogID != logID || logs.Logs[0].SessionID != lease.SessionID {
+		t.Fatalf("runtime logs = %#v, want persisted runtime log", logs)
+	}
+	if err := store.Release(ctx, lease); err != nil {
+		t.Fatalf("Release session: %v", err)
+	}
+}
+
+func operatorDeliveriesContain(deliveries []OperatorEventDelivery, subscriberType, subscriberID string) bool {
+	for _, delivery := range deliveries {
+		if delivery.SubscriberType == subscriberType && delivery.SubscriberID == subscriberID {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -384,7 +384,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 			Role:                  "operator",
 			Mode:                  "global",
 			ModelTier:             "generic",
-			LLMBackend:            "api",
+			LLMBackend:            "anthropic",
 			ConversationMode:      "session",
 			SessionScope:          "global",
 			SessionScopeAuthority: runtimeactors.SessionScopeAuthorityPlatformInternal,


### PR DESCRIPTION
## Summary

Part of #1087.

This PR now stages the explicit SQLite typed runtime store owners and preserves fail-closed SQLite runtime construction while the #1087 gate-promoted raw-SQL runtime consumers remain unresolved. It no longer claims to close #1087.

The PR keeps the selected SQLite store implementations and API observability proof for session/startup/delivery/replay/conversation/turn/observability rows, but restores the runtime construction blocker so SQLite is not treated as a construction-ready local runtime backend before pipeline coordination/background nodes, budget tracking/spend ledger, tool executor entity/human-task persistence and diagnostics, and runtime diagnostics/logging are migrated to backend-neutral owners or explicitly split by lead-approved tracker repair.

## Governing refs/context

Exact governing spec sections updated in this PR:
- `engine.runtime_store_backend_selection`
- `engine.runtime_store_schema_dialect_bootstrap`
- `engine.runtime_core_persistence_store_contracts`
- `engine.agent_session_management`
- API surfaces: `/v1/rpc run.trace`, `/v1/ws run.subscribe_trace`, `/v1/ws event.subscribe`, `/v1/ws runtime.subscribe_logs`

Binding issue/gate context:
- #1087 pre-audit and gate outcome: `approved as first slice`
- Parent tracker: #1066
- Sibling deferrals: #1088 default flip / zero-service local run proof, #1089 docs/CI/parent closeout
- Post-review correction: #1087 remains open because the gate-promoted raw-SQL runtime consumers are not migrated or split in this PR.

## Semantic migration

New canonical owner staged by this PR:
- `internal/store.SQLiteRuntimeStore` provides typed SQLite store owners for session registry, startup ownership, delivery/replay/receipts, conversation/turn rows, and `apiv1.ObservabilityReadStore`.

Old producer / reader / writer path now invalid:
- SQLite split-error stubs for delivery/replay/receipt surfaces are removed where typed SQLite owners exist.
- SQLite must not pass a raw runtime SQL handle to Postgres-only runtime consumers.

Old path still authoritative / still surviving:
- SQLite runtime construction remains fail-closed through `runtime.Stores.ConstructionBlocker`.
- Explicit Postgres selection still passes `RuntimeSQLDB` to Postgres-owned raw SQL runtime components.
- The gate-promoted raw-SQL consumers remain unresolved for #1087 and must be migrated or explicitly split before SQLite runtime construction can be unblocked.

Migration completeness:
- Partial for #1087 typed SQLite store/API observability groundwork.
- Not complete for #1087 runtime construction readiness.
- Not a SQLite default flip (#1088), docs/CI parent closeout (#1089), or production multi-writer SQLite promotion.

## Validation

- `go test ./cmd/swarm -run 'TestBuildStores(SQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit|AcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./internal/store -run 'TestSQLiteRuntimeStore' -count=1`
- `go test ./internal/apiv1 -run TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces -count=1`
- `go test ./...`