### PR TITLE
[agent-e][issue #1017] Add bundle.register API

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -433,6 +433,8 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		},
 	}
 	apiReadOptions := apiv1.OperatorReadOptions{
+		RepoRoot:         repo,
+		PlatformSpecPath: resolvedPlatformSpecPath,
 		Ready: func() bool {
 			return ready.Load()
 		},

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -1542,7 +1542,7 @@
     },
     {
       "name": "bundle.register",
-      "description": "Register a bundle into the persisted bundle catalog without starting a runtime. The request submits a BundleRegistrationEnvelopeV1 YAML document plus optional raw data files. The server materializes those files into a temporary contract root, computes the canonical bundle_hash through internal/runtime/contracts.BundleHash, stores canonical bundle catalog projection bytes through the shared store UPSERT owner, and returns the canonical bundle_hash. This method never mutates runs and never restores rows whose bundle_source was previously marked deleted.\n",
+      "description": "Register a bundle into the persisted bundle catalog without starting a runtime. The request submits a BundleRegistrationEnvelopeV1 YAML document plus optional BundleRegisterDataBlobV1 entries. The server materializes those files into a temporary contract root, computes the canonical bundle_hash through internal/runtime/contracts.BundleHash, stores canonical bundle catalog projection bytes through the shared store UPSERT owner, and returns the canonical bundle_hash. This method never mutates runs and never restores rows whose bundle_source was previously marked deleted.\n",
       "params": [
         {
           "name": "content_yaml",
@@ -1556,7 +1556,7 @@
           "name": "data_blob",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/BundleRegistrationDataBlob"
+            "$ref": "#/components/schemas/BundleRegisterDataBlobV1"
           }
         },
         {
@@ -7793,17 +7793,52 @@
         ],
         "type": "object"
       },
-      "BundleRegistrationDataBlob": {
-        "additionalProperties": {
-          "contentEncoding": "base64",
-          "type": "string"
+      "BundleRegisterDataBlobV1": {
+        "additionalProperties": false,
+        "description": "Optional structured raw data files for bundle.register; the server persists canonical projection bytes.",
+        "properties": {
+          "api_version": {
+            "const": "swarm.bundle.data.v1",
+            "type": "string"
+          },
+          "entries": {
+            "description": "Ordered data entries sorted strictly by normalized path.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "data_base64": {
+                  "contentEncoding": "base64",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Strictly sorted slash-separated path under flows/\u003cflow\u003e/data/... with the same normalization and collision rules as BundleRegistrationFile.path.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "data_base64"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
         },
-        "description": "Optional raw data files keyed by slash-separated bundle-relative path; values are standard base64 bytes.",
+        "required": [
+          "api_version",
+          "entries"
+        ],
         "type": "object"
       },
       "BundleRegistrationEnvelopeV1": {
         "additionalProperties": false,
         "properties": {
+          "api_version": {
+            "const": "swarm.bundle.register.v1",
+            "description": "Envelope version for non-destructive bundle.register materialization.",
+            "type": "string"
+          },
           "files": {
             "description": "Text contract files to materialize under the temporary bundle root. package.yaml is required.",
             "items": {
@@ -7811,15 +7846,10 @@
             },
             "minItems": 1,
             "type": "array"
-          },
-          "version": {
-            "const": "swarm.bundle.registration.v1",
-            "description": "Envelope version for non-destructive bundle.register materialization.",
-            "type": "string"
           }
         },
         "required": [
-          "version",
+          "api_version",
           "files"
         ],
         "type": "object"
@@ -7827,19 +7857,19 @@
       "BundleRegistrationFile": {
         "additionalProperties": false,
         "properties": {
-          "content": {
-            "description": "UTF-8 text content for YAML, prompt, policy, and other non-data bundle files.",
+          "path": {
+            "description": "Slash-separated path relative to the bundle root. Empty, dot, dot-dot, absolute, backslash, NUL, non-NFC, duplicate, and ASCII case-colliding paths are invalid.",
+            "minLength": 1,
             "type": "string"
           },
-          "path": {
-            "description": "Slash-separated path relative to the bundle root. Absolute paths, backslashes, NUL, and parent traversal are invalid.",
-            "minLength": 1,
+          "text": {
+            "description": "UTF-8 text content for YAML, prompt, policy, and other non-data bundle files.",
             "type": "string"
           }
         },
         "required": [
           "path",
-          "content"
+          "text"
         ],
         "type": "object"
       },
@@ -7849,8 +7879,13 @@
           "bundle_hash": {
             "$ref": "#/components/schemas/BundleHash"
           },
-          "idempotency_replayed": {
-            "description": "True when the response was returned from the API idempotency owner.",
+          "data_size_bytes": {
+            "description": "Size of persisted data_blob bytes, or 0 when has_data is false.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "has_data": {
+            "description": "True when the persisted bundle row carries an auxiliary data_blob.",
             "type": "boolean"
           },
           "registered": {
@@ -7861,7 +7896,8 @@
         "required": [
           "bundle_hash",
           "registered",
-          "idempotency_replayed"
+          "has_data",
+          "data_size_bytes"
         ],
         "type": "object"
       },

--- a/docs/specs/swarm-platform/platform/contracts/openrpc.json
+++ b/docs/specs/swarm-platform/platform/contracts/openrpc.json
@@ -323,7 +323,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -399,7 +399,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -454,7 +454,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -514,7 +514,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -568,7 +568,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -626,7 +626,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -767,7 +767,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -893,7 +893,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1113,7 +1113,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1151,7 +1151,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1254,7 +1254,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1541,6 +1541,140 @@
       }
     },
     {
+      "name": "bundle.register",
+      "description": "Register a bundle into the persisted bundle catalog without starting a runtime. The request submits a BundleRegistrationEnvelopeV1 YAML document plus optional raw data files. The server materializes those files into a temporary contract root, computes the canonical bundle_hash through internal/runtime/contracts.BundleHash, stores canonical bundle catalog projection bytes through the shared store UPSERT owner, and returns the canonical bundle_hash. This method never mutates runs and never restores rows whose bundle_source was previously marked deleted.\n",
+      "params": [
+        {
+          "name": "content_yaml",
+          "required": true,
+          "description": "YAML-encoded BundleRegistrationEnvelopeV1. This is an upload envelope, not server-local filesystem authority.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "data_blob",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/BundleRegistrationDataBlob"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BundleRegistrationResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32006,
+          "message": "Application error: BUNDLE_REGISTER_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_REGISTER_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  }
+                },
+                "required": [
+                  "bundle_hash"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32017,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "conversation.current_for_agent",
       "description": "Read the agent's current (most-recent active) session. Replaces the\nownership-violating agent.get_session that earlier drafts proposed —\nagent.* doesn't own sessions; conversation.* does.\n",
       "params": [
@@ -1643,7 +1777,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1681,7 +1815,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1724,7 +1858,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1762,7 +1896,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1858,7 +1992,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1896,7 +2030,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1984,7 +2118,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2022,7 +2156,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2155,7 +2289,7 @@
       },
       "errors": [
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2215,7 +2349,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2292,7 +2426,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2330,7 +2464,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2498,7 +2632,7 @@
       },
       "errors": [
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2631,7 +2765,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2853,7 +2987,7 @@
           }
         },
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -2888,7 +3022,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -2923,7 +3057,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -2976,7 +3110,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3033,7 +3167,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3091,7 +3225,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3129,7 +3263,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3167,7 +3301,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3209,7 +3343,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3308,7 +3442,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3346,7 +3480,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -3384,7 +3518,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -3439,7 +3573,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3499,7 +3633,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -3553,7 +3687,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3611,7 +3745,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3792,7 +3926,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3830,7 +3964,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -3882,7 +4016,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -3924,7 +4058,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4019,7 +4153,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4057,7 +4191,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4109,7 +4243,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -4154,7 +4288,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4235,7 +4369,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4390,7 +4524,7 @@
       },
       "errors": [
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4428,7 +4562,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4480,7 +4614,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4588,7 +4722,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4626,7 +4760,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4668,7 +4802,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4749,7 +4883,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4833,7 +4967,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -4933,7 +5067,7 @@
           }
         },
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
           "data": {
             "additionalProperties": false,
@@ -4983,7 +5117,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5021,7 +5155,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5059,7 +5193,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5149,7 +5283,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5290,7 +5424,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5328,7 +5462,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5370,7 +5504,7 @@
           }
         },
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5408,7 +5542,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5583,7 +5717,7 @@
           }
         },
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -5618,7 +5752,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -5653,7 +5787,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -5706,7 +5840,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5763,7 +5897,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5821,7 +5955,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5909,7 +6043,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5947,7 +6081,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5989,7 +6123,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6089,7 +6223,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6190,7 +6324,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6470,7 +6604,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -6508,7 +6642,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6589,7 +6723,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6620,7 +6754,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6701,7 +6835,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6732,7 +6866,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7656,6 +7790,78 @@
         },
         "required": [
           "fingerprint"
+        ],
+        "type": "object"
+      },
+      "BundleRegistrationDataBlob": {
+        "additionalProperties": {
+          "contentEncoding": "base64",
+          "type": "string"
+        },
+        "description": "Optional raw data files keyed by slash-separated bundle-relative path; values are standard base64 bytes.",
+        "type": "object"
+      },
+      "BundleRegistrationEnvelopeV1": {
+        "additionalProperties": false,
+        "properties": {
+          "files": {
+            "description": "Text contract files to materialize under the temporary bundle root. package.yaml is required.",
+            "items": {
+              "$ref": "#/components/schemas/BundleRegistrationFile"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "version": {
+            "const": "swarm.bundle.registration.v1",
+            "description": "Envelope version for non-destructive bundle.register materialization.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "files"
+        ],
+        "type": "object"
+      },
+      "BundleRegistrationFile": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "UTF-8 text content for YAML, prompt, policy, and other non-data bundle files.",
+            "type": "string"
+          },
+          "path": {
+            "description": "Slash-separated path relative to the bundle root. Absolute paths, backslashes, NUL, and parent traversal are invalid.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BundleRegistrationResult": {
+        "additionalProperties": false,
+        "properties": {
+          "bundle_hash": {
+            "$ref": "#/components/schemas/BundleHash"
+          },
+          "idempotency_replayed": {
+            "description": "True when the response was returned from the API idempotency owner.",
+            "type": "boolean"
+          },
+          "registered": {
+            "description": "True only when this call inserted a new bundle catalog row; false for duplicate same-content registration.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "bundle_hash",
+          "registered",
+          "idempotency_replayed"
         ],
         "type": "object"
       },
@@ -9644,6 +9850,7 @@
           "read:entities",
           "read:events",
           "read:bundles",
+          "write:bundles",
           "read:mailbox",
           "approve:mailbox",
           "read:agents",
@@ -10137,8 +10344,46 @@
           "type": "object"
         }
       },
-      "BUNDLE_UNAVAILABLE": {
+      "BUNDLE_REGISTER_CONFLICT": {
         "code": -32006,
+        "message": "Application error: BUNDLE_REGISTER_CONFLICT",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "BUNDLE_REGISTER_CONFLICT",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                }
+              },
+              "required": [
+                "bundle_hash"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "BUNDLE_UNAVAILABLE": {
+        "code": -32007,
         "message": "Application error: BUNDLE_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10188,7 +10433,7 @@
         }
       },
       "ENTITY_NOT_FOUND": {
-        "code": -32007,
+        "code": -32008,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10226,7 +10471,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -10279,7 +10524,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10317,7 +10562,7 @@
         }
       },
       "EVENT_PUBLISH_FAILED": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: EVENT_PUBLISH_FAILED",
         "data": {
           "additionalProperties": false,
@@ -10374,7 +10619,7 @@
         }
       },
       "EVENT_REPLAY_NOT_ELIGIBLE": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -10428,7 +10673,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -10466,7 +10711,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -10521,7 +10766,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10581,7 +10826,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10619,7 +10864,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -10678,7 +10923,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -10723,7 +10968,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -10775,7 +11020,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -10817,7 +11062,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10855,7 +11100,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10893,7 +11138,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -10951,7 +11196,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -10982,7 +11227,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11013,7 +11258,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -11051,7 +11296,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11089,7 +11334,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -11131,7 +11376,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11169,7 +11414,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32029,
