### PR TITLE
[agent-f][issue #1015] Stamp serve bundle source facts

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -26,6 +26,7 @@ type runtimeProjectSupervisor struct {
 	cfg              *config.Config
 	stores           storeBundle
 	ready            *atomic.Bool
+	dev              bool
 	startRuntime     func(context.Context, *runtime.Runtime) error
 	shutdownRuntime  func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
@@ -51,13 +52,19 @@ func newRuntimeProjectSupervisor(
 	initialBundle *runtimecontracts.WorkflowContractBundle,
 	initialSource semanticview.Source,
 	initialRT *runtime.Runtime,
+	devMode ...bool,
 ) *runtimeProjectSupervisor {
+	dev := false
+	if len(devMode) > 0 {
+		dev = devMode[0]
+	}
 	return &runtimeProjectSupervisor{
 		repoRoot:         strings.TrimSpace(repoRoot),
 		platformSpecPath: strings.TrimSpace(platformSpecPath),
 		cfg:              cfg,
 		stores:           stores,
 		ready:            ready,
+		dev:              dev,
 		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
 			return rt.Start(ctx)
 		},
@@ -155,6 +162,10 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if err != nil {
 		return builderpkg.ProjectStatus{}, fmt.Errorf("derive project bundle identity: %w", err)
 	}
+	bundleSourceFact, err := prepareServeBundleSource(ctx, s.stores, bundle, bundleIdentity.Fingerprint, s.dev)
+	if err != nil {
+		return builderpkg.ProjectStatus{}, fmt.Errorf("prepare project bundle source: %w", err)
+	}
 	workspaces := s.newWorkspaces(s.stores, s.repoRoot, resolvedRoot, source)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		return builderpkg.ProjectStatus{}, err
@@ -174,6 +185,7 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 			WorkflowModule:     module,
 			WorkspaceLifecycle: workspaces,
 			BundleFingerprint:  bundleIdentity.Fingerprint,
+			BundleSourceFact:   bundleSourceFact,
 		},
 	})
 	if err != nil {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -16,10 +16,12 @@ import (
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	workspace "swarm/internal/runtime/workspace"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShutdown(t *testing.T) {
@@ -179,11 +181,16 @@ func writeProjectRoot(t *testing.T) string {
 func testBuilderSupervisorBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
 	t.Helper()
 	dir := t.TempDir()
+	platformPath := filepath.Join(t.TempDir(), "platform-spec.yaml")
+	if err := os.WriteFile(platformPath, []byte("platform:\n  name: swarm\n  version: test\n"), 0o644); err != nil {
+		t.Fatalf("write platform-spec.yaml: %v", err)
+	}
 	packagePath := filepath.Join(dir, "package.yaml")
 	if err := os.WriteFile(packagePath, []byte("name: test\nversion: 1.0.0\nflows: []\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 	bundle := testWorkflowValidationBundle()
+	bundle.Paths = runtimecontracts.ResolveWorkflowContractPathsWithOverrides(filepath.Dir(dir), dir, platformPath)
 	bundle.Paths.ProjectPackageFile = packagePath
 	bundle.Semantics.Name = "test"
 	bundle.Semantics.Version = "1.0.0"
@@ -201,6 +208,7 @@ func newSupervisorForLoadProjectFailureTest(
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
 	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), "", nil, nil, nil)
+	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {
 			return nil, nil, fmt.Errorf("contracts root = %q, want %q", got, projectRoot)
@@ -300,14 +308,21 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesRuntimeStartFailure(t *te
 
 func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t *testing.T) {
 	projectRoot := writeProjectRoot(t)
-	expectedIdentity, err := runtimecontracts.BootBundleIdentity(testBuilderSupervisorBundle(t))
+	expectedBundle := testBuilderSupervisorBundle(t)
+	expectedIdentity, err := runtimecontracts.BootBundleIdentity(expectedBundle)
 	if err != nil {
 		t.Fatalf("BootBundleIdentity: %v", err)
 	}
+	expectedHash, err := runtimecontracts.BundleHash(expectedBundle)
+	if err != nil {
+		t.Fatalf("BundleHash: %v", err)
+	}
 
 	var gotFingerprint string
+	var gotSourceFact runtimecorrelation.BundleSourceFact
 	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(_ context.Context, deps runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
 		gotFingerprint = deps.Options.BundleFingerprint
+		gotSourceFact = deps.Options.BundleSourceFact
 		return &runtimepkg.Runtime{}, nil
 	})
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
@@ -322,6 +337,9 @@ func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t 
 	}
 	if gotFingerprint != expectedIdentity.Fingerprint {
 		t.Fatalf("BundleFingerprint = %q, want %q", gotFingerprint, expectedIdentity.Fingerprint)
+	}
+	if gotSourceFact.BundleHash != expectedHash || gotSourceFact.BundleSource != storerunlifecycle.BundleSourceEphemeral || gotSourceFact.BundleFingerprint != expectedIdentity.Fingerprint {
+		t.Fatalf("BundleSourceFact = %#v, want hash=%q source=%q fingerprint=%q", gotSourceFact, expectedHash, storerunlifecycle.BundleSourceEphemeral, expectedIdentity.Fingerprint)
 	}
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -317,6 +317,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("bundle match admission failed", "error", err)
 		return 3
 	}
+	bundleSourceFact, err := prepareServeBundleSource(ctx, stores, bundle, bootBundleIdentity.Fingerprint, opts.Dev)
+	if err != nil {
+		slog.Error("prepare bundle source", "error", err)
+		return 3
+	}
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
 		return 1
@@ -383,6 +388,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			EnableToolGateway:  true,
 			ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
 			BundleFingerprint:  bootBundleIdentity.Fingerprint,
+			BundleSourceFact:   bundleSourceFact,
 			Credentials:        credentialStore,
 			BootStartedAt:      bootStartedAt,
 			BootProgress:       reporter.runtimeSink(),
@@ -401,7 +407,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt, opts.Dev)
 	defer func() {
 		if err := closeServeRuntime(context.Background(), supervisor, opts, workspaces); err != nil {
 			log.Printf("runtime shutdown failed: %v", err)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2245,6 +2245,54 @@ func assertServeRuntimeUnavailableBundleRunOrphaned(t *testing.T, ctx context.Co
 	}
 }
 
+func TestPrepareServeBundleSourcePersistsCatalogForContractsServe(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier12-runtime-tools/test-flow-data-access")
+	identity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity: %v", err)
+	}
+
+	fact, err := prepareServeBundleSource(ctx, storeBundle{Postgres: pg}, bundle, identity.Fingerprint, false)
+	if err != nil {
+		t.Fatalf("prepareServeBundleSource: %v", err)
+	}
+	if fact.BundleSource != storerunlifecycle.BundleSourcePersisted || fact.BundleHash == "" || fact.BundleFingerprint != identity.Fingerprint {
+		t.Fatalf("source fact = %#v", fact)
+	}
+	detail, err := pg.LoadBundleCatalog(ctx, fact.BundleHash)
+	if err != nil {
+		t.Fatalf("LoadBundleCatalog(%s): %v", fact.BundleHash, err)
+	}
+	if detail.BundleHash != fact.BundleHash || detail.AgentCount == 0 || detail.ContentYAML == "" {
+		t.Fatalf("bundle catalog detail = %#v", detail)
+	}
+}
+
+func TestPrepareServeBundleSourceDevStampsEphemeralWithoutCatalogRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier12-runtime-tools/test-flow-data-access")
+	identity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity: %v", err)
+	}
+
+	fact, err := prepareServeBundleSource(ctx, storeBundle{Postgres: pg}, bundle, identity.Fingerprint, true)
+	if err != nil {
+		t.Fatalf("prepareServeBundleSource(dev): %v", err)
+	}
+	if fact.BundleSource != storerunlifecycle.BundleSourceEphemeral || fact.BundleHash == "" || fact.BundleFingerprint != identity.Fingerprint {
+		t.Fatalf("source fact = %#v", fact)
+	}
+	if _, err := pg.LoadBundleCatalog(ctx, fact.BundleHash); err != store.ErrBundleNotFound {
+		t.Fatalf("LoadBundleCatalog(dev hash) error = %v, want ErrBundleNotFound", err)
+	}
+}
+
 func TestCLI_NoArgCommandsRejectUnexpectedArgs(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/cmd/swarm/serve_bundle_source.go
+++ b/cmd/swarm/serve_bundle_source.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/store"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+func prepareServeBundleSource(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle, legacyFingerprint string, dev bool) (runtimecorrelation.BundleSourceFact, error) {
+	bundleHash, err := runtimecontracts.BundleHash(bundle)
+	if err != nil {
+		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("derive canonical bundle hash: %w", err)
+	}
+	source := storerunlifecycle.BundleSourcePersisted
+	if dev {
+		source = storerunlifecycle.BundleSourceEphemeral
+	}
+	fact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        bundleHash,
+		BundleSource:      source,
+		BundleFingerprint: strings.TrimSpace(legacyFingerprint),
+	}.Normalized()
+	if dev {
+		return fact, nil
+	}
+	if stores.Postgres == nil {
+		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("postgres bundle catalog store is required for persisted serve bundle source")
+	}
+	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("project bundle catalog row: %w", err)
+	}
+	if projection.BundleHash != bundleHash {
+		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("bundle catalog projection hash %q does not match source fact %q", projection.BundleHash, bundleHash)
+	}
+	if _, err := stores.Postgres.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+		ParsedJSON:  projection.ParsedJSON,
+		DataBlob:    projection.DataBlob,
+		Metadata:    projection.Metadata,
+	}); err != nil {
+		return runtimecorrelation.BundleSourceFact{}, err
+	}
+	return fact, nil
+}

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5490,7 +5490,7 @@ run_model:
     run_resume: 'POST /runs/:run_id/resume — resume a paused run.'
     run_cancel: 'POST /runs/:run_id/cancel — cancel a running run. Drains in-flight events.'
 multi_bundle_persistence:
-  status: promoted_source_authority_no_runtime_behavior
+  status: promoted_source_authority_with_partial_runtime_behavior
   promoted_by: '#1012'
   source_evidence:
     draft: docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md
@@ -5500,8 +5500,9 @@ multi_bundle_persistence:
   authority_rule: >
     This section is the merge-bearing source authority for multi-bundle persistence, bundle identity, bundle-aware
     resume/delete/fork semantics, planned bundle API methods, and planned CLI command shape. The draft is now evidence
-    only. Runtime, API handler, CLI implementation, database migration, and generated OpenRPC publication remain separately
-    gated implementation work unless a later PR explicitly promotes and proves them.
+    only. Database foundation, read-only bundle catalog APIs, and supported local serve ingest/source stamping now have
+    promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
+    generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
     current_openrpc_status: bundle_read_catalog_and_run_fork_methods_published
     rule: >
@@ -5646,9 +5647,10 @@ multi_bundle_persistence:
   persistence_model:
     live_schema_boundary: >
       platform_tables.tables is the current runtime DDL source. #1013 promotes the bundles table and
-      runs.bundle_hash/runs.bundle_source into the live schema foundation. API/runtime behavior,
-      reader migration, ingest/source stamping, and public dual-accept naming remain separately
-      gated implementation work unless a later PR explicitly promotes and proves them.
+      runs.bundle_hash/runs.bundle_source into the live schema foundation. Serve ingest/source stamping for local
+      `swarm serve --contracts` is promoted by multi_bundle_persistence.persistence_model.serve_ingest_projection.
+      Reader migration, API routing, CLI/fork behavior, delete/runtime cleanup, and public dual-accept naming remain
+      separately gated implementation work unless a later PR explicitly promotes and proves them.
     bundles_table:
       planned_live_owner_after_migration: platform_tables.tables.bundles
       primary_key: bundle_hash
@@ -5661,14 +5663,50 @@ multi_bundle_persistence:
         - data_blob
         - metadata
       stores:
-        - uploaded or registered contract YAML bytes
-        - data/ bundle blob bytes when included by the canonical hash rule
+        - deterministic serve-ingest YAML archive for non-data canonical bundle inputs
+        - data/ bundle blob archive bytes when included by the canonical hash rule
         - parsed JSON projection for safe server-side inspection
       does_not_store:
         - external code
         - host filesystem dependencies
         - credentials
         - generated runtime state
+    serve_ingest_projection:
+      status: implemented_for_local_postgres_serve_contracts
+      projection_owner: internal/runtime/contracts.BuildBundleCatalogProjection
+      store_owner: internal/store.PostgresStore.UpsertBundleCatalog
+      source_fact_owner: cmd/swarm.prepareServeBundleSource
+      runtime_context_owner: internal/runtime/correlation.BundleSourceFact
+      applies_to:
+        persisted: '`swarm serve --contracts` computes BundleHash, writes or reuses one bundles row, and stamps every new run row with bundle_hash plus bundle_source=persisted.'
+        ephemeral: '`swarm serve --contracts --dev` computes the same BundleHash, writes no bundles row, and stamps every new run row with bundle_hash plus bundle_source=ephemeral.'
+      content_yaml: >
+        Deterministic YAML archive named `swarm.bundle.catalog.v1`. The archive lists every non-data canonical bundle
+        input by canonical label and stores the bundle_hash v1 canonical content bytes as base64, plus a canonical_inputs list containing all
+        bundle_hash v1 labels, policies, and byte sizes. It never stores host absolute paths. Flow data/ raw entries are
+        excluded from content_yaml and live only in data_blob.
+      data_blob: >
+        NULL when the canonical bundle has no flow data/ raw inputs. Otherwise a deterministic JSON byte archive named
+        `swarm.bundle.catalog.v1` with entries sorted by canonical label; each entry records label, byte size, and exact
+        raw bytes as base64.
+      parsed_json: >
+        Definition-only JSON projection with projection_version, workflow name/version, canonical input labels/policies,
+        and agent definitions. Agent definitions may include agent_id, flow_instance, role, type, model_tier,
+        conversation_mode, session_scope, prompt_path, subscriptions, and tools. Runtime-owned fields such as status,
+        runtime_state, queues, active task, watchdog, last_tool_outcome, pending deliveries, and delivery lifecycle are
+        forbidden.
+      metadata: >
+        JSON object containing projection_version, source=`swarm serve --contracts`, workflow_name, workflow_version,
+        file_count, and data_file_count.
+      idempotency: >
+        Reusing an existing bundles row with the same bundle_hash is allowed only when content_yaml, parsed_json,
+        data_blob, and metadata match the computed projection. A hash collision or stale row with different stored
+        content fails closed before runtime construction.
+      split_boundaries:
+        - DB-loaded same-bundle source/fork loaders remain #1024.
+        - New-work routing and bundle_hash admission remain #1022.
+        - Bundle register/delete APIs remain #1017/#1018/#1019.
+        - SQLite runtime support remains blocked by #1087/#1088 unless separately gated.
     runs_table:
       planned_live_owner_after_migration: platform_tables.tables.runs
       promoted_fields:
@@ -5890,6 +5928,12 @@ multi_bundle_persistence:
       reason: Production readers must migrate from bundle_fingerprint/null-collapse behavior to bundle_source availability semantics.
     bundle_ingest_and_run_stamping:
       tracker: '#1015'
+      implementation_status: live_for_supported_postgres_serve_contracts
+      runtime_owners:
+        - internal/runtime/contracts.BuildBundleCatalogProjection
+        - internal/store.PostgresStore.UpsertBundleCatalog
+        - cmd/swarm.prepareServeBundleSource
+        - internal/runtime/correlation.BundleSourceFact
       reason: serve --contracts / --dev ingest, canonical hashing, bundle row writes, and persisted/ephemeral run stamping are runtime boot implementation.
     startup_recovery_unavailable_bundle:
       tracker: '#1016'

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -275,7 +275,7 @@ func TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints(t *testin
 func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkMethods(t *testing.T) {
 	root := loadPlatformSpecYAMLNode(t)
 	multi := mustMappingValue(t, root, "multi_bundle_persistence")
-	assertScalarValue(t, mustMappingValue(t, multi, "status"), "promoted_source_authority_no_runtime_behavior")
+	assertScalarValue(t, mustMappingValue(t, multi, "status"), "promoted_source_authority_with_partial_runtime_behavior")
 
 	sourceEvidence := mustMappingValue(t, multi, "source_evidence")
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
@@ -313,6 +313,15 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 
 	persistence := mustMappingValue(t, multi, "persistence_model")
 	assertScalarContains(t, mustMappingValue(t, persistence, "live_schema_boundary"), "#1013 promotes the bundles table")
+	serveIngest := mustMappingValue(t, persistence, "serve_ingest_projection")
+	assertScalarValue(t, mustMappingValue(t, serveIngest, "status"), "implemented_for_local_postgres_serve_contracts")
+	assertScalarValue(t, mustMappingValue(t, serveIngest, "projection_owner"), "internal/runtime/contracts.BuildBundleCatalogProjection")
+	assertScalarValue(t, mustMappingValue(t, serveIngest, "store_owner"), "internal/store.PostgresStore.UpsertBundleCatalog")
+	assertScalarValue(t, mustMappingValue(t, serveIngest, "source_fact_owner"), "cmd/swarm.prepareServeBundleSource")
+	assertScalarContains(t, mustMappingValue(t, serveIngest, "content_yaml"), "canonical content bytes as base64")
+	assertScalarContains(t, mustMappingValue(t, serveIngest, "data_blob"), "raw bytes as base64")
+	assertScalarContains(t, mustMappingValue(t, serveIngest, "parsed_json"), "Runtime-owned fields")
+	assertScalarContains(t, mustMappingValue(t, serveIngest, "idempotency"), "fails closed before runtime construction")
 	platformTables := mustMappingValue(t, mustMappingValue(t, root, "platform_tables"), "tables")
 	if mappingValue(platformTables, "bundles") == nil {
 		t.Fatal("bundles table must be live in platform_tables after the DB migration child lands")

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -48,6 +48,7 @@ type EventBus struct {
 	runtimeIngressDispatchGate  RuntimeIngressDispatchGate
 	runDispatchGate             RunDispatchGate
 	bundleFingerprint           string
+	bundleSourceFact            runtimecorrelation.BundleSourceFact
 	outboxSweeperActive         bool
 	inFlightPublishes           atomic.Int64
 }
@@ -89,6 +90,7 @@ type EventBusOptions struct {
 	RuntimeIngressDispatchGate  RuntimeIngressDispatchGate
 	RunDispatchGate             RunDispatchGate
 	BundleFingerprint           string
+	BundleSourceFact            runtimecorrelation.BundleSourceFact
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -159,6 +161,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		runtimeIngressDispatchGate:  opts.RuntimeIngressDispatchGate,
 		runDispatchGate:             opts.RunDispatchGate,
 		bundleFingerprint:           strings.TrimSpace(opts.BundleFingerprint),
+		bundleSourceFact:            opts.BundleSourceFact.Normalized(),
 	}
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -1050,6 +1050,7 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
+	ctx = eb.withBundleFingerprint(ctx)
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
 	ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
 	start := time.Now()

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -400,10 +400,23 @@ func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {
 	if ctx == nil || eb == nil {
 		return ctx
 	}
+	if _, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		return ctx
+	}
+	eb.mu.RLock()
+	sourceFact := eb.bundleSourceFact
+	fingerprint := eb.bundleFingerprint
+	eb.mu.RUnlock()
+	if sourceFact.BundleFingerprint == "" {
+		sourceFact.BundleFingerprint = fingerprint
+	}
+	if !sourceFact.Empty() {
+		return runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+	}
 	if runtimecorrelation.BundleFingerprintFromContext(ctx) != "" {
 		return ctx
 	}
-	return runtimecorrelation.WithBundleFingerprint(ctx, eb.bundleFingerprint)
+	return runtimecorrelation.WithBundleFingerprint(ctx, fingerprint)
 }
 
 func (eb *EventBus) WithBundleFingerprint(ctx context.Context) context.Context {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -225,11 +225,14 @@ type recordedLogEntry struct {
 	Detail     any
 	Lineage    runtimecorrelation.RuntimeLineage
 	HasLineage bool
+	SourceFact runtimecorrelation.BundleSourceFact
+	HasSource  bool
 }
 
 func (h *recordingLoggerHook) Log(ctx context.Context, _ diaglog.Level, _, _, action, _, _, _, _, _ string, _ map[string]string, detail any, _ string, _ int) error {
 	lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx)
-	h.entries = append(h.entries, recordedLogEntry{Action: action, Detail: detail, Lineage: lineage, HasLineage: ok})
+	sourceFact, hasSource := runtimecorrelation.BundleSourceFactFromContext(ctx)
+	h.entries = append(h.entries, recordedLogEntry{Action: action, Detail: detail, Lineage: lineage, HasLineage: ok, SourceFact: sourceFact, HasSource: hasSource})
 	return nil
 }
 
@@ -678,6 +681,43 @@ func TestEventBusPublish_AttachesTypedRuntimeDiagnosticLineage(t *testing.T) {
 		published.Lineage.Classification != runtimecorrelation.RuntimeLineageClassificationForkLocal {
 		t.Fatalf("published diagnostic lineage = %#v", published.Lineage)
 	}
+}
+
+func TestEventBusPublish_AttachesBundleSourceFactToRuntimeLogs(t *testing.T) {
+	logger := &recordingLoggerHook{}
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      "persisted",
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	bus, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+		Logger:           logger,
+		BundleSourceFact: sourceFact,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
+	if err := bus.Publish(context.Background(), events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("task.requested"),
+		RunID:     uuid.NewString(),
+		Payload:   []byte(`{"entity_id":"ent-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}.WithEntityID("ent-1")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delivered event")
+	}
+	for _, entry := range logger.entries {
+		if entry.HasSource && entry.SourceFact == sourceFact.Normalized() {
+			return
+		}
+	}
+	t.Fatalf("bundle source fact not found in runtime logs: %#v", logger.entries)
 }
 
 func TestEventBusPublish_UsesPayloadValidator(t *testing.T) {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1356,6 +1356,44 @@ func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *te
 	}
 }
 
+func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	runID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		BundleSource:      "persisted",
+		BundleFingerprint: "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+	}
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		BundleSourceFact: sourceFact,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.PublishDirect(context.Background(), events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("scan.requested"),
+		SourceAgent: "test",
+		CreatedAt:   time.Now().UTC(),
+		Payload:     []byte(`{}`),
+	}, []string{"agent-a"}); err != nil {
+		t.Fatalf("PublishDirect: %v", err)
+	}
+	var bundleHash, bundleSource, legacyFingerprint string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&bundleHash, &bundleSource, &legacyFingerprint); err != nil {
+		t.Fatalf("load run bundle source: %v", err)
+	}
+	if bundleHash != sourceFact.BundleHash || bundleSource != sourceFact.BundleSource || legacyFingerprint != sourceFact.BundleFingerprint {
+		t.Fatalf("bundle identity = hash:%q source:%q fingerprint:%q, want canonical source fact %#v", bundleHash, bundleSource, legacyFingerprint, sourceFact)
+	}
+}
+
 func TestEventBusPublishDeferred_PersistsInboundEventBeforeInterceptorsRun(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -497,6 +497,7 @@ func (eb *EventBus) logRuntime(ctx context.Context, level diaglog.Level, message
 		return nil
 	}
 	ctx = runtimecorrelation.WithRuntimeDiagnosticLineage(ctx, eventID, eventType)
+	ctx = eb.withBundleFingerprint(ctx)
 	if err := logger.Log(ctx, level, message, component, action, eventID, eventType, agentID, entityID, sessionID, correlation, detail, errText, durationUS); err != nil {
 		diaglog.ProcessLog("error", "diagnostics", "runtime log persistence failed",
 			"component", strings.TrimSpace(component),

--- a/internal/runtime/contracts/bundle_catalog_projection.go
+++ b/internal/runtime/contracts/bundle_catalog_projection.go
@@ -1,0 +1,230 @@
+package contracts
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const bundleCatalogProjectionVersion = "swarm.bundle.catalog.v1"
+
+type BundleCatalogProjection struct {
+	BundleHash  string
+	ContentYAML string
+	ParsedJSON  map[string]any
+	DataBlob    []byte
+	Metadata    map[string]any
+}
+
+type bundleCatalogProjectedFile struct {
+	Label     string
+	Policy    string
+	SizeBytes int
+}
+
+type bundleCatalogDataArchive struct {
+	ProjectionVersion string                   `json:"projection_version"`
+	Entries           []bundleCatalogDataEntry `json:"entries"`
+}
+
+type bundleCatalogDataEntry struct {
+	Label         string `json:"label"`
+	SizeBytes     int    `json:"size_bytes"`
+	ContentBase64 string `json:"content_base64"`
+}
+
+// BuildBundleCatalogProjection is the serve-ingest owner for persisted bundle
+// rows. It stores definition bytes and definition-only JSON; runtime state is
+// intentionally excluded.
+func BuildBundleCatalogProjection(bundle *WorkflowContractBundle) (BundleCatalogProjection, error) {
+	bundleHash, err := BundleHash(bundle)
+	if err != nil {
+		return BundleCatalogProjection{}, err
+	}
+	entries, err := bundleHashEntries(bundle)
+	if err != nil {
+		return BundleCatalogProjection{}, err
+	}
+	files := make([]bundleCatalogProjectedFile, 0, len(entries))
+	dataEntries := make([]bundleCatalogDataEntry, 0)
+	contentFiles := make([]bundleCatalogDataEntry, 0)
+	for _, entry := range entries {
+		content, err := canonicalBundleHashContent(entry.Path, entry.Policy)
+		if err != nil {
+			return BundleCatalogProjection{}, fmt.Errorf("canonicalize bundle catalog input %s: %w", entry.Label, err)
+		}
+		policy := bundleCatalogPolicyName(entry.Policy)
+		files = append(files, bundleCatalogProjectedFile{
+			Label:     entry.Label,
+			Policy:    policy,
+			SizeBytes: len(content),
+		})
+		projected := bundleCatalogDataEntry{
+			Label:         entry.Label,
+			SizeBytes:     len(content),
+			ContentBase64: base64.StdEncoding.EncodeToString(content),
+		}
+		if entry.Policy == bundleHashRaw {
+			dataEntries = append(dataEntries, projected)
+		} else {
+			contentFiles = append(contentFiles, projected)
+		}
+	}
+
+	contentYAML := renderBundleCatalogContentYAML(contentFiles, files)
+	dataBlob, err := renderBundleCatalogDataBlob(dataEntries)
+	if err != nil {
+		return BundleCatalogProjection{}, err
+	}
+	parsed := map[string]any{
+		"projection_version": bundleCatalogProjectionVersion,
+		"workflow": map[string]any{
+			"name":    strings.TrimSpace(bundle.Semantics.Name),
+			"version": strings.TrimSpace(bundle.Semantics.Version),
+		},
+		"files":  bundleCatalogFilesJSON(files),
+		"agents": bundleCatalogAgentsJSON(bundle),
+	}
+	metadata := map[string]any{
+		"projection_version": bundleCatalogProjectionVersion,
+		"source":             "swarm serve --contracts",
+		"workflow_name":      strings.TrimSpace(bundle.Semantics.Name),
+		"workflow_version":   strings.TrimSpace(bundle.Semantics.Version),
+		"file_count":         len(files),
+		"data_file_count":    len(dataEntries),
+	}
+	return BundleCatalogProjection{
+		BundleHash:  bundleHash,
+		ContentYAML: contentYAML,
+		ParsedJSON:  parsed,
+		DataBlob:    dataBlob,
+		Metadata:    metadata,
+	}, nil
+}
+
+func bundleCatalogPolicyName(policy bundleHashContentPolicy) string {
+	switch policy {
+	case bundleHashYAML:
+		return "yaml"
+	case bundleHashPrompt:
+		return "prompt_text"
+	case bundleHashRaw:
+		return "raw_data"
+	default:
+		return "unknown"
+	}
+}
+
+func renderBundleCatalogContentYAML(contentFiles []bundleCatalogDataEntry, files []bundleCatalogProjectedFile) string {
+	var b strings.Builder
+	b.WriteString("projection_version: ")
+	b.WriteString(bundleCatalogProjectionVersion)
+	b.WriteString("\nfiles:\n")
+	for _, file := range contentFiles {
+		b.WriteString("  - label: ")
+		b.WriteString(strconv.Quote(file.Label))
+		b.WriteString("\n    content_base64: ")
+		b.WriteString(strconv.Quote(file.ContentBase64))
+		b.WriteString("\n    size_bytes: ")
+		b.WriteString(strconv.Itoa(file.SizeBytes))
+		b.WriteString("\n")
+	}
+	b.WriteString("canonical_inputs:\n")
+	for _, file := range files {
+		b.WriteString("  - label: ")
+		b.WriteString(strconv.Quote(file.Label))
+		b.WriteString("\n    policy: ")
+		b.WriteString(file.Policy)
+		b.WriteString("\n    size_bytes: ")
+		b.WriteString(strconv.Itoa(file.SizeBytes))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderBundleCatalogDataBlob(entries []bundleCatalogDataEntry) ([]byte, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(bundleCatalogDataArchive{
+		ProjectionVersion: bundleCatalogProjectionVersion,
+		Entries:           entries,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode bundle catalog data blob: %w", err)
+	}
+	return raw, nil
+}
+
+func bundleCatalogFilesJSON(files []bundleCatalogProjectedFile) []map[string]any {
+	out := make([]map[string]any, 0, len(files))
+	for _, file := range files {
+		out = append(out, map[string]any{
+			"label":      file.Label,
+			"policy":     file.Policy,
+			"size_bytes": file.SizeBytes,
+		})
+	}
+	return out
+}
+
+func bundleCatalogAgentsJSON(bundle *WorkflowContractBundle) map[string]any {
+	entries := bundle.AgentEntries()
+	agentIDs := make([]string, 0, len(entries))
+	for agentID := range entries {
+		agentIDs = append(agentIDs, agentID)
+	}
+	sort.Strings(agentIDs)
+	out := make(map[string]any, len(agentIDs))
+	for _, agentID := range agentIDs {
+		entry := entries[agentID]
+		def := map[string]any{
+			"agent_id": agentID,
+		}
+		addStringField(def, "role", entry.Role)
+		addStringField(def, "type", firstNonEmpty(entry.Type, entry.NodeType))
+		addStringField(def, "model_tier", entry.ModelTier)
+		addStringField(def, "conversation_mode", entry.ConversationMode)
+		addStringField(def, "session_scope", entry.SessionScope)
+		addStringField(def, "prompt_path", entry.PromptRef)
+		if source, ok := bundle.AgentContractSource(agentID); ok {
+			addStringField(def, "flow_instance", source.FlowID)
+		}
+		addStringListField(def, "subscriptions", entry.Subscriptions)
+		addStringListField(def, "tools", entry.ConfiguredTools())
+		out[agentID] = def
+	}
+	return out
+}
+
+func addStringField(values map[string]any, key, value string) {
+	if value = strings.TrimSpace(value); value != "" {
+		values[key] = value
+	}
+}
+
+func addStringListField(values map[string]any, key string, raw []string) {
+	items := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	if len(items) == 0 {
+		return
+	}
+	sort.Strings(items)
+	values[key] = items
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -2,6 +2,8 @@ package contracts
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -91,6 +93,97 @@ func TestBundleHashV1AcceptsCurrentPlatformSpec(t *testing.T) {
 	}
 	if !regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`).MatchString(got) {
 		t.Fatalf("BundleHash = %q, want v1 bundle hash shape", got)
+	}
+}
+
+func TestBundleCatalogProjectionUsesCanonicalInputsWithoutHostPaths(t *testing.T) {
+	root, platform := writeEquivalentBundleHashFixture(t, "\n", "name: projection\nversion: \"1.0.0\"\nflows:\n  - id: alpha\n    flow: alpha\n")
+	writeBundleHashText(t, filepath.Join(root, "flows", "alpha", "agents.yaml"), `
+agents:
+  reviewer:
+    role: review
+`)
+	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
+	bundle := bundleHashTestBundle(root, platform)
+	bundle.Semantics.Name = "projection"
+	bundle.Semantics.Version = "1.0.0"
+	bundle.Agents = map[string]AgentRegistryEntry{
+		"reviewer": {
+			Role:             "review",
+			Type:             "managed",
+			ModelTier:        "haiku",
+			PromptRef:        "flows/alpha/prompts/reviewer.md",
+			Subscriptions:    []string{"scan.requested"},
+			Tools:            []string{"web_search"},
+			ConversationMode: "session",
+		},
+	}
+
+	projection, err := BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	if !regexp.MustCompile(`^bundle-v1:sha256:[a-f0-9]{64}$`).MatchString(projection.BundleHash) {
+		t.Fatalf("BundleHash = %q, want v1 shape", projection.BundleHash)
+	}
+	if strings.Contains(projection.ContentYAML, root) || strings.Contains(projection.ContentYAML, platform) {
+		t.Fatalf("ContentYAML leaked host path:\n%s", projection.ContentYAML)
+	}
+	if !strings.Contains(projection.ContentYAML, `label: "bundle/package.yaml"`) {
+		t.Fatalf("ContentYAML missing package label:\n%s", projection.ContentYAML)
+	}
+	canonicalPackage, err := canonicalBundleHashContent(filepath.Join(root, "package.yaml"), bundleHashYAML)
+	if err != nil {
+		t.Fatalf("canonical package: %v", err)
+	}
+	if !strings.Contains(projection.ContentYAML, base64.StdEncoding.EncodeToString(canonicalPackage)) {
+		t.Fatalf("ContentYAML missing base64 package bytes:\n%s", projection.ContentYAML)
+	}
+	var data struct {
+		Entries []struct {
+			Label         string `json:"label"`
+			ContentBase64 string `json:"content_base64"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(projection.DataBlob, &data); err != nil {
+		t.Fatalf("decode DataBlob: %v", err)
+	}
+	if len(data.Entries) != 1 || data.Entries[0].Label != "bundle/flows/alpha/data/payload.bin" || data.Entries[0].ContentBase64 != base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}) {
+		t.Fatalf("data blob = %#v", data)
+	}
+	agents, ok := projection.ParsedJSON["agents"].(map[string]any)
+	if !ok {
+		t.Fatalf("agents projection = %#v", projection.ParsedJSON["agents"])
+	}
+	reviewer, ok := agents["reviewer"].(map[string]any)
+	if !ok {
+		t.Fatalf("reviewer projection = %#v", agents["reviewer"])
+	}
+	if _, hasRuntimeState := reviewer["runtime_state"]; hasRuntimeState {
+		t.Fatalf("agents projection contains runtime state: %#v", reviewer)
+	}
+	if projection.Metadata["projection_version"] != bundleCatalogProjectionVersion || projection.Metadata["source"] != "swarm serve --contracts" {
+		t.Fatalf("metadata = %#v", projection.Metadata)
+	}
+}
+
+func TestBundleCatalogProjectionStableForEquivalentCanonicalContent(t *testing.T) {
+	rootA, platformA := writeEquivalentBundleHashFixture(t, "\r\n", "name: equivalent\r\nversion: \"1.0.0\"\r\nflows: []\r\n")
+	rootB, platformB := writeEquivalentBundleHashFixture(t, "\n", "flows: []\nversion: \"1.0.0\"\nname: equivalent\n")
+
+	projectionA, err := BuildBundleCatalogProjection(bundleHashTestBundle(rootA, platformA))
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection A: %v", err)
+	}
+	projectionB, err := BuildBundleCatalogProjection(bundleHashTestBundle(rootB, platformB))
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection B: %v", err)
+	}
+	if projectionA.BundleHash != projectionB.BundleHash {
+		t.Fatalf("equivalent hashes drifted: A=%s B=%s", projectionA.BundleHash, projectionB.BundleHash)
+	}
+	if projectionA.ContentYAML != projectionB.ContentYAML {
+		t.Fatalf("equivalent content_yaml projections drifted:\nA=%s\nB=%s", projectionA.ContentYAML, projectionB.ContentYAML)
 	}
 }
 

--- a/internal/runtime/correlation/context.go
+++ b/internal/runtime/correlation/context.go
@@ -13,6 +13,25 @@ type runIDContextKey struct{}
 type handlerIDContextKey struct{}
 type runtimeLineageContextKey struct{}
 type bundleFingerprintContextKey struct{}
+type bundleSourceFactContextKey struct{}
+
+type BundleSourceFact struct {
+	BundleHash        string
+	BundleSource      string
+	BundleFingerprint string
+}
+
+func (f BundleSourceFact) Normalized() BundleSourceFact {
+	f.BundleHash = strings.TrimSpace(f.BundleHash)
+	f.BundleSource = strings.TrimSpace(f.BundleSource)
+	f.BundleFingerprint = strings.TrimSpace(f.BundleFingerprint)
+	return f
+}
+
+func (f BundleSourceFact) Empty() bool {
+	f = f.Normalized()
+	return f.BundleHash == "" && f.BundleSource == "" && f.BundleFingerprint == ""
+}
 
 type RuntimeLineageRowCategory string
 
@@ -226,6 +245,36 @@ func BundleFingerprintFromContext(ctx context.Context) string {
 	}
 	fingerprint, _ := ctx.Value(bundleFingerprintContextKey{}).(string)
 	return strings.TrimSpace(fingerprint)
+}
+
+func WithBundleSourceFact(ctx context.Context, fact BundleSourceFact) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	fact = fact.Normalized()
+	if fact.Empty() {
+		return ctx
+	}
+	ctx = context.WithValue(ctx, bundleSourceFactContextKey{}, fact)
+	if fact.BundleFingerprint != "" {
+		ctx = WithBundleFingerprint(ctx, fact.BundleFingerprint)
+	}
+	return ctx
+}
+
+func BundleSourceFactFromContext(ctx context.Context) (BundleSourceFact, bool) {
+	if ctx == nil {
+		return BundleSourceFact{}, false
+	}
+	fact, ok := ctx.Value(bundleSourceFactContextKey{}).(BundleSourceFact)
+	if !ok {
+		return BundleSourceFact{}, false
+	}
+	fact = fact.Normalized()
+	if fact.Empty() {
+		return BundleSourceFact{}, false
+	}
+	return fact, true
 }
 
 func CorrelateEvent(ctx context.Context, evt events.Event) (context.Context, events.Event) {

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -417,7 +417,16 @@ func ensureRuntimeLogRunRow(ctx context.Context, db storerunlifecycle.DBTX, runI
 	if _, err := uuid.Parse(runID); err != nil {
 		return err
 	}
-	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{})
+	opts := storerunlifecycle.EnsureActiveOptions{}
+	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		opts.HasBundleHashCol = true
+		opts.HasBundleSourceCol = true
+		opts.HasBundleFingerprintCol = true
+		opts.BundleHash = fact.BundleHash
+		opts.BundleSource = fact.BundleSource
+		opts.BundleFingerprint = fact.BundleFingerprint
+	}
+	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "", opts)
 }
 
 func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detailMap map[string]any, runID, parentEventID, handlerID string) map[string]any {

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
@@ -286,6 +287,40 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	}
 	if got := strings.TrimSpace(asString(details["run_id"])); got != runID {
 		t.Fatalf("details.run_id = %q, want %q", got, runID)
+	}
+}
+
+func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	runID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+
+	if err := logger.Log(ctx, RuntimeLogEntry{
+		Level:     "info",
+		Message:   "runtime log",
+		Component: "workflow-runtime",
+		Action:    "bundle_source_fact",
+	}); err != nil {
+		t.Fatalf("logger.Log: %v", err)
+	}
+	var gotHash, gotSource, gotFingerprint string
+	if err := db.QueryRow(`
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&gotHash, &gotSource, &gotFingerprint); err != nil {
+		t.Fatalf("load run bundle source: %v", err)
+	}
+	if gotHash != sourceFact.BundleHash || gotSource != sourceFact.BundleSource || gotFingerprint != sourceFact.BundleFingerprint {
+		t.Fatalf("run bundle source = hash:%q source:%q fingerprint:%q, want %#v", gotHash, gotSource, gotFingerprint, sourceFact)
 	}
 }
 

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -7,6 +7,7 @@ import (
 
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
 	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	"swarm/internal/runtime/semanticview"
@@ -14,7 +15,7 @@ import (
 	runtimetools "swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
@@ -25,6 +26,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 		ContractBundle:      source,
 		PayloadValidator:    payloadValidator,
 		BundleFingerprint:   bundleFingerprint,
+		BundleSourceFact:    bundleSourceFact,
 	})
 }
 

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -67,7 +67,16 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	if err != nil {
 		return ErrInvalidMutationLogWriter(err.Error())
 	}
-	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{}); err != nil {
+	opts := storerunlifecycle.EnsureActiveOptions{}
+	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		opts.HasBundleHashCol = true
+		opts.HasBundleSourceCol = true
+		opts.HasBundleFingerprintCol = true
+		opts.BundleHash = fact.BundleHash
+		opts.BundleSource = fact.BundleSource
+		opts.BundleFingerprint = fact.BundleFingerprint
+	}
+	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", opts); err != nil {
 		return err
 	}
 

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -1,8 +1,15 @@
 package mutationlog
 
 import (
+	"context"
+	"database/sql"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
 )
 
 func TestReconstructEntityStateProjection_FailsOnMalformedGateKey(t *testing.T) {
@@ -74,5 +81,40 @@ func TestReconstructEntityStateProjection_AppliesNestedFieldMutationsOverTopLeve
 	}
 	if _, ok := got.Fields["metadata.region"]; ok {
 		t.Fatalf("Fields contains literal dotted key: %#v", got.Fields)
+	}
+}
+
+func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+
+	if err := Insert(ctx, db, Record{
+		EntityID:   uuid.NewString(),
+		Field:      "status",
+		OldValue:   nil,
+		NewValue:   "open",
+		WriterType: "system_node",
+		WriterID:   "review",
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	var gotHash, gotFingerprint sql.NullString
+	var gotSource string
+	if err := db.QueryRow(`
+		SELECT bundle_hash, bundle_source, bundle_fingerprint
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&gotHash, &gotSource, &gotFingerprint); err != nil {
+		t.Fatalf("load run bundle source: %v", err)
+	}
+	if !gotHash.Valid || gotHash.String != sourceFact.BundleHash || gotSource != sourceFact.BundleSource || !gotFingerprint.Valid || gotFingerprint.String != sourceFact.BundleFingerprint {
+		t.Fatalf("run bundle source = hash:%q valid:%v source:%q fingerprint:%q valid:%v, want %#v", gotHash.String, gotHash.Valid, gotSource, gotFingerprint.String, gotFingerprint.Valid, sourceFact)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -66,6 +66,7 @@ type RuntimeOptions struct {
 	EnableToolGateway  bool
 	ToolGatewayToken   string
 	BundleFingerprint  string
+	BundleSourceFact   runtimecorrelation.BundleSourceFact
 	WorkflowModule     runtimepipeline.WorkflowModule
 	LLMRuntime         llm.Runtime
 	Credentials        runtimecredentials.Store
@@ -93,6 +94,7 @@ type validatedRuntimeDeps struct {
 	RuntimeLogCapabilities   runtimeLogCapabilityResolver
 	EventReceiptCapability   func(context.Context) (bool, error)
 	TrimmedBundleFingerprint string
+	BundleSourceFact         runtimecorrelation.BundleSourceFact
 }
 
 const BootProgressTotalSteps = 22
@@ -327,6 +329,7 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 		RuntimeLogCapabilities:   runtimeLogSchemaCapabilities(stores),
 		EventReceiptCapability:   canonicalEventReceiptCapabilities(stores),
 		TrimmedBundleFingerprint: strings.TrimSpace(opts.BundleFingerprint),
+		BundleSourceFact:         opts.BundleSourceFact.Normalized(),
 	}, nil
 }
 
@@ -374,7 +377,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	}
 	payloadValidator := boot.payloadValidator(rt.Logger)
 	boot.bindPayloadValidator(payloadValidator)
-	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, boot.TrimmedBundleFingerprint, func() []runtimebus.EventInterceptor {
+	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, boot.TrimmedBundleFingerprint, boot.BundleSourceFact, func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil
 		}

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -130,3 +130,41 @@ func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.
 		t.Fatalf("ListBundleCatalogAgents malformed error = %v, want runtime field rejection", err)
 	}
 }
+
+func TestBundleCatalogWriteSurfaceUpsertsAndRejectsHashCollision(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	bundleHash := "bundle-v1:sha256:5555555555555555555555555555555555555555555555555555555555555555"
+	req := BundleCatalogUpsert{
+		BundleHash:  bundleHash,
+		ContentYAML: "projection_version: swarm.bundle.catalog.v1\nfiles: []\n",
+		ParsedJSON: map[string]any{
+			"agents": map[string]any{
+				"researcher": map[string]any{
+					"role": "research",
+				},
+			},
+		},
+		DataBlob: []byte(`{"projection_version":"swarm.bundle.catalog.v1","entries":[]}`),
+		Metadata: map[string]any{
+			"source": "test",
+		},
+	}
+
+	detail, err := pg.UpsertBundleCatalog(ctx, req)
+	if err != nil {
+		t.Fatalf("UpsertBundleCatalog: %v", err)
+	}
+	if detail.BundleHash != bundleHash || detail.AgentCount != 1 || !detail.HasData || detail.Metadata["source"] != "test" {
+		t.Fatalf("detail = %#v", detail)
+	}
+
+	if _, err := pg.UpsertBundleCatalog(ctx, req); err != nil {
+		t.Fatalf("UpsertBundleCatalog idempotent: %v", err)
+	}
+	req.ContentYAML = "projection_version: swarm.bundle.catalog.v1\nfiles: [changed]\n"
+	if _, err := pg.UpsertBundleCatalog(ctx, req); err == nil || !strings.Contains(err.Error(), "different content") {
+		t.Fatalf("UpsertBundleCatalog collision error = %v, want different content", err)
+	}
+}

--- a/internal/store/bundle_catalog_write_surface.go
+++ b/internal/store/bundle_catalog_write_surface.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var canonicalBundleHashPattern = regexp.MustCompile(`^bundle-v1:sha256:[0-9a-f]{64}$`)
+
+type BundleCatalogUpsert struct {
+	BundleHash  string
+	ContentYAML string
+	ParsedJSON  map[string]any
+	DataBlob    []byte
+	Metadata    map[string]any
+}
+
+func (s *PostgresStore) UpsertBundleCatalog(ctx context.Context, req BundleCatalogUpsert) (BundleCatalogDetail, error) {
+	if err := s.requireBundleCatalogCapabilities(ctx); err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	req.BundleHash = strings.TrimSpace(req.BundleHash)
+	if !canonicalBundleHashPattern.MatchString(req.BundleHash) {
+		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog upsert requires canonical bundle_hash bundle-v1:sha256:<64 lowercase hex>")
+	}
+	if strings.TrimSpace(req.ContentYAML) == "" {
+		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog upsert requires content_yaml")
+	}
+	parsedRaw, err := normalizedBundleCatalogJSON(req.ParsedJSON)
+	if err != nil {
+		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog parsed_json: %w", err)
+	}
+	metadataRaw, err := normalizedBundleCatalogJSON(req.Metadata)
+	if err != nil {
+		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog metadata: %w", err)
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, data_blob, metadata)
+		VALUES ($1, $2, $3::jsonb, $4::bytea, $5::jsonb)
+		ON CONFLICT (bundle_hash) DO NOTHING
+	`, req.BundleHash, req.ContentYAML, parsedRaw, nullableBytes(req.DataBlob), metadataRaw); err != nil {
+		return BundleCatalogDetail{}, fmt.Errorf("upsert bundle catalog: %w", err)
+	}
+	if err := assertBundleCatalogUpsertIdempotent(ctx, tx, req.BundleHash, req.ContentYAML, parsedRaw, req.DataBlob, metadataRaw); err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	return s.LoadBundleCatalog(ctx, req.BundleHash)
+}
+
+func assertBundleCatalogUpsertIdempotent(ctx context.Context, tx bundleCatalogTx, bundleHash, contentYAML string, parsedRaw, dataBlob, metadataRaw []byte) error {
+	var gotContent string
+	var gotParsed []byte
+	var gotData []byte
+	var gotMetadata []byte
+	if err := tx.QueryRowContext(ctx, `
+		SELECT content_yaml, COALESCE(parsed_json, '{}'::jsonb), data_blob, COALESCE(metadata, '{}'::jsonb)
+		FROM bundles
+		WHERE bundle_hash = $1
+		FOR SHARE
+	`, bundleHash).Scan(&gotContent, &gotParsed, &gotData, &gotMetadata); err != nil {
+		return fmt.Errorf("load bundle catalog upsert result: %w", err)
+	}
+	gotParsed, err := normalizedBundleCatalogJSONBytes(gotParsed)
+	if err != nil {
+		return fmt.Errorf("stored bundle catalog parsed_json: %w", err)
+	}
+	gotMetadata, err = normalizedBundleCatalogJSONBytes(gotMetadata)
+	if err != nil {
+		return fmt.Errorf("stored bundle catalog metadata: %w", err)
+	}
+	if gotContent != contentYAML || !bytes.Equal(gotParsed, parsedRaw) || !bytes.Equal(nullableBytes(gotData), nullableBytes(dataBlob)) || !bytes.Equal(gotMetadata, metadataRaw) {
+		return fmt.Errorf("bundle catalog row for %s already exists with different content", bundleHash)
+	}
+	return nil
+}
+
+type bundleCatalogTx interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func normalizedBundleCatalogJSON(values map[string]any) ([]byte, error) {
+	if values == nil {
+		values = map[string]any{}
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+	return normalizedBundleCatalogJSONBytes(raw)
+}
+
+func normalizedBundleCatalogJSONBytes(raw []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		raw = []byte(`{}`)
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, err
+	}
+	if decoded == nil {
+		decoded = map[string]any{}
+	}
+	return json.Marshal(decoded)
+}
+
+func nullableBytes(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1293,8 +1293,14 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 	}
 	opts := runLifecycleOptions(caps)
 	opts.ReopenCompleted = reopenCompleted
-	opts.BundleSource = storerunlifecycle.BundleSourceLegacy
-	opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
+	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		opts.BundleHash = fact.BundleHash
+		opts.BundleSource = fact.BundleSource
+		opts.BundleFingerprint = fact.BundleFingerprint
+	} else {
+		opts.BundleSource = storerunlifecycle.BundleSourceLegacy
+		opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
+	}
 	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
 }
 

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -52,6 +52,48 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsSe
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 }
 
