### PR TITLE
[agent-c][issue #1019] Implement force bundle delete cleanup

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -32,6 +32,7 @@ import (
 	"swarm/internal/runtime"
 	runtimebootverify "swarm/internal/runtime/bootverify"
 	"swarm/internal/runtime/budgetspend"
+	runtimebundledelete "swarm/internal/runtime/bundledelete"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecorrelation "swarm/internal/runtime/correlation"
@@ -597,12 +598,20 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Ready: func() bool {
 			return ready.Load()
 		},
-		Database:            stores.Postgres,
-		Runs:                stores.Postgres,
-		Observability:       apiObservability,
-		Entities:            apiEntities,
-		AgentConversations:  apiAgentConversations,
-		BundleCatalog:       stores.Postgres,
+		Database:           stores.Postgres,
+		Runs:               stores.Postgres,
+		Observability:      apiObservability,
+		Entities:           apiEntities,
+		AgentConversations: apiAgentConversations,
+		BundleCatalog:      stores.Postgres,
+		BundleDelete: &runtimebundledelete.Coordinator{
+			Planner:            stores.Postgres,
+			Cleaner:            stores.Postgres,
+			Finalizer:          stores.Postgres,
+			Locks:              stores.Postgres,
+			ContainerInventory: workspaces,
+			Containers:         runtimedestructivereset.ManagedContainerStopper{Runtime: workspaces},
+		},
 		ConversationForks:   stores.Postgres,
 		ForkChatExecutor:    apiv1.NewLLMForkChatExecutor(forkChatLLM),
 		RunBundleContext:    stores.Postgres,

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -236,6 +236,7 @@ nodes:
       - "old #987 and #988 wording says to reuse destructivereset even though DefaultPlatformCleanupCatalog deletes run-scoped history rows"
       - "source/schema/availability prerequisites are now merge-bearing; startup recovery auto-orphan (#1016) introduces the first runtime preservation cleanup owner consumer"
       - "bundle.delete --force Phase 3 (#1019) must consume the preservation cleanup owner rather than local per-consumer SQL"
+      - "bundle.delete --force (#1019) must also close same-runtime post-delete new-work admission: event.publish and run.start must not recreate runs.bundle_source=persisted after the source bundle row is deleted"
       - "bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner"
       - "server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern"
     representative_issues:

--- a/docs/watchlists/semantic-correctness.yaml
+++ b/docs/watchlists/semantic-correctness.yaml
@@ -237,6 +237,7 @@ nodes:
       - "source/schema/availability prerequisites are now merge-bearing; startup recovery auto-orphan (#1016) introduces the first runtime preservation cleanup owner consumer"
       - "bundle.delete --force Phase 3 (#1019) must consume the preservation cleanup owner rather than local per-consumer SQL"
       - "bundle.delete --force (#1019) must also close same-runtime post-delete new-work admission: event.publish and run.start must not recreate runs.bundle_source=persisted after the source bundle row is deleted"
+      - "bundle.delete --force (#1019) must also close direct run-row writers for the same persisted runtime source fact: runtime-log and mutation-log persistence must not recreate runs.bundle_source=persisted after the source bundle row is deleted"
       - "bundle.delete Phase 5 atomic runs/bundles mutation is a separate #1009 sibling and must not be folded into the preservation cleanup owner"
       - "server-wide runtime.nuke bundle-catalog integration (#1027) is a separate destructive-reset/runtime-admin concern"
     representative_issues:

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -388,7 +388,13 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	if !sequenceContainsScalar(admissionConsumers, "/v1/rpc run.start") {
 		t.Fatal("post_delete_new_work_admission must bind run.start")
 	}
-	assertScalarContains(t, mustMappingValue(t, postDeleteAdmission, "rule"), "same-runtime event.publish and run.start attempts return BUNDLE_UNAVAILABLE")
+	if !sequenceContainsScalar(admissionConsumers, "internal/runtime.RuntimeLogger runtime-log run-row persistence") {
+		t.Fatal("post_delete_new_work_admission must bind runtime-log persistence")
+	}
+	if !sequenceContainsScalar(admissionConsumers, "internal/runtime/mutationlog mutation-log run-row persistence") {
+		t.Fatal("post_delete_new_work_admission must bind mutation-log persistence")
+	}
+	assertScalarContains(t, mustMappingValue(t, postDeleteAdmission, "rule"), "event.publish, run.start, runtime-log, and mutation-log attempts fail closed")
 	invalid := mustMappingValue(t, phaseFive, "invalid_implementations")
 	if !sequenceContainsScalar(invalid, "deleting the bundles row before marking eligible runs deleted") {
 		t.Fatal("phase_5_atomicity must reject delete-before-update implementations")

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -17,17 +17,17 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 55 {
-		t.Fatalf("method count = %d, want 55", report.MethodCount)
+	if report.MethodCount != 56 {
+		t.Fatalf("method count = %d, want 56", report.MethodCount)
 	}
-	if report.SchemaCount != 103 {
-		t.Fatalf("schema count = %d, want 103", report.SchemaCount)
+	if report.SchemaCount != 104 {
+		t.Fatalf("schema count = %d, want 104", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 37 {
 		t.Fatalf("error code count = %d, want 37", report.ErrorCodeCount)
 	}
-	if report.MutatingMethodCount != 21 {
-		t.Fatalf("mutating method count = %d, want 21", report.MutatingMethodCount)
+	if report.MutatingMethodCount != 22 {
+		t.Fatalf("mutating method count = %d, want 22", report.MutatingMethodCount)
 	}
 	if report.SubscriptionMethodCnt != 4 {
 		t.Fatalf("subscription method count = %d, want 4", report.SubscriptionMethodCnt)
@@ -67,11 +67,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 55 {
-		t.Fatalf("generated OpenRPC methods = %d, want 55", len(doc.Methods))
+	if len(doc.Methods) != 56 {
+		t.Fatalf("generated OpenRPC methods = %d, want 56", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 103 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 103", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 104 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 104", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 37 {
 		t.Fatalf("generated OpenRPC errors = %d, want 37", len(doc.Components.Errors))
@@ -100,12 +100,12 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if _, ok := methods["agent.delivery_diagnostics"]; !ok {
 		t.Fatal("generated OpenRPC missing agent.delivery_diagnostics")
 	}
-	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register"} {
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete"} {
 		if _, ok := methods[methodName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", methodName)
 		}
 	}
-	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult", "BundleRegistrationEnvelopeV1", "BundleRegistrationFile", "BundleRegisterDataBlobV1", "BundleRegistrationResult"} {
+	for _, schemaName := range []string{"BundleSummary", "BundleListResult", "BundleDetail", "BundleAgentDefinition", "BundleAgentsResult", "BundleRegistrationEnvelopeV1", "BundleRegistrationFile", "BundleRegisterDataBlobV1", "BundleRegistrationResult", "BundleDeleteResult"} {
 		if _, ok := doc.Components.Schemas[schemaName]; !ok {
 			t.Fatalf("generated OpenRPC missing %s", schemaName)
 		}
@@ -282,7 +282,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
 
 	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
-	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_and_run_fork_methods_published")
+	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_run_fork_and_force_delete_methods_published")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.list")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "run.fork")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.register")
@@ -344,13 +344,13 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	apiSurface := mustMappingValue(t, multi, "api_surface")
-	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "bundle_read_catalog_register_and_run_fork_generated_openrpc")
+	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "bundle_read_catalog_register_run_fork_and_force_delete_generated_openrpc")
 
 	bundleDelete := mustMappingValue(t, multi, "bundle_delete")
 	phaseFive := mustMappingValue(t, bundleDelete, "phase_5_atomicity")
 	assertScalarValue(t, mustMappingValue(t, phaseFive, "tracker"), "#1009")
-	assertScalarValue(t, mustMappingValue(t, phaseFive, "implementation_status"), "source_authority_only_no_runtime_behavior")
-	assertScalarValue(t, mustMappingValue(t, phaseFive, "canonical_runtime_owner"), "future bundle catalog store transaction/mutator")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "implementation_status"), "implemented_for_force_delete_runtime_non_force_pending")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "canonical_runtime_owner"), "internal/store.PostgresStore.ApplyBundleDeleteFinalMutation")
 	appliesTo := mustMappingValue(t, phaseFive, "applies_to")
 	if !sequenceContainsScalar(appliesTo, "#1018 non-force bundle.delete final bundle availability mutation") {
 		t.Fatal("phase_5_atomicity must bind non-force bundle.delete")
@@ -359,17 +359,21 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 		t.Fatal("phase_5_atomicity must bind force bundle.delete")
 	}
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "one database transaction")
+	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "serializes run creation")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "before deleting the matching bundles")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "transaction_rule"), "shared store transaction owner")
 	order := mustMappingValue(t, phaseFive, "transaction_order")
-	if len(order.Content) != 2 {
-		t.Fatalf("phase_5_atomicity transaction_order has %d items, want 2", len(order.Content))
+	if len(order.Content) != 3 {
+		t.Fatalf("phase_5_atomicity transaction_order has %d items, want 3", len(order.Content))
 	}
-	if got := scalarValue(order.Content[0]); got != "update_eligible_runs_bundle_source_to_deleted" {
-		t.Fatalf("phase_5_atomicity transaction_order[0] = %q, want update first", got)
+	if got := scalarValue(order.Content[0]); got != "lock_runs_table_against_new_persisted_bundle_references" {
+		t.Fatalf("phase_5_atomicity transaction_order[0] = %q, want run-creation lock first", got)
 	}
-	if got := scalarValue(order.Content[1]); got != "delete_matching_bundles_row" {
-		t.Fatalf("phase_5_atomicity transaction_order[1] = %q, want delete second", got)
+	if got := scalarValue(order.Content[1]); got != "update_eligible_runs_bundle_source_to_deleted" {
+		t.Fatalf("phase_5_atomicity transaction_order[1] = %q, want update second", got)
+	}
+	if got := scalarValue(order.Content[2]); got != "delete_matching_bundles_row" {
+		t.Fatalf("phase_5_atomicity transaction_order[2] = %q, want delete last", got)
 	}
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "read runs.bundle_source before consulting bundles")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_UNAVAILABLE")
@@ -447,10 +451,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
-	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_and_run_fork_method_catalog")
+	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_run_fork_and_force_delete_method_catalog")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.register is also published")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "does not imply a swarm bundle register CLI consumer")
-	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.delete")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "Force-only bundle.delete is promoted")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "split to #1018")
 
 	for _, relPath := range []string{
 		filepath.Join("cmd", "swarm", "main.go"),
@@ -479,18 +484,13 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	api := loadRepoAPISpec(t)
-	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register"} {
+	for _, methodName := range []string{"bundle.list", "bundle.get", "bundle.agents", "bundle.register", "bundle.delete"} {
 		if _, ok := api.MethodCatalog[methodName]; !ok {
 			t.Fatalf("%s must be in live method_catalog after bundle catalog implementation lands", methodName)
 		}
 	}
 	if _, ok := api.MethodCatalog["run.fork"]; !ok {
 		t.Fatal("run.fork missing from live method_catalog after API/runtime handler promotion")
-	}
-	for _, methodName := range []string{"bundle.delete"} {
-		if _, ok := api.MethodCatalog[methodName]; ok {
-			t.Fatalf("%s must not be in live method_catalog until handler implementation lands", methodName)
-		}
 	}
 	generated, err := GenerateOpenRPC(api)
 	if err != nil {
@@ -499,12 +499,6 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	var doc OpenRPCDocument
 	if err := json.Unmarshal(generated, &doc); err != nil {
 		t.Fatalf("unmarshal generated openrpc: %v", err)
-	}
-	for _, method := range doc.Methods {
-		switch method.Name {
-		case "bundle.delete":
-			t.Fatalf("%s must not be published in generated OpenRPC until implementation lands", method.Name)
-		}
 	}
 }
 

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -23,8 +23,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 104 {
 		t.Fatalf("schema count = %d, want 104", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 37 {
-		t.Fatalf("error code count = %d, want 37", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 38 {
+		t.Fatalf("error code count = %d, want 38", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 22 {
 		t.Fatalf("mutating method count = %d, want 22", report.MutatingMethodCount)
@@ -73,8 +73,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 104 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 104", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 37 {
-		t.Fatalf("generated OpenRPC errors = %d, want 37", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 38 {
+		t.Fatalf("generated OpenRPC errors = %d, want 38", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -378,6 +378,17 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "read runs.bundle_source before consulting bundles")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_UNAVAILABLE")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_DATA_INTEGRITY_ERROR")
+	postDeleteAdmission := mustMappingValue(t, phaseFive, "post_delete_new_work_admission")
+	assertScalarValue(t, mustMappingValue(t, postDeleteAdmission, "status"), "implemented_for_force_delete_runtime")
+	assertScalarValue(t, mustMappingValue(t, postDeleteAdmission, "canonical_owner"), "internal/store/runlifecycle.EnsureActive")
+	admissionConsumers := mustMappingValue(t, postDeleteAdmission, "consumed_by")
+	if !sequenceContainsScalar(admissionConsumers, "/v1/rpc event.publish") {
+		t.Fatal("post_delete_new_work_admission must bind event.publish")
+	}
+	if !sequenceContainsScalar(admissionConsumers, "/v1/rpc run.start") {
+		t.Fatal("post_delete_new_work_admission must bind run.start")
+	}
+	assertScalarContains(t, mustMappingValue(t, postDeleteAdmission, "rule"), "same-runtime event.publish and run.start attempts return BUNDLE_UNAVAILABLE")
 	invalid := mustMappingValue(t, phaseFive, "invalid_implementations")
 	if !sequenceContainsScalar(invalid, "deleting the bundles row before marking eligible runs deleted") {
 		t.Fatal("phase_5_atomicity must reject delete-before-update implementations")

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -31,8 +31,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 55 {
-		t.Fatalf("method count = %d, want 55", len(openRPCNames))
+	if len(openRPCNames) != 56 {
+		t.Fatalf("method count = %d, want 56", len(openRPCNames))
 	}
 	if _, ok := registry.Method("run.fork"); !ok {
 		t.Fatal("run.fork missing from generated registry")

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -121,8 +121,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 55 {
-		t.Fatalf("generated OpenRPC methods = %d, want 55", len(doc.Methods))
+	if len(doc.Methods) != 56 {
+		t.Fatalf("generated OpenRPC methods = %d, want 56", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"swarm/internal/apispec"
 	"swarm/internal/events"
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
+	"swarm/internal/runtime/bundledelete"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecorrelation "swarm/internal/runtime/correlation"
@@ -220,6 +221,7 @@ func approvedMutatingHTTPRuntimeMethods() []string {
 		"agent.replay_backlog",
 		"agent.restart",
 		"agent.send_directive",
+		"bundle.delete",
 		"bundle.register",
 		"conversation.fork",
 		"conversation.fork_chat",
@@ -278,6 +280,12 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			Params:         map[string]any{"agent_id": "agent-a", "directive": "continue", "run_id": runID},
 			ConflictParams: map[string]any{"agent_id": "agent-a", "directive": "pause", "run_id": runID},
 			ResultKeys:     []string{"ok", "run_id", "run_id_resolution", "directive_event_id", "directive_event_type"},
+			SuccessEffects: 1,
+		},
+		"bundle.delete": {
+			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "dry_run": false},
+			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "dry_run": true},
+			ResultKeys:     []string{"ok", "status", "operation_name", "bundle_hash", "force", "deleted", "dry_run", "active_runs_stopped", "deliveries_cancelled", "containers_stopped", "plan", "cleanup", "containers", "final_mutation"},
 			SuccessEffects: 1,
 		},
 		"conversation.fork": {
@@ -558,6 +566,8 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.runtimeIngress.errs["runtime.resume"] = runtimeingress.ErrNotPaused
 		}}},
 		{Method: "runtime.nuke", Params: map[string]any{"dry_run": false, "idempotency_key": "idem-error"}, Code: RuntimeNukeInProgressCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.nuke.planErr = destructivereset.ErrOperationInProgress }}},
+		{Method: "bundle.delete", Params: map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "idempotency_key": "idem-error"}, Code: BundleNotFoundCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.bundleDelete.err = store.ErrBundleNotFound }}},
+		{Method: "bundle.delete", Params: map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "idempotency_key": "idem-error"}, Code: BundleDeleteInProgressCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.bundleDelete.err = bundledelete.ErrOperationInProgress }}},
 	}
 }
 
@@ -665,6 +675,7 @@ type mutatingRuntimeProbeState struct {
 	bundleCatalog       *mutatingProbeBundleCatalog
 	forks               *fakeConversationForkLifecycleStore
 	nuke                *recordingRuntimeNukeOwners
+	bundleDelete        *recordingBundleDeleteExecutor
 	effects             int
 }
 
@@ -689,6 +700,9 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 			errs: map[string]error{},
 		},
 		nuke: newRecordingRuntimeNukeOwners(),