+        "code": -32030,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11211,7 +11456,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32030,
+        "code": -32031,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11249,7 +11494,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32031,
+        "code": -32032,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11292,7 +11537,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH": {
-        "code": -32032,
+        "code": -32033,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
         "data": {
           "additionalProperties": false,
@@ -11327,7 +11572,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH_FORK": {
-        "code": -32033,
+        "code": -32034,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
         "data": {
           "additionalProperties": false,
@@ -11377,7 +11622,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32034,
+        "code": -32035,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5839,8 +5839,8 @@ multi_bundle_persistence:
         result: Agent definitions from the persisted bundle bytes
       bundle.register:
         kind: mutate
-        params: BundleRegistrationEnvelopeV1 content_yaml, data_blob?, idempotency_key?
-        result: BundleRegistrationResult with bundle_hash, registered, and idempotency_replayed
+        params: BundleRegistrationEnvelopeV1 content_yaml, BundleRegisterDataBlobV1 data_blob?, idempotency_key?
+        result: BundleRegistrationResult with bundle_hash, registered, has_data, and data_size_bytes
         rule: >
           Registration materializes the submitted BundleRegistrationEnvelopeV1 into a temporary contract root, consumes the
           canonical internal/runtime/contracts.BundleHash owner, persists exactly one shared bundle catalog row through the
@@ -10536,12 +10536,12 @@ api_specification:
         type: object
         additionalProperties: false
         required:
-        - version
+        - api_version
         - files
         properties:
-          version:
+          api_version:
             type: string
-            const: swarm.bundle.registration.v1
+            const: swarm.bundle.register.v1
             description: Envelope version for non-destructive bundle.register materialization.
           files:
             type: array
@@ -10554,37 +10554,64 @@ api_specification:
         additionalProperties: false
         required:
         - path
-        - content
+        - text
         properties:
           path:
             type: string
             minLength: 1
-            description: Slash-separated path relative to the bundle root. Absolute paths, backslashes, NUL, and parent traversal are invalid.
-          content:
+            description: Slash-separated path relative to the bundle root. Empty, dot, dot-dot, absolute, backslash, NUL, non-NFC, duplicate, and ASCII case-colliding paths are invalid.
+          text:
             type: string
             description: UTF-8 text content for YAML, prompt, policy, and other non-data bundle files.
-      BundleRegistrationDataBlob:
+      BundleRegisterDataBlobV1:
         type: object
-        additionalProperties:
-          type: string
-          contentEncoding: base64
-        description: Optional raw data files keyed by slash-separated bundle-relative path; values are standard base64 bytes.
+        additionalProperties: false
+        required:
+        - api_version
+        - entries
+        properties:
+          api_version:
+            type: string
+            const: swarm.bundle.data.v1
+          entries:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              required:
+              - path
+              - data_base64
+              properties:
+                path:
+                  type: string
+                  minLength: 1
+                  description: Strictly sorted slash-separated path under flows/<flow>/data/... with the same normalization and collision rules as BundleRegistrationFile.path.
+                data_base64:
+                  type: string
+                  contentEncoding: base64
+            description: Ordered data entries sorted strictly by normalized path.
+        description: Optional structured raw data files for bundle.register; the server persists canonical projection bytes.
       BundleRegistrationResult:
         type: object
         additionalProperties: false
         required:
         - bundle_hash
         - registered
-        - idempotency_replayed
+        - has_data
+        - data_size_bytes
         properties:
           bundle_hash:
             $ref: '#/components/schemas/BundleHash'
           registered:
             type: boolean
             description: True only when this call inserted a new bundle catalog row; false for duplicate same-content registration.
-          idempotency_replayed:
+          has_data:
             type: boolean
-            description: True when the response was returned from the API idempotency owner.
+            description: True when the persisted bundle row carries an auxiliary data_blob.
+          data_size_bytes:
+            type: integer
+            minimum: 0
+            description: Size of persisted data_blob bytes, or 0 when has_data is false.
       HealthCheckResult:
         type: object
         additionalProperties: false
@@ -13284,7 +13311,7 @@ api_specification:
       tier: should_have
       description: >
         Register a bundle into the persisted bundle catalog without starting a runtime. The request submits a
-        BundleRegistrationEnvelopeV1 YAML document plus optional raw data files. The server materializes those files into a
+        BundleRegistrationEnvelopeV1 YAML document plus optional BundleRegisterDataBlobV1 entries. The server materializes those files into a
         temporary contract root, computes the canonical bundle_hash through internal/runtime/contracts.BundleHash, stores
         canonical bundle catalog projection bytes through the shared store UPSERT owner, and returns the canonical
         bundle_hash. This method never mutates runs and never restores rows whose bundle_source was previously marked
@@ -13302,7 +13329,7 @@ api_specification:
       - name: data_blob
         required: false
         schema:
-          $ref: '#/components/schemas/BundleRegistrationDataBlob'
+          $ref: '#/components/schemas/BundleRegisterDataBlobV1'
       - name: idempotency_key
         required: false
         schema:

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5504,18 +5504,19 @@ multi_bundle_persistence:
     promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
     generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
-    current_openrpc_status: bundle_read_catalog_and_run_fork_methods_published
+    current_openrpc_status: bundle_read_catalog_register_and_run_fork_methods_published
     rule: >
       Generated openrpc.json is derived from api_specification.method_catalog and must continue to match the currently
       registered /v1/rpc handler set. The read-only bundle.list, bundle.get, and bundle.agents catalog methods are now
       published because their handlers and store owner are implemented in the same gated PR. run.fork is now published
       because its selected-contract API/runtime handler owner is implemented in the same gated PR. Mutating bundle.register
-      and destructive bundle.delete remain source authority only until their API/runtime handlers are implemented and
-      registered in a later gated PR.
+      is now published because its handler, idempotency behavior, shared bundle catalog writer, and generated artifacts are
+      implemented together. Destructive bundle.delete remains source authority only until its API/runtime handler is
+      implemented and registered in a later gated PR.
     proof_expectation: >
-      Source-authority promotion proof must verify that bundle.register and bundle.delete are not silently published in
-      generated OpenRPC without implementation, and that future implementation PRs promote matching method_catalog entries
-      and generated artifacts together.
+      Source-authority promotion proof must verify that bundle.delete is not silently published in generated OpenRPC
+      without implementation, and that future implementation PRs promote matching method_catalog entries and generated
+      artifacts together.
   bundle_identity:
     canonical_name: bundle_hash
     format: 'bundle-v1:sha256:<64 lowercase hex>'
@@ -5822,7 +5823,7 @@ multi_bundle_persistence:
         - containers_stopped
         - dry_run
   api_surface:
-    publication_status: partial_bundle_read_catalog_and_run_fork_generated_openrpc
+    publication_status: bundle_read_catalog_register_and_run_fork_generated_openrpc
     command_transport_owner: api_specification
     bundle_methods_planned:
       bundle.list:
@@ -5838,8 +5839,15 @@ multi_bundle_persistence:
         result: Agent definitions from the persisted bundle bytes
       bundle.register:
         kind: mutate
-        params: content_yaml, data_blob?, idempotency_key?
-        result: BundleRegistrationResult with bundle_hash
+        params: BundleRegistrationEnvelopeV1 content_yaml, data_blob?, idempotency_key?
+        result: BundleRegistrationResult with bundle_hash, registered, and idempotency_replayed
+        rule: >
+          Registration materializes the submitted BundleRegistrationEnvelopeV1 into a temporary contract root, consumes the
+          canonical internal/runtime/contracts.BundleHash owner, persists exactly one shared bundle catalog row through the
+          store UPSERT owner, and does not start runtime work or update runs. Re-registering the same canonical content is a
+          no-op. Existing same-hash rows with different persisted content/projection fail closed with
+          BUNDLE_REGISTER_CONFLICT. Re-registering a previously deleted hash never restores runs.bundle_source from deleted
+          to persisted.
       bundle.delete:
         kind: destructive_mutate
         params: bundle_hash, force?, dry_run?, idempotency_key?
@@ -10174,6 +10182,7 @@ api_specification:
         '
       ttl: 24 hours after first completed response stored.
       mutating_methods:
+      - bundle.register
       - event.publish
       - event.replay
       - run.fork
@@ -10263,6 +10272,7 @@ api_specification:
       - read:entities
       - read:events
       - read:bundles
+      - write:bundles
       - read:mailbox
       - approve:mailbox
       - read:agents
@@ -10362,6 +10372,7 @@ api_specification:
         - read:entities
         - read:events
         - read:bundles
+        - write:bundles
         - read:mailbox
         - approve:mailbox
         - read:agents
@@ -10521,6 +10532,59 @@ api_specification:
             type: array
             items:
               $ref: '#/components/schemas/BundleAgentDefinition'
+      BundleRegistrationEnvelopeV1:
+        type: object
+        additionalProperties: false
+        required:
+        - version
+        - files
+        properties:
+          version:
+            type: string
+            const: swarm.bundle.registration.v1
+            description: Envelope version for non-destructive bundle.register materialization.
+          files:
+            type: array
+            minItems: 1
+            items:
+              $ref: '#/components/schemas/BundleRegistrationFile'
+            description: Text contract files to materialize under the temporary bundle root. package.yaml is required.
+      BundleRegistrationFile:
+        type: object
+        additionalProperties: false
+        required:
+        - path
+        - content
+        properties:
+          path:
+            type: string
+            minLength: 1
+            description: Slash-separated path relative to the bundle root. Absolute paths, backslashes, NUL, and parent traversal are invalid.
+          content:
+            type: string
+            description: UTF-8 text content for YAML, prompt, policy, and other non-data bundle files.
+      BundleRegistrationDataBlob:
+        type: object
+        additionalProperties:
+          type: string
+          contentEncoding: base64
+        description: Optional raw data files keyed by slash-separated bundle-relative path; values are standard base64 bytes.
+      BundleRegistrationResult:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        - registered
+        - idempotency_replayed
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          registered:
+            type: boolean
+            description: True only when this call inserted a new bundle catalog row; false for duplicate same-content registration.
+          idempotency_replayed:
+            type: boolean
+            description: True when the response was returned from the API idempotency owner.
       HealthCheckResult:
         type: object
         additionalProperties: false
@@ -12694,6 +12758,14 @@ api_specification:
             $ref: '#/components/schemas/Sha256Fingerprint'
           cause:
             type: string
+      BUNDLE_REGISTER_CONFLICT:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
       UNSUPPORTED_BUNDLE_HASH:
         type: object
         additionalProperties: false
@@ -13208,6 +13280,41 @@ api_specification:
           $ref: '#/components/schemas/BundleAgentsResult'
       errors:
       - BUNDLE_NOT_FOUND
+    bundle.register:
+      tier: should_have
+      description: >
+        Register a bundle into the persisted bundle catalog without starting a runtime. The request submits a
+        BundleRegistrationEnvelopeV1 YAML document plus optional raw data files. The server materializes those files into a
+        temporary contract root, computes the canonical bundle_hash through internal/runtime/contracts.BundleHash, stores
+        canonical bundle catalog projection bytes through the shared store UPSERT owner, and returns the canonical
+        bundle_hash. This method never mutates runs and never restores rows whose bundle_source was previously marked
+        deleted.
+      scope:
+        required:
+        - write:bundles
+      idempotency: per the convention.
+      params:
+      - name: content_yaml
+        required: true
+        description: YAML-encoded BundleRegistrationEnvelopeV1. This is an upload envelope, not server-local filesystem authority.
+        schema:
+          type: string
+      - name: data_blob
+        required: false
+        schema:
+          $ref: '#/components/schemas/BundleRegistrationDataBlob'
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleRegistrationResult'
+      errors:
+      - BUNDLE_REGISTER_CONFLICT
+      - IDEMPOTENCY_CONFLICT
     health.subscribe:
       tier: should_have
       description: WebSocket heartbeat subscription. Notifications carry the same shape as health.check returns.
@@ -15179,8 +15286,8 @@ api_specification:
         Legacy dynamic bundle.open/reload/close remains deferred and is not the multi-bundle public API. #1012 promotes the
         authoritative multi-bundle source model under multi_bundle_persistence, with planned bundle.list/get/agents/register/delete,
         run.fork, and bundle_hash create-new-work semantics. The read-only bundle.list/get/agents catalog methods and
-        run.fork are now published in method_catalog/OpenRPC with handlers; bundle.register/delete remain withheld until
-        their gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
+        non-destructive bundle.register and run.fork are now published in method_catalog/OpenRPC with handlers;
+        bundle.delete remains withheld until its gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
         language is migration evidence only after the #1001 bundle_hash decision.
     verify:
       methods:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -16,17 +16,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 54 {
-		t.Fatalf("method count = %d, want 54", report.MethodCount)
+	if report.MethodCount != 55 {
+		t.Fatalf("method count = %d, want 55", report.MethodCount)
 	}
-	if report.SchemaCount != 99 {
-		t.Fatalf("schema count = %d, want 99", report.SchemaCount)
+	if report.SchemaCount != 103 {
+		t.Fatalf("schema count = %d, want 103", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 35 {
-		t.Fatalf("error code count = %d, want 35", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 36 {
+		t.Fatalf("error code count = %d, want 36", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 20 {
-		t.Fatalf("mutating method count = %d, want 20", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 21 {
+		t.Fatalf("mutating method count = %d, want 21", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
@@ -66,14 +66,14 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 54 {
-		t.Fatalf("generated OpenRPC methods = %d, want 54", len(doc.Methods))
+	if len(doc.Methods) != 55 {
+		t.Fatalf("generated OpenRPC methods = %d, want 55", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 99 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 99", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 103 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 103", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 35 {
-		t.Fatalf("generated OpenRPC errors = %d, want 35", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 36 {
+		t.Fatalf("generated OpenRPC errors = %d, want 36", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
@@ -99,12 +99,12 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := methods["agent.delivery_diagnostics"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.delivery_diagnostics")
 	}
-	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents"} {
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register"} {
 		if _, ok := methods[methodName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", methodName)
 		}
 	}
-	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult"} {
+	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult", "BundleRegistrationEnvelopeV1", "BundleRegistrationFile", "BundleRegistrationDataBlob", "BundleRegistrationResult"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}
@@ -281,11 +281,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
 
 	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
-	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_and_run_fork_methods_published")
+	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_and_run_fork_methods_published")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.list")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "run.fork")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.register")
-	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "later gated PR")
+	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "now published")
 
 	identity := mustMappingValue(t, multi, "bundle_identity")
 	assertScalarValue(t, mustMappingValue(t, identity, "canonical_name"), "bundle_hash")
@@ -343,7 +343,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	apiSurface := mustMappingValue(t, multi, "api_surface")
-	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "partial_bundle_read_catalog_and_run_fork_generated_openrpc")
+	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "bundle_read_catalog_register_and_run_fork_generated_openrpc")
 
 	bundleDelete := mustMappingValue(t, multi, "bundle_delete")
 	phaseFive := mustMappingValue(t, bundleDelete, "phase_5_atomicity")
@@ -460,15 +460,15 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	api := loadRepoAPISpec(t)
-	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents"} {
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register"} {
 		if _, ok := api.MethodCatalog[methodName]; !ok {
-			t.Fatalf("%s must be in live method_catalog after read-only bundle catalog implementation lands", methodName)
+			t.Fatalf("%s must be in live method_catalog after bundle catalog implementation lands", methodName)
 		}
 	}
 	if _, ok := api.MethodCatalog["run.fork"]; !ok {
 		t.Fatal("run.fork missing from live method_catalog after API/runtime handler promotion")
 	}
-	for _, methodName := range []string{"bundle.register", "bundle.delete"} {
+	for _, methodName := range []string{"bundle.delete"} {
 		if _, ok := api.MethodCatalog[methodName]; ok {
 			t.Fatalf("%s must not be in live method_catalog until handler implementation lands", methodName)
 		}
@@ -483,7 +483,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 	for _, method := range doc.Methods {
 		switch method.Name {
-		case "bundle.register", "bundle.delete":
+		case "bundle.delete":
 			t.Fatalf("%s must not be published in generated OpenRPC until implementation lands", method.Name)
 		}
 	}

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -104,7 +104,7 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 			t.Fatalf("generated OpenRPC missing %s", methodName)
 		}
 	}
-	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult", "BundleRegistrationEnvelopeV1", "BundleRegistrationFile", "BundleRegistrationDataBlob", "BundleRegistrationResult"} {
+	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult", "BundleRegistrationEnvelopeV1", "BundleRegistrationFile", "BundleRegisterDataBlobV1", "BundleRegistrationResult"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -29,11 +30,14 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 54 {
-		t.Fatalf("method count = %d, want 54", len(openRPCNames))
+	if len(openRPCNames) != 55 {
+		t.Fatalf("method count = %d, want 55", len(openRPCNames))
 	}
 	if _, ok := registry.Method("run.fork"); !ok {
 		t.Fatal("run.fork missing from generated registry")
+	}
+	if _, ok := registry.Method("bundle.register"); !ok {
+		t.Fatal("bundle.register missing from generated registry")
 	}
 	if _, ok := registry.Method("rpc.unsubscribe"); !ok {
 		t.Fatal("rpc.unsubscribe missing from generated registry")
@@ -587,6 +591,121 @@ func TestOperatorBundleCatalogHandlersErrors(t *testing.T) {
 	}
 }
 
+func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempotency(t *testing.T) {
+	catalog := &fakeBundleCatalogReadStore{
+		details: map[string]store.BundleCatalogDetail{},
+		agents:  map[string]store.BundleCatalogAgentsResult{},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:           func() time.Time { return time.Unix(1700000200, 0).UTC() },
+			BundleCatalog: catalog,
+			Idempotency:   newRecordingAPIIdempotencyStore(),
+		}),
+	})
+	envelope := testBundleRegistrationEnvelope()
+
+	first := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"register","method":"bundle.register","params":{"content_yaml":%q,"idempotency_key":"idem-register"}}`, envelope))
+	if first.Error != nil {
+		t.Fatalf("bundle.register error = %#v", first.Error)
+	}
+	result := asMap(t, first.Result)
+	bundleHash, ok := result["bundle_hash"].(string)
+	if !ok || !bundleHashPattern.MatchString(bundleHash) {
+		t.Fatalf("bundle.register bundle_hash = %#v", result["bundle_hash"])
+	}
+	if result["registered"] != true || result["idempotency_replayed"] != false {
+		t.Fatalf("bundle.register result = %#v", result)
+	}
+	if len(catalog.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(catalog.upserts))
+	}
+	upsert := catalog.upserts[0]
+	if upsert.BundleHash != bundleHash || !strings.Contains(upsert.ContentYAML, "bundle/package.yaml") || !strings.Contains(upsert.ContentYAML, "platform/platform-spec.yaml") {
+		t.Fatalf("bundle.register upsert = %#v", upsert)
+	}
+	if upsert.Metadata["source"] != "bundle.register" || upsert.Metadata["platform_spec_sha256"] == "" {
+		t.Fatalf("bundle.register metadata = %#v", upsert.Metadata)
+	}
+	agents := asMap(t, upsert.ParsedJSON["agents"])
+	researcher := asMap(t, agents["researcher"])
+	if researcher["model_tier"] != "tier2" || researcher["conversation_mode"] != "stateless" {
+		t.Fatalf("projected researcher = %#v", researcher)
+	}
+
+	replay := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"replay","method":"bundle.register","params":{"content_yaml":%q,"idempotency_key":"idem-register"}}`, envelope))
+	if replay.Error != nil {
+		t.Fatalf("bundle.register replay error = %#v", replay.Error)
+	}
+	replayResult := asMap(t, replay.Result)
+	if replayResult["bundle_hash"] != bundleHash || replayResult["registered"] != true || replayResult["idempotency_replayed"] != true {
+		t.Fatalf("bundle.register replay result = %#v", replayResult)
+	}
+	if len(catalog.upserts) != 1 {
+		t.Fatalf("upserts after replay = %d, want 1", len(catalog.upserts))
+	}
+
+	duplicate := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"duplicate","method":"bundle.register","params":{"content_yaml":%q}}`, envelope))
+	if duplicate.Error != nil {
+		t.Fatalf("bundle.register duplicate error = %#v", duplicate.Error)
+	}
+	if duplicateResult := asMap(t, duplicate.Result); duplicateResult["registered"] != false || duplicateResult["idempotency_replayed"] != false {
+		t.Fatalf("bundle.register duplicate result = %#v", duplicateResult)
+	}
+}
+
+func TestOperatorBundleRegisterHandlersFailClosed(t *testing.T) {
+	catalog := &fakeBundleCatalogReadStore{
+		details: map[string]store.BundleCatalogDetail{},
+		agents:  map[string]store.BundleCatalogAgentsResult{},
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			BundleCatalog: catalog,
+			Idempotency:   newRecordingAPIIdempotencyStore(),
+		}),
+	})
+
+	unconsumed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"unconsumed","method":"bundle.register","params":{"content_yaml":%q,"data_blob":{"unreferenced.bin":"AQI="}}}`, testBundleRegistrationEnvelope()))
+	if unconsumed.Error == nil || unconsumed.Error.Code != codeInvalidParams {
+		t.Fatalf("bundle.register unconsumed error = %#v, want invalid params", unconsumed.Error)
+	}
+	if len(catalog.upserts) != 0 {
+		t.Fatalf("upserts after invalid registration = %d, want 0", len(catalog.upserts))
+	}
+
+	catalog.conflict = true
+	conflict := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"conflict","method":"bundle.register","params":{"content_yaml":%q}}`, testBundleRegistrationEnvelope()))
+	if conflict.Error == nil {
+		t.Fatal("bundle.register conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != BundleRegisterConflictCode {
+		t.Fatalf("bundle.register conflict data = %#v", data)
+	}
+}
+
+func testBundleRegistrationEnvelope() string {
+	return `version: swarm.bundle.registration.v1
+files:
+  - path: package.yaml
+    content: |
+      name: registered
+      version: "1.0.0"
+      flows: []
+  - path: agents.yaml
+    content: |
+      researcher:
+        id: researcher
+        role: research
+        model_tier: tier2
+        conversation_mode: stateless
+        subscriptions:
+          - scan.requested
+`
+}
+
 func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {
 	t.Helper()
 	rec := httptest.NewRecorder()
@@ -659,6 +778,8 @@ type fakeBundleCatalogReadStore struct {
 	details    map[string]store.BundleCatalogDetail
 	agents     map[string]store.BundleCatalogAgentsResult
 	missing    map[string]bool
+	upserts    []store.BundleCatalogUpsert
+	conflict   bool
 }
 
 func (s *fakeBundleCatalogReadStore) ListBundleCatalog(_ context.Context, opts store.BundleCatalogListOptions) (store.BundleCatalogListResult, error) {
@@ -691,7 +812,37 @@ func (s *fakeBundleCatalogReadStore) ListBundleCatalogAgents(_ context.Context, 
 	return result, nil
 }
 
+func (s *fakeBundleCatalogReadStore) UpsertBundleCatalog(_ context.Context, req store.BundleCatalogUpsert) (store.BundleCatalogUpsertResult, error) {
+	if s.conflict {
+		return store.BundleCatalogUpsertResult{}, &store.BundleCatalogConflictError{BundleHash: req.BundleHash}
+	}
+	if s.details == nil {
+		s.details = map[string]store.BundleCatalogDetail{}
+	}
+	if s.agents == nil {
+		s.agents = map[string]store.BundleCatalogAgentsResult{}
+	}
+	_, exists := s.details[req.BundleHash]
+	s.upserts = append(s.upserts, req)
+	detail := store.BundleCatalogDetail{
+		BundleHash:    req.BundleHash,
+		ContentYAML:   req.ContentYAML,
+		ParsedJSON:    req.ParsedJSON,
+		Metadata:      req.Metadata,
+		AgentCount:    1,
+		HasData:       len(req.DataBlob) > 0,
+		DataSizeBytes: int64(len(req.DataBlob)),
+		IngestedAt:    time.Unix(1700000200, 0).UTC(),
+	}
+	if exists {
+		detail = s.details[req.BundleHash]
+	}
+	s.details[req.BundleHash] = detail
+	return store.BundleCatalogUpsertResult{Detail: detail, Registered: !exists}, nil
+}
+
 var _ BundleCatalogReadStore = (*fakeBundleCatalogReadStore)(nil)
+var _ BundleCatalogRegisterStore = (*fakeBundleCatalogReadStore)(nil)
 
 func testHandler(t *testing.T, opts Options) *Handler {
 	t.Helper()

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -2,6 +2,7 @@ package apiv1
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -622,8 +623,11 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 	if !ok || !bundleHashPattern.MatchString(bundleHash) {
 		t.Fatalf("bundle.register bundle_hash = %#v", result["bundle_hash"])
 	}
-	if result["registered"] != true || result["idempotency_replayed"] != false {
+	if result["registered"] != true || result["has_data"] != false || result["data_size_bytes"] != float64(0) {
 		t.Fatalf("bundle.register result = %#v", result)
+	}
+	if _, ok := result["idempotency_replayed"]; ok {
+		t.Fatalf("bundle.register result must not expose idempotency_replayed: %#v", result)
 	}
 	if len(catalog.upserts) != 1 {
 		t.Fatalf("upserts = %d, want 1", len(catalog.upserts))
@@ -632,7 +636,7 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 	if upsert.BundleHash != bundleHash || !strings.Contains(upsert.ContentYAML, "bundle/package.yaml") || !strings.Contains(upsert.ContentYAML, "platform/platform-spec.yaml") {
 		t.Fatalf("bundle.register upsert = %#v", upsert)
 	}
-	if upsert.Metadata["source"] != "bundle.register" || upsert.Metadata["platform_spec_sha256"] != platformHash {
+	if upsert.Metadata["registered_by"] != "bundle.register" || upsert.Metadata["platform_spec_hash"] != "sha256:"+platformHash || upsert.Metadata["platform_spec_source"] != "server_effective" {
 		t.Fatalf("bundle.register metadata = %#v", upsert.Metadata)
 	}
 	agents := asMap(t, upsert.ParsedJSON["agents"])
@@ -646,7 +650,7 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 		t.Fatalf("bundle.register replay error = %#v", replay.Error)
 	}
 	replayResult := asMap(t, replay.Result)
-	if replayResult["bundle_hash"] != bundleHash || replayResult["registered"] != true || replayResult["idempotency_replayed"] != true {
+	if replayResult["bundle_hash"] != bundleHash || replayResult["registered"] != true || replayResult["has_data"] != false {
 		t.Fatalf("bundle.register replay result = %#v", replayResult)
 	}
 	if len(catalog.upserts) != 1 {
@@ -657,8 +661,30 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 	if duplicate.Error != nil {
 		t.Fatalf("bundle.register duplicate error = %#v", duplicate.Error)
 	}
-	if duplicateResult := asMap(t, duplicate.Result); duplicateResult["registered"] != false || duplicateResult["idempotency_replayed"] != false {
+	if duplicateResult := asMap(t, duplicate.Result); duplicateResult["registered"] != false || duplicateResult["has_data"] != false {
 		t.Fatalf("bundle.register duplicate result = %#v", duplicateResult)
+	}
+
+	dataBlob := map[string]any{
+		"api_version": "swarm.bundle.data.v1",
+		"entries": []any{
+			map[string]any{"path": "flows/alpha/data/payload.bin", "data_base64": base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03})},
+		},
+	}
+	dataBlobRaw, err := json.Marshal(dataBlob)
+	if err != nil {
+		t.Fatalf("marshal data_blob: %v", err)
+	}
+	withData := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"data","method":"bundle.register","params":{"content_yaml":%q,"data_blob":%s}}`, testBundleRegistrationEnvelopeWithFlowData(), dataBlobRaw))
+	if withData.Error != nil {
+		t.Fatalf("bundle.register with data error = %#v", withData.Error)
+	}
+	withDataResult := asMap(t, withData.Result)
+	if withDataResult["registered"] != true || withDataResult["has_data"] != true {
+		t.Fatalf("bundle.register with data result = %#v", withDataResult)
+	}
+	if got := withDataResult["data_size_bytes"].(float64); got <= 0 {
+		t.Fatalf("bundle.register data_size_bytes = %v, want >0", got)
 	}
 }
 
@@ -677,7 +703,7 @@ func TestOperatorBundleRegisterHandlersFailClosed(t *testing.T) {
 		}),
 	})
 
