### PR TITLE
[agent-h][issue #1124] Add loopback API token default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ Requires Docker, a contract bundle, and credentials for the configured shipped L
 # 1. clone
 git clone https://github.com/<org>/swarm && cd swarm
 
-# 2. point at a contract bundle and provide the Compose backend credential
+# 2. point at a contract bundle and provide Compose credentials
 export SWARM_CONTRACTS_HOST_DIR=/absolute/path/to/your/contracts
 echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> .env
+echo "SWARM_API_TOKEN=$(uuidgen | tr '[:upper:]' '[:lower:]')" >> .env
 
 # 3. boot
 docker compose up -d postgres orchestrator
@@ -106,7 +107,12 @@ docker compose exec orchestrator swarm run \
 
 If you only need the local database, `docker compose up -d postgres` is supported
 without `SWARM_CONTRACTS_HOST_DIR`. The contracts path is required only when
-starting the `orchestrator` service.
+starting the `orchestrator` service. The Compose orchestrator also requires
+`SWARM_API_TOKEN` because it binds the API inside the container on `0.0.0.0`.
+Plain local `swarm serve` and foreground `swarm run` use the built-in dev API
+token only on numeric loopback binds, with bearer auth still enabled. Set an
+explicit token before exposing the API beyond loopback; the built-in token is
+not user isolation on a shared host.
 
 ### LLM Backend Profiles
 
@@ -276,7 +282,8 @@ The trajectory points at running whole company divisions as autonomous flows. Th
 
 Requirements: Go 1.23, Docker, Postgres 16 (provided via `docker-compose.yml`).
 Start only the database with `docker compose up -d postgres`; starting the
-orchestrator additionally requires `SWARM_CONTRACTS_HOST_DIR`.
+orchestrator additionally requires `SWARM_CONTRACTS_HOST_DIR` and an explicit
+`SWARM_API_TOKEN` because the Compose API listener is non-loopback.
 
 ```bash
 # build

--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -157,8 +157,8 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "entities list", args: []string{"entities", "list"}},
 		{name: "entity view", args: []string{"entity", "view", "entity-1"}},
 		{name: "entity aggregate", args: []string{"entity", "aggregate"}},
-		{name: "run connect start", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--no-follow"}},
-		{name: "run connect reattach", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1"}},
+		{name: "run connect start", args: []string{"run", "--connect", "http://192.0.2.10:1", "--event", "scan.requested", "--payload", payloadPath, "--no-follow"}},
+		{name: "run connect reattach", args: []string{"run", "--connect", "http://192.0.2.10:1", "--reattach", "run-1"}},
 		{name: "version server", args: []string{"version", "--server"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"swarm/internal/apiv1"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -78,8 +80,10 @@ func newCLIAPIClient(opts rootCommandOptions) (*cliAPIClient, error) {
 }
 
 type cliAPISettings struct {
-	rpcEndpoint string
-	token       string
+	rpcEndpoint   string
+	token         string
+	tokenSource   string
+	tokenExplicit bool
 }
 
 type cliAPIConfigFile struct {
@@ -122,11 +126,11 @@ func resolveCLIAPISettings(opts rootCommandOptions) (cliAPISettings, error) {
 	if err != nil {
 		return cliAPISettings{}, err
 	}
-	token, err := resolveCLIAPIToken(opts, cfg)
+	token, err := resolveCLIAPIToken(opts, cfg, endpoint)
 	if err != nil {
 		return cliAPISettings{}, err
 	}
-	return cliAPISettings{rpcEndpoint: endpoint, token: token}, nil
+	return cliAPISettings{rpcEndpoint: endpoint, token: token.token, tokenSource: token.source, tokenExplicit: token.explicit}, nil
 }
 
 func resolveCLIAPIRPCEndpoint(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {
@@ -142,20 +146,32 @@ func resolveCLIAPIRPCEndpoint(opts rootCommandOptions, cfg cliAPIConfigFile) (st
 	return cliAPIRPCEndpointFromServer(server, "API server")
 }
 
-func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {
+type cliAPITokenResolution struct {
+	token    string
+	source   string
+	explicit bool
+}
+
+func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile, rpcEndpoint string) (cliAPITokenResolution, error) {
 	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
-		return readCLIAPITokenFile(tokenFile, "--api-token-file")
+		return readCLIAPIExplicitTokenFile(tokenFile, "--api-token-file")
 	}
 	if token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")); token != "" {
-		return token, nil
+		return cliAPITokenResolution{token: token, source: string(apiv1.AuthTokenSourceEnvironment), explicit: true}, nil
 	}
 	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
-		return readCLIAPITokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
+		return readCLIAPIExplicitTokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
 	}
 	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
-		return readCLIAPITokenFile(tokenFile, "config api_token_file")
+		return readCLIAPIExplicitTokenFile(tokenFile, "config api_token_file")
 	}
-	return "", errCLIAPITokenRequired
+	if cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+		return cliAPITokenResolution{
+			token:  apiv1.DefaultLoopbackAPIToken,
+			source: string(apiv1.AuthTokenSourceBuiltInLoopbackToken),
+		}, nil
+	}
+	return cliAPITokenResolution{}, errCLIAPITokenRequired
 }
 
 type cliServeListenerAddressOptions struct {
@@ -206,6 +222,22 @@ func resolveCLIServeListenerAddressHighPriority(flagValue string, flagSet bool, 
 		return env, true
 	}
 	return "", false
+}
+
+func readCLIAPIExplicitTokenFile(tokenFile, source string) (cliAPITokenResolution, error) {
+	token, err := readCLIAPITokenFile(tokenFile, source)
+	if err != nil {
+		return cliAPITokenResolution{}, err
+	}
+	return cliAPITokenResolution{token: token, source: source, explicit: true}, nil
+}
+
+func cliAPIRPCEndpointAllowsDefaultToken(endpoint string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return false
+	}
+	return apiv1.DefaultLoopbackAPITokenAllowedHost(parsed.Hostname())
 }
 
 func readCLIAPITokenFile(tokenFile, source string) (string, error) {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"swarm/internal/apiv1"
 )
 
 func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
@@ -112,7 +113,6 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 
 	t.Run("built in API server default remains loopback base", func(t *testing.T) {
 		isolateCLIAPIConfigEnv(t)
-		t.Setenv("SWARM_API_TOKEN", "env-token")
 
 		client, err := newCLIAPIClient(rootCommandOptions{})
 		if err != nil {
@@ -121,10 +121,71 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 		if client.endpoint != "http://127.0.0.1:8081/v1/rpc" {
 			t.Fatalf("endpoint = %q", client.endpoint)
 		}
-		if client.token != "env-token" {
+		if client.token != apiv1.DefaultLoopbackAPIToken {
 			t.Fatalf("token = %q", client.token)
 		}
 	})
+}
+
+func TestCLIAPISettingsDefaultTokenLoopbackBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		apiServer  string
+		wantToken  string
+		wantErr    string
+		wantSource string
+	}{
+		{
+			name:       "numeric ipv4 loopback gets default token",
+			apiServer:  "http://127.0.0.1:8081",
+			wantToken:  apiv1.DefaultLoopbackAPIToken,
+			wantSource: string(apiv1.AuthTokenSourceBuiltInLoopbackToken),
+		},
+		{
+			name:       "numeric ipv6 loopback gets default token",
+			apiServer:  "http://[::1]:8081",
+			wantToken:  apiv1.DefaultLoopbackAPIToken,
+			wantSource: string(apiv1.AuthTokenSourceBuiltInLoopbackToken),
+		},
+		{
+			name:      "localhost needs explicit token",
+			apiServer: "http://localhost:8081",
+			wantErr:   "SWARM_API_TOKEN is required",
+		},
+		{
+			name:      "wildcard needs explicit token",
+			apiServer: "http://0.0.0.0:8081",
+			wantErr:   "SWARM_API_TOKEN is required",
+		},
+		{
+			name:      "routable address needs explicit token",
+			apiServer: "http://192.0.2.10:8081",
+			wantErr:   "SWARM_API_TOKEN is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			settings, err := resolveCLIAPISettings(rootCommandOptions{apiServer: tc.apiServer})
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("resolveCLIAPISettings returned nil error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %q, want %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCLIAPISettings: %v", err)
+			}
+			if settings.token != tc.wantToken {
+				t.Fatalf("token = %q, want %q", settings.token, tc.wantToken)
+			}
+			if settings.tokenSource != tc.wantSource || settings.tokenExplicit {
+				t.Fatalf("token source = %q explicit=%v, want source %q explicit=false", settings.tokenSource, settings.tokenExplicit, tc.wantSource)
+			}
+		})
+	}
 }
 
 func TestCLIAPIResolverToleratesContractPathConfigKeys(t *testing.T) {
@@ -382,6 +443,37 @@ func TestAPIConnectionFlagsDriveRuntimeStateCommand(t *testing.T) {
 	opts.httpClient = server.Client()
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", "--api-server", server.URL, "--api-token-file", tokenFile}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestAPIConnectionDefaultLoopbackTokenDrivesRuntimeStateCommand(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiv1.DefaultLoopbackAPIToken {
+			t.Errorf("Authorization = %q, want default loopback bearer", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method != "run.list" {
+			t.Errorf("method = %q, want run.list", req.Method)
+		}
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+	}))
+	defer server.Close()
+
+	opts := defaultRootCommandOptions()
+	opts.httpClient = server.Client()
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"runs", "--api-server", server.URL}, &stdout, &stderr, opts)
 	if code != 0 {
 		t.Fatalf("exit = %d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -18,7 +18,7 @@ const (
 	cliExitInterrupted = 130
 )
 
-var errCLIAPITokenRequired = errors.New("SWARM_API_TOKEN is required for runtime-state CLI commands")
+var errCLIAPITokenRequired = errors.New("SWARM_API_TOKEN is required for non-loopback API targets")
 
 type cliAPIErrorClassifier struct {
 	runtimeExit   int

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -900,6 +900,11 @@ func decisionForMailboxStatus(status string) string {
 
 func testRootCommandOptions(server *httptest.Server) rootCommandOptions {
 	opts := defaultRootCommandOptions()
+	if strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")) == "" && strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")) == "" {
+		// Missing-token tests now prove fail-closed behavior on non-loopback targets.
+		opts.apiRPCEndpointOverride = "http://192.0.2.10:8081/v1/rpc"
+		return opts
+	}
 	opts.apiRPCEndpointOverride = server.URL + "/v1/rpc"
 	opts.httpClient = server.Client()
 	return opts

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -208,6 +208,15 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("load .env: %v", err)
 		return 1
 	}
+	apiAuth := apiv1.ResolveAuthTokensFromEnvironment()
+	if err := validateServeAPIAuthBinding(opts.APIListenAddr, apiAuth); err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
+		log.Printf("configure v1 api auth: %v", err)
+		return 1
+	}
+	if apiAuth.UsesDefaultLoopbackToken() {
+		log.Print(apiv1.DefaultLoopbackAPITokenWarning)
+	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.ContractsPath,
 		PlatformSpecPath: opts.PlatformSpecPath,
@@ -485,7 +494,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,
-		AuthTokens:       apiv1.AuthTokensFromEnvironment(),
+		AuthTokens:       apiAuth.Tokens,
 		Handlers:         apiv1.OperatorReadHandlers(apiReadOptions),
 		Subscriptions:    apiv1.OperatorSubscriptions(apiReadOptions),
 	})
@@ -2137,6 +2146,23 @@ func validateServeListenAddr(flagName, addr string) error {
 		return fmt.Errorf("%s port must be between 0 and 65535", flagName)
 	}
 	return nil
+}
+
+func validateServeAPIAuthBinding(apiListenAddr string, auth apiv1.AuthTokenResolution) error {
+	if !auth.UsesDefaultLoopbackToken() {
+		return nil
+	}
+	if err := validateServeListenAddr("--api-listen-addr", apiListenAddr); err != nil {
+		return err
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(apiListenAddr))
+	if err != nil {
+		return fmt.Errorf("--api-listen-addr must be a host:port listen address: %w", err)
+	}
+	if apiv1.DefaultLoopbackAPITokenAllowedHost(host) {
+		return nil
+	}
+	return fmt.Errorf("non-loopback API bind %s requires an explicit SWARM_API_TOKEN", strings.TrimSpace(apiListenAddr))
 }
 
 func listenServeHTTPListener(name, addr string) (net.Listener, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3967,8 +3967,11 @@ func TestDockerComposeUsesBackendFlagNotRetiredLLMBackendEnv(t *testing.T) {
 	if !strings.Contains(text, "--backend claude_cli") {
 		t.Fatalf("docker-compose.yml missing canonical --backend claude_cli selector")
 	}
-	if !strings.Contains(text, "SWARM_API_TOKEN: ${SWARM_API_TOKEN:?") {
-		t.Fatalf("docker-compose.yml must require explicit SWARM_API_TOKEN for non-loopback orchestrator API")
+	if !strings.Contains(text, "SWARM_API_TOKEN: ${SWARM_API_TOKEN:-}") {
+		t.Fatalf("docker-compose.yml must keep model rendering tokenless for postgres-only startup")
+	}
+	if !strings.Contains(text, "SWARM_API_TOKEN must be set because the orchestrator API binds to 0.0.0.0.") {
+		t.Fatalf("docker-compose.yml must require explicit SWARM_API_TOKEN inside the orchestrator command")
 	}
 	if strings.Contains(text, "SWARM_API_TOKEN:-"+apiv1.DefaultLoopbackAPIToken) {
 		t.Fatalf("docker-compose.yml must not default the non-loopback API to the built-in token")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
+	"swarm/internal/apiv1"
 	"swarm/internal/config"
 	"swarm/internal/events"
 	runtimepkg "swarm/internal/runtime"
@@ -542,6 +543,38 @@ func TestCLI_ServeListenAddrEnvConfigValidation(t *testing.T) {
 	}
 }
 
+func TestValidateServeAPIAuthBindingDefaultTokenLoopbackBoundary(t *testing.T) {
+	defaultAuth := apiv1.AuthTokenResolution{Tokens: []string{apiv1.DefaultLoopbackAPIToken}, Source: apiv1.AuthTokenSourceBuiltInLoopbackToken}
+	explicitAuth := apiv1.AuthTokenResolution{Tokens: []string{"operator-token"}, Source: apiv1.AuthTokenSourceEnvironment, Explicit: true}
+	tests := []struct {
+		name    string
+		addr    string
+		auth    apiv1.AuthTokenResolution
+		wantErr string
+	}{
+		{name: "default token allowed on ipv4 loopback", addr: "127.0.0.1:8081", auth: defaultAuth},
+		{name: "default token allowed on ipv6 loopback", addr: "[::1]:8081", auth: defaultAuth},
+		{name: "default token rejects localhost", addr: "localhost:8081", auth: defaultAuth, wantErr: "non-loopback API bind localhost:8081 requires an explicit SWARM_API_TOKEN"},
+		{name: "default token rejects wildcard", addr: "0.0.0.0:8081", auth: defaultAuth, wantErr: "non-loopback API bind 0.0.0.0:8081 requires an explicit SWARM_API_TOKEN"},
+		{name: "default token rejects routable", addr: "192.0.2.10:8081", auth: defaultAuth, wantErr: "non-loopback API bind 192.0.2.10:8081 requires an explicit SWARM_API_TOKEN"},
+		{name: "explicit token allows wildcard", addr: "0.0.0.0:8081", auth: explicitAuth},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateServeAPIAuthBinding(tc.addr, tc.auth)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateServeAPIAuthBinding: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestCLI_ServeRuntimeConfigDoesNotFeedListenerConfig(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	runtimeConfig := filepath.Join(t.TempDir(), "runtime.yaml")
@@ -925,8 +958,8 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
 		t.Fatalf("api connection/auth/config promoted_by = %q, want #844", spec.PromotedBy)
 	}
-	if strings.TrimSpace(spec.ImplementationStatus) != "implemented" {
-		t.Fatalf("api connection/auth/config implementation_status = %q, want implemented", spec.ImplementationStatus)
+	if strings.TrimSpace(spec.ImplementationStatus) != "implemented_loopback_default" {
+		t.Fatalf("api connection/auth/config implementation_status = %q, want implemented_loopback_default", spec.ImplementationStatus)
 	}
 	if !strings.Contains(spec.CanonicalOwner, "cli_specification.foundations.api_connection_auth_config_precedence") {
 		t.Fatalf("canonical owner does not point at promoted section: %s", spec.CanonicalOwner)
@@ -972,7 +1005,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("api_token accepted sources missing %q: %#v", want, spec.APIToken.AcceptedSources)
 		}
 	}
-	wantTokenSourceOrder := []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file"}
+	wantTokenSourceOrder := []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file", "built-in loopback default"}
 	if len(spec.APIToken.SourceOrder) != len(wantTokenSourceOrder) {
 		t.Fatalf("api_token source order = %#v, want %#v", spec.APIToken.SourceOrder, wantTokenSourceOrder)
 	}
@@ -987,6 +1020,24 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	} {
 		if !strings.Contains(spec.APIToken.RejectedSources[key], want) {
 			t.Fatalf("api_token rejected source %q missing %q:\n%s", key, want, spec.APIToken.RejectedSources[key])
+		}
+	}
+	if spec.APIToken.BuiltInLoopbackDefault.TokenValue != apiv1.DefaultLoopbackAPIToken {
+		t.Fatalf("built-in default token = %q, want %q", spec.APIToken.BuiltInLoopbackDefault.TokenValue, apiv1.DefaultLoopbackAPIToken)
+	}
+	for _, want := range []string{"127.0.0.0/8", "::1"} {
+		if !stringSliceContains(spec.APIToken.BuiltInLoopbackDefault.AllowedTargetHosts, want) {
+			t.Fatalf("built-in default allowed hosts missing %q: %#v", want, spec.APIToken.BuiltInLoopbackDefault.AllowedTargetHosts)
+		}
+	}
+	for _, want := range []string{"localhost", "0.0.0.0"} {
+		if !stringSliceContains(spec.APIToken.BuiltInLoopbackDefault.RejectedWithoutExplicitToken, want) {
+			t.Fatalf("built-in default rejected hosts missing %q: %#v", want, spec.APIToken.BuiltInLoopbackDefault.RejectedWithoutExplicitToken)
+		}
+	}
+	for _, want := range []string{"no-auth", "Authorization: Bearer"} {
+		if !strings.Contains(spec.APIToken.BuiltInLoopbackDefault.NoAuthBypassRule, want) {
+			t.Fatalf("built-in default no-auth rule missing %q:\n%s", want, spec.APIToken.BuiltInLoopbackDefault.NoAuthBypassRule)
 		}
 	}
 	for key, want := range map[string]string{
@@ -3916,6 +3967,12 @@ func TestDockerComposeUsesBackendFlagNotRetiredLLMBackendEnv(t *testing.T) {
 	if !strings.Contains(text, "--backend claude_cli") {
 		t.Fatalf("docker-compose.yml missing canonical --backend claude_cli selector")
 	}
+	if !strings.Contains(text, "SWARM_API_TOKEN: ${SWARM_API_TOKEN:?") {
+		t.Fatalf("docker-compose.yml must require explicit SWARM_API_TOKEN for non-loopback orchestrator API")
+	}
+	if strings.Contains(text, "SWARM_API_TOKEN:-"+apiv1.DefaultLoopbackAPIToken) {
+		t.Fatalf("docker-compose.yml must not default the non-loopback API to the built-in token")
+	}
 }
 
 func TestLoadRuntimeConfig_RejectsUnsupportedRuntimeControlsFromFile(t *testing.T) {
@@ -5438,10 +5495,18 @@ type cliAPIConnectionAuthConfigSpec struct {
 		Rationale  string `yaml:"rationale"`
 	} `yaml:"api_server"`
 	APIToken struct {
-		AcceptedSources map[string]string `yaml:"accepted_sources"`
-		SourceOrder     []string          `yaml:"source_order"`
-		RejectedSources map[string]string `yaml:"rejected_sources"`
-		TokenFileRule   string            `yaml:"token_file_rule"`
+		AcceptedSources        map[string]string `yaml:"accepted_sources"`
+		SourceOrder            []string          `yaml:"source_order"`
+		RejectedSources        map[string]string `yaml:"rejected_sources"`
+		TokenFileRule          string            `yaml:"token_file_rule"`
+		BuiltInLoopbackDefault struct {
+			TokenValue                   string   `yaml:"token_value"`
+			Source                       string   `yaml:"source"`
+			AppliesWhen                  string   `yaml:"applies_when"`
+			AllowedTargetHosts           []string `yaml:"allowed_target_hosts"`
+			RejectedWithoutExplicitToken []string `yaml:"rejected_without_explicit_token"`
+			NoAuthBypassRule             string   `yaml:"no_auth_bypass_rule"`
+		} `yaml:"built_in_loopback_default"`
 	} `yaml:"api_token"`
 	CLIConfigFile struct {
 		AcceptedSources  map[string]string `yaml:"accepted_sources"`

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -16,12 +16,14 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"swarm/internal/apiv1"
 )
 
 func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	isolateCLIAPIConfigEnv(t)
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+		expectedToken: apiv1.DefaultLoopbackAPIToken,
 		rpcResponder: func(req jsonRPCRequest, callIndex int) map[string]any {
 			switch req.Method {
 			case "health.check":
@@ -659,7 +661,7 @@ func TestRunCommandValidationAndAuthNoCallPaths(t *testing.T) {
 		{name: "connect rejects api port local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--api-port", "8081"}, wantCode: 2, wantStderr: "--api-port requires local foreground mode"},
 		{name: "connect rejects legacy path", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1/api/rpc", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "--connect path must be empty or /v1/rpc"},
 		{name: "connect rejects unsupported scheme", token: "test-token", args: []string{"run", "--connect", "ftp://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "--connect must use http or https"},
-		{name: "missing token exits four", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 4, wantStderr: "SWARM_API_TOKEN is required"},
+		{name: "missing explicit token for non-loopback exits four", args: []string{"run", "--connect", "http://192.0.2.10:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 4, wantStderr: "SWARM_API_TOKEN is required"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.token == "" {
@@ -740,10 +742,15 @@ type runCommandServerOptions struct {
 	wsSubscribed         chan struct{}
 	wsSubscriptionResult map[string]any
 	wsCloseAfterRows     bool
+	expectedToken        string
 }
 
 func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.Server, *[]jsonRPCRequest, *[]jsonRPCRequest) {
 	t.Helper()
+	expectedToken := strings.TrimSpace(opts.expectedToken)
+	if expectedToken == "" {
+		expectedToken = "test-token"
+	}
 	var mu sync.Mutex
 	rpcRequests := []jsonRPCRequest{}
 	wsRequests := []jsonRPCRequest{}
@@ -751,7 +758,7 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/rpc":
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			if got := r.Header.Get("Authorization"); got != "Bearer "+expectedToken {
 				t.Errorf("Authorization = %q, want bearer token", got)
 			}
 			var req jsonRPCRequest
@@ -767,7 +774,7 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 			}
 			writeJSONRPCResult(t, w, req.ID, opts.rpcResponder(req, callIndex))
 		case "/v1/ws":
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			if got := r.Header.Get("Authorization"); got != "Bearer "+expectedToken {
 				t.Errorf("WS Authorization = %q, want bearer token", got)
 			}
 			conn, err := upgrader.Upgrade(w, r, nil)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - postgres
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
-      SWARM_API_TOKEN: ${SWARM_API_TOKEN:?SWARM_API_TOKEN must be set because the orchestrator API binds to 0.0.0.0}
+      SWARM_API_TOKEN: ${SWARM_API_TOKEN:-}
       SWARM_TOOL_GATEWAY_TOKEN: ${SWARM_TOOL_GATEWAY_TOKEN:-}
       SWARM_DB_HOST: postgres
       SWARM_DB_PORT: "5432"
@@ -65,6 +65,10 @@ services:
       - |
         if [ -z "$${SWARM_CONTRACTS_HOST_DIR}" ]; then
           echo "SWARM_CONTRACTS_HOST_DIR must point to a contract bundle for the orchestrator service." >&2
+          exit 2
+        fi
+        if [ -z "$${SWARM_API_TOKEN}" ]; then
+          echo "SWARM_API_TOKEN must be set because the orchestrator API binds to 0.0.0.0." >&2
           exit 2
         fi
         exec /usr/local/bin/orchestrator serve \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - postgres
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      SWARM_API_TOKEN: ${SWARM_API_TOKEN:?SWARM_API_TOKEN must be set because the orchestrator API binds to 0.0.0.0}
       SWARM_TOOL_GATEWAY_TOKEN: ${SWARM_TOOL_GATEWAY_TOKEN:-}
       SWARM_DB_HOST: postgres
       SWARM_DB_PORT: "5432"

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -7763,13 +7763,15 @@ cli_specification:
       `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` fallback is invalid.
     api_connection_auth_config_precedence:
       promoted_by: '#844'
-      implementation_status: implemented
+      loopback_default_implemented_by: '#1124'
+      implementation_status: implemented_loopback_default
       canonical_owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence
       scope: >
         Merge-bearing authority for CLI API base URL selection, bearer-token selection, and CLI config-file
         discovery for API-backed commands. API-backed command leaves consume `--api-server`, `--api-token-file`,
         `SWARM_API_SERVER`, `SWARM_API_TOKEN`, `SWARM_API_TOKEN_FILE`, `SWARM_CONFIG`, XDG config, and built-in
-        defaults through one shared resolver. This contract does not add OpenRPC behavior, retry behavior,
+        defaults through one shared resolver. When no explicit token source is configured, the shared resolver may
+        use the fixed built-in dev API token only for numeric loopback API targets. This contract does not add OpenRPC behavior, retry behavior,
         output rendering, root/global `--config`, inline token flags, or serve listener binding.
       applies_to:
       - Runtime-state CLI commands that call the platform JSON-RPC or WebSocket API.
@@ -7811,6 +7813,7 @@ cli_specification:
         - SWARM_API_TOKEN
         - SWARM_API_TOKEN_FILE
         - config api_token_file
+        - built-in loopback default
         rejected_sources:
           --api-token: >
             Not promoted. Inline token flags leak secrets into shell history and process listings; operators
@@ -7820,7 +7823,25 @@ cli_specification:
             Not promoted. The config file may point at a token file but MUST NOT store the bearer token inline.
         token_file_rule: >
           Token-file sources are read once during CLI command startup by the API client/auth resolver. Missing,
-          unreadable, or blank token-file contents classify through the shared CLI error/exit-code contract.
+          unreadable, or blank token-file contents classify through the shared CLI error/exit-code contract and
+          MUST NOT fall back to the built-in loopback default.
+        built_in_loopback_default:
+          token_value: swarm-dev-loopback-api-token
+          source: built-in-loopback-default
+          applies_when: >
+            Applies only after `--api-token-file`, `SWARM_API_TOKEN`, `SWARM_API_TOKEN_FILE`, and config
+            `api_token_file` are all absent, and only when the API target host is numeric loopback.
+          allowed_target_hosts:
+          - 127.0.0.0/8
+          - ::1
+          rejected_without_explicit_token:
+          - localhost
+          - 0.0.0.0
+          - '::'
+          - wildcard, empty, routable IP, and DNS hosts
+          no_auth_bypass_rule: >
+            The default is a bearer token value, not a no-auth mode. CLI requests still send
+            `Authorization: Bearer <token>` and the v1 API handler still validates the bearer value.
       cli_config_file:
         owner: docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file
         accepted_sources:
@@ -8212,6 +8233,12 @@ cli_specification:
           validation_rule: >
             Values from flags, environment, and CLI config MUST use the host:port address_format above and
             fail before runtime startup if invalid.
+          api_auth_coupling_rule: >
+            If no explicit `SWARM_API_TOKEN` is configured for `swarm serve`, the API listener may start only when
+            its host is numeric loopback (`127.0.0.0/8` or `::1`). `localhost`, wildcard, empty, routable IP, and
+            DNS hosts require an explicit `SWARM_API_TOKEN`. The built-in API token is never valid for a
+            non-loopback API listener. This rule applies to the API listener only; MCP listener and tool-gateway
+            tokens remain owned by local_cli_test_gateway_startup.
           rejected_sources:
             SWARM_API_PORT: 'Not promoted; port-only configuration cannot express bind interface/IP.'
             SWARM_MCP_PORT: 'Not promoted; port-only configuration cannot express bind interface/IP.'
@@ -8237,6 +8264,11 @@ cli_specification:
             stderr_class: listener_bind_failed
             rule: >
               If any enabled listener cannot bind, `swarm serve` MUST exit before runtime readiness is reported.
+          api_default_token_exposure:
+            rule: >
+              If the API listener would use the built-in loopback default token on a non-loopback host,
+              `swarm serve` MUST fail closed before readiness with a diagnostic naming that non-loopback API binds
+              require explicit `SWARM_API_TOKEN`.
         flag_disposition:
           --health-addr:
             disposition: retired_final_v2_1_name_current_migration_evidence
@@ -8699,7 +8731,7 @@ cli_specification:
       proof_expectations:
       - mailbox view renders decision_sheet from mailbox.get without local entity/downstream reconstruction
       - missing or malformed decision_sheet fails closed as a malformed RPC result
-      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - invalid args and missing explicit token for non-loopback API targets make zero API calls
       - static no-bypass proof for no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy transports
       split_tail: >
         File-backed decision payload, richer approve/reject/defer mutation result
@@ -8747,7 +8779,7 @@ cli_specification:
       - exact /v1/rpc mailbox.approve call with mailbox_id, optional decision_payload, and optional idempotency_key params only
       - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.approve, including idempotency_replayed and downstream event detail
       - malformed response proof for missing idempotency_replayed and incomplete or invalid downstream detail
-      - invalid args, conflicting payload flags including explicitly blank conflicting values, blank/missing/unreadable payload files, blank/malformed/null/non-object payload JSON, and missing SWARM_API_TOKEN make zero API calls
+      - invalid args, conflicting payload flags including explicitly blank conflicting values, blank/missing/unreadable payload files, blank/malformed/null/non-object payload JSON, and missing explicit token for non-loopback API targets make zero API calls
       - file-backed and inline payload inputs share the same canonical object validation and param construction
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or retired swarm control mailbox path usage
       split_tail: >
@@ -8764,7 +8796,7 @@ cli_specification:
       proof_expectations:
       - exact /v1/rpc mailbox.reject call with mailbox_id, reason, and optional idempotency_key params only
       - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.reject
-      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - invalid args and missing explicit token for non-loopback API targets make zero API calls
     mailbox_defer:
       command: swarm mailbox defer <mailbox-item-id>
       tier: must_have
@@ -8776,7 +8808,7 @@ cli_specification:
       proof_expectations:
       - exact /v1/rpc mailbox.defer call with mailbox_id, until, and optional idempotency_key params only
       - success rendering consumes only MailboxDecisionResult fields from /v1/rpc mailbox.defer
-      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - invalid args and missing explicit token for non-loopback API targets make zero API calls
     health:
       command: swarm health
       tier: must_have
@@ -8936,7 +8968,7 @@ cli_specification:
         auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc agent.list call with flow/role params only when provided
-      - fail-closed SWARM_API_TOKEN behavior before any request
+      - fail-closed non-loopback API token behavior before any request
       - invalid args/flags make zero API calls
       - malformed agent.list responses fail closed
       - no direct DB/store/runtime/EventBus/agentcontrol reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, or token fallback
@@ -9013,7 +9045,7 @@ cli_specification:
       - exact /v1/rpc agent.restart call with agent_id param
       - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
       - output renders agent_id and validates OkResult.ok is true
-      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - invalid args/flags and missing explicit token for non-loopback API targets make zero API calls
       - AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT, HTTP failures, unknown RPC errors, and malformed success responses fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/agentcontrol reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, dashboard/Builder REST, conversation owners, directive, or replay method usage
     agent_replay:
@@ -9045,7 +9077,7 @@ cli_specification:
       - --event-id is required and no event-targeted replay request is made without it
       - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
       - output renders event_id, replay_event_id, audit_event_id, original_delivery.delivery_id, and new_delivery.delivery_id from AgentReplayResult.original_delivery/new_delivery
-      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - invalid args/flags and missing explicit token for non-loopback API targets make zero API calls
       - EVENT_NOT_FOUND, EVENT_REPLAY_NO_DELIVERY_HISTORY, EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL, EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE, EVENT_REPLAY_NOT_ELIGIBLE, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT, HTTP failures, unknown RPC errors, and malformed success responses fail closed with tested exit codes
       - no agent.replay_backlog, direct DB/store/runtime/EventBus/agentcontrol, dashboard/Builder REST, legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, directive, restart, list, or view method usage
     agent_replay_backlog:
@@ -9071,7 +9103,7 @@ cli_specification:
       - exact /v1/rpc agent.replay_backlog call with agent_id param
       - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
       - output renders replayed_count and validates ok is true
-      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - invalid args/flags and missing explicit token for non-loopback API targets make zero API calls
       - AGENT_NOT_FOUND, IDEMPOTENCY_CONFLICT, HTTP failures, unknown RPC errors, and malformed success responses fail closed with tested exit codes
       - no agent.replay, event.replay, direct DB/store/runtime/EventBus/agentcontrol, dashboard/Builder REST, legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, directive, restart, list, or view method usage
     agent_directive:
@@ -9103,7 +9135,7 @@ cli_specification:
       - --run-id passes run_id exactly and does not trigger local run/session lookup
       - --idempotency-key passes idempotency_key exactly when provided and is never generated or persisted locally
       - output renders server-owned run_id, run_id_resolution, directive_event_id, and directive_event_type
-      - invalid args/flags and missing SWARM_API_TOKEN make zero API calls
+      - invalid args/flags and missing explicit token for non-loopback API targets make zero API calls
       - AGENT_NOT_FOUND, RUN_NOT_FOUND, AGENT_NOT_RUNNING, RUN_ALREADY_TERMINAL, AMBIGUOUS_RUN_TARGET, IDEMPOTENCY_CONFLICT, HTTP failures, and malformed success responses fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/agentcontrol reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, dashboard/Builder REST, conversation owners, restart, or replay method usage
     events_list:
@@ -9136,7 +9168,7 @@ cli_specification:
       proof_expectations:
       - exact /v1/rpc event.list call with filter, since, until, limit, and cursor params only
       - filter fields match EventListFilter and bool has_dead_letter is sent only when explicitly provided
-      - invalid flags and missing SWARM_API_TOKEN make zero API calls
+      - invalid flags and missing explicit token for non-loopback API targets make zero API calls
       - malformed event list results and HTTP/RPC failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     events_follow:
@@ -9170,7 +9202,7 @@ cli_specification:
       proof_expectations:
       - exact /v1/ws event.subscribe call with filter and replay_since params only
       - filter shape is identical to event.list EventListFilter; pagination and list-only until are not accepted
-      - invalid flags and missing SWARM_API_TOKEN make zero WS calls
+      - invalid flags and missing explicit token for non-loopback API targets make zero WS calls
       - malformed subscription result/notification and HTTP/RPC/WS failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.subscribe_trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     event_view:
@@ -9191,7 +9223,7 @@ cli_specification:
         - EVENT_NOT_FOUND
       proof_expectations:
       - exact /v1/rpc event.get call with event_id param only
-      - missing or blank event id and missing SWARM_API_TOKEN make zero API calls
+      - missing or blank event id and missing explicit token for non-loopback API targets make zero API calls
       - EVENT_NOT_FOUND, HTTP/RPC failures, and malformed EventFull results fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.publish, event.replay, agent.replay, or agent.replay_backlog usage
     event_replay:
@@ -9232,7 +9264,7 @@ cli_specification:
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
       - exact /v1/rpc event.replay call with event_id, optional subscribers, and optional idempotency_key params only
-      - missing or blank event id, blank --subscriber, invalid args, and missing SWARM_API_TOKEN make zero API calls
+      - missing or blank event id, blank --subscriber, invalid args, and missing explicit token for non-loopback API targets make zero API calls
       - success output renders server-owned replay_event_id, audit_event_id, subscribers_replayed, and original/new delivery lineage
       - EVENT_NOT_FOUND, replay conflict errors, auth/HTTP/RPC failures, and malformed EventReplayResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.publish, agent.replay, or agent.replay_backlog usage
@@ -9296,7 +9328,7 @@ cli_specification:
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
       - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted
-      - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing SWARM_API_TOKEN make zero API calls
+      - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing explicit token for non-loopback API targets make zero API calls
       - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
@@ -9330,7 +9362,7 @@ cli_specification:
         auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc conversation.list call with agent_id, run_id, limit, and cursor params only when corresponding CLI flags are provided
-      - invalid flags, blank OpaqueId flags, out-of-range --limit, and missing SWARM_API_TOKEN make zero API calls
+      - invalid flags, blank OpaqueId flags, out-of-range --limit, and missing explicit token for non-loopback API targets make zero API calls
       - success output renders only ConversationSummary fields and next_cursor returned by the server
       - empty conversations array, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, conversation.get_turn, or forkchat usage
@@ -9353,7 +9385,7 @@ cli_specification:
         - SESSION_NOT_FOUND
       proof_expectations:
       - exact /v1/rpc conversation.get call with session_id param only
-      - missing/blank/invalid session id and missing SWARM_API_TOKEN make zero API calls
+      - missing/blank/invalid session id and missing explicit token for non-loopback API targets make zero API calls
       - success output renders only ConversationDetail and shallow Turn fields returned by the server, including turn_index
       - SESSION_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, conversation.get_turn reconstruction, or forkchat usage
@@ -9386,7 +9418,7 @@ cli_specification:
         - TURN_NOT_FOUND
       proof_expectations:
       - exact /v1/rpc conversation.get_turn call with session_id and turn_index params only; include_logs is omitted so the API default remains authoritative
-      - missing/blank/invalid session id, invalid turn_index, turn_id-shaped selector attempts, and missing SWARM_API_TOKEN make zero API calls
+      - missing/blank/invalid session id, invalid turn_index, turn_id-shaped selector attempts, and missing explicit token for non-loopback API targets make zero API calls
       - success output renders only ConversationTurnDetail fields returned by the server; runtime logs are consumed from the API result, not independently queried
       - SESSION_NOT_FOUND, TURN_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, runtime.logs, run.trace, or forkchat usage
@@ -9556,7 +9588,7 @@ cli_specification:
         auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc entity.list call with run_id, flow, type, current_state, limit, and cursor params only when supplied
-      - missing SWARM_API_TOKEN, blank optional flags, invalid run_id OpaqueId envelope, invalid limit, invalid args, and unsupported flags make zero API calls
+      - missing explicit token for non-loopback API targets, blank optional flags, invalid run_id OpaqueId envelope, invalid limit, invalid args, and unsupported flags make zero API calls
       - empty result, next_cursor rendering, auth/HTTP/RPC failures, malformed result, and malformed EntitySummary rows fail closed with tested exit-code behavior
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
     entity_view:
@@ -9588,7 +9620,7 @@ cli_specification:
         entity_not_found: 5
       proof_expectations:
       - exact /v1/rpc entity.get call with required entity_id and optional run_id params only
-      - missing/blank/invalid entity id, blank or invalid --run-id, invalid args, unsupported flags, and missing SWARM_API_TOKEN make zero API calls
+      - missing/blank/invalid entity id, blank or invalid --run-id, invalid args, unsupported flags, and missing explicit token for non-loopback API targets make zero API calls
       - ENTITY_NOT_FOUND maps to resource-not-found exit 5
       - auth/HTTP/RPC failures, malformed EntityFull result, malformed nested EntitySummary, and missing fields/gates/accumulated maps fail closed with tested exit-code behavior
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
@@ -9626,7 +9658,7 @@ cli_specification:
         auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc entity.aggregate call with run_id, group_by, and type params only when supplied
-      - missing SWARM_API_TOKEN, blank optional flags, invalid run_id OpaqueId envelope, unsupported group_by, invalid args, and unsupported flags make zero API calls
+      - missing explicit token for non-loopback API targets, blank optional flags, invalid run_id OpaqueId envelope, unsupported group_by, invalid args, and unsupported flags make zero API calls
       - omitted --group-by sends no group_by and relies on the server default current_state
       - empty result, deterministic aggregate rendering, auth/HTTP/RPC failures, missing counts, and negative counts fail closed with tested exit-code behavior
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, query_entities, search_entities, get_entity, or swarm investigate usage
@@ -9678,7 +9710,7 @@ cli_specification:
       - exact /v1/rpc runtime.logs call with run_id, entity_id, session_id, component, level, error_code, source, since, until, limit, cursor, and order params only
       - exact /v1/ws runtime.subscribe_logs call with run_id, entity_id, session_id, component, level, error_code, source, and replay_since params only
       - follow rejects --since, --until, --limit, --cursor, and --order before opening the WebSocket; --replay-since is accepted only with --follow
-      - invalid flags and missing SWARM_API_TOKEN make zero API or WS calls
+      - invalid flags and missing explicit token for non-loopback API targets make zero API or WS calls
       - malformed runtime.logs results, malformed runtime.subscribe_logs subscription results/notifications, auth/HTTP/RPC/WS failures, and cancellation are tested with closed exit-code behavior
       - no direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and no legacy /api/*, /rpc, /api/rpc, /ws, or /api/ws usage
     incidents:
@@ -9725,7 +9757,7 @@ cli_specification:
         auth_or_missing_token: 4
       proof_expectations:
       - exact /v1/rpc runtime.incidents call with since_hours, component, level, mcp_only, limit, and cursor params only when supplied
-      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - invalid args and missing explicit token for non-loopback API targets make zero API calls
       - since_hours is validated as 1-720 and limit as 1-500 before API calls
       - level is validated as debug, info, warn, or error before API calls
       - empty result, next_cursor rendering, auth/HTTP/RPC failures, malformed result, and malformed Incident rows are tested with closed exit-code behavior
@@ -9962,6 +9994,14 @@ api_specification:
         HTTP request and on the WebSocket upgrade. Token presence and validity
 
         are the only check in v1; the token grants every scope in the catalog.
+
+        When no explicit API token is configured for numeric-loopback local dev,
+
+        the implementation may use the built-in loopback default token governed
+
+        by cli_specification.foundations.api_connection_auth_config_precedence.
+
+        This remains bearer-token auth and MUST NOT become a loopback no-auth bypass.
 
         '
       forward_compatibility: "Each method declares its required scope(s) in this spec (see scopes\nsection). v1 enforcement\

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"os"
 	"regexp"
 	"strings"
@@ -32,6 +33,28 @@ const (
 	transportHTTP      = "http"
 	transportWebSocket = "websocket"
 )
+
+const (
+	DefaultLoopbackAPIToken        = "swarm-dev-loopback-api-token"
+	DefaultLoopbackAPITokenWarning = "using built-in dev API token on loopback; set SWARM_API_TOKEN before exposing"
+)
+
+type AuthTokenSource string
+
+const (
+	AuthTokenSourceEnvironment          AuthTokenSource = "SWARM_API_TOKEN"
+	AuthTokenSourceBuiltInLoopbackToken AuthTokenSource = "built-in-loopback-default"
+)
+
+type AuthTokenResolution struct {
+	Tokens   []string
+	Source   AuthTokenSource
+	Explicit bool
+}
+
+func (r AuthTokenResolution) UsesDefaultLoopbackToken() bool {
+	return !r.Explicit && r.Source == AuthTokenSourceBuiltInLoopbackToken
+}
 
 type Handler struct {
 	registry *Registry
@@ -130,11 +153,31 @@ func NewHandler(opts Options) (*Handler, error) {
 }
 
 func AuthTokensFromEnvironment() []string {
+	return ResolveAuthTokensFromEnvironment().Tokens
+}
+
+func ResolveAuthTokensFromEnvironment() AuthTokenResolution {
 	value := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN"))
-	if value == "" {
-		return nil
+	if value != "" {
+		return AuthTokenResolution{
+			Tokens:   []string{value},
+			Source:   AuthTokenSourceEnvironment,
+			Explicit: true,
+		}
 	}
-	return []string{value}
+	return AuthTokenResolution{
+		Tokens: []string{DefaultLoopbackAPIToken},
+		Source: AuthTokenSourceBuiltInLoopbackToken,
+	}
+}
+
+func DefaultLoopbackAPITokenAllowedHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" {
+		return false
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -75,6 +75,31 @@ func TestAuthTokensFromEnvironmentUsesOnlyUnifiedToken(t *testing.T) {
 	}
 }
 
+func TestResolveAuthTokensFromEnvironmentDefaultsToLoopbackToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	resolution := ResolveAuthTokensFromEnvironment()
+	if !resolution.UsesDefaultLoopbackToken() {
+		t.Fatalf("resolution = %#v, want default loopback token", resolution)
+	}
+	want := []string{DefaultLoopbackAPIToken}
+	if !reflect.DeepEqual(resolution.Tokens, want) {
+		t.Fatalf("tokens = %v, want %v", resolution.Tokens, want)
+	}
+}
+
+func TestDefaultLoopbackAPITokenAllowedHost(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "127.42.0.7", "::1", "[::1]"} {
+		if !DefaultLoopbackAPITokenAllowedHost(host) {
+			t.Fatalf("host %q rejected, want numeric loopback accepted", host)
+		}
+	}
+	for _, host := range []string{"", "localhost", "0.0.0.0", "::", "192.168.1.10", "example.test"} {
+		if DefaultLoopbackAPITokenAllowedHost(host) {
+			t.Fatalf("host %q accepted, want non-loopback/DNS rejected", host)
+		}
+	}
+}
+
 func TestLegacyEnvironmentTokensDoNotAuthorizeV1Transports(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "")
 	t.Setenv("SWARM_BUILDER_AUTH_TOKEN", "legacy-builder")
@@ -85,8 +110,8 @@ func TestLegacyEnvironmentTokensDoNotAuthorizeV1Transports(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"auth","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`))
 	req.Header.Set("Authorization", "Bearer legacy-builder")
 	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("/v1/rpc status = %d, want 503 with no canonical token configured body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("/v1/rpc status = %d, want 401 with only the default canonical token configured body=%s", rec.Code, rec.Body.String())
 	}
 
 	server := httptest.NewServer(handler)