+		bundleDelete: &recordingBundleDeleteExecutor{
+			bundleHash: runStartTestBundleHash,
+		},
 	}
 	state.observability.events["evt-1"] = mutatingProbeOriginalEvent("evt-1", []string{"agent-a"}, eventReplayStatusDelivered)
 	state.events = &mutatingProbeEventPublisher{state: state}
@@ -832,6 +846,7 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 		ResetQuiescer:         recordingRuntimeNukeQuiescer{s.nuke},
 		ResetCleaner:          recordingRuntimeNukeCleaner{s.nuke},
 		ResetContainers:       recordingRuntimeNukeContainerStopper{s.nuke},
+		BundleDelete:          s.bundleDelete,
 		Source:                source,
 		MailboxApprovalRoutes: map[string]string{"review_request": "mailbox.item_decided"},
 		Bundle: runtimecontracts.BundleIdentity{
@@ -847,7 +862,45 @@ func (s *mutatingRuntimeProbeState) recordEffect() {
 }
 
 func (s *mutatingRuntimeProbeState) effectCount() int {
-	return s.effects + len(s.nuke.calls)
+	return s.effects + len(s.nuke.calls) + len(s.bundleDelete.calls)
+}
+
+type recordingBundleDeleteExecutor struct {
+	calls      []bundledelete.Request
+	err        error
+	bundleHash string
+}
+
+func (e *recordingBundleDeleteExecutor) Execute(_ context.Context, req bundledelete.Request) (bundledelete.Result, error) {
+	e.calls = append(e.calls, req)
+	if e.err != nil {
+		return bundledelete.Result{}, e.err
+	}
+	bundleHash := strings.TrimSpace(req.BundleHash)
+	if bundleHash == "" {
+		bundleHash = strings.TrimSpace(e.bundleHash)
+	}
+	return bundledelete.Result{
+		OK:                  true,
+		Status:              "completed",
+		OperationName:       bundledelete.DefaultOperationName,
+		BundleHash:          bundleHash,
+		Force:               req.Force,
+		Deleted:             true,
+		DryRun:              req.DryRun,
+		ActiveRunsStopped:   1,
+		DeliveriesCancelled: 1,
+		ContainersStopped:   1,
+		Plan: bundledelete.Plan{
+			BundleHash: bundleHash,
+			ActiveRuns: []bundledelete.RunRef{{
+				RunID:        "00000000-0000-0000-0000-000000000101",
+				Status:       "running",
+				BundleHash:   bundleHash,
+				BundleSource: "persisted",
+			}},
+		},
+	}, nil
 }
 
 type mutatingProbeIdempotencyStore struct {

--- a/internal/apiv1/operator_bundle_delete.go
+++ b/internal/apiv1/operator_bundle_delete.go
@@ -1,0 +1,126 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"swarm/internal/runtime/bundledelete"
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/store"
+)
+
+const bundleDeleteIdempotencyTTL = 24 * time.Hour
+
+func OperatorBundleDeleteHandlers(opts OperatorReadOptions) map[string]MethodHandler {
+	if opts.BundleDelete == nil || opts.Idempotency == nil {
+		return nil
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return map[string]MethodHandler{
+		"bundle.delete": func(ctx context.Context, req Request) (any, error) {
+			return executeBundleDelete(ctx, req, opts, now().UTC())
+		},
+	}
+}
+
+func executeBundleDelete(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	bundleHash, err := requiredBundleHashParam(req.Params, "bundle_hash")
+	if err != nil {
+		return nil, err
+	}
+	force, err := optionalBoolParam(req.Params, "force", false)
+	if err != nil {
+		return nil, err
+	}
+	if !force {
+		return nil, NewInvalidParamsError(map[string]any{
+			"field":      "force",
+			"reason":     "non-force bundle.delete remains split to #1018; force=true is required for #1019",
+			"tracked_by": "#1018",
+		})
+	}
+	dryRun, err := optionalBoolParam(req.Params, "dry_run", false)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
+	if err != nil {
+		return nil, err
+	}
+	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+		Method:         req.Method,
+		ActorTokenID:   req.ActorTokenID,
+		IdempotencyKey: idempotencyKey,
+		RequestHash:    req.RequestHash,
+		ResourceID:     bundleHash,
+		TTL:            bundleDeleteIdempotencyTTL,
+		Now:            now,
+	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		result, err := opts.BundleDelete.Execute(ctx, bundledelete.Request{
+			ActorTokenID: req.ActorTokenID,
+			RequestHash:  req.RequestHash,
+			BundleHash:   bundleHash,
+			Force:        force,
+			DryRun:       dryRun,
+			RequestedAt:  now,
+		})
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		response, err := json.Marshal(result)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		return store.APIIdempotencyCompletion{
+			ResourceID: bundleHash,
+			Response:   response,
+		}, nil
+	})
+	if err != nil {
+		return nil, bundleDeleteError(bundleHash, err)
+	}
+	var stored bundledelete.Result
+	if err := json.Unmarshal(completion.Response, &stored); err != nil {
+		if replay {
+			return nil, fmt.Errorf("decode bundle.delete idempotency response: %w", err)
+		}
+		return nil, fmt.Errorf("decode bundle.delete response: %w", err)
+	}
+	return stored, nil
+}
+
+func bundleDeleteError(bundleHash string, err error) error {
+	var conflict *store.APIIdempotencyConflictError
+	if errors.As(err, &conflict) {
+		return NewApplicationError(IdempotencyConflictCode, false, map[string]any{
+			"original_request_hash":    conflict.OriginalRequestHash,
+			"conflicting_request_hash": conflict.ConflictingRequestHash,
+			"original_response_ref": map[string]any{
+				"method":      conflict.Method,
+				"resource_id": conflict.ResourceID,
+			},
+		})
+	}
+	if errors.Is(err, store.ErrBundleNotFound) || errors.Is(err, bundledelete.ErrBundleNotFound) {
+		return NewApplicationError(BundleNotFoundCode, false, map[string]any{"bundle_hash": bundleHash})
+	}
+	if errors.Is(err, bundledelete.ErrOperationInProgress) || errors.Is(err, destructivereset.ErrOperationInProgress) {
+		return NewApplicationError(BundleDeleteInProgressCode, true, map[string]any{
+			"operation_name": bundledelete.DefaultOperationName,
+		})
+	}
+	if errors.Is(err, bundledelete.ErrNonForceSplit) {
+		return NewInvalidParamsError(map[string]any{
+			"field":      "force",
+			"reason":     "non-force bundle.delete remains split to #1018; force=true is required for #1019",
+			"tracked_by": "#1018",
+		})
+	}
+	return err
+}

--- a/internal/apiv1/operator_bundle_delete_test.go
+++ b/internal/apiv1/operator_bundle_delete_test.go
@@ -1,0 +1,122 @@
+package apiv1
+
+import (
+	"testing"
+	"time"
+
+	"swarm/internal/runtime/bundledelete"
+	"swarm/internal/store"
+)
+
+func TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash}
+	idempotency := newRecordingAPIIdempotencyStore()
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:          func() time.Time { return now },
+			Ready:        func() bool { return true },
+			Database:     fakePinger{},
+			Idempotency:  idempotency,
+			BundleDelete: executor,
+		}),
+	})
+
+	body := `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `","force":true,"idempotency_key":"force-1"}}`
+	resp := rpcCall(t, handler, body)
+	if resp.Error != nil {
+		t.Fatalf("bundle.delete force error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["ok"] != true || result["status"] != "completed" || result["bundle_hash"] != runStartTestBundleHash || result["force"] != true || result["deleted"] != true {
+		t.Fatalf("bundle.delete force result = %#v", result)
+	}
+	if len(executor.calls) != 1 {
+		t.Fatalf("bundle.delete executor calls = %d, want 1", len(executor.calls))
+	}
+	if executor.calls[0].BundleHash != runStartTestBundleHash || !executor.calls[0].Force || executor.calls[0].DryRun {
+		t.Fatalf("bundle.delete request = %#v", executor.calls[0])
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("bundle.delete replay error = %#v", replay.Error)
+	}
+	if len(executor.calls) != 1 {
+		t.Fatalf("bundle.delete executor calls after replay = %d, want unchanged 1", len(executor.calls))
+	}
+
+	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","force":true,"dry_run":true,"idempotency_key":"force-1"}}`)
+	if conflict.Error == nil {
+		t.Fatal("bundle.delete idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("bundle.delete conflict data = %#v, want %s", data, IdempotencyConflictCode)
+	}
+}
+
+func TestOperatorBundleDeleteForceErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "missing bundle", err: store.ErrBundleNotFound, code: BundleNotFoundCode},
+		{name: "busy", err: bundledelete.ErrOperationInProgress, code: BundleDeleteInProgressCode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash, err: tt.err}
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					Ready:        func() bool { return true },
+					Database:     fakePinger{},
+					Idempotency:  newRecordingAPIIdempotencyStore(),
+					BundleDelete: executor,
+				}),
+			})
+
+			resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","force":true,"idempotency_key":"force-error"}}`)
+			if resp.Error == nil {
+				t.Fatalf("bundle.delete %s error = nil", tt.name)
+			}
+			if data := asMap(t, resp.Error.Data); data["code"] != tt.code {
+				t.Fatalf("bundle.delete %s data = %#v, want %s", tt.name, data, tt.code)
+			}
+			if len(executor.calls) != 1 {
+				t.Fatalf("bundle.delete executor calls = %d, want 1", len(executor.calls))
+			}
+		})
+	}
+}
+
+func TestOperatorBundleDeleteNonForceFailsClosedBeforeOwner(t *testing.T) {
+	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:        func() bool { return true },
+			Database:     fakePinger{},
+			Idempotency:  newRecordingAPIIdempotencyStore(),
+			BundleDelete: executor,
+		}),
+	})
+
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `"}}`,
+		`{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `","force":false}}`,
+	} {
+		resp := rpcCall(t, handler, body)
+		if resp.Error == nil {
+			t.Fatal("bundle.delete non-force error = nil")
+		}
+		if resp.Error.Code != codeInvalidParams {
+			t.Fatalf("bundle.delete non-force code = %d, want %d", resp.Error.Code, codeInvalidParams)
+		}
+	}
+	if len(executor.calls) != 0 {
+		t.Fatalf("bundle.delete owner calls after non-force = %d, want 0", len(executor.calls))
+	}
+}

