### PR TITLE
[agent-h][issue #1112] Add per-agent usage read owner

### DIFF
--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1315,6 +1315,82 @@
       ]
     },
     {
+      "name": "agent.usage",
+      "description": "Read the owner-backed per-agent LLM token and estimated-cost usage\naggregate. This is a separate owner from agent.diagnose:\nAgentDiagnosis remains lean and must not expose token usage. The API\nhandler validates agent_id and optional created_at window params, then\nconsumes one named per-agent usage read owner over spend_ledger facts.\nIt must not locally reconstruct usage from raw request_payload,\nresponse_payload, agent.diagnose, agent.delivery_diagnostics,\nrun.trace, run.diagnose, dashboard helpers, CLI state, EventBus data,\nor runtime memory.\n\nThe owner is agent-scoped and aggregates retained spend_ledger rows by\nspend_ledger.created_at. since is inclusive; until is exclusive. If no\nwindow is supplied, all retained rows for the agent are aggregated. The\nresponse separates exact and estimated usage_accounting totals and\nprovides model/runtime breakdowns so API provider usage and CLI\nestimated usage are not silently merged. estimated_cost_usd is the\nBudgetTracker guardrail cost estimate, not provider billing truth. This\nmethod does not make run_id, session_id, turn_id, last-turn, or\nprovider-billing claims.\n",
+      "params": [
+        {
+          "name": "agent_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        {
+          "name": "since",
+          "required": false,
+          "description": "Inclusive lower bound over spend_ledger.created_at.",
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        {
+          "name": "until",
+          "required": false,
+          "description": "Exclusive upper bound over spend_ledger.created_at; must be after since when both are supplied.",
+          "schema": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/AgentUsage"
+        }
+      },
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Application error: AGENT_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "AGENT_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "required": [
+                  "agent_id"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "bundle.agents",
       "description": "Return definition-only agent catalog entries projected from the persisted bundle row identified by bundle_hash. This method must not read runtime agents, sessions, queues, diagnoses, active tasks, or status fields, and does not close strict duplicate-slug runtime identity work.\n",
       "params": [
@@ -6969,6 +7045,118 @@
         ],
         "type": "object"
       },
+      "AgentUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/AgentUsageBreakdown"
+            },
+            "type": "array"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/AgentUsageByAccounting"
+          },
+          "window": {
+            "$ref": "#/components/schemas/AgentUsageWindow"
+          }
+        },
+        "required": [
+          "agent_id",
+          "window",
+          "usage",
+          "breakdown"
+        ],
+        "type": "object"
+      },
+      "AgentUsageBreakdown": {
+        "additionalProperties": false,
+        "properties": {
+          "invocation_type": {
+            "description": "Runtime invocation type recorded by the spend ledger, such as api, cli_test, or openai_compatible.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "model": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "totals": {
+            "$ref": "#/components/schemas/AgentUsageTotals"
+          },
+          "usage_accounting": {
+            "$ref": "#/components/schemas/UsageAccounting"
+          }
+        },
+        "required": [
+          "usage_accounting",
+          "invocation_type",
+          "model",
+          "totals"
+        ],
+        "type": "object"
+      },
+      "AgentUsageByAccounting": {
+        "additionalProperties": false,
+        "properties": {
+          "estimated": {
+            "$ref": "#/components/schemas/AgentUsageTotals"
+          },
+          "exact": {
+            "$ref": "#/components/schemas/AgentUsageTotals"
+          }
+        },
+        "required": [
+          "exact",
+          "estimated"
+        ],
+        "type": "object"
+      },
+      "AgentUsageTotals": {
+        "additionalProperties": false,
+        "properties": {
+          "estimated_cost_usd": {
+            "description": "Guardrail cost estimate from BudgetTracker pricing, not provider billing truth.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "input_tokens": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ledger_entries": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "output_tokens": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ledger_entries",
+          "input_tokens",
+          "output_tokens",
+          "estimated_cost_usd"
+        ],
+        "type": "object"
+      },
+      "AgentUsageWindow": {
+        "additionalProperties": false,
+        "description": "Agent usage aggregate window over spend_ledger.created_at. since is\ninclusive when supplied; until is exclusive when supplied. If both\nare omitted, the owner aggregates all retained spend_ledger rows for\nthe agent. This schema intentionally makes no run/session/turn or\nlast-turn claim.\n",
+        "properties": {
+          "since": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "until": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        "type": "object"
+      },
       "BlockingLayer": {
         "description": "Layer-of-the-system identifier when operational_state is \"stalled\".\nEmpty string when state is running or terminal. Source of truth:\nProjectRunOperationalStatus. Current owner emits:\n  \"\" (empty) — state is running or terminal\n  \"scoring_terminal_outcome\" — scoring entities have not reached\n    a terminal scoring outcome (shortlisted/marginal/rejected)\n  \"delivery_lifecycle\" — no active deliveries but events exist\nAdditional values may be added as the operator-state owner gains\nmore diagnostic semantics. Type stays string (not enum) for\nforward compatibility — additive owner extensions must not\nrequire a /v2/ bump.\n",
         "type": "string"
@@ -9234,6 +9422,14 @@
           "parse_ok"
         ],
         "type": "object"
+      },
+      "UsageAccounting": {
+        "description": "Exact means token counts came from a provider usage object. Estimated\nmeans token counts were locally estimated because the runtime surface\ndid not expose provider usage. API consumers must not silently merge\nexact and estimated buckets without preserving this field.\n",
+        "enum": [
+          "exact",
+          "estimated"
+        ],
+        "type": "string"
       },
       "VerifyError": {
         "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -4336,11 +4336,12 @@ platform_tables:
         \      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_run_control_state_status (control_status, updated_at)\n\
         );"
     spend_ledger:
-      description: LLM token and API cost tracking. One row per agent invocation.
+      description: LLM token and API cost tracking. One row per agent invocation. usage_accounting is the canonical exact-vs-estimated usage owner for public read surfaces; existing rows without prior accounting evidence migrate conservatively to estimated.
       ddl: "CREATE TABLE spend_ledger (\n    ledger_id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    entity_id\
         \         UUID,\n    flow_instance     TEXT NOT NULL,\n    agent_id          TEXT NOT NULL,\n    model           \
         \  TEXT NOT NULL,\n    input_tokens      INTEGER NOT NULL DEFAULT 0,\n    output_tokens     INTEGER NOT NULL DEFAULT\
-        \ 0,\n    cost_usd          NUMERIC(10,6) NOT NULL DEFAULT 0,\n    invocation_type   TEXT NOT NULL,\n    created_at\
+        \ 0,\n    cost_usd          NUMERIC(10,6) NOT NULL DEFAULT 0,\n    invocation_type   TEXT NOT NULL,\n    usage_accounting\
+        \ TEXT NOT NULL DEFAULT 'estimated' CHECK (usage_accounting IN ('exact', 'estimated')),\n    created_at\
         \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_spend_flow (flow_instance, created_at),\n    INDEX idx_spend_agent\
         \ (agent_id, created_at)\n);"
     flow_instances:
@@ -11335,6 +11336,102 @@ api_specification:
             $ref: '#/components/schemas/AgentDiagnosisActive'
           last_tool_outcome:
             $ref: '#/components/schemas/AgentDiagnosisLastToolOutcome'
+      UsageAccounting:
+        type: string
+        enum:
+        - exact
+        - estimated
+        description: |
+          Exact means token counts came from a provider usage object. Estimated
+          means token counts were locally estimated because the runtime surface
+          did not expose provider usage. API consumers must not silently merge
+          exact and estimated buckets without preserving this field.
+      AgentUsageWindow:
+        type: object
+        additionalProperties: false
+        description: |
+          Agent usage aggregate window over spend_ledger.created_at. since is
+          inclusive when supplied; until is exclusive when supplied. If both
+          are omitted, the owner aggregates all retained spend_ledger rows for
+          the agent. This schema intentionally makes no run/session/turn or
+          last-turn claim.
+        properties:
+          since:
+            $ref: '#/components/schemas/Timestamp'
+          until:
+            $ref: '#/components/schemas/Timestamp'
+      AgentUsageTotals:
+        type: object
+        additionalProperties: false
+        required:
+        - ledger_entries
+        - input_tokens
+        - output_tokens
+        - estimated_cost_usd
+        properties:
+          ledger_entries:
+            type: integer
+            minimum: 0
+          input_tokens:
+            type: integer
+            minimum: 0
+          output_tokens:
+            type: integer
+            minimum: 0
+          estimated_cost_usd:
+            type: number
+            minimum: 0
+            description: Guardrail cost estimate from BudgetTracker pricing, not provider billing truth.
+      AgentUsageByAccounting:
+        type: object
+        additionalProperties: false
+        required:
+        - exact
+        - estimated
+        properties:
+          exact:
+            $ref: '#/components/schemas/AgentUsageTotals'
+          estimated:
+            $ref: '#/components/schemas/AgentUsageTotals'
+      AgentUsageBreakdown:
+        type: object
+        additionalProperties: false
+        required:
+        - usage_accounting
+        - invocation_type
+        - model
+        - totals
+        properties:
+          usage_accounting:
+            $ref: '#/components/schemas/UsageAccounting'
+          invocation_type:
+            type: string
+            minLength: 1
+            description: Runtime invocation type recorded by the spend ledger, such as api, cli_test, or openai_compatible.
+          model:
+            type: string
+            minLength: 1
+          totals:
+            $ref: '#/components/schemas/AgentUsageTotals'
+      AgentUsage:
+        type: object
+        additionalProperties: false
+        required:
+        - agent_id
+        - window
+        - usage
+        - breakdown
+        properties:
+          agent_id:
+            $ref: '#/components/schemas/OpaqueId'
+          window:
+            $ref: '#/components/schemas/AgentUsageWindow'
+          usage:
+            $ref: '#/components/schemas/AgentUsageByAccounting'
+          breakdown:
+            type: array
+            items:
+              $ref: '#/components/schemas/AgentUsageBreakdown'
       AgentDeliveryDiagnosticsSummary:
         type: object
         additionalProperties: false
@@ -13887,6 +13984,53 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/AgentDiagnosis'
+      errors:
+      - AGENT_NOT_FOUND
+    agent.usage:
+      tier: should_have
+      description: |
+        Read the owner-backed per-agent LLM token and estimated-cost usage
+        aggregate. This is a separate owner from agent.diagnose:
+        AgentDiagnosis remains lean and must not expose token usage. The API
+        handler validates agent_id and optional created_at window params, then
+        consumes one named per-agent usage read owner over spend_ledger facts.
+        It must not locally reconstruct usage from raw request_payload,
+        response_payload, agent.diagnose, agent.delivery_diagnostics,
+        run.trace, run.diagnose, dashboard helpers, CLI state, EventBus data,
+        or runtime memory.
+
+        The owner is agent-scoped and aggregates retained spend_ledger rows by
+        spend_ledger.created_at. since is inclusive; until is exclusive. If no
+        window is supplied, all retained rows for the agent are aggregated. The
+        response separates exact and estimated usage_accounting totals and
+        provides model/runtime breakdowns so API provider usage and CLI
+        estimated usage are not silently merged. estimated_cost_usd is the
+        BudgetTracker guardrail cost estimate, not provider billing truth. This
+        method does not make run_id, session_id, turn_id, last-turn, or
+        provider-billing claims.
+      scope:
+        required:
+        - read:agents
+      params:
+      - name: agent_id
+        required: true
+        schema:
+          $ref: '#/components/schemas/OpaqueId'
+      - name: since
+        required: false
+        description: Inclusive lower bound over spend_ledger.created_at.
+        schema:
+          $ref: '#/components/schemas/Timestamp'
+      - name: until
+        required: false
+        description: Exclusive upper bound over spend_ledger.created_at; must be after since when both are supplied.
+        schema:
+          $ref: '#/components/schemas/Timestamp'
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/AgentUsage'
       errors:
       - AGENT_NOT_FOUND
     agent.delivery_diagnostics:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,11 +16,11 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 52 {
-		t.Fatalf("method count = %d, want 52", report.MethodCount)
+	if report.MethodCount != 53 {
+		t.Fatalf("method count = %d, want 53", report.MethodCount)
 	}
-	if report.SchemaCount != 92 {
-		t.Fatalf("schema count = %d, want 92", report.SchemaCount)
+	if report.SchemaCount != 98 {
+		t.Fatalf("schema count = %d, want 98", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 32 {
 		t.Fatalf("error code count = %d, want 32", report.ErrorCodeCount)
@@ -66,11 +66,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 52 {
-		t.Fatalf("generated OpenRPC methods = %d, want 52", len(doc.Methods))
+	if len(doc.Methods) != 53 {
+		t.Fatalf("generated OpenRPC methods = %d, want 53", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 92 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 92", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 98 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 98", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 32 {
 		t.Fatalf("generated OpenRPC errors = %d, want 32", len(doc.Components.Errors))
@@ -92,6 +92,9 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	}
 	if _, ok := methods["agent.diagnose"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.diagnose")
+	}
+	if _, ok := methods["agent.usage"]; !ok {
+		t.Fatal("generated OpenRPC missing agent.usage")
 	}
 	if _, ok := methods["agent.delivery_diagnostics"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.delivery_diagnostics")
@@ -127,6 +130,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 		t.Fatal("generated OpenRPC missing AgentDiagnosisLastToolOutcome")
 	}
 	for _, schemaName := range []string{"AgentDeliveryDiagnostics", "AgentDeliveryDiagnosticsSummary", "AgentDeliveryFailure", "AgentDeadLetterDelivery"} {
+		if _, ok := doc.Components.Schemas[schemaName]; !ok {
+			t.Fatalf("generated OpenRPC missing %s", schemaName)
+		}
+	}
+	for _, schemaName := range []string{"UsageAccounting", "AgentUsageWindow", "AgentUsageTotals", "AgentUsageByAccounting", "AgentUsageBreakdown", "AgentUsage"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -29,8 +29,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 52 {
-		t.Fatalf("method count = %d, want 52", len(openRPCNames))
+	if len(openRPCNames) != 53 {
+		t.Fatalf("method count = %d, want 53", len(openRPCNames))
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 52 {
-		t.Fatalf("generated OpenRPC methods = %d, want 52", len(doc.Methods))
+	if len(doc.Methods) != 53 {
+		t.Fatalf("generated OpenRPC methods = %d, want 53", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -243,6 +243,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 		"agent.diagnose",
 		"agent.get",
 		"agent.list",
+		"agent.usage",
 		"bundle.agents",
 		"bundle.get",
 		"bundle.list",
@@ -276,6 +277,7 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"agent.diagnose":                 {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent_id", "status", "queue", "runtime_state", "active", "last_tool_outcome"}},
 		"agent.get":                      {Params: map[string]any{"agent_id": "agent-1"}, ResultKeys: []string{"agent"}},
 		"agent.list":                     {Params: map[string]any{}, ResultKeys: []string{"agents"}},
+		"agent.usage":                    {Params: map[string]any{"agent_id": "agent-1", "since": "2026-05-21T09:00:00Z", "until": "2026-05-21T10:00:00Z"}, ResultKeys: []string{"agent_id", "window", "usage", "breakdown"}},
 		"bundle.agents":                  {Params: map[string]any{"bundle_hash": readOnlyProbeBundleHash}, ResultKeys: []string{"agents"}},
 		"bundle.get":                     {Params: map[string]any{"bundle_hash": readOnlyProbeBundleHash}, ResultKeys: []string{"bundle_hash", "content_yaml", "parsed_json", "metadata", "agent_count", "has_data", "data_size_bytes", "ingested_at"}},
 		"bundle.list":                    {Params: map[string]any{}, ResultKeys: []string{"bundles"}},
@@ -322,6 +324,16 @@ func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 			Options: func(t *testing.T) OperatorReadOptions {
 				opts := readOnlyRuntimeProbeOptions(t)
 				opts.AgentConversations = &fakeAgentConversationReadStore{agentDiagnosisErr: store.ErrAgentNotFound}
+				return opts
+			},
+		},
+		{
+			Method: "agent.usage",
+			Params: map[string]any{"agent_id": "missing"},
+			Code:   AgentNotFoundCode,
+			Options: func(t *testing.T) OperatorReadOptions {
+				opts := readOnlyRuntimeProbeOptions(t)
+				opts.AgentConversations = &fakeAgentConversationReadStore{agentUsageErr: store.ErrAgentNotFound}
 				return opts
 			},
 		},
@@ -674,6 +686,48 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 					},
 				},
 			},
+			agentUsageResult: store.OperatorAgentUsage{
+				AgentID: "agent-1",
+				Window: store.OperatorAgentUsageWindow{
+					Since: ptrTime(now.Add(-time.Hour)),
+					Until: ptrTime(now),
+				},
+				Usage: store.OperatorAgentUsageByAccounting{
+					Exact: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      100,
+						OutputTokens:     25,
+						EstimatedCostUSD: 0.000675,
+					},
+					Estimated: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      50,
+						OutputTokens:     10,
+						EstimatedCostUSD: 0.000300,
+					},
+				},
+				Breakdown: []store.OperatorAgentUsageBreakdown{{
+					UsageAccounting: store.AgentUsageAccountingExact,
+					InvocationType:  "api",
+					Model:           "claude-3-5-sonnet",
+					Totals: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      100,
+						OutputTokens:     25,
+						EstimatedCostUSD: 0.000675,
+					},
+				}, {
+					UsageAccounting: store.AgentUsageAccountingEstimated,
+					InvocationType:  "cli_test",
+					Model:           "claude-cli-sonnet",
+					Totals: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      50,
+						OutputTokens:     10,
+						EstimatedCostUSD: 0.000300,
+					},
+				}},
+			},
 			agentDeliveryDiagnosticsResult: store.OperatorAgentDeliveryDiagnostics{
 				AgentID: "agent-1",
 				Summary: store.OperatorAgentDeliveryDiagnosticsSummary{
@@ -919,6 +973,27 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 			}
 			if subscribers, ok := downstream["subscribers"].([]any); !ok || len(subscribers) != 0 {
 				t.Fatalf("mailbox.get decision_sheet.downstream_preview.subscribers = %#v", downstream["subscribers"])
+			}
+		}
+	}
+	if methodName == "agent.usage" {
+		usage := asMap(t, result["usage"])
+		exact := asMap(t, usage["exact"])
+		estimated := asMap(t, usage["estimated"])
+		if exact["input_tokens"] != float64(100) || estimated["input_tokens"] != float64(50) {
+			t.Fatalf("agent.usage exact/estimated totals = %#v", usage)
+		}
+		breakdown, ok := result["breakdown"].([]any)
+		if !ok || len(breakdown) != 2 {
+			t.Fatalf("agent.usage breakdown = %#v", result["breakdown"])
+		}
+		first := asMap(t, breakdown[0])
+		if first["usage_accounting"] != "exact" || first["invocation_type"] != "api" {
+			t.Fatalf("agent.usage first breakdown = %#v", first)
+		}
+		for _, forbidden := range []string{"token_usage", "run_id", "session_id", "turn_id"} {
+			if _, ok := result[forbidden]; ok {
+				t.Fatalf("agent.usage exposed forbidden field %q: %#v", forbidden, result)
 			}
 		}
 	}

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -19,6 +19,8 @@ type fakeAgentConversationReadStore struct {
 	agentErr                            error
 	agentDiagnosisResult                store.OperatorAgentDiagnosis
 	agentDiagnosisErr                   error
+	agentUsageResult                    store.OperatorAgentUsage
+	agentUsageErr                       error
 	agentDeliveryDiagnosticsResult      store.OperatorAgentDeliveryDiagnostics
 	agentDeliveryDiagnosticsErr         error
 	listConversationsResult             store.OperatorConversationListResult
@@ -34,6 +36,8 @@ type fakeAgentConversationReadStore struct {
 	lastAgentID                         string
 	lastAgentDiagnosisID                string
 	lastAgentDiagnosisOptions           store.OperatorAgentDiagnosisOptions
+	lastAgentUsageID                    string
+	lastAgentUsageOptions               store.OperatorAgentUsageOptions
 	lastAgentDeliveryDiagnosticsID      string
 	lastAgentDeliveryDiagnosticsOptions store.OperatorAgentDeliveryDiagnosticsOptions
 	lastConversationSessionID           string
@@ -56,6 +60,12 @@ func (s *fakeAgentConversationReadStore) LoadOperatorAgentDiagnosis(_ context.Co
 	s.lastAgentDiagnosisID = agentID
 	s.lastAgentDiagnosisOptions = opts
 	return s.agentDiagnosisResult, s.agentDiagnosisErr
+}
+
+func (s *fakeAgentConversationReadStore) LoadOperatorAgentUsage(_ context.Context, agentID string, opts store.OperatorAgentUsageOptions) (store.OperatorAgentUsage, error) {
+	s.lastAgentUsageID = agentID
+	s.lastAgentUsageOptions = opts
+	return s.agentUsageResult, s.agentUsageErr
 }
 
 func (s *fakeAgentConversationReadStore) LoadOperatorAgentDeliveryDiagnostics(_ context.Context, agentID string, opts store.OperatorAgentDeliveryDiagnosticsOptions) (store.OperatorAgentDeliveryDiagnostics, error) {
@@ -157,6 +167,48 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 					RecordedAt:    "2026-05-21T10:01:00Z",
 				},
 			},
+		},
+		agentUsageResult: store.OperatorAgentUsage{
+			AgentID: "agent-1",
+			Window: store.OperatorAgentUsageWindow{
+				Since: ptrTime(now.Add(-time.Hour)),
+				Until: ptrTime(now),
+			},
+			Usage: store.OperatorAgentUsageByAccounting{
+				Exact: store.OperatorAgentUsageTotals{
+					LedgerEntries:    1,
+					InputTokens:      100,
+					OutputTokens:     25,
+					EstimatedCostUSD: 0.000675,
+				},
+				Estimated: store.OperatorAgentUsageTotals{
+					LedgerEntries:    1,
+					InputTokens:      50,
+					OutputTokens:     10,
+					EstimatedCostUSD: 0.000300,
+				},
+			},
+			Breakdown: []store.OperatorAgentUsageBreakdown{{
+				UsageAccounting: store.AgentUsageAccountingExact,
+				InvocationType:  "api",
+				Model:           "claude-3-5-sonnet",
+				Totals: store.OperatorAgentUsageTotals{
+					LedgerEntries:    1,
+					InputTokens:      100,
+					OutputTokens:     25,
+					EstimatedCostUSD: 0.000675,
+				},
+			}, {
+				UsageAccounting: store.AgentUsageAccountingEstimated,
+				InvocationType:  "cli_test",
+				Model:           "claude-cli-sonnet",
+				Totals: store.OperatorAgentUsageTotals{
+					LedgerEntries:    1,
+					InputTokens:      50,
+					OutputTokens:     10,
+					EstimatedCostUSD: 0.000300,
+				},
+			}},
 		},
 		agentDeliveryDiagnosticsResult: store.OperatorAgentDeliveryDiagnostics{
 			AgentID: "agent-1",
@@ -330,6 +382,39 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 	for _, splitField := range []string{"bundle_version", "watchdog", "token_usage", "failures_recent", "dead_letters_recent"} {
 		if _, ok := diagnosis[splitField]; ok {
 			t.Fatalf("agent.diagnose exposed split field %q: %#v", splitField, diagnosis)
+		}
+	}
+
+	usageResp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent-usage","method":"agent.usage","params":{"agent_id":"agent-1","since":"2026-05-21T09:00:00Z","until":"2026-05-21T10:00:00Z"}}`)
+	if usageResp.Error != nil {
+		t.Fatalf("agent.usage error = %#v", usageResp.Error)
+	}
+	if reads.lastAgentUsageID != "agent-1" {
+		t.Fatalf("agent.usage id = %q", reads.lastAgentUsageID)
+	}
+	if reads.lastAgentUsageOptions.Since == nil || reads.lastAgentUsageOptions.Until == nil {
+		t.Fatalf("agent.usage options missing window = %#v", reads.lastAgentUsageOptions)
+	}
+	usage := asMap(t, usageResp.Result)
+	if usage["agent_id"] != "agent-1" {
+		t.Fatalf("agent.usage agent_id = %#v", usage["agent_id"])
+	}
+	totals := asMap(t, usage["usage"])
+	exactTotals := asMap(t, totals["exact"])
+	estimatedTotals := asMap(t, totals["estimated"])
+	if exactTotals["input_tokens"] != float64(100) || estimatedTotals["input_tokens"] != float64(50) {
+		t.Fatalf("agent.usage exact/estimated totals = %#v", totals)
+	}
+	breakdown, ok := usage["breakdown"].([]any)
+	if !ok || len(breakdown) != 2 {
+		t.Fatalf("agent.usage breakdown = %#v", usage["breakdown"])
+	}
+	if first := asMap(t, breakdown[0]); first["usage_accounting"] != "exact" || first["invocation_type"] != "api" {
+		t.Fatalf("agent.usage first breakdown = %#v", first)
+	}
+	for _, forbidden := range []string{"token_usage", "run_id", "session_id", "turn_id"} {
+		if _, ok := usage[forbidden]; ok {
+			t.Fatalf("agent.usage exposed forbidden field %q: %#v", forbidden, usage)
 		}
 	}
 
@@ -658,6 +743,13 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 			wantApp: AgentNotFoundCode,
 		},
 		{
+			name:    "agent usage missing",
+			method:  "agent.usage",
+			body:    `{"jsonrpc":"2.0","id":"usage","method":"agent.usage","params":{"agent_id":"missing"}}`,
+			reads:   &fakeAgentConversationReadStore{agentUsageErr: store.ErrAgentNotFound},
+			wantApp: AgentNotFoundCode,
+		},
+		{
 			name:    "agent delivery diagnostics missing",
 			method:  "agent.delivery_diagnostics",
 			body:    `{"jsonrpc":"2.0","id":"agent-delivery-diagnostics","method":"agent.delivery_diagnostics","params":{"agent_id":"missing"}}`,
@@ -710,6 +802,38 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 				t.Fatalf("error code = %#v, want %s", data["code"], tc.wantApp)
 			}
 		})
+	}
+}
+
+func TestOperatorAgentUsageFailsClosedOnMalformedOwnerData(t *testing.T) {
+	reads := &fakeAgentConversationReadStore{
+		agentUsageResult: store.OperatorAgentUsage{
+			AgentID: "agent-1",
+			Usage: store.OperatorAgentUsageByAccounting{
+				Exact: store.OperatorAgentUsageTotals{},
+				Estimated: store.OperatorAgentUsageTotals{
+					LedgerEntries: -1,
+				},
+			},
+			Breakdown: []store.OperatorAgentUsageBreakdown{},
+		},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: reads,
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agent-usage","method":"agent.usage","params":{"agent_id":"agent-1"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.usage returned success for malformed owner result")
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d", resp.Error.Code, codeInternalError)
+	}
+	if !strings.Contains(fmt.Sprint(resp.Error.Message, resp.Error.Data), "agent.usage owner returned malformed result") {
+		t.Fatalf("error = %#v, want malformed owner result", resp.Error)
 	}
 }
 
@@ -964,6 +1088,21 @@ func TestOperatorAgentDiagnoseRejectsBadQueueCursor(t *testing.T) {
 		t.Fatal("agent.diagnose returned success for invalid queue_cursor")
 	}
 	assertReadOnlyProbeInvalidParams(t, "agent.diagnose", resp, "queue_cursor")
+}
+
+func TestOperatorAgentUsageRejectsInvalidWindow(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentConversations: &fakeAgentConversationReadStore{},
+		}),
+	})
+
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"probe-agent-usage","method":"agent.usage","params":{"agent_id":"agent-1","since":"2026-05-21T10:00:00Z","until":"2026-05-21T10:00:00Z"}}`)
+	if resp.Error == nil {
+		t.Fatal("agent.usage returned success for invalid window")
+	}
+	assertReadOnlyProbeInvalidParams(t, "agent.usage", resp, "until")
 }
 
 func TestOperatorAgentDeliveryDiagnosticsRejectsLimits(t *testing.T) {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -43,6 +43,7 @@ type AgentConversationReadStore interface {
 	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
 	LoadOperatorAgentDiagnosis(context.Context, string, store.OperatorAgentDiagnosisOptions) (store.OperatorAgentDiagnosis, error)
+	LoadOperatorAgentUsage(context.Context, string, store.OperatorAgentUsageOptions) (store.OperatorAgentUsage, error)
 	LoadOperatorAgentDeliveryDiagnostics(context.Context, string, store.OperatorAgentDeliveryDiagnosticsOptions) (store.OperatorAgentDeliveryDiagnostics, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
@@ -420,6 +421,31 @@ func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]Meth
 			}
 			return result, nil
 		},
+		"agent.usage": func(ctx context.Context, req Request) (any, error) {
+			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+			if err != nil {
+				return nil, err
+			}
+			agentID, err := requiredStringParam(req.Params, "agent_id")
+			if err != nil {
+				return nil, err
+			}
+			usageOpts, err := operatorAgentUsageOptionsFromParams(req.Params)
+			if err != nil {
+				return nil, err
+			}
+			result, err := reads.LoadOperatorAgentUsage(ctx, agentID, usageOpts)
+			if errors.Is(err, store.ErrAgentNotFound) {
+				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+			}
+			if err != nil {
+				return nil, err
+			}
+			if err := validateAgentUsageResult(result); err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
 		"agent.delivery_diagnostics": func(ctx context.Context, req Request) (any, error) {
 			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
 			if err != nil {
@@ -668,6 +694,58 @@ func validateAgentDeliveryDiagnosticsResult(item store.OperatorAgentDeliveryDiag
 		if err := validateAgentDeadLetterDeliveryResult(deadLetter, i); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateAgentUsageResult(item store.OperatorAgentUsage) error {
+	if strings.TrimSpace(item.AgentID) == "" {
+		return fmt.Errorf("agent.usage owner returned malformed result: agent_id is required")
+	}
+	if item.Window.Since != nil && item.Window.Until != nil && !item.Window.Since.Before(*item.Window.Until) {
+		return fmt.Errorf("agent.usage owner returned malformed result: window.until must be after window.since")
+	}
+	if err := validateAgentUsageTotals("usage.exact", item.Usage.Exact); err != nil {
+		return err
+	}
+	if err := validateAgentUsageTotals("usage.estimated", item.Usage.Estimated); err != nil {
+		return err
+	}
+	if item.Breakdown == nil {
+		return fmt.Errorf("agent.usage owner returned malformed result: breakdown must be an array")
+	}
+	for i, row := range item.Breakdown {
+		prefix := fmt.Sprintf("breakdown[%d]", i)
+		switch row.UsageAccounting {
+		case store.AgentUsageAccountingExact, store.AgentUsageAccountingEstimated:
+		default:
+			return fmt.Errorf("agent.usage owner returned malformed result: %s.usage_accounting=%q is invalid", prefix, row.UsageAccounting)
+		}
+		if strings.TrimSpace(row.InvocationType) == "" {
+			return fmt.Errorf("agent.usage owner returned malformed result: %s.invocation_type is required", prefix)
+		}
+		if strings.TrimSpace(row.Model) == "" {
+			return fmt.Errorf("agent.usage owner returned malformed result: %s.model is required", prefix)
+		}
+		if err := validateAgentUsageTotals(prefix+".totals", row.Totals); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAgentUsageTotals(path string, totals store.OperatorAgentUsageTotals) error {
+	if totals.LedgerEntries < 0 {
+		return fmt.Errorf("agent.usage owner returned malformed result: %s.ledger_entries must be non-negative", path)
+	}
+	if totals.InputTokens < 0 {
+		return fmt.Errorf("agent.usage owner returned malformed result: %s.input_tokens must be non-negative", path)
+	}
+	if totals.OutputTokens < 0 {
+		return fmt.Errorf("agent.usage owner returned malformed result: %s.output_tokens must be non-negative", path)
+	}
+	if totals.EstimatedCostUSD < 0 {
+		return fmt.Errorf("agent.usage owner returned malformed result: %s.estimated_cost_usd must be non-negative", path)
 	}
 	return nil
 }
@@ -1058,6 +1136,21 @@ func operatorAgentListOptionsFromParams(params map[string]any) (store.OperatorAg
 	}
 	if out.Role, _, err = optionalStringParam(params, "role"); err != nil {
 		return store.OperatorAgentListOptions{}, err
+	}
+	return out, nil
+}
+
+func operatorAgentUsageOptionsFromParams(params map[string]any) (store.OperatorAgentUsageOptions, error) {
+	out := store.OperatorAgentUsageOptions{}
+	var err error
+	if out.Since, err = timestampParam(params, "since"); err != nil {
+		return store.OperatorAgentUsageOptions{}, err
+	}
+	if out.Until, err = timestampParam(params, "until"); err != nil {
+		return store.OperatorAgentUsageOptions{}, err
+	}
+	if out.Since != nil && out.Until != nil && !out.Since.Before(*out.Until) {
+		return store.OperatorAgentUsageOptions{}, NewInvalidParamsError(map[string]any{"field": "until", "reason": "must be after since"})
 	}
 	return out, nil
 }

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -33,6 +33,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: agent.usage
+    transport: http
+    required_params: [agent_id]
+    declared_errors: [AGENT_NOT_FOUND]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersTypedErrors}]}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}, {kind: go_test, name: TestOperatorAgentUsageFailsClosedOnMalformedOwnerData}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: agent.delivery_diagnostics
     transport: http
     required_params: [agent_id]

--- a/internal/runtime/budget.go
+++ b/internal/runtime/budget.go
@@ -210,15 +210,16 @@ func (t *BudgetTracker) TerminalInstanceStates() []string {
 }
 
 type SpendRecord struct {
-	EntityID       string
-	FlowInstance   string
-	AgentID        string
-	Model          string
-	InputTokens    int
-	OutputTokens   int
-	CostUSD        float64
-	InvocationType string
-	RecordedAt     time.Time
+	EntityID        string
+	FlowInstance    string
+	AgentID         string
+	Model           string
+	InputTokens     int
+	OutputTokens    int
+	CostUSD         float64
+	InvocationType  string
+	UsageAccounting string
+	RecordedAt      time.Time
 }
 
 func (r SpendRecord) EffectiveEntityID() string {
@@ -245,6 +246,7 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 	rec.AgentID = strings.TrimSpace(rec.AgentID)
 	rec.Model = strings.TrimSpace(rec.Model)
 	rec.InvocationType = strings.TrimSpace(strings.ToLower(rec.InvocationType))
+	rec.UsageAccounting = strings.TrimSpace(strings.ToLower(rec.UsageAccounting))
 	if rec.FlowInstance == "" {
 		return fmt.Errorf("spend flow_instance is required")
 	}
@@ -256,6 +258,11 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 	}
 	if rec.InvocationType == "" {
 		return fmt.Errorf("spend invocation_type is required")
+	}
+	switch rec.UsageAccounting {
+	case string(llm.BudgetUsageExact), string(llm.BudgetUsageEstimated):
+	default:
+		return fmt.Errorf("spend usage_accounting must be exact or estimated")
 	}
 	if rec.InputTokens < 0 {
 		rec.InputTokens = 0
@@ -269,9 +276,9 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 
 	const q = `
 		INSERT INTO spend_ledger (
-			entity_id, flow_instance, agent_id, model, input_tokens, output_tokens, cost_usd, invocation_type, created_at
+			entity_id, flow_instance, agent_id, model, input_tokens, output_tokens, cost_usd, invocation_type, usage_accounting, created_at
 		) VALUES (
-			NULLIF($1,'')::uuid, $2, $3, $4, $5, $6, $7, $8, $9
+			NULLIF($1,'')::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10
 		)
 	`
 	if _, err := t.db.ExecContext(ctx, q,
@@ -283,6 +290,7 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 		rec.OutputTokens,
 		rec.CostUSD,
 		rec.InvocationType,
+		rec.UsageAccounting,
 		rec.RecordedAt,
 	); err != nil {
 		return fmt.Errorf("insert spend_ledger: %w", err)
@@ -322,6 +330,12 @@ func (t *BudgetTracker) RecordLLMUsage(ctx context.Context, entityID string, age
 		OutputTokens:   usage.OutputTokens,
 		CostUSD:        t.estimateLLMCostUSD(usage.Model, usage.InputTokens, usage.OutputTokens),
 		InvocationType: runtimeMode,
+		UsageAccounting: func() string {
+			if exact {
+				return string(llm.BudgetUsageExact)
+			}
+			return string(llm.BudgetUsageEstimated)
+		}(),
 	})
 }
 

--- a/internal/runtime/budget_test.go
+++ b/internal/runtime/budget_test.go
@@ -1,10 +1,13 @@
 package runtime
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -25,5 +28,42 @@ func TestBudgetTracker_KeepsTerminalStatesInstanceOwned(t *testing.T) {
 	}
 	if got, want := trackerB.TerminalInstanceStates(), []string{"closed"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("trackerB.TerminalInstanceStates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBudgetTracker_RecordLLMUsagePersistsUsageAccounting(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	tracker := &BudgetTracker{db: db}
+	ctx := context.Background()
+
+	mock.ExpectExec("INSERT INTO spend_ledger").
+		WithArgs("", "flow/1", "agent-1", "claude-3-5-sonnet", 11, 7, sqlmock.AnyArg(), "api", "exact", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := tracker.RecordLLMUsage(ctx, "", "agent-1", "api", llm.UsageTokens{
+		Model:        "claude-3-5-sonnet",
+		InputTokens:  11,
+		OutputTokens: 7,
+	}, true, map[string]any{"flow_instance": "flow/1"}); err != nil {
+		t.Fatalf("RecordLLMUsage exact: %v", err)
+	}
+
+	mock.ExpectExec("INSERT INTO spend_ledger").
+		WithArgs("", "flow/1", "agent-1", "claude-cli-sonnet", 13, 5, sqlmock.AnyArg(), "cli_test", "estimated", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := tracker.RecordLLMUsage(ctx, "", "agent-1", "cli_test", llm.UsageTokens{
+		Model:        "claude-cli-sonnet",
+		InputTokens:  13,
+		OutputTokens: 5,
+	}, false, map[string]any{"flow_instance": "flow/1"}); err != nil {
+		t.Fatalf("RecordLLMUsage estimated: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -312,6 +312,15 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 
 	resp := convertAnthropicResponse(parsed)
 	resp.Raw = rawResp
+	var usage UsageTokens
+	if r.budget != nil {
+		var ok bool
+		usage, ok = extractUsageTokensFromJSON(rawResp)
+		if !ok {
+			return nil, fmt.Errorf("anthropic response missing usage")
+		}
+		usage.Model = strings.TrimSpace(coalesce(usage.Model, reqBody.Model))
+	}
 
 	s.Messages = append(s.Messages, message, resp.Message)
 	s.TurnCount++
@@ -336,10 +345,9 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 
 	// Spend ledger: exact usage for API runtime when usage fields are present.
 	if r.budget != nil {
-		usage := extractUsageTokensFromJSON(rawResp)
-		usage.Model = strings.TrimSpace(coalesce(usage.Model, reqBody.Model))
 		if err := r.budget.RecordEntityLLMUsage(ctx, entityID, s.AgentID, "api", usage, true, map[string]any{
-			"session_id": s.ID,
+			"session_id":       s.ID,
+			"usage_accounting": string(BudgetUsageExact),
 		}); err != nil {
 			logPublisherRuntime(ctx, r.events, "warn", "record_api_llm_usage_failed", "Recording API LLM usage failed", s.AgentID, s.ID, entityID, nil, err)
 		}
@@ -604,23 +612,26 @@ type anthropicResponse struct {
 	} `json:"error"`
 }
 
-func extractUsageTokensFromJSON(raw []byte) UsageTokens {
+func extractUsageTokensFromJSON(raw []byte) (UsageTokens, bool) {
 	if len(raw) == 0 {
-		return UsageTokens{}
+		return UsageTokens{}, false
 	}
 	var obj struct {
 		Model string `json:"model"`
 		Usage struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
+			InputTokens  *int `json:"input_tokens"`
+			OutputTokens *int `json:"output_tokens"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(raw, &obj); err != nil {
-		return UsageTokens{}
+		return UsageTokens{}, false
+	}
+	if obj.Usage.InputTokens == nil || obj.Usage.OutputTokens == nil {
+		return UsageTokens{}, false
 	}
 	return UsageTokens{
-		InputTokens:  obj.Usage.InputTokens,
-		OutputTokens: obj.Usage.OutputTokens,
+		InputTokens:  *obj.Usage.InputTokens,
+		OutputTokens: *obj.Usage.OutputTokens,
 		Model:        obj.Model,
-	}
+	}, true
 }

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -156,6 +156,63 @@ func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
 	}
 }
 
