### PR TITLE
[agent-e][issue #1022] Enforce bundle-hash event ingress

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -89,6 +89,7 @@ type diagnosticBundleIdentity struct {
 	WorkflowName    *string `json:"workflow_name"`
 	WorkflowVersion *string `json:"workflow_version"`
 	Fingerprint     string  `json:"fingerprint"`
+	BundleHash      string  `json:"bundle_hash,omitempty"`
 }
 
 type diagnosticRunHeader struct {
@@ -1002,6 +1003,9 @@ func validateDiagnosticHealthCheck(result diagnosticHealthCheckResult) error {
 	if strings.TrimSpace(result.Bundle.Fingerprint) == "" {
 		return fmt.Errorf("malformed health.check result: bundle.fingerprint is required")
 	}
+	if hash := strings.TrimSpace(result.Bundle.BundleHash); hash != "" && !cliBundleHashPattern.MatchString(hash) {
+		return fmt.Errorf("malformed health.check result: bundle.bundle_hash must be bundle-v1:sha256:<64 lowercase hex>")
+	}
 	if result.Bundle.WorkflowName == nil {
 		return fmt.Errorf("malformed health.check result: bundle.workflow_name is required")
 	}
@@ -1167,6 +1171,9 @@ func writeDiagnosticHealth(out io.Writer, result diagnosticHealthCheckResult) {
 		emptyDash(stringPointerValue(result.Bundle.WorkflowName)),
 		emptyDash(stringPointerValue(result.Bundle.WorkflowVersion)),
 	)
+	if hash := strings.TrimSpace(result.Bundle.BundleHash); hash != "" {
+		fmt.Fprintf(out, "bundle_hash=%s\n", hash)
+	}
 }
 
 func intPointerValue(value *int) int {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -1298,6 +1298,28 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			wantStderr: "bundle.workflow_name is required",
 		},
 		{
+			name: "health invalid bundle hash",
+			args: []string{"health"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"alive":      true,
+					"ready":      true,
+					"db_ok":      true,
+					"runtime_ok": true,
+					"bundle": map[string]any{
+						"fingerprint":      "sha256:abc",
+						"bundle_hash":      "sha256:abc",
+						"workflow_name":    "workflow",
+						"workflow_version": "v1",
+					},
+				})
+			},
+			wantCode:   3,
+			wantStderr: "bundle.bundle_hash must be bundle-v1:sha256:<64 lowercase hex>",
+		},
+		{
 			name: "health missing workflow version",
 			args: []string{"health"},
 			handler: func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -282,6 +282,9 @@ func eventPublishErrorExitCode(err error) int {
 		notFoundCodes: []string{"RUN_NOT_FOUND", "EVENT_NOT_FOUND"},
 		conflictCodes: []string{
 			"BUNDLE_MISMATCH",
+			"BUNDLE_SCOPE_REQUIRED",
+			"BUNDLE_UNAVAILABLE",
+			"BUNDLE_DATA_INTEGRITY_ERROR",
 			"UNSUPPORTED_BUNDLE_HASH",
 			"UNSUPPORTED_BUNDLE_REF",
 			"EVENT_NOT_DECLARED",

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -284,6 +284,36 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 			wantStderr: "BUNDLE_MISMATCH",
 		},
 		{
+			name: "bundle scope required exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "BUNDLE_SCOPE_REQUIRED")
+			},
+			wantCode:   6,
+			wantStderr: "BUNDLE_SCOPE_REQUIRED",
+		},
+		{
+			name: "bundle unavailable exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "BUNDLE_UNAVAILABLE")
+			},
+			wantCode:   6,
+			wantStderr: "BUNDLE_UNAVAILABLE",
+		},
+		{
+			name: "bundle data integrity exits six",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeEventPublishJSONRPCError(t, w, req.ID, "BUNDLE_DATA_INTEGRITY_ERROR")
+			},
+			wantCode:   6,
+			wantStderr: "BUNDLE_DATA_INTEGRITY_ERROR",
+		},
+		{
 			name: "unsupported canonical bundle exits six",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -481,6 +481,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("prepare bundle source", "error", err)
 		return 3
 	}
+	bootBundleIdentity.BundleHash = strings.TrimSpace(bundleSourceFact.BundleHash)
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		slog.Error("validate workspaces", "error", err)
 		return 1
@@ -612,6 +613,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		BundleCatalog:       stores.Postgres,
 		ConversationForks:   stores.Postgres,
 		ForkChatExecutor:    apiv1.NewLLMForkChatExecutor(forkChatLLM),