--- a/internal/apiv1/operator_bundle_delete_test.go
+++ b/internal/apiv1/operator_bundle_delete_test.go
@@ -1,11 +1,21 @@
 package apiv1
 
 import (
+	"context"
+	"database/sql"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"swarm/internal/runtime/bundledelete"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
 )
 
 func TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency(t *testing.T) {
@@ -119,4 +129,119 @@ func TestOperatorBundleDeleteNonForceFailsClosedBeforeOwner(t *testing.T) {
 	if len(executor.calls) != 0 {
 		t.Fatalf("bundle.delete owner calls after non-force = %d, want 0", len(executor.calls))
 	}
+}
+
+func TestOperatorBundleDeleteForceBlocksPostDeleteNewWorkFromPersistedRuntimeSource(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	seedOperatorBundleDeleteBundle(t, ctx, db, runStartTestBundleHash)
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        runStartTestBundleHash,
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: runStartTestFingerprint,
+	}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle:   source,
+		BundleSourceFact: sourceFact,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:           func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
+			Ready:         func() bool { return true },
+			Database:      fakePinger{},
+			Runs:          pg,
+			Observability: pg,
+			Idempotency:   pg,
+			Events:        bus,
+			Source:        source,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     runStartTestFingerprint,
+			},
+			BundleDelete: &bundledelete.Coordinator{
+				Planner:            pg,
+				Cleaner:            pg,
+				Finalizer:          pg,
+				Locks:              pg,
+				ContainerInventory: emptyBundleDeleteContainerInventory{},
+				Containers:         noopBundleDeleteContainers{},
+				Now:                func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
+			},
+		}),
+	})
+
+	deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","force":true,"idempotency_key":"force-delete-current-runtime"}}`)
+	if deleted.Error != nil {
+		t.Fatalf("bundle.delete error = %#v", deleted.Error)
+	}
+	if result := asMap(t, deleted.Result); result["deleted"] != true {
+		t.Fatalf("bundle.delete result = %#v, want deleted", result)
+	}
+
+	published := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "publish-after-delete"))
+	assertBundleUnavailableNewWork(t, published, "event.publish")
+	if count := countEventsByName(t, db, "scan.requested"); count != 0 {
+		t.Fatalf("scan.requested events after event.publish = %d, want 0", count)
+	}
+	if count := countAllRunRows(t, db); count != 0 {
+		t.Fatalf("run rows after event.publish = %d, want 0", count)
+	}
+
+	runID := uuid.NewString()
+	started := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "start-after-delete"))
+	assertBundleUnavailableNewWork(t, started, "run.start")
+	if count := countRunRowsByID(t, db, runID); count != 0 {
+		t.Fatalf("run rows after run.start = %d, want 0", count)
+	}
+	if count := countEventRowsByRunID(t, db, runID); count != 0 {
+		t.Fatalf("event rows after run.start = %d, want 0", count)
+	}
+	if count := countAPIIdempotencyRows(t, db); count != 1 {
+		t.Fatalf("api_idempotency rows after rejected new work = %d, want only bundle.delete row", count)
+	}
+}
+
+func seedOperatorBundleDeleteBundle(t *testing.T, ctx context.Context, db *sql.DB, bundleHash string) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, metadata, ingested_at)
+		VALUES ($1, 'version: 1', '{}'::jsonb, '{}'::jsonb, now())
+	`, bundleHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
+}
+
+func assertBundleUnavailableNewWork(t *testing.T, resp rpcResponse, method string) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("%s error = nil, want BUNDLE_UNAVAILABLE", method)
+	}
+	if data := asMap(t, resp.Error.Data); data["code"] != BundleUnavailableCode {
+		t.Fatalf("%s error data = %#v, want %s", method, data, BundleUnavailableCode)
+	}
+}
+
+type emptyBundleDeleteContainerInventory struct{}
+
+func (emptyBundleDeleteContainerInventory) ManagedResetContainerInventory(context.Context) ([]destructivereset.ContainerRef, error) {
+	return nil, nil
+}
+
+type noopBundleDeleteContainers struct{}
+
+func (noopBundleDeleteContainers) Apply(_ context.Context, req destructivereset.ContainerResetRequest) (destructivereset.ContainerResetResult, error) {
+	return destructivereset.ContainerResetResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+		Selected:      req.Result.Plan.EntityContainers,
+	}, nil
 }

--- a/internal/apiv1/operator_bundle_delete_test.go
+++ b/internal/apiv1/operator_bundle_delete_test.go
@@ -153,14 +153,15 @@ func TestOperatorBundleDeleteForceBlocksPostDeleteNewWorkFromPersistedRuntimeSou
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:           func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
-			Ready:         func() bool { return true },
-			Database:      fakePinger{},
-			Runs:          pg,
-			Observability: pg,
-			Idempotency:   pg,
-			Events:        bus,
-			Source:        source,
+			Now:              func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Runs:             pg,
+			Observability:    pg,
+			Idempotency:      pg,
+			Events:           bus,
+			Source:           source,
+			RunBundleContext: pg,
 			Bundle: runtimecontracts.BundleIdentity{
 				WorkflowName:    "review",
 				WorkflowVersion: "1.0.0",

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"swarm/internal/runtime/bundledelete"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
@@ -57,6 +58,10 @@ type BundleCatalogReadStore interface {
 	ListBundleCatalogAgents(context.Context, string) (store.BundleCatalogAgentsResult, error)
 }
 
+type BundleDeleteExecutor interface {
+	Execute(context.Context, bundledelete.Request) (bundledelete.Result, error)
+}
+
 type OperatorReadOptions struct {
 	Now                   func() time.Time
 	Ready                 func() bool
@@ -68,6 +73,7 @@ type OperatorReadOptions struct {
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
 	BundleCatalog         BundleCatalogReadStore
+	BundleDelete          BundleDeleteExecutor
 	ConversationForks     ConversationForkLifecycleStore
 	ForkChatExecutor      ForkChatExecutor
 	RunBundleContext      RunBundleContextStore
@@ -251,6 +257,9 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorBundleRegisterHandlers(opts) {
+		handlers[name] = handler
+	}
+	for name, handler := range OperatorBundleDeleteHandlers(opts) {
 		handlers[name] = handler
 	}
 	for name, handler := range OperatorConversationForkHandlers(opts) {

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	runtimebus "swarm/internal/runtime/bus"
 	"swarm/internal/store"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 const runStartIDempotencyTTL = 24 * time.Hour
@@ -166,6 +167,16 @@ func runStartIdempotencyError(err error) error {
 }
 
 func runStartPublishError(eventName string, err error) error {
+	var bundleUnavailable *storerunlifecycle.PersistedBundleUnavailableError
+	if errors.As(err, &bundleUnavailable) || errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
+		details := map[string]any{"event_name": eventName}
+		if bundleUnavailable != nil {
+			details["bundle_hash"] = bundleUnavailable.BundleHash
+			details["bundle_source"] = bundleUnavailable.BundleSource
+			details["cause"] = bundleUnavailable.Cause
+		}
+		return NewApplicationError(BundleUnavailableCode, false, details)
+	}
 	if errors.Is(err, runtimebus.ErrPayloadValidation) || strings.Contains(err.Error(), "validate event payload") {
 		return NewApplicationError(PayloadValidationFailedCode, false, map[string]any{
 			"violations": []map[string]any{{

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -18,6 +18,7 @@ const (
 	BundleUnavailableCode                = "BUNDLE_UNAVAILABLE"
 	BundleDataIntegrityErrorCode         = "BUNDLE_DATA_INTEGRITY_ERROR"
 	BundleRegisterConflictCode           = "BUNDLE_REGISTER_CONFLICT"
+	BundleDeleteInProgressCode           = "BUNDLE_DELETE_IN_PROGRESS"
 	UnsupportedBundleHashCode            = "UNSUPPORTED_BUNDLE_HASH"
 	UnsupportedBundleHashForkCode        = "UNSUPPORTED_BUNDLE_HASH_FORK"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -168,6 +168,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: bundle.delete
+    transport: http
+    required_params: [bundle_hash]
+    declared_errors: [BUNDLE_NOT_FOUND, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
+    required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceErrors}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: bundle.get
     transport: http
     required_params: [bundle_hash]

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -180,8 +180,8 @@ methods:
     idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
     result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
     notification_schema: {status: not_applicable}
-    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
-    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml}, {kind: artifact, path: docs/specs/swarm-platform/platform/contracts/openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
   - method: bundle.get
     transport: http

--- a/internal/runtime/bundledelete/coordinator.go
+++ b/internal/runtime/bundledelete/coordinator.go
@@ -1,0 +1,219 @@
+package bundledelete
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/runtime/preservationcleanup"
+)
+
+type Coordinator struct {
+	Planner            Planner
+	Cleaner            PreservationCleaner
+	Finalizer          Finalizer
+	Locks              LockManager
+	ContainerInventory ManagedContainerInventoryReader
+	Containers         ManagedContainerStopper
+	Now                func() time.Time
+	Operation          string
+	LockKey            string
+}
+
+func (c *Coordinator) Execute(ctx context.Context, req Request) (Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c == nil {
+		return Result{}, fmt.Errorf("bundle delete coordinator is required")
+	}
+	now := c.now()
+	req, err := NormalizeRequest(req, now)
+	if err != nil {
+		return Result{}, err
+	}
+	if c.Planner == nil {
+		return Result{}, fmt.Errorf("bundle delete planner is required")
+	}
+	if c.Cleaner == nil {
+		return Result{}, fmt.Errorf("bundle delete preservation cleaner is required")
+	}
+	if c.Finalizer == nil {
+		return Result{}, fmt.Errorf("bundle delete finalizer is required")
+	}
+	if c.Locks == nil {
+		return Result{}, fmt.Errorf("bundle delete lock manager is required")
+	}
+	if c.ContainerInventory == nil {
+		return Result{}, fmt.Errorf("bundle delete managed container inventory is required")
+	}
+	if c.Containers == nil {
+		return Result{}, fmt.Errorf("bundle delete managed container stopper is required")
+	}
+
+	lease, acquired, err := c.Locks.TryAcquire(ctx, c.lockKey())
+	if err != nil {
+		return Result{}, err
+	}
+	if !acquired {
+		return Result{}, ErrOperationInProgress
+	}
+	if lease == nil {
+		return Result{}, fmt.Errorf("bundle delete lock lease is missing")
+	}
+	defer func() {
+		_ = lease.Release(context.Background())
+	}()
+
+	plan, err := c.Planner.PlanBundleDelete(ctx, req)
+	if err != nil {
+		return Result{}, err
+	}
+	plan.PlannedAt = req.RequestedAt
+	containers, err := c.managedContainersForPlan(ctx, plan)
+	result := Result{
+		OK:            true,
+		Status:        "completed",
+		OperationName: c.operationName(),
+		BundleHash:    req.BundleHash,
+		Force:         req.Force,
+		DryRun:        req.DryRun,
+		Plan:          plan,
+	}
+	if err != nil {
+		return result.withPartialFailure("managed_containers", err), nil
+	}
+	result.Plan.EntityContainers = containers
+
+	if req.DryRun {
+		containerResult, err := c.applyContainers(ctx, req, result.Plan, preservationcleanup.Result{})
+		if err != nil {
+			return result.withPartialFailure("managed_containers", err).asDryRun(), nil
+		}
+		result.Status = "dry_run"
+		result.Containers = containerResult
+		result.ActiveRunsStopped = len(result.Plan.ActiveRuns)
+		result.DeliveriesCancelled = len(result.Plan.ActiveDeliveries)
+		result.ContainersStopped = len(containerResult.Selected)
+		return result, nil
+	}
+
+	cleanup, err := c.Cleaner.ApplyBundleForceDeletePreservationCleanup(ctx, preservationcleanup.Request{
+		OperationName: preservationcleanup.BundleForceDeleteOperationName,
+		RequestedAt:   req.RequestedAt,
+		ControlledBy:  preservationcleanup.BundleForceDeleteControlledBy,
+		Targets:       ActiveRunTargets(result.Plan),
+	})
+	if err != nil {
+		return result.withPartialFailure("preservation_cleanup", err), nil
+	}
+	result.Cleanup = cleanup
+	result.ActiveRunsStopped = len(cleanup.Runs)
+	result.DeliveriesCancelled = len(cleanup.Deliveries)
+
+	containerResult, err := c.applyContainers(ctx, req, result.Plan, cleanup)
+	if err != nil {
+		return result.withPartialFailure("managed_containers", err), nil
+	}
+	result.Containers = containerResult
+	result.ContainersStopped = len(containerResult.Stopped)
+	if len(containerResult.Failed) > 0 {
+		partial := result
+		for _, failure := range containerResult.Failed {
+			partial = partial.withPartialFailure("managed_containers", fmt.Errorf("%s: %s", failure.Container.Name, failure.Error))
+		}
+		return partial, nil
+	}
+
+	final, err := c.Finalizer.ApplyBundleDeleteFinalMutation(ctx, FinalMutationRequest{
+		OperationName: c.operationName(),
+		BundleHash:    req.BundleHash,
+		RequestedAt:   req.RequestedAt,
+	})
+	if err != nil {
+		return result.withPartialFailure("phase_5_bundle_delete", err), nil
+	}
+	result.FinalMutation = final
+	result.Deleted = final.Deleted
+	return result, nil
+}
+
+func (c *Coordinator) managedContainersForPlan(ctx context.Context, plan Plan) ([]destructivereset.ContainerRef, error) {
+	refs, err := c.ContainerInventory.ManagedResetContainerInventory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	affected := AffectedRunIDs(plan)
+	out := make([]destructivereset.ContainerRef, 0, len(refs))
+	for _, ref := range refs {
+		if _, ok := affected[strings.TrimSpace(ref.RunID)]; !ok {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func (c *Coordinator) applyContainers(ctx context.Context, req Request, plan Plan, cleanup preservationcleanup.Result) (destructivereset.ContainerResetResult, error) {
+	cleanupResult := destructivereset.CleanupResult{
+		OperationName: c.operationName(),
+		DryRun:        req.DryRun,
+		AppliedAt:     cleanup.AppliedAt,
+		RunIDs:        AffectedRunIDList(plan),
+	}
+	return c.Containers.Apply(ctx, destructivereset.ContainerResetRequest{
+		Result: destructivereset.Result{
+			OperationName: c.operationName(),
+			DryRun:        req.DryRun,
+			PlannedAt:     plan.PlannedAt,
+			Plan: destructivereset.Plan{
+				EntityContainers: plan.EntityContainers,
+			},
+		},
+		Cleanup:      cleanupResult,
+		ActorTokenID: req.ActorTokenID,
+		RequestedAt:  req.RequestedAt,
+	})
+}
+
+func (c *Coordinator) now() time.Time {
+	if c != nil && c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (c *Coordinator) operationName() string {
+	if c == nil || strings.TrimSpace(c.Operation) == "" {
+		return DefaultOperationName
+	}
+	return strings.TrimSpace(c.Operation)
+}
+
+func (c *Coordinator) lockKey() string {
+	if c == nil || strings.TrimSpace(c.LockKey) == "" {
+		return destructivereset.DefaultLockKey
+	}
+	return strings.TrimSpace(c.LockKey)
+}
+
+func (r Result) withPartialFailure(scope string, err error) Result {
+	r.OK = false
+	r.Status = "partial_failure"
+	r.PartialFailure = true
+	if err != nil {
+		r.Errors = append(r.Errors, PartialError{
+			Scope:   strings.TrimSpace(scope),
+			Message: strings.TrimSpace(err.Error()),
+		})
+	}
+	return r
+}
+
+func (r Result) asDryRun() Result {
+	r.Status = "dry_run"
+	r.DryRun = true
+	return r
+}

--- a/internal/runtime/bundledelete/coordinator_test.go
+++ b/internal/runtime/bundledelete/coordinator_test.go
@@ -1,0 +1,231 @@
+package bundledelete
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/runtime/preservationcleanup"
+)
+
+func TestCoordinatorExecutesForceDeleteOwnerChain(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	runID := "00000000-0000-0000-0000-000000000101"
+	owner := newFakeOwners(runID)
+	coordinator := owner.coordinator(now)
+
+	result, err := coordinator.Execute(context.Background(), Request{
+		ActorTokenID: "token",
+		RequestHash:  "hash",
+		BundleHash:   testBundleHash,
+		Force:        true,
+		RequestedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !result.OK || result.Status != "completed" || !result.Deleted || result.ActiveRunsStopped != 1 || result.DeliveriesCancelled != 1 || result.ContainersStopped != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if got, want := owner.calls, []string{"lock", "plan", "inventory", "cleanup", "containers", "final"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("calls = %#v, want %#v", got, want)
+	}
+	if owner.cleanupRequest.Targets[0].ReasonCode != preservationcleanup.BundleForceDeletedReason {
+		t.Fatalf("cleanup reason = %q", owner.cleanupRequest.Targets[0].ReasonCode)
+	}
+	if owner.lockKey != destructivereset.DefaultLockKey {
+		t.Fatalf("lock key = %q, want shared destructive key %q", owner.lockKey, destructivereset.DefaultLockKey)
+	}
+}
+
+func TestCoordinatorDryRunDoesNotMutateCleanupOrFinalizer(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	owner := newFakeOwners("00000000-0000-0000-0000-000000000101")
+	result, err := owner.coordinator(now).Execute(context.Background(), Request{
+		ActorTokenID: "token",
+		RequestHash:  "hash",
+		BundleHash:   testBundleHash,
+		Force:        true,
+		DryRun:       true,
+		RequestedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("Execute dry-run: %v", err)
+	}
+	if !result.OK || result.Status != "dry_run" || result.Deleted {
+		t.Fatalf("dry-run result = %#v", result)
+	}
+	if got, want := owner.calls, []string{"lock", "plan", "inventory", "containers"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("dry-run calls = %#v, want %#v", got, want)
+	}
+}
+
+func TestCoordinatorPhaseFailureStopsBeforeFinalMutation(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	owner := newFakeOwners("00000000-0000-0000-0000-000000000101")
+	owner.containerFailed = true
+	result, err := owner.coordinator(now).Execute(context.Background(), Request{
+		ActorTokenID: "token",
+		RequestHash:  "hash",
+		BundleHash:   testBundleHash,
+		Force:        true,
+		RequestedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("Execute with container failure: %v", err)
+	}
+	if result.OK || result.Status != "partial_failure" || !result.PartialFailure || result.Deleted {
+		t.Fatalf("partial result = %#v", result)
+	}
+	if got, want := owner.calls, []string{"lock", "plan", "inventory", "cleanup", "containers"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("partial calls = %#v, want %#v", got, want)
+	}
+}
+
+func TestCoordinatorBusyFailsClosed(t *testing.T) {
+	owner := newFakeOwners("00000000-0000-0000-0000-000000000101")
+	owner.lockAcquired = false
+	_, err := owner.coordinator(time.Now()).Execute(context.Background(), Request{
+		ActorTokenID: "token",
+		RequestHash:  "hash",
+		BundleHash:   testBundleHash,
+		Force:        true,
+	})
+	if !errors.Is(err, ErrOperationInProgress) {
+		t.Fatalf("busy error = %v, want ErrOperationInProgress", err)
+	}
+}
+
+const testBundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type fakeOwners struct {
+	calls           []string
+	lockKey         string
+	lockAcquired    bool
+	runID           string
+	cleanupRequest  preservationcleanup.Request
+	containerFailed bool
+}
+
+func newFakeOwners(runID string) *fakeOwners {
+	return &fakeOwners{lockAcquired: true, runID: runID}
+}
+
+func (o *fakeOwners) coordinator(now time.Time) *Coordinator {
+	return &Coordinator{
+		Planner:            o,
+		Cleaner:            o,
+		Finalizer:          o,
+		Locks:              o,
+		ContainerInventory: o,
+		Containers:         o,
+		Now:                func() time.Time { return now },
+	}
+}
+
+func (o *fakeOwners) TryAcquire(_ context.Context, lockKey string) (destructivereset.LockLease, bool, error) {
+	o.calls = append(o.calls, "lock")
+	o.lockKey = lockKey
+	if !o.lockAcquired {
+		return nil, false, nil
+	}
+	return fakeLease{}, true, nil
+}
+
+func (o *fakeOwners) PlanBundleDelete(_ context.Context, req Request) (Plan, error) {
+	o.calls = append(o.calls, "plan")
+	return Plan{
+		BundleHash: req.BundleHash,
+		ActiveRuns: []RunRef{{
+			RunID:        o.runID,
+			Status:       "running",
+			BundleHash:   req.BundleHash,
+			BundleSource: "persisted",
+		}},
+		AffectedRuns: []RunRef{{
+			RunID:        o.runID,
+			Status:       "running",
+			BundleHash:   req.BundleHash,
+			BundleSource: "persisted",
+		}},
+		ActiveDeliveries: []DeliveryRef{{DeliveryID: "delivery-1", RunID: o.runID, Status: "pending"}},
+	}, nil
+}
+
+func (o *fakeOwners) ManagedResetContainerInventory(_ context.Context) ([]destructivereset.ContainerRef, error) {
+	o.calls = append(o.calls, "inventory")
+	return []destructivereset.ContainerRef{{
+		Name:          "swarm-agent-1",
+		Kind:          "agent",
+		Action:        destructivereset.ContainerActionStop,
+		ResetEligible: true,
+		RunID:         o.runID,
+	}, {
+		Name:          "swarm-agent-other",
+		Kind:          "agent",
+		Action:        destructivereset.ContainerActionStop,
+		ResetEligible: true,
+		RunID:         "00000000-0000-0000-0000-000000000202",
+	}}, nil
+}
+
+func (o *fakeOwners) ApplyBundleForceDeletePreservationCleanup(_ context.Context, req preservationcleanup.Request) (preservationcleanup.Result, error) {
+	o.calls = append(o.calls, "cleanup")
+	o.cleanupRequest = req
+	return preservationcleanup.Result{
+		OperationName: req.OperationName,
+		AppliedAt:     req.RequestedAt,
+		ControlledBy:  req.ControlledBy,
+		Runs:          []preservationcleanup.RunResult{{RunID: o.runID, Status: preservationcleanup.RunStatusCancelled}},
+		Deliveries:    []preservationcleanup.DeliveryResult{{DeliveryID: "delivery-1", RunID: o.runID, Status: preservationcleanup.DeliveryOutcomeDeadLetter}},
+	}, nil
+}
+
+func (o *fakeOwners) Apply(_ context.Context, req destructivereset.ContainerResetRequest) (destructivereset.ContainerResetResult, error) {
+	o.calls = append(o.calls, "containers")
+	result := destructivereset.ContainerResetResult{
+		OperationName: req.Result.OperationName,
+		DryRun:        req.Result.DryRun,
+		AppliedAt:     req.RequestedAt,
+		Selected:      req.Result.Plan.EntityContainers,
+	}
+	if req.Result.DryRun {
+		return result, nil
+	}
+	if o.containerFailed {
+		result.Failed = []destructivereset.ContainerStopFailure{{Container: req.Result.Plan.EntityContainers[0], Error: "stop failed"}}
+		return result, nil
+	}
+	result.Stopped = req.Result.Plan.EntityContainers
+	return result, nil
+}
+
+func (o *fakeOwners) ApplyBundleDeleteFinalMutation(_ context.Context, req FinalMutationRequest) (FinalMutationResult, error) {
+	o.calls = append(o.calls, "final")
+	return FinalMutationResult{
+		OperationName:     req.OperationName,
+		BundleHash:        req.BundleHash,
+		AppliedAt:         req.RequestedAt,
+		RunsMarkedDeleted: 1,
+		BundleRowsDeleted: 1,
+		Deleted:           true,
+	}, nil
+}
+
+type fakeLease struct{}
+
+func (fakeLease) Release(context.Context) error { return nil }
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runtime/bundledelete/types.go
+++ b/internal/runtime/bundledelete/types.go
@@ -1,0 +1,200 @@
+package bundledelete
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/runtime/destructivereset"
+	"swarm/internal/runtime/preservationcleanup"
+)
+
+const (
+	DefaultOperationName = "bundle.delete"
+	ForceControlledBy    = DefaultOperationName
+)
+
+var (
+	ErrInvalidRequest      = errors.New("bundle delete invalid request")
+	ErrBundleNotFound      = errors.New("bundle delete bundle not found")
+	ErrOperationInProgress = errors.New("bundle delete operation already in progress")
+	ErrActiveRunsRemain    = errors.New("bundle delete active runs remain before final mutation")
+	ErrNonForceSplit       = errors.New("bundle delete non-force behavior is split")
+)
+
+type Request struct {
+	ActorTokenID string
+	RequestHash  string
+	BundleHash   string
+	Force        bool
+	DryRun       bool
+	RequestedAt  time.Time
+}
+
+type Result struct {
+	OK                  bool                                  `json:"ok"`
+	Status              string                                `json:"status"`
+	OperationName       string                                `json:"operation_name"`
+	BundleHash          string                                `json:"bundle_hash"`
+	Force               bool                                  `json:"force"`
+	Deleted             bool                                  `json:"deleted"`
+	DryRun              bool                                  `json:"dry_run"`
+	ActiveRunsStopped   int                                   `json:"active_runs_stopped"`
+	DeliveriesCancelled int                                   `json:"deliveries_cancelled"`
+	ContainersStopped   int                                   `json:"containers_stopped"`
+	PartialFailure      bool                                  `json:"partial_failure"`
+	Plan                Plan                                  `json:"plan"`
+	Cleanup             preservationcleanup.Result            `json:"cleanup"`
+	Containers          destructivereset.ContainerResetResult `json:"containers"`
+	FinalMutation       FinalMutationResult                   `json:"final_mutation"`
+	Errors              []PartialError                        `json:"errors,omitempty"`
+}
+
+type PartialError struct {
+	Scope   string `json:"scope"`
+	Message string `json:"message"`
+}
+
+type Plan struct {
+	BundleHash       string                          `json:"bundle_hash"`
+	PlannedAt        time.Time                       `json:"planned_at"`
+	ActiveRuns       []RunRef                        `json:"active_runs"`
+	NonActiveRuns    []RunRef                        `json:"non_active_runs"`
+	AffectedRuns     []RunRef                        `json:"affected_runs"`
+	ActiveDeliveries []DeliveryRef                   `json:"active_deliveries"`
+	ActiveSessions   []SessionRef                    `json:"active_sessions"`
+	ActiveTimers     []TimerRef                      `json:"active_timers"`
+	EntityContainers []destructivereset.ContainerRef `json:"entity_containers"`
+}
+
+type RunRef struct {
+	RunID             string `json:"run_id"`
+	Status            string `json:"status"`
+	BundleHash        string `json:"bundle_hash,omitempty"`
+	BundleSource      string `json:"bundle_source,omitempty"`
+	BundleFingerprint string `json:"bundle_fingerprint,omitempty"`
+}
+
+type DeliveryRef struct {
+	DeliveryID     string `json:"delivery_id"`
+	RunID          string `json:"run_id"`
+	EventID        string `json:"event_id"`
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	Status         string `json:"status"`
+}
+
+type SessionRef struct {
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id"`
+	AgentID   string `json:"agent_id,omitempty"`
+	Status    string `json:"status"`
+}
+
+type TimerRef struct {
+	TimerID   string `json:"timer_id"`
+	RunID     string `json:"run_id"`
+	TimerName string `json:"timer_name"`
+	Status    string `json:"status"`
+}
+
+type FinalMutationRequest struct {
+	OperationName string
+	BundleHash    string
+	RequestedAt   time.Time
+}
+
+type FinalMutationResult struct {
+	OperationName         string    `json:"operation_name"`
+	BundleHash            string    `json:"bundle_hash"`
+	AppliedAt             time.Time `json:"applied_at"`
+	RunsMarkedDeleted     int       `json:"runs_marked_deleted"`
+	BundleRowsDeleted     int       `json:"bundle_rows_deleted"`
+	RemainingActiveRuns   int       `json:"remaining_active_runs"`
+	Deleted               bool      `json:"deleted"`
+	SourceAuthorityOwner  string    `json:"source_authority_owner"`
+	TransactionOrderProof []string  `json:"transaction_order_proof"`
+}
+
+type Planner interface {
+	PlanBundleDelete(context.Context, Request) (Plan, error)
+}
+
+type PreservationCleaner interface {
+	ApplyBundleForceDeletePreservationCleanup(context.Context, preservationcleanup.Request) (preservationcleanup.Result, error)
+}
+
+type Finalizer interface {
+	ApplyBundleDeleteFinalMutation(context.Context, FinalMutationRequest) (FinalMutationResult, error)
+}
+
+type LockManager interface {
+	TryAcquire(context.Context, string) (destructivereset.LockLease, bool, error)
+}
+
+type ManagedContainerInventoryReader interface {
+	ManagedResetContainerInventory(context.Context) ([]destructivereset.ContainerRef, error)
+}
+
+type ManagedContainerStopper interface {
+	Apply(context.Context, destructivereset.ContainerResetRequest) (destructivereset.ContainerResetResult, error)
+}
+
+func NormalizeRequest(req Request, now time.Time) (Request, error) {
+	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
+	req.RequestHash = strings.TrimSpace(req.RequestHash)
+	req.BundleHash = strings.TrimSpace(req.BundleHash)
+	if req.ActorTokenID == "" {
+		return Request{}, fmt.Errorf("%w: actor token id is required", ErrInvalidRequest)
+	}
+	if req.BundleHash == "" {
+		return Request{}, fmt.Errorf("%w: bundle_hash is required", ErrInvalidRequest)
+	}
+	if !req.Force {
+		return Request{}, ErrNonForceSplit
+	}
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = now.UTC()
+	}
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = time.Now().UTC()
+	}
+	req.RequestedAt = req.RequestedAt.UTC()
+	return req, nil
+}
+
+func ActiveRunTargets(plan Plan) []preservationcleanup.RunTarget {
+	out := make([]preservationcleanup.RunTarget, 0, len(plan.ActiveRuns))
+	for _, run := range plan.ActiveRuns {
+		out = append(out, preservationcleanup.RunTarget{
+			RunID:             strings.TrimSpace(run.RunID),
+			BundleSource:      strings.TrimSpace(run.BundleSource),
+			BundleHash:        strings.TrimSpace(run.BundleHash),
+			BundleFingerprint: strings.TrimSpace(run.BundleFingerprint),
+			ReasonCode:        preservationcleanup.BundleForceDeletedReason,
+		})
+	}
+	return out
+}
+
+func AffectedRunIDs(plan Plan) map[string]struct{} {
+	out := make(map[string]struct{}, len(plan.AffectedRuns))
+	for _, run := range plan.AffectedRuns {
+		if runID := strings.TrimSpace(run.RunID); runID != "" {
+			out[runID] = struct{}{}
+		}
+	}
+	return out
+}
+
+func AffectedRunIDList(plan Plan) []string {
+	out := make([]string, 0, len(plan.AffectedRuns))
+	for _, run := range plan.AffectedRuns {
+		if runID := strings.TrimSpace(run.RunID); runID != "" {
+			out = append(out, runID)
+		}
+	}
+	return out
+}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1366,6 +1366,12 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 		BundleSource:      "persisted",
 		BundleFingerprint: "sha256:4444444444444444444444444444444444444444444444444444444444444444",
 	}
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, sourceFact.BundleHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
 	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
 		BundleSourceFact: sourceFact,
 	})