-	unconsumed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"unconsumed","method":"bundle.register","params":{"content_yaml":%q,"data_blob":{"unreferenced.bin":"AQI="}}}`, testBundleRegistrationEnvelope()))
+	unconsumed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"unconsumed","method":"bundle.register","params":{"content_yaml":%q,"data_blob":{"api_version":"swarm.bundle.data.v1","entries":[{"path":"flows/missing/data/unreferenced.bin","data_base64":"AQI="}]}}}`, testBundleRegistrationEnvelope()))
 	if unconsumed.Error == nil || unconsumed.Error.Code != codeInvalidParams {
 		t.Fatalf("bundle.register unconsumed error = %#v, want invalid params", unconsumed.Error)
 	}
@@ -693,18 +719,57 @@ func TestOperatorBundleRegisterHandlersFailClosed(t *testing.T) {
 	if data := asMap(t, conflict.Error.Data); data["code"] != BundleRegisterConflictCode {
 		t.Fatalf("bundle.register conflict data = %#v", data)
 	}
+
+	malformed := map[string]string{
+		"legacy envelope version": `version: swarm.bundle.registration.v1
+files:
+  - path: package.yaml
+    content: "name: legacy\nversion: \"1.0.0\"\nflows: []\n"
+`,
+		"dot segment": `api_version: swarm.bundle.register.v1
+files:
+  - path: ./package.yaml
+    text: "name: bad\nversion: \"1.0.0\"\nflows: []\n"
+`,
+		"case collision": `api_version: swarm.bundle.register.v1
+files:
+  - path: package.yaml
+    text: "name: bad\nversion: \"1.0.0\"\nflows: []\n"
+  - path: Package.yaml
+    text: "name: bad\n"
+`,
+		"non nfc path": "api_version: swarm.bundle.register.v1\nfiles:\n  - path: cafe\u0301.yaml\n    text: \"name: bad\\n\"\n",
+	}
+	for name, content := range malformed {
+		t.Run(name, func(t *testing.T) {
+			got := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"bad","method":"bundle.register","params":{"content_yaml":%q}}`, content))
+			if got.Error == nil || got.Error.Code != codeInvalidParams {
+				t.Fatalf("bundle.register malformed error = %#v, want invalid params", got.Error)
+			}
+		})
+	}
+
+	badData := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"bad-data","method":"bundle.register","params":{"content_yaml":%q,"data_blob":{"flows/alpha/data/payload.bin":"AQI="}}}`, testBundleRegistrationEnvelope()))
+	if badData.Error == nil || badData.Error.Code != codeInvalidParams {
+		t.Fatalf("bundle.register bad data_blob error = %#v, want invalid params", badData.Error)
+	}
+
+	unsortedData := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"unsorted-data","method":"bundle.register","params":{"content_yaml":%q,"data_blob":{"api_version":"swarm.bundle.data.v1","entries":[{"path":"flows/beta/data/payload.bin","data_base64":"AQI="},{"path":"flows/alpha/data/payload.bin","data_base64":"AQI="}]}}}`, testBundleRegistrationEnvelope()))
+	if unsortedData.Error == nil || unsortedData.Error.Code != codeInvalidParams {
+		t.Fatalf("bundle.register unsorted data_blob error = %#v, want invalid params", unsortedData.Error)
+	}
 }
 
 func testBundleRegistrationEnvelope() string {
-	return `version: swarm.bundle.registration.v1
+	return `api_version: swarm.bundle.register.v1
 files:
   - path: package.yaml
-    content: |
+    text: |
       name: registered
       version: "1.0.0"
       flows: []
   - path: agents.yaml
-    content: |
+    text: |
       researcher:
         id: researcher
         role: research
@@ -712,6 +777,25 @@ files:
         conversation_mode: stateless
         subscriptions:
           - scan.requested
+`
+}
+
+func testBundleRegistrationEnvelopeWithFlowData() string {
+	return `api_version: swarm.bundle.register.v1
+files:
+  - path: package.yaml
+    text: |
+      name: registered-data
+      version: "1.0.0"
+      flows:
+        - id: alpha
+          flow: alpha
+  - path: flows/alpha/schema.yaml
+    text: |
+      initial_state: start
+      states:
+        - start
+        - done
 `
 }
 

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -596,12 +596,19 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 		details: map[string]store.BundleCatalogDetail{},
 		agents:  map[string]store.BundleCatalogAgentsResult{},
 	}