+func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithBundleSourceFact(context.Background(), runtimecorrelation.BundleSourceFact{
+		BundleHash:        testCanonicalBundleHash,
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: testBootBundleFingerprint,
+	})
+
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        "scan.requested",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(persisted): %v", err)
+	}
+	assertRunBundleIdentity(t, db, runID, testCanonicalBundleHash, storerunlifecycle.BundleSourcePersisted, testBootBundleFingerprint)
+
+	ephemeralRunID := uuid.NewString()
+	ephemeralHash := "bundle-v1:sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	ephemeralCtx := runtimecorrelation.WithBundleSourceFact(context.Background(), runtimecorrelation.BundleSourceFact{
+		BundleHash:        ephemeralHash,
+		BundleSource:      storerunlifecycle.BundleSourceEphemeral,
+		BundleFingerprint: testOtherBundleFingerprint,
+	})
+	if err := pg.AppendEvent(ephemeralCtx, events.Event{
+		ID:          uuid.NewString(),
+		RunID:       ephemeralRunID,
+		Type:        "scan.dev",
+		SourceAgent: "test",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("AppendEvent(ephemeral): %v", err)
+	}
+	assertRunBundleIdentity(t, db, ephemeralRunID, ephemeralHash, storerunlifecycle.BundleSourceEphemeral, testOtherBundleFingerprint)
+}
+
 func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -125,6 +167,18 @@ func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) 
 		t.Fatalf("EnsureActive: %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, testCanonicalBundleHash, storerunlifecycle.BundleSourcePersisted, "")
+}
+
+func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	err := storerunlifecycle.EnsureActive(context.Background(), db, uuid.NewString(), "", "", storerunlifecycle.EnsureActiveOptions{
+		HasBundleHashCol:   true,
+		HasBundleSourceCol: true,
+		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	})
+	if err == nil {
+		t.Fatal("EnsureActive error = nil, want missing bundle_hash rejection")
+	}
 }
 
 func TestPostgresStore_ActiveRunBundleAvailabilityConflicts(t *testing.T) {

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -93,6 +93,12 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	if err != nil {
 		return err
 	}
+	if bundleSource == BundleSourceLegacy && bundleHash != "" {
+		return fmt.Errorf("ensure run row: legacy bundle_source cannot carry canonical bundle_hash")
+	}
+	if bundleSource != BundleSourceLegacy && bundleHash == "" {
+		return fmt.Errorf("ensure run row: bundle_hash is required for bundle_source=%s", bundleSource)
+	}
 	reopenStatus := "runs.status"
 	reopenErrorSummary := ""
 	reopenEndedAt := ""


### PR DESCRIPTION
## Summary

- Adds the supported `swarm serve --contracts` source-fact producer: canonical `BundleHash`, persisted bundle catalog UPSERT/reuse, and runtime `BundleSourceFact` propagation.
- Stamps new serve-created run rows with `bundle_hash` plus `bundle_source=persisted`; `--dev` computes the same canonical hash but writes no `bundles` row and stamps `bundle_source=ephemeral`.
- Ratifies the implemented serve-ingest projection and owners into authoritative `platform-spec.yaml`.

Closes #1015.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_identity.canonicalization_v1`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.persistence_model.serve_ingest_projection`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#platform_tables.tables.bundles`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#platform_tables.tables.runs`
- #1015 pre-audit and independent gate: approved as first slice.
- Parent/sibling context: #1011 parent, #979/#1099 canonical hash owner, #1013/#1057 schema foundation, #1014/#1081 reader migration.

## Semantic Migration

- New canonical owners:
  - `internal/runtime/contracts.BuildBundleCatalogProjection`
  - `internal/store.PostgresStore.UpsertBundleCatalog`
  - `cmd/swarm.prepareServeBundleSource`
  - `internal/runtime/correlation.BundleSourceFact`
  - `internal/store/runlifecycle.EnsureActive` for final run-row persistence
- Old producer/reader/writer paths now invalid for serve-created rows:
  - `RuntimeOptions.BundleFingerprint` / EventBus fingerprint-only context as the sole serve source identity
  - `PostgresStore.ensureRunRow` forcing `bundle_source=legacy` for serve contexts
  - runtime diagnostics and mutation-log backstops calling `EnsureActive` without the source fact
- Production paths checked/moved:
  - `runServeRuntime`, builder project reload, RuntimeOptions/EventBus/correlation, Postgres event-store `ensureRunRow`, inbound/LLM callers through that owner, diagnostics, and mutationlog.
  - SQLite `sqliteEnsureRunRow` remains split because SQLite runtime construction is still fail-closed under the approved #1015 gate.
- Migration completeness: complete for the approved #1015 first slice; #1022, #989/#1108/#976/#1024, #1017, #1016, #1018/#1019/#1027, #981, and SQLite runtime support remain split.

## Proof

- `go test ./...`
- `go test ./internal/runtime/contracts -run 'BundleHashV1|BundleCatalogProjection' -count=1`
- `go test ./internal/store -run 'RunBundleSource|RunLifecycleOwner|BundleCatalog' -count=1`
- `go test ./cmd/swarm -run 'PrepareServeBundleSource|RuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime|ServeBundleMatchAdmission' -count=1`
- `go test ./internal/runtime ./internal/runtime/bus ./internal/runtime/mutationlog -run 'BundleSourceFact|RuntimeLogger_Log_StampsBundleSourceFactOnRunRow|InsertStampsBundleSourceFact|TypedRuntimeDiagnosticLineage' -count=1`
- `go test ./internal/apispec -run MultiBundleSourceAuthority -count=1`