--- a/internal/runtime/destructivereset/types.go
+++ b/internal/runtime/destructivereset/types.go
@@ -10,7 +10,8 @@ import (
 
 const (
 	DefaultOperationName = "runtime.destructive_reset"
-	defaultLockKey       = "swarm:runtime:destructive-reset"
+	DefaultLockKey       = "swarm:runtime:destructive-reset"
+	defaultLockKey       = DefaultLockKey
 
 	QuiescenceControlledBy = DefaultOperationName
 	QuiescenceReasonCode   = "runtime_nuke_cancelled"

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -300,6 +300,7 @@ func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
 		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 	}
+	seedRuntimeLogBundleRow(t, db, sourceFact.BundleHash)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
 
@@ -321,6 +322,38 @@ func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
 	}
 	if gotHash != sourceFact.BundleHash || gotSource != sourceFact.BundleSource || gotFingerprint != sourceFact.BundleFingerprint {
 		t.Fatalf("run bundle source = hash:%q source:%q fingerprint:%q, want %#v", gotHash, gotSource, gotFingerprint, sourceFact)
+	}
+}
+
+func TestRuntimeLogger_LogRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	runID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	seedRuntimeLogBundleRow(t, db, sourceFact.BundleHash)
+	if _, err := db.ExecContext(context.Background(), `DELETE FROM bundles WHERE bundle_hash = $1`, sourceFact.BundleHash); err != nil {
+		t.Fatalf("delete bundle row: %v", err)
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+
+	err := logger.Log(ctx, RuntimeLogEntry{
+		Level:     "info",
+		Message:   "runtime log",
+		Component: "workflow-runtime",
+		Action:    "bundle_source_deleted",
+	})
+	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
+		t.Fatalf("logger.Log error = %v, want ErrPersistedBundleUnavailable", err)
+	}
+	assertRunRowExists(t, db, runID, false)
+	if count := countRuntimeLogRowsForRun(t, db, runID); count != 0 {
+		t.Fatalf("runtime log rows for %s = %d, want 0", runID, count)
 	}
 }
 
