### PR TITLE
[agent-f][issue #1020] Add DB-loaded serve bundle mode

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -35,11 +35,12 @@ type runtimeProjectSupervisor struct {
 	newWorkspaces    func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle
 	createRuntime    func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
 
-	mu            sync.RWMutex
-	currentRoot   string
-	currentSource semanticview.Source
-	currentBundle *runtimecontracts.WorkflowContractBundle
-	currentRT     *runtime.Runtime
+	mu                              sync.RWMutex
+	currentRoot                     string
+	currentSource                   semanticview.Source
+	currentBundle                   *runtimecontracts.WorkflowContractBundle
+	currentRT                       *runtime.Runtime
+	sourceReplacementDisabledReason string
 }
 
 func newRuntimeProjectSupervisor(
@@ -126,6 +127,12 @@ func (s *runtimeProjectSupervisor) ReloadProject(ctx context.Context, projectDir
 	return s.loadProject(ctx, projectDir)
 }
 
+func (s *runtimeProjectSupervisor) DisableSourceReplacement(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sourceReplacementDisabledReason = strings.TrimSpace(reason)
+}
+
 func (s *runtimeProjectSupervisor) CloseProject(ctx context.Context) (builderpkg.ProjectStatus, error) {
 	return s.CloseProjectWithShutdownOptions(ctx, runtime.DefaultShutdownOptions())
 }
@@ -142,6 +149,9 @@ func (s *runtimeProjectSupervisor) CloseProjectWithShutdownOptions(ctx context.C
 }
 
 func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir string) (builderpkg.ProjectStatus, error) {
+	if reason := s.sourceReplacementDisabled(); reason != "" {
+		return s.CurrentProject(), fmt.Errorf("project source replacement is disabled: %s", reason)
+	}
 	resolvedRoot, err := normalizeContractsRoot(resolvePath(s.repoRoot, projectDir))
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err
@@ -198,6 +208,12 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	}
 	slog.Info("builder project loaded", "project_dir", filepath.Clean(resolvedRoot), "workflow", strings.TrimSpace(status.WorkflowName))
 	return status, nil
+}
+
+func (s *runtimeProjectSupervisor) sourceReplacementDisabled() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return strings.TrimSpace(s.sourceReplacementDisabledReason)
 }
 
 func (s *runtimeProjectSupervisor) replaceCurrentRuntime(

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -343,6 +343,23 @@ func TestRuntimeProjectSupervisorLoadProject_PassesBundleFingerprintToRuntime(t 
 	}
 }
 
+func TestRuntimeProjectSupervisorOpenProjectFailsClosedWhenSourceReplacementDisabled(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		t.Fatal("createRuntime should not be called when DB-loaded source replacement is disabled")
+		return nil, nil
+	})
+	supervisor.DisableSourceReplacement("DB-loaded --bundle-hash pins one catalog source for this process")
+
+	status, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err == nil || !strings.Contains(err.Error(), "project source replacement is disabled") || !strings.Contains(err.Error(), "DB-loaded --bundle-hash") {
+		t.Fatalf("OpenProject err = %v, want source replacement disabled", err)
+	}
+	if status.Loaded {
+		t.Fatalf("status.Loaded = true, want false")
+	}
+}
+
 type builderControlTestAgent struct{ id string }
 
 func (a builderControlTestAgent) ID() string                      { return a.id }

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -119,6 +119,24 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if opts.Dev && cmd.Flags().Changed("require-bundle-match") && opts.RequireBundleMatch {
 				return fmt.Errorf("--dev cannot be combined with --require-bundle-match")
 			}
+			if cmd.Flags().Changed("bundle-hash") {
+				opts.BundleHash = strings.TrimSpace(opts.BundleHash)
+				if opts.BundleHash == "" {
+					return fmt.Errorf("--bundle-hash must be non-empty")
+				}
+				if !cliBundleHashPattern.MatchString(opts.BundleHash) {
+					return fmt.Errorf("--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>")
+				}
+				if cmd.Flags().Changed("contracts") {
+					return fmt.Errorf("--bundle-hash is mutually exclusive with --contracts")
+				}
+				if opts.Dev {
+					return fmt.Errorf("--bundle-hash is mutually exclusive with --dev")
+				}
+				if cmd.Flags().Changed("store") && !strings.EqualFold(strings.TrimSpace(opts.StoreMode), "postgres") {
+					return fmt.Errorf("--bundle-hash requires --store postgres")
+				}
+			}
 			if opts.Dev {
 				opts.AbandonActiveRuns = true
 				opts.NoRequireBundleMatch = true
@@ -162,6 +180,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", opts.ConfigPath, "Optional path to Swarm runtime config")
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, or openai_compatible")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
+	cmd.Flags().StringVar(&opts.BundleHash, "bundle-hash", opts.BundleHash, "Load a persisted bundle catalog row by canonical bundle_hash (serial single-bundle process)")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -33,6 +33,7 @@ import (
 	runtimebootverify "swarm/internal/runtime/bootverify"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimecredentials "swarm/internal/runtime/credentials"
 	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimeingress "swarm/internal/runtime/ingress"
@@ -51,6 +52,8 @@ import (
 	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
 	storebackend "swarm/internal/store/backendselection"
+	"swarm/internal/store/runbundle"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 const (
@@ -161,6 +164,7 @@ type serveOptions struct {
 	ConfigPath           string
 	Backend              string
 	ContractsPath        string
+	BundleHash           string
 	PlatformSpecPath     string
 	StoreMode            string
 	StoreModeSet         bool
@@ -176,6 +180,33 @@ type serveOptions struct {
 	Output               io.Writer
 }
 
+type serveRuntimeBundle struct {
+	module           runtimepipeline.WorkflowModule
+	bundle           *runtimecontracts.WorkflowContractBundle
+	source           semanticview.Source
+	contractsRoot    string
+	platformSpecPath string
+	bootIdentity     runtimecontracts.BundleIdentity
+	bundleSourceFact runtimecorrelation.BundleSourceFact
+	dbLoaded         bool
+	cleanup          func() error
+}
+
+type dbLoadedServeRunForkAvailability struct {
+	bundleHash string
+}
+
+func (a dbLoadedServeRunForkAvailability) LoadRunBundleAvailability(_ context.Context, runID string) (runbundle.Availability, error) {
+	return runbundle.Availability{
+		RunID:            strings.TrimSpace(runID),
+		BundleHash:       strings.TrimSpace(a.bundleHash),
+		BundleSource:     storerunlifecycle.BundleSourcePersisted,
+		BundleRowPresent: true,
+		ErrorCode:        runbundle.CodeBundleUnavailable,
+		Cause:            "db_loaded_same_bundle_fork_split_to_1024",
+	}, nil
+}
+
 func defaultServeOptions() serveOptions {
 	return serveOptions{
 		StoreMode:          storebackend.ActiveDefaultBackend().String(),
@@ -185,6 +216,118 @@ func defaultServeOptions() serveOptions {
 		SelfCheck:          true,
 		RequireBundleMatch: true,
 	}
+}
+
+func (b serveRuntimeBundle) serveIdentityDetail() string {
+	if b.dbLoaded && strings.TrimSpace(b.bundleSourceFact.BundleHash) != "" {
+		return strings.TrimSpace(b.bundleSourceFact.BundleHash)
+	}
+	return strings.TrimSpace(b.bootIdentity.Fingerprint)
+}
+
+func serveConfigLoadDetail(configDetail string, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) string {
+	parts := []string{"config=" + strings.TrimSpace(configDetail)}
+	if hash := strings.TrimSpace(opts.BundleHash); hash != "" {
+		parts = append(parts, "bundle_hash="+hash)
+	} else {
+		parts = append(parts, "contracts="+filepath.Clean(resolvedPaths.ContractsPath))
+	}
+	return strings.Join(parts, " ")
+}
+
+func loadServeRuntimeBundle(ctx context.Context, repo string, stores storeBundle, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) (serveRuntimeBundle, error) {
+	if bundleHash := strings.TrimSpace(opts.BundleHash); bundleHash != "" {
+		return loadServeRuntimeBundleFromCatalog(ctx, repo, stores, bundleHash)
+	}
+	contractsRoot, err := normalizeContractsRoot(resolvedPaths.ContractsPath)
+	if err != nil {
+		return serveRuntimeBundle{}, fmt.Errorf("resolve contracts: %w", err)
+	}
+	module, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPaths.PlatformSpecPath)
+	if err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	bootIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		return serveRuntimeBundle{}, fmt.Errorf("compute boot bundle identity: %w", err)
+	}
+	return serveRuntimeBundle{
+		module:           module,
+		bundle:           bundle,
+		source:           semanticview.Wrap(bundle),
+		contractsRoot:    contractsRoot,
+		platformSpecPath: resolvedPaths.PlatformSpecPath,
+		bootIdentity:     bootIdentity,
+	}, nil
+}
+
+func loadServeRuntimeBundleFromCatalog(ctx context.Context, repo string, stores storeBundle, bundleHash string) (serveRuntimeBundle, error) {
+	if stores.Postgres == nil {
+		return serveRuntimeBundle{}, fmt.Errorf("BUNDLE_UNAVAILABLE: swarm serve --bundle-hash requires postgres bundle catalog store")
+	}
+	if err := runtimecontracts.ValidateBundleHash(bundleHash); err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	record, err := stores.Postgres.LoadBundleCatalogRuntimeRecord(ctx, bundleHash)
+	if errors.Is(err, store.ErrBundleNotFound) {
+		return serveRuntimeBundle{}, fmt.Errorf("BUNDLE_UNAVAILABLE: bundle_hash %s is not present in bundles", bundleHash)
+	}
+	if err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	runtimeSource, err := runtimecontracts.LoadBundleCatalogRuntimeSource(repo, runtimecontracts.BundleCatalogRuntimeLoadRequest{
+		BundleHash:  record.BundleHash,
+		ContentYAML: record.ContentYAML,
+		DataBlob:    record.DataBlob,
+	})
+	if err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			_ = runtimeSource.Cleanup()
+		}
+	}()
+	module, source, err := newSwarmWorkflowModuleForBundle(runtimeSource.Bundle)
+	if err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	bootIdentity, err := runtimecontracts.BootBundleIdentity(runtimeSource.Bundle)
+	if err != nil {
+		return serveRuntimeBundle{}, fmt.Errorf("compute DB-loaded boot bundle identity: %w", err)
+	}
+	fact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        runtimeSource.BundleHash,
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: bootIdentity.Fingerprint,
+	}.Normalized()
+	cleanupOnError = false
+	return serveRuntimeBundle{
+		module:           module,
+		bundle:           runtimeSource.Bundle,
+		source:           source,
+		contractsRoot:    runtimeSource.ContractsRoot,
+		platformSpecPath: runtimeSource.PlatformSpecPath,
+		bootIdentity:     bootIdentity,
+		bundleSourceFact: fact,
+		dbLoaded:         true,
+		cleanup:          runtimeSource.Cleanup,
+	}, nil
+}
+
+func prepareLoadedServeBundleSource(ctx context.Context, stores storeBundle, loaded serveRuntimeBundle, dev bool) (runtimecorrelation.BundleSourceFact, error) {
+	if loaded.dbLoaded {
+		if dev {
+			return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("--bundle-hash is mutually exclusive with --dev")
+		}
+		fact := loaded.bundleSourceFact.Normalized()
+		if fact.BundleSource != storerunlifecycle.BundleSourcePersisted || strings.TrimSpace(fact.BundleHash) == "" {
+			return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("DB-loaded serve bundle source fact must be persisted with bundle_hash")
+		}
+		return fact, nil
+	}
+	return prepareServeBundleSource(ctx, stores, loaded.bundle, loaded.bootIdentity.Fingerprint, dev)
 }
 
 func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver) (runtimellm.Runtime, error) {
@@ -217,8 +360,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("resolve CLI path config: %v", err)
 		return 1
 	}