+	platformSpec := testBundleRegistrationPlatformSpec(t)
+	platformHash, err := fileSHA256Hex(platformSpec)
+	if err != nil {
+		t.Fatalf("hash platform spec: %v", err)
+	}
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:           func() time.Time { return time.Unix(1700000200, 0).UTC() },
-			BundleCatalog: catalog,
-			Idempotency:   newRecordingAPIIdempotencyStore(),
+			Now:              func() time.Time { return time.Unix(1700000200, 0).UTC() },
+			RepoRoot:         t.TempDir(),
+			PlatformSpecPath: platformSpec,
+			BundleCatalog:    catalog,
+			Idempotency:      newRecordingAPIIdempotencyStore(),
 		}),
 	})
 	envelope := testBundleRegistrationEnvelope()
@@ -625,7 +632,7 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 	if upsert.BundleHash != bundleHash || !strings.Contains(upsert.ContentYAML, "bundle/package.yaml") || !strings.Contains(upsert.ContentYAML, "platform/platform-spec.yaml") {
 		t.Fatalf("bundle.register upsert = %#v", upsert)
 	}
-	if upsert.Metadata["source"] != "bundle.register" || upsert.Metadata["platform_spec_sha256"] == "" {
+	if upsert.Metadata["source"] != "bundle.register" || upsert.Metadata["platform_spec_sha256"] != platformHash {
 		t.Fatalf("bundle.register metadata = %#v", upsert.Metadata)
 	}
 	agents := asMap(t, upsert.ParsedJSON["agents"])
@@ -663,8 +670,10 @@ func TestOperatorBundleRegisterHandlersFailClosed(t *testing.T) {
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			BundleCatalog: catalog,
-			Idempotency:   newRecordingAPIIdempotencyStore(),
+			RepoRoot:         t.TempDir(),
+			PlatformSpecPath: testBundleRegistrationPlatformSpec(t),
+			BundleCatalog:    catalog,
+			Idempotency:      newRecordingAPIIdempotencyStore(),
 		}),
 	})
 
