### PR TITLE
[agent-c][issue #1016] Gate unavailable-bundle startup recovery

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -45,6 +45,7 @@ import (
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
+	runtimestartuprecovery "swarm/internal/runtime/startuprecovery"
 	runtimetools "swarm/internal/runtime/tools"
 	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
@@ -59,6 +60,7 @@ const (
 	serveMCPRoutes          = "/mcp /tools/"
 	serveReadinessRoutes    = "/healthz /readyz"
 	serveGatewayTokenBytes  = 32
+	serveExitDataIntegrity  = 78
 )
 
 var (
@@ -73,6 +75,36 @@ type serveWorkspaceLifecycle interface {
 	workspace.DevEntityContainerCleaner
 	runtimedestructivereset.ManagedContainerInventoryReader
 	runtimedestructivereset.ManagedContainerRuntime
+}
+
+type serveStartupRecoveryContainers struct {
+	lifecycle serveWorkspaceLifecycle
+}
+
+func (s serveStartupRecoveryContainers) ManagedContainers(ctx context.Context) ([]runtimestartuprecovery.ManagedContainer, error) {
+	if s.lifecycle == nil {
+		return nil, fmt.Errorf("workspace lifecycle is not configured")
+	}
+	refs, err := s.lifecycle.ManagedResetContainerInventory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]runtimestartuprecovery.ManagedContainer, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, runtimestartuprecovery.ManagedContainer{
+			Name:  strings.TrimSpace(ref.Name),
+			RunID: strings.TrimSpace(ref.RunID),
+			Kind:  strings.TrimSpace(ref.Kind),
+		})
+	}
+	return out, nil
+}
+
+func (s serveStartupRecoveryContainers) StopManagedContainer(ctx context.Context, name string) error {
+	if s.lifecycle == nil {
+		return fmt.Errorf("workspace lifecycle is not configured")
+	}
+	return s.lifecycle.StopManagedContainer(ctx, name)
 }
 
 type previousEnv struct {
@@ -242,14 +274,39 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		}
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
+	workspaces := configuredWorkspaceLifecycleForServe(stores.SQLDB, repo, contractsRoot, source)
+	if workspaces == nil {
+		slog.Error("workspace lifecycle is not configured")
+		return 1
+	}
+	if stores.Postgres != nil {
+		recovery, err := runtimestartuprecovery.Recover(ctx, runtimestartuprecovery.Request{
+			AvailabilityReader: stores.Postgres,
+			CleanupStore:       stores.Postgres,
+			Containers:         serveStartupRecoveryContainers{lifecycle: workspaces},
+			RequestedAt:        time.Now().UTC(),
+		})
+		if err != nil {
+			slog.Error("unavailable bundle startup recovery failed", "error", err)
+			if runtimestartuprecovery.IsDataIntegrityError(err) {
+				return serveExitDataIntegrity
+			}
+			return 3
+		}
+		if len(recovery.OrphanTargets) > 0 || len(recovery.StoppedContainers) > 0 {
+			log.Printf("unavailable bundle startup recovery complete: orphaned_runs=%d deliveries=%d sessions=%d timers=%d containers=%d pipeline_receipts=%d",
+				len(recovery.Cleanup.Runs),
+				len(recovery.Cleanup.Deliveries),
+				len(recovery.Cleanup.Sessions),
+				len(recovery.Cleanup.Timers),
+				len(recovery.StoppedContainers),
+				recovery.Cleanup.PipelineReceiptCount,
+			)
+		}
+	}
 	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, bootBundleIdentity.Fingerprint, opts.RequireBundleMatch); err != nil {
 		slog.Error("bundle match admission failed", "error", err)
 		return 3
-	}
-	workspaces := configuredWorkspaceLifecycleForServe(stores.SQLDB, repo, contractsRoot, source)
-	if opts.Dev && workspaces == nil {
-		slog.Error("dev entity cleanup owner unavailable", "error", "workspace lifecycle is not configured")
-		return 1
 	}
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
@@ -1687,7 +1744,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresStore, bootFingerprint string, requireMatch bool) error {
 	bootFingerprint = strings.TrimSpace(bootFingerprint)
 	if !requireMatch {
-		log.Printf("bundle match admission disabled by --no-require-bundle-match; active run bundle source state will not block startup")
+		log.Printf("legacy bundle match admission disabled by --no-require-bundle-match; startup recovery has already consumed active run bundle source state")
 		return nil
 	}
 	if bootFingerprint == "" {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -32,6 +32,7 @@ import (
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimemcp "swarm/internal/runtime/mcp"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/preservationcleanup"
 	runtimerunforkexecution "swarm/internal/runtime/runforkexecution"
 	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 	"swarm/internal/runtime/semanticview"
@@ -39,6 +40,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 	"swarm/internal/store"
 	storebackend "swarm/internal/store/backendselection"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
@@ -1937,6 +1939,309 @@ func TestServeBundleMatchAdmissionAllowsPersistedPresentAndDisabled(t *testing.T
 	}
 	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, false); err != nil {
 		t.Fatalf("enforceServeBundleMatchAdmission disabled: %v", err)
+	}
+}
+
+func TestRunServeRuntimeUnavailableBundleStartupRecoveryFailsPersistedMissingBeforeCleanup(t *testing.T) {
+	_, db, _ := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	persistedMissingRunID := uuid.NewString()
+	legacyRunID := uuid.NewString()
+	missingHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES
+			($1::uuid, 'running', $2, 'persisted', now()),
+			($3::uuid, 'running', NULL, 'legacy', now())
+	`, persistedMissingRunID, missingHash, legacyRunID); err != nil {
+		t.Fatalf("seed mixed active runs: %v", err)
+	}
+
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:         writeServeRuntimeTestConfig(t),
+		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code != serveExitDataIntegrity {
+		t.Fatalf("runServeRuntime code = %d, want %d\noutput:\n%s", code, serveExitDataIntegrity, out.String())
+	}
+	assertServeRuntimeRunStillActive(t, ctx, &store.PostgresStore{DB: db}, persistedMissingRunID)
+	assertServeRuntimeRunStillActive(t, ctx, &store.PostgresStore{DB: db}, legacyRunID)
+	if strings.Contains(out.String(), "ready") {
+		t.Fatalf("serve reached readiness despite persisted-missing startup recovery failure:\n%s", out.String())
+	}
+}
+
+func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailableRuns(t *testing.T) {
+	stoppedContainers := []string{}
+	_, db, _ := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{
+			managedContainers: []runtimedestructivereset.ContainerRef{
+				{Name: "swarm-legacy-agent", RunID: serveRuntimeLegacyRunIDForTest, Kind: "agent"},
+				{Name: "swarm-unrelated-agent", RunID: uuid.NewString(), Kind: "agent"},
+			},
+			stoppedContainers: &stoppedContainers,
+		}
+	})
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, conversation_mode)
+		VALUES ('agent-a', 'operator', 'default', 'task')
+	`); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	contractsRoot, err := normalizeContractsRoot(resolvePath(repoRoot(), filepath.Join("tests", "tier8-boot-verification", "test-boot-success")))
+	if err != nil {
+		t.Fatalf("contracts root: %v", err)
+	}
+	_, bundle, err := newSwarmWorkflowModule(repoRoot(), contractsRoot, resolvePath(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("load test workflow bundle: %v", err)
+	}
+	bootIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		t.Fatalf("boot bundle identity: %v", err)
+	}
+	persistedRunID := uuid.NewString()
+	persistedHash := "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: serve-test', '{}'::jsonb)
+	`, persistedHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES ($1::uuid, 'running', $2, 'persisted', now())
+	`, persistedRunID, persistedHash); err != nil {
+		t.Fatalf("seed persisted-present run: %v", err)
+	}
+
+	orphanTargets := []struct {
+		runID       string
+		source      string
+		cause       string
+		fingerprint string
+	}{
+		{runID: uuid.NewString(), source: storerunlifecycle.BundleSourceEphemeral, cause: preservationcleanup.BundleEphemeralOrphanedReason},
+		{runID: uuid.NewString(), source: storerunlifecycle.BundleSourceDeleted, cause: preservationcleanup.BundleDeletedOrphanedReason},
+		{runID: serveRuntimeLegacyRunIDForTest, source: storerunlifecycle.BundleSourceLegacy, cause: preservationcleanup.BundleLegacyOrphanedReason, fingerprint: bootIdentity.Fingerprint},
+	}
+	for _, target := range orphanTargets {
+		seedServeRuntimeUnavailableBundleRunState(t, ctx, db, target.runID, target.source, target.fingerprint)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	assertServeRuntimeRunStillActive(t, context.Background(), &store.PostgresStore{DB: db}, persistedRunID)
+	for _, target := range orphanTargets {
+		assertServeRuntimeUnavailableBundleRunOrphaned(t, context.Background(), &store.PostgresStore{DB: db}, target.runID, target.cause)
+	}
+	if len(stoppedContainers) != 1 || stoppedContainers[0] != "swarm-legacy-agent" {
+		t.Fatalf("stopped containers = %#v, want only legacy run container", stoppedContainers)
+	}
+}
+
+const serveRuntimeLegacyRunIDForTest = "11111111-2222-3333-4444-555555555555"
+
+func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+	t.Helper()
+	oldBuildStores := buildStoresForServe
+	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
+	dsn, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	runtimePG, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimePG.DB.Close() })
+	buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
+			return storeBundle{}, err
+		}
+		return storeBundle{
+			Postgres:           runtimePG,
+			SQLDB:              runtimePG.DB,
+			SchemaBootstrapper: runtimePG,
+			EventStore:         runtimePG,
+			SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
+			ConversationStore:  runtimePG,
+			ManagerStore:       runtimePG,
+			ScheduleStore:      runtimePG,
+			TurnStore:          runtimePG,
+		}, nil
+	}
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
+		return workspaceFactory()
+	}
+	t.Cleanup(func() {
+		buildStoresForServe = oldBuildStores
+		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
+	})
+	return dsn, db, runtimePG
+}
+
+func seedServeRuntimeUnavailableBundleRunState(t *testing.T, ctx context.Context, db *sql.DB, runID, source, fingerprint string) {
+	t.Helper()
+	sessionID := uuid.NewString()
+	timerID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_source, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', $2, NULLIF($3, ''), now())
+	`, runID, source, fingerprint); err != nil {
+		t.Fatalf("seed unavailable bundle run %s: %v", source, err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, 'global', '{}'::jsonb, 'test', 'agent', now()
+		)
+	`, eventID, runID, "startup."+source+".event"); err != nil {
+		t.Fatalf("seed event %s: %v", source, err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-a', 'in_progress', $3::uuid, 'agent_processing', now()
+		)
+	`, runID, eventID, sessionID); err != nil {
+		t.Fatalf("seed delivery %s: %v", source, err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (session_id, run_id, agent_id, scope_key, scope, runtime_mode, status)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $2::text, 'flow', 'session', 'active')
+	`, sessionID, runID); err != nil {
+		t.Fatalf("seed session %s: %v", source, err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (timer_id, timer_name, run_id, fire_event, fire_at, status)
+		VALUES ($1::uuid, $2, $3::uuid, 'timer.fired', now() + interval '1 hour', 'active')
+	`, timerID, "timer-"+source, runID); err != nil {
+		t.Fatalf("seed timer %s: %v", source, err)
+	}
+}
+
+func assertServeRuntimeRunStillActive(t *testing.T, ctx context.Context, pg *store.PostgresStore, runID string) {
+	t.Helper()
+	var status string
+	if err := pg.DB.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, runID).Scan(&status); err != nil {
+		t.Fatalf("load run %s: %v", runID, err)
+	}
+	if status != "running" {
+		t.Fatalf("run %s status = %s, want running", runID, status)
+	}
+	var controlRows int
+	if err := pg.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_control_state WHERE run_id = $1::uuid`, runID).Scan(&controlRows); err != nil {
+		t.Fatalf("count control rows %s: %v", runID, err)
+	}
+	if controlRows != 0 {
+		t.Fatalf("run %s control rows = %d, want none", runID, controlRows)
+	}
+}
+
+func assertServeRuntimeUnavailableBundleRunOrphaned(t *testing.T, ctx context.Context, pg *store.PostgresStore, runID, reason string) {
+	t.Helper()
+	var runStatus, errorSummary, controlStatus, controlReason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT r.status, COALESCE(r.error_summary, ''), rc.control_status, COALESCE(rc.reason, '')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = $1::uuid
+	`, runID).Scan(&runStatus, &errorSummary, &controlStatus, &controlReason); err != nil {
+		t.Fatalf("load orphaned run %s: %v", runID, err)
+	}
+	if runStatus != "cancelled" || errorSummary != reason || controlStatus != "stopped" || controlReason != reason {
+		t.Fatalf("orphaned run %s = %s/%s/%s/%s, want cancelled/%s/stopped/%s", runID, runStatus, errorSummary, controlStatus, controlReason, reason, reason)
+	}
+	var deadLetters int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND status = 'dead_letter'
+		  AND reason_code = $2
+		  AND active_session_id IS NULL
+	`, runID, reason).Scan(&deadLetters); err != nil {
+		t.Fatalf("count orphaned deliveries %s: %v", runID, err)
+	}
+	if deadLetters != 1 {
+		t.Fatalf("orphaned run %s dead-letter deliveries = %d, want 1", runID, deadLetters)
+	}
+	var receipts int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts er
+		JOIN events e ON e.event_id = er.event_id
+		WHERE e.run_id = $1::uuid
+		  AND er.outcome = 'dead_letter'
+		  AND er.reason_code = $2
+		  AND er.subscriber_id IN ('agent-a', 'pipeline')
+	`, runID, reason).Scan(&receipts); err != nil {
+		t.Fatalf("count orphaned receipts %s: %v", runID, err)
+	}
+	if receipts != 2 {
+		t.Fatalf("orphaned run %s receipts = %d, want agent and pipeline", runID, receipts)
+	}
+	var sessions int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_sessions
+		WHERE run_id = $1::uuid
+		  AND status = 'terminated'
+		  AND termination_reason = 'orphaned'
+		  AND termination_detail = $2
+	`, runID, reason).Scan(&sessions); err != nil {
+		t.Fatalf("count orphaned sessions %s: %v", runID, err)
+	}
+	if sessions != 1 {
+		t.Fatalf("orphaned run %s sessions = %d, want 1", runID, sessions)
+	}
+	var timers int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND status = 'cancelled'
+	`, runID).Scan(&timers); err != nil {
+		t.Fatalf("count orphaned timers %s: %v", runID, err)
+	}
+	if timers != 1 {
+		t.Fatalf("orphaned run %s timers = %d, want 1", runID, timers)
 	}
 }
 
@@ -4839,7 +5144,9 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 
 type serveRuntimeWorkspaceStub struct {
 	stubWorkspaceLifecycle
-	cleanup func(context.Context) (runtimedestructivereset.ContainerResetResult, error)
+	cleanup           func(context.Context) (runtimedestructivereset.ContainerResetResult, error)
+	managedContainers []runtimedestructivereset.ContainerRef
+	stoppedContainers *[]string
 }
 
 func (s serveRuntimeWorkspaceStub) CleanupDevEntityContainers(ctx context.Context) (runtimedestructivereset.ContainerResetResult, error) {
@@ -4849,15 +5156,18 @@ func (s serveRuntimeWorkspaceStub) CleanupDevEntityContainers(ctx context.Contex
 	return runtimedestructivereset.ContainerResetResult{}, nil
 }
 
-func (serveRuntimeWorkspaceStub) ManagedResetContainerInventory(context.Context) ([]runtimedestructivereset.ContainerRef, error) {
-	return nil, nil
+func (s serveRuntimeWorkspaceStub) ManagedResetContainerInventory(context.Context) ([]runtimedestructivereset.ContainerRef, error) {
+	return append([]runtimedestructivereset.ContainerRef(nil), s.managedContainers...), nil
 }
 
 func (serveRuntimeWorkspaceStub) InspectManagedContainer(context.Context, string) (runtimedestructivereset.ManagedContainerInspection, error) {
 	return runtimedestructivereset.ManagedContainerInspection{}, nil
 }
 
-func (serveRuntimeWorkspaceStub) StopManagedContainer(context.Context, string) error {
+func (s serveRuntimeWorkspaceStub) StopManagedContainer(_ context.Context, name string) error {
+	if s.stoppedContainers != nil {
+		*s.stoppedContainers = append(*s.stoppedContainers, name)
+	}
 	return nil
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5643,6 +5643,25 @@ multi_bundle_persistence:
         result_error: BUNDLE_UNAVAILABLE
         rationale: The server lacks authoritative bundle bytes for resume/fork after restart or deletion.
     active_restart_recovery:
+      startup_owner:
+        implemented_by:
+          - internal/runtime/startuprecovery
+          - internal/runtime/preservationcleanup
+          - internal/store.PostgresStore.ApplyUnavailableBundleStartupPreservationCleanup
+        ordering: >
+          Serve startup runs this owner after platform schema/state-store initialization and after
+          runtime_boot.active_run_abandon_quiescence, but before legacy bundle-match admission, runtime start,
+          API readiness, or late delivery recovery.
+        persisted_missing_rule: >
+          Any active run classified as BUNDLE_DATA_INTEGRITY_ERROR by the canonical run bundle availability owner
+          fails serve before cleanup/readiness. Mixed persisted-missing and orphanable active rows must not apply
+          partial preservation cleanup.
+        orphan_cleanup_scope: >
+          Active ephemeral, deleted, and legacy runs are cancelled with the bundle orphan reason in
+          runs.error_summary, run_control_state is stopped, pending/in-progress same-run agent/node deliveries are
+          dead-lettered with receipts, active/suspended agent sessions terminate with reason orphaned and the bundle
+          cause as detail, active run-scoped timers are cancelled, and run-scoped managed containers are stopped when
+          their managed identity proves the affected run_id.
       persisted_bundle_present: restart_may_resume_or_recover_the_run_under_runtime_recovery_owners
       persisted_bundle_missing: fail_serve_with_BUNDLE_DATA_INTEGRITY_ERROR_until_operator_repairs_data
       ephemeral_deleted_or_legacy: >

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -228,14 +228,14 @@ nodes:
     title: Multi-Bundle Preservation Cleanup Owner
     parent_class: multi-bundle source-authority and runtime lifecycle cleanup drift between destructive reset deletion and preservation-mode orphan/delete transitions
     canonical_owners:
-      - "issue #1012 / platform-spec.yaml multi-bundle source authority before runtime implementation"
-      - future internal/runtime/preservationcleanup owner for preserve-and-transition cleanup
+      - "platform-spec.yaml multi_bundle_persistence source authority and resume/recovery matrix"
+      - internal/runtime/preservationcleanup owner for preserve-and-transition cleanup cause/result semantics
       - internal/runtime/destructivereset remains the separate destructive reset owner for runtime.nuke only
     why_this_node_exists: multi-bundle unavailable-bundle cleanup must preserve historical run, event, delivery, session, timer, audit, and entity rows while transitioning their terminal state; reusing the existing destructive reset delete catalog would erase the audit identity the bundle lifecycle requires.
     known_manifestations:
       - "old #987 and #988 wording says to reuse destructivereset even though DefaultPlatformCleanupCatalog deletes run-scoped history rows"
-      - current master has no preservationcleanup owner and no merge-bearing platform-spec authority for bundle_source, bundles, bundle.delete, or bundle unavailable error codes
-      - "startup recovery auto-orphan (#1016) and bundle.delete --force Phase 3 (#1019) must consume one preservation cleanup owner rather than local per-consumer SQL"
+      - "source/schema/availability prerequisites are now merge-bearing; startup recovery auto-orphan (#1016) introduces the first runtime preservation cleanup owner consumer"
+      - "bundle.delete --force Phase 3 (#1019) must consume the preservation cleanup owner rather than local per-consumer SQL"
       - "bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner"
       - "server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern"
     representative_issues:
@@ -257,7 +257,7 @@ nodes:
         - add a destructivereset mode flag while preserving delete-path ownership
         - patch only startup auto-orphan or only bundle.delete --force instead of centralizing the shared preservation owner
         - transition one table without accounting for runs, run_control_state, deliveries, sessions, timers, events, audits, turns, entity_state, and entity_mutations
-    current_action_pressure: "source-authority and owner-boundary first slice under issue 1008; runtime implementation remains blocked until #1012 source authority lands or a later gate explicitly widens"
+    current_action_pressure: "#1016 startup-recovery child introduces the first runtime preservation cleanup owner consumer and closes the serve-startup recovery slice; parent preservation cleanup remains open/tracked by #1008/#1011 for #1019 bundle.delete --force, #1027 runtime.nuke, and explicitly split siblings"
   - id: boot_check_definition_drift
     title: Boot Check Definition Drift
     parent_class: semantic correctness drift between authoritative boot-check definitions and enforcement/proof surfaces

--- a/internal/runtime/preservationcleanup/types.go
+++ b/internal/runtime/preservationcleanup/types.go
@@ -1,0 +1,155 @@
+package preservationcleanup
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+const (
+	UnavailableBundleStartupOperationName = "swarm.serve.unavailable_bundle_startup_recovery"
+	UnavailableBundleStartupControlledBy  = UnavailableBundleStartupOperationName
+
+	BundleEphemeralOrphanedReason = "bundle_ephemeral_orphaned"
+	BundleDeletedOrphanedReason   = "bundle_deleted_orphaned"
+	BundleLegacyOrphanedReason    = "bundle_legacy_orphaned"
+
+	SessionTerminationReasonOrphaned = "orphaned"
+
+	DeliveryOutcomeDeadLetter = "dead_letter"
+	RunStatusCancelled        = "cancelled"
+	RunControlStatusStopped   = "stopped"
+	TimerStatusCancelled      = "cancelled"
+)
+
+type Request struct {
+	OperationName string
+	RequestedAt   time.Time
+	ControlledBy  string
+	Targets       []RunTarget
+}
+
+type RunTarget struct {
+	RunID             string
+	BundleSource      string
+	BundleHash        string
+	BundleFingerprint string
+	ReasonCode        string
+}
+
+type Result struct {
+	OperationName        string
+	AppliedAt            time.Time
+	ControlledBy         string
+	Runs                 []RunResult
+	Deliveries           []DeliveryResult
+	PipelineReceiptCount int
+	Sessions             []SessionResult
+	Timers               []TimerResult
+}
+
+type RunResult struct {
+	RunID          string
+	BundleSource   string
+	PreviousStatus string
+	Status         string
+	ReasonCode     string
+	Changed        bool
+}
+
+type DeliveryResult struct {
+	DeliveryID      string
+	RunID           string
+	EventID         string
+	SubscriberType  string
+	SubscriberID    string
+	PreviousStatus  string
+	Status          string
+	ReasonCode      string
+	PreviousReason  string
+	ActiveSessionID string
+	Changed         bool
+}
+
+type SessionResult struct {
+	SessionID      string
+	RunID          string
+	AgentID        string
+	PreviousStatus string
+	Status         string
+	ReasonCode     string
+	Changed        bool
+}
+
+type TimerResult struct {
+	TimerID        string
+	RunID          string
+	TimerName      string
+	PreviousStatus string
+	Status         string
+	ReasonCode     string
+	Changed        bool
+}
+
+func CauseForBundleSource(source string) (string, bool) {
+	switch strings.TrimSpace(source) {
+	case storerunlifecycle.BundleSourceEphemeral:
+		return BundleEphemeralOrphanedReason, true
+	case storerunlifecycle.BundleSourceDeleted:
+		return BundleDeletedOrphanedReason, true
+	case storerunlifecycle.BundleSourceLegacy:
+		return BundleLegacyOrphanedReason, true
+	default:
+		return "", false
+	}
+}
+
+func NormalizeRunTarget(target RunTarget) (RunTarget, error) {
+	target.RunID = strings.TrimSpace(target.RunID)
+	target.BundleHash = strings.TrimSpace(target.BundleHash)
+	target.BundleFingerprint = strings.TrimSpace(target.BundleFingerprint)
+	target.ReasonCode = strings.TrimSpace(target.ReasonCode)
+	source, err := storerunlifecycle.CanonicalBundleSource(target.BundleSource)
+	if err != nil {
+		return RunTarget{}, err
+	}
+	target.BundleSource = source
+	if target.RunID == "" {
+		return RunTarget{}, fmt.Errorf("preservation cleanup run_id is required")
+	}
+	if target.ReasonCode == "" {
+		cause, ok := CauseForBundleSource(source)
+		if !ok {
+			return RunTarget{}, fmt.Errorf("preservation cleanup unsupported bundle source %q", source)
+		}
+		target.ReasonCode = cause
+	}
+	return target, nil
+}
+
+func NormalizeTargets(targets []RunTarget) ([]RunTarget, error) {
+	seen := map[string]struct{}{}
+	out := make([]RunTarget, 0, len(targets))
+	for _, target := range targets {
+		normalized, err := NormalizeRunTarget(target)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[normalized.RunID]; ok {
+			continue
+		}
+		seen[normalized.RunID] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func TerminalReasonCodes() []string {
+	return []string{
+		BundleEphemeralOrphanedReason,
+		BundleDeletedOrphanedReason,
+		BundleLegacyOrphanedReason,
+	}
+}

--- a/internal/runtime/startuprecovery/recovery.go
+++ b/internal/runtime/startuprecovery/recovery.go
@@ -1,0 +1,163 @@
+package startuprecovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/runtime/preservationcleanup"
+	"swarm/internal/store/runbundle"
+)
+
+type AvailabilityReader interface {
+	ActiveRunBundleAvailabilities(context.Context) ([]runbundle.Availability, error)
+}
+
+type PreservationCleanupStore interface {
+	ApplyUnavailableBundleStartupPreservationCleanup(context.Context, preservationcleanup.Request) (preservationcleanup.Result, error)
+}
+
+type ManagedContainer struct {
+	Name  string
+	RunID string
+	Kind  string
+}
+
+type ManagedContainerOwner interface {
+	ManagedContainers(context.Context) ([]ManagedContainer, error)
+	StopManagedContainer(context.Context, string) error
+}
+
+type Request struct {
+	AvailabilityReader AvailabilityReader
+	CleanupStore       PreservationCleanupStore
+	Containers         ManagedContainerOwner
+	RequestedAt        time.Time
+}
+
+type Result struct {
+	CheckedAvailabilities []runbundle.Availability
+	DataIntegrityErrors   []runbundle.Availability
+	OrphanTargets         []preservationcleanup.RunTarget
+	StoppedContainers     []ManagedContainer
+	Cleanup               preservationcleanup.Result
+}
+
+type DataIntegrityError struct {
+	Conflicts []runbundle.Availability
+}
+
+func (e DataIntegrityError) Error() string {
+	details := make([]string, 0, len(e.Conflicts))
+	for _, conflict := range e.Conflicts {
+		details = append(details, conflict.DetailString())
+	}
+	return fmt.Sprintf("%s: persisted bundle data integrity failure for %d active run(s): %s", runbundle.CodeBundleDataIntegrityError, len(e.Conflicts), strings.Join(details, "; "))
+}
+
+func IsDataIntegrityError(err error) bool {
+	var target DataIntegrityError
+	return errors.As(err, &target)
+}
+
+func Recover(ctx context.Context, req Request) (Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if req.AvailabilityReader == nil {
+		return Result{}, fmt.Errorf("startup recovery availability reader is required")
+	}
+	at := req.RequestedAt.UTC()
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	availabilities, err := req.AvailabilityReader.ActiveRunBundleAvailabilities(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{CheckedAvailabilities: append([]runbundle.Availability(nil), availabilities...)}
+	for _, availability := range availabilities {
+		switch {
+		case availability.Available():
+			continue
+		case availability.DataIntegrityError():
+			result.DataIntegrityErrors = append(result.DataIntegrityErrors, availability)
+		case availability.Unavailable():
+			cause, ok := preservationcleanup.CauseForBundleSource(availability.BundleSource)
+			if !ok {
+				return result, fmt.Errorf("startup recovery unsupported unavailable bundle source %q for run %s", availability.BundleSource, availability.RunID)
+			}
+			result.OrphanTargets = append(result.OrphanTargets, preservationcleanup.RunTarget{
+				RunID:             availability.RunID,
+				BundleSource:      availability.BundleSource,
+				BundleHash:        availability.BundleHash,
+				BundleFingerprint: availability.BundleFingerprint,
+				ReasonCode:        cause,
+			})
+		default:
+			return result, fmt.Errorf("startup recovery unsupported bundle availability for run %s: %s", availability.RunID, availability.DetailString())
+		}
+	}
+	if len(result.DataIntegrityErrors) > 0 {
+		return result, DataIntegrityError{Conflicts: append([]runbundle.Availability(nil), result.DataIntegrityErrors...)}
+	}
+	if len(result.OrphanTargets) == 0 {
+		return result, nil
+	}
+	if req.Containers == nil {
+		return result, fmt.Errorf("startup recovery managed container owner is required for orphaned active runs")
+	}
+	stopped, err := stopRunScopedManagedContainers(ctx, req.Containers, result.OrphanTargets)
+	if err != nil {
+		return result, err
+	}
+	result.StoppedContainers = stopped
+
+	if req.CleanupStore == nil {
+		return result, fmt.Errorf("startup recovery preservation cleanup store is required")
+	}
+	cleanup, err := req.CleanupStore.ApplyUnavailableBundleStartupPreservationCleanup(ctx, preservationcleanup.Request{
+		OperationName: preservationcleanup.UnavailableBundleStartupOperationName,
+		RequestedAt:   at,
+		ControlledBy:  preservationcleanup.UnavailableBundleStartupControlledBy,
+		Targets:       result.OrphanTargets,
+	})
+	if err != nil {
+		return result, err
+	}
+	result.Cleanup = cleanup
+	return result, nil
+}
+
+func stopRunScopedManagedContainers(ctx context.Context, owner ManagedContainerOwner, targets []preservationcleanup.RunTarget) ([]ManagedContainer, error) {
+	runIDs := map[string]struct{}{}
+	for _, target := range targets {
+		if target.RunID != "" {
+			runIDs[target.RunID] = struct{}{}
+		}
+	}
+	containers, err := owner.ManagedContainers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("startup recovery inspect managed containers: %w", err)
+	}
+	stopped := []ManagedContainer{}
+	for _, container := range containers {
+		container.Name = strings.TrimSpace(container.Name)
+		container.RunID = strings.TrimSpace(container.RunID)
+		container.Kind = strings.TrimSpace(container.Kind)
+		if container.Name == "" || container.RunID == "" {
+			continue
+		}
+		if _, ok := runIDs[container.RunID]; !ok {
+			continue
+		}
+		if err := owner.StopManagedContainer(ctx, container.Name); err != nil {
+			return stopped, fmt.Errorf("startup recovery stop managed container %s for run %s: %w", container.Name, container.RunID, err)
+		}
+		stopped = append(stopped, container)
+	}
+	return stopped, nil
+}

--- a/internal/runtime/startuprecovery/recovery_test.go
+++ b/internal/runtime/startuprecovery/recovery_test.go
@@ -1,0 +1,138 @@
+package startuprecovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/runtime/preservationcleanup"
+	"swarm/internal/store/runbundle"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+func TestRecoverFailsPersistedMissingBeforeCleanupOrContainers(t *testing.T) {
+	reader := fakeAvailabilityReader{items: []runbundle.Availability{
+		{
+			RunID:        "11111111-1111-1111-1111-111111111111",
+			Status:       "running",
+			BundleSource: storerunlifecycle.BundleSourcePersisted,
+			BundleHash:   "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222",
+			ErrorCode:    runbundle.CodeBundleDataIntegrityError,
+			Cause:        "persisted_missing_bundle_row",
+		},
+		{
+			RunID:        "22222222-2222-2222-2222-222222222222",
+			Status:       "running",
+			BundleSource: storerunlifecycle.BundleSourceLegacy,
+			ErrorCode:    runbundle.CodeBundleUnavailable,
+			Cause:        storerunlifecycle.BundleSourceLegacy,
+		},
+	}}
+	cleanup := &fakeCleanupStore{}
+	containers := &fakeContainerOwner{items: []ManagedContainer{{Name: "swarm-agent", RunID: "22222222-2222-2222-2222-222222222222", Kind: "agent"}}}
+
+	result, err := Recover(context.Background(), Request{
+		AvailabilityReader: reader,
+		CleanupStore:       cleanup,
+		Containers:         containers,
+		RequestedAt:        time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC),
+	})
+	if err == nil || !IsDataIntegrityError(err) || !strings.Contains(err.Error(), runbundle.CodeBundleDataIntegrityError) {
+		t.Fatalf("Recover err = %v, want data integrity error", err)
+	}
+	if len(result.DataIntegrityErrors) != 1 || len(result.OrphanTargets) != 1 {
+		t.Fatalf("result = %#v, want classified data-integrity plus orphanable target", result)
+	}
+	if cleanup.called {
+		t.Fatal("cleanup store was called despite data-integrity failure")
+	}
+	if len(containers.stopped) != 0 {
+		t.Fatalf("stopped containers = %#v, want none before cleanup", containers.stopped)
+	}
+}
+
+func TestRecoverStopsRunScopedContainersThenAppliesPreservationCleanup(t *testing.T) {
+	runID := "22222222-2222-2222-2222-222222222222"
+	reader := fakeAvailabilityReader{items: []runbundle.Availability{
+		{
+			RunID:        runID,
+			Status:       "running",
+			BundleSource: storerunlifecycle.BundleSourceLegacy,
+			ErrorCode:    runbundle.CodeBundleUnavailable,
+			Cause:        storerunlifecycle.BundleSourceLegacy,
+		},
+		{
+			RunID:            "33333333-3333-3333-3333-333333333333",
+			Status:           "running",
+			BundleSource:     storerunlifecycle.BundleSourcePersisted,
+			BundleHash:       "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+			BundleRowPresent: true,
+		},
+	}}
+	cleanup := &fakeCleanupStore{}
+	containers := &fakeContainerOwner{items: []ManagedContainer{
+		{Name: "swarm-agent-selected", RunID: runID, Kind: "agent"},
+		{Name: "swarm-agent-other", RunID: "44444444-4444-4444-4444-444444444444", Kind: "agent"},
+	}}
+
+	result, err := Recover(context.Background(), Request{
+		AvailabilityReader: reader,
+		CleanupStore:       cleanup,
+		Containers:         containers,
+		RequestedAt:        time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(result.OrphanTargets) != 1 || result.OrphanTargets[0].RunID != runID || result.OrphanTargets[0].ReasonCode != preservationcleanup.BundleLegacyOrphanedReason {
+		t.Fatalf("orphan targets = %#v, want legacy run target", result.OrphanTargets)
+	}
+	if len(containers.stopped) != 1 || containers.stopped[0] != "swarm-agent-selected" {
+		t.Fatalf("stopped containers = %#v, want selected run-scoped container only", containers.stopped)
+	}
+	if !cleanup.called || len(cleanup.request.Targets) != 1 || cleanup.request.Targets[0].RunID != runID {
+		t.Fatalf("cleanup request = called:%v %#v, want selected run", cleanup.called, cleanup.request)
+	}
+}
+
+type fakeAvailabilityReader struct {
+	items []runbundle.Availability
+	err   error
+}
+
+func (r fakeAvailabilityReader) ActiveRunBundleAvailabilities(context.Context) ([]runbundle.Availability, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return append([]runbundle.Availability(nil), r.items...), nil
+}
+
+type fakeCleanupStore struct {
+	called  bool
+	request preservationcleanup.Request
+}
+
+func (s *fakeCleanupStore) ApplyUnavailableBundleStartupPreservationCleanup(_ context.Context, req preservationcleanup.Request) (preservationcleanup.Result, error) {
+	s.called = true
+	s.request = req
+	return preservationcleanup.Result{
+		OperationName: req.OperationName,
+		AppliedAt:     req.RequestedAt,
+		ControlledBy:  req.ControlledBy,
+	}, nil
+}
+
+type fakeContainerOwner struct {
+	items   []ManagedContainer
+	stopped []string
+}
+
+func (o *fakeContainerOwner) ManagedContainers(context.Context) ([]ManagedContainer, error) {
+	return append([]ManagedContainer(nil), o.items...), nil
+}
+
+func (o *fakeContainerOwner) StopManagedContainer(_ context.Context, name string) error {
+	o.stopped = append(o.stopped, name)
+	return nil
+}

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lib/pq"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/preservationcleanup"
 	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
@@ -431,8 +432,10 @@ func activeRunQuiescenceDeliveryTerminal(status, reasonCode string) bool {
 }
 
 func activeRunQuiescenceTerminalReasonCodes() []string {
-	return []string{
+	out := []string{
 		runtimedestructivereset.QuiescenceReasonCode,
 		runtimerunquiescence.ServeAbandonReasonCode,
 	}
+	out = append(out, preservationcleanup.TerminalReasonCodes()...)
+	return out
 }

--- a/internal/store/preservation_cleanup.go
+++ b/internal/store/preservation_cleanup.go
@@ -1,0 +1,420 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"swarm/internal/runtime/preservationcleanup"
+)
+
+type preservationCleanupRunTarget struct {
+	RunID        string
+	Status       string
+	BundleSource string
+}
+
+type preservationCleanupSessionTarget struct {
+	SessionID string
+	RunID     string
+	AgentID   string
+	Status    string
+}
+
+type preservationCleanupTimerTarget struct {
+	TimerID   string
+	RunID     string
+	TimerName string
+	Status    string
+}
+
+func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx context.Context, req preservationcleanup.Request) (preservationcleanup.Result, error) {
+	if s == nil || s.DB == nil {
+		return preservationcleanup.Result{}, fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	if err := requirePreservationCleanupCapabilities(caps); err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	now := req.RequestedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	operationName := strings.TrimSpace(req.OperationName)
+	if operationName == "" {
+		operationName = preservationcleanup.UnavailableBundleStartupOperationName
+	}
+	controlledBy := strings.TrimSpace(req.ControlledBy)
+	if controlledBy == "" {
+		controlledBy = operationName
+	}
+	targets, err := preservationcleanup.NormalizeTargets(req.Targets)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	out := preservationcleanup.Result{
+		OperationName: operationName,
+		AppliedAt:     now,
+		ControlledBy:  controlledBy,
+	}
+	if len(targets) == 0 {
+		return out, nil
+	}
+	targetByRun := make(map[string]preservationcleanup.RunTarget, len(targets))
+	runIDs := make([]string, 0, len(targets))
+	for _, target := range targets {
+		targetByRun[target.RunID] = target
+		runIDs = append(runIDs, target.RunID)
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return preservationcleanup.Result{}, fmt.Errorf("begin unavailable bundle preservation cleanup tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	runs, err := lockUnavailableBundlePreservationRunsTx(ctx, tx, runIDs)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	activeRunIDs := make([]string, 0, len(runs))
+	for _, run := range runs {
+		target, ok := targetByRun[run.RunID]
+		if !ok {
+			return preservationcleanup.Result{}, fmt.Errorf("preservation cleanup locked unexpected run %s", run.RunID)
+		}
+		if run.BundleSource != target.BundleSource {
+			return preservationcleanup.Result{}, fmt.Errorf("preservation cleanup source changed for run %s: got %s want %s", run.RunID, run.BundleSource, target.BundleSource)
+		}
+		activeRunIDs = append(activeRunIDs, run.RunID)
+		out.Runs = append(out.Runs, preservationcleanup.RunResult{
+			RunID:          run.RunID,
+			BundleSource:   run.BundleSource,
+			PreviousStatus: run.Status,
+			Status:         preservationcleanup.RunStatusCancelled,
+			ReasonCode:     target.ReasonCode,
+			Changed:        activeRunQuiescenceRunStatusActive(run.Status),
+		})
+	}
+	if len(activeRunIDs) == 0 {
+		if err := tx.Commit(); err != nil {
+			return preservationcleanup.Result{}, fmt.Errorf("commit empty unavailable bundle preservation cleanup tx: %w", err)
+		}
+		committed = true
+		return out, nil
+	}
+
+	deliveries, err := lockUnavailableBundlePreservationDeliveriesTx(ctx, tx, activeRunIDs)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	for _, delivery := range deliveries {
+		target := targetByRun[delivery.RunID]
+		out.Deliveries = append(out.Deliveries, preservationcleanup.DeliveryResult{
+			DeliveryID:      delivery.DeliveryID,
+			RunID:           delivery.RunID,
+			EventID:         delivery.EventID,
+			SubscriberType:  delivery.SubscriberType,
+			SubscriberID:    delivery.SubscriberID,
+			PreviousStatus:  delivery.Status,
+			Status:          preservationcleanup.DeliveryOutcomeDeadLetter,
+			ReasonCode:      target.ReasonCode,
+			PreviousReason:  delivery.ReasonCode,
+			ActiveSessionID: delivery.ActiveSessionID,
+			Changed:         delivery.Status != preservationcleanup.DeliveryOutcomeDeadLetter || delivery.ReasonCode != target.ReasonCode,
+		})
+	}
+	sessions, err := lockUnavailableBundlePreservationSessionsTx(ctx, tx, activeRunIDs)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	for _, session := range sessions {
+		target := targetByRun[session.RunID]
+		out.Sessions = append(out.Sessions, preservationcleanup.SessionResult{
+			SessionID:      session.SessionID,
+			RunID:          session.RunID,
+			AgentID:        session.AgentID,
+			PreviousStatus: session.Status,
+			Status:         "terminated",
+			ReasonCode:     target.ReasonCode,
+			Changed:        session.Status != "terminated",
+		})
+	}
+	timers, err := lockUnavailableBundlePreservationTimersTx(ctx, tx, activeRunIDs)
+	if err != nil {
+		return preservationcleanup.Result{}, err
+	}
+	for _, timer := range timers {
+		target := targetByRun[timer.RunID]
+		out.Timers = append(out.Timers, preservationcleanup.TimerResult{
+			TimerID:        timer.TimerID,
+			RunID:          timer.RunID,
+			TimerName:      timer.TimerName,
+			PreviousStatus: timer.Status,
+			Status:         preservationcleanup.TimerStatusCancelled,
+			ReasonCode:     target.ReasonCode,
+			Changed:        timer.Status != preservationcleanup.TimerStatusCancelled,
+		})
+	}
+
+	eventReasons := map[string]string{}
+	for _, delivery := range deliveries {
+		target := targetByRun[delivery.RunID]
+		if err := terminalizeActiveRunQuiescenceDeliveryTx(ctx, tx, delivery, target.ReasonCode, target.ReasonCode, now); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+		if delivery.EventID != "" {
+			eventReasons[delivery.EventID] = target.ReasonCode
+		}
+	}
+	for eventID, reason := range eventReasons {
+		if err := upsertActiveRunQuiescencePipelineReceiptTx(ctx, tx, eventID, reason, reason, now); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+		out.PipelineReceiptCount++
+	}
+	for _, session := range sessions {
+		target := targetByRun[session.RunID]
+		if err := terminateUnavailableBundlePreservationSessionTx(ctx, tx, session.SessionID, target.ReasonCode, now); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+	}
+	for _, timer := range timers {
+		if err := cancelUnavailableBundlePreservationTimerTx(ctx, tx, timer.TimerID); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+	}
+	for _, run := range runs {
+		target := targetByRun[run.RunID]
+		if err := markUnavailableBundlePreservationRunTx(ctx, tx, run.RunID, target.ReasonCode, now); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+		if err := upsertActiveRunQuiescenceRunControlTx(ctx, tx, run.RunID, target.ReasonCode, controlledBy, now); err != nil {
+			return preservationcleanup.Result{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return preservationcleanup.Result{}, fmt.Errorf("commit unavailable bundle preservation cleanup tx: %w", err)
+	}
+	committed = true
+	return out, nil
+}
+
+func requirePreservationCleanupCapabilities(caps StoreSchemaCapabilities) error {
+	if !caps.Events.HasRuns || !caps.Events.RunTerminalFields || !caps.Events.RunBundleSource {
+		return fmt.Errorf("unavailable bundle preservation cleanup requires runs terminal fields and bundle_source")
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		if caps.Events.Deliveries != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+		}
+		return fmt.Errorf("unavailable bundle preservation cleanup requires canonical event_deliveries.run_id")
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	}
+	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
+		if caps.Conversations.Sessions != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
+		}
+		return fmt.Errorf("unavailable bundle preservation cleanup requires canonical agent_sessions.run_id")
+	}
+	if caps.Schedules != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("timers/schedules", caps.Schedules)
+	}
+	return nil
+}
+
+func lockUnavailableBundlePreservationRunsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]preservationCleanupRunTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id::text, COALESCE(status, ''), COALESCE(bundle_source, '')
+		FROM runs
+		WHERE run_id = ANY($1::uuid[])
+		  AND lower(COALESCE(status, '')) IN ('running', 'paused')
+		ORDER BY run_id::text
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock unavailable bundle preservation runs: %w", err)
+	}
+	defer rows.Close()
+	var out []preservationCleanupRunTarget
+	for rows.Next() {
+		var item preservationCleanupRunTarget
+		if err := rows.Scan(&item.RunID, &item.Status, &item.BundleSource); err != nil {
+			return nil, fmt.Errorf("scan unavailable bundle preservation run: %w", err)
+		}
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.Status = strings.TrimSpace(item.Status)
+		item.BundleSource = strings.TrimSpace(item.BundleSource)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read unavailable bundle preservation runs: %w", err)
+	}
+	return out, nil
+}
+
+func lockUnavailableBundlePreservationDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]activeRunQuiescenceDeliveryTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			d.delivery_id::text,
+			d.run_id::text,
+			d.event_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id::text, '')
+		FROM event_deliveries d
+		WHERE d.run_id = ANY($1::uuid[])
+		  AND d.subscriber_type IN ('agent', 'node')
+		  AND d.status IN ('pending', 'in_progress')
+		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock unavailable bundle preservation deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []activeRunQuiescenceDeliveryTarget
+	for rows.Next() {
+		var item activeRunQuiescenceDeliveryTarget
+		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.ActiveSessionID); err != nil {
+			return nil, fmt.Errorf("scan unavailable bundle preservation delivery: %w", err)
+		}
+		item.DeliveryID = strings.TrimSpace(item.DeliveryID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.EventID = strings.TrimSpace(item.EventID)
+		item.SubscriberType = strings.TrimSpace(item.SubscriberType)
+		item.SubscriberID = strings.TrimSpace(item.SubscriberID)
+		item.Status = strings.TrimSpace(item.Status)
+		item.ReasonCode = strings.TrimSpace(item.ReasonCode)
+		item.ActiveSessionID = strings.TrimSpace(item.ActiveSessionID)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read unavailable bundle preservation deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func lockUnavailableBundlePreservationSessionsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]preservationCleanupSessionTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT session_id::text, run_id::text, COALESCE(agent_id, ''), COALESCE(status, '')
+		FROM agent_sessions
+		WHERE run_id = ANY($1::uuid[])
+		  AND status IN ('active', 'suspended')
+		ORDER BY run_id::text, agent_id, session_id::text
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock unavailable bundle preservation sessions: %w", err)
+	}
+	defer rows.Close()
+	var out []preservationCleanupSessionTarget
+	for rows.Next() {
+		var item preservationCleanupSessionTarget
+		if err := rows.Scan(&item.SessionID, &item.RunID, &item.AgentID, &item.Status); err != nil {
+			return nil, fmt.Errorf("scan unavailable bundle preservation session: %w", err)
+		}
+		item.SessionID = strings.TrimSpace(item.SessionID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.AgentID = strings.TrimSpace(item.AgentID)
+		item.Status = strings.TrimSpace(item.Status)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read unavailable bundle preservation sessions: %w", err)
+	}
+	return out, nil
+}
+
+func lockUnavailableBundlePreservationTimersTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]preservationCleanupTimerTarget, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT timer_id::text, run_id::text, COALESCE(timer_name, ''), COALESCE(status, '')
+		FROM timers
+		WHERE run_id = ANY($1::uuid[])
+		  AND status = 'active'
+		ORDER BY run_id::text, timer_name, timer_id::text
+		FOR UPDATE
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("lock unavailable bundle preservation timers: %w", err)
+	}
+	defer rows.Close()
+	var out []preservationCleanupTimerTarget
+	for rows.Next() {
+		var item preservationCleanupTimerTarget
+		if err := rows.Scan(&item.TimerID, &item.RunID, &item.TimerName, &item.Status); err != nil {
+			return nil, fmt.Errorf("scan unavailable bundle preservation timer: %w", err)
+		}
+		item.TimerID = strings.TrimSpace(item.TimerID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.TimerName = strings.TrimSpace(item.TimerName)
+		item.Status = strings.TrimSpace(item.Status)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read unavailable bundle preservation timers: %w", err)
+	}
+	return out, nil
+}
+
+func terminateUnavailableBundlePreservationSessionTx(ctx context.Context, tx *sql.Tx, sessionID, reasonCode string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET
+			status = 'terminated',
+			termination_reason = $2,
+			termination_detail = $3,
+			successor_session_id = NULL,
+			terminated_at = COALESCE(terminated_at, $4),
+			lease_holder = NULL,
+			lease_expires_at = NULL,
+			updated_at = $4
+		WHERE session_id = $1::uuid
+		  AND status IN ('active', 'suspended')
+	`, sessionID, preservationcleanup.SessionTerminationReasonOrphaned, reasonCode, at.UTC()); err != nil {
+		return fmt.Errorf("terminate unavailable bundle preservation session %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+func cancelUnavailableBundlePreservationTimerTx(ctx context.Context, tx *sql.Tx, timerID string) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE timers
+		SET status = 'cancelled'
+		WHERE timer_id = $1::uuid
+		  AND status = 'active'
+	`, timerID); err != nil {
+		return fmt.Errorf("cancel unavailable bundle preservation timer %s: %w", timerID, err)
+	}
+	return nil
+}
+
+func markUnavailableBundlePreservationRunTx(ctx context.Context, tx *sql.Tx, runID, reasonCode string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET
+			status = 'cancelled',
+			error_summary = $2,
+			ended_at = COALESCE(ended_at, $3)
+		WHERE run_id = $1::uuid
+		  AND lower(COALESCE(status, '')) IN ('running', 'paused')
+	`, runID, reasonCode, at.UTC()); err != nil {
+		return fmt.Errorf("mark unavailable bundle preservation run %s: %w", runID, err)
+	}
+	return nil
+}