-	resolvedContractsPath := resolvedPaths.ContractsPath
-	resolvedPlatformSpecPath := resolvedPaths.PlatformSpecPath
 
 	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
 		RepoRoot:        repo,
@@ -231,7 +372,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	cfg := cfgResult.Config
-	reporter.emit(2, "config_load", "ok", fmt.Sprintf("config=%s contracts=%s", cfgResult.Detail(), filepath.Clean(resolvedContractsPath)))
+	reporter.emit(2, "config_load", "ok", serveConfigLoadDetail(cfgResult.Detail(), resolvedPaths, opts))
 	storeSelection, err := resolveRuntimeStoreSelection(repo, opts.StoreMode, opts.StoreModeSet, cfg)
 	if err != nil {
 		reporter.emit(3, "db_connection", "FAILED", err.Error())
@@ -246,26 +387,26 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
-	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
-	if err != nil {
-		reporter.emit(4, "bundle_load", "FAILED", err.Error())
-		log.Printf("resolve contracts: %v", err)
-		return 1
-	}
-	module, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPlatformSpecPath)
+	loadedBundle, err := loadServeRuntimeBundle(ctx, repo, stores, resolvedPaths, opts)
 	if err != nil {
 		reporter.emit(4, "bundle_load", "FAILED", err.Error())
 		log.Printf("load Swarm contracts: %v", err)
 		return 1
 	}
-	bootBundleIdentity, err := runtimecontracts.BootBundleIdentity(bundle)
-	if err != nil {
-		reporter.emit(4, "bundle_load", "FAILED", err.Error())
-		log.Printf("compute boot bundle identity: %v", err)
-		return 1
+	if loadedBundle.cleanup != nil {
+		defer func() {
+			if err := loadedBundle.cleanup(); err != nil {
+				log.Printf("cleanup DB-loaded bundle runtime source failed: %v", err)
+			}
+		}()
 	}
-	source := semanticview.Wrap(bundle)
-	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(bootBundleIdentity.Fingerprint, source))
+	module := loadedBundle.module
+	bundle := loadedBundle.bundle
+	source := loadedBundle.source
+	contractsRoot := loadedBundle.contractsRoot
+	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
+	bootBundleIdentity := loadedBundle.bootIdentity
+	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(loadedBundle.serveIdentityDetail(), source))
 	stateStoreSummary, err := initializeStateStores(ctx, stores, bundle)
 	if err != nil {
 		slog.Error("initialize state stores", "error", err)
@@ -313,11 +454,15 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			)
 		}
 	}
-	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, bootBundleIdentity.Fingerprint, opts.RequireBundleMatch); err != nil {
+	pinnedBundleHash := ""
+	if loadedBundle.dbLoaded {
+		pinnedBundleHash = strings.TrimSpace(loadedBundle.bundleSourceFact.BundleHash)
+	}
+	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, loadedBundle.serveIdentityDetail(), opts.RequireBundleMatch, pinnedBundleHash); err != nil {
 		slog.Error("bundle match admission failed", "error", err)
 		return 3
 	}
-	bundleSourceFact, err := prepareServeBundleSource(ctx, stores, bundle, bootBundleIdentity.Fingerprint, opts.Dev)
+	bundleSourceFact, err := prepareLoadedServeBundleSource(ctx, stores, loadedBundle, opts.Dev)
 	if err != nil {
 		slog.Error("prepare bundle source", "error", err)
 		return 3
@@ -408,6 +553,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt, opts.Dev)
+	if loadedBundle.dbLoaded {
+		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins one persisted bundle for the process; dynamic project reload is split to RuntimeContextManager work")
+	}
 	defer func() {
 		if err := closeServeRuntime(context.Background(), supervisor, opts, workspaces); err != nil {
 			log.Printf("runtime shutdown failed: %v", err)
@@ -432,6 +580,10 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			Containers: workspaces,
 		},
 	}