@@ -704,6 +713,19 @@ files:
         subscriptions:
           - scan.requested
 `
+}
+
+func testBundleRegistrationPlatformSpec(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "specs", "swarm-platform", "platform", "contracts", "platform-spec.yaml"))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "platform-spec.yaml")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write temp platform spec: %v", err)
+	}
+	return path
 }
 
 func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -112,8 +112,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 54 {
-		t.Fatalf("generated OpenRPC methods = %d, want 54", len(doc.Methods))
+	if len(doc.Methods) != 55 {
+		t.Fatalf("generated OpenRPC methods = %d, want 55", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -300,7 +300,7 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 		"bundle.register": {
 			Params:         map[string]any{"content_yaml": testBundleRegistrationEnvelope()},
 			ConflictParams: map[string]any{"content_yaml": strings.Replace(testBundleRegistrationEnvelope(), "name: registered", "name: registered-conflict", 1)},
-			ResultKeys:     []string{"bundle_hash", "registered", "idempotency_replayed"},
+			ResultKeys:     []string{"bundle_hash", "registered", "has_data", "data_size_bytes"},
 			SuccessEffects: 1,
 		},
 		"event.publish": {

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -219,6 +219,7 @@ func approvedMutatingHTTPRuntimeMethods() []string {
 		"agent.replay_backlog",
 		"agent.restart",
 		"agent.send_directive",
+		"bundle.register",
 		"conversation.fork",
 		"conversation.fork_chat",
 		"conversation.fork_delete",
@@ -294,6 +295,12 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			Params:         map[string]any{"fork_id": forkID},
 			ConflictParams: map[string]any{"fork_id": "00000000-0000-0000-0000-000000000302"},
 			ResultKeys:     []string{"ok", "fork_id", "deleted", "already_deleted", "idempotency_replayed"},
+			SuccessEffects: 1,
+		},
+		"bundle.register": {
+			Params:         map[string]any{"content_yaml": testBundleRegistrationEnvelope()},
+			ConflictParams: map[string]any{"content_yaml": strings.Replace(testBundleRegistrationEnvelope(), "name: registered", "name: registered-conflict", 1)},
+			ResultKeys:     []string{"bundle_hash", "registered", "idempotency_replayed"},
 			SuccessEffects: 1,
 		},
 		"event.publish": {
@@ -445,6 +452,9 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		}}},
 		{Method: "conversation.fork_delete", Params: map[string]any{"fork_id": forkID, "idempotency_key": "idem-error"}, Code: ForkNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.forks.deleteErr = store.ErrConversationForkNotFound
+		}}},
+		{Method: "bundle.register", Params: map[string]any{"content_yaml": testBundleRegistrationEnvelope(), "idempotency_key": "idem-error"}, Code: BundleRegisterConflictCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.bundleCatalog.conflict = true
 		}}},
 
 		{Method: "run.fork", Params: map[string]any{"source_run_id": missingRunID, "fork_event_id": runForkTestEventID, "idempotency_key": "idem-error"}, Code: RunNotFoundCode},
@@ -641,6 +651,7 @@ type mutatingRuntimeProbeState struct {
 	agentControl        *mutatingProbeAgentControl
 	runtimeIngress      *mutatingProbeRuntimeIngress
 	mailbox             *mutatingProbeMailboxStore
+	bundleCatalog       *mutatingProbeBundleCatalog
 	forks               *fakeConversationForkLifecycleStore
 	nuke                *recordingRuntimeNukeOwners
 	effects             int
@@ -682,6 +693,7 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 	state.agentControl.state = state
 	state.runtimeIngress.state = state
 	state.mailbox = newMutatingProbeMailboxStore(state)
+	state.bundleCatalog = &mutatingProbeBundleCatalog{state: state, details: map[string]store.BundleCatalogDetail{}}
 	state.forks = &fakeConversationForkLifecycleStore{
 		createResult: store.OperatorConversationForkSession{
 			ForkID:          "00000000-0000-0000-0000-000000000301",
@@ -795,6 +807,7 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 			AssistantMessage: "forkchat sandbox response: inspect fork",
 		}},
 		Mailbox:               s.mailbox,
+		BundleCatalog:         s.bundleCatalog,
 		Idempotency:           s.idempotency,
 		Events:                s.events,
 		RunForkAvailability:   s.runForkAvailability,
@@ -870,6 +883,55 @@ func (s *mutatingProbeIdempotencyStore) WithAPIIdempotency(
 	s.hashes[key] = req.RequestHash
 	return completion, false, nil
 }
+
+type mutatingProbeBundleCatalog struct {
+	state    *mutatingRuntimeProbeState
+	details  map[string]store.BundleCatalogDetail
+	conflict bool
+}
+
+func (s *mutatingProbeBundleCatalog) ListBundleCatalog(context.Context, store.BundleCatalogListOptions) (store.BundleCatalogListResult, error) {
+	return store.BundleCatalogListResult{Bundles: []store.BundleCatalogSummary{}}, nil
+}
+
+func (s *mutatingProbeBundleCatalog) LoadBundleCatalog(_ context.Context, bundleHash string) (store.BundleCatalogDetail, error) {
+	detail, ok := s.details[strings.TrimSpace(bundleHash)]
+	if !ok {
+		return store.BundleCatalogDetail{}, store.ErrBundleNotFound
+	}
+	return detail, nil
+}
+
+func (s *mutatingProbeBundleCatalog) ListBundleCatalogAgents(context.Context, string) (store.BundleCatalogAgentsResult, error) {
+	return store.BundleCatalogAgentsResult{Agents: []store.BundleCatalogAgentDefinition{}}, nil
+}
+
+func (s *mutatingProbeBundleCatalog) UpsertBundleCatalog(_ context.Context, req store.BundleCatalogUpsert) (store.BundleCatalogUpsertResult, error) {
+	if s.conflict {
+		return store.BundleCatalogUpsertResult{}, &store.BundleCatalogConflictError{BundleHash: req.BundleHash}
+	}
+	if s.details == nil {
+		s.details = map[string]store.BundleCatalogDetail{}
+	}
+	_, exists := s.details[req.BundleHash]
+	if !exists {
+		s.state.recordEffect()
+		s.details[req.BundleHash] = store.BundleCatalogDetail{
+			BundleHash:    req.BundleHash,
+			ContentYAML:   req.ContentYAML,
+			ParsedJSON:    req.ParsedJSON,
+			Metadata:      req.Metadata,
+			AgentCount:    1,
+			HasData:       len(req.DataBlob) > 0,
+			DataSizeBytes: int64(len(req.DataBlob)),
+			IngestedAt:    s.state.now,
+		}
+	}
+	return store.BundleCatalogUpsertResult{Detail: s.details[req.BundleHash], Registered: !exists}, nil
+}
+
+var _ BundleCatalogReadStore = (*mutatingProbeBundleCatalog)(nil)
+var _ BundleCatalogRegisterStore = (*mutatingProbeBundleCatalog)(nil)
 
 type mutatingProbeEventPublisher struct {
 	state             *mutatingRuntimeProbeState

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -796,6 +796,8 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 	t.Helper()
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	return OperatorReadOptions{
+		RepoRoot:          t.TempDir(),
+		PlatformSpecPath:  testBundleRegistrationPlatformSpec(t),
 		Now:               func() time.Time { return s.now },
 		Ready:             func() bool { return true },
 		Database:          fakePinger{},

--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -44,6 +43,11 @@ type bundleRegistrationFile struct {
 
 type bundleRegistrationMaterializedInput struct {
 	Label string
+}
+
+type bundleRegistrationRuntimeContext struct {
+	RepoRoot         string
+	PlatformSpecPath string
 }
 
 func OperatorBundleRegisterHandlers(opts OperatorReadOptions) map[string]MethodHandler {
@@ -85,7 +89,7 @@ func executeBundleRegister(ctx context.Context, req Request, opts OperatorReadOp
 		TTL:            bundleRegisterIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		projection, err := buildBundleRegistrationProjection(params)
+		projection, err := buildBundleRegistrationProjection(params, bundleRegistrationRuntimeContextFromOptions(opts))
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
@@ -173,15 +177,15 @@ func bundleRegistrationDataBlobParam(params map[string]any) (map[string][]byte, 
 	return out, nil
 }
 
-func buildBundleRegistrationProjection(params bundleRegistrationParams) (runtimecontracts.BundleCatalogProjection, error) {
+func buildBundleRegistrationProjection(params bundleRegistrationParams, runtimeCtx bundleRegistrationRuntimeContext) (runtimecontracts.BundleCatalogProjection, error) {
 	root, inputs, err := materializeBundleRegistration(params)
 	if err != nil {
 		return runtimecontracts.BundleCatalogProjection{}, err
 	}
 	defer os.RemoveAll(root)
 
-	repoRoot := defaultBundleRegistrationRepoRoot()
-	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	repoRoot := strings.TrimSpace(runtimeCtx.RepoRoot)
+	platformSpec := strings.TrimSpace(runtimeCtx.PlatformSpecPath)
 	platformHash, err := fileSHA256Hex(platformSpec)
 	if err != nil {
 		return runtimecontracts.BundleCatalogProjection{}, err
@@ -334,6 +338,24 @@ func bundleRegisterIdempotencyError(err error) error {
 	return err
 }
 
+func bundleRegistrationRuntimeContextFromOptions(opts OperatorReadOptions) bundleRegistrationRuntimeContext {
+	repoRoot := strings.TrimSpace(opts.RepoRoot)
+	platformSpec := strings.TrimSpace(opts.PlatformSpecPath)
+	if platformSpec == "" {
+		if repoRoot == "" {
+			repoRoot = defaultBundleRegistrationRepoRoot()
+		}
+		platformSpec = runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	}
+	if repoRoot == "" {
+		repoRoot = filepath.Dir(platformSpec)
+	}
+	return bundleRegistrationRuntimeContext{
+		RepoRoot:         repoRoot,
+		PlatformSpecPath: platformSpec,
+	}
+}
+
 func fileSHA256Hex(path string) (string, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -344,9 +366,5 @@ func fileSHA256Hex(path string) (string, error) {
 }
 
 func defaultBundleRegistrationRepoRoot() string {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "."
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	return "."
 }

--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -8,14 +8,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/store"
 
+	"golang.org/x/text/unicode/norm"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,23 +29,29 @@ type BundleCatalogRegisterStore interface {
 }
 
 type bundleRegisterResult struct {
-	BundleHash          string `json:"bundle_hash"`
-	Registered          bool   `json:"registered"`
-	IdempotencyReplayed bool   `json:"idempotency_replayed"`
+	BundleHash    string `json:"bundle_hash"`
+	Registered    bool   `json:"registered"`
+	HasData       bool   `json:"has_data"`
+	DataSizeBytes int64  `json:"data_size_bytes"`
 }
 
 type bundleRegistrationEnvelopeV1 struct {
-	Version string                   `yaml:"version"`
-	Files   []bundleRegistrationFile `yaml:"files"`
+	APIVersion string                   `yaml:"api_version"`
+	Files      []bundleRegistrationFile `yaml:"files"`
 }
 
 type bundleRegistrationFile struct {
-	Path    string `yaml:"path"`
-	Content string `yaml:"content"`
+	Path string  `yaml:"path"`
+	Text *string `yaml:"text"`
 }
 
 type bundleRegistrationMaterializedInput struct {
 	Label string
+}
+
+type bundleRegistrationDataEntry struct {
+	Path string
+	Data []byte
 }
 
 type bundleRegistrationRuntimeContext struct {
@@ -107,8 +116,10 @@ func executeBundleRegister(ctx context.Context, req Request, opts OperatorReadOp
 			return store.APIIdempotencyCompletion{}, err
 		}
 		result := bundleRegisterResult{
-			BundleHash: upsert.Detail.BundleHash,
-			Registered: upsert.Registered,
+			BundleHash:    upsert.Detail.BundleHash,
+			Registered:    upsert.Registered,
+			HasData:       upsert.Detail.HasData,
+			DataSizeBytes: upsert.Detail.DataSizeBytes,
 		}
 		raw, err := json.Marshal(result)
 		if err != nil {
@@ -126,13 +137,12 @@ func executeBundleRegister(ctx context.Context, req Request, opts OperatorReadOp
 		}
 		return nil, fmt.Errorf("decode bundle.register response: %w", err)
 	}
-	result.IdempotencyReplayed = replay
 	return result, nil
 }
 
 type bundleRegistrationParams struct {
 	ContentYAML string
-	DataBlob    map[string][]byte
+	DataBlob    []bundleRegistrationDataEntry
 }
 
 func bundleRegistrationParamsFromRequest(params map[string]any) (bundleRegistrationParams, error) {
@@ -147,29 +157,69 @@ func bundleRegistrationParamsFromRequest(params map[string]any) (bundleRegistrat
 	return bundleRegistrationParams{ContentYAML: contentYAML, DataBlob: dataBlob}, nil
 }
 
-func bundleRegistrationDataBlobParam(params map[string]any) (map[string][]byte, error) {
+func bundleRegistrationDataBlobParam(params map[string]any) ([]bundleRegistrationDataEntry, error) {
 	if params == nil || isEmptyParam(params["data_blob"]) {
 		return nil, nil
 	}
 	raw, ok := params["data_blob"].(map[string]any)
 	if !ok {
-		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob", "reason": "must be an object mapping bundle-relative paths to base64 strings"})
+		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob", "reason": "must be a BundleRegisterDataBlobV1 object"})
 	}
-	out := make(map[string][]byte, len(raw))
-	for key, value := range raw {
-		path, err := cleanBundleRegistrationPath(key, "data_blob")
+	if len(raw) != 2 {
+		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob", "reason": "must contain only api_version and entries"})
+	}
+	apiVersion, ok := raw["api_version"].(string)
+	if !ok || strings.TrimSpace(apiVersion) != "swarm.bundle.data.v1" {
+		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob.api_version", "reason": "must be swarm.bundle.data.v1"})
+	}
+	rawEntries, ok := raw["entries"].([]any)
+	if !ok {
+		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob.entries", "reason": "must be an ordered array"})
+	}
+	out := make([]bundleRegistrationDataEntry, 0, len(rawEntries))
+	seen := map[string]string{}
+	var previous string
+	for i, value := range rawEntries {
+		field := fmt.Sprintf("data_blob.entries[%d]", i)
+		entry, ok := value.(map[string]any)
+		if !ok {
+			return nil, NewInvalidParamsError(map[string]any{"field": field, "reason": "must be an object"})
+		}
+		if len(entry) != 2 {
+			return nil, NewInvalidParamsError(map[string]any{"field": field, "reason": "must contain only path and data_base64"})
+		}
+		rawPath, ok := entry["path"].(string)
+		if !ok {
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".path", "reason": "must be a string"})
+		}
+		path, err := cleanBundleRegistrationPath(rawPath, field+".path")
 		if err != nil {
 			return nil, err
 		}
-		encoded, ok := value.(string)
+		if err := validateBundleRegistrationDataPath(path, field+".path"); err != nil {
+			return nil, err
+		}
+		folded := asciiFoldBundleRegistrationPath(path)
+		if existing, exists := seen[folded]; exists {
+			if existing == path {
+				return nil, NewInvalidParamsError(map[string]any{"field": field + ".path", "reason": "duplicate bundle-relative path " + path})
+			}
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".path", "reason": "ASCII case-colliding bundle-relative paths " + existing + " and " + path})
+		}
+		if previous != "" && path <= previous {
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".path", "reason": "data entries must be sorted strictly by normalized path"})
+		}
+		seen[folded] = path
+		previous = path
+		encoded, ok := entry["data_base64"].(string)
 		if !ok || strings.TrimSpace(encoded) == "" {
-			return nil, NewInvalidParamsError(map[string]any{"field": "data_blob." + path, "reason": "must be a non-empty base64 string"})
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".data_base64", "reason": "must be a non-empty base64 string"})
 		}
 		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
 		if err != nil {
-			return nil, NewInvalidParamsError(map[string]any{"field": "data_blob." + path, "reason": "must be standard base64"})
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".data_base64", "reason": "must be standard padded base64"})
 		}
-		out[path] = decoded
+		out = append(out, bundleRegistrationDataEntry{Path: path, Data: decoded})
 	}
 	if len(out) == 0 {
 		return nil, nil
@@ -204,16 +254,23 @@ func buildBundleRegistrationProjection(params bundleRegistrationParams, runtimeC
 	if err := verifyBundleRegistrationInputsConsumed(inputs, projection); err != nil {
 		return runtimecontracts.BundleCatalogProjection{}, err
 	}
+	projection.Metadata = bundleRegistrationMetadata(projection, platformHash)
 	return projection, nil
 }
 
 func materializeBundleRegistration(params bundleRegistrationParams) (string, []bundleRegistrationMaterializedInput, error) {
 	var envelope bundleRegistrationEnvelopeV1
-	if err := yaml.Unmarshal([]byte(params.ContentYAML), &envelope); err != nil {
+	decoder := yaml.NewDecoder(strings.NewReader(params.ContentYAML))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&envelope); err != nil {
 		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml", "reason": "must be a BundleRegistrationEnvelopeV1 YAML document"})
 	}
-	if strings.TrimSpace(envelope.Version) != "swarm.bundle.registration.v1" {
-		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.version", "reason": "must be swarm.bundle.registration.v1"})
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml", "reason": "must contain exactly one YAML document"})
+	}
+	if strings.TrimSpace(envelope.APIVersion) != "swarm.bundle.register.v1" {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.api_version", "reason": "must be swarm.bundle.register.v1"})
 	}
 	if len(envelope.Files) == 0 {
 		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.files", "reason": "must contain at least package.yaml"})
@@ -229,17 +286,21 @@ func materializeBundleRegistration(params bundleRegistrationParams) (string, []b
 		}
 	}()
 
-	seen := map[string]struct{}{}
+	seen := map[string]string{}
 	var inputs []bundleRegistrationMaterializedInput
 	writeInput := func(rel string, content []byte, field string) error {
 		clean, err := cleanBundleRegistrationPath(rel, field)
 		if err != nil {
 			return err
 		}
-		if _, exists := seen[clean]; exists {
+		folded := asciiFoldBundleRegistrationPath(clean)
+		if existing, exists := seen[folded]; exists {
+			if existing != clean {
+				return NewInvalidParamsError(map[string]any{"field": field, "reason": "ASCII case-colliding bundle-relative paths " + existing + " and " + clean})
+			}
 			return NewInvalidParamsError(map[string]any{"field": field, "reason": "duplicate bundle-relative path " + clean})
 		}
-		seen[clean] = struct{}{}
+		seen[folded] = clean
 		path := filepath.Join(root, filepath.FromSlash(clean))
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return err
@@ -252,16 +313,19 @@ func materializeBundleRegistration(params bundleRegistrationParams) (string, []b
 	}
 	for i, file := range envelope.Files {
 		field := fmt.Sprintf("content_yaml.files[%d].path", i)
-		if err := writeInput(file.Path, []byte(file.Content), field); err != nil {
+		if file.Text == nil {
+			return "", nil, NewInvalidParamsError(map[string]any{"field": fmt.Sprintf("content_yaml.files[%d].text", i), "reason": "text is required"})
+		}
+		if err := writeInput(file.Path, []byte(*file.Text), field); err != nil {
 			return "", nil, err
 		}
 	}
-	for rel, content := range params.DataBlob {
-		if err := writeInput(rel, content, "data_blob"); err != nil {
+	for i, entry := range params.DataBlob {
+		if err := writeInput(entry.Path, entry.Data, fmt.Sprintf("data_blob.entries[%d].path", i)); err != nil {
 			return "", nil, err
 		}
 	}
-	if _, ok := seen["package.yaml"]; !ok {
+	if seen["package.yaml"] != "package.yaml" {
 		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.files", "reason": "package.yaml is required"})
 	}
 	cleanup = false
@@ -269,18 +333,61 @@ func materializeBundleRegistration(params bundleRegistrationParams) (string, []b
 }
 
 func cleanBundleRegistrationPath(raw, field string) (string, error) {
-	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be non-empty"})
 	}
-	if strings.Contains(raw, "\x00") || strings.Contains(raw, "\\") || filepath.IsAbs(raw) {
+	if strings.TrimSpace(raw) != raw {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must not contain surrounding whitespace"})
+	}
+	if !utf8.ValidString(raw) {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be valid UTF-8"})
+	}
+	if norm.NFC.String(raw) != raw {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be NFC-normalized"})
+	}
+	if strings.Contains(raw, "\x00") || strings.Contains(raw, "\\") || strings.HasPrefix(raw, "/") || filepath.IsAbs(raw) {
 		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be a slash-separated relative bundle path"})
 	}
-	clean := filepath.ToSlash(filepath.Clean(raw))
-	if clean == "." || strings.HasPrefix(clean, "../") || clean == ".." || strings.Contains(clean, "/../") {
-		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must stay inside the bundle root"})
+	for _, segment := range strings.Split(raw, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must not contain empty, '.', or '..' segments"})
+		}
 	}
-	return clean, nil
+	return raw, nil
+}
+
+func validateBundleRegistrationDataPath(path, field string) error {
+	segments := strings.Split(path, "/")
+	if len(segments) < 4 || segments[0] != "flows" || segments[1] == "" || segments[2] != "data" {
+		return NewInvalidParamsError(map[string]any{"field": field, "reason": "data_blob entries must be under flows/<flow>/data/..."})
+	}
+	return nil
+}
+
+func asciiFoldBundleRegistrationPath(path string) string {
+	buf := []byte(path)
+	for i, b := range buf {
+		if b >= 'A' && b <= 'Z' {
+			buf[i] = b + ('a' - 'A')
+		}
+	}
+	return string(buf)
+}
+
+func bundleRegistrationMetadata(projection runtimecontracts.BundleCatalogProjection, platformHash string) map[string]any {
+	metadata := map[string]any{
+		"api_version":               "swarm.bundle.metadata.v1",
+		"registered_by":             "bundle.register",
+		"platform_spec_source":      "server_effective",
+		"platform_spec_hash":        "sha256:" + platformHash,
+		"platform_spec_path_policy": "server_internal_not_user_supplied",
+	}
+	for _, key := range []string{"projection_version", "workflow_name", "workflow_version", "file_count", "data_file_count"} {
+		if value, ok := projection.Metadata[key]; ok {
+			metadata[key] = value
+		}
+	}
+	return metadata
 }
 
 func verifyBundleRegistrationInputsConsumed(inputs []bundleRegistrationMaterializedInput, projection runtimecontracts.BundleCatalogProjection) error {

--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -1,0 +1,352 @@
+package apiv1
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+
+	"gopkg.in/yaml.v3"
+)
+
+const bundleRegisterIdempotencyTTL = 24 * time.Hour
+
+type BundleCatalogRegisterStore interface {
+	UpsertBundleCatalog(context.Context, store.BundleCatalogUpsert) (store.BundleCatalogUpsertResult, error)
+}
+
+type bundleRegisterResult struct {
+	BundleHash          string `json:"bundle_hash"`
+	Registered          bool   `json:"registered"`
+	IdempotencyReplayed bool   `json:"idempotency_replayed"`
+}
+
+type bundleRegistrationEnvelopeV1 struct {
+	Version string                   `yaml:"version"`
+	Files   []bundleRegistrationFile `yaml:"files"`
+}
+
+type bundleRegistrationFile struct {
+	Path    string `yaml:"path"`
+	Content string `yaml:"content"`
+}
+
+type bundleRegistrationMaterializedInput struct {
+	Label string
+}
+
+func OperatorBundleRegisterHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.BundleCatalog == nil || opts.Idempotency == nil {
+		return nil
+	}
+	if _, ok := opts.BundleCatalog.(BundleCatalogRegisterStore); !ok {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"bundle.register": func(ctx context.Context, req Request) (any, error) {
+			return executeBundleRegister(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func executeBundleRegister(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	writer, err := requireBundleCatalogRegisterStore(opts.BundleCatalog)
+	if err != nil {
+		return nil, err
+	}
+	params, err := bundleRegistrationParamsFromRequest(req.Params)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		TTL:            bundleRegisterIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		projection, err := buildBundleRegistrationProjection(params)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		upsert, err := writer.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+			BundleHash:  projection.BundleHash,
+			ContentYAML: projection.ContentYAML,
+			ParsedJSON:  projection.ParsedJSON,
+			DataBlob:    projection.DataBlob,
+			Metadata:    projection.Metadata,
+		})
+		if errors.Is(err, store.ErrBundleCatalogConflict) {
+			return store.APIIdempotencyCompletion{}, NewApplicationError(BundleRegisterConflictCode, false, map[string]any{"bundle_hash": projection.BundleHash})
+		}
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		result := bundleRegisterResult{
+			BundleHash: upsert.Detail.BundleHash,
+			Registered: upsert.Registered,
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{ResourceID: result.BundleHash, Response: raw}, nil
+	})
+	if err != nil {
+		return nil, bundleRegisterIdempotencyError(err)
+	}
+	var result bundleRegisterResult
+	if err := json.Unmarshal(completion.Response, &result); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode bundle.register idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode bundle.register response: %w", err)
+	}
+	result.IdempotencyReplayed = replay
+	return result, nil
+}
+
+type bundleRegistrationParams struct {
+	ContentYAML string
+	DataBlob    map[string][]byte
+}
+
+func bundleRegistrationParamsFromRequest(params map[string]any) (bundleRegistrationParams, error) {
+	contentYAML, err := requiredStringParam(params, "content_yaml")
+	if err != nil {
+		return bundleRegistrationParams{}, err
+	}
+	dataBlob, err := bundleRegistrationDataBlobParam(params)
+	if err != nil {
+		return bundleRegistrationParams{}, err
+	}
+	return bundleRegistrationParams{ContentYAML: contentYAML, DataBlob: dataBlob}, nil
+}
+
+func bundleRegistrationDataBlobParam(params map[string]any) (map[string][]byte, error) {
+	if params == nil || isEmptyParam(params["data_blob"]) {
+		return nil, nil
+	}
+	raw, ok := params["data_blob"].(map[string]any)
+	if !ok {
+		return nil, NewInvalidParamsError(map[string]any{"field": "data_blob", "reason": "must be an object mapping bundle-relative paths to base64 strings"})
+	}
+	out := make(map[string][]byte, len(raw))
+	for key, value := range raw {
+		path, err := cleanBundleRegistrationPath(key, "data_blob")
+		if err != nil {
+			return nil, err
+		}
+		encoded, ok := value.(string)
+		if !ok || strings.TrimSpace(encoded) == "" {
+			return nil, NewInvalidParamsError(map[string]any{"field": "data_blob." + path, "reason": "must be a non-empty base64 string"})
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+		if err != nil {
+			return nil, NewInvalidParamsError(map[string]any{"field": "data_blob." + path, "reason": "must be standard base64"})
+		}
+		out[path] = decoded
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func buildBundleRegistrationProjection(params bundleRegistrationParams) (runtimecontracts.BundleCatalogProjection, error) {
+	root, inputs, err := materializeBundleRegistration(params)
+	if err != nil {
+		return runtimecontracts.BundleCatalogProjection{}, err
+	}
+	defer os.RemoveAll(root)
+
+	repoRoot := defaultBundleRegistrationRepoRoot()
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	platformHash, err := fileSHA256Hex(platformSpec)
+	if err != nil {
+		return runtimecontracts.BundleCatalogProjection{}, err
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
+	if err != nil {
+		return runtimecontracts.BundleCatalogProjection{}, NewInvalidParamsError(map[string]any{"field": "content_yaml", "reason": "bundle registration envelope does not materialize a valid workflow contract bundle", "error": err.Error()})
+	}
+	projection, err := runtimecontracts.BuildBundleCatalogProjectionWithOptions(bundle, runtimecontracts.BundleCatalogProjectionOptions{
+		Source:             "bundle.register",
+		PlatformSpecSHA256: platformHash,
+	})
+	if err != nil {
+		return runtimecontracts.BundleCatalogProjection{}, err
+	}
+	if err := verifyBundleRegistrationInputsConsumed(inputs, projection); err != nil {
+		return runtimecontracts.BundleCatalogProjection{}, err
+	}
+	return projection, nil
+}
+
+func materializeBundleRegistration(params bundleRegistrationParams) (string, []bundleRegistrationMaterializedInput, error) {
+	var envelope bundleRegistrationEnvelopeV1
+	if err := yaml.Unmarshal([]byte(params.ContentYAML), &envelope); err != nil {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml", "reason": "must be a BundleRegistrationEnvelopeV1 YAML document"})
+	}
+	if strings.TrimSpace(envelope.Version) != "swarm.bundle.registration.v1" {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.version", "reason": "must be swarm.bundle.registration.v1"})
+	}
+	if len(envelope.Files) == 0 {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.files", "reason": "must contain at least package.yaml"})
+	}
+	root, err := os.MkdirTemp("", "swarm-bundle-register-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(root)
+		}
+	}()
+
+	seen := map[string]struct{}{}
+	var inputs []bundleRegistrationMaterializedInput
+	writeInput := func(rel string, content []byte, field string) error {
+		clean, err := cleanBundleRegistrationPath(rel, field)
+		if err != nil {
+			return err
+		}
+		if _, exists := seen[clean]; exists {
+			return NewInvalidParamsError(map[string]any{"field": field, "reason": "duplicate bundle-relative path " + clean})
+		}
+		seen[clean] = struct{}{}
+		path := filepath.Join(root, filepath.FromSlash(clean))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return err
+		}
+		inputs = append(inputs, bundleRegistrationMaterializedInput{Label: "bundle/" + clean})
+		return nil
+	}
+	for i, file := range envelope.Files {
+		field := fmt.Sprintf("content_yaml.files[%d].path", i)
+		if err := writeInput(file.Path, []byte(file.Content), field); err != nil {
+			return "", nil, err
+		}
+	}
+	for rel, content := range params.DataBlob {
+		if err := writeInput(rel, content, "data_blob"); err != nil {
+			return "", nil, err
+		}
+	}
+	if _, ok := seen["package.yaml"]; !ok {
+		return "", nil, NewInvalidParamsError(map[string]any{"field": "content_yaml.files", "reason": "package.yaml is required"})
+	}
+	cleanup = false
+	return root, inputs, nil
+}
+
+func cleanBundleRegistrationPath(raw, field string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be non-empty"})
+	}
+	if strings.Contains(raw, "\x00") || strings.Contains(raw, "\\") || filepath.IsAbs(raw) {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must be a slash-separated relative bundle path"})
+	}
+	clean := filepath.ToSlash(filepath.Clean(raw))
+	if clean == "." || strings.HasPrefix(clean, "../") || clean == ".." || strings.Contains(clean, "/../") {
+		return "", NewInvalidParamsError(map[string]any{"field": field, "reason": "path must stay inside the bundle root"})
+	}
+	return clean, nil
+}
+
+func verifyBundleRegistrationInputsConsumed(inputs []bundleRegistrationMaterializedInput, projection runtimecontracts.BundleCatalogProjection) error {
+	consumed := map[string]struct{}{}
+	files, ok := projection.ParsedJSON["files"].([]map[string]any)
+	if ok {
+		for _, file := range files {
+			if label, ok := file["label"].(string); ok {
+				consumed[strings.TrimSpace(label)] = struct{}{}
+			}
+		}
+	} else if rawFiles, ok := projection.ParsedJSON["files"].([]any); ok {
+		for _, raw := range rawFiles {
+			file, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if label, ok := file["label"].(string); ok {
+				consumed[strings.TrimSpace(label)] = struct{}{}
+			}
+		}
+	}
+	for _, input := range inputs {
+		if _, ok := consumed[input.Label]; !ok {
+			return NewInvalidParamsError(map[string]any{
+				"field":  "content_yaml",
+				"reason": "materialized input is not consumed by canonical bundle_hash owner",
+				"label":  input.Label,
+			})
+		}
+	}
+	return nil
+}
+
+func requireBundleCatalogRegisterStore(reads BundleCatalogReadStore) (BundleCatalogRegisterStore, error) {
+	writer, ok := reads.(BundleCatalogRegisterStore)
+	if !ok || writer == nil {
+		return nil, fmt.Errorf("bundle catalog register store is required")
+	}
+	return writer, nil
+}
+
+func bundleRegisterIdempotencyError(err error) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	return err
+}
+
+func fileSHA256Hex(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func defaultBundleRegistrationRepoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -60,6 +60,8 @@ type BundleCatalogReadStore interface {
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
+	RepoRoot              string
+	PlatformSpecPath      string
 	Database              Pinger
 	Runs                  RunReadStore
 	Observability         ObservabilityReadStore

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -247,6 +247,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 	for name, handler := range OperatorBundleCatalogHandlers(opts) {
 		handlers[name] = handler
 	}
+	for name, handler := range OperatorBundleRegisterHandlers(opts) {
+		handlers[name] = handler
+	}
 	for name, handler := range OperatorConversationForkHandlers(opts) {
 		handlers[name] = handler
 	}

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -16,6 +16,7 @@ const (
 	BundleNotFoundCode                   = "BUNDLE_NOT_FOUND"
 	BundleUnavailableCode                = "BUNDLE_UNAVAILABLE"
 	BundleDataIntegrityErrorCode         = "BUNDLE_DATA_INTEGRITY_ERROR"
+	BundleRegisterConflictCode           = "BUNDLE_REGISTER_CONFLICT"
 	UnsupportedBundleHashCode            = "UNSUPPORTED_BUNDLE_HASH"
 	UnsupportedBundleHashForkCode        = "UNSUPPORTED_BUNDLE_HASH_FORK"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -198,6 +198,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: bundle.register
+    transport: http
+    required_params: [content_yaml]
+    declared_errors: [BUNDLE_REGISTER_CONFLICT, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleRegisterHandlersFailClosed}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempotency}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: conversation.current_for_agent
     transport: http
     required_params: [agent_id]

--- a/internal/runtime/contracts/bundle_catalog_projection.go
+++ b/internal/runtime/contracts/bundle_catalog_projection.go
@@ -19,6 +19,11 @@ type BundleCatalogProjection struct {
 	Metadata    map[string]any
 }
 
+type BundleCatalogProjectionOptions struct {
+	Source             string
+	PlatformSpecSHA256 string
+}
+
 type bundleCatalogProjectedFile struct {
 	Label     string
 	Policy    string
@@ -36,10 +41,16 @@ type bundleCatalogDataEntry struct {
 	ContentBase64 string `json:"content_base64"`
 }
 
-// BuildBundleCatalogProjection is the serve-ingest owner for persisted bundle
-// rows. It stores definition bytes and definition-only JSON; runtime state is
-// intentionally excluded.
+// BuildBundleCatalogProjection is the shared owner for persisted bundle rows.
+// It stores canonical definition bytes and definition-only JSON; runtime state
+// and server-local paths are intentionally excluded.
 func BuildBundleCatalogProjection(bundle *WorkflowContractBundle) (BundleCatalogProjection, error) {
+	return BuildBundleCatalogProjectionWithOptions(bundle, BundleCatalogProjectionOptions{
+		Source: "swarm serve --contracts",
+	})
+}
+
+func BuildBundleCatalogProjectionWithOptions(bundle *WorkflowContractBundle, opts BundleCatalogProjectionOptions) (BundleCatalogProjection, error) {
 	bundleHash, err := BundleHash(bundle)
 	if err != nil {
 		return BundleCatalogProjection{}, err
@@ -90,11 +101,14 @@ func BuildBundleCatalogProjection(bundle *WorkflowContractBundle) (BundleCatalog
 	}
 	metadata := map[string]any{
 		"projection_version": bundleCatalogProjectionVersion,
-		"source":             "swarm serve --contracts",
+		"source":             firstNonEmpty(opts.Source, "swarm serve --contracts"),
 		"workflow_name":      strings.TrimSpace(bundle.Semantics.Name),
 		"workflow_version":   strings.TrimSpace(bundle.Semantics.Version),
 		"file_count":         len(files),
 		"data_file_count":    len(dataEntries),
+	}
+	if hash := strings.TrimSpace(opts.PlatformSpecSHA256); hash != "" {
+		metadata["platform_spec_sha256"] = hash
 	}
 	return BundleCatalogProjection{
 		BundleHash:  bundleHash,

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -245,6 +245,51 @@ func TestBundleHashV1RejectsSymlinksWhenSupported(t *testing.T) {
 	}
 }
 
+func TestBundleCatalogProjectionConsumesCanonicalBundleHashOwner(t *testing.T) {
+	root, platform := writeEquivalentBundleHashFixture(t, "\n", "name: projected\nversion: \"1.0.0\"\nflows: []\n")
+	writeBundleHashText(t, filepath.Join(root, "agents.yaml"), `
+researcher:
+  id: researcher
+  role: research
+  model_tier: tier2
+  conversation_mode: stateless
+  subscriptions:
+    - scan.requested
+`)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(filepath.Dir(root), root, platform)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	wantHash, err := BundleHash(bundle)
+	if err != nil {
+		t.Fatalf("BundleHash: %v", err)
+	}
+	projection, err := BuildBundleCatalogProjectionWithOptions(bundle, BundleCatalogProjectionOptions{
+		Source:             "bundle.register",
+		PlatformSpecSHA256: strings.Repeat("a", 64),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjectionWithOptions: %v", err)
+	}
+	if projection.BundleHash != wantHash {
+		t.Fatalf("projection bundle hash = %q, want %q", projection.BundleHash, wantHash)
+	}
+	if projection.Metadata["source"] != "bundle.register" || projection.Metadata["platform_spec_sha256"] != strings.Repeat("a", 64) {
+		t.Fatalf("projection metadata = %#v", projection.Metadata)
+	}
+	agents := projection.ParsedJSON["agents"].(map[string]any)
+	researcher := agents["researcher"].(map[string]any)
+	if researcher["model_tier"] != "tier2" || researcher["conversation_mode"] != "stateless" {
+		t.Fatalf("projected researcher = %#v", researcher)
+	}
+	if _, ok := researcher["status"]; ok {
+		t.Fatalf("projection leaked runtime status: %#v", researcher)
+	}
+	if !strings.Contains(projection.ContentYAML, "bundle/agents.yaml") || !strings.Contains(projection.ContentYAML, "platform/platform-spec.yaml") {
+		t.Fatalf("projection content_yaml missing canonical inputs:\n%s", projection.ContentYAML)
+	}
+}
+
 func TestBundleHashV1YAMLProfile(t *testing.T) {
 	equivalentA, err := canonicalBundleHashYAML([]byte(`
 value: &num !!int 1

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -198,7 +198,12 @@ func TestBundleCatalogUpsertRegistersDuplicatesConflictsAndDoesNotRestoreDeleted
 		t.Fatalf("first upsert = %#v", first)
 	}
 
