### PR TITLE
[agent-g][issue #1148] Add backend-neutral budget spend owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -31,6 +31,7 @@ import (
 	"swarm/internal/config"
 	"swarm/internal/runtime"
 	runtimebootverify "swarm/internal/runtime/bootverify"
+	"swarm/internal/runtime/budgetspend"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecorrelation "swarm/internal/runtime/correlation"
@@ -130,6 +131,7 @@ type storeBundle struct {
 	ManagerStore        runtimemanager.ManagerPersistence
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	MailboxStore        runtimetools.MailboxPersistence
+	BudgetSpendStore    budgetspend.Store
 	MailboxAPIStore     apiv1.MailboxAPIStore
 	ObservabilityStore  apiv1.ObservabilityReadStore
 	RuntimeIngressStore runtimeingress.Store
@@ -150,6 +152,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ScheduleStore:       s.ScheduleStore,
 		StartupOwnership:    s.StartupOwnership,
 		MailboxStore:        s.MailboxStore,
+		BudgetSpendStore:    s.BudgetSpendStore,
 		RuntimeIngressStore: s.RuntimeIngressStore,
 		TurnStore:           s.TurnStore,
 	}
@@ -2013,6 +2016,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ManagerStore:        pg,
 			ScheduleStore:       pg,
 			MailboxStore:        pg,
+			BudgetSpendStore:    pg,
 			MailboxAPIStore:     pg,
 			ObservabilityStore:  pg,
 			RuntimeIngressStore: pg,
@@ -2036,7 +2040,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (budget tracking/spend ledger, tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
+			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
 			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB),
@@ -2045,6 +2049,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ManagerStore:        sqliteStore,
 			ScheduleStore:       sqliteStore,
 			MailboxStore:        sqliteStore,
+			BudgetSpendStore:    sqliteStore,
 			MailboxAPIStore:     sqliteStore,
 			ObservabilityStore:  sqliteStore,
 			RuntimeIngressStore: sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -181,7 +181,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -196,6 +196,12 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
+	}
+	if strings.Contains(runtimeStores.ConstructionBlocker, "budget tracking/spend ledger") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1148 budget/spend owner removed from residual blocker", runtimeStores.ConstructionBlocker)
+	}
+	if runtimeStores.BudgetSpendStore == nil {
+		t.Fatal("sqlite runtimeStores BudgetSpendStore missing backend-neutral budget/spend owner")
 	}
 	if runtimeStores.PipelineStore == nil || !runtimeStores.PipelineStore.Enabled() {
 		t.Fatal("sqlite runtimeStores PipelineStore missing enabled backend-neutral pipeline owner")

--- a/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
+++ b/docs/specs/swarm-platform/platform/contracts/platform-spec.yaml
@@ -2259,12 +2259,12 @@ engine:
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
         - >
           May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
-          and observability semantics, but must not be treated as a construction-ready runtime backend while the #1087
-          raw-SQL consumer blocker remains unresolved.
+          observability semantics, and #1148 budget/spend rows, but must not be treated as a construction-ready runtime
+          backend while the remaining #1087 raw-SQL consumer blocker remains unresolved.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
-        - Must keep runtime construction fail-closed until budget tracking/spend ledger, tool-executor entity/human-task
-          persistence and diagnostics, and runtime diagnostics/logging either gain backend-neutral owners for SQLite or
-          receive explicit lead-approved split/tracker repair.
+        - Must keep runtime construction fail-closed until tool-executor entity/human-task persistence and diagnostics, and
+          runtime diagnostics/logging either gain backend-neutral owners for SQLite or receive explicit lead-approved
+          split/tracker repair.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2299,9 +2299,23 @@ engine:
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
         replay scope consumption. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
       excludes:
-      - budget/spend ledger owned by #1148
       - tool executor entity and human-task persistence/diagnostics owned by #1149
       - runtime diagnostics/logging owned by #1150
+    - name: runtime_budget_spend_rows
+      owner: internal/runtime/budgetspend.Store consumed through runtime.Stores.BudgetSpendStore and internal/runtime.BudgetTracker
+      sqlite_owner: internal/store.SQLiteRuntimeStore budget/spend methods over spend_ledger and entity_state
+      postgres_owner: internal/store.PostgresStore budget/spend methods over spend_ledger and entity_state
+      scope: >
+        SQLite supports explicit local-dev budget tracking construction, LLM spend recording, flow-instance resolution,
+        active entity enumeration, system/global/entity spend aggregation, threshold event evaluation, and emergency mailbox
+        side effects through the same BudgetTracker behavior owner. Postgres remains authoritative for production runtime
+        budget/spend semantics. SQLite must not substitute an in-memory spend ledger for persisted local runtime budget truth.
+      excludes:
+      - public operator agent.usage reads over spend_ledger owned by #1157
+      - tool executor entity and human-task persistence/diagnostics owned by #1149
+      - runtime diagnostics/logging owned by #1150
+      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - production multi-writer SQLite budget concurrency semantics
     - name: mailbox_rows
       owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
       sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
@@ -2355,10 +2369,9 @@ engine:
       runtime_sql_handle_for_sqlite: omitted
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
-        accidentally treated as SQLite owners. Because budget tracking/spend ledger, tool-executor SQL diagnostics/entity
-        helpers, and SQL runtime logging are still gate-promoted #1087 consumers, runtime.NewRuntime must fail closed for
-        SQLite until those consumers move to backend-neutral store owners or receive explicit lead-approved split/tracker
-        repair.
+        accidentally treated as SQLite owners. Because tool-executor SQL diagnostics/entity helpers and SQL runtime logging
+        are still gate-promoted #1087 consumers, runtime.NewRuntime must fail closed for SQLite until those consumers move
+        to backend-neutral store owners or receive explicit lead-approved split/tracker repair.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."

--- a/internal/runtime/budget.go
+++ b/internal/runtime/budget.go
@@ -2,16 +2,15 @@ package runtime
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	"swarm/internal/config"
 	"swarm/internal/events"
+	"swarm/internal/runtime/budgetspend"
 	runtimebus "swarm/internal/runtime/bus"
 	models "swarm/internal/runtime/core/actors"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
@@ -41,7 +40,7 @@ func budgetExecutionScopeKey(actor models.AgentConfig) string {
 //
 // It is not accounting-grade. The intent is runaway-spend prevention.
 type BudgetTracker struct {
-	db             *sql.DB
+	store          budgetspend.Store
 	bus            *runtimebus.EventBus
 	cfg            *config.Config
 	logger         *RuntimeLogger
@@ -55,6 +54,8 @@ type BudgetTracker struct {
 	scopeMu   sync.Map          // key(scope) => *sync.Mutex
 }
 
+type SpendRecord = budgetspend.SpendRecord
+
 type budgetThresholds struct {
 	Enabled   bool
 	Warning   float64
@@ -62,9 +63,9 @@ type budgetThresholds struct {
 	Emergency float64
 }
 
-func NewBudgetTracker(db *sql.DB, bus *runtimebus.EventBus, cfg *config.Config, mailbox runtimetools.MailboxPersistence, logger *RuntimeLogger, source semanticview.Source) *BudgetTracker {
+func NewBudgetTracker(store budgetspend.Store, bus *runtimebus.EventBus, cfg *config.Config, mailbox runtimetools.MailboxPersistence, logger *RuntimeLogger, source semanticview.Source) *BudgetTracker {
 	return &BudgetTracker{
-		db:             db,
+		store:          store,
 		bus:            bus,
 		cfg:            cfg,
 		logger:         logger,
@@ -158,7 +159,7 @@ func (t *BudgetTracker) LockExecutionScope(entityID string) func() {
 // EvaluateAll periodically re-evaluates budget state to ensure month-boundary
 // "resume" transitions are emitted even when spend is paused (spec v2.0).
 func (t *BudgetTracker) EvaluateAll(ctx context.Context) {
-	if t == nil || t.db == nil {
+	if t == nil || t.store == nil {
 		return
 	}
 	runID, err := runtimecurrentstate.RequireRunID(ctx)
@@ -175,23 +176,11 @@ func (t *BudgetTracker) EvaluateAll(ctx context.Context) {
 		}
 	}
 
-	// Evaluate each active entity with any spend/metrics.
-	rows, err := t.db.QueryContext(ctx, `
-		SELECT entity_id::text
-		FROM entity_state
-		WHERE run_id = $1::uuid
-		  AND NOT (current_state = ANY($2::text[]))
-		ORDER BY created_at ASC
-	`, runID, pq.Array(t.TerminalInstanceStates()))
+	entityIDs, err := t.store.ListActiveEntityIDs(ctx, runID, t.TerminalInstanceStates())
 	if err != nil {
 		return
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return
-		}
+	for _, id := range entityIDs {
 		if err := t.evaluateAndEmit(ctx, strings.TrimSpace(id)); err != nil {
 			if t.logger != nil {
 				handleRuntimeLogPersistenceError("budget", "evaluate_entity_failed", t.logger.Warn(ctx, "budget", "evaluate_entity_failed", map[string]any{"entity_id": strings.TrimSpace(id)}, err))
@@ -209,33 +198,8 @@ func (t *BudgetTracker) TerminalInstanceStates() []string {
 	return out
 }
 
-type SpendRecord struct {
-	EntityID        string
-	FlowInstance    string
-	AgentID         string
-	Model           string
-	InputTokens     int
-	OutputTokens    int
-	CostUSD         float64
-	InvocationType  string
-	UsageAccounting string
-	RecordedAt      time.Time
-}
-
-func (r SpendRecord) EffectiveEntityID() string {
-	return strings.TrimSpace(r.EntityID)
-}
-
-func (r *SpendRecord) NormalizeEntityID() {
-	if r == nil {
-		return
-	}
-	entityID := r.EffectiveEntityID()
-	r.EntityID = entityID
-}
-
 func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error {
-	if t == nil || t.db == nil {
+	if t == nil || t.store == nil {
 		return nil
 	}
 	if rec.RecordedAt.IsZero() {
@@ -274,25 +238,7 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 		rec.CostUSD = 0
 	}
 
-	const q = `
-		INSERT INTO spend_ledger (
-			entity_id, flow_instance, agent_id, model, input_tokens, output_tokens, cost_usd, invocation_type, usage_accounting, created_at
-		) VALUES (
-			NULLIF($1,'')::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10
-		)
-	`
-	if _, err := t.db.ExecContext(ctx, q,
-		rec.EffectiveEntityID(),
-		rec.FlowInstance,
-		rec.AgentID,
-		rec.Model,
-		rec.InputTokens,
-		rec.OutputTokens,
-		rec.CostUSD,
-		rec.InvocationType,
-		rec.UsageAccounting,
-		rec.RecordedAt,
-	); err != nil {
+	if err := t.store.RecordSpend(ctx, rec); err != nil {
 		return fmt.Errorf("insert spend_ledger: %w", err)
 	}
 
@@ -306,7 +252,7 @@ func (t *BudgetTracker) RecordSpend(ctx context.Context, rec SpendRecord) error 
 }
 
 func (t *BudgetTracker) RecordLLMUsage(ctx context.Context, entityID string, agentID string, runtimeMode string, usage llm.UsageTokens, exact bool, meta any) error {
-	if t == nil || t.db == nil {
+	if t == nil || t.store == nil {
 		return nil
 	}
 	entityID = strings.TrimSpace(entityID)
@@ -353,13 +299,8 @@ func (t *BudgetTracker) resolveSpendFlowInstance(ctx context.Context, entityID s
 	if err != nil {
 		return "", err
 	}
-	var flowInstance string
-	if err := t.db.QueryRowContext(ctx, `
-		SELECT COALESCE(flow_instance, '')
-		FROM entity_state
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-	`, identity.RunID, identity.EntityID).Scan(&flowInstance); err != nil {
+	flowInstance, err := t.store.ResolveFlowInstance(ctx, identity.RunID, identity.EntityID)
+	if err != nil {
 		return "", fmt.Errorf("resolve spend flow_instance for entity %s: %w", entityID, err)
 	}
 	flowInstance = strings.TrimSpace(flowInstance)
@@ -410,7 +351,7 @@ func modelTier(model string) string {
 }
 
 func (t *BudgetTracker) evaluateAndEmit(ctx context.Context, entityID string) error {
-	if t == nil || t.db == nil || t.bus == nil || t.cfg == nil {
+	if t == nil || t.store == nil || t.bus == nil || t.cfg == nil {
 		return nil
 	}
 	entityID = strings.TrimSpace(entityID)
@@ -445,30 +386,11 @@ func (t *BudgetTracker) evaluateScope(ctx context.Context, scope string, entityI
 	now := time.Now().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 
-	var spent float64
-	var err error
-	switch {
-	case scope == "system":
-		err = t.db.QueryRowContext(ctx, `
-			SELECT COALESCE(SUM(cost_usd), 0)
-			FROM spend_ledger
-			WHERE created_at >= $1
-		`, start).Scan(&spent)
-	case entityID == "":
-		err = t.db.QueryRowContext(ctx, `
-			SELECT COALESCE(SUM(cost_usd), 0)
-			FROM spend_ledger
-			WHERE entity_id IS NULL
-			  AND created_at >= $1
-		`, start).Scan(&spent)
-	default:
-		err = t.db.QueryRowContext(ctx, `
-			SELECT COALESCE(SUM(cost_usd), 0)
-			FROM spend_ledger
-			WHERE entity_id = $1::uuid
-			  AND created_at >= $2
-		`, entityID, start).Scan(&spent)
-	}
+	spent, err := t.store.SumSpendUSD(ctx, budgetspend.SpendQuery{
+		Scope:    budgetScope(scope, entityID),
+		EntityID: entityID,
+		Since:    start,
+	})
 	if err != nil {
 		return err
 	}
@@ -553,6 +475,22 @@ func (t *BudgetTracker) evaluateScope(ctx context.Context, scope string, entityI
 		}
 	}
 	return nil
+}
+
+func budgetScope(scope string, entityID string) budgetspend.Scope {
+	switch strings.TrimSpace(scope) {
+	case string(budgetspend.ScopeSystem):
+		return budgetspend.ScopeSystem
+	case string(budgetspend.ScopeEntity):
+		return budgetspend.ScopeEntity
+	case string(budgetspend.ScopeGlobal):
+		return budgetspend.ScopeGlobal
+	default:
+		if strings.TrimSpace(entityID) != "" {
+			return budgetspend.ScopeEntity
+		}
+		return budgetspend.ScopeGlobal
+	}
 }
 
 func budgetThresholdsFromSource(source semanticview.Source) budgetThresholds {

--- a/internal/runtime/budget_test.go
+++ b/internal/runtime/budget_test.go
@@ -2,13 +2,18 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"swarm/internal/config"
+	"swarm/internal/runtime/budgetspend"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	llm "swarm/internal/runtime/llm"
 	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
 )
 
 func TestBudgetTracker_KeepsTerminalStatesInstanceOwned(t *testing.T) {
@@ -32,18 +37,10 @@ func TestBudgetTracker_KeepsTerminalStatesInstanceOwned(t *testing.T) {
 }
 
 func TestBudgetTracker_RecordLLMUsagePersistsUsageAccounting(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
-	}
-	defer db.Close()
-
-	tracker := &BudgetTracker{db: db}
+	store := &budgetSpendStoreCapture{}
+	tracker := &BudgetTracker{store: store}
 	ctx := context.Background()
 
-	mock.ExpectExec("INSERT INTO spend_ledger").
-		WithArgs("", "flow/1", "agent-1", "claude-3-5-sonnet", 11, 7, sqlmock.AnyArg(), "api", "exact", sqlmock.AnyArg()).
-		WillReturnResult(sqlmock.NewResult(0, 1))
 	if err := tracker.RecordLLMUsage(ctx, "", "agent-1", "api", llm.UsageTokens{
 		Model:        "claude-3-5-sonnet",
 		InputTokens:  11,
@@ -51,10 +48,19 @@ func TestBudgetTracker_RecordLLMUsagePersistsUsageAccounting(t *testing.T) {
 	}, true, map[string]any{"flow_instance": "flow/1"}); err != nil {
 		t.Fatalf("RecordLLMUsage exact: %v", err)
 	}
+	if len(store.records) != 1 {
+		t.Fatalf("records after exact = %d, want 1", len(store.records))
+	}
+	assertBudgetSpendRecord(t, store.records[0], budgetspend.SpendRecord{
+		FlowInstance:    "flow/1",
+		AgentID:         "agent-1",
+		Model:           "claude-3-5-sonnet",
+		InputTokens:     11,
+		OutputTokens:    7,
+		InvocationType:  "api",
+		UsageAccounting: "exact",
+	})
 
-	mock.ExpectExec("INSERT INTO spend_ledger").
-		WithArgs("", "flow/1", "agent-1", "claude-cli-sonnet", 13, 5, sqlmock.AnyArg(), "cli_test", "estimated", sqlmock.AnyArg()).
-		WillReturnResult(sqlmock.NewResult(0, 1))
 	if err := tracker.RecordLLMUsage(ctx, "", "agent-1", "cli_test", llm.UsageTokens{
 		Model:        "claude-cli-sonnet",
 		InputTokens:  13,
@@ -62,8 +68,186 @@ func TestBudgetTracker_RecordLLMUsagePersistsUsageAccounting(t *testing.T) {
 	}, false, map[string]any{"flow_instance": "flow/1"}); err != nil {
 		t.Fatalf("RecordLLMUsage estimated: %v", err)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if len(store.records) != 2 {
+		t.Fatalf("records after estimated = %d, want 2", len(store.records))
 	}
+	assertBudgetSpendRecord(t, store.records[1], budgetspend.SpendRecord{
+		FlowInstance:    "flow/1",
+		AgentID:         "agent-1",
+		Model:           "claude-cli-sonnet",
+		InputTokens:     13,
+		OutputTokens:    5,
+		InvocationType:  "cli_test",
+		UsageAccounting: "estimated",
+	})
+}
+
+func assertBudgetSpendRecord(t *testing.T, got budgetspend.SpendRecord, want budgetspend.SpendRecord) {
+	t.Helper()
+	if got.FlowInstance != want.FlowInstance || got.AgentID != want.AgentID || got.Model != want.Model || got.InputTokens != want.InputTokens || got.OutputTokens != want.OutputTokens || got.InvocationType != want.InvocationType || got.UsageAccounting != want.UsageAccounting {
+		t.Fatalf("spend record = %#v, want matching %#v", got, want)
+	}
+	if got.RecordedAt.IsZero() {
+		t.Fatal("spend record RecordedAt is zero")
+	}
+}
+
+type budgetSpendStoreCapture struct {
+	records    []budgetspend.SpendRecord
+	sum        float64
+	sumQueries []budgetspend.SpendQuery
+}
+
+func (s *budgetSpendStoreCapture) RecordSpend(_ context.Context, rec budgetspend.SpendRecord) error {
+	s.records = append(s.records, rec)
+	return nil
+}
+
+func (s *budgetSpendStoreCapture) ResolveFlowInstance(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (s *budgetSpendStoreCapture) ListActiveEntityIDs(context.Context, string, []string) ([]string, error) {
+	return nil, nil
+}
+
+func (s *budgetSpendStoreCapture) SumSpendUSD(_ context.Context, query budgetspend.SpendQuery) (float64, error) {
+	s.sumQueries = append(s.sumQueries, query)
+	return s.sum, nil
+}
+
+func TestBudgetTracker_RecordSpendNormalizesThroughBudgetSpendOwner(t *testing.T) {
+	store := &budgetSpendStoreCapture{}
+	tracker := &BudgetTracker{store: store}
+	if err := tracker.RecordSpend(context.Background(), SpendRecord{
+		FlowInstance:    " flow/1 ",
+		AgentID:         " agent-1 ",
+		Model:           " claude ",
+		InputTokens:     -1,
+		OutputTokens:    -2,
+		CostUSD:         -3,
+		InvocationType:  " API ",
+		UsageAccounting: " EXACT ",
+		RecordedAt:      time.Time{},
+	}); err != nil {
+		t.Fatalf("RecordSpend: %v", err)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("records = %d, want 1", len(store.records))
+	}
+	got := store.records[0]
+	if got.FlowInstance != "flow/1" || got.AgentID != "agent-1" || got.Model != "claude" || got.InputTokens != 0 || got.OutputTokens != 0 || got.CostUSD != 0 || got.InvocationType != "api" || got.UsageAccounting != "exact" {
+		t.Fatalf("normalized spend record = %#v", got)
+	}
+}
+
+func TestBudgetTrackerThresholdEventAndEmergencyMailboxConsumeBudgetSpendOwner(t *testing.T) {
+	store := &budgetSpendStoreCapture{sum: 0.95}
+	eventStore := &bootSelfCheckDescriptorStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	mailbox := &budgetMailboxCapture{}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"budget_warning_percent":   {Value: 50},
+			"budget_throttle_percent":  {Value: 75},
+			"budget_emergency_percent": {Value: 90},
+		}},
+	})
+	tracker := NewBudgetTracker(store, bus, &config.Config{Extensions: map[string]any{
+		"budget": map[string]any{"system_monthly_cap": 1},
+	}}, mailbox, nil, source)
+
+	if err := tracker.RecordSpend(context.Background(), SpendRecord{
+		FlowInstance:    "global",
+		AgentID:         "agent-1",
+		Model:           "claude",
+		InputTokens:     1,
+		OutputTokens:    1,
+		CostUSD:         0.95,
+		InvocationType:  "api",
+		UsageAccounting: "exact",
+	}); err != nil {
+		t.Fatalf("RecordSpend: %v", err)
+	}
+	events := eventStore.appendedEvents()
+	if len(events) != 1 || string(events[0].Type) != "platform.budget_threshold_crossed" {
+		t.Fatalf("events = %#v, want one platform.budget_threshold_crossed", events)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal budget event payload: %v", err)
+	}
+	if payload["level"] != "emergency" {
+		t.Fatalf("budget event level = %#v, want emergency", payload["level"])
+	}
+	if len(mailbox.items) != 1 || mailbox.items[0].Priority != "critical" || mailbox.items[0].Type != "alert" {
+		t.Fatalf("mailbox items = %#v, want one critical alert", mailbox.items)
+	}
+	if len(store.sumQueries) != 1 || store.sumQueries[0].Scope != budgetspend.ScopeSystem {
+		t.Fatalf("sum queries = %#v, want one system aggregate", store.sumQueries)
+	}
+}
+
+func TestNewRuntimeConstructsBudgetTrackerFromBackendNeutralStore(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	store := &budgetSpendStoreCapture{}
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
+		EventStore:       &minimalRuntimeEventStore{},
+		BudgetSpendStore: store,
+	}, Options: RuntimeOptions{
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+	}})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if rt.Budget == nil {
+		t.Fatal("Runtime Budget = nil, want backend-neutral budget tracker")
+	}
+	if rt.Budget.store != store {
+		t.Fatalf("Runtime Budget store = %#v, want backend-neutral store %#v", rt.Budget.store, store)
+	}
+	if rt.Stores.SQLDB != nil {
+		t.Fatalf("Runtime Stores.SQLDB = %#v, want nil raw SQL handle", rt.Stores.SQLDB)
+	}
+}
+
+type budgetMailboxCapture struct {
+	items []runtimetools.MailboxItem
+}
+
+func (m *budgetMailboxCapture) InsertMailboxItem(_ context.Context, item runtimetools.MailboxItem) (string, error) {
+	m.items = append(m.items, item)
+	return "mailbox-1", nil
+}
+
+func (*budgetMailboxCapture) ListMailboxItems(context.Context, string, int) ([]runtimetools.MailboxItem, error) {
+	return nil, nil
+}
+
+func (*budgetMailboxCapture) CountMailboxItems(context.Context, string) (int, error) {
+	return 0, nil
+}
+
+func (*budgetMailboxCapture) GetMailboxItem(context.Context, string) (runtimetools.MailboxItem, error) {
+	return runtimetools.MailboxItem{}, nil
+}
+
+func (*budgetMailboxCapture) DecideMailboxItem(context.Context, string, string, string, string) error {
+	return nil
+}
+
+func (*budgetMailboxCapture) ExpireMailboxItems(context.Context, int) ([]runtimetools.MailboxItem, error) {
+	return nil, nil
+}
+
+func (*budgetMailboxCapture) ListUnnotifiedCriticalMailboxItems(context.Context, int) ([]runtimetools.MailboxItem, error) {
+	return nil, nil
+}
+
+func (*budgetMailboxCapture) MarkMailboxItemNotified(context.Context, string) error {
+	return nil
 }

--- a/internal/runtime/budgetspend/store.go
+++ b/internal/runtime/budgetspend/store.go
@@ -1,0 +1,55 @@
+package budgetspend
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+type Scope string
+
+const (
+	ScopeSystem Scope = "system"
+	ScopeGlobal Scope = "global"
+	ScopeEntity Scope = "entity"
+)
+
+// Store is the backend-neutral owner for runtime budget/spend persistence.
+// Runtime budget policy lives in BudgetTracker; this contract owns the
+// persisted spend_ledger/entity_state reads and writes it needs.
+type Store interface {
+	RecordSpend(ctx context.Context, rec SpendRecord) error
+	ResolveFlowInstance(ctx context.Context, runID string, entityID string) (string, error)
+	ListActiveEntityIDs(ctx context.Context, runID string, terminalStates []string) ([]string, error)
+	SumSpendUSD(ctx context.Context, query SpendQuery) (float64, error)
+}
+
+type SpendRecord struct {
+	EntityID        string
+	FlowInstance    string
+	AgentID         string
+	Model           string
+	InputTokens     int
+	OutputTokens    int
+	CostUSD         float64
+	InvocationType  string
+	UsageAccounting string
+	RecordedAt      time.Time
+}
+
+func (r SpendRecord) EffectiveEntityID() string {
+	return strings.TrimSpace(r.EntityID)
+}
+
+func (r *SpendRecord) NormalizeEntityID() {
+	if r == nil {
+		return
+	}
+	r.EntityID = r.EffectiveEntityID()
+}
+
+type SpendQuery struct {
+	Scope    Scope
+	EntityID string
+	Since    time.Time
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"swarm/internal/events"
 	runtimeagents "swarm/internal/runtime/agents"
 	runtimeauthority "swarm/internal/runtime/authority"
+	"swarm/internal/runtime/budgetspend"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
@@ -48,6 +49,7 @@ type Stores struct {
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	StartupOwnership    runtimestartupownership.Store
 	MailboxStore        runtimetools.MailboxPersistence
+	BudgetSpendStore    budgetspend.Store
 	InboundStore        InboundPersistence
 	RuntimeIngressStore runtimeingress.Store
 	TurnStore           llm.TurnPersistence
@@ -460,8 +462,8 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		}
 	}
 
-	if stores.SQLDB != nil {
-		rt.Budget = NewBudgetTracker(stores.SQLDB, rt.Bus, cfg, stores.MailboxStore, rt.Logger, source)
+	if stores.BudgetSpendStore != nil {
+		rt.Budget = NewBudgetTracker(stores.BudgetSpendStore, rt.Bus, cfg, stores.MailboxStore, rt.Logger, source)
 	}
 
 	backendProfile, err := cfg.LLMBackendProfile()

--- a/internal/store/budget_spend.go
+++ b/internal/store/budget_spend.go
@@ -1,0 +1,333 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"swarm/internal/runtime/budgetspend"
+)
+
+var _ budgetspend.Store = (*PostgresStore)(nil)
+var _ budgetspend.Store = (*SQLiteRuntimeStore)(nil)
+
+func (s *PostgresStore) RecordSpend(ctx context.Context, rec budgetspend.SpendRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres budget spend store is required")
+	}
+	rec = normalizeBudgetSpendRecord(rec)
+	if err := validateBudgetSpendEntity(rec.EntityID); err != nil {
+		return err
+	}
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO spend_ledger (
+			entity_id, flow_instance, agent_id, model, input_tokens, output_tokens, cost_usd, invocation_type, usage_accounting, created_at
+		) VALUES (
+			NULLIF($1,'')::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10
+		)
+	`, rec.EntityID, rec.FlowInstance, rec.AgentID, rec.Model, rec.InputTokens, rec.OutputTokens, rec.CostUSD, rec.InvocationType, rec.UsageAccounting, rec.RecordedAt)
+	if err != nil {
+		return fmt.Errorf("record postgres spend: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ResolveFlowInstance(ctx context.Context, runID string, entityID string) (string, error) {
+	if s == nil || s.DB == nil {
+		return "", fmt.Errorf("postgres budget spend store is required")
+	}
+	runID, entityID, err := validateBudgetSpendIdentity(runID, entityID)
+	if err != nil {
+		return "", err
+	}
+	var flowInstance string
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, runID, entityID).Scan(&flowInstance); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(flowInstance), nil
+}
+
+func (s *PostgresStore) ListActiveEntityIDs(ctx context.Context, runID string, terminalStates []string) ([]string, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres budget spend store is required")
+	}
+	runID, err := validateBudgetRunID(runID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT entity_id::text
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND NOT (current_state = ANY($2::text[]))
+		ORDER BY created_at ASC
+	`, runID, pq.Array(normalizeBudgetTerminalStates(terminalStates)))
+	if err != nil {
+		return nil, fmt.Errorf("list postgres active budget entities: %w", err)
+	}
+	defer rows.Close()
+	return scanBudgetEntityIDs(rows)
+}
+
+func (s *PostgresStore) SumSpendUSD(ctx context.Context, query budgetspend.SpendQuery) (float64, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("postgres budget spend store is required")
+	}
+	query = normalizeBudgetSpendQuery(query)
+	var spent float64
+	var err error
+	switch query.Scope {
+	case budgetspend.ScopeSystem:
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE created_at >= $1
+		`, query.Since).Scan(&spent)
+	case budgetspend.ScopeGlobal:
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE entity_id IS NULL
+			  AND created_at >= $1
+		`, query.Since).Scan(&spent)
+	case budgetspend.ScopeEntity:
+		if err := validateBudgetSpendEntityRequired(query.EntityID); err != nil {
+			return 0, err
+		}
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE entity_id = $1::uuid
+			  AND created_at >= $2
+		`, query.EntityID, query.Since).Scan(&spent)
+	default:
+		return 0, fmt.Errorf("unsupported budget spend scope %q", query.Scope)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("sum postgres spend: %w", err)
+	}
+	return spent, nil
+}
+
+func (s *SQLiteRuntimeStore) RecordSpend(ctx context.Context, rec budgetspend.SpendRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite budget spend store is required")
+	}
+	rec = normalizeBudgetSpendRecord(rec)
+	if err := validateBudgetSpendEntity(rec.EntityID); err != nil {
+		return err
+	}
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO spend_ledger (
+			entity_id, flow_instance, agent_id, model, input_tokens, output_tokens, cost_usd, invocation_type, usage_accounting, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sqliteNullUUID(rec.EntityID), rec.FlowInstance, rec.AgentID, rec.Model, rec.InputTokens, rec.OutputTokens, rec.CostUSD, rec.InvocationType, rec.UsageAccounting, rec.RecordedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("record sqlite spend: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ResolveFlowInstance(ctx context.Context, runID string, entityID string) (string, error) {
+	if s == nil || s.DB == nil {
+		return "", fmt.Errorf("sqlite budget spend store is required")
+	}
+	runID, entityID, err := validateBudgetSpendIdentity(runID, entityID)
+	if err != nil {
+		return "", err
+	}
+	var flowInstance string
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE run_id = ?
+		  AND entity_id = ?
+	`, runID, entityID).Scan(&flowInstance); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(flowInstance), nil
+}
+
+func (s *SQLiteRuntimeStore) ListActiveEntityIDs(ctx context.Context, runID string, terminalStates []string) ([]string, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite budget spend store is required")
+	}
+	runID, err := validateBudgetRunID(runID)
+	if err != nil {
+		return nil, err
+	}
+	args := []any{runID}
+	query := `
+		SELECT entity_id
+		FROM entity_state
+		WHERE run_id = ?
+	`
+	states := normalizeBudgetTerminalStates(terminalStates)
+	if len(states) > 0 {
+		placeholders := make([]string, 0, len(states))
+		for _, state := range states {
+			placeholders = append(placeholders, "?")
+			args = append(args, state)
+		}
+		query += " AND current_state NOT IN (" + strings.Join(placeholders, ", ") + ")"
+	}
+	query += " ORDER BY created_at ASC"
+	rows, err := s.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list sqlite active budget entities: %w", err)
+	}
+	defer rows.Close()
+	return scanBudgetEntityIDs(rows)
+}
+
+func (s *SQLiteRuntimeStore) SumSpendUSD(ctx context.Context, query budgetspend.SpendQuery) (float64, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("sqlite budget spend store is required")
+	}
+	query = normalizeBudgetSpendQuery(query)
+	var spent float64
+	var err error
+	switch query.Scope {
+	case budgetspend.ScopeSystem:
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE created_at >= ?
+		`, query.Since.UTC()).Scan(&spent)
+	case budgetspend.ScopeGlobal:
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE entity_id IS NULL
+			  AND created_at >= ?
+		`, query.Since.UTC()).Scan(&spent)
+	case budgetspend.ScopeEntity:
+		if err := validateBudgetSpendEntityRequired(query.EntityID); err != nil {
+			return 0, err
+		}
+		err = s.DB.QueryRowContext(ctx, `
+			SELECT COALESCE(SUM(cost_usd), 0)
+			FROM spend_ledger
+			WHERE entity_id = ?
+			  AND created_at >= ?
+		`, query.EntityID, query.Since.UTC()).Scan(&spent)
+	default:
+		return 0, fmt.Errorf("unsupported budget spend scope %q", query.Scope)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("sum sqlite spend: %w", err)
+	}
+	return spent, nil
+}
+
+func normalizeBudgetSpendRecord(rec budgetspend.SpendRecord) budgetspend.SpendRecord {
+	rec.NormalizeEntityID()
+	rec.FlowInstance = strings.TrimSpace(rec.FlowInstance)
+	rec.AgentID = strings.TrimSpace(rec.AgentID)
+	rec.Model = strings.TrimSpace(rec.Model)
+	rec.InvocationType = strings.TrimSpace(strings.ToLower(rec.InvocationType))
+	rec.UsageAccounting = strings.TrimSpace(strings.ToLower(rec.UsageAccounting))
+	if rec.RecordedAt.IsZero() {
+		rec.RecordedAt = time.Now().UTC()
+	} else {
+		rec.RecordedAt = rec.RecordedAt.UTC()
+	}
+	return rec
+}
+
+func normalizeBudgetSpendQuery(query budgetspend.SpendQuery) budgetspend.SpendQuery {
+	query.EntityID = strings.TrimSpace(query.EntityID)
+	if query.Since.IsZero() {
+		query.Since = time.Now().UTC()
+	} else {
+		query.Since = query.Since.UTC()
+	}
+	return query
+}
+
+func normalizeBudgetTerminalStates(states []string) []string {
+	out := make([]string, 0, len(states))
+	seen := map[string]struct{}{}
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		out = append(out, state)
+	}
+	return out
+}
+
+func scanBudgetEntityIDs(rows *sql.Rows) ([]string, error) {
+	out := make([]string, 0)
+	for rows.Next() {
+		var entityID string
+		if err := rows.Scan(&entityID); err != nil {
+			return nil, fmt.Errorf("scan active budget entity: %w", err)
+		}
+		entityID = strings.TrimSpace(entityID)
+		if entityID != "" {
+			out = append(out, entityID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active budget entities: %w", err)
+	}
+	return out, nil
+}
+
+func validateBudgetRunID(runID string) (string, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return "", fmt.Errorf("budget spend run_id is required")
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", fmt.Errorf("budget spend run_id must be uuid: %w", err)
+	}
+	return runID, nil
+}
+
+func validateBudgetSpendEntity(entityID string) error {
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return nil
+	}
+	_, err := uuid.Parse(entityID)
+	if err != nil {
+		return fmt.Errorf("budget spend entity_id must be uuid: %w", err)
+	}
+	return nil
+}
+
+func validateBudgetSpendEntityRequired(entityID string) error {
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return fmt.Errorf("budget spend entity_id is required")
+	}
+	return validateBudgetSpendEntity(entityID)
+}
+
+func validateBudgetSpendIdentity(runID string, entityID string) (string, string, error) {
+	runID, err := validateBudgetRunID(runID)
+	if err != nil {
+		return "", "", err
+	}
+	entityID = strings.TrimSpace(entityID)
+	if err := validateBudgetSpendEntityRequired(entityID); err != nil {
+		return "", "", err
+	}
+	return runID, entityID, nil
+}

--- a/internal/store/budget_spend_test.go
+++ b/internal/store/budget_spend_test.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"swarm/internal/runtime/budgetspend"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+)
+
+func TestSQLiteRuntimeStoreBudgetSpendPersistence(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	activeEntity := uuid.NewString()
+	terminalEntity := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Second)
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+
+	seedSQLiteBudgetRun(t, ctx, store, runID, now)
+	seedSQLiteBudgetEntity(t, ctx, store, runID, activeEntity, "flow/active", "active", now)
+	seedSQLiteBudgetEntity(t, ctx, store, runID, terminalEntity, "flow/done", "done", now)
+
+	if err := store.RecordSpend(ctx, budgetspend.SpendRecord{
+		EntityID:        activeEntity,
+		FlowInstance:    "flow/active",
+		AgentID:         "agent-1",
+		Model:           "claude-sonnet",
+		InputTokens:     10,
+		OutputTokens:    4,
+		CostUSD:         1.25,
+		InvocationType:  "api",
+		UsageAccounting: "exact",
+		RecordedAt:      now,
+	}); err != nil {
+		t.Fatalf("RecordSpend(entity): %v", err)
+	}
+	if err := store.RecordSpend(ctx, budgetspend.SpendRecord{
+		FlowInstance:    "global",
+		AgentID:         "agent-global",
+		Model:           "claude-cli",
+		InputTokens:     8,
+		OutputTokens:    2,
+		CostUSD:         0.75,
+		InvocationType:  "cli_test",
+		UsageAccounting: "estimated",
+		RecordedAt:      now,
+	}); err != nil {
+		t.Fatalf("RecordSpend(global): %v", err)
+	}
+
+	flow, err := store.ResolveFlowInstance(ctx, runID, activeEntity)
+	if err != nil {
+		t.Fatalf("ResolveFlowInstance: %v", err)
+	}
+	if flow != "flow/active" {
+		t.Fatalf("flow instance = %q, want flow/active", flow)
+	}
+	active, err := store.ListActiveEntityIDs(ctx, runID, []string{"done"})
+	if err != nil {
+		t.Fatalf("ListActiveEntityIDs: %v", err)
+	}
+	if len(active) != 1 || active[0] != activeEntity {
+		t.Fatalf("active entities = %#v, want only %s", active, activeEntity)
+	}
+
+	since := now.Add(-time.Hour)
+	system, err := store.SumSpendUSD(ctx, budgetspend.SpendQuery{Scope: budgetspend.ScopeSystem, Since: since})
+	if err != nil {
+		t.Fatalf("SumSpendUSD(system): %v", err)
+	}
+	global, err := store.SumSpendUSD(ctx, budgetspend.SpendQuery{Scope: budgetspend.ScopeGlobal, Since: since})
+	if err != nil {
+		t.Fatalf("SumSpendUSD(global): %v", err)
+	}
+	entity, err := store.SumSpendUSD(ctx, budgetspend.SpendQuery{Scope: budgetspend.ScopeEntity, EntityID: activeEntity, Since: since})
+	if err != nil {
+		t.Fatalf("SumSpendUSD(entity): %v", err)
+	}
+	if system != 2.0 || global != 0.75 || entity != 1.25 {
+		t.Fatalf("spend sums system=%v global=%v entity=%v, want 2.0/0.75/1.25", system, global, entity)
+	}
+
+	var exactRows, estimatedRows int
+	if err := store.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM spend_ledger WHERE usage_accounting = 'exact'`).Scan(&exactRows); err != nil {
+		t.Fatalf("count exact rows: %v", err)
+	}
+	if err := store.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM spend_ledger WHERE usage_accounting = 'estimated'`).Scan(&estimatedRows); err != nil {
+		t.Fatalf("count estimated rows: %v", err)
+	}
+	if exactRows != 1 || estimatedRows != 1 {
+		t.Fatalf("usage accounting rows exact=%d estimated=%d, want 1/1", exactRows, estimatedRows)
+	}
+}
+
+func TestPostgresStoreBudgetSpendPersistenceQueries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	recordedAt := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO spend_ledger")).
+		WithArgs(entityID, "flow/1", "agent-1", "claude-sonnet", 10, 4, 1.25, "api", "exact", recordedAt).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := pg.RecordSpend(ctx, budgetspend.SpendRecord{
+		EntityID:        entityID,
+		FlowInstance:    "flow/1",
+		AgentID:         "agent-1",
+		Model:           "claude-sonnet",
+		InputTokens:     10,
+		OutputTokens:    4,
+		CostUSD:         1.25,
+		InvocationType:  "api",
+		UsageAccounting: "exact",
+		RecordedAt:      recordedAt,
+	}); err != nil {
+		t.Fatalf("RecordSpend: %v", err)
+	}
+
+	mock.ExpectQuery("FROM entity_state").
+		WithArgs(runID, entityID).
+		WillReturnRows(sqlmock.NewRows([]string{"flow_instance"}).AddRow("flow/1"))
+	flow, err := pg.ResolveFlowInstance(ctx, runID, entityID)
+	if err != nil {
+		t.Fatalf("ResolveFlowInstance: %v", err)
+	}
+	if flow != "flow/1" {
+		t.Fatalf("flow = %q, want flow/1", flow)
+	}
+
+	mock.ExpectQuery("SELECT entity_id::text").
+		WithArgs(runID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"entity_id"}).AddRow(entityID))
+	active, err := pg.ListActiveEntityIDs(ctx, runID, []string{"done"})
+	if err != nil {
+		t.Fatalf("ListActiveEntityIDs: %v", err)
+	}
+	if len(active) != 1 || active[0] != entityID {
+		t.Fatalf("active entities = %#v, want %s", active, entityID)
+	}
+
+	since := recordedAt.Add(-time.Hour)
+	mock.ExpectQuery("FROM spend_ledger").
+		WithArgs(entityID, since).
+		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(1.25))
+	spent, err := pg.SumSpendUSD(ctx, budgetspend.SpendQuery{Scope: budgetspend.ScopeEntity, EntityID: entityID, Since: since})
+	if err != nil {
+		t.Fatalf("SumSpendUSD: %v", err)
+	}
+	if spent != 1.25 {
+		t.Fatalf("spent = %v, want 1.25", spent)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func seedSQLiteBudgetEntity(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, runID, entityID, flowInstance, state string, at time.Time) {
+	t.Helper()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (?, ?, ?, 'budget_entity', ?, ?, ?, '{}', '{}', '{}', 1, ?, ?, ?)
+	`, runID, entityID, flowInstance, entityID, entityID, state, at, at, at); err != nil {
+		t.Fatalf("seed sqlite budget entity %s: %v", entityID, err)
+	}
+}
+
+func seedSQLiteBudgetRun(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, runID string, at time.Time) {
+	t.Helper()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, at); err != nil {
+		t.Fatalf("seed sqlite budget run %s: %v", runID, err)
+	}
+}


### PR DESCRIPTION
Closes #1148.
Part of #1087 and #1066.

## Summary

This PR promotes `internal/runtime/budgetspend.Store` as the backend-neutral runtime budget/spend persistence owner and wires it through `runtime.Stores.BudgetSpendStore` into `BudgetTracker`.

Postgres keeps the production implementation over `spend_ledger` and `entity_state`. SQLite gets explicit local-dev implementations for spend recording, flow-instance resolution, active entity enumeration, and system/global/entity spend aggregation. The SQLite runtime construction blocker now removes only the #1148 budget/spend segment and still fails closed for #1149 tool/human-task persistence and #1150 runtime diagnostics/logging.

## Governing Refs

Exact spec refs updated in this PR:
- `platform-spec.yaml` `engine.runtime_core_persistence_store_contracts`
- `platform-spec.yaml` `platform_tables.tables.spend_ledger`
- `platform-spec.yaml` `platform.budget_threshold_crossed`
- `platform-spec.yaml` `components.schemas.AgentUsage`

Binding issue/gate context:
- #1148 pre-audit and independent gate
- #1157 split for public `agent.usage` reads over `spend_ledger`
- #1087/#1066 parent runtime-store portability trackers

## Semantic Migration

New canonical owner: `internal/runtime/budgetspend.Store`, consumed through `runtime.Stores.BudgetSpendStore` and `internal/runtime.BudgetTracker`.

Old non-authoritative path now invalid for #1148: `BudgetTracker.db *sql.DB`, `NewBudgetTracker(db *sql.DB, ...)`, and raw Postgres SQL in `internal/runtime/budget.go` as the generic runtime budget/spend owner.

Production paths checked: Postgres store implementation, SQLite selected store implementation, `cmd/swarm buildStores`, `runtime.NewRuntime`, LLM `BudgetGuard` consumers, threshold event emission, and emergency mailbox insertion.

Migration completeness: complete for #1148 runtime budget/spend construction. Not claiming #1087 closure, #1088 default flip readiness, #1089 closeout, #1157 public `agent.usage` parity, #1149, #1150, or production SQLite multi-writer semantics.

## Proof

- `go test ./cmd/swarm -run 'TestBuildStores(SQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit|AcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./internal/store -run 'Test(SQLiteRuntimeStoreBudgetSpendPersistence|PostgresStoreBudgetSpendPersistenceQueries|SQLiteRuntimeStoreSelectedCoreContracts)' -count=1`
- `go test ./internal/runtime -run 'Test(BudgetTracker|NewRuntimeConstructsBudgetTrackerFromBackendNeutralStore|RuntimeDepsValidateOwnsRequiredBootInputs)' -count=1`
- `go test ./internal/runtime/llm -run 'Test(OpenAICompatibleRuntimeConversationToolBudgetAndPersistence|AnthropicAPIRuntimeFailsClosedWhenUsageMissingForBudgetAccounting|ProviderContractsValidateShippedRuntimes)' -count=1`
- `go test ./...`