+	runForkAvailability := apiv1.RunForkAvailabilityStore(stores.Postgres)
+	if loadedBundle.dbLoaded {
+		runForkAvailability = dbLoadedServeRunForkAvailability{bundleHash: loadedBundle.bundleSourceFact.BundleHash}
+	}
 	apiReadOptions := apiv1.OperatorReadOptions{
 		Ready: func() bool {
 			return ready.Load()
@@ -444,7 +596,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		BundleCatalog:       stores.Postgres,
 		ConversationForks:   stores.Postgres,
 		ForkChatExecutor:    apiv1.NewLLMForkChatExecutor(forkChatLLM),
-		RunForkAvailability: stores.Postgres,
+		RunForkAvailability: runForkAvailability,
 		RunFork: apiv1.SelectedContractRunForkExecutor{
 			Store: stores.Postgres,
 			SourceLoader: runtimerunforkexecution.ContractBundleSourceLoader{
@@ -1890,30 +2042,68 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 	}
 }
 
-func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresStore, bootFingerprint string, requireMatch bool) error {
-	bootFingerprint = strings.TrimSpace(bootFingerprint)
+func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresStore, bootIdentity string, requireMatch bool, pinnedBundleHash string) error {
+	bootIdentity = strings.TrimSpace(bootIdentity)
+	pinnedBundleHash = strings.TrimSpace(pinnedBundleHash)
 	if !requireMatch {
 		log.Printf("legacy bundle match admission disabled by --no-require-bundle-match; startup recovery has already consumed active run bundle source state")
-		return nil
 	}
-	if bootFingerprint == "" {
-		return fmt.Errorf("boot bundle fingerprint is required")
+	enforceActiveAvailability := requireMatch || pinnedBundleHash != ""
+	if enforceActiveAvailability && bootIdentity == "" {
+		return fmt.Errorf("boot bundle identity is required")
 	}
 	if pg == nil {
 		return nil
 	}
-	conflicts, err := pg.ActiveRunBundleAvailabilityConflicts(ctx)
+	if enforceActiveAvailability {
+		conflicts, err := pg.ActiveRunBundleAvailabilityConflicts(ctx)
+		if err != nil {
+			return err
+		}
+		if len(conflicts) > 0 {
+			details := make([]string, 0, len(conflicts))
+			for _, conflict := range conflicts {
+				details = append(details, conflict.DetailString())
+			}
+			return fmt.Errorf("active run bundle availability conflict: boot bundle %s cannot resume %d active run(s): %s", bootIdentity, len(conflicts), strings.Join(details, "; "))
+		}
+	}
+	if pinnedBundleHash == "" {
+		return nil
+	}
+	mismatches, err := activeRunPinnedBundleHashConflicts(ctx, pg, pinnedBundleHash)
 	if err != nil {
 		return err
 	}
-	if len(conflicts) == 0 {
+	if len(mismatches) == 0 {
 		return nil
 	}
-	details := make([]string, 0, len(conflicts))
-	for _, conflict := range conflicts {
-		details = append(details, conflict.DetailString())
+	details := make([]string, 0, len(mismatches))
+	for _, mismatch := range mismatches {
+		details = append(details, mismatch.DetailString())
 	}
-	return fmt.Errorf("active run bundle availability conflict: boot bundle %s cannot resume %d active run(s): %s", bootFingerprint, len(conflicts), strings.Join(details, "; "))
+	return fmt.Errorf("active run pinned bundle_hash conflict: DB-loaded serve bundle_hash %s cannot resume %d active run(s) with different bundle_hash: %s", pinnedBundleHash, len(mismatches), strings.Join(details, "; "))
+}
+
+func activeRunPinnedBundleHashConflicts(ctx context.Context, pg *store.PostgresStore, pinnedBundleHash string) ([]runbundle.Availability, error) {
+	pinnedBundleHash = strings.TrimSpace(pinnedBundleHash)
+	if pinnedBundleHash == "" {
+		return nil, nil
+	}
+	availabilities, err := pg.ActiveRunBundleAvailabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conflicts := make([]runbundle.Availability, 0, len(availabilities))
+	for _, availability := range availabilities {
+		if !availability.Available() {
+			continue
+		}
+		if strings.TrimSpace(availability.BundleHash) != pinnedBundleHash {
+			conflicts = append(conflicts, availability)
+		}
+	}
+	return conflicts, nil
 }
 
 func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
@@ -1965,6 +2155,14 @@ func newSwarmWorkflowModule(repoRoot, contractsRoot, platformSpecPath string) (r
 	if err != nil {
 		return nil, nil, err
 	}
+	module, _, err := newSwarmWorkflowModuleForBundle(bundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	return module, bundle, nil
+}
+
+func newSwarmWorkflowModuleForBundle(bundle *runtimecontracts.WorkflowContractBundle) (runtimepipeline.WorkflowModule, semanticview.Source, error) {
 	source := semanticview.Wrap(bundle)
 	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
 	if err != nil {
@@ -1981,7 +2179,7 @@ func newSwarmWorkflowModule(repoRoot, contractsRoot, platformSpecPath string) (r
 		nodes:          nodes,
 		guardRegistry:  runtimepipeline.NewContractGuardRegistry(source),
 		actionRegistry: runtimepipeline.NewContractActionRegistry(source),
-	}, bundle, nil
+	}, source, nil
 }
 
 func (m *swarmWorkflowModule) SemanticSource() semanticview.Source { return m.source }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -313,7 +313,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -322,6 +322,87 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 		if strings.Contains(stdout.String(), notWant) {
 			t.Fatalf("serve help exposed unpromoted listener/topology flag %q:\n%s", notWant, stdout.String())
 		}
+	}
+}
+
+func TestCLI_ServeBundleHashValidationAndSerialScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantStderr string
+		wantHash   string
+	}{
+		{
+			name:       "blank bundle hash rejected",
+			args:       []string{"serve", "--bundle-hash", "  "},
+			wantCode:   2,
+			wantStderr: "--bundle-hash must be non-empty",
+		},
+		{
+			name:       "legacy fingerprint shape rejected",
+			args:       []string{"serve", "--bundle-hash", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			wantCode:   2,
+			wantStderr: "--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>",
+		},
+		{
+			name:       "contracts conflict rejected",
+			args:       []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--contracts", "contracts"},
+			wantCode:   2,
+			wantStderr: "--bundle-hash is mutually exclusive with --contracts",
+		},
+		{
+			name:       "dev conflict rejected",
+			args:       []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--dev"},
+			wantCode:   2,
+			wantStderr: "--bundle-hash is mutually exclusive with --dev",
+		},
+		{
+			name:       "sqlite conflict rejected",
+			args:       []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--store", "sqlite"},
+			wantCode:   2,
+			wantStderr: "--bundle-hash requires --store postgres",
+		},
+		{
+			name:     "canonical bundle hash accepted",
+			args:     []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:0"},
+			wantCode: 0,
+			wantHash: "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured serveOptions
+			called := false
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+				called = true
+				captured = serveOpts
+				return 0
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, opts)
+			if code != tc.wantCode {
+				t.Fatalf("serve code = %d, want %d\nstdout=%s\nstderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if tc.wantStderr != "" {
+				if !strings.Contains(stderr.String(), tc.wantStderr) {
+					t.Fatalf("serve stderr missing %q:\n%s", tc.wantStderr, stderr.String())
+				}
+				if called {
+					t.Fatal("serve runtime started despite invalid bundle hash configuration")
+				}
+				return
+			}
+			if !called {
+				t.Fatal("serve runtime was not called for valid bundle hash")
+			}
+			if captured.BundleHash != tc.wantHash {
+				t.Fatalf("BundleHash = %q, want %q", captured.BundleHash, tc.wantHash)
+			}
+		})
 	}
 }
 
@@ -1884,7 +1965,7 @@ func TestServeBundleMatchAdmissionRejectsActiveAvailabilityConflicts(t *testing.
 		t.Fatalf("seed active legacy run: %v", err)
 	}
 
-	err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true)
+	err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true, "")
 	if err == nil {
 		t.Fatal("enforceServeBundleMatchAdmission error = nil, want availability conflict")
 	}