-	req.Metadata = map[string]any{"source": "swarm serve --contracts"}
+	metadataConflict := req
+	metadataConflict.Metadata = map[string]any{"source": "swarm serve --contracts"}
+	if _, err := pg.UpsertBundleCatalog(ctx, metadataConflict); !errors.Is(err, ErrBundleCatalogConflict) {
+		t.Fatalf("UpsertBundleCatalog metadata conflict error = %v, want ErrBundleCatalogConflict", err)
+	}
+
 	duplicate, err := pg.UpsertBundleCatalog(ctx, req)
 	if err != nil {
 		t.Fatalf("UpsertBundleCatalog duplicate: %v", err)

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -152,19 +152,82 @@ func TestBundleCatalogWriteSurfaceUpsertsAndRejectsHashCollision(t *testing.T) {
 		},
 	}
 
-	detail, err := pg.UpsertBundleCatalog(ctx, req)
+	first, err := pg.UpsertBundleCatalog(ctx, req)
 	if err != nil {
 		t.Fatalf("UpsertBundleCatalog: %v", err)
 	}
+	detail := first.Detail
 	if detail.BundleHash != bundleHash || detail.AgentCount != 1 || !detail.HasData || detail.Metadata["source"] != "test" {
 		t.Fatalf("detail = %#v", detail)
 	}