@@ -870,6 +903,30 @@ func assertRunRowExists(t *testing.T, db *sql.DB, runID string, want bool) {
 	if exists != want {
 		t.Fatalf("run row exists = %v for %q, want %v", exists, runID, want)
 	}
+}
+
+func seedRuntimeLogBundleRow(t *testing.T, db *sql.DB, bundleHash string) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, bundleHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
+}
+
+func countRuntimeLogRowsForRun(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'platform.runtime_log'
+	`, runID).Scan(&count); err != nil {
+		t.Fatalf("count runtime log rows for %s: %v", runID, err)
+	}
+	return count
 }
 
 type runtimeLogPayloadArg struct {

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -3,6 +3,7 @@ package mutationlog
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -92,6 +93,7 @@ func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
 		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 	}
+	seedMutationLogBundleRow(t, db, sourceFact.BundleHash)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
 
@@ -117,4 +119,66 @@ func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
 	if !gotHash.Valid || gotHash.String != sourceFact.BundleHash || gotSource != sourceFact.BundleSource || !gotFingerprint.Valid || gotFingerprint.String != sourceFact.BundleFingerprint {
 		t.Fatalf("run bundle source = hash:%q valid:%v source:%q fingerprint:%q valid:%v, want %#v", gotHash.String, gotHash.Valid, gotSource, gotFingerprint.String, gotFingerprint.Valid, sourceFact)
 	}
+}
+
+func TestInsertRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	seedMutationLogBundleRow(t, db, sourceFact.BundleHash)
+	if _, err := db.ExecContext(context.Background(), `DELETE FROM bundles WHERE bundle_hash = $1`, sourceFact.BundleHash); err != nil {
+		t.Fatalf("delete bundle row: %v", err)
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+
+	err := Insert(ctx, db, Record{
+		EntityID:   uuid.NewString(),
+		Field:      "status",
+		OldValue:   nil,
+		NewValue:   "open",
+		WriterType: "system_node",
+		WriterID:   "review",
+	})
+	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
+		t.Fatalf("Insert error = %v, want ErrPersistedBundleUnavailable", err)
+	}
+	if count := countMutationLogRunRows(t, db, runID); count != 0 {
+		t.Fatalf("run rows for %s = %d, want 0", runID, count)
+	}
+	if count := countMutationRowsForRun(t, db, runID); count != 0 {
+		t.Fatalf("entity_mutations rows for %s = %d, want 0", runID, count)
+	}
+}
+
+func seedMutationLogBundleRow(t *testing.T, db *sql.DB, bundleHash string) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, bundleHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
+}
+
+func countMutationLogRunRows(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM runs WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count run rows for %s: %v", runID, err)
+	}
+	return count
+}
+
+func countMutationRowsForRun(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM entity_mutations WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count entity_mutations rows for %s: %v", runID, err)
+	}
+	return count
 }

--- a/internal/runtime/preservationcleanup/types.go
+++ b/internal/runtime/preservationcleanup/types.go
@@ -11,10 +11,13 @@ import (
 const (
 	UnavailableBundleStartupOperationName = "swarm.serve.unavailable_bundle_startup_recovery"
 	UnavailableBundleStartupControlledBy  = UnavailableBundleStartupOperationName
+	BundleForceDeleteOperationName        = "bundle.delete.force"
+	BundleForceDeleteControlledBy         = "bundle.delete"
 
 	BundleEphemeralOrphanedReason = "bundle_ephemeral_orphaned"
 	BundleDeletedOrphanedReason   = "bundle_deleted_orphaned"
 	BundleLegacyOrphanedReason    = "bundle_legacy_orphaned"
+	BundleForceDeletedReason      = "bundle_force_deleted"
 
 	SessionTerminationReasonOrphaned = "orphaned"
 
@@ -151,5 +154,6 @@ func TerminalReasonCodes() []string {
 		BundleEphemeralOrphanedReason,
 		BundleDeletedOrphanedReason,
 		BundleLegacyOrphanedReason,
+		BundleForceDeletedReason,
 	}
 }

--- a/internal/store/bundle_delete.go
+++ b/internal/store/bundle_delete.go
@@ -1,0 +1,365 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"swarm/internal/runtime/bundledelete"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+func (s *PostgresStore) PlanBundleDelete(ctx context.Context, req bundledelete.Request) (bundledelete.Plan, error) {
+	if s == nil || s.DB == nil {
+		return bundledelete.Plan{}, fmt.Errorf("postgres store is required")
+	}
+	bundleHash := strings.TrimSpace(req.BundleHash)
+	if bundleHash == "" {
+		return bundledelete.Plan{}, fmt.Errorf("%w: bundle_hash is required", bundledelete.ErrInvalidRequest)
+	}
+	if err := s.requireBundleDeletePlanningCapabilities(ctx); err != nil {
+		return bundledelete.Plan{}, err
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM bundles WHERE bundle_hash = $1)`, bundleHash).Scan(&exists); err != nil {
+		return bundledelete.Plan{}, fmt.Errorf("plan bundle delete bundle row: %w", err)
+	}
+	if !exists {
+		return bundledelete.Plan{}, ErrBundleNotFound
+	}
+	plan := bundledelete.Plan{
+		BundleHash: bundleHash,
+		PlannedAt:  req.RequestedAt.UTC(),
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			run_id::text,
+			COALESCE(status, ''),
+			COALESCE(bundle_hash, ''),
+			COALESCE(bundle_source, ''),
+			COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE bundle_hash = $1
+		  AND bundle_source = $2
+		ORDER BY run_id::text
+	`, bundleHash, storerunlifecycle.BundleSourcePersisted)
+	if err != nil {
+		return bundledelete.Plan{}, fmt.Errorf("plan bundle delete runs: %w", err)
+	}
+	defer rows.Close()
+	activeRunIDs := []string{}
+	for rows.Next() {
+		var run bundledelete.RunRef
+		if err := rows.Scan(&run.RunID, &run.Status, &run.BundleHash, &run.BundleSource, &run.BundleFingerprint); err != nil {
+			return bundledelete.Plan{}, fmt.Errorf("scan bundle delete run: %w", err)
+		}
+		normalizeBundleDeleteRunRef(&run)
+		plan.AffectedRuns = append(plan.AffectedRuns, run)
+		if bundleDeleteRunStatusActive(run.Status) {
+			plan.ActiveRuns = append(plan.ActiveRuns, run)
+			activeRunIDs = append(activeRunIDs, run.RunID)
+		} else {
+			plan.NonActiveRuns = append(plan.NonActiveRuns, run)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return bundledelete.Plan{}, fmt.Errorf("read bundle delete runs: %w", err)
+	}
+	if len(activeRunIDs) > 0 {
+		deliveries, err := s.planBundleDeleteDeliveries(ctx, activeRunIDs)
+		if err != nil {
+			return bundledelete.Plan{}, err
+		}
+		plan.ActiveDeliveries = deliveries
+		sessions, err := s.planBundleDeleteSessions(ctx, activeRunIDs)
+		if err != nil {
+			return bundledelete.Plan{}, err
+		}
+		plan.ActiveSessions = sessions
+		timers, err := s.planBundleDeleteTimers(ctx, activeRunIDs)
+		if err != nil {
+			return bundledelete.Plan{}, err
+		}
+		plan.ActiveTimers = timers
+	}
+	return plan, nil
+}
+
+func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req bundledelete.FinalMutationRequest) (bundledelete.FinalMutationResult, error) {
+	if s == nil || s.DB == nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("postgres store is required")
+	}
+	bundleHash := strings.TrimSpace(req.BundleHash)
+	if bundleHash == "" {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("%w: bundle_hash is required", bundledelete.ErrInvalidRequest)
+	}
+	if err := s.requireBundleDeleteFinalMutationCapabilities(ctx); err != nil {
+		return bundledelete.FinalMutationResult{}, err
+	}
+	now := req.RequestedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	operationName := strings.TrimSpace(req.OperationName)
+	if operationName == "" {
+		operationName = bundledelete.DefaultOperationName
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("begin bundle delete final mutation tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var lockedHash string
+	err = tx.QueryRowContext(ctx, `
+		SELECT bundle_hash
+		FROM bundles
+		WHERE bundle_hash = $1
+		FOR UPDATE
+	`, bundleHash).Scan(&lockedHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return bundledelete.FinalMutationResult{}, ErrBundleNotFound
+	}
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("lock bundle delete bundle row: %w", err)
+	}
+
+	activeRemaining, err := lockBundleDeleteReferencingRunsTx(ctx, tx, bundleHash)
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, err
+	}
+	result := bundledelete.FinalMutationResult{
+		OperationName:        operationName,
+		BundleHash:           bundleHash,
+		AppliedAt:            now,
+		RemainingActiveRuns:  activeRemaining,
+		SourceAuthorityOwner: "store.ApplyBundleDeleteFinalMutation",
+		TransactionOrderProof: []string{
+			"update_eligible_runs_bundle_source_to_deleted",
+			"delete_matching_bundles_row",
+		},
+	}
+	if activeRemaining > 0 {
+		return result, bundledelete.ErrActiveRunsRemain
+	}
+	updateResult, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET bundle_source = $2
+		WHERE bundle_hash = $1
+		  AND bundle_source = $3
+		  AND lower(COALESCE(status, '')) NOT IN ('running', 'paused')
+	`, bundleHash, storerunlifecycle.BundleSourceDeleted, storerunlifecycle.BundleSourcePersisted)
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("mark bundle delete runs deleted: %w", err)
+	}
+	updated, err := updateResult.RowsAffected()
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("count bundle delete run source updates: %w", err)
+	}
+	deleteResult, err := tx.ExecContext(ctx, `DELETE FROM bundles WHERE bundle_hash = $1`, bundleHash)
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("delete bundle row: %w", err)
+	}
+	deleted, err := deleteResult.RowsAffected()
+	if err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("count deleted bundle rows: %w", err)
+	}
+	result.RunsMarkedDeleted = int(updated)
+	result.BundleRowsDeleted = int(deleted)
+	result.Deleted = deleted > 0
+	if err := tx.Commit(); err != nil {
+		return bundledelete.FinalMutationResult{}, fmt.Errorf("commit bundle delete final mutation tx: %w", err)
+	}
+	committed = true
+	return result, nil
+}
+
+func (s *PostgresStore) requireBundleDeletePlanningCapabilities(ctx context.Context) error {
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasColumns("bundles", "bundle_hash") {
+		return fmt.Errorf("bundle delete requires bundles.bundle_hash")
+	}
+	caps := detectStoreSchemaCapabilities(catalog)
+	if err := requirePreservationCleanupCapabilities(caps); err != nil {
+		return err
+	}
+	if !caps.Events.RunBundleHash || !caps.Events.RunBundleSource {
+		return fmt.Errorf("bundle delete requires runs.bundle_hash and runs.bundle_source")
+	}
+	return nil
+}
+
+func (s *PostgresStore) requireBundleDeleteFinalMutationCapabilities(ctx context.Context) error {
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	if !catalog.hasColumns("bundles", "bundle_hash") {
+		return fmt.Errorf("bundle delete requires bundles.bundle_hash")
+	}
+	caps := detectStoreSchemaCapabilities(catalog)
+	if !caps.Events.RunBundleHash || !caps.Events.RunBundleSource {
+		return fmt.Errorf("bundle delete requires runs.bundle_hash and runs.bundle_source")
+	}
+	return nil
+}
+
+func (s *PostgresStore) planBundleDeleteDeliveries(ctx context.Context, runIDs []string) ([]bundledelete.DeliveryRef, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			d.delivery_id::text,
+			d.run_id::text,
+			d.event_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, '')
+		FROM event_deliveries d
+		WHERE d.run_id = ANY($1::uuid[])
+		  AND d.subscriber_type IN ('agent', 'node')
+		  AND d.status IN ('pending', 'in_progress')
+		ORDER BY d.run_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("plan bundle delete deliveries: %w", err)
+	}
+	defer rows.Close()
+	out := []bundledelete.DeliveryRef{}
+	for rows.Next() {
+		var item bundledelete.DeliveryRef
+		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status); err != nil {
+			return nil, fmt.Errorf("scan bundle delete delivery: %w", err)
+		}
+		normalizeBundleDeleteDeliveryRef(&item)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read bundle delete deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) planBundleDeleteSessions(ctx context.Context, runIDs []string) ([]bundledelete.SessionRef, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT session_id::text, run_id::text, COALESCE(agent_id, ''), COALESCE(status, '')
+		FROM agent_sessions
+		WHERE run_id = ANY($1::uuid[])
+		  AND status IN ('active', 'suspended')
+		ORDER BY run_id::text, agent_id, session_id::text
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("plan bundle delete sessions: %w", err)
+	}
+	defer rows.Close()
+	out := []bundledelete.SessionRef{}
+	for rows.Next() {
+		var item bundledelete.SessionRef
+		if err := rows.Scan(&item.SessionID, &item.RunID, &item.AgentID, &item.Status); err != nil {
+			return nil, fmt.Errorf("scan bundle delete session: %w", err)
+		}
+		item.SessionID = strings.TrimSpace(item.SessionID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.AgentID = strings.TrimSpace(item.AgentID)
+		item.Status = strings.TrimSpace(item.Status)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read bundle delete sessions: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) planBundleDeleteTimers(ctx context.Context, runIDs []string) ([]bundledelete.TimerRef, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT timer_id::text, run_id::text, COALESCE(timer_name, ''), COALESCE(status, '')
+		FROM timers
+		WHERE run_id = ANY($1::uuid[])
+		  AND status = 'active'
+		ORDER BY run_id::text, timer_name, timer_id::text
+	`, pq.Array(runIDs))
+	if err != nil {
+		return nil, fmt.Errorf("plan bundle delete timers: %w", err)
+	}
+	defer rows.Close()
+	out := []bundledelete.TimerRef{}
+	for rows.Next() {
+		var item bundledelete.TimerRef
+		if err := rows.Scan(&item.TimerID, &item.RunID, &item.TimerName, &item.Status); err != nil {
+			return nil, fmt.Errorf("scan bundle delete timer: %w", err)
+		}
+		item.TimerID = strings.TrimSpace(item.TimerID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.TimerName = strings.TrimSpace(item.TimerName)
+		item.Status = strings.TrimSpace(item.Status)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read bundle delete timers: %w", err)
+	}
+	return out, nil
+}
+
+func lockBundleDeleteReferencingRunsTx(ctx context.Context, tx *sql.Tx, bundleHash string) (int, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM runs
+		WHERE bundle_hash = $1
+		  AND bundle_source = $2
+		FOR UPDATE
+	`, bundleHash, storerunlifecycle.BundleSourcePersisted)
+	if err != nil {
+		return 0, fmt.Errorf("lock bundle delete referencing runs: %w", err)
+	}
+	defer rows.Close()
+	active := 0
+	for rows.Next() {
+		var status string
+		if err := rows.Scan(&status); err != nil {
+			return 0, fmt.Errorf("scan bundle delete referencing run: %w", err)
+		}
+		if bundleDeleteRunStatusActive(status) {
+			active++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read bundle delete referencing runs: %w", err)
+	}
+	return active, nil
+}
+
+func normalizeBundleDeleteRunRef(run *bundledelete.RunRef) {
+	run.RunID = strings.TrimSpace(run.RunID)
+	run.Status = strings.TrimSpace(run.Status)
+	run.BundleHash = strings.TrimSpace(run.BundleHash)
+	run.BundleSource = strings.TrimSpace(run.BundleSource)
+	run.BundleFingerprint = strings.TrimSpace(run.BundleFingerprint)
+}
+
+func normalizeBundleDeleteDeliveryRef(delivery *bundledelete.DeliveryRef) {
+	delivery.DeliveryID = strings.TrimSpace(delivery.DeliveryID)
+	delivery.RunID = strings.TrimSpace(delivery.RunID)
+	delivery.EventID = strings.TrimSpace(delivery.EventID)
+	delivery.SubscriberType = strings.TrimSpace(delivery.SubscriberType)
+	delivery.SubscriberID = strings.TrimSpace(delivery.SubscriberID)
+	delivery.Status = strings.TrimSpace(delivery.Status)
+}
+
+func bundleDeleteRunStatusActive(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "paused":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/store/bundle_delete.go
+++ b/internal/store/bundle_delete.go
@@ -133,6 +133,9 @@ func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req 
 		return bundledelete.FinalMutationResult{}, fmt.Errorf("lock bundle delete bundle row: %w", err)
 	}
 
+	if err := lockBundleDeleteRunCreationTx(ctx, tx); err != nil {
+		return bundledelete.FinalMutationResult{}, err
+	}
 	activeRemaining, err := lockBundleDeleteReferencingRunsTx(ctx, tx, bundleHash)
 	if err != nil {
 		return bundledelete.FinalMutationResult{}, err
@@ -144,6 +147,7 @@ func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req 
 		RemainingActiveRuns:  activeRemaining,
 		SourceAuthorityOwner: "store.ApplyBundleDeleteFinalMutation",
 		TransactionOrderProof: []string{
+			"lock_runs_table_against_new_persisted_bundle_references",
 			"update_eligible_runs_bundle_source_to_deleted",
 			"delete_matching_bundles_row",
 		},
@@ -308,6 +312,13 @@ func (s *PostgresStore) planBundleDeleteTimers(ctx context.Context, runIDs []str
 		return nil, fmt.Errorf("read bundle delete timers: %w", err)
 	}
 	return out, nil
+}
+
+func lockBundleDeleteRunCreationTx(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `LOCK TABLE runs IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+		return fmt.Errorf("lock bundle delete run creation: %w", err)
+	}
+	return nil
 }
 
 func lockBundleDeleteReferencingRunsTx(ctx context.Context, tx *sql.Tx, bundleHash string) (int, error) {

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -30,7 +30,7 @@ func TestPostgresStore_BundleDeleteForceCleanupAndFinalMutation(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
-	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model_tier, conversation_mode) VALUES ('agent-a', 'operator', 'default', 'session')`); err != nil {
+	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, conversation_mode) VALUES ('agent-a', 'operator', 'default', 'session')`); err != nil {
 		t.Fatalf("seed agent: %v", err)
 	}
 	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/runtime/bundledelete"
+	"swarm/internal/runtime/preservationcleanup"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
+)
+
+const bundleDeleteTestHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const bundleDeleteOtherHash = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+func TestPostgresStore_BundleDeleteForceCleanupAndFinalMutation(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model_tier, conversation_mode) VALUES ('agent-a', 'operator', 'default', 'session')`); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteOtherHash)
+
+	activeRunID := uuid.NewString()
+	completedRunID := uuid.NewString()
+	otherRunID := uuid.NewString()
+	sessionID := uuid.NewString()
+	timerID := uuid.NewString()
+	seedBundleDeleteRun(t, ctx, pg, activeRunID, "running", bundleDeleteTestHash)
+	seedBundleDeleteRun(t, ctx, pg, completedRunID, "completed", bundleDeleteTestHash)
+	seedBundleDeleteRun(t, ctx, pg, otherRunID, "running", bundleDeleteOtherHash)
+	eventID := seedDestructiveResetEvent(t, ctx, pg, activeRunID, "bundle.delete.pending")
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'agent', 'agent-a', 'pending', $3::uuid, 'ready', now()
+		)
+	`, activeRunID, eventID, sessionID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO agent_sessions (session_id, run_id, agent_id, scope_key, scope, runtime_mode, status)
+		VALUES ($1::uuid, $2::uuid, 'agent-a', $2::text, 'flow', 'session', 'active')
+	`, sessionID, activeRunID); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO timers (timer_id, timer_name, run_id, fire_event, fire_at, status)
+		VALUES ($1::uuid, 'bundle-delete-timer', $2::uuid, 'timer.fired', now() + interval '1 hour', 'active')
+	`, timerID, activeRunID); err != nil {
+		t.Fatalf("seed timer: %v", err)
+	}
+
+	plan, err := pg.PlanBundleDelete(ctx, bundledelete.Request{
+		ActorTokenID: "token",
+		BundleHash:   bundleDeleteTestHash,
+		Force:        true,
+		RequestedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("PlanBundleDelete: %v", err)
+	}
+	if len(plan.ActiveRuns) != 1 || len(plan.NonActiveRuns) != 1 || len(plan.AffectedRuns) != 2 || len(plan.ActiveDeliveries) != 1 || len(plan.ActiveSessions) != 1 || len(plan.ActiveTimers) != 1 {
+		t.Fatalf("plan counts active=%d non_active=%d affected=%d deliveries=%d sessions=%d timers=%d",
+			len(plan.ActiveRuns), len(plan.NonActiveRuns), len(plan.AffectedRuns), len(plan.ActiveDeliveries), len(plan.ActiveSessions), len(plan.ActiveTimers))
+	}
+
+	cleanupResult, err := pg.ApplyBundleForceDeletePreservationCleanup(ctx, preservationcleanup.Request{
+		OperationName: preservationcleanup.BundleForceDeleteOperationName,
+		RequestedAt:   now,
+		ControlledBy:  preservationcleanup.BundleForceDeleteControlledBy,
+		Targets:       bundledelete.ActiveRunTargets(plan),
+	})
+	if err != nil {
+		t.Fatalf("ApplyBundleForceDeletePreservationCleanup: %v", err)
+	}
+	if len(cleanupResult.Runs) != 1 || len(cleanupResult.Deliveries) != 1 || len(cleanupResult.Sessions) != 1 || len(cleanupResult.Timers) != 1 {
+		t.Fatalf("cleanup counts runs=%d deliveries=%d sessions=%d timers=%d", len(cleanupResult.Runs), len(cleanupResult.Deliveries), len(cleanupResult.Sessions), len(cleanupResult.Timers))
+	}
+
+	final, err := pg.ApplyBundleDeleteFinalMutation(ctx, bundledelete.FinalMutationRequest{
+		OperationName: bundledelete.DefaultOperationName,
+		BundleHash:    bundleDeleteTestHash,
+		RequestedAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyBundleDeleteFinalMutation: %v", err)
+	}
+	if !final.Deleted || final.BundleRowsDeleted != 1 || final.RunsMarkedDeleted != 2 {
+		t.Fatalf("final mutation = %#v, want deleted row and two run source updates", final)
+	}
+
+	assertBundleDeleteRun(t, ctx, pg, activeRunID, "cancelled", storerunlifecycle.BundleSourceDeleted, preservationcleanup.BundleForceDeletedReason)
+	assertBundleDeleteRun(t, ctx, pg, completedRunID, "completed", storerunlifecycle.BundleSourceDeleted, "")
+	assertBundleDeleteRun(t, ctx, pg, otherRunID, "running", storerunlifecycle.BundleSourcePersisted, "")
+	assertUnavailableBundlePreservationDelivery(t, ctx, pg, eventID, preservationcleanup.BundleForceDeletedReason)
+	assertUnavailableBundlePreservationReceipt(t, ctx, pg, eventID, "agent-a", preservationcleanup.BundleForceDeletedReason)
+	assertUnavailableBundlePreservationReceipt(t, ctx, pg, eventID, activeRunQuiescencePipelineSubscriberID, preservationcleanup.BundleForceDeletedReason)
+	assertUnavailableBundlePreservationSession(t, ctx, pg, sessionID, preservationcleanup.BundleForceDeletedReason)
+	assertUnavailableBundlePreservationTimer(t, ctx, pg, timerID)
+	assertBundleRowAbsent(t, ctx, pg, bundleDeleteTestHash)
+	assertBundleRowPresent(t, ctx, pg, bundleDeleteOtherHash)
+}
+
+func TestPostgresStore_BundleDeleteFinalMutationFailsBeforeDeletingWithActiveRuns(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	runID := uuid.NewString()
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)
+	seedBundleDeleteRun(t, ctx, pg, runID, "running", bundleDeleteTestHash)
+
+	_, err = pg.ApplyBundleDeleteFinalMutation(ctx, bundledelete.FinalMutationRequest{
+		OperationName: bundledelete.DefaultOperationName,
+		BundleHash:    bundleDeleteTestHash,
+		RequestedAt:   time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, bundledelete.ErrActiveRunsRemain) {
+		t.Fatalf("ApplyBundleDeleteFinalMutation active error = %v, want ErrActiveRunsRemain", err)
+	}
+	assertBundleDeleteRun(t, ctx, pg, runID, "running", storerunlifecycle.BundleSourcePersisted, "")
+	assertBundleRowPresent(t, ctx, pg, bundleDeleteTestHash)
+}
+
+func seedBundleDeleteBundle(t *testing.T, ctx context.Context, pg *PostgresStore, bundleHash string) {
+	t.Helper()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, metadata, ingested_at)
+		VALUES ($1, 'version: 1', '{}'::jsonb, '{}'::jsonb, now())
+		ON CONFLICT (bundle_hash) DO NOTHING
+	`, bundleHash); err != nil {
+		t.Fatalf("seed bundle %s: %v", bundleHash, err)
+	}
+}
+
+func seedBundleDeleteRun(t *testing.T, ctx context.Context, pg *PostgresStore, runID, status, bundleHash string) {
+	t.Helper()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, $2, $3, $4, $5, now())
+	`, runID, status, bundleHash, storerunlifecycle.BundleSourcePersisted, testBootBundleFingerprint); err != nil {
+		t.Fatalf("seed bundle delete run %s: %v", runID, err)
+	}
+}
+
+func assertBundleDeleteRun(t *testing.T, ctx context.Context, pg *PostgresStore, runID, wantStatus, wantSource, wantError string) {
+	t.Helper()
+	var status, source, errorSummary string
+	var endedAt sql.NullTime
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, bundle_source, COALESCE(error_summary, ''), ended_at
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &source, &errorSummary, &endedAt); err != nil {
+		t.Fatalf("load run %s: %v", runID, err)
+	}
+	if status != wantStatus || source != wantSource || errorSummary != wantError {
+		t.Fatalf("run %s = status:%s source:%s error:%s ended:%v, want %s/%s/%s", runID, status, source, errorSummary, endedAt.Valid, wantStatus, wantSource, wantError)
+	}
+	if wantStatus == "cancelled" && !endedAt.Valid {
+		t.Fatalf("run %s cancelled without ended_at", runID)
+	}
+	if wantStatus == "cancelled" {
+		var controlStatus, reason, controlledBy string
+		if err := pg.DB.QueryRowContext(ctx, `
+			SELECT control_status, COALESCE(reason, ''), COALESCE(controlled_by, '')
+			FROM run_control_state
+			WHERE run_id = $1::uuid
+		`, runID).Scan(&controlStatus, &reason, &controlledBy); err != nil {
+			t.Fatalf("load run control %s: %v", runID, err)
+		}
+		if controlStatus != preservationcleanup.RunControlStatusStopped || reason != preservationcleanup.BundleForceDeletedReason || controlledBy != preservationcleanup.BundleForceDeleteControlledBy {
+			t.Fatalf("run control %s = %s/%s/%s, want stopped/%s/%s", runID, controlStatus, reason, controlledBy, preservationcleanup.BundleForceDeletedReason, preservationcleanup.BundleForceDeleteControlledBy)
+		}
+	}
+}
+
+func assertBundleRowPresent(t *testing.T, ctx context.Context, pg *PostgresStore, bundleHash string) {
+	t.Helper()
+	var exists bool
+	if err := pg.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM bundles WHERE bundle_hash = $1)`, bundleHash).Scan(&exists); err != nil {
+		t.Fatalf("check bundle row %s: %v", bundleHash, err)
+	}
+	if !exists {
+		t.Fatalf("bundle row %s missing, want present", bundleHash)
+	}
+}
+
+func assertBundleRowAbsent(t *testing.T, ctx context.Context, pg *PostgresStore, bundleHash string) {
+	t.Helper()
+	var exists bool
+	if err := pg.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM bundles WHERE bundle_hash = $1)`, bundleHash).Scan(&exists); err != nil {
+		t.Fatalf("check bundle row %s: %v", bundleHash, err)
+	}
+	if exists {
+		t.Fatalf("bundle row %s present, want absent", bundleHash)
+	}
+}

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"swarm/internal/events"
 	"swarm/internal/runtime/bundledelete"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/preservationcleanup"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
@@ -204,6 +206,52 @@ func TestPostgresStore_BundleDeleteFinalMutationSerializesConcurrentRunCreation(
 	assertBundleRowPresent(t, ctx, pg, bundleDeleteTestHash)
 }
 
+func TestPostgresStore_BundleDeleteFinalMutationBlocksPostDeletePersistedSourceRunCreation(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)
+	final, err := pg.ApplyBundleDeleteFinalMutation(ctx, bundledelete.FinalMutationRequest{
+		OperationName: bundledelete.DefaultOperationName,
+		BundleHash:    bundleDeleteTestHash,
+		RequestedAt:   time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ApplyBundleDeleteFinalMutation: %v", err)
+	}
+	if !final.Deleted {
+		t.Fatalf("final mutation = %#v, want deleted", final)
+	}
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	publishCtx := runtimecorrelation.WithBundleSourceFact(ctx, runtimecorrelation.BundleSourceFact{
+		BundleHash:        bundleDeleteTestHash,
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: testBootBundleFingerprint,
+	})
+	err = pg.AppendEvent(publishCtx, events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        "scan.requested",
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"topic":"medicine"}`),
+		CreatedAt:   time.Date(2026, 5, 31, 12, 1, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
+		t.Fatalf("AppendEvent after delete error = %v, want ErrPersistedBundleUnavailable", err)
+	}
+	assertBundleDeleteRunAbsent(t, ctx, pg, runID)
+	assertBundleDeleteEventAbsent(t, ctx, pg, eventID)
+	assertBundleRowAbsent(t, ctx, pg, bundleDeleteTestHash)
+}
+
 func seedBundleDeleteBundle(t *testing.T, ctx context.Context, pg *PostgresStore, bundleHash string) {
 	t.Helper()
 	if _, err := pg.DB.ExecContext(ctx, `
@@ -254,6 +302,28 @@ func assertBundleDeleteRun(t *testing.T, ctx context.Context, pg *PostgresStore,
 		if controlStatus != preservationcleanup.RunControlStatusStopped || reason != preservationcleanup.BundleForceDeletedReason || controlledBy != preservationcleanup.BundleForceDeleteControlledBy {
 			t.Fatalf("run control %s = %s/%s/%s, want stopped/%s/%s", runID, controlStatus, reason, controlledBy, preservationcleanup.BundleForceDeletedReason, preservationcleanup.BundleForceDeleteControlledBy)
 		}
+	}
+}
+
+func assertBundleDeleteRunAbsent(t *testing.T, ctx context.Context, pg *PostgresStore, runID string) {
+	t.Helper()
+	var count int
+	if err := pg.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM runs WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count run %s: %v", runID, err)
+	}
+	if count != 0 {
+		t.Fatalf("run %s count = %d, want absent", runID, count)
+	}
+}
+
+func assertBundleDeleteEventAbsent(t *testing.T, ctx context.Context, pg *PostgresStore, eventID string) {
+	t.Helper()
+	var count int
+	if err := pg.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = $1::uuid`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count event %s: %v", eventID, err)
+	}
+	if count != 0 {
+		t.Fatalf("event %s count = %d, want absent", eventID, count)
 	}
 }
 

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -142,6 +142,68 @@ func TestPostgresStore_BundleDeleteFinalMutationFailsBeforeDeletingWithActiveRun
 	assertBundleRowPresent(t, ctx, pg, bundleDeleteTestHash)
 }
 