@@ -1902,6 +1983,12 @@ func TestServeBundleMatchAdmissionRejectsActiveAvailabilityConflicts(t *testing.
 		if !strings.Contains(got, want) {
 			t.Fatalf("admission error = %q, want detail %q", got, want)
 		}
+	}
+
+	pinnedHash := "bundle-v1:sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	err = enforceServeBundleMatchAdmission(ctx, pg, pinnedHash, false, pinnedHash)
+	if err == nil || !strings.Contains(err.Error(), "active run bundle availability conflict") {
+		t.Fatalf("DB-loaded disabled legacy admission error = %v, want active availability conflict", err)
 	}
 }
 
@@ -1927,7 +2014,7 @@ func TestServeBundleMatchAdmissionAllowsPersistedPresentAndDisabled(t *testing.T
 	`, uuid.NewString(), persistedHash, uuid.NewString(), missingHash); err != nil {
 		t.Fatalf("seed persisted-present and completed-missing runs: %v", err)
 	}
-	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true); err != nil {
+	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, true, ""); err != nil {
 		t.Fatalf("enforceServeBundleMatchAdmission persisted-present/completed-missing: %v", err)
 	}
 
@@ -1937,8 +2024,175 @@ func TestServeBundleMatchAdmissionAllowsPersistedPresentAndDisabled(t *testing.T
 	`, uuid.NewString(), missingHash); err != nil {
 		t.Fatalf("seed disabled persisted-missing run: %v", err)
 	}
-	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, false); err != nil {
+	if err := enforceServeBundleMatchAdmission(ctx, pg, bootFingerprint, false, ""); err != nil {
 		t.Fatalf("enforceServeBundleMatchAdmission disabled: %v", err)
+	}
+}
+
+func TestServeBundleMatchAdmissionRejectsDifferentPersistedActiveRunInDBLoadedMode(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	pinnedHash := "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	otherHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	otherRunID := uuid.NewString()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES
+			($1, 'name: pinned', '{}'::jsonb),
+			($2, 'name: other', '{}'::jsonb)
+	`, pinnedHash, otherHash); err != nil {
+		t.Fatalf("seed bundle rows: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES
+			($1::uuid, 'running', $2, 'persisted', now()),
+			($3::uuid, 'paused', $4, 'persisted', now()),
+			($5::uuid, 'completed', $4, 'persisted', now())
+	`, uuid.NewString(), pinnedHash, otherRunID, otherHash, uuid.NewString()); err != nil {
+		t.Fatalf("seed active persisted runs: %v", err)
+	}
+
+	err := enforceServeBundleMatchAdmission(ctx, pg, pinnedHash, true, pinnedHash)
+	if err == nil {
+		t.Fatal("enforceServeBundleMatchAdmission error = nil, want pinned bundle_hash conflict")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"active run pinned bundle_hash conflict",
+		pinnedHash,
+		otherRunID,
+		otherHash,
+		"bundle_source=persisted",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("admission error = %q, want detail %q", got, want)
+		}
+	}
+
+	err = enforceServeBundleMatchAdmission(ctx, pg, pinnedHash, false, pinnedHash)
+	if err == nil || !strings.Contains(err.Error(), "active run pinned bundle_hash conflict") {
+		t.Fatalf("disabled legacy admission error = %v, want DB-loaded pinned conflict", err)
+	}
+}
+
+func TestDBLoadedServeRunForkAvailabilityFailsClosed(t *testing.T) {
+	hash := "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	runID := uuid.NewString()
+
+	availability, err := (dbLoadedServeRunForkAvailability{bundleHash: hash}).LoadRunBundleAvailability(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRunBundleAvailability: %v", err)
+	}
+	if !availability.Unavailable() {
+		t.Fatalf("availability = %#v, want unavailable", availability)
+	}
+	if availability.RunID != runID || availability.BundleHash != hash || availability.BundleSource != storerunlifecycle.BundleSourcePersisted {
+		t.Fatalf("availability = %#v, want DB-loaded persisted unavailable for %s", availability, hash)
+	}
+	if availability.Cause != "db_loaded_same_bundle_fork_split_to_1024" {
+		t.Fatalf("availability cause = %q", availability.Cause)
+	}
+}
+
+func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier12-runtime-tools", "test-flow-data-access"))
+	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	if _, err := pg.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+		ParsedJSON:  projection.ParsedJSON,
+		DataBlob:    projection.DataBlob,
+		Metadata:    projection.Metadata,
+	}); err != nil {
+		t.Fatalf("UpsertBundleCatalog: %v", err)
+	}
+	if _, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), storeBundle{}, projection.BundleHash); err == nil || !strings.Contains(err.Error(), "requires postgres bundle catalog store") {
+		t.Fatalf("loadServeRuntimeBundleFromCatalog without Postgres err = %v, want Postgres-only failure", err)
+	}
+
+	loaded, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), storeBundle{Postgres: pg}, projection.BundleHash)
+	if err != nil {
+		t.Fatalf("loadServeRuntimeBundleFromCatalog: %v", err)
+	}
+	defer func() {
+		if loaded.cleanup != nil {
+			if err := loaded.cleanup(); err != nil {
+				t.Fatalf("cleanup DB-loaded runtime source: %v", err)
+			}
+		}
+	}()
+
+	if !loaded.dbLoaded {
+		t.Fatal("dbLoaded = false, want true")
+	}
+	if loaded.serveIdentityDetail() != projection.BundleHash {
+		t.Fatalf("serve identity = %q, want bundle hash %q", loaded.serveIdentityDetail(), projection.BundleHash)
+	}
+	if loaded.bundleSourceFact.BundleHash != projection.BundleHash || loaded.bundleSourceFact.BundleSource != storerunlifecycle.BundleSourcePersisted {
+		t.Fatalf("bundle source fact = %#v, want persisted %s", loaded.bundleSourceFact, projection.BundleHash)
+	}
+	if strings.Contains(loaded.contractsRoot, filepath.Join("tests", "tier12-runtime-tools", "test-flow-data-access")) {
+		t.Fatalf("DB-loaded contracts root leaked local fixture path: %s", loaded.contractsRoot)
+	}
+	if _, err := os.Stat(filepath.Join(loaded.contractsRoot, "flows", "support", "data", "exclusions.yaml")); err != nil {
+		t.Fatalf("DB-loaded source missing reconstructed data file: %v", err)
+	}
+	prepared, err := prepareLoadedServeBundleSource(ctx, storeBundle{Postgres: pg}, loaded, false)
+	if err != nil {
+		t.Fatalf("prepareLoadedServeBundleSource: %v", err)
+	}
+	if prepared.BundleHash != projection.BundleHash || prepared.BundleSource != storerunlifecycle.BundleSourcePersisted {
+		t.Fatalf("prepared source fact = %#v, want persisted %s", prepared, projection.BundleHash)
+	}
+	if _, err := prepareLoadedServeBundleSource(ctx, storeBundle{Postgres: pg}, loaded, true); err == nil || !strings.Contains(err.Error(), "--bundle-hash is mutually exclusive with --dev") {
+		t.Fatalf("prepareLoadedServeBundleSource dev error = %v", err)
+	}
+}
+
+func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
+	_, _, _ = installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	missingHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:         writeServeRuntimeTestConfig(t),
+		BundleHash:         missingHash,
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: true,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{
+		"bundle_hash=" + missingHash,
+		"BUNDLE_UNAVAILABLE",
+		"bundle_hash " + missingHash + " is not present in bundles",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "ready                      ok") || strings.Contains(out.String(), "[22/22]") {
+		t.Fatalf("serve reached readiness after missing DB-loaded bundle:\n%s", out.String())
 	}
 }
 

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -5497,10 +5497,12 @@ multi_bundle_persistence:
     canonical_hash_first_slice: '#979 / PR #1033'
     bundle_hash_naming: '#1001'
     run_fork_cli_authority_absorbed_from: '#1038'