+	if !first.Registered {
+		t.Fatalf("first upsert registered = false, want true")
+	}
 
-	if _, err := pg.UpsertBundleCatalog(ctx, req); err != nil {
+	duplicate, err := pg.UpsertBundleCatalog(ctx, req)
+	if err != nil {
 		t.Fatalf("UpsertBundleCatalog idempotent: %v", err)
 	}
+	if duplicate.Registered {
+		t.Fatalf("duplicate upsert registered = true, want false")
+	}
 	req.ContentYAML = "projection_version: swarm.bundle.catalog.v1\nfiles: [changed]\n"
-	if _, err := pg.UpsertBundleCatalog(ctx, req); err == nil || !strings.Contains(err.Error(), "different content") {
-		t.Fatalf("UpsertBundleCatalog collision error = %v, want different content", err)
+	if _, err := pg.UpsertBundleCatalog(ctx, req); !errors.Is(err, ErrBundleCatalogConflict) {
+		t.Fatalf("UpsertBundleCatalog collision error = %v, want ErrBundleCatalogConflict", err)
+	}
+}
+
+func TestBundleCatalogUpsertRegistersDuplicatesConflictsAndDoesNotRestoreDeletedRuns(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	bundleHash := "bundle-v1:sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	req := BundleCatalogUpsert{
+		BundleHash:  bundleHash,
+		ContentYAML: "projection_version: swarm.bundle.catalog.v1\nfiles: []\ncanonical_inputs: []\n",
+		ParsedJSON:  map[string]any{"agents": map[string]any{}},
+		DataBlob:    []byte(`{"entries":[]}`),
+		Metadata:    map[string]any{"source": "bundle.register"},
+	}
+	first, err := pg.UpsertBundleCatalog(ctx, req)
+	if err != nil {
+		t.Fatalf("UpsertBundleCatalog first: %v", err)
+	}
+	if !first.Registered || first.Detail.BundleHash != bundleHash || !first.Detail.HasData {
+		t.Fatalf("first upsert = %#v", first)
+	}
+
+	req.Metadata = map[string]any{"source": "swarm serve --contracts"}
+	duplicate, err := pg.UpsertBundleCatalog(ctx, req)
+	if err != nil {
+		t.Fatalf("UpsertBundleCatalog duplicate: %v", err)
+	}
+	if duplicate.Registered || duplicate.Detail.Metadata["source"] != "bundle.register" {
+		t.Fatalf("duplicate upsert = %#v, want no-op preserving original row", duplicate)
+	}
+
+	conflict := req
+	conflict.ContentYAML = "projection_version: swarm.bundle.catalog.v1\nfiles:\n  - label: \"bundle/package.yaml\"\n    content_base64: \"e30=\"\n    size_bytes: 2\ncanonical_inputs: []\n"
+	if _, err := pg.UpsertBundleCatalog(ctx, conflict); !errors.Is(err, ErrBundleCatalogConflict) {
+		t.Fatalf("UpsertBundleCatalog conflict error = %v, want ErrBundleCatalogConflict", err)
+	}
+
+	runID := "00000000-0000-0000-0000-000000000444"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES ($1::uuid, 'completed', $2, 'deleted', NOW())
+	`, runID, bundleHash); err != nil {
+		t.Fatalf("seed deleted run: %v", err)
+	}
+	if _, err := pg.UpsertBundleCatalog(ctx, req); err != nil {
+		t.Fatalf("UpsertBundleCatalog deleted re-register: %v", err)
+	}
+	var source string
+	if err := db.QueryRowContext(ctx, `SELECT bundle_source FROM runs WHERE run_id = $1::uuid`, runID).Scan(&source); err != nil {
+		t.Fatalf("load run bundle_source: %v", err)
+	}
+	if source != "deleted" {
+		t.Fatalf("bundle_source after re-register = %q, want deleted", source)
 	}
 }

--- a/internal/store/bundle_catalog_write_surface.go
+++ b/internal/store/bundle_catalog_write_surface.go
@@ -20,73 +20,114 @@ type BundleCatalogUpsert struct {
 	Metadata    map[string]any
 }
 
-func (s *PostgresStore) UpsertBundleCatalog(ctx context.Context, req BundleCatalogUpsert) (BundleCatalogDetail, error) {
+type BundleCatalogUpsertResult struct {
+	Detail     BundleCatalogDetail `json:"bundle"`
+	Registered bool                `json:"registered"`
+}
+
+type BundleCatalogConflictError struct {
+	BundleHash string
+}
+
+func (e *BundleCatalogConflictError) Error() string {
+	return "bundle catalog row already exists with different content"
+}
+
+func (e *BundleCatalogConflictError) Is(target error) bool {
+	return target == ErrBundleCatalogConflict
+}
+
+func (s *PostgresStore) UpsertBundleCatalog(ctx context.Context, req BundleCatalogUpsert) (BundleCatalogUpsertResult, error) {
 	if err := s.requireBundleCatalogCapabilities(ctx); err != nil {
-		return BundleCatalogDetail{}, err
+		return BundleCatalogUpsertResult{}, err
 	}
 	req.BundleHash = strings.TrimSpace(req.BundleHash)
 	if !canonicalBundleHashPattern.MatchString(req.BundleHash) {
-		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog upsert requires canonical bundle_hash bundle-v1:sha256:<64 lowercase hex>")
+		return BundleCatalogUpsertResult{}, fmt.Errorf("bundle catalog upsert requires canonical bundle_hash bundle-v1:sha256:<64 lowercase hex>")
 	}
 	if strings.TrimSpace(req.ContentYAML) == "" {
-		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog upsert requires content_yaml")
+		return BundleCatalogUpsertResult{}, fmt.Errorf("bundle catalog upsert requires content_yaml")
 	}
 	parsedRaw, err := normalizedBundleCatalogJSON(req.ParsedJSON)
 	if err != nil {
-		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog parsed_json: %w", err)
+		return BundleCatalogUpsertResult{}, fmt.Errorf("bundle catalog parsed_json: %w", err)
 	}
 	metadataRaw, err := normalizedBundleCatalogJSON(req.Metadata)
 	if err != nil {
-		return BundleCatalogDetail{}, fmt.Errorf("bundle catalog metadata: %w", err)
+		return BundleCatalogUpsertResult{}, fmt.Errorf("bundle catalog metadata: %w", err)
 	}
 
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return BundleCatalogDetail{}, err
+		return BundleCatalogUpsertResult{}, err
 	}
 	defer tx.Rollback()
 
-	if _, err := tx.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, data_blob, metadata)
 		VALUES ($1, $2, $3::jsonb, $4::bytea, $5::jsonb)
 		ON CONFLICT (bundle_hash) DO NOTHING
-	`, req.BundleHash, req.ContentYAML, parsedRaw, nullableBytes(req.DataBlob), metadataRaw); err != nil {
-		return BundleCatalogDetail{}, fmt.Errorf("upsert bundle catalog: %w", err)
+	`, req.BundleHash, req.ContentYAML, parsedRaw, nullableBytes(req.DataBlob), metadataRaw)
+	if err != nil {
+		return BundleCatalogUpsertResult{}, fmt.Errorf("upsert bundle catalog: %w", err)
+	}
+	registered := false
+	if rows, err := result.RowsAffected(); err == nil {
+		registered = rows > 0
 	}
 	if err := assertBundleCatalogUpsertIdempotent(ctx, tx, req.BundleHash, req.ContentYAML, parsedRaw, req.DataBlob, metadataRaw); err != nil {
-		return BundleCatalogDetail{}, err
+		return BundleCatalogUpsertResult{}, err
+	}
+	detail, err := loadBundleCatalogInTx(ctx, tx, req.BundleHash)
+	if err != nil {
+		return BundleCatalogUpsertResult{}, err
 	}
 	if err := tx.Commit(); err != nil {
-		return BundleCatalogDetail{}, err
+		return BundleCatalogUpsertResult{}, err
 	}
-	return s.LoadBundleCatalog(ctx, req.BundleHash)
+	return BundleCatalogUpsertResult{Detail: detail, Registered: registered}, nil
 }
 
-func assertBundleCatalogUpsertIdempotent(ctx context.Context, tx bundleCatalogTx, bundleHash, contentYAML string, parsedRaw, dataBlob, metadataRaw []byte) error {
+func assertBundleCatalogUpsertIdempotent(ctx context.Context, tx bundleCatalogTx, bundleHash, contentYAML string, parsedRaw, dataBlob, _ []byte) error {
 	var gotContent string
 	var gotParsed []byte
 	var gotData []byte
-	var gotMetadata []byte
 	if err := tx.QueryRowContext(ctx, `
-		SELECT content_yaml, COALESCE(parsed_json, '{}'::jsonb), data_blob, COALESCE(metadata, '{}'::jsonb)
+		SELECT content_yaml, COALESCE(parsed_json, '{}'::jsonb), data_blob
 		FROM bundles
 		WHERE bundle_hash = $1
 		FOR SHARE
-	`, bundleHash).Scan(&gotContent, &gotParsed, &gotData, &gotMetadata); err != nil {
+	`, bundleHash).Scan(&gotContent, &gotParsed, &gotData); err != nil {
 		return fmt.Errorf("load bundle catalog upsert result: %w", err)
 	}
 	gotParsed, err := normalizedBundleCatalogJSONBytes(gotParsed)
 	if err != nil {
 		return fmt.Errorf("stored bundle catalog parsed_json: %w", err)
 	}