+func TestAnthropicAPIRuntimeFailsClosedWhenUsageMissingForBudgetAccounting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"claude-3-5-sonnet","content":[{"type":"text","text":"done"}]}`))
+	}))
+	defer server.Close()
+
+	turns := &turnCapture{}
+	budget := &budgetCapture{}
+	runtime := NewAnthropicAPIRuntime(&config.Config{
+		LLM: config.LLMConfig{
+			ClaudeAPI: config.ClaudeAPIConfig{
+				DefaultModel: "claude-3-5-sonnet",
+				MaxRetries:   1,
+			},
+		},
+	}, sessions.NewInMemoryRegistry(time.Second), "worker-1", turns, nil, budget, nil)
+	runtime.apiURL = server.URL
+	runtime.apiKey = "test-key"
+
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	_, err = runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "missing usage") {
+		t.Fatalf("ContinueSession error = %v, want missing usage", err)
+	}
+	if len(turns.records) != 0 {
+		t.Fatalf("turn records = %#v, want no persisted successful turn", turns.records)
+	}
+	if budget.usage.InputTokens != 0 || budget.usage.OutputTokens != 0 {
+		t.Fatalf("budget usage = %#v, want no recorded usage", budget.usage)
+	}
+}
+
+func TestAnthropicUsageExtractionRequiresBothUsageFields(t *testing.T) {
+	usage, ok := extractUsageTokensFromJSON([]byte(`{"model":"claude-3-5-sonnet","usage":{"input_tokens":3,"output_tokens":4}}`))
+	if !ok {
+		t.Fatal("extractUsageTokensFromJSON returned ok=false for valid usage")
+	}
+	if usage.Model != "claude-3-5-sonnet" || usage.InputTokens != 3 || usage.OutputTokens != 4 {
+		t.Fatalf("usage = %#v, want model/input/output", usage)
+	}
+	for _, raw := range [][]byte{
+		nil,
+		[]byte(`{}`),
+		[]byte(`{"model":"claude","usage":{"input_tokens":1}}`),
+		[]byte(`not-json`),
+	} {
+		if got, ok := extractUsageTokensFromJSON(raw); ok {
+			t.Fatalf("extractUsageTokensFromJSON(%q) = %#v, true; want false", raw, got)
+		}
+	}
+}
+
 func TestOpenAICompatibleRuntimeFailsClosedWhenCredentialMissing(t *testing.T) {
 	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "")
 	requests := 0

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -609,6 +609,102 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOw
 	}
 }
 
+func TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated(t *testing.T) {
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-1",
+			Role:             "researcher",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"usage"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent agent-1: %v", err)
+	}
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-2",
+			Role:             "other",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"usage"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent agent-2: %v", err)
+	}
+
+	since := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	rows := []struct {
+		agentID         string
+		model           string
+		inputTokens     int
+		outputTokens    int
+		costUSD         string
+		invocationType  string
+		usageAccounting string
+		createdAt       time.Time
+	}{
+		{"agent-1", "claude-3-5-sonnet", 100, 25, "0.000675", "api", AgentUsageAccountingExact, since},
+		{"agent-1", "claude-cli-sonnet", 50, 10, "0.000300", "cli_test", AgentUsageAccountingEstimated, since.Add(time.Minute)},
+		{"agent-1", "claude-3-5-sonnet", 7, 3, "0.000010", "api", AgentUsageAccountingExact, until},
+		{"agent-2", "claude-3-5-sonnet", 999, 999, "1.000000", "api", AgentUsageAccountingExact, since.Add(time.Minute)},
+	}
+	for _, row := range rows {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO spend_ledger (
+				flow_instance, agent_id, model, input_tokens, output_tokens,
+				cost_usd, invocation_type, usage_accounting, created_at
+			) VALUES (
+				'flow/a', $1, $2, $3, $4, $5::numeric, $6, $7, $8
+			)
+		`, row.agentID, row.model, row.inputTokens, row.outputTokens, row.costUSD, row.invocationType, row.usageAccounting, row.createdAt); err != nil {
+			t.Fatalf("seed spend row %+v: %v", row, err)
+		}
+	}
+
+	result, err := pg.LoadOperatorAgentUsage(ctx, "agent-1", OperatorAgentUsageOptions{Since: &since, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentUsage: %v", err)
+	}
+	if result.AgentID != "agent-1" {
+		t.Fatalf("agent_id = %q", result.AgentID)
+	}
+	if result.Window.Since == nil || !result.Window.Since.Equal(since) || result.Window.Until == nil || !result.Window.Until.Equal(until) {
+		t.Fatalf("window = %#v", result.Window)
+	}
+	if result.Usage.Exact.LedgerEntries != 1 || result.Usage.Exact.InputTokens != 100 || result.Usage.Exact.OutputTokens != 25 {
+		t.Fatalf("exact usage = %#v", result.Usage.Exact)
+	}
+	if result.Usage.Estimated.LedgerEntries != 1 || result.Usage.Estimated.InputTokens != 50 || result.Usage.Estimated.OutputTokens != 10 {
+		t.Fatalf("estimated usage = %#v", result.Usage.Estimated)
+	}
+	if len(result.Breakdown) != 2 {
+		t.Fatalf("breakdown = %#v, want two rows", result.Breakdown)
+	}
+	if got := result.Breakdown[0]; got.UsageAccounting != AgentUsageAccountingExact || got.InvocationType != "api" || got.Model != "claude-3-5-sonnet" {
+		t.Fatalf("first breakdown = %#v", got)
+	}
+	if got := result.Breakdown[1]; got.UsageAccounting != AgentUsageAccountingEstimated || got.InvocationType != "cli_test" || got.Model != "claude-cli-sonnet" {
+		t.Fatalf("second breakdown = %#v", got)
+	}
+}
+
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsDoesNotRequireConversationOwners(t *testing.T) {
 	dsn, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/store/operator_agent_usage_read_surface.go
+++ b/internal/store/operator_agent_usage_read_surface.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	AgentUsageAccountingExact     = "exact"
+	AgentUsageAccountingEstimated = "estimated"
+)
+
+type OperatorAgentUsageOptions struct {
+	Since *time.Time
+	Until *time.Time
+}
+
+type OperatorAgentUsage struct {
+	AgentID   string                         `json:"agent_id"`
+	Window    OperatorAgentUsageWindow       `json:"window"`
+	Usage     OperatorAgentUsageByAccounting `json:"usage"`
+	Breakdown []OperatorAgentUsageBreakdown  `json:"breakdown"`
+}
+
+type OperatorAgentUsageWindow struct {
+	Since *time.Time `json:"since,omitempty"`
+	Until *time.Time `json:"until,omitempty"`
+}
+
+type OperatorAgentUsageByAccounting struct {
+	Exact     OperatorAgentUsageTotals `json:"exact"`
+	Estimated OperatorAgentUsageTotals `json:"estimated"`
+}
+
+type OperatorAgentUsageTotals struct {
+	LedgerEntries    int     `json:"ledger_entries"`
+	InputTokens      int64   `json:"input_tokens"`
+	OutputTokens     int64   `json:"output_tokens"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+}
+
+type OperatorAgentUsageBreakdown struct {
+	UsageAccounting string                   `json:"usage_accounting"`
+	InvocationType  string                   `json:"invocation_type"`
+	Model           string                   `json:"model"`
+	Totals          OperatorAgentUsageTotals `json:"totals"`
+}
+
+func (s *PostgresStore) LoadOperatorAgentUsage(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) (OperatorAgentUsage, error) {
+	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentUsage(ctx, agentID, opts)
+}
+
+func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentUsage(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) (OperatorAgentUsage, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return OperatorAgentUsage{}, ErrAgentNotFound
+	}
+	if err := validateOperatorAgentUsageWindow(opts); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	if err := r.requireAgentUsageCapabilities(ctx); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	if err := r.ensureAgentUsageAgentExists(ctx, agentID); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+
+	breakdown, err := r.loadAgentUsageBreakdown(ctx, agentID, opts)
+	if err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	result := OperatorAgentUsage{
+		AgentID:   agentID,
+		Window:    OperatorAgentUsageWindow{Since: copyTimePtr(opts.Since), Until: copyTimePtr(opts.Until)},
+		Breakdown: breakdown,
+	}
+	if result.Breakdown == nil {
+		result.Breakdown = []OperatorAgentUsageBreakdown{}
+	}
+	for _, row := range breakdown {
+		switch row.UsageAccounting {
+		case AgentUsageAccountingExact:
+			result.Usage.Exact = addOperatorAgentUsageTotals(result.Usage.Exact, row.Totals)
+		case AgentUsageAccountingEstimated:
+			result.Usage.Estimated = addOperatorAgentUsageTotals(result.Usage.Estimated, row.Totals)
+		default:
+			return OperatorAgentUsage{}, fmt.Errorf("agent usage read owner returned unsupported usage_accounting %q", row.UsageAccounting)
+		}
+	}
+	return result, nil
+}
+
+func validateOperatorAgentUsageWindow(opts OperatorAgentUsageOptions) error {
+	if opts.Since != nil && opts.Until != nil && !opts.Since.Before(*opts.Until) {
+		return fmt.Errorf("agent usage window requires since before until")
+	}
+	return nil
+}
+
+func copyTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := value.UTC()
+	return &copied
+}
+
+func addOperatorAgentUsageTotals(a, b OperatorAgentUsageTotals) OperatorAgentUsageTotals {
+	return OperatorAgentUsageTotals{
+		LedgerEntries:    a.LedgerEntries + b.LedgerEntries,
+		InputTokens:      a.InputTokens + b.InputTokens,
+		OutputTokens:     a.OutputTokens + b.OutputTokens,
+		EstimatedCostUSD: a.EstimatedCostUSD + b.EstimatedCostUSD,
+	}
+}
+
+func (r *OperatorAgentConversationReadSurface) requireAgentUsageCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("operator agent usage read owner requires postgres store")
+	}
+	caps, err := r.resolveConversationCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Agents != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agents", caps.Agents)
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, r.db)
+	if err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"agents": {
+			"agent_id", "status",
+		},
+		"spend_ledger": {
+			"agent_id", "model", "input_tokens", "output_tokens", "cost_usd",
+			"invocation_type", "usage_accounting", "created_at",
+		},
+	}
+	for table, columns := range required {
+		if !catalog.hasColumns(table, columns...) {
+			return fmt.Errorf("agent usage read owner requires canonical %s columns: %s", table, strings.Join(columns, ", "))
+		}
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) ensureAgentUsageAgentExists(ctx context.Context, agentID string) error {
+	var exists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM agents
+			WHERE agent_id = $1
+			  AND status NOT IN ('terminated', 'ephemeral')
+		)
+	`, agentID).Scan(&exists); err != nil {
+		return fmt.Errorf("load agent usage agent: %w", err)
+	}
+	if !exists {
+		return ErrAgentNotFound
+	}
+	return nil
+}
+
+func (r *OperatorAgentConversationReadSurface) loadAgentUsageBreakdown(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) ([]OperatorAgentUsageBreakdown, error) {
+	args := []any{agentID}
+	windowClause := strings.Builder{}
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		windowClause.WriteString(fmt.Sprintf("\n		  AND created_at >= $%d", len(args)))
+	}
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		windowClause.WriteString(fmt.Sprintf("\n		  AND created_at < $%d", len(args)))
+	}
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			usage_accounting,
+			invocation_type,
+			model,
+			COUNT(*)::int,
+			COALESCE(SUM(input_tokens), 0)::bigint,
+			COALESCE(SUM(output_tokens), 0)::bigint,
+			COALESCE(SUM(cost_usd), 0)::float8
+		FROM spend_ledger
+		WHERE agent_id = $1
+		  %s
+		GROUP BY usage_accounting, invocation_type, model
+		ORDER BY CASE usage_accounting WHEN 'exact' THEN 0 WHEN 'estimated' THEN 1 ELSE 2 END ASC, invocation_type ASC, model ASC
+	`, windowClause.String()), args...)
+	if err != nil {
+		return nil, fmt.Errorf("load agent usage breakdown: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OperatorAgentUsageBreakdown
+	for rows.Next() {
+		var row OperatorAgentUsageBreakdown
+		if err := rows.Scan(
+			&row.UsageAccounting,
+			&row.InvocationType,
+			&row.Model,
+			&row.Totals.LedgerEntries,
+			&row.Totals.InputTokens,
+			&row.Totals.OutputTokens,
+			&row.Totals.EstimatedCostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent usage breakdown: %w", err)
+		}
+		row.UsageAccounting = strings.TrimSpace(row.UsageAccounting)
+		row.InvocationType = strings.TrimSpace(row.InvocationType)
+		row.Model = strings.TrimSpace(row.Model)
+		if err := validateOperatorAgentUsageBreakdown(row); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read agent usage breakdown: %w", err)
+	}
+	return out, nil
+}
+
+func validateOperatorAgentUsageBreakdown(row OperatorAgentUsageBreakdown) error {
+	switch row.UsageAccounting {
+	case AgentUsageAccountingExact, AgentUsageAccountingEstimated:
+	default:
+		return fmt.Errorf("agent usage read owner returned unsupported usage_accounting %q", row.UsageAccounting)
+	}
+	if row.InvocationType == "" {
+		return fmt.Errorf("agent usage read owner returned empty invocation_type")
+	}
+	if row.Model == "" {
+		return fmt.Errorf("agent usage read owner returned empty model")
+	}
+	if row.Totals.LedgerEntries < 0 || row.Totals.InputTokens < 0 || row.Totals.OutputTokens < 0 || row.Totals.EstimatedCostUSD < 0 {
+		return fmt.Errorf("agent usage read owner returned negative totals")
+	}
+	return nil
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -224,6 +224,11 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return err
 		}
 	}
+	if catalog.hasTable("spend_ledger") && !catalog.hasColumns("spend_ledger", "usage_accounting") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE spend_ledger ADD COLUMN IF NOT EXISTS usage_accounting TEXT NOT NULL DEFAULT 'estimated' CHECK (usage_accounting IN ('exact', 'estimated'))`); err != nil {
+			return fmt.Errorf("ensure spend_ledger.usage_accounting column: %w", err)
+		}
+	}
 	if catalog.hasTable("dead_letters") {
 		for _, stmt := range []struct {
 			column string


### PR DESCRIPTION
## Summary

Closes #1112
Part of #852

Adds a separate read-only `agent.usage` owner for per-agent token/spend usage instead of widening `agent.diagnose`. The API aggregates retained `spend_ledger` rows by agent and optional `since`/`until` window, separates exact vs estimated accounting, and exposes estimated guardrail cost only.

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.agent.usage`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.AgentUsage`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#platform_tables.tables.spend_ledger`
- #1112 pre-audit and independent gate: separate read-only per-agent usage owner; keep `agent.diagnose` lean; no dashboard/CLI consumer in this slice.

## Semantic Migration

- New canonical owner: `agent.usage` over typed store read owner `LoadOperatorAgentUsage`, backed by `spend_ledger` facts.
- Old invalid path: handler-local SQL joins or adding token/spend fields to `agent.diagnose` remain non-authoritative.
- Persisted owner update: `spend_ledger.usage_accounting` records exact vs estimated usage; existing rows without prior evidence migrate conservatively to `estimated`.
- Production paths checked: API runtime records exact provider usage; CLI/runtime estimated usage remains estimated; Anthropic API now fails closed on absent/malformed provider usage when budget accounting is active; OpenAI-compatible missing usage remains fail-closed.
- Migration complete for the approved #1112 first slice. #852 remains open for dashboard consumers, token rollup presentation, richer read-owner fields, and other non-B tails.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec -count=1`
- `go test ./internal/apispec ./internal/apiv1 -run 'OpenRPC|AgentUsage|AgentConversation|RegistryMethodNames' -count=1`
- `go test ./internal/store -run 'AgentUsage|ConversationReadSurface|Schema|Spend' -count=1`
- `go test ./internal/runtime ./internal/runtime/llm -run 'BudgetTracker|Usage|OpenAICompatible|Anthropic' -count=1`
- `go test ./...`