+    serve_db_loaded_runtime_source: '#1020'
   authority_rule: >
     This section is the merge-bearing source authority for multi-bundle persistence, bundle identity, bundle-aware
     resume/delete/fork semantics, planned bundle API methods, and planned CLI command shape. The draft is now evidence
-    only. Database foundation, read-only bundle catalog APIs, and supported local serve ingest/source stamping now have
+    only. Database foundation, read-only bundle catalog APIs, supported local serve ingest/source stamping, and serial
+    Postgres-backed `swarm serve --bundle-hash` DB-loaded boot now have
     promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
     generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
@@ -5648,9 +5650,11 @@ multi_bundle_persistence:
     live_schema_boundary: >
       platform_tables.tables is the current runtime DDL source. #1013 promotes the bundles table and
       runs.bundle_hash/runs.bundle_source into the live schema foundation. Serve ingest/source stamping for local
-      `swarm serve --contracts` is promoted by multi_bundle_persistence.persistence_model.serve_ingest_projection.
-      Reader migration, API routing, CLI/fork behavior, delete/runtime cleanup, and public dual-accept naming remain
-      separately gated implementation work unless a later PR explicitly promotes and proves them.
+      `swarm serve --contracts` is promoted by multi_bundle_persistence.persistence_model.serve_ingest_projection;
+      serial Postgres-backed `swarm serve --bundle-hash` boot is promoted by
+      multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source. Reader migration, API routing,
+      CLI/fork behavior beyond this serve flag, delete/runtime cleanup, multi-bundle concurrency, and public
+      dual-accept naming remain separately gated implementation work unless a later PR explicitly promotes and proves them.
     bundles_table:
       planned_live_owner_after_migration: platform_tables.tables.bundles
       primary_key: bundle_hash
@@ -5707,6 +5711,29 @@ multi_bundle_persistence:
         - New-work routing and bundle_hash admission remain #1022.
         - Bundle register/delete APIs remain #1017/#1018/#1019.
         - SQLite runtime support remains blocked by #1087/#1088 unless separately gated.
+    serve_db_loaded_runtime_source:
+      status: implemented_for_serial_postgres_serve_bundle_hash
+      cli_flag: 'swarm serve --bundle-hash <bundle-v1:sha256:<64 lowercase hex>>'
+      canonical_store_owner: internal/store.PostgresStore.LoadBundleCatalogRuntimeRecord
+      runtime_source_owner: internal/runtime/contracts.LoadBundleCatalogRuntimeSource
+      serve_boot_owner: cmd/swarm.loadServeRuntimeBundleFromCatalog
+      source_fact_owner: cmd/swarm.prepareLoadedServeBundleSource
+      source_replacement_guard: cmd/swarm.runtimeProjectSupervisor.DisableSourceReplacement
+      supported_surface:
+        - Exactly one canonical bundle_hash is pinned for the process. The flag is mutually exclusive with --contracts and --dev.
+        - The mode is Postgres-only. SQLite, no-store, missing store, missing bundle row, malformed archive, missing bytes, hash mismatch, and noncanonical hash fail closed before runtime readiness.
+        - The runtime loader consumes stored bundles.content_yaml and raw bundles.data_blob bytes only; parsed_json is inspection output and is never a runtime source.
+        - The loader reconstructs platform spec, contract definition files, prompts, and flow data/ raw bytes into a process-owned temporary source, then recomputes BundleHash and requires it to equal the requested bundle_hash before runtime construction.
+        - Every run writer reachable under the booted runtime consumes BundleSourceFact with bundle_source=persisted and bundle_hash equal to the requested canonical hash.
+        - Runtime project OpenProject/ReloadProject source replacement is disabled while the process is pinned to a DB-loaded bundle source.
+        - External executable code, tools, container images, credentials, and host environment dependencies remain environment-owned and are not stored in the bundles row.
+      split_boundaries:
+        - Parallel multi-bundle runtime contexts and dispatcher/store isolation remain #981.
+        - Same-bundle selected-contract fork execution from DB bytes remains #1024.
+        - Cross-bundle fork routing remains #976.
+        - Create-new-work bundle_hash routing/admission remains #1022.
+        - Bundle CLI inventory and swarm fork consumers remain #1023/#989.
+        - Delete/runtime.nuke/lifecycle cleanup remains #987/#988/#998/#1008/#1009.
     runs_table:
       planned_live_owner_after_migration: platform_tables.tables.runs
       promoted_fields:
@@ -5895,7 +5922,7 @@ multi_bundle_persistence:
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
   cli_surface:
-    publication_status: source_authority_not_implemented_until_cli_api_runtime_children
+    publication_status: partial_runtime_serve_bundle_hash_implemented_other_cli_children_pending
     bundle_commands_planned:
       - swarm bundle list
       - swarm bundle show <bundle-hash>
@@ -5903,7 +5930,7 @@ multi_bundle_persistence:
       - swarm bundle register <path-or-archive>
       - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     modified_commands_planned:
-      - swarm serve --bundle-hash <bundle_hash>
+      - swarm serve --bundle-hash <bundle_hash> (implemented serial Postgres DB-loaded process mode)
       - swarm serve --dev
       - swarm agents list --run-id <run-id>
       - swarm event publish <event-name> --bundle-hash <bundle_hash>
@@ -5949,7 +5976,17 @@ multi_bundle_persistence:
       reason: Forced bundle.delete preservation cleanup, mutex, quiescence, delivery/session/timer/container cleanup, and result projection are destructive-runtime implementation.
     serve_db_loaded_bundle:
       tracker: '#1020'
-      reason: swarm serve --bundle-hash DB-loaded YAML/data runtime boot mode is serve/runtime implementation and may depend on #981.
+      implementation_status: serial_postgres_single_bundle_process_promoted
+      runtime_owners:
+        - internal/store.PostgresStore.LoadBundleCatalogRuntimeRecord
+        - internal/runtime/contracts.LoadBundleCatalogRuntimeSource
+        - cmd/swarm.loadServeRuntimeBundleFromCatalog
+        - cmd/swarm.prepareLoadedServeBundleSource
+        - cmd/swarm.runtimeProjectSupervisor.DisableSourceReplacement
+      reason: >
+        swarm serve --bundle-hash DB-loaded YAML/data runtime boot mode is implemented for one canonical
+        Postgres-backed bundle_hash per process. Multi-bundle runtime concurrency and selected-contract fork
+        reuse remain split to #981/#1024.
     bundle_safe_list_read_scoping:
       tracker: '#1021'
       reason: agent/event/run/log/incident read/list method scoping and generated OpenRPC shape are API read-model implementation.