-	gotMetadata, err = normalizedBundleCatalogJSONBytes(gotMetadata)
-	if err != nil {
-		return fmt.Errorf("stored bundle catalog metadata: %w", err)
-	}
-	if gotContent != contentYAML || !bytes.Equal(gotParsed, parsedRaw) || !bytes.Equal(nullableBytes(gotData), nullableBytes(dataBlob)) || !bytes.Equal(gotMetadata, metadataRaw) {
-		return fmt.Errorf("bundle catalog row for %s already exists with different content", bundleHash)
+	if gotContent != contentYAML || !bytes.Equal(gotParsed, parsedRaw) || !bytes.Equal(nullableBytes(gotData), nullableBytes(dataBlob)) {
+		return &BundleCatalogConflictError{BundleHash: strings.TrimSpace(bundleHash)}
 	}
 	return nil
+}
+
+func loadBundleCatalogInTx(ctx context.Context, tx bundleCatalogTx, bundleHash string) (BundleCatalogDetail, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT
+			bundle_hash,
+			content_yaml,
+			COALESCE(parsed_json, '{}'::jsonb),
+			COALESCE(metadata, '{}'::jsonb),
+			data_blob IS NOT NULL,
+			COALESCE(octet_length(data_blob), 0)::bigint,
+			ingested_at
+		FROM bundles
+		WHERE bundle_hash = $1
+	`, strings.TrimSpace(bundleHash))
+	scanned, err := scanBundleCatalogRow(row)
+	if err != nil {
+		return BundleCatalogDetail{}, err
+	}
+	return scanned.toDetail()
 }
 
 type bundleCatalogTx interface {

--- a/internal/store/bundle_catalog_write_surface.go
+++ b/internal/store/bundle_catalog_write_surface.go
@@ -88,23 +88,28 @@ func (s *PostgresStore) UpsertBundleCatalog(ctx context.Context, req BundleCatal
 	return BundleCatalogUpsertResult{Detail: detail, Registered: registered}, nil
 }
 
-func assertBundleCatalogUpsertIdempotent(ctx context.Context, tx bundleCatalogTx, bundleHash, contentYAML string, parsedRaw, dataBlob, _ []byte) error {
+func assertBundleCatalogUpsertIdempotent(ctx context.Context, tx bundleCatalogTx, bundleHash, contentYAML string, parsedRaw, dataBlob, metadataRaw []byte) error {
 	var gotContent string
 	var gotParsed []byte
 	var gotData []byte
+	var gotMetadata []byte
 	if err := tx.QueryRowContext(ctx, `
-		SELECT content_yaml, COALESCE(parsed_json, '{}'::jsonb), data_blob
-		FROM bundles
-		WHERE bundle_hash = $1
-		FOR SHARE
-	`, bundleHash).Scan(&gotContent, &gotParsed, &gotData); err != nil {
+			SELECT content_yaml, COALESCE(parsed_json, '{}'::jsonb), data_blob, COALESCE(metadata, '{}'::jsonb)
+			FROM bundles
+			WHERE bundle_hash = $1
+			FOR SHARE
+		`, bundleHash).Scan(&gotContent, &gotParsed, &gotData, &gotMetadata); err != nil {
 		return fmt.Errorf("load bundle catalog upsert result: %w", err)
 	}
 	gotParsed, err := normalizedBundleCatalogJSONBytes(gotParsed)
 	if err != nil {
 		return fmt.Errorf("stored bundle catalog parsed_json: %w", err)
 	}
-	if gotContent != contentYAML || !bytes.Equal(gotParsed, parsedRaw) || !bytes.Equal(nullableBytes(gotData), nullableBytes(dataBlob)) {
+	gotMetadata, err = normalizedBundleCatalogJSONBytes(gotMetadata)
+	if err != nil {
+		return fmt.Errorf("stored bundle catalog metadata: %w", err)
+	}
+	if gotContent != contentYAML || !bytes.Equal(gotParsed, parsedRaw) || !bytes.Equal(nullableBytes(gotData), nullableBytes(dataBlob)) || !bytes.Equal(gotMetadata, metadataRaw) {
 		return &BundleCatalogConflictError{BundleHash: strings.TrimSpace(bundleHash)}
 	}
 	return nil

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -12,6 +12,8 @@ var ErrBundleNotFound = errors.New("store: bundle not found")
 
 var ErrInvalidBundleCatalogCursor = errors.New("store: invalid bundle catalog cursor")
 
+var ErrBundleCatalogConflict = errors.New("store: bundle catalog content conflict")
+
 var ErrEventNotFound = errors.New("store: event not found")
 
 var ErrInvalidObservabilityCursor = errors.New("store: invalid observability cursor")


### PR DESCRIPTION
## Summary

Implements the remaining #1017 `bundle.register` slice as a public `/v1/rpc` mutating method backed by the shared bundle catalog projection and store UPSERT owners now present on `origin/master` after #1142.

Closes #1017
Part of #1011
Related to #1015 / #1142

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.api_surface`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_identity.canonicalization_v1`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.conventions.idempotency`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.bundle.register`
- #1017 Pre-Implementation Coverage Audit refresh and approved first-slice gate

## Semantic Migration

- New canonical owner: `internal/runtime/contracts.BuildBundleCatalogProjection` / `BuildBundleCatalogProjectionWithOptions` plus `internal/store.PostgresStore.UpsertBundleCatalog`.
- Old invalid paths: handler-local bundle hash interpretation, `BundleFingerprint`/prefix rewriting as `bundle_hash`, direct bundle table inserts from API handlers, and any register path that restores `runs.bundle_source='deleted'`.
- Production paths checked for surviving old behavior: `/v1/rpc bundle.register`, generated OpenRPC/method catalog, API idempotency owner, bundle catalog store upsert, readback through `bundle.list/get/agents`, and serve-ingest owner compatibility from #1142.
- Migration completeness: complete for the #1017 `bundle.register` API slice; #1011 parent and #1015 serve-ingest/runtime follow-on accounting remain separate.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/runtime/contracts -run 'BundleHashV1|BundleCatalogProjection' -count=1`
- `go test ./internal/store -run 'BundleCatalog|APIIdempotency|SchemaDDL' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/apiv1 -run 'Bundle|OpenRPC|Compliance|RegistryMethodNames|ResultSchemas|Mutating|RunFork' -count=1`
- `go test ./...`