--- a/internal/store/preservation_cleanup_test.go
+++ b/internal/store/preservation_cleanup_test.go
@@ -1,0 +1,236 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/runtime/preservationcleanup"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_ApplyUnavailableBundleStartupPreservationCleanup_OrphansRunScopedState(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 27, 9, 30, 0, 0, time.UTC)
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model_tier, conversation_mode)
+		VALUES ('agent-a', 'operator', 'default', 'session')
+	`); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+
+	targets := []preservationcleanup.RunTarget{}
+	byRun := map[string]preservationcleanup.RunTarget{}
+	type seededRun struct {
+		runID       string
+		eventID     string
+		untouchedID string
+		sessionID   string
+		timerID     string
+	}
+	seeded := map[string]seededRun{}
+	for _, source := range []string{
+		storerunlifecycle.BundleSourceEphemeral,
+		storerunlifecycle.BundleSourceDeleted,
+		storerunlifecycle.BundleSourceLegacy,
+	} {
+		runID := uuid.NewString()
+		sessionID := uuid.NewString()
+		timerID := uuid.NewString()
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO runs (run_id, status, bundle_source, bundle_fingerprint, started_at)
+			VALUES ($1::uuid, 'running', $2, $3, now())
+			ON CONFLICT (run_id) DO UPDATE SET
+				status = 'running',
+				bundle_source = EXCLUDED.bundle_source,
+				bundle_fingerprint = EXCLUDED.bundle_fingerprint
+		`, runID, source, testBootBundleFingerprint); err != nil {
+			t.Fatalf("seed run %s: %v", source, err)
+		}
+		eventID := seedDestructiveResetEvent(t, ctx, pg, runID, "startup."+source+".pending")
+		untouchedID := seedDestructiveResetEvent(t, ctx, pg, runID, "startup."+source+".failed")
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'agent', 'agent-a', 'in_progress', $3::uuid, 'agent_processing', now()
+			)
+		`, runID, eventID, sessionID); err != nil {
+			t.Fatalf("seed active delivery %s: %v", source, err)
+		}
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at, delivered_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'agent', 'agent-a', 'failed', 1, 'agent_retryable_error', now(), now()
+			)
+		`, runID, untouchedID); err != nil {
+			t.Fatalf("seed retryable failed delivery %s: %v", source, err)
+		}
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO agent_sessions (session_id, run_id, agent_id, scope_key, scope, runtime_mode, status)
+			VALUES ($1::uuid, $2::uuid, 'agent-a', $2::text, 'flow', 'session', 'active')
+		`, sessionID, runID); err != nil {
+			t.Fatalf("seed session %s: %v", source, err)
+		}
+		if _, err := pg.DB.ExecContext(ctx, `
+			INSERT INTO timers (timer_id, timer_name, run_id, fire_event, fire_at, status)
+			VALUES ($1::uuid, $2, $3::uuid, 'timer.fired', now() + interval '1 hour', 'active')
+		`, timerID, "timer-"+source, runID); err != nil {
+			t.Fatalf("seed timer %s: %v", source, err)
+		}
+		cause, ok := preservationcleanup.CauseForBundleSource(source)
+		if !ok {
+			t.Fatalf("missing cause for source %s", source)
+		}
+		target := preservationcleanup.RunTarget{RunID: runID, BundleSource: source, BundleFingerprint: testBootBundleFingerprint, ReasonCode: cause}
+		targets = append(targets, target)
+		byRun[runID] = target
+		seeded[source] = seededRun{runID: runID, eventID: eventID, untouchedID: untouchedID, sessionID: sessionID, timerID: timerID}
+	}
+
+	result, err := pg.ApplyUnavailableBundleStartupPreservationCleanup(ctx, preservationcleanup.Request{
+		OperationName: preservationcleanup.UnavailableBundleStartupOperationName,
+		RequestedAt:   now,
+		ControlledBy:  preservationcleanup.UnavailableBundleStartupControlledBy,
+		Targets:       targets,
+	})
+	if err != nil {
+		t.Fatalf("ApplyUnavailableBundleStartupPreservationCleanup: %v", err)
+	}
+	if len(result.Runs) != 3 || len(result.Deliveries) != 3 || len(result.Sessions) != 3 || len(result.Timers) != 3 || result.PipelineReceiptCount != 3 {
+		t.Fatalf("cleanup result = runs:%d deliveries:%d sessions:%d timers:%d pipeline:%d, want 3 each", len(result.Runs), len(result.Deliveries), len(result.Sessions), len(result.Timers), result.PipelineReceiptCount)
+	}
+
+	for source, item := range seeded {
+		target := byRun[item.runID]
+		assertUnavailableBundlePreservationRun(t, ctx, pg, item.runID, source, target.ReasonCode)
+		assertUnavailableBundlePreservationDelivery(t, ctx, pg, item.eventID, target.ReasonCode)
+		assertUnavailableBundlePreservationReceipt(t, ctx, pg, item.eventID, "agent-a", target.ReasonCode)
+		assertUnavailableBundlePreservationReceipt(t, ctx, pg, item.eventID, activeRunQuiescencePipelineSubscriberID, target.ReasonCode)
+		assertUnavailableBundlePreservationSession(t, ctx, pg, item.sessionID, target.ReasonCode)
+		assertUnavailableBundlePreservationTimer(t, ctx, pg, item.timerID)
+		assertUnavailableBundlePreservationFailedDeliveryUntouched(t, ctx, pg, item.untouchedID)
+	}
+	var eventCount int
+	if err := pg.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&eventCount); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if eventCount != 6 {
+		t.Fatalf("events count = %d, want 6 preserved rows", eventCount)
+	}
+}
+
+func assertUnavailableBundlePreservationRun(t *testing.T, ctx context.Context, pg *PostgresStore, runID, wantSource, wantReason string) {
+	t.Helper()
+	var status, source, errorSummary, controlStatus, controlReason, controlledBy string
+	var endedAt sql.NullTime
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT
+			r.status,
+			r.bundle_source,
+			COALESCE(r.error_summary, ''),
+			r.ended_at,
+			rc.control_status,
+			COALESCE(rc.reason, ''),
+			COALESCE(rc.controlled_by, '')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = $1::uuid
+	`, runID).Scan(&status, &source, &errorSummary, &endedAt, &controlStatus, &controlReason, &controlledBy); err != nil {
+		t.Fatalf("load run/control %s: %v", runID, err)
+	}
+	if status != "cancelled" || source != wantSource || errorSummary != wantReason || !endedAt.Valid {
+		t.Fatalf("run %s = status:%s source:%s error:%s ended:%v, want cancelled/%s/%s/ended", runID, status, source, errorSummary, endedAt.Valid, wantSource, wantReason)
+	}
+	if controlStatus != "stopped" || controlReason != wantReason || controlledBy != preservationcleanup.UnavailableBundleStartupControlledBy {
+		t.Fatalf("run control %s = %s/%s/%s, want stopped/%s/%s", runID, controlStatus, controlReason, controlledBy, wantReason, preservationcleanup.UnavailableBundleStartupControlledBy)
+	}
+}
+
+func assertUnavailableBundlePreservationDelivery(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, wantReason string) {
+	t.Helper()
+	var status, reason string
+	var activeSession sql.NullString
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), active_session_id::text
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-a'
+	`, eventID).Scan(&status, &reason, &activeSession); err != nil {
+		t.Fatalf("load delivery %s: %v", eventID, err)
+	}
+	if status != "dead_letter" || reason != wantReason || activeSession.Valid {
+		t.Fatalf("delivery %s = %s/%s active=%v, want dead_letter/%s/no active session", eventID, status, reason, activeSession.Valid, wantReason)
+	}
+}
+
+func assertUnavailableBundlePreservationReceipt(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, subscriberID, wantReason string) {
+	t.Helper()
+	var outcome, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = $2
+	`, eventID, subscriberID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load receipt %s/%s: %v", eventID, subscriberID, err)
+	}
+	if outcome != "dead_letter" || reason != wantReason {
+		t.Fatalf("receipt %s/%s = %s/%s, want dead_letter/%s", eventID, subscriberID, outcome, reason, wantReason)
+	}
+}
+
+func assertUnavailableBundlePreservationSession(t *testing.T, ctx context.Context, pg *PostgresStore, sessionID, wantDetail string) {
+	t.Helper()
+	var status, reason, detail string
+	var terminatedAt sql.NullTime
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(termination_reason, ''), COALESCE(termination_detail, ''), terminated_at
+		FROM agent_sessions
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&status, &reason, &detail, &terminatedAt); err != nil {
+		t.Fatalf("load session %s: %v", sessionID, err)
+	}
+	if status != "terminated" || reason != preservationcleanup.SessionTerminationReasonOrphaned || detail != wantDetail || !terminatedAt.Valid {
+		t.Fatalf("session %s = %s/%s/%s ended:%v, want terminated/orphaned/%s/ended", sessionID, status, reason, detail, terminatedAt.Valid, wantDetail)
+	}
+}
+
+func assertUnavailableBundlePreservationTimer(t *testing.T, ctx context.Context, pg *PostgresStore, timerID string) {
+	t.Helper()
+	var status string
+	if err := pg.DB.QueryRowContext(ctx, `SELECT status FROM timers WHERE timer_id = $1::uuid`, timerID).Scan(&status); err != nil {
+		t.Fatalf("load timer %s: %v", timerID, err)
+	}
+	if status != "cancelled" {
+		t.Fatalf("timer %s status = %s, want cancelled", timerID, status)
+	}
+}
+
+func assertUnavailableBundlePreservationFailedDeliveryUntouched(t *testing.T, ctx context.Context, pg *PostgresStore, eventID string) {
+	t.Helper()
+	var status, reason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, eventID).Scan(&status, &reason); err != nil {
+		t.Fatalf("load untouched delivery %s: %v", eventID, err)
+	}
+	if status != "failed" || reason != "agent_retryable_error" {
+		t.Fatalf("untouched delivery %s = %s/%s, want failed/agent_retryable_error", eventID, status, reason)
+	}
+}