+		RunBundleContext:    stores.Postgres,
 		RunForkAvailability: runForkAvailability,
 		RunFork: apiv1.SelectedContractRunForkExecutor{
 			Store: stores.Postgres,

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -436,7 +436,7 @@ func runCommandHealth(ctx context.Context, client *cliAPIClient) (diagnosticHeal
 	return result, nil
 }
 
-func runCommandStart(ctx context.Context, client *cliAPIClient, _ diagnosticHealthCheckResult, opts runCommandOptions, payload map[string]any) (runStartResult, error) {
+func runCommandStart(ctx context.Context, client *cliAPIClient, health diagnosticHealthCheckResult, opts runCommandOptions, payload map[string]any) (runStartResult, error) {
 	params := map[string]any{
 		"event_name": strings.TrimSpace(opts.eventName),
 		"payload":    payload,
@@ -445,6 +445,8 @@ func runCommandStart(ctx context.Context, client *cliAPIClient, _ diagnosticHeal
 		params["bundle_hash"] = bundleHash
 	} else if fingerprint := strings.TrimSpace(opts.bundleFingerprint); fingerprint != "" {
 		params["bundle_ref"] = map[string]any{"fingerprint": fingerprint}
+	} else if bundleHash := strings.TrimSpace(health.Bundle.BundleHash); bundleHash != "" {
+		params["bundle_hash"] = bundleHash
 	}
 	if runID := strings.TrimSpace(opts.runID); runID != "" {
 		params["run_id"] = runID
@@ -716,6 +718,9 @@ func runCommandErrorExitCode(err error) int {
 		notFoundCodes: []string{"RUN_NOT_FOUND"},
 		conflictCodes: []string{
 			"BUNDLE_MISMATCH",
+			"BUNDLE_SCOPE_REQUIRED",
+			"BUNDLE_UNAVAILABLE",
+			"BUNDLE_DATA_INTEGRITY_ERROR",
 			"UNSUPPORTED_BUNDLE_HASH",
 			"UNSUPPORTED_BUNDLE_REF",
 			"EVENT_NOT_DECLARED",

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -32,8 +32,8 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 				if got := req.Params["event_name"]; got != "scan.requested" {
 					t.Fatalf("event_name = %#v, want scan.requested", got)
 				}
-				if _, ok := req.Params["bundle_hash"]; ok {
-					t.Fatalf("bundle_hash unexpectedly present without bundle flag: %#v", req.Params)
+				if got := req.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+					t.Fatalf("bundle_hash = %#v, want health.check bundle hash", got)
 				}
 				if _, ok := req.Params["bundle_ref"]; ok {
 					t.Fatalf("bundle_ref unexpectedly present without bundle flag: %#v", req.Params)
@@ -153,6 +153,9 @@ func TestRunCommandConnectedNoFollowUsesHealthAndRunStartOnly(t *testing.T) {
 			case "health.check":
 				return runCommandHealthResult()
 			case "run.start":
+				if got := req.Params["bundle_hash"]; got != "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+					t.Fatalf("bundle_hash = %#v, want health.check bundle hash", got)
+				}
 				return map[string]any{"run_id": "run-no-follow", "status": "running"}
 			default:
 				t.Fatalf("unexpected method = %q", req.Method)
@@ -278,7 +281,7 @@ func TestRunCommandBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testi
 func TestRunCommandStartApplicationErrorsExitSixAndDoNotFollow(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
-	for _, codeName := range []string{"EVENT_NOT_DECLARED", "PAYLOAD_VALIDATION_FAILED", "EVENT_PUBLISH_FAILED"} {
+	for _, codeName := range []string{"BUNDLE_SCOPE_REQUIRED", "BUNDLE_UNAVAILABLE", "BUNDLE_DATA_INTEGRITY_ERROR", "BUNDLE_MISMATCH", "EVENT_NOT_DECLARED", "PAYLOAD_VALIDATION_FAILED", "EVENT_PUBLISH_FAILED"} {
 		t.Run(codeName, func(t *testing.T) {
 			var calls []jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -873,6 +876,7 @@ func runCommandHealthResult() map[string]any {
 			"workflow_name":    "review",
 			"workflow_version": "1.2.3",
 			"fingerprint":      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"bundle_hash":      "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 	}
 }

--- a/cmd/swarm/version_command_test.go
+++ b/cmd/swarm/version_command_test.go
@@ -80,6 +80,7 @@ func TestVersionServerUsesHealthCheck(t *testing.T) {
 		"Server:",
 		"alive=true ready=false db_ok=true runtime_ok=false",
 		"bundle fingerprint=sha256:server workflow_name=workflow workflow_version=v1",
+		"bundle_hash=bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
@@ -265,6 +266,7 @@ func validVersionHealthResult() map[string]any {
 		"runtime_ok": false,
 		"bundle": map[string]any{
 			"fingerprint":      "sha256:server",
+			"bundle_hash":      "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			"workflow_name":    "workflow",
 			"workflow_version": "v1",
 		},

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -23,8 +23,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 103 {
 		t.Fatalf("schema count = %d, want 103", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 36 {
-		t.Fatalf("error code count = %d, want 36", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 37 {
+		t.Fatalf("error code count = %d, want 37", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 21 {
 		t.Fatalf("mutating method count = %d, want 21", report.MutatingMethodCount)
@@ -73,8 +73,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 103 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 103", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 36 {
-		t.Fatalf("generated OpenRPC errors = %d, want 36", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 37 {
+		t.Fatalf("generated OpenRPC errors = %d, want 37", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
@@ -255,7 +255,7 @@ func TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints(t *testin
 		assertOpenRPCParamDescriptionContains(t, methodName, params, "bundle_ref",
 			"#1001",
 			"bundle_ref.fingerprint",
-			"boot-fingerprint assertion path",
+			"not authoritative for create-new-work scope or routing",
 			"cannot be combined with bundle_hash",
 		)
 	}

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -19,6 +19,7 @@ import (
 	runtimeagentcontrol "swarm/internal/runtime/agentcontrol"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/destructivereset"
 	runtimeingress "swarm/internal/runtime/ingress"
 	runtimeruncontrol "swarm/internal/runtime/runcontrol"
@@ -304,8 +305,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"event.publish": {
-			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
-			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
+			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}},
+			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}},
 			ResultKeys:     []string{"event_id", "run_id", "new_run_created", "deliveries"},
 			SuccessEffects: 1,
 		},
@@ -352,8 +353,8 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 			SuccessEffects: 1,
 		},
 		"run.start": {
-			Params:         map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
-			ConflictParams: map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
+			Params:         map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "run_id": runID},
+			ConflictParams: map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "dentistry"}, "run_id": runID},
 			ResultKeys:     []string{"run_id", "status"},
 			SuccessEffects: 1,
 		},
@@ -397,22 +398,28 @@ type mutatingHTTPRuntimeErrorProbe struct {
 func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 	runID := "00000000-0000-0000-0000-000000000101"
 	missingRunID := "00000000-0000-0000-0000-000000000999"
-	badBundleFingerprint := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	canonicalEvent := map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
-	validLegacyEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	otherBundleHash := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	validEvent := map[string]any{"bundle_hash": runStartTestBundleHash, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	legacyOnlyEvent := map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}, "event_name": "scan.requested", "payload": map[string]any{"topic": "medicine"}, "idempotency_key": "idem-error"}
+	invalidBundleHashEvent := mergeProbeParams(validEvent, map[string]any{"bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	sourceSessionID := "00000000-0000-0000-0000-000000000201"
 	forkID := "00000000-0000-0000-0000-000000000301"
 	return []mutatingHTTPRuntimeErrorProbe{
-		{Method: "event.publish", Params: canonicalEvent, Code: UnsupportedBundleHashCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_hash": runStartTestBundleHash}), Code: UnsupportedBundleHashCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badBundleFingerprint}}), Code: BundleMismatchCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
-		{Method: "event.publish", Params: validLegacyEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
-		{Method: "event.publish", Params: validLegacyEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},
-		{Method: "event.publish", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: RunAlreadyTerminalCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+		{Method: "event.publish", Params: legacyOnlyEvent, Code: BundleScopeRequiredCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": runStartTestFingerprint}}), Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": otherBundleHash}), Code: BundleUnavailableCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": otherBundleHash, "run_id": runID}), Code: BundleMismatchCode},
+		{Method: "event.publish", Params: invalidBundleHashEvent, Code: UnsupportedBundleHashCode},
+		{Method: "event.publish", Params: mergeProbeParams(legacyOnlyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}}), Code: UnsupportedBundleRefCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
+		{Method: "event.publish", Params: validEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
+		{Method: "event.publish", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": missingRunID}), Code: RunNotFoundCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID, "source_event_id": "00000000-0000-0000-0000-000000000998"}), Code: EventNotFoundCode},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: BundleDataIntegrityErrorCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.runForkAvailability.rows[runID] = runForkDataIntegrity(runID, runStartTestBundleHash)
+		}}},
+		{Method: "event.publish", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: RunAlreadyTerminalCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runs.headers[runID] = store.RunHeader{RunID: runID, Status: "completed"}
 		}}},
 
@@ -469,13 +476,17 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 			s.runForkAvailability.rows[runForkTestSourceRunID] = runForkDataIntegrity(runForkTestSourceRunID, runForkTestBundleHash)
 		}}},
 
-		{Method: "run.start", Params: mergeProbeParams(canonicalEvent, map[string]any{"run_id": runID}), Code: UnsupportedBundleHashCode},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_hash": runStartTestBundleHash, "run_id": runID}), Code: UnsupportedBundleHashCode},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"fingerprint": badBundleFingerprint}, "run_id": runID}), Code: BundleMismatchCode},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"event_name": "scan.missing", "run_id": runID}), Code: EventNotDeclaredCode},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
-		{Method: "run.start", Params: mergeProbeParams(validLegacyEvent, map[string]any{"run_id": runID}), Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
+		{Method: "run.start", Params: legacyOnlyEvent, Code: BundleScopeRequiredCode},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": otherBundleHash}), Code: BundleUnavailableCode},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"bundle_hash": otherBundleHash, "run_id": runID}), Code: BundleMismatchCode},
+		{Method: "run.start", Params: invalidBundleHashEvent, Code: UnsupportedBundleHashCode},
+		{Method: "run.start", Params: mergeProbeParams(legacyOnlyEvent, map[string]any{"bundle_ref": map[string]any{"label": "latest"}, "run_id": runID}), Code: UnsupportedBundleRefCode},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"run_id": runID}), Code: BundleDataIntegrityErrorCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.runForkAvailability.rows[runID] = runForkDataIntegrity(runID, runStartTestBundleHash)
+		}}},
+		{Method: "run.start", Params: mergeProbeParams(validEvent, map[string]any{"event_name": "scan.missing"}), Code: EventNotDeclaredCode},
+		{Method: "run.start", Params: validEvent, Code: EventPublishFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = errors.New("simulated publish failure") }}},
+		{Method: "run.start", Params: validEvent, Code: PayloadValidationFailedCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.events.publishErr = runtimebus.ErrPayloadValidation }}},
 
 		{Method: "run.stop", Params: map[string]any{"run_id": runID, "idempotency_key": "idem-error"}, Code: RunNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runControl.errs["stop"] = &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrRunNotFound, RunID: runID}
@@ -684,8 +695,8 @@ func newMutatingRuntimeProbeState(t *testing.T, methodName string) *mutatingRunt
 	state.runFork = &mutatingProbeRunForkExecutor{state: state}
 	state.runForkAvailability = &recordingRunForkAvailability{
 		rows: map[string]runbundle.Availability{
-			runID:                  runForkAvailable(runID, runForkTestBundleHash),
-			otherRunID:             runForkAvailable(otherRunID, runForkTestBundleHash),
+			runID:                  runForkAvailable(runID, runStartTestBundleHash),
+			otherRunID:             runForkAvailable(otherRunID, runStartTestBundleHash),
 			runForkTestSourceRunID: runForkAvailable(runForkTestSourceRunID, runForkTestBundleHash),
 		},
 	}
@@ -812,6 +823,7 @@ func (s *mutatingRuntimeProbeState) options(t *testing.T) OperatorReadOptions {
 		BundleCatalog:         s.bundleCatalog,
 		Idempotency:           s.idempotency,
 		Events:                s.events,
+		RunBundleContext:      s.runForkAvailability,
 		RunForkAvailability:   s.runForkAvailability,
 		RunFork:               s.runFork,
 		RunControl:            s.runControl,
@@ -950,6 +962,10 @@ func (p *mutatingProbeEventPublisher) Publish(_ context.Context, evt events.Even
 	p.state.recordEffect()
 	p.state.storeEvent(evt, nil)
 	return nil
+}
+
+func (p *mutatingProbeEventPublisher) WithBundleFingerprint(ctx context.Context) context.Context {
+	return runtimecorrelation.WithBundleSourceFact(ctx, runStartTestBundleSourceFact())
 }
 
 func (p *mutatingProbeEventPublisher) PublishTx(ctx context.Context, _ *sql.Tx, evt events.Event) error {

--- a/internal/apiv1/operator_bundle_admission.go
+++ b/internal/apiv1/operator_bundle_admission.go
@@ -1,0 +1,181 @@
+package apiv1
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/store"
+	"swarm/internal/store/runbundle"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+type RunBundleContextStore interface {
+	LoadRunBundleAvailability(context.Context, string) (runbundle.Availability, error)
+}
+
+type runtimeBundleSourceFactProvider interface {
+	WithBundleFingerprint(context.Context) context.Context
+}
+
+func resolveEventPublicationBundleScope(
+	ctx context.Context,
+	opts OperatorReadOptions,
+	params eventPublicationParams,
+	identity bundleIdentityParam,
+	cfg eventPublicationConfig,
+) (context.Context, eventPublicationParams, error) {
+	requestedHash := strings.TrimSpace(identity.BundleHash)
+	currentFact, hasCurrentFact := eventPublicationRuntimeSourceFact(ctx, opts.Events)
+	runAvailability, hasRunContext, err := eventPublicationRunBundleContext(ctx, opts, params, cfg)
+	if err != nil {
+		return ctx, params, err
+	}
+
+	resolvedHash := requestedHash
+	if hasRunContext {
+		if requestedHash != "" && runAvailability.BundleHash != "" && requestedHash != runAvailability.BundleHash {
+			return ctx, params, NewApplicationError(BundleMismatchCode, false, bundleMismatchDetails(params.RunID, requestedHash, runAvailability))
+		}
+		if err := eventPublicationRunBundleAvailable(runAvailability); err != nil {
+			return ctx, params, err
+		}
+		resolvedHash = runAvailability.BundleHash
+		params.BundleSource = runAvailability.BundleSource
+	}
+	if resolvedHash == "" {
+		details := map[string]any{
+			"field":  "bundle_hash",
+			"reason": "bundle_hash is required when no existing run bundle context is available",
+		}
+		if params.RunIDProvided {
+			details["run_id"] = strings.TrimSpace(params.RunID)
+		}
+		return ctx, params, NewApplicationError(BundleScopeRequiredCode, false, details)
+	}
+	if !hasCurrentFact || strings.TrimSpace(currentFact.BundleHash) == "" {
+		return ctx, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+			"bundle_hash": resolvedHash,
+			"run_id":      strings.TrimSpace(params.RunID),
+			"cause":       "runtime_source_fact_missing",
+		})
+	}
+	currentFact = currentFact.Normalized()
+	if currentFact.BundleHash != resolvedHash {
+		return ctx, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+			"bundle_hash":        resolvedHash,
+			"run_id":             strings.TrimSpace(params.RunID),
+			"active_bundle_hash": currentFact.BundleHash,
+			"cause":              "single_active_runtime_unavailable",
+		})
+	}
+
+	params.BundleHash = resolvedHash
+	params.BundleSource = currentFact.BundleSource
+	params.BundleFingerprint = currentFact.BundleFingerprint
+	return runtimecorrelation.WithBundleSourceFact(ctx, currentFact), params, nil
+}
+
+func eventPublicationRuntimeSourceFact(ctx context.Context, publisher EventPublisher) (runtimecorrelation.BundleSourceFact, bool) {
+	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		return fact, true
+	}
+	provider, ok := publisher.(runtimeBundleSourceFactProvider)
+	if !ok || provider == nil {
+		return runtimecorrelation.BundleSourceFact{}, false
+	}
+	enriched := provider.WithBundleFingerprint(ctx)
+	return runtimecorrelation.BundleSourceFactFromContext(enriched)
+}
+
+func eventPublicationRunBundleContext(
+	ctx context.Context,
+	opts OperatorReadOptions,
+	params eventPublicationParams,
+	cfg eventPublicationConfig,
+) (runbundle.Availability, bool, error) {
+	if !params.RunIDProvided {
+		return runbundle.Availability{}, false, nil
+	}
+	reader := opts.RunBundleContext
+	if reader == nil {
+		return runbundle.Availability{}, false, errors.New("run bundle context store is required")
+	}
+	availability, err := reader.LoadRunBundleAvailability(ctx, params.RunID)
+	if errors.Is(err, store.ErrRunNotFound) {
+		if cfg.requireExistingExplicitRun {
+			return runbundle.Availability{}, false, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": params.RunID})
+		}
+		return runbundle.Availability{}, false, nil
+	}
+	if err != nil {
+		return runbundle.Availability{}, false, err
+	}
+	return availability, true, nil
+}
+
+func eventPublicationRunBundleAvailable(availability runbundle.Availability) error {
+	source, err := storerunlifecycle.CanonicalBundleSource(availability.BundleSource)
+	if err != nil {
+		return err
+	}
+	availability.BundleSource = source
+	if availability.ErrorCode == BundleDataIntegrityErrorCode {
+		return NewApplicationError(BundleDataIntegrityErrorCode, false, bundleAvailabilityDetails(availability))
+	}
+	switch source {
+	case storerunlifecycle.BundleSourcePersisted:
+		if availability.BundleHash == "" || !availability.BundleRowPresent {
+			if availability.Cause == "" {
+				availability.Cause = "persisted_missing_bundle_context"
+			}
+			return NewApplicationError(BundleDataIntegrityErrorCode, false, bundleAvailabilityDetails(availability))
+		}
+		return nil
+	case storerunlifecycle.BundleSourceEphemeral:
+		if availability.BundleHash != "" {
+			return nil
+		}
+		if availability.Cause == "" {
+			availability.Cause = "ephemeral_missing_hash"
+		}
+	case storerunlifecycle.BundleSourceDeleted, storerunlifecycle.BundleSourceLegacy:
+		if availability.Cause == "" {
+			availability.Cause = source
+		}
+	}
+	return NewApplicationError(BundleUnavailableCode, false, bundleAvailabilityDetails(availability))
+}
+
+func bundleMismatchDetails(runID, requestedHash string, availability runbundle.Availability) map[string]any {
+	return map[string]any{
+		"run_id":          strings.TrimSpace(runID),
+		"requested_hash":  strings.TrimSpace(requestedHash),
+		"run_bundle_hash": strings.TrimSpace(availability.BundleHash),
+		"bundle_source":   strings.TrimSpace(availability.BundleSource),
+	}
+}
+
+func bundleAvailabilityDetails(availability runbundle.Availability) map[string]any {
+	details := map[string]any{}
+	if availability.RunID != "" {
+		details["run_id"] = strings.TrimSpace(availability.RunID)
+	}
+	if availability.Status != "" {
+		details["status"] = strings.TrimSpace(availability.Status)
+	}
+	if availability.BundleHash != "" {
+		details["bundle_hash"] = strings.TrimSpace(availability.BundleHash)
+	}
+	if availability.BundleSource != "" {
+		details["bundle_source"] = strings.TrimSpace(availability.BundleSource)
+	}
+	if availability.BundleFingerprint != "" {
+		details["legacy_bundle_fingerprint"] = strings.TrimSpace(availability.BundleFingerprint)
+	}
+	if availability.Cause != "" {
+		details["cause"] = strings.TrimSpace(availability.Cause)
+	}
+	return details
+}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
-	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimerunstart "swarm/internal/runtime/runstart"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
@@ -33,6 +32,8 @@ type eventPublishDelivery struct {
 }
 
 type eventPublicationParams struct {
+	BundleHash        string
+	BundleSource      string
 	BundleFingerprint string
 	EventID           string
 	EventName         string
@@ -43,6 +44,7 @@ type eventPublicationParams struct {
 	IdempotencyKey    string
 	Emitter           string
 	NewRunCreated     bool
+	RunIDProvided     bool
 }
 
 type eventPublicationConfig struct {
@@ -151,8 +153,6 @@ func executeOperatorEventPublication(
 	now time.Time,
 	cfg eventPublicationConfig,
 ) (store.APIIdempotencyCompletion, bool, error) {
-	bootFingerprint := strings.TrimSpace(opts.Bundle.Fingerprint)
-	ctx = runtimecorrelation.WithBundleFingerprint(ctx, bootFingerprint)
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return store.APIIdempotencyCompletion{}, false, err
@@ -165,7 +165,11 @@ func executeOperatorEventPublication(
 		TTL:            runStartIDempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		params, err := eventPublicationParamsFromRequest(req, bootFingerprint, cfg)
+		params, bundleIdentity, err := eventPublicationParamsFromRequest(req, cfg)
+		if err != nil {
+			return store.APIIdempotencyCompletion{}, err
+		}
+		ctx, params, err = resolveEventPublicationBundleScope(ctx, opts, params, bundleIdentity, cfg)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
@@ -201,75 +205,66 @@ func executeOperatorEventPublication(
 	})
 }
 
-func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg eventPublicationConfig) (eventPublicationParams, error) {
+func eventPublicationParamsFromRequest(req Request, cfg eventPublicationConfig) (eventPublicationParams, bundleIdentityParam, error) {
 	eventName := stringParam(req.Params, "event_name")
 	if eventName == "" {
-		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
+		return eventPublicationParams{}, bundleIdentityParam{}, NewInvalidParamsError(map[string]any{"field": "event_name", "reason": "required parameter is missing"})
 	}
 	bundleIdentity, err := bundleIdentityInputParam(req.Params)
 	if err != nil {
-		return eventPublicationParams{}, err
+		return eventPublicationParams{}, bundleIdentityParam{}, err
 	}
-	if bundleIdentity.BundleHash != "" {
-		return eventPublicationParams{}, NewApplicationError(UnsupportedBundleHashCode, false, map[string]any{
-			"reason": "bundle_hash runtime assertions require canonical bundle source facts; use legacy bundle_ref.fingerprint during the #1001 transition",
-		})
-	}
-	fingerprint := bundleIdentity.LegacyFingerprint
-	if fingerprint != "" && fingerprint != strings.TrimSpace(bootFingerprint) {
-		return eventPublicationParams{}, NewApplicationError(BundleMismatchCode, false, bundleIdentity.mismatchDetails(bootFingerprint))
-	}
-	runID, _, err := optionalStringParam(req.Params, "run_id")
+	runID, runIDProvided, err := optionalStringParam(req.Params, "run_id")
 	if err != nil {
-		return eventPublicationParams{}, err
+		return eventPublicationParams{}, bundleIdentityParam{}, err
 	}
 	sourceEventID, sourceEventIDSet, err := optionalStringParam(req.Params, "source_event_id")
 	if err != nil {
-		return eventPublicationParams{}, err
+		return eventPublicationParams{}, bundleIdentityParam{}, err
 	}
 	if sourceEventIDSet {
 		if sourceEventID == "" {
-			return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
+			return eventPublicationParams{}, bundleIdentityParam{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
 		}
 		parsed, err := uuid.Parse(sourceEventID)
 		if err != nil {
-			return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
+			return eventPublicationParams{}, bundleIdentityParam{}, NewInvalidParamsError(map[string]any{"field": "source_event_id", "reason": "must be a UUID"})
 		}
 		sourceEventID = parsed.String()
 	}
 	if sourceEventID != "" && runID == "" {
-		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "is required when source_event_id is provided"})
+		return eventPublicationParams{}, bundleIdentityParam{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "is required when source_event_id is provided"})
 	}
 	newRun := false
 	if runID == "" {
 		runID = uuid.NewString()
 		newRun = true
 	} else if parsed, err := uuid.Parse(runID); err != nil {
-		return eventPublicationParams{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "must be a UUID"})
+		return eventPublicationParams{}, bundleIdentityParam{}, NewInvalidParamsError(map[string]any{"field": "run_id", "reason": "must be a UUID"})
 	} else {
 		runID = parsed.String()
 	}
 	injectEntityID := cfg.injectRunIDEntityIDWhenMissing && (!cfg.injectRunIDEntityIDOnlyNewRun || newRun)
 	payload, entityID, err := eventPublicationPayload(req.Params, runID, injectEntityID)
 	if err != nil {
-		return eventPublicationParams{}, err
+		return eventPublicationParams{}, bundleIdentityParam{}, err
 	}
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
-		return eventPublicationParams{}, err
+		return eventPublicationParams{}, bundleIdentityParam{}, err
 	}
 	emitter := ""
 	if cfg.allowEmitterParam {
 		emitter, _, err = optionalStringParam(req.Params, "emitter")
 		if err != nil {
-			return eventPublicationParams{}, err
+			return eventPublicationParams{}, bundleIdentityParam{}, err
 		}
 	}
 	if emitter == "" && cfg.sourceAgent != nil {
 		emitter = cfg.sourceAgent(req)
 	}
 	return eventPublicationParams{
-		BundleFingerprint: fingerprint,
+		BundleFingerprint: bundleIdentity.LegacyFingerprint,
 		EventID:           uuid.NewString(),
 		EventName:         eventName,
 		Payload:           payload,
@@ -279,7 +274,8 @@ func eventPublicationParamsFromRequest(req Request, bootFingerprint string, cfg 
 		IdempotencyKey:    idempotencyKey,
 		Emitter:           emitter,
 		NewRunCreated:     newRun,
-	}, nil
+		RunIDProvided:     runIDProvided,
+	}, bundleIdentity, nil
 }
 
 func eventPublicationPayload(params map[string]any, runID string, injectRunIDEntityID bool) (json.RawMessage, string, error) {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -18,6 +18,7 @@ import (
 	runtimereplayclaim "swarm/internal/runtime/replayclaim"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
@@ -25,7 +26,7 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -99,22 +100,22 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	}
 }
 
-func TestOperatorEventPublishHandlersRejectCanonicalBundleHashUntilSourceOwner(t *testing.T) {
+func TestOperatorEventPublishHandlersRequireCanonicalBundleHashForCreateNewWork(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	handler := eventPublishTestHandler(t, pg, bus, source)
 
-	resp := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-hash"))
+	resp := rpcCall(t, handler, eventPublishBodyWithLegacyFingerprint("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-legacy"))
 	if resp.Error == nil {
-		t.Fatal("event.publish canonical bundle_hash error = nil")
+		t.Fatal("event.publish missing canonical bundle_hash error = nil")
 	}
-	if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
-		t.Fatalf("unsupported bundle hash data = %#v", data)
+	if data := asMap(t, resp.Error.Data); data["code"] != BundleScopeRequiredCode {
+		t.Fatalf("bundle scope required data = %#v", data)
 	}
 	assertNoEventPublishPersistence(t, db)
 }
@@ -123,7 +124,7 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *
 		err:           errors.New("simulated post-commit receipt failure"),
 	}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -247,7 +248,7 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 		err:           errors.New("simulated normal-run completion failure"),
 	}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -306,7 +307,7 @@ func TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError(t *tes
 		err:           errors.New("simulated pre-commit replay scope failure"),
 	}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(failing, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(failing, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -340,7 +341,7 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -363,6 +364,17 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 	}
 	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
 		t.Fatalf("scan.requested events after targeted publish = %d, want 2", count)
+	}
+
+	mismatch := rpcCall(t, handler, eventPublishBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"mismatch"}`, "", "idem-existing-run-mismatch"))
+	if mismatch.Error == nil {
+		t.Fatal("mismatched run bundle event.publish error = nil")
+	}
+	if data := asMap(t, mismatch.Error.Data); data["code"] != BundleMismatchCode {
+		t.Fatalf("mismatched run bundle data = %#v, want %s", data, BundleMismatchCode)
+	}
+	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
+		t.Fatalf("scan.requested events after mismatched target = %d, want 2", count)
 	}
 
 	missingRunID := uuid.NewString()
@@ -393,7 +405,7 @@ func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) 
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -432,7 +444,7 @@ func TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -541,11 +553,11 @@ func TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence
 }
 
 func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
-	t.Run("bundle mismatch", func(t *testing.T) {
+	t.Run("non-routable bundle hash", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -553,10 +565,10 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 
 		resp := rpcCall(t, handler, eventPublishBody("", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "", "idem-event-mismatch"))
 		if resp.Error == nil {
-			t.Fatal("event.publish bundle mismatch error = nil")
+			t.Fatal("event.publish non-routable bundle error = nil")
 		}
-		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
-			t.Fatalf("bundle mismatch data = %#v", data)
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleUnavailableCode {
+			t.Fatalf("bundle unavailable data = %#v", data)
 		}
 		assertNoEventPublishPersistence(t, db)
 	})
@@ -565,7 +577,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -585,7 +597,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -605,7 +617,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -626,7 +638,8 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
-			ContractBundle: source,
+			ContractBundle:   source,
+			BundleSourceFact: runStartTestBundleSourceFact(),
 			PayloadValidator: func(eventType string, payload []byte) error {
 				if eventType != "scan.requested" {
 					return fmt.Errorf("unexpected event type %q", eventType)
@@ -653,7 +666,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -672,7 +685,7 @@ func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -751,17 +764,19 @@ func eventPublishTestHandlerWithObservability(t *testing.T, pg *store.PostgresSt
 
 func eventPublishTestHandlerWithStores(t *testing.T, runs RunReadStore, observability ObservabilityReadStore, idempotency APIIdempotencyStore, publisher EventPublisher, source semanticview.Source) *Handler {
 	t.Helper()
+	runBundleContext, _ := runs.(RunBundleContextStore)
 	return testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:           func() time.Time { return time.Now().UTC() },
-			Ready:         func() bool { return true },
-			Database:      fakePinger{},
-			Runs:          runs,
-			Observability: observability,
-			Idempotency:   idempotency,
-			Events:        publisher,
-			Source:        source,
+			Now:              func() time.Time { return time.Now().UTC() },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Runs:             runs,
+			Observability:    observability,
+			Idempotency:      idempotency,
+			Events:           publisher,
+			Source:           source,
+			RunBundleContext: runBundleContext,
 			Bundle: runtimecontracts.BundleIdentity{
 				WorkflowName:    "review",
 				WorkflowVersion: "1.0.0",
@@ -863,7 +878,7 @@ func eventPublishBodyWithBothBundleInputs(runID, bundleHash, fingerprint, eventN
 
 func eventPublishBodyWithSource(runID, sourceEventID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
 	parts := []string{
-		fmt.Sprintf(`"bundle_ref":{"fingerprint":%q}`, fingerprint),
+		fmt.Sprintf(`"bundle_hash":%q`, runStartTestBundleHashForFingerprint(fingerprint)),
 		fmt.Sprintf(`"event_name":%q`, eventName),
 		fmt.Sprintf(`"payload":%s`, payload),
 		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
@@ -873,6 +888,22 @@ func eventPublishBodyWithSource(runID, sourceEventID, fingerprint, eventName, pa
 	}
 	if strings.TrimSpace(sourceEventID) != "" {
 		parts = append(parts, fmt.Sprintf(`"source_event_id":%q`, sourceEventID))
+	}
+	if strings.TrimSpace(emitter) != "" {
+		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
+}
+
+func eventPublishBodyWithLegacyFingerprint(runID, fingerprint, eventName, payload, emitter, idempotencyKey string) string {
+	parts := []string{
+		fmt.Sprintf(`"bundle_ref":{"fingerprint":%q}`, fingerprint),
+		fmt.Sprintf(`"event_name":%q`, eventName),
+		fmt.Sprintf(`"payload":%s`, payload),
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(runID) != "" {
+		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
 	}
 	if strings.TrimSpace(emitter) != "" {
 		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
@@ -893,8 +924,8 @@ func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eve
 	if runStatus != "running" || triggerType != eventName || triggerID != eventID {
 		t.Fatalf("run row status=%q trigger=%q/%q, want running/%s/%s", runStatus, triggerType, triggerID, eventName, eventID)
 	}
-	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != runStartTestFingerprint {
-		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint %q", bundleHash, bundleSource, legacyFingerprint, runStartTestFingerprint)
+	if bundleHash != runStartTestBundleHash || bundleSource != storerunlifecycle.BundleSourceEphemeral || legacyFingerprint != runStartTestFingerprint {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want %s/%s/%s", bundleHash, bundleSource, legacyFingerprint, runStartTestBundleHash, storerunlifecycle.BundleSourceEphemeral, runStartTestFingerprint)
 	}
 	var entityID, gotProducedBy string
 	var payload json.RawMessage

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -70,6 +70,7 @@ type OperatorReadOptions struct {
 	BundleCatalog         BundleCatalogReadStore
 	ConversationForks     ConversationForkLifecycleStore
 	ForkChatExecutor      ForkChatExecutor
+	RunBundleContext      RunBundleContextStore
 	RunForkAvailability   RunForkAvailabilityStore
 	RunFork               RunForkExecutor
 	AgentControl          AgentControlController

--- a/internal/apiv1/operator_run_completion_system_node_test.go
+++ b/internal/apiv1/operator_run_completion_system_node_test.go
@@ -27,8 +27,8 @@ func TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces(t *testin
 	source := semanticview.Wrap(bundle)
 	var coordinator *runtimepipeline.PipelineCoordinator
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
-		ContractBundle:    source,
-		BundleFingerprint: runStartTestFingerprint,
+		ContractBundle:   source,
+		BundleSourceFact: runStartTestBundleSourceFact(),
 		InterceptorProvider: func() []runtimebus.EventInterceptor {
 			if coordinator == nil {
 				return nil

--- a/internal/apiv1/operator_run_fork_test.go
+++ b/internal/apiv1/operator_run_fork_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"swarm/internal/store"
 	"swarm/internal/store/runbundle"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
@@ -211,7 +212,7 @@ func (s *recordingRunForkAvailability) LoadRunBundleAvailability(_ context.Conte
 	}
 	availability, ok := s.rows[strings.TrimSpace(runID)]
 	if !ok {
-		return runbundle.Availability{}, fmt.Errorf("run %s not found", strings.TrimSpace(runID))
+		return runbundle.Availability{}, fmt.Errorf("run %s not found: %w", strings.TrimSpace(runID), store.ErrRunNotFound)
 	}
 	return availability, nil
 }

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -14,20 +14,37 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/flowmodel"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
 const runStartTestFingerprint = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 const runStartTestBundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
+func runStartTestBundleSourceFact() runtimecorrelation.BundleSourceFact {
+	return runtimecorrelation.BundleSourceFact{
+		BundleHash:        runStartTestBundleHash,
+		BundleSource:      storerunlifecycle.BundleSourceEphemeral,
+		BundleFingerprint: runStartTestFingerprint,
+	}
+}
+
+func runStartTestEventBusOptions(source semanticview.Source) runtimebus.EventBusOptions {
+	return runtimebus.EventBusOptions{
+		ContractBundle:   source,
+		BundleSourceFact: runStartTestBundleSourceFact(),
+	}
+}
+
 func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -93,11 +110,11 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 	}
 }
 
-func TestOperatorRunStartHandlersPersistBootFingerprintWhenBundleRefOmitted(t *testing.T) {
+func TestOperatorRunStartHandlersRequireBundleHashForCreateNewWork(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -105,17 +122,30 @@ func TestOperatorRunStartHandlersPersistBootFingerprintWhenBundleRefOmitted(t *t
 	runID := uuid.NewString()
 
 	started := rpcCall(t, handler, runStartBodyWithoutBundle(runID, "scan.requested", `{"topic":"medicine"}`, "idem-start-no-bundle"))
-	if started.Error != nil {
-		t.Fatalf("run.start error = %#v", started.Error)
+	if started.Error == nil {
+		t.Fatal("run.start missing bundle_hash error = nil")
 	}
-	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
+	if data := asMap(t, started.Error.Data); data["code"] != BundleScopeRequiredCode {
+		t.Fatalf("missing bundle scope data = %#v", data)
+	}
+	assertNoRunStartPersistence(t, db, runID)
+
+	legacyRunID := uuid.NewString()
+	legacy := rpcCall(t, handler, runStartBodyWithLegacyFingerprint(legacyRunID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-start-legacy-only"))
+	if legacy.Error == nil {
+		t.Fatal("run.start legacy-only bundle_ref error = nil")
+	}
+	if data := asMap(t, legacy.Error.Data); data["code"] != BundleScopeRequiredCode {
+		t.Fatalf("legacy-only bundle scope data = %#v", data)
+	}
+	assertNoRunStartPersistence(t, db, legacyRunID)
 }
 
-func TestOperatorRunStartHandlersRejectCanonicalBundleHashUntilSourceOwner(t *testing.T) {
+func TestOperatorRunStartHandlersAcceptCanonicalBundleHashForCreateNewWork(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -123,21 +153,18 @@ func TestOperatorRunStartHandlersRejectCanonicalBundleHashUntilSourceOwner(t *te
 	runID := uuid.NewString()
 
 	resp := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runStartTestBundleHash, "scan.requested", `{"topic":"medicine"}`, "idem-start-hash"))
-	if resp.Error == nil {
-		t.Fatal("run.start canonical bundle_hash error = nil")
+	if resp.Error != nil {
+		t.Fatalf("run.start canonical bundle_hash error = %#v", resp.Error)
 	}
-	if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
-		t.Fatalf("unsupported bundle hash data = %#v", data)
-	}
-	assertNoRunStartPersistence(t, db, runID)
+	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
 }
 
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
-	t.Run("bundle mismatch", func(t *testing.T) {
+	t.Run("non-routable bundle hash", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -146,19 +173,51 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 
 		resp := rpcCall(t, handler, runStartBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "idem-mismatch"))
 		if resp.Error == nil {
-			t.Fatal("run.start bundle mismatch error = nil")
+			t.Fatal("run.start non-routable bundle error = nil")
 		}
-		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
-			t.Fatalf("bundle mismatch data = %#v", data)
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleUnavailableCode {
+			t.Fatalf("bundle unavailable data = %#v", data)
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
 
-	t.Run("invalid bundle fingerprint", func(t *testing.T) {
+	t.Run("existing run bundle mismatch", func(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
+		if err != nil {
+			t.Fatalf("NewEventBusWithOptions: %v", err)
+		}
+		handler := runStartTestHandler(t, pg, bus, source)
+		runID := uuid.NewString()
+		if _, err := db.Exec(`
+			INSERT INTO runs (run_id, status, bundle_hash, bundle_source, bundle_fingerprint)
+			VALUES ($1::uuid, 'running', $2, $3, $4)
+		`, runID, runStartTestBundleHash, storerunlifecycle.BundleSourceEphemeral, runStartTestFingerprint); err != nil {
+			t.Fatalf("seed run bundle context: %v", err)
+		}
+
+		resp := rpcCall(t, handler, runStartBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"medicine"}`, "idem-existing-mismatch"))
+		if resp.Error == nil {
+			t.Fatal("run.start existing-run bundle mismatch error = nil")
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleMismatchCode {
+			t.Fatalf("bundle mismatch data = %#v", data)
+		}
+		if count := countEventRowsByRunID(t, db, runID); count != 0 {
+			t.Fatalf("event rows for mismatched run = %d, want 0", count)
+		}
+		if count := countAPIIdempotencyRows(t, db); count != 0 {
+			t.Fatalf("api_idempotency rows after mismatch = %d, want 0", count)
+		}
+	})
+
+	t.Run("invalid canonical bundle hash", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -169,8 +228,8 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		if resp.Error == nil {
 			t.Fatal("run.start invalid bundle fingerprint error = nil")
 		}
-		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleRefCode {
-			t.Fatalf("unsupported bundle ref data = %#v", data)
+		if data := asMap(t, resp.Error.Data); data["code"] != UnsupportedBundleHashCode {
+			t.Fatalf("unsupported bundle hash data = %#v", data)
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
@@ -179,7 +238,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -200,7 +259,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -221,7 +280,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -260,7 +319,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		}
 		bundle.Nodes["scan-orchestrator"] = bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"]
 		source := semanticview.Wrap(bundle)
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -293,7 +352,8 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
-			ContractBundle: source,
+			ContractBundle:   source,
+			BundleSourceFact: runStartTestBundleSourceFact(),
 			PayloadValidator: func(eventType string, payload []byte) error {
 				if eventType != "scan.requested" {
 					return fmt.Errorf("unexpected event type %q", eventType)
@@ -321,7 +381,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -352,7 +412,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -368,7 +428,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		_, db, _ := testutil.StartPostgres(t)
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 		if err != nil {
 			t.Fatalf("NewEventBusWithOptions: %v", err)
 		}
@@ -407,7 +467,7 @@ func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -441,13 +501,14 @@ func runStartTestHandler(t *testing.T, pg *store.PostgresStore, bus EventPublish
 	return testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:         func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
-			Ready:       func() bool { return true },
-			Database:    fakePinger{},
-			Runs:        pg,
-			Idempotency: pg,
-			Events:      bus,
-			Source:      source,
+			Now:              func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Runs:             pg,
+			Idempotency:      pg,
+			Events:           bus,
+			Source:           source,
+			RunBundleContext: pg,
 			Bundle: runtimecontracts.BundleIdentity{
 				WorkflowName:    "review",
 				WorkflowVersion: "1.0.0",
@@ -465,7 +526,22 @@ func (p failingRunStartPublisher) Publish(context.Context, events.Event) error {
 	return p.err
 }
 
+func (p failingRunStartPublisher) WithBundleFingerprint(ctx context.Context) context.Context {
+	return runtimecorrelation.WithBundleSourceFact(ctx, runStartTestBundleSourceFact())
+}
+
 func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_hash":%q,"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
+		runStartTestBundleHashForFingerprint(fingerprint),
+		eventName,
+		payload,
+		runID,
+		idempotencyKey,
+	)
+}
+
+func runStartBodyWithLegacyFingerprint(runID, fingerprint, eventName, payload, idempotencyKey string) string {
 	return fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":"start","method":"run.start","params":{"bundle_ref":{"fingerprint":%q},"event_name":%q,"payload":%s,"run_id":%q,"idempotency_key":%q}}`,
 		fingerprint,
@@ -474,6 +550,14 @@ func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string)
 		runID,
 		idempotencyKey,
 	)
+}
+
+func runStartTestBundleHashForFingerprint(fingerprint string) string {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if strings.HasPrefix(fingerprint, "sha256:") {
+		return "bundle-v1:" + fingerprint
+	}
+	return fingerprint
 }
 
 func runStartBodyWithBundleHash(runID, bundleHash, eventName, payload, idempotencyKey string) string {
@@ -556,8 +640,8 @@ func assertRunStartPersistence(t *testing.T, db *sql.DB, runID, eventName, bundl
 	if runStatus != "running" || triggerType != eventName {
 		t.Fatalf("run row status=%q trigger=%q, want running/%s", runStatus, triggerType, eventName)
 	}
-	if bundleHash != "" || bundleSource != "legacy" || legacyFingerprint != bundleFingerprint {
-		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want legacy with compatibility fingerprint %q", bundleHash, bundleSource, legacyFingerprint, bundleFingerprint)
+	if bundleHash != runStartTestBundleHash || bundleSource != storerunlifecycle.BundleSourceEphemeral || legacyFingerprint != bundleFingerprint {
+		t.Fatalf("run row bundle identity = hash:%q source:%q fingerprint:%q, want %s/%s/%s", bundleHash, bundleSource, legacyFingerprint, runStartTestBundleHash, storerunlifecycle.BundleSourceEphemeral, bundleFingerprint)
 	}
 	var entityID, producedBy string
 	var payload json.RawMessage

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -13,6 +13,7 @@ import (
 const (
 	MethodUnavailableCode                = "METHOD_UNAVAILABLE"
 	BundleMismatchCode                   = "BUNDLE_MISMATCH"
+	BundleScopeRequiredCode              = "BUNDLE_SCOPE_REQUIRED"
 	BundleNotFoundCode                   = "BUNDLE_NOT_FOUND"
 	BundleUnavailableCode                = "BUNDLE_UNAVAILABLE"
 	BundleDataIntegrityErrorCode         = "BUNDLE_DATA_INTEGRITY_ERROR"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -426,7 +426,7 @@ methods:
   - method: event.publish
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, BUNDLE_SCOPE_REQUIRED, BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, RUN_NOT_FOUND, EVENT_NOT_FOUND, RUN_ALREADY_TERMINAL, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
@@ -696,7 +696,7 @@ methods:
   - method: run.start
     transport: http
     required_params: [event_name, payload]
-    declared_errors: [BUNDLE_MISMATCH, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_MISMATCH, BUNDLE_SCOPE_REQUIRED, BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, UNSUPPORTED_BUNDLE_HASH, UNSUPPORTED_BUNDLE_REF, EVENT_NOT_DECLARED, EVENT_PUBLISH_FAILED, PAYLOAD_VALIDATION_FAILED, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}

--- a/internal/runtime/contracts/bundle_identity.go
+++ b/internal/runtime/contracts/bundle_identity.go
@@ -18,6 +18,7 @@ type BundleIdentity struct {
 	WorkflowName    string `json:"workflow_name"`
 	WorkflowVersion string `json:"workflow_version"`
 	Fingerprint     string `json:"fingerprint"`
+	BundleHash      string `json:"bundle_hash,omitempty"`
 }
 
 type bundleIdentityEntry struct {

--- a/internal/store/run_bundle_availability.go
+++ b/internal/store/run_bundle_availability.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"swarm/internal/store/runbundle"
@@ -41,5 +42,9 @@ func (s *PostgresStore) LoadRunBundleAvailability(ctx context.Context, runID str
 	if s == nil || s.DB == nil {
 		return runbundle.Availability{}, fmt.Errorf("postgres store is required")
 	}
-	return runbundle.LoadAvailability(ctx, s.DB, runID)
+	availability, err := runbundle.LoadAvailability(ctx, s.DB, runID)
+	if errors.Is(err, runbundle.ErrRunNotFound) {
+		return runbundle.Availability{}, ErrRunNotFound
+	}
+	return availability, err
 }

--- a/internal/store/runbundle/availability.go
+++ b/internal/store/runbundle/availability.go
@@ -15,6 +15,8 @@ const (
 	CodeBundleDataIntegrityError = "BUNDLE_DATA_INTEGRITY_ERROR"
 )
 
+var ErrRunNotFound = errors.New("run bundle: run not found")
+
 type Availability struct {
 	RunID             string
 	Status            string
@@ -87,7 +89,7 @@ func LoadAvailability(ctx context.Context, db queryer, runID string) (Availabili
 		WHERE run_id = $1::uuid
 	`, runID).Scan(&row.RunID, &row.Status, &row.BundleHash, &row.BundleSource, &row.BundleFingerprint)
 	if errors.Is(err, sql.ErrNoRows) {
-		return Availability{}, fmt.Errorf("run %s not found", runID)
+		return Availability{}, fmt.Errorf("run %s not found: %w", runID, ErrRunNotFound)
 	}
 	if err != nil {
 		return Availability{}, fmt.Errorf("load run bundle availability: %w", err)

--- a/openrpc.json
+++ b/openrpc.json
@@ -323,7 +323,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -399,7 +399,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -454,7 +454,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -514,7 +514,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -568,7 +568,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -626,7 +626,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -767,7 +767,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -893,7 +893,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1113,7 +1113,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1151,7 +1151,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1254,7 +1254,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1614,7 +1614,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1777,7 +1777,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1815,7 +1815,7 @@
           }
         },
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1858,7 +1858,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1896,7 +1896,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1992,7 +1992,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2030,7 +2030,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2118,7 +2118,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2156,7 +2156,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2289,7 +2289,7 @@
       },
       "errors": [
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2349,7 +2349,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2426,7 +2426,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2464,7 +2464,7 @@
           }
         },
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2632,7 +2632,7 @@
       },
       "errors": [
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2765,7 +2765,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2877,7 +2877,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.",
+          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when run_id is omitted. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE. cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -2885,7 +2885,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.",
+          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, is not authoritative for create-new-work scope or routing, and cannot be combined with bundle_hash.",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -2964,12 +2964,66 @@
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   },
+                  "bundle_source": {
+                    "type": "string"
+                  },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "requested_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "run_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
+          "message": "Application error: BUNDLE_SCOPE_REQUIRED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_SCOPE_REQUIRED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
                   }
                 },
                 "required": [
-                  "boot_fingerprint"
+                  "field",
+                  "reason"
                 ],
                 "type": "object"
               },
@@ -2987,7 +3041,110 @@
           }
         },
         {
-          "code": -32033,
+          "code": -32008,
+          "message": "Application error: BUNDLE_UNAVAILABLE",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_UNAVAILABLE",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "active_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_source": {
+                    "type": "string"
+                  },
+                  "cause": {
+                    "type": "string"
+                  },
+                  "legacy_bundle_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32003,
+          "message": "Application error: BUNDLE_DATA_INTEGRITY_ERROR",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_DATA_INTEGRITY_ERROR",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_source": {
+                    "type": "string"
+                  },
+                  "cause": {
+                    "type": "string"
+                  },
+                  "legacy_bundle_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32034,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -3022,7 +3179,7 @@
           }
         },
         {
-          "code": -32035,
+          "code": -32036,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -3057,7 +3214,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -3110,7 +3267,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3167,7 +3324,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3225,7 +3382,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3263,7 +3420,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3301,7 +3458,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3343,7 +3500,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3442,7 +3599,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3480,7 +3637,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -3518,7 +3675,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -3573,7 +3730,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3633,7 +3790,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -3687,7 +3844,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3745,7 +3902,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3926,7 +4083,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3964,7 +4121,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4016,7 +4173,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -4058,7 +4215,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4153,7 +4310,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4191,7 +4348,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4243,7 +4400,7 @@
           }
         },
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -4288,7 +4445,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4369,7 +4526,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4524,7 +4681,7 @@
       },
       "errors": [
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4562,7 +4719,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4614,7 +4771,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4722,7 +4879,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4760,7 +4917,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -4802,7 +4959,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4883,7 +5040,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4967,7 +5124,7 @@
       },
       "errors": [
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -4982,6 +5139,9 @@
               "details": {
                 "additionalProperties": false,
                 "properties": {
+                  "active_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
                   "bundle_hash": {
                     "$ref": "#/components/schemas/BundleHash"
                   },
@@ -5067,7 +5227,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
           "data": {
             "additionalProperties": false,
@@ -5117,7 +5277,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5155,7 +5315,7 @@
           }
         },
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5193,7 +5353,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5283,7 +5443,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5424,7 +5584,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5462,7 +5622,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5504,7 +5664,7 @@
           }
         },
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5542,7 +5702,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5605,12 +5765,12 @@
     {
       "name": "run.start",
       "deprecated": true,
-      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a new run by injecting an event into the runtime bus.\nOptionally declares the canonical bundle_hash input name reserved\nby #1001. Until the canonical runtime source-fact owner is promoted,\nsupplied bundle_hash fails closed with UNSUPPORTED_BUNDLE_HASH rather\nthan being compared to the legacy boot fingerprint. If bundle_hash is\nomitted, the boot-time bundle is used. Per-run dynamic bundle loading is\ndeferred (see deferred_namespaces.bundle_lifecycle). Legacy\nbundle_ref.fingerprint remains the deprecated #1001\ntransition assertion path and cannot be combined with bundle_hash.\n",
+      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a run by injecting an event into the runtime bus. Create-new-work admission follows event.publish bundle_hash semantics: if no existing run row provides bundle context, bundle_hash is required. If run_id is supplied but no run row exists, the call is still create-new-work and run_id alone is not bundle scope. If caller bundle_hash and existing run context disagree, the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved bundle_hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE. Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with bundle_hash.\n",
       "params": [
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional canonical bundle identity assertion name reserved by #1001. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e, cannot be combined with legacy bundle_ref, and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.",
+          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when no existing run row supplies bundle context. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE; cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -5618,7 +5778,7 @@
         {
           "name": "bundle_ref",
           "required": false,
-          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, remains the current operational boot-fingerprint assertion path, and cannot be combined with bundle_hash.",
+          "description": "Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only, is not authoritative for create-new-work scope or routing, and cannot be combined with bundle_hash.",
           "schema": {
             "$ref": "#/components/schemas/BundleRef"
           }
@@ -5694,12 +5854,66 @@
                   "boot_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
                   },
+                  "bundle_source": {
+                    "type": "string"
+                  },
                   "provided_fingerprint": {
                     "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "requested_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "run_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32007,
+          "message": "Application error: BUNDLE_SCOPE_REQUIRED",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_SCOPE_REQUIRED",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
                   }
                 },
                 "required": [
-                  "boot_fingerprint"
+                  "field",
+                  "reason"
                 ],
                 "type": "object"
               },
@@ -5717,7 +5931,110 @@
           }
         },
         {
-          "code": -32033,
+          "code": -32008,
+          "message": "Application error: BUNDLE_UNAVAILABLE",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_UNAVAILABLE",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "active_bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_source": {
+                    "type": "string"
+                  },
+                  "cause": {
+                    "type": "string"
+                  },
+                  "legacy_bundle_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32003,
+          "message": "Application error: BUNDLE_DATA_INTEGRITY_ERROR",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_DATA_INTEGRITY_ERROR",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  },
+                  "bundle_source": {
+                    "type": "string"
+                  },
+                  "cause": {
+                    "type": "string"
+                  },
+                  "legacy_bundle_fingerprint": {
+                    "$ref": "#/components/schemas/Sha256Fingerprint"
+                  },
+                  "run_id": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32034,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -5752,7 +6069,7 @@
           }
         },
         {
-          "code": -32035,
+          "code": -32036,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -5787,7 +6104,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -5840,7 +6157,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5897,7 +6214,7 @@
           }
         },
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -5955,7 +6272,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6043,7 +6360,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6081,7 +6398,7 @@
           }
         },
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -6123,7 +6440,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6223,7 +6540,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6324,7 +6641,7 @@
       },
       "errors": [
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6604,7 +6921,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -6642,7 +6959,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6723,7 +7040,7 @@
       },
       "errors": [
         {
-          "code": -32024,
+          "code": -32025,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6754,7 +7071,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6835,7 +7152,7 @@
       },
       "errors": [
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -6866,7 +7183,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7768,14 +8085,17 @@
         "type": "object"
       },
       "BundleHash": {
-        "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name. Until the canonical source-fact owner is promoted, runtime identity assertions that supply bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH.",
+        "description": "Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:\u003chex\u003e fingerprints are not accepted under the bundle_hash name.",
         "pattern": "^bundle-v1:sha256:[a-f0-9]{64}$",
         "type": "string"
       },
       "BundleIdentity": {
         "additionalProperties": false,
-        "description": "Server bundle identity returned by health.check. Three fields:\nfingerprint is the load-bearing identity (sha256 of normalized\ncontents); workflow_name and workflow_version are human-friendly\nlabels. Server-local filesystem paths are intentionally NOT\nexposed — they leak deployment internals and aren't meaningful\nto external Phase-2 consumers. Operators querying \"what bundle\nis this server running?\" get the fingerprint (definitive) and\nthe labels (informational).\n",
+        "description": "Server bundle identity returned by health.check. bundle_hash is the active canonical v1 bundle identity when the runtime has a promoted source fact and is the value clients use for create-new-work bundle scope. fingerprint is legacy boot/runtime identity metadata retained for health/check compatibility; workflow_name and workflow_version are human-friendly labels. Server-local filesystem paths are intentionally NOT exposed — they leak deployment internals and aren't meaningful to external Phase-2 consumers.\n",
         "properties": {
+          "bundle_hash": {
+            "$ref": "#/components/schemas/BundleHash"
+          },
           "fingerprint": {
             "$ref": "#/components/schemas/Sha256Fingerprint"
           },
@@ -10351,13 +10671,22 @@
                 "boot_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"
                 },
+                "bundle_source": {
+                  "type": "string"
+                },
                 "provided_fingerprint": {
                   "$ref": "#/components/schemas/Sha256Fingerprint"
+                },
+                "requested_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                },
+                "run_bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                },
+                "run_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
                 }
               },
-              "required": [
-                "boot_fingerprint"
-              ],
               "type": "object"
             },
             "retryable": {
@@ -10449,8 +10778,53 @@
           "type": "object"
         }
       },
-      "BUNDLE_UNAVAILABLE": {
+      "BUNDLE_SCOPE_REQUIRED": {
         "code": -32007,
+        "message": "Application error: BUNDLE_SCOPE_REQUIRED",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "BUNDLE_SCOPE_REQUIRED",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "run_id": {
+                  "$ref": "#/components/schemas/OpaqueId"
+                }
+              },
+              "required": [
+                "field",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "BUNDLE_UNAVAILABLE": {
+        "code": -32008,
         "message": "Application error: BUNDLE_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10465,6 +10839,9 @@
             "details": {
               "additionalProperties": false,
               "properties": {
+                "active_bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                },
                 "bundle_hash": {
                   "$ref": "#/components/schemas/BundleHash"
                 },
@@ -10500,7 +10877,7 @@
         }
       },
       "ENTITY_NOT_FOUND": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10538,7 +10915,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -10591,7 +10968,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10629,7 +11006,7 @@
         }
       },
       "EVENT_PUBLISH_FAILED": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: EVENT_PUBLISH_FAILED",
         "data": {
           "additionalProperties": false,
@@ -10686,7 +11063,7 @@
         }
       },
       "EVENT_REPLAY_NOT_ELIGIBLE": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -10740,7 +11117,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -10778,7 +11155,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -10833,7 +11210,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -10893,7 +11270,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -10931,7 +11308,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -10990,7 +11367,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -11035,7 +11412,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -11087,7 +11464,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -11129,7 +11506,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11167,7 +11544,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11205,7 +11582,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -11263,7 +11640,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11294,7 +11671,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11325,7 +11702,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -11363,7 +11740,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11401,7 +11778,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -11443,7 +11820,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32029,
+        "code": -32030,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11481,7 +11858,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32030,
+        "code": -32031,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11523,7 +11900,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32031,
+        "code": -32032,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11561,7 +11938,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32032,
+        "code": -32033,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11604,7 +11981,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH": {
-        "code": -32033,
+        "code": -32034,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
         "data": {
           "additionalProperties": false,
@@ -11639,7 +12016,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH_FORK": {
-        "code": -32034,
+        "code": -32035,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
         "data": {
           "additionalProperties": false,
@@ -11689,7 +12066,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32035,
+        "code": -32036,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5925,10 +5925,13 @@ multi_bundle_persistence:
     bundle_aware_existing_methods_planned:
       event.publish:
         rule: >
-          New-run publication reserves bundle_hash after #1001, but current runtime assertion with bundle_hash fails closed
-          until canonical runtime source facts are promoted. Existing-run publication will validate against the run's
-          canonical bundle identity after the separately gated source-fact/reader owners land. Legacy bundle_ref/bundle_fingerprint
-          wrappers are transition-only and must not remain authoritative after the rename migration.
+          New-run publication requires canonical bundle_hash when run_id is absent. Existing-run publication resolves bundle
+          context from runs.bundle_hash/runs.bundle_source. If caller bundle_hash and existing run context disagree, the
+          method fails closed with BUNDLE_MISMATCH before mutation or idempotency completion. Until RuntimeContextManager
+          lands, the reduced supported scope routes only to the single active runtime whose BundleSourceFact bundle_hash
+          matches the resolved/requested bundle_hash; other valid hashes fail closed with BUNDLE_UNAVAILABLE rather than
+          falling back to ambient boot state. Legacy bundle_ref/bundle_fingerprint wrappers are transition-only parser inputs
+          and are not authoritative for create-new-work scope.
       run.start:
         rule: Deprecated wrapper follows event.publish bundle_hash semantics while it remains present.
       run.list:
@@ -8625,7 +8628,9 @@ cli_specification:
           behavior: >
             Start runtime/API/MCP through the existing serve startup owner, call health.check, call run.start, subscribe
             with run.subscribe_trace, render composed trace rows and final summary until terminal. Local runtime config and
-            backend selection consume the same shared resolver as `swarm serve`.
+            backend selection consume the same shared resolver as `swarm serve`. When the caller does not pass
+            `--bundle-hash` or the deprecated `--bundle-fingerprint`, run.start uses the active canonical bundle_hash
+            returned by health.check for create-new-work scope.
           ctrl_c: 'First Ctrl-C calls run.stop after a run_id exists, shuts down the locally started runtime, and exits 130. A second interrupt may hard-exit.'
         foreground_connected_start:
           invocation: swarm run --connect <url> --event <name> --payload <file>
@@ -8652,7 +8657,7 @@ cli_specification:
         workflow_failed_or_cancelled: 7
         interrupted: 130
       proof_expectations:
-      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; run.start carries optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint only when the corresponding bundle flag is supplied; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted, while --bundle-fingerprint remains the transition boot-fingerprint assertion
+      - exact /v1/rpc calls for health.check, run.start, run.get, and run.stop; health.check exposes the active canonical bundle_hash when available; run.start carries explicit --bundle-hash or the health.check bundle_hash when create-new-work scope is required, or deprecated legacy bundle_ref.fingerprint only when the corresponding legacy flag is supplied; missing create-new-work bundle scope maps server BUNDLE_SCOPE_REQUIRED, valid non-routable hashes map BUNDLE_UNAVAILABLE, and --bundle-fingerprint remains non-authoritative transition input
       - connected start failures for EVENT_NOT_DECLARED, PAYLOAD_VALIDATION_FAILED, EVENT_PUBLISH_FAILED, bundle identity rejection, and IDEMPOTENCY_CONFLICT render canonical API codes on stderr, exit 6, and do not open /v1/ws or follow work after failed run.start
       - exact /v1/ws subscription for run.subscribe_trace where follow is in scope
       - no direct DB/store/runtime/EventBus reads or writes
@@ -9364,9 +9369,10 @@ cli_specification:
         idempotency key, then sends exactly those params to /v1/rpc event.publish through the shared v1 API client. The server
         remains the event-publication owner:
         it validates declared event/payload/run/bundle/idempotency semantics, publishes through the runtime EventBus/store
-        owner, derives delivery rows, and returns EventPublishResult. Until canonical runtime source facts are promoted,
-        --bundle-hash is serialized as bundle_hash but the server rejects it with UNSUPPORTED_BUNDLE_HASH; --bundle-fingerprint
-        remains the transition assertion path against the current boot fingerprint.
+        owner, derives delivery rows, and returns EventPublishResult. The server requires --bundle-hash for create-new-work
+        when --run-id is omitted, checks optional --bundle-hash against existing run context when --run-id is supplied, and
+        rejects valid but non-routable hashes with BUNDLE_UNAVAILABLE under the single-active-runtime boundary. --bundle-fingerprint
+        remains deprecated transition input and is not authoritative for create-new-work scope or routing.
       flags:
       - name: --payload-json <json-object>
         required: true
@@ -9380,10 +9386,10 @@ cli_specification:
         behavior: Optional parent/source event id for explicit checkpoint lineage. Must be used with --run-id and must name an event from the same run.
       - name: --bundle-hash <bundle-v1:sha256:...>
         maps_to: bundle_hash
-        behavior: Optional canonical assertion name. Cannot be combined with --bundle-fingerprint; currently maps to server UNSUPPORTED_BUNDLE_HASH until canonical runtime source facts are promoted.
+        behavior: Canonical bundle scope. Required by the server when --run-id is omitted; optional with --run-id as a same-run bundle assertion. Cannot be combined with --bundle-fingerprint.
       - name: --bundle-fingerprint <sha256:...>
         maps_to: bundle_ref.fingerprint
-        behavior: Deprecated legacy alias for --bundle-hash during #1001. Optional assertion that the server is running the expected boot bundle fingerprint. Cannot be combined with --bundle-hash.
+        behavior: Deprecated legacy alias retained only as transition input. It cannot satisfy create-new-work bundle scope, does not route work, and cannot be combined with --bundle-hash.
       - name: --emitter <source>
         maps_to: emitter
         behavior: Optional producer identifier. Omitted means the server default emitter applies.
@@ -9404,6 +9410,9 @@ cli_specification:
         - EVENT_NOT_FOUND
         publish_rejected_errors:
         - BUNDLE_MISMATCH
+        - BUNDLE_SCOPE_REQUIRED
+        - BUNDLE_UNAVAILABLE
+        - BUNDLE_DATA_INTEGRITY_ERROR
         - UNSUPPORTED_BUNDLE_HASH
         - UNSUPPORTED_BUNDLE_REF
         - EVENT_NOT_DECLARED
@@ -9411,7 +9420,7 @@ cli_specification:
         - RUN_ALREADY_TERMINAL
         - IDEMPOTENCY_CONFLICT
       proof_expectations:
-      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only; bundle_hash serialization maps server UNSUPPORTED_BUNDLE_HASH until canonical source facts are promoted
+      - exact /v1/rpc event.publish call with event_name, required payload, optional run_id, optional source_event_id, optional canonical bundle_hash or deprecated legacy bundle_ref.fingerprint, optional emitter, and optional idempotency_key params only; missing create-new-work bundle scope maps to server BUNDLE_SCOPE_REQUIRED and valid non-routable hashes map to BUNDLE_UNAVAILABLE
       - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing explicit token for non-loopback API targets make zero API calls
       - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
@@ -10438,13 +10447,7 @@ api_specification:
         where content is identical.
       algorithm_migration: If a future version migrates to a different hash algorithm, the prefix changes (e.g., `blake3:<hex>`).
         v1 commits to sha256 only.
-      role_in_v1: "fingerprint is the load-bearing boot/runtime identity in current v1 runtime source facts. Public input\
-        \ surfaces reserve canonical bundle_hash (`bundle-v1:sha256:<hex>`) after #1001, but current runtime identity\
-        \ assertions with bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH until the separately gated canonical source-fact\
-        \ owner promotes real v1 bundle_hash source facts. Legacy BundleRef/bundle_ref.fingerprint remains the transition\
-        \ assertion path against the boot fingerprint. BundleIdentity (returned by health.check) still carries fingerprint\
-        \ + workflow_name + workflow_version until the source-fact owner promotes v1 bundle_hash output. No API surface accepts\
-        \ filesystem paths.\n"
+      role_in_v1: "fingerprint is legacy boot/runtime identity metadata and remains exposed in BundleIdentity for health/check compatibility. Public input surfaces use canonical bundle_hash (`bundle-v1:sha256:<hex>`) for promoted bundle scope after #1001/#1015. Legacy BundleRef/bundle_ref.fingerprint is a deprecated transition parser input and is not authoritative for create-new-work admission, routing, or mismatch decisions. No API surface accepts filesystem paths.\n"
   components:
     description: 'Reusable JSON Schema components. Methods reference these via $ref. The
 
@@ -10474,7 +10477,7 @@ api_specification:
       BundleHash:
         type: string
         pattern: ^bundle-v1:sha256:[a-f0-9]{64}$
-        description: Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:<hex> fingerprints are not accepted under the bundle_hash name. Until the canonical source-fact owner is promoted, runtime identity assertions that supply bundle_hash fail closed with UNSUPPORTED_BUNDLE_HASH.
+        description: Canonical v1 bundle identity. Public input surfaces use this shape for bundle_hash; legacy sha256:<hex> fingerprints are not accepted under the bundle_hash name.
       ScopeName:
         description: 'Action-resource scopes used for v1 authorization. v1 enforcement
 
@@ -10519,11 +10522,11 @@ api_specification:
           fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
       BundleIdentity:
-        description: "Server bundle identity returned by health.check. Three fields:\nfingerprint is the load-bearing identity\
-          \ (sha256 of normalized\ncontents); workflow_name and workflow_version are human-friendly\nlabels. Server-local\
-          \ filesystem paths are intentionally NOT\nexposed \u2014 they leak deployment internals and aren't meaningful\n\
-          to external Phase-2 consumers. Operators querying \"what bundle\nis this server running?\" get the fingerprint (definitive)\
-          \ and\nthe labels (informational).\n"
+        description: "Server bundle identity returned by health.check. bundle_hash is the active canonical v1 bundle identity\
+          \ when the runtime has a promoted source fact and is the value clients use for create-new-work bundle scope. fingerprint\
+          \ is legacy boot/runtime identity metadata retained for health/check compatibility; workflow_name and workflow_version\
+          \ are human-friendly labels. Server-local filesystem paths are intentionally NOT exposed \u2014 they leak deployment\
+          \ internals and aren't meaningful to external Phase-2 consumers.\n"
         type: object
         additionalProperties: false
         required:
@@ -10531,6 +10534,8 @@ api_specification:
         - workflow_version
         - fingerprint
         properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
           workflow_name:
             type: string
           workflow_version:
@@ -12888,13 +12893,32 @@ api_specification:
       BUNDLE_MISMATCH:
         type: object
         additionalProperties: false
-        required:
-        - boot_fingerprint
         properties:
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
+          requested_hash:
+            $ref: '#/components/schemas/BundleHash'
+          run_bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          bundle_source:
+            type: string
           provided_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
           boot_fingerprint:
             $ref: '#/components/schemas/Sha256Fingerprint'
+      BUNDLE_SCOPE_REQUIRED:
+        type: object
+        additionalProperties: false
+        required:
+        - field
+        - reason
+        properties:
+          field:
+            type: string
+          reason:
+            type: string
+          run_id:
+            $ref: '#/components/schemas/OpaqueId'
       BUNDLE_NOT_FOUND:
         type: object
         additionalProperties: false
@@ -12912,6 +12936,8 @@ api_specification:
           status:
             type: string
           bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          active_bundle_hash:
             $ref: '#/components/schemas/BundleHash'
           bundle_source:
             type: string
@@ -13548,18 +13574,22 @@ api_specification:
       - name: bundle_hash
         required: false
         description: >-
-          Optional canonical bundle identity assertion name reserved by #1001. Must be
-          bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref,
-          and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime
-          source facts are promoted.
+          Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:<64 lowercase hex>.
+          Required when run_id is omitted. When run_id
+          identifies an existing run, optional bundle_hash must match that run's
+          canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH.
+          Until RuntimeContextManager lands, the resolved hash must match the single
+          active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE.
+          cannot be combined with legacy bundle_ref; malformed or combined inputs fail
+          closed with UNSUPPORTED_BUNDLE_HASH.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
         description: >-
           Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only,
-          remains the current operational boot-fingerprint assertion path, and cannot be
-          combined with bundle_hash.
+          is not authoritative for create-new-work scope or routing, and cannot be combined
+          with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -13597,6 +13627,9 @@ api_specification:
           $ref: '#/components/schemas/EventPublishResult'
       errors:
       - BUNDLE_MISMATCH
+      - BUNDLE_SCOPE_REQUIRED
+      - BUNDLE_UNAVAILABLE
+      - BUNDLE_DATA_INTEGRITY_ERROR
       - UNSUPPORTED_BUNDLE_HASH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
@@ -13663,23 +13696,13 @@ api_specification:
       description: 'Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call
         event.publish directly.
 
-        Start a new run by injecting an event into the runtime bus.
-
-        Optionally declares the canonical bundle_hash input name reserved
-
-        by #1001. Until the canonical runtime source-fact owner is promoted,
-
-        supplied bundle_hash fails closed with UNSUPPORTED_BUNDLE_HASH rather
-
-        than being compared to the legacy boot fingerprint. If bundle_hash is
-
-        omitted, the boot-time bundle is used. Per-run dynamic bundle loading is
-
-        deferred (see deferred_namespaces.bundle_lifecycle). Legacy
-
-        bundle_ref.fingerprint remains the deprecated #1001
-
-        transition assertion path and cannot be combined with bundle_hash.
+        Start a run by injecting an event into the runtime bus. Create-new-work admission follows event.publish bundle_hash
+        semantics: if no existing run row provides bundle context, bundle_hash is required. If run_id is supplied but no
+        run row exists, the call is still create-new-work and run_id alone is not bundle scope. If caller bundle_hash and
+        existing run context disagree, the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the
+        resolved bundle_hash must match the single active runtime source fact or the method fails closed with
+        BUNDLE_UNAVAILABLE. Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with
+        bundle_hash.
 
         '
       scope:
@@ -13690,18 +13713,22 @@ api_specification:
       - name: bundle_hash
         required: false
         description: >-
-          Optional canonical bundle identity assertion name reserved by #1001. Must be
-          bundle-v1:sha256:<64 lowercase hex>, cannot be combined with legacy bundle_ref,
-          and currently fails closed with UNSUPPORTED_BUNDLE_HASH until canonical runtime
-          source facts are promoted.
+          Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:<64 lowercase hex>.
+          Required when no existing run row supplies
+          bundle context. When run_id identifies an existing run, optional bundle_hash
+          must match that run's canonical runs.bundle_hash or the method fails closed
+          with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must
+          match the single active runtime source fact or the method fails closed with
+          BUNDLE_UNAVAILABLE; cannot be combined with legacy bundle_ref; malformed or
+          combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: bundle_ref
         required: false
         description: >-
           Deprecated transition alias during #1001. Carries bundle_ref.fingerprint only,
-          remains the current operational boot-fingerprint assertion path, and cannot be
-          combined with bundle_hash.
+          is not authoritative for create-new-work scope or routing, and cannot be combined
+          with bundle_hash.
         schema:
           $ref: '#/components/schemas/BundleRef'
       - name: event_name
@@ -13738,6 +13765,9 @@ api_specification:
               $ref: '#/components/schemas/RunStatus'
       errors:
       - BUNDLE_MISMATCH
+      - BUNDLE_SCOPE_REQUIRED
+      - BUNDLE_UNAVAILABLE
+      - BUNDLE_DATA_INTEGRITY_ERROR
       - UNSUPPORTED_BUNDLE_HASH
       - UNSUPPORTED_BUNDLE_REF
       - EVENT_NOT_DECLARED
@@ -15548,8 +15578,8 @@ api_specification:
         defaults use the MCP listener, and retired `--health-addr` MUST NOT be used. The helper MUST NOT
         stop broad Docker inventory or truncate database tables directly. Corpus startup
         migrates from legacy `/api/rpc` run.start payloads with builder-token auth to `curl /v1/rpc {method: run.start,
-        params: {bundle_hash?, event_name, payload, idempotency_key?}}` with the unified token. Legacy bundle_ref remains
-        a transition alias only. run.start is now a
+        params: {bundle_hash, event_name, payload, idempotency_key?}}` for create-new-work with the unified token. Legacy bundle_ref remains
+        a transition alias only and is not bundle scope. run.start is now a
         deprecated wrapper over event.publish until the helper moves to the canonical event.publish method.'
       cli_v2_read_commands: "Promoted CLI v2 read commands map to v1 methods:\n  swarm runs     \u2192 run.list\n  swarm\
         \ status   \u2192 run.diagnose (default), run.get for header-only mode if exposed\n  swarm trace    \u2192 run.trace,\


### PR DESCRIPTION
## Summary

Closes #1022.

This PR closes the approved first-slice #1022 class for reduced single-active-runtime `/v1/rpc event.publish` and deprecated `/v1/rpc run.start` create/target admission:

- Introduces one shared `internal/apiv1` bundle admission resolver consumed by both methods.
- Requires canonical `bundle_hash` for create-new-work when no existing run row provides bundle context.
- Resolves existing-run context from `runs.bundle_hash` / `runs.bundle_source`, rejects caller/run disagreement with `BUNDLE_MISMATCH`, and fails non-routable valid hashes with `BUNDLE_UNAVAILABLE` under the current single-active-runtime boundary.
- Removes blanket canonical `bundle_hash` rejection while preserving canonical shape and legacy/canonical combination validation.
- Updates `platform-spec.yaml`, generated OpenRPC, API spec tests, compliance matrix, CLI error mapping, and supported `/v1/rpc` probes.

## Governing Refs / Context

- Pre-audit: https://github.com/yazzaoui/Swarm/issues/1022#issuecomment-4585543686
- Independent gate: https://github.com/yazzaoui/Swarm/issues/1022#issuecomment-4585561308 (`approved as first slice`)
- Binding spec sections updated/consumed:
  - `multi_bundle_persistence.bundle_identity.canonicalization_v1`
  - `multi_bundle_persistence.api_surface.bundle_aware_existing_methods_planned.event.publish`
  - `multi_bundle_persistence.explicit_splits.create_new_work_bundle_hash`
  - `api_specification.method_catalog.event.publish`
  - `api_specification.method_catalog.run.start`
  - `api_specification.components.errors`
- Parent remains open: #1011.
- Broader parent remains open: #981 RuntimeContextManager / concurrent per-bundle runtime context routing.

## Semantic Migration

- New canonical owner: `internal/apiv1/operator_bundle_admission.go` via `resolveEventPublicationBundleScope`.
- Old invalid/non-authoritative paths:
  - unconditional canonical `bundle_hash` rejection in event publication params
  - `opts.Bundle.Fingerprint` / boot fingerprint as request admission authority
  - legacy `bundle_ref.fingerprint` as create-new-work scope or mismatch authority
- Production paths checked for surviving old behavior:
  - `/v1/rpc event.publish`
  - `/v1/rpc run.start`
  - `swarm event publish` and `swarm run` API pass-through/error mapping
  - EventBus source fact propagation and run-row source stamping
  - run bundle availability reader over `runs.bundle_hash` / `runs.bundle_source`
  - `event.replay`, `agent.replay`, mailbox decision publishing, `run.fork`, and retired Builder `/api/rpc run.start` as split/different contexts
- Migration completeness: complete for the #1022 approved first slice. Full concurrent per-bundle runtime routing remains tracked by #981.

## Validation

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apiv1 -run 'OperatorRunStartHandlers|OperatorEventPublishHandlers|OpenRPCMutatingHTTPRuntimeProbes' -count=1`
- `go test ./internal/apispec ./cmd/swarm ./internal/store/runbundle ./internal/store -run 'TestPlatformAPISpecValidationCoverage|TestGeneratedOpenRPCArtifactMatchesPlatformSpec|TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints|TestEventPublish|TestRunCommand|RunBundle|BundleAvailability' -count=1`
- `go test ./...`