--- a/internal/runtime/contracts/bundle_catalog_projection.go
+++ b/internal/runtime/contracts/bundle_catalog_projection.go
@@ -20,9 +20,9 @@ type BundleCatalogProjection struct {
 }
 
 type bundleCatalogProjectedFile struct {
-	Label     string
-	Policy    string
-	SizeBytes int
+	Label     string `json:"label" yaml:"label"`
+	Policy    string `json:"policy" yaml:"policy"`
+	SizeBytes int    `json:"size_bytes" yaml:"size_bytes"`
 }
 
 type bundleCatalogDataArchive struct {
@@ -31,9 +31,9 @@ type bundleCatalogDataArchive struct {
 }
 
 type bundleCatalogDataEntry struct {
-	Label         string `json:"label"`
-	SizeBytes     int    `json:"size_bytes"`
-	ContentBase64 string `json:"content_base64"`
+	Label         string `json:"label" yaml:"label"`
+	SizeBytes     int    `json:"size_bytes" yaml:"size_bytes"`
+	ContentBase64 string `json:"content_base64" yaml:"content_base64"`
 }
 
 // BuildBundleCatalogProjection is the serve-ingest owner for persisted bundle

--- a/internal/runtime/contracts/bundle_catalog_runtime_loader.go
+++ b/internal/runtime/contracts/bundle_catalog_runtime_loader.go
@@ -1,0 +1,252 @@
+package contracts
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type BundleCatalogRuntimeLoadRequest struct {
+	BundleHash  string
+	ContentYAML string
+	DataBlob    []byte
+}
+
+type BundleCatalogRuntimeSource struct {
+	BundleHash       string
+	ContractsRoot    string
+	PlatformSpecPath string
+	Bundle           *WorkflowContractBundle
+	tempRoot         string
+}
+
+type bundleCatalogContentArchive struct {
+	ProjectionVersion string                       `yaml:"projection_version"`
+	Files             []bundleCatalogDataEntry     `yaml:"files"`
+	CanonicalInputs   []bundleCatalogProjectedFile `yaml:"canonical_inputs"`
+}
+
+// LoadBundleCatalogRuntimeSource reconstructs a runtime-loadable bundle from a
+// persisted bundle catalog row. The stored archives remain the canonical source
+// bytes; parsed_json is intentionally not accepted as runtime authority.
+func LoadBundleCatalogRuntimeSource(repoRoot string, req BundleCatalogRuntimeLoadRequest) (BundleCatalogRuntimeSource, error) {
+	req.BundleHash = strings.TrimSpace(req.BundleHash)
+	if err := ValidateBundleHash(req.BundleHash); err != nil {
+		return BundleCatalogRuntimeSource{}, err
+	}
+	content, err := decodeBundleCatalogContentArchive(req.ContentYAML)
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, err
+	}
+	dataEntries, err := decodeBundleCatalogRuntimeDataBlob(req.DataBlob)
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, err
+	}
+	files, err := bundleCatalogRuntimeFiles(content, dataEntries)
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, err
+	}
+
+	tempRoot, err := os.MkdirTemp("", "swarm-bundle-catalog-*")
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("create bundle catalog runtime root: %w", err)
+	}
+	if err := os.Chmod(tempRoot, 0o755); err != nil {
+		_ = os.RemoveAll(tempRoot)
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("make bundle catalog runtime root readable: %w", err)
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			_ = os.RemoveAll(tempRoot)
+		}
+	}()
+
+	contractsRoot := filepath.Join(tempRoot, "contracts")
+	platformSpecPath := filepath.Join(tempRoot, "platform", "platform-spec.yaml")
+	if err := materializeBundleCatalogRuntimeFiles(tempRoot, files); err != nil {
+		return BundleCatalogRuntimeSource{}, err
+	}
+	if _, err := os.Stat(filepath.Join(contractsRoot, "package.yaml")); err != nil {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("bundle catalog runtime source missing bundle/package.yaml: %w", err)
+	}
+	if _, err := os.Stat(platformSpecPath); err != nil {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("bundle catalog runtime source missing platform/platform-spec.yaml: %w", err)
+	}
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, contractsRoot, platformSpecPath)
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("load bundle catalog runtime source: %w", err)
+	}
+	gotHash, err := BundleHash(bundle)
+	if err != nil {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("verify bundle catalog runtime hash: %w", err)
+	}
+	if gotHash != req.BundleHash {
+		return BundleCatalogRuntimeSource{}, fmt.Errorf("bundle catalog runtime hash mismatch: reconstructed %s, requested %s", gotHash, req.BundleHash)
+	}
+
+	cleanupOnError = false
+	return BundleCatalogRuntimeSource{
+		BundleHash:       req.BundleHash,
+		ContractsRoot:    contractsRoot,
+		PlatformSpecPath: platformSpecPath,
+		Bundle:           bundle,
+		tempRoot:         tempRoot,
+	}, nil
+}
+
+func (s BundleCatalogRuntimeSource) Cleanup() error {
+	if strings.TrimSpace(s.tempRoot) == "" {
+		return nil
+	}
+	return os.RemoveAll(s.tempRoot)
+}
+
+func decodeBundleCatalogContentArchive(contentYAML string) (bundleCatalogContentArchive, error) {
+	contentYAML = strings.TrimSpace(contentYAML)
+	if contentYAML == "" {
+		return bundleCatalogContentArchive{}, fmt.Errorf("bundle catalog content_yaml is required")
+	}
+	var archive bundleCatalogContentArchive
+	if err := yaml.Unmarshal([]byte(contentYAML), &archive); err != nil {
+		return bundleCatalogContentArchive{}, fmt.Errorf("decode bundle catalog content_yaml: %w", err)
+	}
+	if strings.TrimSpace(archive.ProjectionVersion) != bundleCatalogProjectionVersion {
+		return bundleCatalogContentArchive{}, fmt.Errorf("bundle catalog content_yaml projection_version = %q, want %q", archive.ProjectionVersion, bundleCatalogProjectionVersion)
+	}
+	if len(archive.CanonicalInputs) == 0 {
+		return bundleCatalogContentArchive{}, fmt.Errorf("bundle catalog content_yaml canonical_inputs is empty")
+	}
+	return archive, nil
+}
+
+func decodeBundleCatalogRuntimeDataBlob(dataBlob []byte) ([]bundleCatalogDataEntry, error) {
+	if len(dataBlob) == 0 {
+		return nil, nil
+	}
+	var archive bundleCatalogDataArchive
+	if err := json.Unmarshal(dataBlob, &archive); err != nil {
+		return nil, fmt.Errorf("decode bundle catalog data_blob: %w", err)
+	}
+	if strings.TrimSpace(archive.ProjectionVersion) != bundleCatalogProjectionVersion {
+		return nil, fmt.Errorf("bundle catalog data_blob projection_version = %q, want %q", archive.ProjectionVersion, bundleCatalogProjectionVersion)
+	}
+	return archive.Entries, nil
+}
+
+func bundleCatalogRuntimeFiles(content bundleCatalogContentArchive, dataEntries []bundleCatalogDataEntry) (map[string][]byte, error) {
+	inputs := make(map[string]bundleCatalogProjectedFile, len(content.CanonicalInputs))
+	for _, input := range content.CanonicalInputs {
+		input.Label = strings.TrimSpace(input.Label)
+		input.Policy = strings.TrimSpace(input.Policy)
+		if err := validateBundleCatalogRuntimeInput(input); err != nil {
+			return nil, err
+		}
+		if _, exists := inputs[input.Label]; exists {
+			return nil, fmt.Errorf("duplicate bundle catalog canonical input %q", input.Label)
+		}
+		inputs[input.Label] = input
+	}
+
+	files := make(map[string][]byte, len(inputs))
+	if err := appendBundleCatalogRuntimeEntries(files, inputs, content.Files, false); err != nil {
+		return nil, err
+	}
+	if err := appendBundleCatalogRuntimeEntries(files, inputs, dataEntries, true); err != nil {
+		return nil, err
+	}
+
+	for label := range inputs {
+		if _, exists := files[label]; !exists {
+			return nil, fmt.Errorf("bundle catalog runtime source missing canonical input %q", label)
+		}
+	}
+	return files, nil
+}
+
+func validateBundleCatalogRuntimeInput(input bundleCatalogProjectedFile) error {
+	if err := validateBundleHashLabel(input.Label); err != nil {
+		return err
+	}
+	switch input.Policy {
+	case "yaml", "prompt_text", "raw_data":
+	default:
+		return fmt.Errorf("bundle catalog canonical input %q has unsupported policy %q", input.Label, input.Policy)
+	}
+	if input.SizeBytes < 0 {
+		return fmt.Errorf("bundle catalog canonical input %q has negative size", input.Label)
+	}
+	return nil
+}
+
+func appendBundleCatalogRuntimeEntries(files map[string][]byte, inputs map[string]bundleCatalogProjectedFile, entries []bundleCatalogDataEntry, wantRaw bool) error {
+	for _, entry := range entries {
+		label := strings.TrimSpace(entry.Label)
+		input, exists := inputs[label]
+		if !exists {
+			return fmt.Errorf("bundle catalog runtime entry %q is not listed in canonical_inputs", label)
+		}
+		isRaw := input.Policy == "raw_data"
+		if wantRaw != isRaw {
+			return fmt.Errorf("bundle catalog runtime entry %q stored in wrong archive for policy %q", label, input.Policy)
+		}
+		if _, duplicate := files[label]; duplicate {
+			return fmt.Errorf("duplicate bundle catalog runtime entry %q", label)
+		}
+		content, err := base64.StdEncoding.DecodeString(strings.TrimSpace(entry.ContentBase64))
+		if err != nil {
+			return fmt.Errorf("decode bundle catalog runtime entry %q: %w", label, err)
+		}
+		if entry.SizeBytes != len(content) || input.SizeBytes != len(content) {
+			return fmt.Errorf("bundle catalog runtime entry %q size mismatch: entry=%d canonical=%d decoded=%d", label, entry.SizeBytes, input.SizeBytes, len(content))
+		}
+		files[label] = content
+	}
+	return nil
+}
+
+func materializeBundleCatalogRuntimeFiles(tempRoot string, files map[string][]byte) error {
+	labels := make([]string, 0, len(files))
+	for label := range files {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		target, err := bundleCatalogRuntimeFilePath(tempRoot, label)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create bundle catalog runtime dir for %s: %w", label, err)
+		}
+		if err := os.WriteFile(target, files[label], 0o644); err != nil {
+			return fmt.Errorf("write bundle catalog runtime file %s: %w", label, err)
+		}
+	}
+	return nil
+}
+
+func bundleCatalogRuntimeFilePath(tempRoot, label string) (string, error) {
+	if err := validateBundleHashLabel(label); err != nil {
+		return "", err
+	}
+	switch {
+	case label == "platform/platform-spec.yaml":
+		return filepath.Join(tempRoot, "platform", "platform-spec.yaml"), nil
+	case strings.HasPrefix(label, "bundle/"):
+		rel := strings.TrimPrefix(label, "bundle/")
+		if rel == "" {
+			return "", fmt.Errorf("bundle catalog runtime label %q has empty bundle path", label)
+		}
+		return filepath.Join(tempRoot, "contracts", filepath.FromSlash(rel)), nil
+	default:
+		return "", fmt.Errorf("bundle catalog runtime label %q is outside supported platform/bundle namespaces", label)
+	}
+}

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -27,7 +27,10 @@ const (
 	bundleHashV1Prelude = "swarm-bundle-hash-v1\n"
 )
 