--- a/internal/store/run_bundle_availability.go
+++ b/internal/store/run_bundle_availability.go
@@ -9,7 +9,7 @@ import (
 
 type ActiveRunBundleAvailabilityConflict = runbundle.Availability
 
-func (s *PostgresStore) ActiveRunBundleAvailabilityConflicts(ctx context.Context) ([]ActiveRunBundleAvailabilityConflict, error) {
+func (s *PostgresStore) ActiveRunBundleAvailabilities(ctx context.Context) ([]runbundle.Availability, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required")
 	}
@@ -20,5 +20,19 @@ func (s *PostgresStore) ActiveRunBundleAvailabilityConflicts(ctx context.Context
 	if !caps.Events.HasRuns || !caps.Events.RunBundleHash || !caps.Events.RunBundleSource {
 		return nil, fmt.Errorf("active run bundle availability requires runs.bundle_hash and runs.bundle_source")
 	}
-	return runbundle.ListActiveConflicts(ctx, s.DB)
+	return runbundle.ListActiveAvailabilities(ctx, s.DB)
+}
+
+func (s *PostgresStore) ActiveRunBundleAvailabilityConflicts(ctx context.Context) ([]ActiveRunBundleAvailabilityConflict, error) {
+	availabilities, err := s.ActiveRunBundleAvailabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conflicts := make([]runbundle.Availability, 0, len(availabilities))
+	for _, availability := range availabilities {
+		if !availability.Available() {
+			conflicts = append(conflicts, availability)
+		}
+	}
+	return conflicts, nil
 }


### PR DESCRIPTION
## Summary

Closes #1016.

Implements the approved first-slice startup recovery class for active runs whose bundle availability is classified by the canonical run-bundle owner:
- persisted + bundle row present continues startup;
- persisted + missing bundle row fails serve before readiness with `BUNDLE_DATA_INTEGRITY_ERROR`;
- ephemeral/deleted/legacy active rows auto-orphan through preservation cleanup before runtime readiness.

## Governing Refs

Exact binding spec sections:
- `platform-spec.yaml#multi_bundle_persistence.resume_and_recovery.resume_eligibility`
- `platform-spec.yaml#multi_bundle_persistence.resume_and_recovery.active_restart_recovery`
- `platform-spec.yaml#multi_bundle_persistence.bundle_delete.phase_5_atomicity.reader_invariant`
- `platform-spec.yaml#runtime_boot.active_run_abandon_quiescence`

Binding issue/gate context:
- #1016 Pre-Implementation Coverage Audit
- #1016 independent gate outcome: `approved as first slice`
- adjacent issue context from #988, #998, #1004, #1008, #1009, #1011, #1013, and #1014

## Semantic Migration

New canonical owners introduced/consumed:
- `internal/runtime/startuprecovery`: serve-time scan/partition owner consuming `internal/store/runbundle.Availability`.
- `internal/runtime/preservationcleanup`: typed preservation cleanup cause/result semantics.
- `internal/store.PostgresStore.ApplyUnavailableBundleStartupPreservationCleanup`: store mutation owner for the #1016 startup auto-orphan path.

Old path now invalid:
- `cmd/swarm.enforceServeBundleMatchAdmission` as the owner of all active unavailable bundle states.
- `--no-require-bundle-match` bypassing persisted-missing data-integrity recovery.
- one-off serve SQL or destructive reset cleanup for preservation-mode orphaning.

Production paths checked:
- `cmd/swarm.runServeRuntime`
- `internal/store/runbundle` availability readers
- active-run quiescence/receipt late-writer terminal reason guards
- run/control/delivery/session/timer cleanup tables
- managed-container identity adapter used by serve startup recovery
- destructive reset/runtime.nuke siblings left untouched

Migration completeness:
- Complete for the #1016 startup recovery child.
- Parent preservation cleanup remains open for #1019 force-delete and #1027 runtime.nuke siblings.

## Tests

- `go test ./cmd/swarm ./internal/store ./internal/runtime/startuprecovery ./internal/store/runbundle -count=1`
- `go test ./...`