+func TestPostgresStore_BundleDeleteFinalMutationSerializesConcurrentRunCreation(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)
+
+	runCreationTx, err := pg.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin run creation tx: %v", err)
+	}
+	defer func() { _ = runCreationTx.Rollback() }()
+	if _, err := runCreationTx.ExecContext(ctx, `LOCK TABLE runs IN ROW EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("hold run creation lock: %v", err)
+	}
+
+	finalCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := pg.ApplyBundleDeleteFinalMutation(finalCtx, bundledelete.FinalMutationRequest{
+			OperationName: bundledelete.DefaultOperationName,
+			BundleHash:    bundleDeleteTestHash,
+			RequestedAt:   time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("final mutation completed before concurrent run creation released: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	runID := uuid.NewString()
+	if _, err := runCreationTx.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, bundle_fingerprint, started_at)
+		VALUES ($1::uuid, 'running', $2, $3, $4, now())
+	`, runID, bundleDeleteTestHash, storerunlifecycle.BundleSourcePersisted, testBootBundleFingerprint); err != nil {
+		t.Fatalf("insert concurrent run: %v", err)
+	}
+	if err := runCreationTx.Commit(); err != nil {
+		t.Fatalf("commit concurrent run: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, bundledelete.ErrActiveRunsRemain) {
+			t.Fatalf("final mutation concurrent error = %v, want ErrActiveRunsRemain", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("final mutation did not finish after concurrent run creation committed")
+	}
+	assertBundleDeleteRun(t, ctx, pg, runID, "running", storerunlifecycle.BundleSourcePersisted, "")
+	assertBundleRowPresent(t, ctx, pg, bundleDeleteTestHash)
+}
+
 func seedBundleDeleteBundle(t *testing.T, ctx context.Context, pg *PostgresStore, bundleHash string) {
 	t.Helper()
 	if _, err := pg.DB.ExecContext(ctx, `

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1321,7 +1321,6 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 		opts.BundleHash = fact.BundleHash
 		opts.BundleSource = fact.BundleSource
 		opts.BundleFingerprint = fact.BundleFingerprint
-		opts.ValidateBundleAvailable = persistedBundleRunCreationValidationRequired(ctx, caps)
 	} else {
 		opts.BundleSource = storerunlifecycle.BundleSourceLegacy
 		opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -73,11 +73,35 @@ func (s *PostgresStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt event
 		evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, tx), evt)
 		switch caps.Events.Log {
 		case SchemaFlavorCanonical:
+			if tx == nil && persistedBundleRunCreationValidationRequired(ctx, caps) {
+				return s.appendEventSpecWithRunCreationValidationTx(ctx, caps, evt)
+			}
 			return s.appendEventSpec(ctx, caps, tx, evt)
 		default:
 			return unsupportedSchemaCapability("events", caps.Events.Log)
 		}
 	})
+}
+
+func (s *PostgresStore) appendEventSpecWithRunCreationValidationTx(ctx context.Context, caps StoreSchemaCapabilities, evt events.Event) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin event source validation tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit event source validation tx: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (s *PostgresStore) PersistEventWithDeliveries(ctx context.Context, evt events.Event, agentIDs []string) error {
@@ -1297,11 +1321,27 @@ func (s *PostgresStore) ensureRunRow(ctx context.Context, caps StoreSchemaCapabi
 		opts.BundleHash = fact.BundleHash
 		opts.BundleSource = fact.BundleSource
 		opts.BundleFingerprint = fact.BundleFingerprint
+		opts.ValidateBundleAvailable = persistedBundleRunCreationValidationRequired(ctx, caps)
 	} else {
 		opts.BundleSource = storerunlifecycle.BundleSourceLegacy
 		opts.BundleFingerprint = runtimecorrelation.BundleFingerprintFromContext(ctx)
 	}
 	return storerunlifecycle.EnsureActive(ctx, chooseExecQueryer(s.DB, tx), runID, triggerEventID, triggerEventType, opts)
+}
+
+func persistedBundleRunCreationValidationRequired(ctx context.Context, caps StoreSchemaCapabilities) bool {
+	if !caps.Events.HasRuns || !caps.Events.RunBundleHash || !caps.Events.RunBundleSource {
+		return false
+	}
+	fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx)
+	if !ok {
+		return false
+	}
+	source, err := storerunlifecycle.CanonicalBundleSource(fact.BundleSource)
+	if err != nil {
+		return false
+	}
+	return source == storerunlifecycle.BundleSourcePersisted && strings.TrimSpace(fact.BundleHash) != ""
 }
 
 func canonicalRunTerminalStatus(raw string) (string, error) {

--- a/internal/store/preservation_cleanup.go
+++ b/internal/store/preservation_cleanup.go
@@ -32,6 +32,14 @@ type preservationCleanupTimerTarget struct {
 }
 
 func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx context.Context, req preservationcleanup.Request) (preservationcleanup.Result, error) {
+	return s.applyPreservationCleanup(ctx, req, preservationcleanup.UnavailableBundleStartupOperationName, preservationcleanup.UnavailableBundleStartupControlledBy)
+}
+
+func (s *PostgresStore) ApplyBundleForceDeletePreservationCleanup(ctx context.Context, req preservationcleanup.Request) (preservationcleanup.Result, error) {
+	return s.applyPreservationCleanup(ctx, req, preservationcleanup.BundleForceDeleteOperationName, preservationcleanup.BundleForceDeleteControlledBy)
+}
+
+func (s *PostgresStore) applyPreservationCleanup(ctx context.Context, req preservationcleanup.Request, defaultOperationName, defaultControlledBy string) (preservationcleanup.Result, error) {
 	if s == nil || s.DB == nil {
 		return preservationcleanup.Result{}, fmt.Errorf("postgres store is required")
 	}
@@ -48,11 +56,14 @@ func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx con
 	}
 	operationName := strings.TrimSpace(req.OperationName)
 	if operationName == "" {
-		operationName = preservationcleanup.UnavailableBundleStartupOperationName
+		operationName = strings.TrimSpace(defaultOperationName)
 	}
 	controlledBy := strings.TrimSpace(req.ControlledBy)
 	if controlledBy == "" {
-		controlledBy = operationName
+		controlledBy = strings.TrimSpace(defaultControlledBy)
+		if controlledBy == "" {
+			controlledBy = operationName
+		}
 	}
 	targets, err := preservationcleanup.NormalizeTargets(req.Targets)
 	if err != nil {
@@ -75,7 +86,7 @@ func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx con
 
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return preservationcleanup.Result{}, fmt.Errorf("begin unavailable bundle preservation cleanup tx: %w", err)
+		return preservationcleanup.Result{}, fmt.Errorf("begin preservation cleanup tx: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -109,7 +120,7 @@ func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx con
 	}
 	if len(activeRunIDs) == 0 {
 		if err := tx.Commit(); err != nil {
-			return preservationcleanup.Result{}, fmt.Errorf("commit empty unavailable bundle preservation cleanup tx: %w", err)
+			return preservationcleanup.Result{}, fmt.Errorf("commit empty preservation cleanup tx: %w", err)
 		}
 		committed = true
 		return out, nil
@@ -205,7 +216,7 @@ func (s *PostgresStore) ApplyUnavailableBundleStartupPreservationCleanup(ctx con
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return preservationcleanup.Result{}, fmt.Errorf("commit unavailable bundle preservation cleanup tx: %w", err)
+		return preservationcleanup.Result{}, fmt.Errorf("commit preservation cleanup tx: %w", err)
 	}
 	committed = true
 	return out, nil

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -56,6 +56,12 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, testCanonicalBundleHash); err != nil {
+		t.Fatalf("seed canonical bundle row: %v", err)
+	}
 	ctx := runtimecorrelation.WithBundleSourceFact(context.Background(), runtimecorrelation.BundleSourceFact{
 		BundleHash:        testCanonicalBundleHash,
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -162,6 +163,12 @@ func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) 
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, testCanonicalBundleHash); err != nil {
+		t.Fatalf("seed canonical bundle row: %v", err)
+	}
 
 	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{
 		HasStartedAtCol:    true,
@@ -185,6 +192,23 @@ func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) 
 	if err == nil {
 		t.Fatal("EnsureActive error = nil, want missing bundle_hash rejection")
 	}
+}
+
+func TestRunLifecycleOwnerRejectsPersistedSourceWithoutBundleRow(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+
+	err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{
+		HasBundleHashCol:   true,
+		HasBundleSourceCol: true,
+		BundleHash:         testCanonicalBundleHash,
+		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	})
+	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
+		t.Fatalf("EnsureActive error = %v, want ErrPersistedBundleUnavailable", err)
+	}
+	assertRunRowAbsent(t, db, runID)
 }
 
 func TestPostgresStore_ActiveRunBundleAvailabilityConflicts(t *testing.T) {
@@ -269,5 +293,16 @@ func assertRunBundleIdentity(t *testing.T, db *sql.DB, runID, wantHash, wantSour
 		}
 	} else if !gotFingerprint.Valid || gotFingerprint.String != wantLegacyFingerprint {
 		t.Fatalf("bundle_fingerprint = %q valid=%v, want %q", gotFingerprint.String, gotFingerprint.Valid, wantLegacyFingerprint)
+	}
+}
+
+func assertRunRowAbsent(t *testing.T, db *sql.DB, runID string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM runs WHERE run_id = $1::uuid`, runID).Scan(&count); err != nil {
+		t.Fatalf("count run rows for %s: %v", runID, err)
+	}
+	if count != 0 {
+		t.Fatalf("run rows for %s = %d, want 0", runID, count)
 	}
 }

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -33,7 +33,6 @@ type EnsureActiveOptions struct {
 	HasBundleHashCol        bool
 	HasBundleSourceCol      bool
 	HasBundleFingerprintCol bool
-	ValidateBundleAvailable bool
 	BundleHash              string
 	BundleSource            string
 	BundleFingerprint       string
@@ -109,6 +108,10 @@ func CanonicalBundleSource(raw string) (string, error) {
 }
 
 func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string, opts EnsureActiveOptions) error {
+	return ensureActive(ctx, db, runID, triggerEventID, triggerEventType, opts, true)
+}
+
+func ensureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEventType string, opts EnsureActiveOptions, allowTransactionWrap bool) error {
 	if db == nil {
 		return nil
 	}
@@ -130,7 +133,29 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	if bundleSource != BundleSourceLegacy && bundleHash == "" {
 		return fmt.Errorf("ensure run row: bundle_hash is required for bundle_source=%s", bundleSource)
 	}
-	if opts.ValidateBundleAvailable && bundleSource == BundleSourcePersisted {
+	if bundleSource == BundleSourcePersisted {
+		if allowTransactionWrap {
+			if sqlDB, ok := db.(*sql.DB); ok {
+				tx, err := sqlDB.BeginTx(ctx, nil)
+				if err != nil {
+					return fmt.Errorf("ensure run row: begin persisted bundle source validation tx: %w", err)
+				}
+				committed := false
+				defer func() {
+					if !committed {
+						_ = tx.Rollback()
+					}
+				}()
+				if err := ensureActive(ctx, tx, runID, triggerEventID, triggerEventType, opts, false); err != nil {
+					return err
+				}
+				if err := tx.Commit(); err != nil {
+					return fmt.Errorf("ensure run row: commit persisted bundle source validation tx: %w", err)
+				}
+				committed = true
+				return nil
+			}
+		}
 		if err := lockRunCreation(ctx, db); err != nil {
 			return err
 		}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -3,6 +3,7 @@ package runlifecycle
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ type EnsureActiveOptions struct {
 	HasBundleHashCol        bool
 	HasBundleSourceCol      bool
 	HasBundleFingerprintCol bool
+	ValidateBundleAvailable bool
 	BundleHash              string
 	BundleSource            string
 	BundleFingerprint       string
@@ -44,6 +46,35 @@ const (
 	BundleSourceLegacy    = "legacy"
 	defaultBundleSource   = BundleSourceLegacy
 )
+
+var ErrPersistedBundleUnavailable = errors.New("persisted bundle source unavailable")
+
+type PersistedBundleUnavailableError struct {
+	BundleHash   string
+	BundleSource string
+	Cause        string
+}
+
+func (e *PersistedBundleUnavailableError) Error() string {
+	if e == nil {
+		return ErrPersistedBundleUnavailable.Error()
+	}
+	parts := []string{ErrPersistedBundleUnavailable.Error()}
+	if e.BundleHash != "" {
+		parts = append(parts, "bundle_hash="+strings.TrimSpace(e.BundleHash))
+	}
+	if e.BundleSource != "" {
+		parts = append(parts, "bundle_source="+strings.TrimSpace(e.BundleSource))
+	}
+	if e.Cause != "" {
+		parts = append(parts, "cause="+strings.TrimSpace(e.Cause))
+	}
+	return strings.Join(parts, " ")
+}
+
+func (e *PersistedBundleUnavailableError) Unwrap() error {
+	return ErrPersistedBundleUnavailable
+}
 
 func CanonicalTerminalStatus(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
@@ -98,6 +129,22 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	}
 	if bundleSource != BundleSourceLegacy && bundleHash == "" {
 		return fmt.Errorf("ensure run row: bundle_hash is required for bundle_source=%s", bundleSource)
+	}
+	if opts.ValidateBundleAvailable && bundleSource == BundleSourcePersisted {
+		if err := lockRunCreation(ctx, db); err != nil {
+			return err
+		}
+		exists, err := persistedBundleRowExists(ctx, db, bundleHash)
+		if err != nil {
+			return fmt.Errorf("ensure run row: validate persisted bundle source: %w", err)
+		}
+		if !exists {
+			return &PersistedBundleUnavailableError{
+				BundleHash:   bundleHash,
+				BundleSource: bundleSource,
+				Cause:        "persisted_missing_bundle_row",
+			}
+		}
 	}
 	reopenStatus := "runs.status"
 	reopenErrorSummary := ""
@@ -169,6 +216,31 @@ func EnsureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 		return fmt.Errorf("ensure run row: %w", err)
 	}
 	return nil
+}
+
+func lockRunCreation(ctx context.Context, db DBTX) error {
+	if _, err := db.ExecContext(ctx, `LOCK TABLE runs IN ROW EXCLUSIVE MODE`); err != nil {
+		return fmt.Errorf("ensure run row: lock run creation: %w", err)
+	}
+	return nil
+}
+
+func persistedBundleRowExists(ctx context.Context, db DBTX, bundleHash string) (bool, error) {
+	bundleHash = strings.TrimSpace(bundleHash)
+	if bundleHash == "" {
+		return false, nil
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM bundles
+			WHERE bundle_hash = $1
+		)
+	`, bundleHash).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func SyncCounts(ctx context.Context, db DBTX, runID string) error {

--- a/openrpc.json
+++ b/openrpc.json
@@ -323,7 +323,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -399,7 +399,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -454,7 +454,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -514,7 +514,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -568,7 +568,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -626,7 +626,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -767,7 +767,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -893,7 +893,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1113,7 +1113,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1151,7 +1151,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1254,7 +1254,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1411,7 +1411,7 @@
       },
       "errors": [
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: BUNDLE_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1451,6 +1451,187 @@
       ]
     },
     {
+      "name": "bundle.delete",
+      "description": "Force-only destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the bundle-delete owner chain for execution: shared destructive-operation mutex, bundle plan, preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and the #1009 source-first final store transaction. `force=false` and omitted force are intentionally fail-closed and split to #1018; this method MUST NOT implement non-force deletion, CLI behavior, runtime.nuke include_bundles, or broad multi-bundle lifecycle cleanup.\n",
+      "params": [
+        {
+          "name": "bundle_hash",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BundleHash"
+          }
+        },
+        {
+          "name": "force",
+          "required": false,
+          "schema": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "dry_run",
+          "required": false,
+          "schema": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "idempotency_key",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BundleDeleteResult"
+        }
+      },
+      "errors": [
+        {
+          "code": -32006,
+          "message": "Application error: BUNDLE_NOT_FOUND",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_NOT_FOUND",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  }
+                },
+                "required": [
+                  "bundle_hash"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32004,
+          "message": "Application error: BUNDLE_DELETE_IN_PROGRESS",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_DELETE_IN_PROGRESS",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "operation_name": {
+                    "const": "bundle.delete",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_name"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32019,
+          "message": "Application error: IDEMPOTENCY_CONFLICT",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "IDEMPOTENCY_CONFLICT",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "conflicting_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_request_hash": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "original_response_ref": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "resource_id": {
+                        "$ref": "#/components/schemas/OpaqueId"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "resource_id"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "original_request_hash",
+                  "conflicting_request_hash",
+                  "original_response_ref"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        }
+      ]
+    },
+    {
       "name": "bundle.get",
       "description": "Read one persisted bundle catalog row by canonical bundle_hash. The result returns stored config, parsed projection, metadata, and data presence facts only; it does not expose runtime state or server-local filesystem paths.\n",
       "params": [
@@ -1471,7 +1652,7 @@
       },
       "errors": [
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: BUNDLE_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1576,7 +1757,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: BUNDLE_REGISTER_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1614,7 +1795,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1777,7 +1958,7 @@
       },
       "errors": [
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1815,7 +1996,7 @@
           }
         },
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1858,7 +2039,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1896,7 +2077,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1992,7 +2173,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2030,7 +2211,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2118,7 +2299,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2156,7 +2337,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2289,7 +2470,7 @@
       },
       "errors": [
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2349,7 +2530,7 @@
       },
       "errors": [
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2426,7 +2607,7 @@
       },
       "errors": [
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2464,7 +2645,7 @@
           }
         },
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2632,7 +2813,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2765,7 +2946,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2946,7 +3127,7 @@
       },
       "errors": [
         {
-          "code": -32004,
+          "code": -32005,
           "message": "Application error: BUNDLE_MISMATCH",
           "data": {
             "additionalProperties": false,
@@ -2996,7 +3177,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: BUNDLE_SCOPE_REQUIRED",
           "data": {
             "additionalProperties": false,
@@ -3041,7 +3222,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3144,7 +3325,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -3179,7 +3360,7 @@
           }
         },
         {
-          "code": -32036,
+          "code": -32037,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -3214,7 +3395,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -3267,7 +3448,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3324,7 +3505,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3382,7 +3563,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3420,7 +3601,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3458,7 +3639,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3500,7 +3681,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3599,7 +3780,7 @@
       },
       "errors": [
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3637,7 +3818,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -3675,7 +3856,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -3730,7 +3911,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3790,7 +3971,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -3844,7 +4025,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3902,7 +4083,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4083,7 +4264,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4121,7 +4302,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4173,7 +4354,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -4215,7 +4396,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4310,7 +4491,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4348,7 +4529,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4400,7 +4581,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -4445,7 +4626,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4526,7 +4707,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4681,7 +4862,7 @@
       },
       "errors": [
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4719,7 +4900,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4771,7 +4952,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4879,7 +5060,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4917,7 +5098,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4959,7 +5140,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5040,7 +5221,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5124,7 +5305,7 @@
       },
       "errors": [
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -5227,7 +5408,7 @@
           }
         },
         {
-          "code": -32035,
+          "code": -32036,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
           "data": {
             "additionalProperties": false,
@@ -5277,7 +5458,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5315,7 +5496,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5353,7 +5534,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5443,7 +5624,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5584,7 +5765,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5622,7 +5803,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5664,7 +5845,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5702,7 +5883,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5836,7 +6017,7 @@
       },
       "errors": [
         {
-          "code": -32004,
+          "code": -32005,
           "message": "Application error: BUNDLE_MISMATCH",
           "data": {
             "additionalProperties": false,
@@ -5886,7 +6067,7 @@
           }
         },
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: BUNDLE_SCOPE_REQUIRED",
           "data": {
             "additionalProperties": false,
@@ -5931,7 +6112,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -6034,7 +6215,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -6069,7 +6250,7 @@
           }
         },
         {
-          "code": -32036,
+          "code": -32037,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -6104,7 +6285,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -6157,7 +6338,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -6214,7 +6395,7 @@
           }
         },
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -6272,7 +6453,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6360,7 +6541,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6398,7 +6579,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -6440,7 +6621,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6540,7 +6721,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6641,7 +6822,7 @@
       },
       "errors": [
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6921,7 +7102,7 @@
       },
       "errors": [
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -6959,7 +7140,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7040,7 +7221,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -7071,7 +7252,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7152,7 +7333,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -7183,7 +7364,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -8035,6 +8216,112 @@
         },
         "required": [
           "agents"
+        ],
+        "type": "object"
+      },
+      "BundleDeleteResult": {
+        "additionalProperties": false,
+        "properties": {
+          "active_runs_stopped": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "bundle_hash": {
+            "$ref": "#/components/schemas/BundleHash"
+          },
+          "cleanup": {
+            "additionalProperties": true,
+            "description": "Exact result from the preservation cleanup owner.",
+            "type": "object"
+          },
+          "containers": {
+            "additionalProperties": true,
+            "description": "Exact result from the managed container identity filter/stop owner.",
+            "type": "object"
+          },
+          "containers_stopped": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "deliveries_cancelled": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "dry_run": {
+            "type": "boolean"
+          },
+          "errors": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "scope",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "final_mutation": {
+            "additionalProperties": true,
+            "description": "Exact result from the",
+            "type": "object"
+          },
+          "force": {
+            "const": true,
+            "type": "boolean"
+          },
+          "ok": {
+            "description": "True for dry-run or fully completed apply; false when the operation completed with explicit partial failures.",
+            "type": "boolean"
+          },
+          "operation_name": {
+            "const": "bundle.delete",
+            "type": "string"
+          },
+          "partial_failure": {
+            "type": "boolean"
+          },
+          "plan": {
+            "additionalProperties": true,
+            "description": "Exact result from the bundle-delete plan owner.",
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "dry_run",
+              "completed",
+              "partial_failure"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "status",
+          "operation_name",
+          "bundle_hash",
+          "force",
+          "deleted",
+          "dry_run",
+          "active_runs_stopped",
+          "deliveries_cancelled",
+          "containers_stopped",
+          "partial_failure",
+          "plan",
+          "cleanup",
+          "containers",
+          "final_mutation"
         ],
         "type": "object"
       },
@@ -10652,8 +10939,47 @@
           "type": "object"
         }
       },
-      "BUNDLE_MISMATCH": {
+      "BUNDLE_DELETE_IN_PROGRESS": {
         "code": -32004,
+        "message": "Application error: BUNDLE_DELETE_IN_PROGRESS",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "BUNDLE_DELETE_IN_PROGRESS",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "operation_name": {
+                  "const": "bundle.delete",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "operation_name"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "BUNDLE_MISMATCH": {
+        "code": -32005,
         "message": "Application error: BUNDLE_MISMATCH",
         "data": {
           "additionalProperties": false,
@@ -10703,7 +11029,7 @@
         }
       },
       "BUNDLE_NOT_FOUND": {
-        "code": -32005,
+        "code": -32006,
         "message": "Application error: BUNDLE_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10741,7 +11067,7 @@
         }
       },
       "BUNDLE_REGISTER_CONFLICT": {
-        "code": -32006,
+        "code": -32007,
         "message": "Application error: BUNDLE_REGISTER_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -10779,7 +11105,7 @@
         }
       },
       "BUNDLE_SCOPE_REQUIRED": {
-        "code": -32007,
+        "code": -32008,
         "message": "Application error: BUNDLE_SCOPE_REQUIRED",
         "data": {
           "additionalProperties": false,
@@ -10824,7 +11150,7 @@
         }
       },
       "BUNDLE_UNAVAILABLE": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: BUNDLE_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10877,7 +11203,7 @@
         }
       },
       "ENTITY_NOT_FOUND": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10915,7 +11241,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -10968,7 +11294,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11006,7 +11332,7 @@
         }
       },
       "EVENT_PUBLISH_FAILED": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: EVENT_PUBLISH_FAILED",
         "data": {
           "additionalProperties": false,
@@ -11063,7 +11389,7 @@
         }
       },
       "EVENT_REPLAY_NOT_ELIGIBLE": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -11117,7 +11443,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -11155,7 +11481,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -11210,7 +11536,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11270,7 +11596,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11308,7 +11634,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -11367,7 +11693,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -11412,7 +11738,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -11464,7 +11790,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -11506,7 +11832,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11544,7 +11870,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11582,7 +11908,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -11640,7 +11966,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11671,7 +11997,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11702,7 +12028,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -11740,7 +12066,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11778,7 +12104,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32029,
+        "code": -32030,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -11820,7 +12146,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32030,
+        "code": -32031,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11858,7 +12184,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32031,
+        "code": -32032,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11900,7 +12226,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32032,
+        "code": -32033,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11938,7 +12264,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32033,
+        "code": -32034,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11981,7 +12307,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH": {
-        "code": -32034,
+        "code": -32035,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
         "data": {
           "additionalProperties": false,
@@ -12016,7 +12342,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH_FORK": {
-        "code": -32035,
+        "code": -32036,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
         "data": {
           "additionalProperties": false,
@@ -12066,7 +12392,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32036,
+        "code": -32037,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5864,6 +5864,20 @@ multi_bundle_persistence:
         active-run recheck and source update. Concurrent readers observe either the pre-delete persisted source with an
         existing bundle row or the post-delete deleted source with no row. They must not observe a legitimate delete as
         bundle_source=persisted with a missing bundle row.
+      post_delete_new_work_admission:
+        status: implemented_for_force_delete_runtime
+        canonical_owner: internal/store/runlifecycle.EnsureActive
+        consumed_by:
+          - internal/store.PostgresStore.ensureRunRow
+          - internal/runtime/bus.EventBus publish paths through PostgresStore.AppendEventTx
+          - /v1/rpc event.publish
+          - /v1/rpc run.start
+        rule: >
+          New work stamped from a persisted runtime BundleSourceFact MUST serialize against the runs table, re-check that
+          bundles still contains the source bundle_hash in the same event transaction, and fail closed before inserting a
+          run or event when the bundle row has been deleted. A successful bundle.delete --force must therefore make later
+          same-runtime event.publish and run.start attempts return BUNDLE_UNAVAILABLE rather than recreating
+          bundle_source=persisted with a missing bundle row.
       reader_invariant: >
         Bundle availability readers MUST read runs.bundle_source before consulting bundles. Readers only look up bundles
         when bundle_source=persisted. bundle_source in (ephemeral, deleted, legacy) returns BUNDLE_UNAVAILABLE without a

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5549,19 +5549,19 @@ multi_bundle_persistence:
     promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
     generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
-    current_openrpc_status: bundle_read_catalog_register_and_run_fork_methods_published
+    current_openrpc_status: bundle_read_catalog_register_run_fork_and_force_delete_methods_published
     rule: >
       Generated openrpc.json is derived from api_specification.method_catalog and must continue to match the currently
       registered /v1/rpc handler set. The read-only bundle.list, bundle.get, and bundle.agents catalog methods are now
       published because their handlers and store owner are implemented in the same gated PR. run.fork is now published
       because its selected-contract API/runtime handler owner is implemented in the same gated PR. Mutating bundle.register
       is now published because its handler, idempotency behavior, shared bundle catalog writer, and generated artifacts are
-      implemented together. Destructive bundle.delete remains source authority only until its API/runtime handler is
-      implemented and registered in a later gated PR.
+      implemented together. Force-only bundle.delete is now published because its API/runtime handler owner is implemented
+      in the same gated PR; omitted or false force remains fail-closed and split to #1018.
     proof_expectation: >
-      Source-authority promotion proof must verify that bundle.delete is not silently published in generated OpenRPC
-      without implementation, and that future implementation PRs promote matching method_catalog entries and generated
-      artifacts together.
+      Source-authority promotion proof must verify that generated OpenRPC methods are not silently published without
+      implementation, and that future implementation PRs promote matching method_catalog entries and generated artifacts
+      together.
   bundle_identity:
     canonical_name: bundle_hash
     format: 'bundle-v1:sha256:<64 lowercase hex>'
@@ -5840,17 +5840,19 @@ multi_bundle_persistence:
       Without --force, deleting a bundle with any active run using that bundle fails closed with BUNDLE_HAS_ACTIVE_RUNS.
     phase_5_atomicity:
       tracker: '#1009'
-      implementation_status: source_authority_only_no_runtime_behavior
-      canonical_runtime_owner: future bundle catalog store transaction/mutator
+      implementation_status: implemented_for_force_delete_runtime_non_force_pending
+      canonical_runtime_owner: internal/store.PostgresStore.ApplyBundleDeleteFinalMutation
       applies_to:
         - '#1018 non-force bundle.delete final bundle availability mutation'
         - '#1019 bundle.delete --force final bundle availability mutation after preservation cleanup succeeds'
       transaction_rule: >
-        The final bundle availability mutation MUST execute in one database transaction. The transaction updates every
-        eligible referencing run from bundle_source=persisted to bundle_source=deleted before deleting the matching bundles
-        row. API handlers, CLI consumers, force-delete orchestration, and non-force delete orchestration MUST consume the
-        shared store transaction owner rather than issuing local raw SQL for this transition.
+        The final bundle availability mutation MUST execute in one database transaction. The transaction first serializes
+        run creation for the runs table, then rechecks/locks referencing persisted run rows, then updates every eligible
+        referencing run from bundle_source=persisted to bundle_source=deleted before deleting the matching bundles row. API
+        handlers, CLI consumers, force-delete orchestration, and non-force delete orchestration MUST consume the shared
+        store transaction owner rather than issuing local raw SQL for this transition.
       transaction_order:
+        - lock_runs_table_against_new_persisted_bundle_references
         - update_eligible_runs_bundle_source_to_deleted
         - delete_matching_bundles_row
       eligible_runs: >
@@ -5858,9 +5860,10 @@ multi_bundle_persistence:
         is owned by #1018 for non-force delete, and active-run quiescence plus preservation cleanup is owned by #1019/#1008
         for force delete before Phase 5 is reachable.
       isolation: >
-        PostgreSQL READ COMMITTED is sufficient when both statements are inside the same transaction: concurrent readers
-        observe either the pre-delete persisted source with an existing bundle row or the post-delete deleted source with no
-        row. They must not observe a legitimate delete as bundle_source=persisted with a missing bundle row.
+        PostgreSQL READ COMMITTED is sufficient only when the final transaction blocks concurrent run creation before the
+        active-run recheck and source update. Concurrent readers observe either the pre-delete persisted source with an
+        existing bundle row or the post-delete deleted source with no row. They must not observe a legitimate delete as
+        bundle_source=persisted with a missing bundle row.
       reader_invariant: >
         Bundle availability readers MUST read runs.bundle_source before consulting bundles. Readers only look up bundles
         when bundle_source=persisted. bundle_source in (ephemeral, deleted, legacy) returns BUNDLE_UNAVAILABLE without a
@@ -5893,7 +5896,7 @@ multi_bundle_persistence:
         - containers_stopped
         - dry_run
   api_surface:
-    publication_status: bundle_read_catalog_register_and_run_fork_generated_openrpc
+    publication_status: bundle_read_catalog_register_run_fork_and_force_delete_generated_openrpc
     command_transport_owner: api_specification
     bundle_methods_planned:
       bundle.list:
@@ -10029,7 +10032,7 @@ api_specification:
       downgraded to backlog before it can be used as implementation authority.
   multi_bundle_publication_boundary:
     owner: multi_bundle_persistence.api_surface
-    status: partial_bundle_read_catalog_register_and_run_fork_method_catalog
+    status: partial_bundle_read_catalog_register_run_fork_and_force_delete_method_catalog
     rule: >
       #1012 promotes the multi-bundle API contract as source authority, including bundle.* methods, run.fork, bundle_hash
       filters, and bundle_hash create-new-work params. The read-only bundle.list, bundle.get, and bundle.agents methods are
@@ -10038,10 +10041,11 @@ api_specification:
       bundle register CLI consumer in #1023's read-only inventory slice. run.fork is also promoted into
       method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by #989. The swarm bundle
       list/show/agents and swarm fork CLI consumers are implemented by #1023 and consume only those canonical /v1/rpc
-      methods. Remaining unimplemented multi-bundle methods such as bundle.delete are not in method_catalog/OpenRPC until
-      a later gated API/runtime implementation PR registers handlers and regenerates openrpc.json/proof artifacts in the
-      same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or #1038 prose as API authority after
-      #1012.
+      methods. Force-only bundle.delete is promoted into method_catalog/OpenRPC with matching API/runtime handler proof by
+      #1019; omitted or false force remains fail-closed and split to #1018. Remaining multi-bundle methods and shapes are
+      not in method_catalog/OpenRPC until a later gated API/runtime implementation PR registers handlers and regenerates
+      openrpc.json/proof artifacts in the same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or
+      #1038 prose as API authority after #1012.
     blocked_children:
       cross_bundle_fork: '#976'
       bundle_hash_dual_accept_migration: '#1001'
@@ -10337,6 +10341,7 @@ api_specification:
       - bundle.register
       - event.publish
       - event.replay
+      - bundle.delete
       - run.fork
       - agent.replay
       - run.start
@@ -10760,6 +10765,88 @@ api_specification:
             type: integer
             minimum: 0
             description: Size of persisted data_blob bytes, or 0 when has_data is false.
+      BundleDeleteResult:
+        type: object
+        additionalProperties: false
+        required:
+        - ok
+        - status
+        - operation_name
+        - bundle_hash
+        - force
+        - deleted
+        - dry_run
+        - active_runs_stopped
+        - deliveries_cancelled
+        - containers_stopped
+        - partial_failure
+        - plan
+        - cleanup
+        - containers
+        - final_mutation
+        properties:
+          ok:
+            type: boolean
+            description: True for dry-run or fully completed apply; false when the operation completed with explicit partial
+              failures.
+          status:
+            type: string
+            enum:
+            - dry_run
+            - completed
+            - partial_failure
+          operation_name:
+            type: string
+            const: bundle.delete
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          force:
+            type: boolean
+            const: true
+          deleted:
+            type: boolean
+          dry_run:
+            type: boolean
+          active_runs_stopped:
+            type: integer
+            minimum: 0
+          deliveries_cancelled:
+            type: integer
+            minimum: 0
+          containers_stopped:
+            type: integer
+            minimum: 0
+          partial_failure:
+            type: boolean
+          plan:
+            type: object
+            additionalProperties: true
+            description: Exact result from the bundle-delete plan owner.
+          cleanup:
+            type: object
+            additionalProperties: true
+            description: Exact result from the preservation cleanup owner.
+          containers:
+            type: object
+            additionalProperties: true
+            description: Exact result from the managed container identity filter/stop owner.
+          final_mutation:
+            type: object
+            additionalProperties: true
+            description: Exact result from the #1009 source-first bundle delete transaction owner.
+          errors:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              required:
+              - scope
+              - message
+              properties:
+                scope:
+                  type: string
+                message:
+                  type: string
       HealthCheckResult:
         type: object
         additionalProperties: false
@@ -12946,6 +13033,15 @@ api_specification:
         properties:
           bundle_hash:
             $ref: '#/components/schemas/BundleHash'
+      BUNDLE_DELETE_IN_PROGRESS:
+        type: object
+        additionalProperties: false
+        required:
+        - operation_name
+        properties:
+          operation_name:
+            type: string
+            const: bundle.delete
       BUNDLE_UNAVAILABLE:
         type: object
         additionalProperties: false
@@ -13536,6 +13632,47 @@ api_specification:
           $ref: '#/components/schemas/BundleRegistrationResult'
       errors:
       - BUNDLE_REGISTER_CONFLICT
+      - IDEMPOTENCY_CONFLICT
+    bundle.delete:
+      tier: should_have
+      description: >
+        Force-only destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency
+        contract and MUST consume the bundle-delete owner chain for execution: shared destructive-operation mutex, bundle
+        plan, preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and
+        the #1009 source-first final store transaction. `force=false` and omitted force are intentionally fail-closed and
+        split to #1018; this method MUST NOT implement non-force deletion, CLI behavior, runtime.nuke include_bundles, or
+        broad multi-bundle lifecycle cleanup.
+      scope:
+        required:
+        - control:runtime
+      idempotency: per the convention.
+      params:
+      - name: bundle_hash
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleHash'
+      - name: force
+        required: false
+        schema:
+          type: boolean
+          default: false
+      - name: dry_run
+        required: false
+        schema:
+          type: boolean
+          default: false
+      - name: idempotency_key
+        required: false
+        schema:
+          type: string
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/BundleDeleteResult'
+      errors:
+      - BUNDLE_NOT_FOUND
+      - BUNDLE_DELETE_IN_PROGRESS
       - IDEMPOTENCY_CONFLICT
     health.subscribe:
       tier: should_have

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5870,13 +5870,16 @@ multi_bundle_persistence:
         consumed_by:
           - internal/store.PostgresStore.ensureRunRow
           - internal/runtime/bus.EventBus publish paths through PostgresStore.AppendEventTx
+          - internal/runtime.RuntimeLogger runtime-log run-row persistence
+          - internal/runtime/mutationlog mutation-log run-row persistence
           - /v1/rpc event.publish
           - /v1/rpc run.start
         rule: >
-          New work stamped from a persisted runtime BundleSourceFact MUST serialize against the runs table, re-check that
-          bundles still contains the source bundle_hash in the same event transaction, and fail closed before inserting a
-          run or event when the bundle row has been deleted. A successful bundle.delete --force must therefore make later
-          same-runtime event.publish and run.start attempts return BUNDLE_UNAVAILABLE rather than recreating
+          New work or run-scoped runtime/mutation records stamped from a persisted runtime BundleSourceFact MUST serialize
+          against the runs table, re-check that bundles still contains the source bundle_hash in the same transaction as
+          the run-row creation, and fail closed before inserting a run, event, runtime-log row, or mutation-log row when
+          the bundle row has been deleted. A successful bundle.delete --force must therefore make later same-runtime
+          event.publish, run.start, runtime-log, and mutation-log attempts fail closed rather than recreating
           bundle_source=persisted with a missing bundle row.
       reader_invariant: >
         Bundle availability readers MUST read runs.bundle_source before consulting bundles. Readers only look up bundles


### PR DESCRIPTION
## Summary

Implements the approved #1019 force-only `bundle.delete` owner chain:

- adds `internal/runtime/bundledelete.Coordinator` to serialize force delete with the shared destructive-operation mutex, plan affected persisted runs, run preservation cleanup, stop matching managed containers, and run the final bundle source mutation;
- generalizes the #1016 preservation cleanup owner for `bundle_force_deleted` without using destructive reset cleanup semantics;
- adds the reusable #1009 Phase 5 store mutator that marks eligible persisted runs `bundle_source='deleted'` before deleting the matching bundle row in one transaction;
- publishes `bundle.delete` through `/v1/rpc`, generated OpenRPC, and the compliance matrix, with omitted/false `force` failing closed and tracked to #1018.

Closes #1019.

## Governing Refs / Context

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_delete`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_delete.phase_5_atomicity`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#multi_bundle_persistence.bundle_delete.force_owner_chain`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.method_catalog.bundle.delete`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#components.schemas.BundleDeleteResult`
- Binding issue/gate context: #1019 pre-audit and independent gate outcome on the issue thread.

## Semantic Migration

- New canonical owner: `internal/runtime/bundledelete.Coordinator` for force-delete orchestration.
- Cleanup owner consumed/generalized: `internal/runtime/preservationcleanup` plus `PostgresStore.ApplyBundleForceDeletePreservationCleanup` for `bundle_force_deleted`.
- Final source-authority owner: `PostgresStore.ApplyBundleDeleteFinalMutation` for update-runs-before-delete-bundle-row Phase 5 ordering.
- Old invalid paths: API/runtime code must not delete bundle rows directly, must not run local per-consumer cleanup SQL, and must not use destructive reset cleanup for preservation-mode force delete.
- Production paths checked: `/v1/rpc bundle.delete`, API idempotency, shared destructive-operation lock, store planner/finalizer, preservation cleanup, managed container identity filtering, generated OpenRPC, and method catalog publication.
- Migration complete for #1019 force-only behavior. #1018 non-force `bundle.delete`, #1027 `runtime.nuke include_bundles`, CLI, and broader multi-bundle lifecycle cleanup remain split.

## Validation

- `go run ./cmd/swarm-openrpc-gen`
- `go test ./internal/runtime/bundledelete -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorBundleDelete|TestOpenRPCMutatingHTTPRuntimeProbes|TestGeneratedOpenRPC|TestOpenRPCCompliance|TestOpenRPCSuccessfulResultSchemas' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/store -run 'TestPostgresStore_BundleDelete|TestPostgresStore_ApplyUnavailableBundleStartupPreservationCleanup' -count=1`
- `go test ./cmd/swarm ./internal/store ./internal/runtime/bundledelete ./internal/apiv1 ./internal/apispec -count=1`
- `go test ./...`