@@ -96,8 +121,8 @@ func TestLegacyEnvironmentTokensDoNotAuthorizeV1Transports(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected websocket auth failure")
 	}
-	if resp == nil || resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("/v1/ws response = %#v, want 503 with no canonical token configured", resp)
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("/v1/ws response = %#v, want 401 with only the default canonical token configured", resp)
 	}
 }
 


### PR DESCRIPTION
Closes #1124

## Summary

Implements the approved loopback-scoped local-dev API token boundary for `/v1/rpc` and `/v1/ws` consumers. A fixed built-in bearer token is used only when no explicit API token is configured and the API target or serve bind host is numeric loopback. Non-loopback API binds and CLI targets still fail closed unless an explicit token is configured.

## Governing Refs

- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`
- `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#api_specification.auth.v1_model`
- Adjacent split context: `docs/specs/swarm-platform/platform/contracts/platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup` for MCP/tool-gateway auth, which remains out of scope.

## Semantic Migration

- New canonical owner: `internal/apiv1` owns typed API token resolution, the built-in loopback token value, and numeric-loopback host classification.
- CLI consumer: `cmd/swarm/cli_api.go` consumes that owner for API-backed commands and preserves explicit token precedence.
- Serve consumer: `cmd/swarm/main.go` consumes the same owner and rejects default-token startup on non-loopback API binds before readiness.
- Old invalid paths: tokenless numeric-loopback CLI/API startup no longer fails before request; tokenless non-loopback CLI/API remains fail-closed; Compose no longer relies on any default token for its `0.0.0.0` API bind.
- Production paths checked: `/v1/rpc`, `/v1/ws`, API-backed CLI resolver, local foreground `swarm run`, `swarm run --connect`, `swarm serve`, Docker Compose, `scripts/run_clear.sh`, MCP/tool-gateway regression, and token-free `swarm verify` split behavior.
- Migration completeness: complete for the approved child class `loopback_scoped_default_v1_api_token_owner`.

## Validation

- `go test ./...`
- `go test ./internal/apiv1 -run 'TestResolveAuthTokensFromEnvironmentDefaultsToLoopbackToken|TestDefaultLoopbackAPITokenAllowedHost|TestHandlerHTTPAuthBoundary' -count=1`
- `go test ./cmd/swarm -run 'TestDockerComposeUsesBackendFlagNotRetiredLLMBackendEnv|TestValidateServeAPIAuthBindingDefaultTokenLoopbackBoundary|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `env -u SWARM_API_TOKEN SWARM_CONTRACTS_HOST_DIR=/tmp docker compose config` succeeds, preserving documented postgres-only Compose startup/model rendering.
- `SWARM_API_TOKEN=test-token SWARM_CONTRACTS_HOST_DIR=/tmp docker compose config` succeeds.
- `TestDockerComposeUsesBackendFlagNotRetiredLLMBackendEnv` asserts Compose does not default the non-loopback orchestrator API to the built-in token and keeps an orchestrator-command-level explicit-token check.