-var yamlJSONNumberPattern = regexp.MustCompile(`^-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?$`)
+var (
+	bundleHashV1Pattern   = regexp.MustCompile(`^bundle-v1:sha256:[0-9a-f]{64}$`)
+	yamlJSONNumberPattern = regexp.MustCompile(`^-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?$`)
+)
 
 type bundleHashContentPolicy int
 
@@ -79,6 +82,20 @@ func BundleHash(bundle *WorkflowContractBundle) (string, error) {
 		hasher.Write(content)
 	}
 	return bundleHashV1Prefix + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func IsBundleHash(value string) bool {
+	return bundleHashV1Pattern.MatchString(strings.TrimSpace(value))
+}
+
+func ValidateBundleHash(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("bundle_hash must be non-empty")
+	}
+	if !IsBundleHash(value) {
+		return fmt.Errorf("bundle_hash must be bundle-v1:sha256:<64 lowercase hex>")
+	}
+	return nil
 }
 
 func bundleHashEntries(bundle *WorkflowContractBundle) ([]bundleHashEntry, error) {

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -187,6 +187,100 @@ func TestBundleCatalogProjectionStableForEquivalentCanonicalContent(t *testing.T
 	}
 }
 
+func TestBundleCatalogRuntimeLoaderReconstructsConfigAndData(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	contractsRoot := filepath.Join(repo, "tests", "tier12-runtime-tools", "test-flow-data-access")
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, contractsRoot, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	projection, err := BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+
+	loaded, err := LoadBundleCatalogRuntimeSource(repo, BundleCatalogRuntimeLoadRequest{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+		DataBlob:    projection.DataBlob,
+	})
+	if err != nil {
+		t.Fatalf("LoadBundleCatalogRuntimeSource: %v", err)
+	}
+	defer loaded.Cleanup()
+
+	if loaded.BundleHash != projection.BundleHash {
+		t.Fatalf("loaded hash = %q, want %q", loaded.BundleHash, projection.BundleHash)
+	}
+	gotHash, err := BundleHash(loaded.Bundle)
+	if err != nil {
+		t.Fatalf("BundleHash(loaded): %v", err)
+	}
+	if gotHash != projection.BundleHash {
+		t.Fatalf("loaded BundleHash = %q, want %q", gotHash, projection.BundleHash)
+	}
+	if strings.Contains(loaded.ContractsRoot, contractsRoot) || strings.Contains(loaded.PlatformSpecPath, contractsRoot) {
+		t.Fatalf("loaded runtime source leaked original contracts path: root=%s platform=%s", loaded.ContractsRoot, loaded.PlatformSpecPath)
+	}
+	dataPath := filepath.Join(loaded.ContractsRoot, "flows", "support", "data", "exclusions.yaml")
+	data, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("read reconstructed data file: %v", err)
+	}
+	if !bytes.Contains(data, []byte("unmanaged-host-file-reads")) {
+		t.Fatalf("reconstructed data file = %q", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(loaded.ContractsRoot, "expected.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("non-canonical fixture file was materialized, err=%v", err)
+	}
+	for _, check := range []struct {
+		path string
+		mode os.FileMode
+	}{
+		{path: filepath.Dir(loaded.ContractsRoot), mode: 0o755},
+		{path: loaded.ContractsRoot, mode: 0o755},
+		{path: dataPath, mode: 0o644},
+	} {
+		info, err := os.Stat(check.path)
+		if err != nil {
+			t.Fatalf("stat reconstructed source path %s: %v", check.path, err)
+		}
+		if got := info.Mode().Perm(); got != check.mode {
+			t.Fatalf("mode for %s = %o, want %o", check.path, got, check.mode)
+		}
+	}
+}
+
+func TestBundleCatalogRuntimeLoaderFailsClosedForMissingDataOrHashMismatch(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	contractsRoot := filepath.Join(repo, "tests", "tier12-runtime-tools", "test-flow-data-access")
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, contractsRoot, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	projection, err := BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+
+	_, err = LoadBundleCatalogRuntimeSource(repo, BundleCatalogRuntimeLoadRequest{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing canonical input") {
+		t.Fatalf("missing data_blob error = %v, want missing canonical input", err)
+	}
+
+	_, err = LoadBundleCatalogRuntimeSource(repo, BundleCatalogRuntimeLoadRequest{
+		BundleHash:  "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ContentYAML: projection.ContentYAML,
+		DataBlob:    projection.DataBlob,
+	})
+	if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("hash mismatch error = %v, want hash mismatch", err)
+	}
+}
+
 func TestBundleHashV1PromptPreservesTrailingWhitespace(t *testing.T) {
 	rootA, platformA := writeEquivalentBundleHashFixture(t, "\n", "name: prompt-space\nversion: \"1.0.0\"\nflows: []\n")
 	rootB, platformB := writeEquivalentBundleHashFixture(t, "\n", "name: prompt-space\nversion: \"1.0.0\"\nflows: []\n")

--- a/internal/store/bundle_catalog_read_surface.go
+++ b/internal/store/bundle_catalog_read_surface.go
@@ -44,6 +44,12 @@ type BundleCatalogDetail struct {
 	IngestedAt    time.Time      `json:"ingested_at"`
 }
 
+type BundleCatalogRuntimeRecord struct {
+	BundleHash  string
+	ContentYAML string
+	DataBlob    []byte
+}
+
 type BundleCatalogAgentsResult struct {
 	Agents []BundleCatalogAgentDefinition `json:"agents"`
 }
@@ -199,6 +205,39 @@ func (s *PostgresStore) LoadBundleCatalog(ctx context.Context, bundleHash string
 		return BundleCatalogDetail{}, err
 	}
 	return scanned.toDetail()
+}
+
+func (s *PostgresStore) LoadBundleCatalogRuntimeRecord(ctx context.Context, bundleHash string) (BundleCatalogRuntimeRecord, error) {
+	if err := s.requireBundleCatalogCapabilities(ctx); err != nil {
+		return BundleCatalogRuntimeRecord{}, err
+	}
+	bundleHash = strings.TrimSpace(bundleHash)
+	if bundleHash == "" {
+		return BundleCatalogRuntimeRecord{}, ErrBundleNotFound
+	}
+	var out BundleCatalogRuntimeRecord
+	var dataBlob []byte
+	var hasData bool
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT
+			bundle_hash,
+			content_yaml,
+			COALESCE(data_blob, ''::bytea),
+			data_blob IS NOT NULL
+		FROM bundles
+		WHERE bundle_hash = $1
+	`, bundleHash).Scan(&out.BundleHash, &out.ContentYAML, &dataBlob, &hasData)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BundleCatalogRuntimeRecord{}, ErrBundleNotFound
+	}
+	if err != nil {
+		return BundleCatalogRuntimeRecord{}, fmt.Errorf("load bundle catalog runtime record: %w", err)
+	}
+	out.BundleHash = strings.TrimSpace(out.BundleHash)
+	if hasData {
+		out.DataBlob = append([]byte(nil), dataBlob...)
+	}
+	return out, nil
 }
 
 func (s *PostgresStore) ListBundleCatalogAgents(ctx context.Context, bundleHash string) (BundleCatalogAgentsResult, error) {

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -103,6 +103,22 @@ agents:
 	if agents.Agents[1].AgentID != "reviewer" || agents.Agents[1].FlowInstance != "review/primary" {
 		t.Fatalf("flow agent = %#v", agents.Agents[1])
 	}
+
+	runtimeRecord, err := pg.LoadBundleCatalogRuntimeRecord(ctx, newerHash)
+	if err != nil {
+		t.Fatalf("LoadBundleCatalogRuntimeRecord: %v", err)
+	}
+	if runtimeRecord.BundleHash != newerHash || runtimeRecord.ContentYAML != `name: newer` || string(runtimeRecord.DataBlob) != "blob" {
+		t.Fatalf("runtime record = %#v", runtimeRecord)
+	}
+
+	olderRuntimeRecord, err := pg.LoadBundleCatalogRuntimeRecord(ctx, olderHash)
+	if err != nil {
+		t.Fatalf("LoadBundleCatalogRuntimeRecord older: %v", err)
+	}
+	if olderRuntimeRecord.BundleHash != olderHash || olderRuntimeRecord.DataBlob != nil {
+		t.Fatalf("older runtime record = %#v, want nil data blob", olderRuntimeRecord)
+	}
 }
 
 func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.T) {
@@ -113,6 +129,9 @@ func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.
 	missingHash := "bundle-v1:sha256:9999999999999999999999999999999999999999999999999999999999999999"
 	if _, err := pg.LoadBundleCatalog(ctx, missingHash); !errors.Is(err, ErrBundleNotFound) {
 		t.Fatalf("LoadBundleCatalog missing error = %v, want ErrBundleNotFound", err)
+	}
+	if _, err := pg.LoadBundleCatalogRuntimeRecord(ctx, missingHash); !errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("LoadBundleCatalogRuntimeRecord missing error = %v, want ErrBundleNotFound", err)
 	}
 	if _, err := pg.ListBundleCatalog(ctx, BundleCatalogListOptions{Cursor: "not-a-cursor"}); !errors.Is(err, ErrInvalidBundleCatalogCursor) {
 		t.Fatalf("ListBundleCatalog invalid cursor error = %v, want ErrInvalidBundleCatalogCursor", err)


### PR DESCRIPTION
Closes #1020

## Summary
- Adds serial Postgres-backed `swarm serve --bundle-hash <bundle-v1:sha256:<64 lowercase hex>>` mode.
- Loads runtime bundle bytes from the persisted `bundles` row via stored `content_yaml` and raw `data_blob`, reconstructs a process-owned temp source, recomputes `BundleHash`, and fails closed on missing rows, malformed archives, missing bytes, hash mismatch, unsupported store, or noncanonical input.
- Stamps DB-loaded runtime work with `BundleSourceFact{bundle_source=persisted,bundle_hash=<requested>}` and disables builder source replacement while the process is pinned to the DB-loaded bundle.
- Ratifies the implemented governing rules in `platform-spec.yaml` under `multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source`.

## Governing Refs
- `platform-spec.yaml#multi_bundle_persistence.bundle_identity.canonicalization_v1`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.serve_ingest_projection`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source`
- #1020 Pre-Implementation Coverage Audit and independent gate outcome
- Prior source owners: #979 canonical BundleHash, #1013 schema foundation, #1014 reader migration, #1015 serve ingest/source stamping

## Semantic Migration
- New canonical owner: `internal/runtime/contracts.LoadBundleCatalogRuntimeSource` consumes stored `content_yaml` + raw `data_blob` as runtime authority for DB-loaded serve.
- Store read owner: `internal/store.PostgresStore.LoadBundleCatalogRuntimeRecord` returns only runtime-bearing catalog bytes, not `parsed_json`.
- Serve owner: `cmd/swarm.loadServeRuntimeBundleFromCatalog` and `cmd/swarm.prepareLoadedServeBundleSource` pin one persisted bundle hash per process and preserve run stamping through the existing source-fact path.
- Old producer/reader path now invalid for this surface: local `--contracts` filesystem loading, local ingest/upsert, `parsed_json`, legacy boot fingerprint comparison, and builder OpenProject/ReloadProject source replacement are not runtime authority in DB-loaded mode.
- Checked production paths for surviving old behavior: CLI validation, serve boot bundle loading, bundle catalog read surface, runtime source reconstruction, source fact preparation, run writer source fact path, startup availability admission, and builder source replacement.
- Migration completeness: complete for the approved serial Postgres single-bundle `swarm serve --bundle-hash` slice. Still split: #981 multi-bundle runtime contexts, #1024 same-bundle DB-loaded fork source, #976 cross-bundle fork, #1022 create-new-work bundle routing, #1023/#989 CLI/fork consumers, and delete/runtime cleanup trackers.

## Validation
- `go test ./internal/runtime/contracts -run 'TestBundleCatalogRuntimeLoader|TestBundleHashV1'`
- `go test ./internal/store -run 'TestBundleCatalogReadSurface|TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact'`
- `go test ./cmd/swarm -run 'TestCLI_ServeBundleHashValidationAndSerialScope|TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource|TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness|TestRuntimeProjectSupervisorOpenProjectFailsClosedWhenSourceReplacementDisabled'`
- `go test ./...`