### PR TITLE
[agent-g][issue #1147] Add SQLite pipeline replay owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -121,6 +121,7 @@ type storeBundle struct {
 	RuntimeBlocker      string
 	SchemaBootstrapper  store.SchemaBootstrapper
 	EventStore          runtimebus.EventStore
+	PipelineStore       *runtimepipeline.WorkflowInstanceStore
 	SessionRegistry     sessions.Registry
 	ConversationStore   runtimellm.ConversationPersistence
 	ManagerStore        runtimemanager.ManagerPersistence
@@ -139,6 +140,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		SQLDB:               s.RuntimeSQLDB,
 		ConstructionBlocker: s.RuntimeBlocker,
 		EventStore:          s.EventStore,
+		PipelineStore:       s.PipelineStore,
 		SessionRegistry:     s.SessionRegistry,
 		ConversationStore:   s.ConversationStore,
 		ManagerStore:        s.ManagerStore,
@@ -1844,6 +1846,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			RuntimeSQLDB:        pg.DB,
 			SchemaBootstrapper:  pg,
 			EventStore:          pg,
+			PipelineStore:       runtimepipeline.NewWorkflowInstanceStore(pg.DB),
 			SessionRegistry:     sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
 			ConversationStore:   pg,
 			ManagerStore:        pg,
@@ -1872,9 +1875,10 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (pipeline coordination/background nodes, budget tracking/spend ledger, tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
+			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (budget tracking/spend ledger, tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
+			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB),
 			SessionRegistry:     sqliteStore,
 			ConversationStore:   sqliteStore,
 			ManagerStore:        sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -181,7 +181,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -193,6 +193,12 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 gate-promoted raw-SQL consumers") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1087 raw-SQL consumer fail-closed blocker", runtimeStores.ConstructionBlocker)
+	}
+	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
+	}
+	if runtimeStores.PipelineStore == nil || !runtimeStores.PipelineStore.Enabled() {
+		t.Fatal("sqlite runtimeStores PipelineStore missing enabled backend-neutral pipeline owner")
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", path, err)

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2262,9 +2262,9 @@ engine:
           and observability semantics, but must not be treated as a construction-ready runtime backend while the #1087
           raw-SQL consumer blocker remains unresolved.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
-        - Must keep runtime construction fail-closed until pipeline coordination/background nodes, budget tracking/spend
-          ledger, tool-executor entity/human-task persistence and diagnostics, and runtime diagnostics/logging either gain
-          backend-neutral owners for SQLite or receive explicit lead-approved split/tracker repair.
+        - Must keep runtime construction fail-closed until budget tracking/spend ledger, tool-executor entity/human-task
+          persistence and diagnostics, and runtime diagnostics/logging either gain backend-neutral owners for SQLite or
+          receive explicit lead-approved split/tracker repair.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2290,6 +2290,18 @@ engine:
       postgres_owner: internal/store.PostgresStore schedule methods
       excludes:
       - cross-process timer claim/locking semantics owned by #1087
+    - name: pipeline_coordination_workflow_instance_and_replay_rows
+      owner: runtimepipeline.WorkflowInstanceStore consumed through runtime.Stores.PipelineStore and PipelineCoordinator
+      sqlite_owner: internal/runtime/pipeline.NewSQLiteWorkflowInstanceStore over the selected SQLite runtime store
+      postgres_owner: internal/runtime/pipeline.NewWorkflowInstanceStore over PostgresStore.DB
+      scope: >
+        SQLite supports explicit local-dev pipeline coordination for workflow instance state, pipeline engine transaction/query
+        persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
+        replay scope consumption. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
+      excludes:
+      - budget/spend ledger owned by #1148
+      - tool executor entity and human-task persistence/diagnostics owned by #1149
+      - runtime diagnostics/logging owned by #1150
     - name: mailbox_rows
       owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
       sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
@@ -2343,10 +2355,10 @@ engine:
       runtime_sql_handle_for_sqlite: omitted
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
-        accidentally treated as SQLite owners. Because pipeline coordination/background nodes, budget tracking/spend ledger,
-        tool-executor SQL diagnostics/entity helpers, and SQL runtime logging are still gate-promoted #1087 consumers,
-        runtime.NewRuntime must fail closed for SQLite until those consumers move to backend-neutral store owners or receive
-        explicit lead-approved split/tracker repair.
+        accidentally treated as SQLite owners. Because budget tracking/spend ledger, tool-executor SQL diagnostics/entity
+        helpers, and SQL runtime logging are still gate-promoted #1087 consumers, runtime.NewRuntime must fail closed for
+        SQLite until those consumers move to backend-neutral store owners or receive explicit lead-approved split/tracker
+        repair.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -66,6 +66,7 @@ type PipelineCoordinator struct {
 type PipelineCoordinatorOptions struct {
 	ShardPlanner            any
 	Module                  WorkflowModule
+	WorkflowStore           *WorkflowInstanceStore
 	InstanceActivator       FlowInstanceActivator
 	InstanceDeactivator     FlowInstanceDeactivator
 	TimerScheduler          *Scheduler
@@ -83,11 +84,15 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 	if module == nil {
 		panic("pipeline: workflow module is required")
 	}
+	workflowStore := opts.WorkflowStore
+	if workflowStore == nil {
+		workflowStore = NewWorkflowInstanceStore(db)
+	}
 	return &PipelineCoordinator{
 		bus:                     bus,
 		db:                      db,
 		module:                  module,
-		workflowStore:           NewWorkflowInstanceStore(db),
+		workflowStore:           workflowStore,
 		expressionEval:          newWorkflowExpressionEvaluator(),
 		instanceActivator:       opts.InstanceActivator,
 		instanceDeactivator:     opts.InstanceDeactivator,

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -27,6 +27,25 @@ func (s eventReceiptsCapabilityStub) resolve(context.Context) (bool, error) {
 	return s.enabled, s.err
 }
 
+type typedSystemNodeReceiptStore struct {
+	processed bool
+	marked    int
+}
+
+func (s *typedSystemNodeReceiptStore) SystemNodeProcessed(context.Context, string, string) (bool, error) {
+	return s.processed, nil
+}
+
+func (*typedSystemNodeReceiptStore) SystemNodeDeliveryQuiesced(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s *typedSystemNodeReceiptStore) MarkSystemNodeProcessedAndSettleDelivery(context.Context, string, string, string) error {
+	s.processed = true
+	s.marked++
+	return nil
+}
+
 func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := testPipelineRunContext(t, db)
@@ -285,6 +304,34 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 	}
 	if count != 1 {
 		t.Fatalf("event_receipts rows = %d, want 1", count)
+	}
+}
+
+func TestSystemNodeRunner_UsesTypedReceiptOwnerWithoutRawDB(t *testing.T) {
+	ctx := context.Background()
+	receipts := &typedSystemNodeReceiptStore{}
+	attempts := 0
+	runner := newSystemNodeRunnerWithReceiptStoreAndRetryBase("node-a", deadLetterTestBus{}, nil, receipts, func() []events.EventType {
+		return []events.EventType{"source.evt"}
+	}, func(context.Context, events.Event) error {
+		attempts++
+		return nil
+	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
+	evt := events.Event{
+		ID:        uuid.NewString(),
+		Type:      "source.evt",
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	runner.ProcessEventForTest(ctx, evt)
+	runner.ProcessEventForTest(ctx, evt)
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 after typed receipt owner marks processed", attempts)
+	}
+	if receipts.marked != 1 {
+		t.Fatalf("typed receipt marks = %d, want 1", receipts.marked)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -76,31 +76,16 @@ type pipelineEngineTx struct {
 func (t pipelineEngineTx) Context() context.Context { return t.ctx }
 
 type pipelineEngineTxRunner struct {
-	db *sql.DB
+	store Store
 }
 
 func (r pipelineEngineTxRunner) Run(ctx context.Context, fn func(runtimeengine.Tx) error) error {
-	if r.db == nil {
+	if r.store == nil || !r.store.Enabled() {
 		return fn(pipelineEngineTx{ctx: ctx})
 	}
-	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
-		return fn(pipelineEngineTx{ctx: ctx, tx: tx})
-	}
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	postCommit := make([]func(), 0, 4)
-	txctx := withPipelinePostCommitActions(withSQLTxContext(ctx, tx), &postCommit)
-	if err := fn(pipelineEngineTx{ctx: txctx, tx: tx}); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	flushPipelinePostCommitActions(postCommit)
-	return nil
+	return r.store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return fn(pipelineEngineTx{ctx: txctx, tx: tx})
+	})
 }
 
 type pipelineEngineLocker struct {
@@ -330,7 +315,7 @@ func newCoordinatorEngineEvaluator(pc *PipelineCoordinator) runtimeengine.Evalua
 }
 
 func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext, predicate string) (int, error) {
-	if e.coordinator == nil || e.coordinator.db == nil {
+	if e.coordinator == nil || e.coordinator.workflowStore == nil || !e.coordinator.workflowStore.Enabled() {
 		return 0, nil
 	}
 	parsed, err := parseWorkflowEntityQueryPredicate(predicate, ctx)
@@ -347,7 +332,7 @@ func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext,
 			return 0, err
 		}
 	}
-	return queryEntityStateCount(asString(ctx.Event["run_id"]), e.coordinator.db, e.coordinator.SemanticSource(), contract, parsed)
+	return e.coordinator.workflowStore.QueryEntityCount(context.Background(), asString(ctx.Event["run_id"]), e.coordinator.SemanticSource(), contract, parsed)
 }
 
 func queryEntityStateCount(runID string, db *sql.DB, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {
@@ -505,7 +490,7 @@ func coordinatorEngineDependencies(pc *PipelineCoordinator) runtimeengine.Runtim
 		Source:              source,
 		StateRepo:           pipelineEngineStateRepo{coordinator: pc},
 		EmitVerifier:        pipelineEngineStateRepo{coordinator: pc},
-		TxRunner:            pipelineEngineTxRunner{db: pc.db},
+		TxRunner:            pipelineEngineTxRunner{store: pc.workflowStore},
 		Locker:              pipelineEngineLocker{coordinator: pc},
 		Outbox:              outbox,
 		TimerApplier:        pipelineEngineTimerApplier{coordinator: pc},

--- a/internal/runtime/pipeline/node_background.go
+++ b/internal/runtime/pipeline/node_background.go
@@ -19,11 +19,15 @@ func newBackgroundWorkflowNode(executor WorkflowNodeExecutor, bus systemNodeBus,
 }
 
 func newBackgroundWorkflowNodeWithRetryBase(executor WorkflowNodeExecutor, bus systemNodeBus, db *sql.DB, eventReceiptsCapability func(context.Context) (bool, error), retryBase time.Duration) *backgroundWorkflowNode {
+	return newBackgroundWorkflowNodeWithReceiptStoreAndRetryBase(executor, bus, db, NewWorkflowInstanceStore(db), eventReceiptsCapability, retryBase)
+}
+
+func newBackgroundWorkflowNodeWithReceiptStoreAndRetryBase(executor WorkflowNodeExecutor, bus systemNodeBus, db *sql.DB, receiptStore SystemNodeReceiptPersistence, eventReceiptsCapability func(context.Context) (bool, error), retryBase time.Duration) *backgroundWorkflowNode {
 	if executor == nil || bus == nil {
 		return nil
 	}
 	node := &backgroundWorkflowNode{executor: executor}
-	node.runner = newSystemNodeRunnerWithRetryBase(executor.NodeID(), bus, db, executor.Subscriptions, func(ctx context.Context, evt events.Event) error {
+	node.runner = newSystemNodeRunnerWithReceiptStoreAndRetryBase(executor.NodeID(), bus, db, receiptStore, executor.Subscriptions, func(ctx context.Context, evt events.Event) error {
 		if handled := executor.Handle(ctx, evt); handled {
 			return nil
 		}

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -13,9 +13,7 @@ import (
 	"github.com/google/uuid"
 	"swarm/internal/events"
 	runtimedeadletters "swarm/internal/runtime/deadletters"
-	runtimedestructivereset "swarm/internal/runtime/destructivereset"
 	runtimerterr "swarm/internal/runtime/rterrors"
-	runtimerunquiescence "swarm/internal/runtime/runquiescence"
 )
 
 type systemNodeBus interface {
@@ -32,9 +30,10 @@ type systemNodeNormalRunCompletionConverger interface {
 }
 
 type systemNodeRunner struct {
-	nodeID string
-	bus    systemNodeBus
-	db     *sql.DB
+	nodeID       string
+	bus          systemNodeBus
+	db           *sql.DB
+	receiptStore SystemNodeReceiptPersistence
 
 	retryLimit int
 	backoffFn  func(int) time.Duration
@@ -55,6 +54,10 @@ func newSystemNodeRunner(nodeID string, bus systemNodeBus, db *sql.DB, subscript
 }
 
 func newSystemNodeRunnerWithRetryBase(nodeID string, bus systemNodeBus, db *sql.DB, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error, retryBase time.Duration, eventReceiptsCapability ...func(context.Context) (bool, error)) *systemNodeRunner {
+	return newSystemNodeRunnerWithReceiptStoreAndRetryBase(nodeID, bus, db, NewWorkflowInstanceStore(db), subscriptionsFn, handleFn, retryBase, eventReceiptsCapability...)
+}
+
+func newSystemNodeRunnerWithReceiptStoreAndRetryBase(nodeID string, bus systemNodeBus, db *sql.DB, receiptStore SystemNodeReceiptPersistence, subscriptionsFn func() []events.EventType, handleFn func(context.Context, events.Event) error, retryBase time.Duration, eventReceiptsCapability ...func(context.Context) (bool, error)) *systemNodeRunner {
 	nodeID = strings.TrimSpace(nodeID)
 	if nodeID == "" || bus == nil || handleFn == nil {
 		return nil
@@ -70,6 +73,7 @@ func newSystemNodeRunnerWithRetryBase(nodeID string, bus systemNodeBus, db *sql.
 		nodeID:                  nodeID,
 		bus:                     bus,
 		db:                      db,
+		receiptStore:            receiptStore,
 		retryLimit:              DefaultSystemNodeRetryLimit,
 		backoffFn:               func(attempt int) time.Duration { return defaultSystemNodeBackoff(retryBase, attempt) },
 		subscriptionsFn:         subscriptionsFn,
@@ -297,28 +301,19 @@ func isNonRetryableHandlerError(err error) bool {
 
 func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bool {
 	eventID := strings.TrimSpace(evt.ID)
-	if n == nil || n.db == nil || eventID == "" {
+	if n == nil || n.receiptStore == nil || eventID == "" {
 		return false
 	}
 	if !n.eventReceiptsAvailable(ctx) {
 		return false
 	}
-	var ok bool
-	err := n.db.QueryRowContext(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM event_receipts
-			WHERE subscriber_type = 'node'
-			  AND subscriber_id = $1
-			  AND idempotency_key = $2
-		)
-	`, strings.TrimSpace(n.nodeID), SystemNodeReceiptIdempotencyKey(n.nodeID, eventID)).Scan(&ok)
+	ok, err := n.receiptStore.SystemNodeProcessed(ctx, n.nodeID, eventID)
 	return err == nil && ok
 }
 
 func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) {
 	eventID := strings.TrimSpace(evt.ID)
-	if n == nil || n.db == nil || eventID == "" {
+	if n == nil || n.receiptStore == nil || eventID == "" {
 		return
 	}
 	if n.isActiveRunQuiesced(ctx, evt) {
@@ -348,7 +343,10 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 }
 
 func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID, sideEffects string) error {
-	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, n.db, n.nodeID, eventID, sideEffects)
+	if n == nil || n.receiptStore == nil {
+		return nil
+	}
+	return n.receiptStore.MarkSystemNodeProcessedAndSettleDelivery(ctx, n.nodeID, eventID, sideEffects)
 }
 
 func systemNodeProcessedReceiptSideEffects(nodeID, eventID string) string {
@@ -496,24 +494,13 @@ func (n *systemNodeRunner) convergeNormalRunCompletion(ctx context.Context, evt 
 
 func (n *systemNodeRunner) isActiveRunQuiesced(ctx context.Context, evt events.Event) bool {
 	eventID := strings.TrimSpace(evt.ID)
-	if n == nil || n.db == nil || eventID == "" {
+	if n == nil || n.receiptStore == nil || eventID == "" {
 		return false
 	}
 	if _, err := uuid.Parse(eventID); err != nil {
 		return false
 	}
-	var ok bool
-	err := n.db.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM event_deliveries
-			WHERE event_id = $1::uuid
-			  AND subscriber_type = 'node'
-			  AND subscriber_id = $2
-			  AND status = 'dead_letter'
-			  AND reason_code IN ($3, $4)
-		)
-	`, eventID, n.nodeID, runtimedestructivereset.QuiescenceReasonCode, runtimerunquiescence.ServeAbandonReasonCode).Scan(&ok)
+	ok, err := n.receiptStore.SystemNodeDeliveryQuiesced(ctx, n.nodeID, eventID)
 	if err != nil {
 		slog.Error("system node active run quiescence check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		return true
@@ -522,7 +509,7 @@ func (n *systemNodeRunner) isActiveRunQuiesced(ctx context.Context, evt events.E
 }
 
 func (n *systemNodeRunner) eventReceiptsAvailable(ctx context.Context) bool {
-	if n == nil || n.db == nil {
+	if n == nil || n.receiptStore == nil {
 		return false
 	}
 	n.receiptsMu.Lock()

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"time"
 
@@ -46,11 +47,24 @@ type WorkflowInstancePersistence interface {
 	Enabled() bool
 	Load(ctx context.Context, instanceID string) (WorkflowInstance, bool, error)
 	List(ctx context.Context) ([]WorkflowInstance, error)
+	SelectActiveByFields(ctx context.Context, scopeKey string, selectors []WorkflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error)
 	Create(ctx context.Context, instance WorkflowInstance) error
 	Upsert(ctx context.Context, instance WorkflowInstance) error
 	MarkTerminated(ctx context.Context, instanceID string, terminatedAt time.Time) error
 	Mutate(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error
 	Delete(ctx context.Context, instanceID string) error
+}
+
+type SystemNodeReceiptPersistence interface {
+	SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error)
+	SystemNodeDeliveryQuiesced(ctx context.Context, nodeID, eventID string) (bool, error)
+	MarkSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error
+}
+
+type Store interface {
+	WorkflowInstancePersistence
+	SystemNodeReceiptPersistence
+	RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error
 }
 
 type TransitionEvaluator interface {

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -1,0 +1,179 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
+	runtimerunquiescence "swarm/internal/runtime/runquiescence"
+)
+
+func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error) {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	if s.isSQLite() {
+		var ok bool
+		err := dbQueryRowContext(ctx, s.db, `
+			SELECT EXISTS(
+				SELECT 1
+				FROM event_receipts
+				WHERE subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND idempotency_key = ?
+			)
+		`, nodeID, SystemNodeReceiptIdempotencyKey(nodeID, eventID)).Scan(&ok)
+		return ok, err
+	}
+	var ok bool
+	err := dbQueryRowContext(ctx, s.db, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM event_receipts
+			WHERE subscriber_type = 'node'
+			  AND subscriber_id = $1
+			  AND idempotency_key = $2
+		)
+	`, nodeID, SystemNodeReceiptIdempotencyKey(nodeID, eventID)).Scan(&ok)
+	return ok, err
+}
+
+func (s *WorkflowInstanceStore) SystemNodeDeliveryQuiesced(ctx context.Context, nodeID, eventID string) (bool, error) {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	if _, err := uuid.Parse(eventID); err != nil {
+		return false, nil
+	}
+	if s.isSQLite() {
+		var ok bool
+		err := dbQueryRowContext(ctx, s.db, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM event_deliveries
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND status = 'dead_letter'
+				  AND reason_code IN (?, ?)
+			)
+		`, eventID, nodeID, runtimedestructivereset.QuiescenceReasonCode, runtimerunquiescence.ServeAbandonReasonCode).Scan(&ok)
+		return ok, err
+	}
+	var ok bool
+	err := dbQueryRowContext(ctx, s.db, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND status = 'dead_letter'
+			  AND reason_code IN ($3, $4)
+		)
+	`, eventID, nodeID, runtimedestructivereset.QuiescenceReasonCode, runtimerunquiescence.ServeAbandonReasonCode).Scan(&ok)
+	return ok, err
+}
+
+func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects)
+	}
+	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, s.db, nodeID, eventID, sideEffects)
+}
+
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, `
+			INSERT INTO event_receipts (
+				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+				outcome, reason_code, side_effects, idempotency_key, processed_at
+			)
+			SELECT
+				?, e.event_id, 'node', ?, e.entity_id, e.flow_instance,
+				'no_op', 'idempotent_no_op', ?, ?, ?
+			FROM events e
+			WHERE e.event_id = ?
+			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+				entity_id = excluded.entity_id,
+				flow_instance = excluded.flow_instance,
+				outcome = excluded.outcome,
+				reason_code = excluded.reason_code,
+				side_effects = excluded.side_effects,
+				idempotency_key = excluded.idempotency_key,
+				processed_at = excluded.processed_at
+		`, uuid.NewString(), nodeID, sqliteNodeJSON(sideEffects), SystemNodeReceiptIdempotencyKey(nodeID, eventID), now, eventID)
+		if err != nil {
+			return fmt.Errorf("upsert sqlite system node receipt: %w", err)
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+			return fmt.Errorf("upsert sqlite system node receipt: event %s not found", eventID)
+		}
+		res, err = tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'delivered',
+			    retry_count = COALESCE(retry_count, 0),
+			    reason_code = 'node_processed',
+			    last_error = NULL,
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+			  )
+		`, now, eventID, nodeID)
+		if err != nil {
+			return fmt.Errorf("settle sqlite system node delivery: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows > 0 {
+			return nil
+		}
+		if _, err := tx.ExecContext(txctx, `
+			INSERT INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count,
+				reason_code, last_error, active_session_id, started_at, delivered_at, created_at
+			)
+			SELECT
+				?, e.run_id, e.event_id, 'node', ?, 'delivered', 0,
+				'node_processed', NULL, NULL, ?, ?, ?
+			FROM events e
+			WHERE e.event_id = ?
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM event_deliveries d
+				WHERE d.event_id = e.event_id
+				  AND d.subscriber_type = 'node'
+				  AND d.subscriber_id = ?
+			  )
+		`, uuid.NewString(), nodeID, now, now, now, eventID, nodeID); err != nil {
+			return fmt.Errorf("insert sqlite settled system node delivery: %w", err)
+		}
+		return nil
+	})
+}
+
+func sqliteNodeJSON(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "{}"
+	}
+	return raw
+}

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -14,7 +14,9 @@ import (
 	"github.com/lib/pq"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
+	"swarm/internal/runtime/entityruntime"
 	runtimemutationlog "swarm/internal/runtime/mutationlog"
+	"swarm/internal/runtime/semanticview"
 )
 
 type SchedulePersistence interface {
@@ -90,13 +92,23 @@ type workflowInstancePersistedControl struct {
 }
 
 type WorkflowInstanceStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect workflowStoreDialect
 }
 
-type workflowInstanceFieldSelector struct {
+type WorkflowInstanceFieldSelector struct {
 	Field string
 	Value any
 }
+
+type workflowInstanceFieldSelector = WorkflowInstanceFieldSelector
+
+type workflowStoreDialect string
+
+const (
+	workflowStoreDialectPostgres workflowStoreDialect = "postgres"
+	workflowStoreDialectSQLite   workflowStoreDialect = "sqlite"
+)
 
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
@@ -109,7 +121,11 @@ type workflowCreateEntityInitialValues struct {
 }
 
 func NewWorkflowInstanceStore(db *sql.DB) *WorkflowInstanceStore {
-	return &WorkflowInstanceStore{db: db}
+	return &WorkflowInstanceStore{db: db, dialect: workflowStoreDialectPostgres}
+}
+
+func NewSQLiteWorkflowInstanceStore(db *sql.DB) *WorkflowInstanceStore {
+	return &WorkflowInstanceStore{db: db, dialect: workflowStoreDialectSQLite}
 }
 
 func withWorkflowCreateEntityInitialValues(ctx context.Context, fields map[string]any) context.Context {
@@ -142,6 +158,9 @@ func (s *WorkflowInstanceStore) Load(ctx context.Context, instanceID string) (Wo
 	if instanceID == "" || s == nil || s.db == nil {
 		return WorkflowInstance{}, false, nil
 	}
+	if s.isSQLite() {
+		return s.loadSQLite(ctx, instanceID)
+	}
 	keys := workflowInstanceLookupKeys(instanceID)
 	if len(keys) == 0 {
 		return WorkflowInstance{}, false, nil
@@ -153,12 +172,22 @@ func (s *WorkflowInstanceStore) List(ctx context.Context) ([]WorkflowInstance, e
 	if s == nil || s.db == nil {
 		return nil, nil
 	}
+	if s.isSQLite() {
+		return s.listSQLite(ctx)
+	}
 	return s.listSpec(ctx)
 }
 
 func (s *WorkflowInstanceStore) selectActiveByFields(ctx context.Context, scopeKey string, selectors []workflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error) {
+	return s.SelectActiveByFields(ctx, scopeKey, selectors, excludedStates)
+}
+
+func (s *WorkflowInstanceStore) SelectActiveByFields(ctx context.Context, scopeKey string, selectors []WorkflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error) {
 	if s == nil || s.db == nil {
 		return nil, nil
+	}
+	if s.isSQLite() {
+		return s.selectActiveByFieldsSQLite(ctx, scopeKey, selectors, excludedStates)
 	}
 	return s.selectActiveByFieldsSpec(ctx, scopeKey, selectors, excludedStates)
 }
@@ -166,6 +195,9 @@ func (s *WorkflowInstanceStore) selectActiveByFields(ctx context.Context, scopeK
 func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowInstance) error {
 	if s == nil || s.db == nil {
 		return nil
+	}
+	if s.isSQLite() {
+		return s.upsertSQLite(ctx, instance)
 	}
 	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
 	if err != nil {
@@ -180,6 +212,9 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 func (s *WorkflowInstanceStore) Create(ctx context.Context, instance WorkflowInstance) error {
 	if s == nil || s.db == nil {
 		return nil
+	}
+	if s.isSQLite() {
+		return s.createSQLite(ctx, instance)
 	}
 	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
 	if err != nil {
@@ -248,6 +283,9 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 	if instanceID == "" || s == nil || s.db == nil || fn == nil {
 		return nil
 	}
+	if s.isSQLite() {
+		return s.mutateSQLite(ctx, instanceID, fn)
+	}
 	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
 	if err != nil {
 		return err
@@ -287,6 +325,9 @@ func (s *WorkflowInstanceStore) Mutate(ctx context.Context, instanceID string, f
 func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error {
 	if s == nil || s.db == nil {
 		return nil
+	}
+	if s.isSQLite() {
+		return s.markTerminatedSQLite(ctx, storageRef, terminatedAt)
 	}
 	storageRef = strings.TrimSpace(storageRef)
 	if storageRef == "" {
@@ -334,6 +375,47 @@ func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef s
 
 func (s *WorkflowInstanceStore) Delete(context.Context, string) error {
 	return fmt.Errorf("workflow instance deletion is unsupported: entity_state writes must stay on the mutation-logged upsert path")
+}
+
+func (s *WorkflowInstanceStore) isSQLite() bool {
+	return s != nil && s.dialect == workflowStoreDialectSQLite
+}
+
+func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if s == nil || s.db == nil {
+		return fn(ctx, nil)
+	}
+	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
+		return fn(ctx, tx)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	postCommit := make([]func(), 0, 4)
+	txctx := withPipelinePostCommitActions(withSQLTxContext(ctx, tx), &postCommit)
+	if err := fn(txctx, tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	flushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+func (s *WorkflowInstanceStore) QueryEntityCount(ctx context.Context, runID string, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, nil
+	}
+	if s.isSQLite() {
+		return s.queryEntityStateCountSQLite(ctx, runID, source, contract, predicate)
+	}
+	return queryEntityStateCount(runID, s.db, source, contract, predicate)
 }
 
 func (s *WorkflowInstanceStore) loadSpec(ctx context.Context, keys []string, forUpdate bool) (WorkflowInstance, bool, error) {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -325,7 +325,15 @@ func (s *WorkflowInstanceStore) writeSQLite(ctx context.Context, rowID, storageR
 			Gates:        projection.GatesAny(),
 			Accumulator:  projection.Accumulator,
 		}
-		if err := insertSQLiteEntityStateDiff(txctx, tx, rowID, previous, afterProjection, runtimemutationlog.Writer{
+		previousForDiff := previous
+		if createInfo, ok := workflowCreateEntityInitialValuesFromContext(txctx); ok {
+			nextPrevious, err := insertSQLiteWorkflowCreateEntityInitialValueMutations(txctx, tx, rowID, previous, afterProjection, createInfo.Fields)
+			if err != nil {
+				return err
+			}
+			previousForDiff = nextPrevious
+		}
+		if err := insertSQLiteEntityStateDiff(txctx, tx, rowID, previousForDiff, afterProjection, runtimemutationlog.Writer{
 			Type:        "platform",
 			ID:          "workflow_instance_store",
 			HandlerStep: map[bool]string{true: "create", false: "upsert"}[createOnly],
@@ -514,30 +522,106 @@ func insertSQLiteEntityStateDiff(ctx context.Context, tx *sql.Tx, entityID strin
 	`, runID, time.Now().UTC()); err != nil {
 		return err
 	}
+	for _, rec := range records {
+		if err := insertSQLiteEntityMutationRecord(ctx, tx, runID, rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertSQLiteWorkflowCreateEntityInitialValueMutations(
+	ctx context.Context,
+	tx *sql.Tx,
+	entityID string,
+	before, after runtimemutationlog.EntityStateProjection,
+	initialValues map[string]any,
+) (runtimemutationlog.EntityStateProjection, error) {
+	if len(initialValues) == 0 {
+		return before, nil
+	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	adjusted := runtimemutationlog.EntityStateProjection{
+		CurrentState: before.CurrentState,
+		Fields:       cloneStringAnyMap(before.Fields),
+		Gates:        cloneStringAnyMap(before.Gates),
+		Accumulator:  cloneStringAnyMap(before.Accumulator),
+	}
+	if adjusted.Fields == nil {
+		adjusted.Fields = map[string]any{}
+	}
+	for field, declared := range initialValues {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		finalValue, ok := after.Fields[field]
+		oldValue, hadOld := adjusted.Fields[field]
+		if hadOld && workflowJSONValuesEqual(oldValue, declared) {
+			continue
+		}
+		if err := insertSQLiteEntityMutationRecord(ctx, tx, runID, runtimemutationlog.Record{
+			EntityID:    entityID,
+			Field:       field,
+			OldValue:    oldValueOrNil(oldValue, hadOld),
+			NewValue:    declared,
+			WriterType:  "platform",
+			WriterID:    "entity_initial_value",
+			HandlerStep: "create_entity",
+		}); err != nil {
+			return runtimemutationlog.EntityStateProjection{}, err
+		}
+		if ok && workflowJSONValuesEqual(finalValue, declared) {
+			adjusted.Fields[field] = declared
+			continue
+		}
+		adjusted.Fields[field] = declared
+	}
+	return adjusted, nil
+}
+
+func insertSQLiteEntityMutationRecord(ctx context.Context, tx *sql.Tx, runID string, rec runtimemutationlog.Record) error {
+	if tx == nil {
+		return runtimemutationlog.ErrInvalidMutationLogWriter("mutation log DB is required")
+	}
+	entityID := strings.TrimSpace(rec.EntityID)
+	field := strings.TrimSpace(rec.Field)
+	writerType := strings.TrimSpace(rec.WriterType)
+	writerID := strings.TrimSpace(rec.WriterID)
+	if entityID == "" || field == "" || writerType == "" || writerID == "" {
+		return runtimemutationlog.ErrInvalidMutationLogWriter("entity_id, field, writer_type, and writer_id are required")
+	}
+	oldValue, err := json.Marshal(rec.OldValue)
+	if err != nil {
+		return err
+	}
+	newValue, err := json.Marshal(rec.NewValue)
+	if err != nil {
+		return err
+	}
 	causedByEvent := ""
 	if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
 		if parsed := validSQLiteWorkflowUUID(inbound.ID); parsed != "" {
 			causedByEvent = parsed
 		}
 	}
-	for _, rec := range records {
-		oldValue, err := json.Marshal(rec.OldValue)
-		if err != nil {
-			return err
-		}
-		newValue, err := json.Marshal(rec.NewValue)
-		if err != nil {
-			return err
-		}
-		if _, err := tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 			INSERT INTO entity_mutations (
 				mutation_id, run_id, entity_id, field, old_value, new_value,
 				caused_by_event, writer_type, writer_id, handler_step, created_at
 			)
 			VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), ?)
-		`, uuid.NewString(), runID, entityID, rec.Field, string(oldValue), string(newValue), causedByEvent, rec.WriterType, rec.WriterID, strings.TrimSpace(rec.HandlerStep), time.Now().UTC()); err != nil {
-			return err
-		}
+	`, uuid.NewString(), runID, entityID, field, string(oldValue), string(newValue), causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep), time.Now().UTC()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -1,0 +1,700 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimecurrentstate "swarm/internal/runtime/currentstate"
+	"swarm/internal/runtime/entityruntime"
+	runtimemutationlog "swarm/internal/runtime/mutationlog"
+	"swarm/internal/runtime/semanticview"
+)
+
+func (s *WorkflowInstanceStore) loadSQLite(ctx context.Context, instanceID string) (WorkflowInstance, bool, error) {
+	keys := workflowInstanceLookupKeys(instanceID)
+	if len(keys) == 0 {
+		return WorkflowInstance{}, false, nil
+	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return WorkflowInstance{}, false, err
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(keys)), ",")
+	args := make([]any, 0, len(keys)+1)
+	for _, key := range keys {
+		args = append(args, key)
+	}
+	args = append(args, runID)
+	rows, err := dbQueryContext(ctx, s.db, `
+		SELECT
+			es.entity_id,
+			COALESCE(fi.flow_template, ''),
+			COALESCE(json_extract(fi.config, '$.workflow_version'), ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
+			es.current_state,
+			es.entered_state_at,
+			COALESCE(es.gates, '{}'),
+			COALESCE(es.fields, '{}'),
+			COALESCE(es.accumulator, '{}'),
+			COALESCE(fi.config, '{}'),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			es.slug,
+			es.name,
+			es.created_at,
+			es.updated_at
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.entity_id IN (`+placeholders+`)
+		  AND es.run_id = ?
+		ORDER BY es.created_at DESC, es.entity_id DESC
+		LIMIT 1
+	`, args...)
+	if err != nil {
+		return WorkflowInstance{}, false, err
+	}
+	defer rows.Close()
+	items, err := s.scanSQLiteWorkflowInstances(ctx, rows, runID)
+	if err != nil {
+		return WorkflowInstance{}, false, err
+	}
+	if len(items) == 0 {
+		return WorkflowInstance{}, false, nil
+	}
+	return items[0], true, nil
+}
+
+func (s *WorkflowInstanceStore) listSQLite(ctx context.Context) ([]WorkflowInstance, error) {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := dbQueryContext(ctx, s.db, `
+		SELECT
+			es.entity_id,
+			COALESCE(fi.flow_template, ''),
+			COALESCE(json_extract(fi.config, '$.workflow_version'), ''),
+			COALESCE(fi.status, ''),
+			fi.terminated_at,
+			es.current_state,
+			es.entered_state_at,
+			COALESCE(es.gates, '{}'),
+			COALESCE(es.fields, '{}'),
+			COALESCE(es.accumulator, '{}'),
+			COALESCE(fi.config, '{}'),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			es.slug,
+			es.name,
+			es.created_at,
+			es.updated_at
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = ?
+		ORDER BY es.created_at ASC
+	`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanSQLiteWorkflowInstances(ctx, rows, runID)
+}
+
+func (s *WorkflowInstanceStore) selectActiveByFieldsSQLite(ctx context.Context, scopeKey string, selectors []WorkflowInstanceFieldSelector, excludedStates []string) ([]WorkflowInstance, error) {
+	scopeKey = strings.Trim(strings.TrimSpace(scopeKey), "/")
+	if scopeKey == "" {
+		return nil, nil
+	}
+	selectors = normalizeWorkflowInstanceFieldSelectors(selectors)
+	if len(selectors) == 0 {
+		return nil, nil
+	}
+	items, err := s.listSQLite(ctx)
+	if err != nil {
+		return nil, err
+	}
+	terminalStates := map[string]struct{}{}
+	for _, state := range normalizeWorkflowInstanceExcludedStates(excludedStates) {
+		terminalStates[state] = struct{}{}
+	}
+	out := make([]WorkflowInstance, 0, len(items))
+	for _, item := range items {
+		storageRef := strings.Trim(strings.TrimSpace(item.StorageRef), "/")
+		if storageRef != scopeKey && !strings.HasPrefix(storageRef, scopeKey+"/") {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(item.Status), "terminated") || !item.TerminatedAt.IsZero() {
+			continue
+		}
+		if _, terminal := terminalStates[strings.ToLower(strings.TrimSpace(item.CurrentState))]; terminal {
+			continue
+		}
+		matches := true
+		for _, selector := range selectors {
+			value, ok := workflowMetadataValue(item.Metadata, selector.Field)
+			if !ok || !workflowJSONValuesEqual(value, selector.Value) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
+func (s *WorkflowInstanceStore) upsertSQLite(ctx context.Context, instance WorkflowInstance) error {
+	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.writeSQLite(ctx, identity.RowID(), identity.StorageRef, instance, false)
+}
+
+func (s *WorkflowInstanceStore) createSQLite(ctx context.Context, instance WorkflowInstance) error {
+	instance, identity, ok, err := normalizeWorkflowInstanceForPersistence(instance)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.writeSQLite(ctx, identity.RowID(), identity.StorageRef, instance, true)
+}
+
+func (s *WorkflowInstanceStore) mutateSQLite(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error {
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		instance, ok, err := s.loadSQLite(txctx, instanceID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			instance = WorkflowInstance{InstanceID: strings.TrimSpace(instanceID)}
+		}
+		fn(&instance)
+		return s.Upsert(txctx, instance)
+	})
+}
+
+func (s *WorkflowInstanceStore) markTerminatedSQLite(ctx context.Context, storageRef string, terminatedAt time.Time) error {
+	storageRef = strings.TrimSpace(storageRef)
+	if storageRef == "" {
+		return fmt.Errorf("workflow instance storage_ref is required")
+	}
+	if terminatedAt.IsZero() {
+		terminatedAt = time.Now().UTC()
+	}
+	res, err := dbExecContext(ctx, s.db, `
+		UPDATE flow_instances
+		SET status = 'terminated',
+		    terminated_at = COALESCE(terminated_at, ?)
+		WHERE instance_id = ?
+	`, terminatedAt.UTC(), storageRef)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("flow instance not found: %s", storageRef)
+	}
+	return nil
+}
+
+func (s *WorkflowInstanceStore) writeSQLite(ctx context.Context, rowID, storageRef string, instance WorkflowInstance, createOnly bool) error {
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return err
+	}
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		if createOnly {
+			exists, err := workflowInstanceSQLiteCreateTargetExists(txctx, tx, runID, rowID, storageRef)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return fmt.Errorf("flow instance already exists: %s", storageRef)
+			}
+		}
+		previous, err := s.loadTrackedEntityStateProjectionSQLite(txctx, tx, runID, rowID)
+		if err != nil {
+			return err
+		}
+		projection, err := workflowInstancePersistedProjectionFromInstance(instance, storageRef)
+		if err != nil {
+			return err
+		}
+		fieldsJSON, err := json.Marshal(projection.Fields)
+		if err != nil {
+			return err
+		}
+		gatesJSON, err := json.Marshal(projection.GatesAny())
+		if err != nil {
+			return err
+		}
+		config := projection.ConfigPayload(instance.WorkflowVersion)
+		configJSON, err := json.Marshal(config)
+		if err != nil {
+			return err
+		}
+		accumulatorState, err := json.Marshal(projection.Accumulator)
+		if err != nil {
+			return err
+		}
+		mode := workflowInstanceMode(storageRef)
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(txctx, `
+			INSERT OR IGNORE INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, runID, now); err != nil {
+			return err
+		}
+		if createOnly {
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO flow_instances (
+					instance_id, flow_template, mode, config, status, created_at
+				)
+				VALUES (?, ?, ?, ?, 'active', ?)
+			`, storageRef, instance.WorkflowName, mode, jsonOrDefault(configJSON, "{}"), now); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO entity_state (
+					run_id, entity_id, flow_instance, entity_type, slug, name,
+					current_state, gates, fields, accumulator, revision,
+					entered_state_at, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, NULLIF(?,''), NULLIF(?,''), ?, ?, ?, ?, 1, ?, ?, ?)
+			`, runID, rowID, storageRef, projection.Control.EntityType, projection.Control.Slug, projection.Control.Name,
+				instance.CurrentState, jsonOrDefault(gatesJSON, "{}"), jsonOrDefault(fieldsJSON, "{}"), jsonOrDefault(accumulatorState, "{}"),
+				instance.EnteredStageAt.UTC(), now, now); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO flow_instances (
+					instance_id, flow_template, mode, config, status, created_at
+				)
+				VALUES (?, ?, ?, ?, 'active', ?)
+				ON CONFLICT(instance_id) DO UPDATE SET
+					flow_template = excluded.flow_template,
+					mode = excluded.mode,
+					config = excluded.config,
+					status = CASE WHEN flow_instances.status = 'terminated' THEN flow_instances.status ELSE 'active' END
+			`, storageRef, instance.WorkflowName, mode, jsonOrDefault(configJSON, "{}"), now); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO entity_state (
+					run_id, entity_id, flow_instance, entity_type, slug, name,
+					current_state, gates, fields, accumulator, revision,
+					entered_state_at, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, NULLIF(?,''), NULLIF(?,''), ?, ?, ?, ?, 1, ?, ?, ?)
+				ON CONFLICT(run_id, entity_id) DO UPDATE SET
+					flow_instance = excluded.flow_instance,
+					entity_type = excluded.entity_type,
+					slug = excluded.slug,
+					name = excluded.name,
+					current_state = excluded.current_state,
+					gates = excluded.gates,
+					fields = excluded.fields,
+					accumulator = excluded.accumulator,
+					revision = entity_state.revision + 1,
+					entered_state_at = excluded.entered_state_at,
+					updated_at = excluded.updated_at
+			`, runID, rowID, storageRef, projection.Control.EntityType, projection.Control.Slug, projection.Control.Name,
+				instance.CurrentState, jsonOrDefault(gatesJSON, "{}"), jsonOrDefault(fieldsJSON, "{}"), jsonOrDefault(accumulatorState, "{}"),
+				instance.EnteredStageAt.UTC(), now, now); err != nil {
+				return err
+			}
+		}
+		afterProjection := runtimemutationlog.EntityStateProjection{
+			CurrentState: strings.TrimSpace(instance.CurrentState),
+			Fields:       projection.Fields,
+			Gates:        projection.GatesAny(),
+			Accumulator:  projection.Accumulator,
+		}
+		if err := insertSQLiteEntityStateDiff(txctx, tx, rowID, previous, afterProjection, runtimemutationlog.Writer{
+			Type:        "platform",
+			ID:          "workflow_instance_store",
+			HandlerStep: map[bool]string{true: "create", false: "upsert"}[createOnly],
+		}); err != nil {
+			return err
+		}
+		if err := s.replaceWorkflowTimersSQLite(txctx, tx, runID, rowID, storageRef, instance.TimerState); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (s *WorkflowInstanceStore) scanSQLiteWorkflowInstances(ctx context.Context, rows *sql.Rows, runID string) ([]WorkflowInstance, error) {
+	out := make([]WorkflowInstance, 0, 32)
+	for rows.Next() {
+		var (
+			item            WorkflowInstance
+			gatesRaw        any
+			fieldsRaw       any
+			configRaw       any
+			accRaw          any
+			flowInstance    string
+			entityType      string
+			slug            sql.NullString
+			name            sql.NullString
+			status          sql.NullString
+			terminatedAtRaw any
+			enteredAtRaw    any
+			createdAtRaw    any
+			updatedAtRaw    any
+		)
+		if err := rows.Scan(
+			&item.InstanceID,
+			&item.WorkflowName,
+			&item.WorkflowVersion,
+			&status,
+			&terminatedAtRaw,
+			&item.CurrentState,
+			&enteredAtRaw,
+			&gatesRaw,
+			&fieldsRaw,
+			&accRaw,
+			&configRaw,
+			&flowInstance,
+			&entityType,
+			&slug,
+			&name,
+			&createdAtRaw,
+			&updatedAtRaw,
+		); err != nil {
+			return nil, err
+		}
+		var err error
+		item.EnteredStageAt, _, err = sqliteWorkflowTimeValue(enteredAtRaw)
+		if err != nil {
+			return nil, err
+		}
+		item.CreatedAt, _, err = sqliteWorkflowTimeValue(createdAtRaw)
+		if err != nil {
+			return nil, err
+		}
+		item.UpdatedAt, _, err = sqliteWorkflowTimeValue(updatedAtRaw)
+		if err != nil {
+			return nil, err
+		}
+		if terminatedAt, ok, err := sqliteWorkflowTimeValue(terminatedAtRaw); err != nil {
+			return nil, err
+		} else if ok {
+			item.TerminatedAt = terminatedAt
+		}
+		item.Status = strings.TrimSpace(status.String)
+		projection, err := decodeWorkflowInstancePersistedProjection(sqliteWorkflowJSONBytes(fieldsRaw), sqliteWorkflowJSONBytes(gatesRaw), sqliteWorkflowJSONBytes(accRaw), sqliteWorkflowJSONBytes(configRaw), workflowInstancePersistedControl{
+			StorageRef: strings.TrimSpace(flowInstance),
+			Slug:       slug.String,
+			Name:       name.String,
+			EntityType: entityType,
+		})
+		if err != nil {
+			return nil, err
+		}
+		item.StateBuckets = projection.Accumulator
+		item.Config = projection.Config
+		item.Metadata = projection.Metadata()
+		persistedIdentity, err := workflowInstancePersistedIdentity(nil, WorkflowInstance{
+			InstanceID:   item.InstanceID,
+			StorageRef:   projection.Control.StorageRef,
+			WorkflowName: item.WorkflowName,
+			Metadata:     item.Metadata,
+		})
+		if err != nil {
+			return nil, err
+		}
+		item.StorageRef = persistedIdentity.StorageRef
+		item.InstanceID = persistedIdentity.InstanceID
+		item.TransitionHistory = append([]WorkflowTransitionRecord{}, projection.Control.TransitionHistory...)
+		timers, err := s.loadWorkflowTimersSQLite(ctx, runID, persistedIdentity.RowID())
+		if err != nil {
+			return nil, err
+		}
+		item.TimerState = timers
+		if item.StateBuckets == nil {
+			item.StateBuckets = map[string]any{}
+		}
+		if item.Metadata == nil {
+			item.Metadata = map[string]any{}
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func workflowInstanceSQLiteCreateTargetExists(ctx context.Context, tx *sql.Tx, runID, rowID, storageRef string) (bool, error) {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM flow_instances WHERE instance_id = ?)`, storageRef).Scan(&exists); err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM entity_state WHERE run_id = ? AND entity_id = ?
+		)
+	`, runID, rowID).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+func (s *WorkflowInstanceStore) loadTrackedEntityStateProjectionSQLite(ctx context.Context, tx *sql.Tx, runID, entityID string) (runtimemutationlog.EntityStateProjection, error) {
+	if tx == nil || strings.TrimSpace(entityID) == "" {
+		return runtimemutationlog.EntityStateProjection{}, nil
+	}
+	var currentState sql.NullString
+	var fieldsRaw, gatesRaw, accRaw any
+	err := tx.QueryRowContext(ctx, `
+		SELECT current_state, COALESCE(fields, '{}'), COALESCE(gates, '{}'), COALESCE(accumulator, '{}')
+		FROM entity_state
+		WHERE run_id = ? AND entity_id = ?
+	`, runID, entityID).Scan(&currentState, &fieldsRaw, &gatesRaw, &accRaw)
+	if err == sql.ErrNoRows {
+		return runtimemutationlog.EntityStateProjection{}, nil
+	}
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	fields, err := decodeWorkflowInstanceJSONMap("entity_state.fields", sqliteWorkflowJSONBytes(fieldsRaw))
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	gates, err := decodeWorkflowInstanceJSONBoolMap("entity_state.gates", sqliteWorkflowJSONBytes(gatesRaw))
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	accumulator, err := decodeWorkflowInstanceJSONMap("entity_state.accumulator", sqliteWorkflowJSONBytes(accRaw))
+	if err != nil {
+		return runtimemutationlog.EntityStateProjection{}, err
+	}
+	return runtimemutationlog.EntityStateProjection{
+		CurrentState: strings.TrimSpace(currentState.String),
+		Fields:       fields,
+		Gates:        workflowBoolGatesAsMap(gates),
+		Accumulator:  accumulator,
+	}, nil
+}
+
+func insertSQLiteEntityStateDiff(ctx context.Context, tx *sql.Tx, entityID string, before, after runtimemutationlog.EntityStateProjection, writer runtimemutationlog.Writer) error {
+	records, err := runtimemutationlog.BuildEntityStateDiffRecords(entityID, before, after, writer)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	runID, err := runtimecurrentstate.RequireRunID(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		return err
+	}
+	causedByEvent := ""
+	if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+		if parsed := validSQLiteWorkflowUUID(inbound.ID); parsed != "" {
+			causedByEvent = parsed
+		}
+	}
+	for _, rec := range records {
+		oldValue, err := json.Marshal(rec.OldValue)
+		if err != nil {
+			return err
+		}
+		newValue, err := json.Marshal(rec.NewValue)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO entity_mutations (
+				mutation_id, run_id, entity_id, field, old_value, new_value,
+				caused_by_event, writer_type, writer_id, handler_step, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), ?)
+		`, uuid.NewString(), runID, entityID, rec.Field, string(oldValue), string(newValue), causedByEvent, rec.WriterType, rec.WriterID, strings.TrimSpace(rec.HandlerStep), time.Now().UTC()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *WorkflowInstanceStore) replaceWorkflowTimersSQLite(ctx context.Context, tx *sql.Tx, runID, entityID, storageRef string, timers []WorkflowTimerState) error {
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM timers
+		WHERE run_id = ? AND entity_id = ? AND flow_instance = ? AND owner_node = ? AND owner_agent IS NULL
+	`, runID, entityID, storageRef, workflowInstanceTimerOwnerNode); err != nil {
+		return err
+	}
+	for _, timer := range timers {
+		payloadJSON, err := json.Marshal(map[string]any{
+			"started_by": strings.TrimSpace(timer.StartedBy),
+			"timer_id":   strings.TrimSpace(timer.TimerID),
+		})
+		if err != nil {
+			return err
+		}
+		status := "active"
+		if timer.Cancelled {
+			status = "cancelled"
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO timers (
+				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+				fire_at, recurring, owner_node, task_type, status, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, workflowInstanceTimerRowID(runID, strings.TrimSpace(timer.TimerID), entityID), runID, strings.TrimSpace(timer.TimerID), entityID, storageRef,
+			strings.TrimSpace(timer.EventType), jsonOrDefault(payloadJSON, "{}"), timer.FiresAt.UTC(), timer.Recurring,
+			workflowInstanceTimerOwnerNode, workflowInstanceTimerTaskType(timer), status, workflowTimeOrNow(timer.CreatedAt)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *WorkflowInstanceStore) loadWorkflowTimersSQLite(ctx context.Context, runID, entityID string) ([]WorkflowTimerState, error) {
+	rows, err := dbQueryContext(ctx, s.db, `
+		SELECT timer_name, fire_event, created_at, fire_at, COALESCE(json_extract(fire_payload, '$.started_by'), ''), recurring, status = 'cancelled'
+		FROM timers
+		WHERE run_id = ? AND entity_id = ? AND owner_node = ? AND owner_agent IS NULL
+		ORDER BY created_at ASC, timer_name ASC
+	`, runID, entityID, workflowInstanceTimerOwnerNode)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]WorkflowTimerState, 0, 4)
+	for rows.Next() {
+		var timer WorkflowTimerState
+		var createdRaw, firesRaw any
+		if err := rows.Scan(&timer.TimerID, &timer.EventType, &createdRaw, &firesRaw, &timer.StartedBy, &timer.Recurring, &timer.Cancelled); err != nil {
+			return nil, err
+		}
+		if at, ok, err := sqliteWorkflowTimeValue(createdRaw); err != nil {
+			return nil, err
+		} else if ok {
+			timer.CreatedAt = at
+		}
+		if at, ok, err := sqliteWorkflowTimeValue(firesRaw); err != nil {
+			return nil, err
+		} else if ok {
+			timer.FiresAt = at
+		}
+		out = append(out, timer)
+	}
+	return out, rows.Err()
+}
+
+func (s *WorkflowInstanceStore) queryEntityStateCountSQLite(ctx context.Context, runID string, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {
+	runID, err := runtimecurrentstate.ValidateRunID(runID)
+	if err != nil {
+		return 0, err
+	}
+	items, err := s.listSQLite(runtimecorrelation.WithRunID(ctx, runID))
+	if err != nil {
+		return 0, err
+	}
+	flowRoot := runtimeflowidentity.ScopeKey(source, contract.FlowID)
+	count := 0
+	for _, item := range items {
+		storageRef := strings.Trim(strings.TrimSpace(item.StorageRef), "/")
+		if flowRoot != "" && storageRef != flowRoot && !strings.HasPrefix(storageRef, flowRoot+"/") {
+			continue
+		}
+		materialized, err := entityruntime.Materialize(contract, entityruntime.DeclaredValues(contract, item.Metadata))
+		if err != nil {
+			return 0, err
+		}
+		if workflowQueryPredicateMatches(map[string]any{
+			"fields":         materialized,
+			"current_state":  strings.TrimSpace(item.CurrentState),
+			"entity_type":    contract.EntityType,
+			"flow_instance":  flowRoot,
+			"workflow_name":  contract.FlowID,
+			"workflow_state": strings.TrimSpace(item.CurrentState),
+		}, predicate) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func sqliteWorkflowJSONBytes(raw any) []byte {
+	switch typed := raw.(type) {
+	case nil:
+		return nil
+	case []byte:
+		return typed
+	case string:
+		return []byte(typed)
+	default:
+		encoded, _ := json.Marshal(typed)
+		return encoded
+	}
+}
+
+func sqliteWorkflowTimeValue(raw any) (time.Time, bool, error) {
+	switch typed := raw.(type) {
+	case nil:
+		return time.Time{}, false, nil
+	case time.Time:
+		if typed.IsZero() {
+			return time.Time{}, false, nil
+		}
+		return typed.UTC(), true, nil
+	case string:
+		return parseSQLiteWorkflowTime(typed)
+	case []byte:
+		return parseSQLiteWorkflowTime(string(typed))
+	default:
+		return time.Time{}, false, fmt.Errorf("unsupported sqlite time value %T", raw)
+	}
+}
+
+func parseSQLiteWorkflowTime(raw string) (time.Time, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999 -0700 MST", "2006-01-02 15:04:05.999999 -0700 MST", "2006-01-02 15:04:05.999999999-07:00", "2006-01-02 15:04:05.999999999Z07:00", "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC(), true, nil
+		}
+	}
+	return time.Time{}, false, fmt.Errorf("parse sqlite workflow time %q", raw)
+}
+
+func validSQLiteWorkflowUUID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if _, err := uuid.Parse(raw); err != nil {
+		return ""
+	}
+	return raw
+}

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -1,0 +1,150 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRows(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = withWorkflowCreateEntityInitialValues(ctx, map[string]any{
+		"region": "west",
+		"tier":   float64(1),
+	})
+	storageRef := "root/acme"
+	entityID := FlowInstanceEntityID(storageRef)
+
+	if err := store.Create(ctx, WorkflowInstance{
+		InstanceID:      "acme",
+		StorageRef:      storageRef,
+		WorkflowName:    "root",
+		WorkflowVersion: "v1",
+		CurrentState:    "created",
+		EnteredStageAt:  time.Now().UTC(),
+		Metadata: map[string]any{
+			"flow_path": storageRef,
+			"region":    "west",
+			"tier":      float64(2),
+		},
+	}); err != nil {
+		t.Fatalf("Create workflow instance: %v", err)
+	}
+
+	assertSQLiteMutationCount(t, db, entityID, "region", "entity_initial_value", "create_entity", "null", `"west"`, 1)
+	assertSQLiteMutationCount(t, db, entityID, "region", "workflow_instance_store", "create", "", "", 0)
+	assertSQLiteMutationCount(t, db, entityID, "tier", "entity_initial_value", "create_entity", "null", "1", 1)
+	assertSQLiteMutationCount(t, db, entityID, "tier", "workflow_instance_store", "create", "1", "2", 1)
+}
+
+func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, stmt := range []string{
+		`CREATE TABLE runs (
+			run_id TEXT PRIMARY KEY,
+			status TEXT,
+			started_at TIMESTAMP
+		)`,
+		`CREATE TABLE flow_instances (
+			instance_id TEXT PRIMARY KEY,
+			flow_template TEXT,
+			mode TEXT,
+			config TEXT,
+			status TEXT,
+			terminated_at TIMESTAMP,
+			created_at TIMESTAMP
+		)`,
+		`CREATE TABLE entity_state (
+			run_id TEXT,
+			entity_id TEXT,
+			flow_instance TEXT,
+			entity_type TEXT,
+			slug TEXT,
+			name TEXT,
+			current_state TEXT,
+			gates TEXT,
+			fields TEXT,
+			accumulator TEXT,
+			revision INTEGER,
+			entered_state_at TIMESTAMP,
+			created_at TIMESTAMP,
+			updated_at TIMESTAMP,
+			PRIMARY KEY (run_id, entity_id)
+		)`,
+		`CREATE TABLE timers (
+			timer_id TEXT PRIMARY KEY,
+			run_id TEXT,
+			timer_name TEXT,
+			entity_id TEXT,
+			flow_instance TEXT,
+			fire_event TEXT,
+			fire_payload TEXT,
+			fire_at TIMESTAMP,
+			recurring BOOLEAN,
+			owner_node TEXT,
+			owner_agent TEXT,
+			task_type TEXT,
+			status TEXT,
+			created_at TIMESTAMP
+		)`,
+		`CREATE TABLE entity_mutations (
+			mutation_id TEXT PRIMARY KEY,
+			run_id TEXT,
+			entity_id TEXT,
+			field TEXT,
+			old_value TEXT,
+			new_value TEXT,
+			caused_by_event TEXT,
+			writer_type TEXT,
+			writer_id TEXT,
+			handler_step TEXT,
+			created_at TIMESTAMP
+		)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("create sqlite test schema: %v", err)
+		}
+	}
+	return db
+}
+
+func assertSQLiteMutationCount(t *testing.T, db *sql.DB, entityID, field, writerID, handlerStep, oldValue, newValue string, want int) {
+	t.Helper()
+	query := `
+		SELECT COUNT(*)
+		FROM entity_mutations
+		WHERE entity_id = ?
+		  AND field = ?
+		  AND writer_id = ?
+		  AND handler_step = ?
+	`
+	args := []any{entityID, field, writerID, handlerStep}
+	if oldValue != "" {
+		query += ` AND old_value = ?`
+		args = append(args, oldValue)
+	}
+	if newValue != "" {
+		query += ` AND new_value = ?`
+		args = append(args, newValue)
+	}
+	var got int
+	if err := db.QueryRow(query, args...).Scan(&got); err != nil {
+		t.Fatalf("count sqlite mutation rows: %v", err)
+	}
+	if got != want {
+		t.Fatalf("mutation count for field=%s writer=%s step=%s old=%s new=%s = %d, want %d", field, writerID, handlerStep, oldValue, newValue, got, want)
+	}
+}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -556,6 +556,10 @@ func deriveWorkflowEventPolicy(source semanticview.Source, eventType string, dri
 }
 
 func (pc *PipelineCoordinator) BackgroundNodes(bus systemNodeBus, db *sql.DB) []BackgroundNode {
+	return pc.BackgroundNodesWithReceiptStore(bus, db, pc.workflowStore)
+}
+
+func (pc *PipelineCoordinator) BackgroundNodesWithReceiptStore(bus systemNodeBus, db *sql.DB, receiptStore SystemNodeReceiptPersistence) []BackgroundNode {
 	if pc == nil || bus == nil {
 		return nil
 	}
@@ -566,7 +570,7 @@ func (pc *PipelineCoordinator) BackgroundNodes(bus systemNodeBus, db *sql.DB) []
 			continue
 		}
 		if executor := pc.backgroundWorkflowExecutor(strings.TrimSpace(node.ID)); executor != nil {
-			if bg := newBackgroundWorkflowNodeWithRetryBase(executor, bus, db, pc.eventReceiptsCapability, retryBase); bg != nil {
+			if bg := newBackgroundWorkflowNodeWithReceiptStoreAndRetryBase(executor, bus, db, receiptStore, pc.eventReceiptsCapability, retryBase); bg != nil {
 				out = append(out, bg)
 			}
 		}
@@ -734,7 +738,7 @@ func (pc *PipelineCoordinator) dispatchWorkflowNodeEventResult(ctx context.Conte
 }
 
 func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, nodeID string, evt events.Event) {
-	if pc == nil || pc.db == nil {
+	if pc == nil || pc.workflowStore == nil {
 		return
 	}
 	nodeID = strings.TrimSpace(nodeID)
@@ -746,7 +750,7 @@ func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, no
 		return
 	}
 	sideEffects := systemNodeProcessedReceiptSideEffects(nodeID, eventID)
-	if err := persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, pc.db, nodeID, eventID, sideEffects); err != nil {
+	if err := pc.workflowStore.MarkSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects); err != nil {
 		if logger, ok := pc.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
 				Level:     "error",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -41,6 +41,7 @@ type Stores struct {
 	SQLDB               *sql.DB
 	ConstructionBlocker string
 	EventStore          runtimebus.EventStore
+	PipelineStore       *runtimepipeline.WorkflowInstanceStore
 	SessionRegistry     sessions.Registry
 	ConversationStore   llm.ConversationPersistence
 	ManagerStore        runtimemanager.ManagerPersistence
@@ -424,13 +425,18 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			}
 		}
 	})
-	if stores.SQLDB != nil {
+	pipelineStore := stores.PipelineStore
+	if pipelineStore == nil && stores.SQLDB != nil {
+		pipelineStore = runtimepipeline.NewWorkflowInstanceStore(stores.SQLDB)
+	}
+	if pipelineStore != nil && pipelineStore.Enabled() {
 		artifactRoot, err := runtimepipeline.ResolveArtifactRepoRoot("")
 		if err != nil {
 			return nil, fmt.Errorf("artifact repo root validation failed: %w", err)
 		}
 		rt.Pipeline = runtimepipeline.NewPipelineCoordinatorWithOptions(rt.Bus, stores.SQLDB, runtimepipeline.PipelineCoordinatorOptions{
-			Module: opts.WorkflowModule,
+			Module:        opts.WorkflowModule,
+			WorkflowStore: pipelineStore,
 			InstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
 				if managerRef == nil {
 					return fmt.Errorf("flow instance activator is required")
@@ -450,7 +456,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			BundleFingerprint:       opts.BundleFingerprint,
 		})
 		if rt.Pipeline != nil {
-			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodes(rt.Bus, stores.SQLDB)...)
+			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodesWithReceiptStore(rt.Bus, stores.SQLDB, pipelineStore)...)
 		}
 	}
 

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -237,6 +237,112 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	}
 }
 
+func TestSQLiteRuntimeStorePipelineWorkflowInstanceOwner(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	entityID := runtimepipeline.FlowInstanceEntityID("root/acme")
+	if err := owner.Create(ctx, runtimepipeline.WorkflowInstance{
+		InstanceID:      "acme",
+		WorkflowName:    "root",
+		WorkflowVersion: "v1",
+		CurrentState:    "collecting",
+		EnteredStageAt:  time.Now().UTC(),
+		Metadata: map[string]any{
+			"flow_path":   "root/acme",
+			"slug":        "acme",
+			"name":        "Acme",
+			"entity_type": "company",
+			"score":       float64(7),
+		},
+		StateBuckets: map[string]any{"evidence": []any{"seed"}},
+	}); err != nil {
+		t.Fatalf("Create workflow instance: %v", err)
+	}
+	if err := owner.Mutate(ctx, "root/acme", func(instance *runtimepipeline.WorkflowInstance) {
+		instance.CurrentState = "qualified"
+		instance.Metadata["score"] = float64(9)
+	}); err != nil {
+		t.Fatalf("Mutate workflow instance: %v", err)
+	}
+	loaded, ok, err := owner.Load(ctx, "root/acme")
+	if err != nil {
+		t.Fatalf("Load workflow instance: %v", err)
+	}
+	if !ok || loaded.CurrentState != "qualified" || loaded.Metadata["slug"] != "acme" {
+		t.Fatalf("loaded workflow instance = %#v, want qualified acme", loaded)
+	}
+	selected, err := owner.SelectActiveByFields(ctx, "root", []runtimepipeline.WorkflowInstanceFieldSelector{{Field: "score", Value: float64(9)}}, []string{"terminal"})
+	if err != nil {
+		t.Fatalf("SelectActiveByFields: %v", err)
+	}
+	if len(selected) != 1 || selected[0].StorageRef != "root/acme" {
+		t.Fatalf("selected workflow instances = %#v, want root/acme", selected)
+	}
+	var mutationCount int
+	if err := store.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_mutations WHERE run_id = ? AND entity_id = ?`, runID, entityID).Scan(&mutationCount); err != nil {
+		t.Fatalf("count sqlite entity mutations: %v", err)
+	}
+	if mutationCount == 0 {
+		t.Fatal("sqlite workflow instance owner wrote no entity mutation rows")
+	}
+}
+
+func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	eventID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("company.scanned"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"ok":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := store.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := store.InsertEventDeliveryRoutes(ctx, eventID, []events.DeliveryRoute{{SubscriberType: "node", SubscriberID: "background-node"}}); err != nil {
+		t.Fatalf("InsertEventDeliveryRoutes: %v", err)
+	}
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	if processed, err := owner.SystemNodeProcessed(ctx, "background-node", eventID); err != nil || processed {
+		t.Fatalf("SystemNodeProcessed before mark = %v err=%v, want false nil", processed, err)
+	}
+	if err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`); err != nil {
+		t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery: %v", err)
+	}
+	if processed, err := owner.SystemNodeProcessed(ctx, "background-node", eventID); err != nil || !processed {
+		t.Fatalf("SystemNodeProcessed after mark = %v err=%v, want true nil", processed, err)
+	}
+	var deliveryStatus, receiptOutcome string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status
+		FROM event_deliveries
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&deliveryStatus); err != nil {
+		t.Fatalf("load sqlite node delivery: %v", err)
+	}
+	if deliveryStatus != "delivered" {
+		t.Fatalf("node delivery status = %q, want delivered", deliveryStatus)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&receiptOutcome); err != nil {
+		t.Fatalf("load sqlite node receipt: %v", err)
+	}
+	if receiptOutcome != "no_op" {
+		t.Fatalf("node receipt outcome = %q, want no_op", receiptOutcome)
+	}
+}
+
 func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)


### PR DESCRIPTION
## Summary
- Promotes `runtime.Stores.PipelineStore` / `runtimepipeline.WorkflowInstanceStore` as the backend-neutral runtime boot owner for pipeline coordination, workflow instance persistence, engine tx/query persistence, and system-node receipt settlement.
- Adds SQLite workflow-instance and system-node receipt implementations while preserving Postgres as the production owner for the same surface.
- Updates authoritative `platform-spec.yaml` for the #1147 pipeline/replay selected contract and removes pipeline/background nodes from the remaining SQLite construction blocker.

## Governing Refs / Context
Closes #1147.

Binding refs:
- #1147 Pre-Implementation Coverage Audit and independent gate review.
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml` sections `engine.runtime_store_backend_selection`, `engine.runtime_store_schema_dialect_bootstrap`, and `engine.runtime_core_persistence_store_contracts`.
- #1087 remains the parent for SQLite local-runtime construction residuals.
- #1088 remains blocked; this PR does not flip the SQLite default.
- #1148, #1149, and #1150 remain split for budget/spend, tool/human-task persistence, and runtime diagnostics/logging.

## Semantic Migration
- New canonical owner: `runtime.Stores.PipelineStore` consumed by `runtime.NewRuntime`, `PipelineCoordinator`, engine tx/query persistence, and background/system-node receipt settlement.
- Backend implementations: `runtimepipeline.NewWorkflowInstanceStore(PostgresStore.DB)` for Postgres and `runtimepipeline.NewSQLiteWorkflowInstanceStore(SQLiteRuntimeStore.DB)` for explicit SQLite local-dev runtime stores.
- Old invalid/non-authoritative path: raw `runtime.Stores.SQLDB` / `PipelineCoordinator.db` as the runtime-level pipeline/background construction authority.
- Production paths checked: runtime store construction, runtime boot dependency wiring, pipeline coordinator engine tx/query path, background-node receipt settlement, SQLite workflow/receipt owners, existing Postgres pipeline/bus regression paths.
- Migration complete for #1147 only; #1087 remains open for #1148/#1149/#1150 residual raw-SQL construction blockers.

## Tests
- `go test ./cmd/swarm -run 'TestBuildStores(SQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit|AcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./internal/store -run 'TestSQLiteRuntimeStore(PipelineWorkflowInstanceOwner|SystemNodeReceiptOwnerSettlesDelivery|SelectedCoreContracts|EventDeliveryReplay)' -count=1`
- `go test ./internal/runtime -run TestRuntimeDepsValidateOwnsRequiredBootInputs -count=1`
- `go test ./internal/runtime/pipeline -run 'Test(WorkflowInstanceStore|SystemNode|PipelineCoordinator|PipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistory)' -count=1 -timeout 120s`
- `go test ./internal/runtime/bus -run 'TestEventBusPublish|TestEventBusSweep|TestOutbox' -count=1`
- `go test ./...`