### PR TITLE
[agent-a][issue #1130] Refresh LLM backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ built-in/default config last.
 ```bash
 # Anthropic API transport.
 export ANTHROPIC_API_KEY=...
-swarm serve --backend anthropic --config ./config.yaml
+swarm serve --backend anthropic
 
 # Claude CLI transport.
 export CLAUDE_CODE_OAUTH_TOKEN=...
-swarm serve --backend claude_cli --config ./config.yaml
+swarm serve --backend claude_cli
 
 # Chat Completions-compatible HTTP JSON transport.
 export OPENAI_COMPATIBLE_API_KEY=...
@@ -154,6 +154,8 @@ backend fails fast if its required credential is missing.
 | `anthropic` | `ANTHROPIC_API_KEY` |
 | `claude_cli` | `CLAUDE_CODE_OAUTH_TOKEN` |
 | `openai_compatible` | `OPENAI_COMPATIBLE_API_KEY` |
+
+The following `config.yaml` is for the `openai_compatible` command above:
 
 ```yaml
 # config.yaml

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Swarm runs fleets of LLM agents as a durable, stateful system. You declare it in
 
 More than a simple orchestrator that decides which agent runs next, Swarm runs the system around it. Work is modeled as entities (an order, a ticket, a candidate business) moving through a state machine you declare: the runtime schedules hundreds at once, keeps them isolated, meters their spend, persists their state, and resumes them after a crash, days later if a timer or a human kept them waiting. Any run can be replayed or forked from the log. Deterministic routing is one piece; the rest is the operating system.
 
-Single Go binary, Postgres for persistence. Three LLM backend profiles ship today: `api` for Anthropic API, `cli_test` for the Claude CLI subprocess transport, and `openai_compatible` for Chat Completions-compatible HTTP JSON. All three consume the shared LLM provider adapter contract; native OpenAI Responses and provider-specific OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, or vLLM support remain separate gated runtime/config work.
+Single Go binary, Postgres for persistence. Three LLM backend profiles ship today: `anthropic` for Anthropic API, `claude_cli` for the Claude CLI subprocess transport, and `openai_compatible` for Chat Completions-compatible HTTP JSON. All three consume the shared LLM provider adapter contract; native OpenAI Responses and provider-specific OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, or vLLM support remain separate gated runtime/config work.
 
 **Long-term direction:** entire divisions (engineering, support, operations) running as autonomous Swarm flows. Humans in the loop where judgment is required; agents and deterministic system nodes everywhere else.
 
@@ -82,7 +82,7 @@ Guard failures have explicit semantics: `reject` (default), `discard`, `kill`, o
 
 ## Quickstart
 
-Requires Docker, a contract bundle, and credentials for the configured shipped LLM runtime. The Compose quickstart currently starts the orchestrator with the `cli_test` backend from `docker-compose.yml`; setting `SWARM_LLM_BACKEND` in `.env` does not override that Compose default.
+Requires Docker, a contract bundle, and credentials for the configured shipped LLM runtime. The Compose quickstart currently starts the orchestrator with the `claude_cli` backend from `docker-compose.yml`; `.env` supplies secrets such as `CLAUDE_CODE_OAUTH_TOKEN`, not the backend selector.
 
 ```bash
 # 1. clone
@@ -116,37 +116,69 @@ not user isolation on a shared host.
 
 ### LLM Backend Profiles
 
-Outside the Compose quickstart, select a shipped backend with `SWARM_LLM_BACKEND`
-or the equivalent `llm.backend` config key:
+Outside the Compose quickstart, select a shipped backend with `--backend` or
+the equivalent `llm.backend` config key. Selection precedence is
+`--backend > llm.backend > default anthropic`; environment variables never
+select the backend. Commands that need runtime/operator config discover an
+explicit `--config` first, `config.yaml` beside the running binary second, and
+built-in/default config last.
 
 ```bash
 # Anthropic API transport.
-export SWARM_LLM_BACKEND=api
 export ANTHROPIC_API_KEY=...
+swarm serve --backend anthropic --config ./config.yaml
 
-# Claude CLI transport. The profile id remains cli_test until a separate
-# compatibility/storage migration renames it.
-export SWARM_LLM_BACKEND=cli_test
+# Claude CLI transport.
 export CLAUDE_CODE_OAUTH_TOKEN=...
+swarm serve --backend claude_cli --config ./config.yaml
 
 # Chat Completions-compatible HTTP JSON transport.
-export SWARM_LLM_BACKEND=openai_compatible
 export OPENAI_COMPATIBLE_API_KEY=...
-export SWARM_OPENAI_COMPATIBLE_BASE_URL=https://api.example.com
-export SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL=...
-# Optional low-cost model used when budget policy throttles the actor entity.
-export SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL=...
+swarm serve --backend openai_compatible --config ./config.yaml
 ```
 
-`openai_compatible` treats `SWARM_OPENAI_COMPATIBLE_BASE_URL` or
-`llm.openai_compatible.base_url` as the API base URL and normalizes it to
-`/v1/chat/completions`. Model config keys are
-`llm.openai_compatible.default_model` and
-`llm.openai_compatible.low_cost_model`. This profile is not native OpenAI
+`openai_compatible` uses `llm.openai_compatible.base_url` as the deployment
+configuration for a Chat Completions-compatible HTTP JSON endpoint and
+normalizes it to `/v1/chat/completions`. This profile is not native OpenAI
 Responses API support, not an official-OpenAI-only provider identity, and not
 provider-matrix support for OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex,
-or vLLM. `SWARM_LLM_RUNTIME_MODE` and `llm.runtime_mode` are retired; use
-`SWARM_LLM_BACKEND` or `llm.backend`.
+or vLLM.
+
+Runtime config owns non-secret LLM behavior, including backend selection,
+provider endpoint/base URLs, and model alias maps. Environment variables remain
+for credentials and explicitly-owned infra connection values only. The selected
+backend fails fast if its required credential is missing.
+
+| Backend | Required credential env var |
+|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `claude_cli` | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `openai_compatible` | `OPENAI_COMPATIBLE_API_KEY` |
+
+```yaml
+# config.yaml
+llm:
+  backend: openai_compatible
+  openai_compatible:
+    base_url: https://api.example.com
+  models:
+    regular:
+      anthropic: claude-3-5-sonnet
+      claude_cli: sonnet
+      openai_compatible: gpt-compatible
+```
+
+Authored agents choose provider-agnostic model aliases with `model`. Built-in
+aliases are `cheap`, `regular`, and `frontier`; `llm.models` can override any
+alias per backend profile.
+
+```yaml
+# agents.yaml
+support-agent:
+  model: regular
+  subscriptions: [ticket.created]
+  emit_events: [ticket.triaged]
+```
 
 For an end-to-end walkthrough (building a flow from scratch), see [`docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md`](docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ backend fails fast if its required credential is missing.
 # config.yaml
 llm:
   backend: openai_compatible
+  session:
+    lock_ttl: 10s
+    rotate_after_turns: 40
+    rotate_on_parse_failures: 3
   openai_compatible:
     base_url: https://api.example.com
   models:

--- a/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
+++ b/docs/specs/swarm-platform/SWARM-DEVELOPER-GUIDE.md
@@ -196,11 +196,15 @@ timer.ticket_sla:
 
 ### Step 6: Define the agents
 
+Agents declare provider-agnostic model aliases with `model`. The runtime ships
+with `cheap`, `regular`, and `frontier`; operators can override the concrete
+provider model for each alias through `llm.models`.
+
 ```yaml
 # agents.yaml
 classifier-agent:
   id: classifier-agent
-  model_tier: haiku
+  model: cheap
   subscriptions: [ticket.created]
   emit_events: [ticket.classified]
   tools: []
@@ -210,7 +214,7 @@ classifier-agent:
 
 resolver-agent:
   id: resolver-agent
-  model_tier: sonnet
+  model: regular
   subscriptions: [ticket.assigned]
   emit_events: [ticket.resolved, ticket.escalated]
   tools: [knowledge_base_search]

--- a/docs/specs/swarm-platform/platform/BUILDER-API.md
+++ b/docs/specs/swarm-platform/platform/BUILDER-API.md
@@ -373,7 +373,7 @@ List registered agents with status.
     {
       "agent_id": "workflow-coordinator",
       "role": "workflow_coordinator",
-      "model_tier": "sonnet",
+      "model": "regular",
       "conversation_mode": "session",
       "status": "active",
       "turn_count": 3,
@@ -593,7 +593,7 @@ List agents for a flow (or all).
       "agent_id": "workflow-coordinator",
       "type": "root",
       "role": "workflow_coordinator",
-      "model_tier": "sonnet",
+      "model": "regular",
       "subscriptions": ["..."],
       "emit_events": ["..."],
       "tools": ["..."],

--- a/docs/specs/swarm-platform/platform/platform-guide.md
+++ b/docs/specs/swarm-platform/platform/platform-guide.md
@@ -158,7 +158,7 @@ Several fields are optional in contract YAML because the loader derives them fro
 
 - `schema_name` — derived from the directory name if omitted. A flow at `flows/scoring/` gets name `"scoring"`.
 - `schema_namespace` — derived from the flow path relative to root.
-- `agent_id` — derived from the YAML map key. In `agents.yaml`, `{"coordinator-agent": {model_tier: sonnet, ...}}` means `agent_id = "coordinator-agent"`. An explicit `id` field overrides the map key if present, but this is discouraged.
+- `agent_id` — derived from the YAML map key. In `agents.yaml`, `{"coordinator-agent": {model: regular, ...}}` means `agent_id = "coordinator-agent"`. An explicit `id` field overrides the map key if present, but this is discouraged.
 - `agent_emit_events` — defaults to an empty list. An agent that only observes may omit `emit_events` entirely.
 
 ### Entity Schema And Event Schema
@@ -839,7 +839,7 @@ This constraint is good for onboarding because every agent session has the same 
 
 ### Mount Guarantees
 
-The runtime guarantees that every agent session has all three standard mounts, that `/data` is identical across all workspace classes, that `/workspace` visibility follows the declared scope, that read-only mounts are enforced at the filesystem level, and that mount availability does not vary by `conversation_mode`, `model_tier`, or any other agent property.
+The runtime guarantees that every agent session has all three standard mounts, that `/data` is identical across all workspace classes, that `/workspace` visibility follows the declared scope, that read-only mounts are enforced at the filesystem level, and that mount availability does not vary by `conversation_mode`, `model`, or any other agent property.
 
 ### Deployment Mapping
 

--- a/docs/specs/swarm-platform/platform/platform-spec.md
+++ b/docs/specs/swarm-platform/platform/platform-spec.md
@@ -95,7 +95,7 @@ Canonical format for all flow contract files.
 - `description`: Fields that are optional in contract YAML because the loader derives them from context.
 - `schema_name`: Optional. If omitted, derived from the directory name of the flow package. A flow at flows/processing/ gets name "processing" automatically.
 - `schema_namespace`: Optional. If omitted, derived from the flow path relative to root. A flow at flows/processing/ gets namespace "processing". Root flow gets empty namespace.
-- `agent_id`: Optional. If omitted, the YAML map key IS the agent ID. agents.yaml uses map keys as canonical identifiers: {"instance-coordinator": {model_tier: sonnet, ...}} means agent_id = "instance-coordinator". Explicit id field overrides the map key if present, but this is discouraged.
+- `agent_id`: Optional. If omitted, the YAML map key IS the agent ID. agents.yaml uses map keys as canonical identifiers: {"instance-coordinator": {model: regular, ...}} means agent_id = "instance-coordinator". Explicit id field overrides the map key if present, but this is discouraged.
 - `agent_emit_events`: Optional. If omitted, defaults to empty list []. An agent that only observes (subscribes but never emits) may omit emit_events entirely.
 ## file_layout
 
@@ -1609,7 +1609,7 @@ CREATE TABLE entity_state (
 
 ### agents
 
-- `description`: Runtime agent registry. One row per agent instance. Carries the full runtime descriptor: role (from agents.yaml), parent_agent_id (managerial hierarchy), config (agent-specific configuration from contracts), subscriptions/emit_events/tools/permissions (materialized from contracts at boot for fast runtime lookup). flow_instance nullable for root-level agents not scoped to any flow. entity_id nullable — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth. This table is the runtime materialization. llm_backend specifies the LLM invocation backend — api (Anthropic API transport), cli_test (Claude CLI transport), openai_compatible (Chat Completions-compatible HTTP transport), mock (fixture replay), local (local model). This is a deployment/agent property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.
+- `description`: Runtime agent registry. One row per agent instance. Carries the full persisted runtime descriptor: role/model/llm_backend/conversation_mode/parent_agent_id as typed columns, subscriptions/emit_events/tools/permissions as JSONB arrays, and runtime_descriptor JSONB for the remaining control-plane fields that do not already have a first-class persisted column. flow_instance nullable for root-level agents not scoped to any flow. entity_id nullable — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth. This table is the runtime materialization. llm_backend stores the backend profile id owned by llm_provider_selection_config_authority. Active runtime profiles are anthropic (Anthropic API transport), claude_cli (Claude CLI transport), and openai_compatible (Chat Completions-compatible HTTP transport); legacy api and cli_test persisted rows are migration/backfill inputs only and are not valid new config/operator inputs. mock and local are reserved persisted profile ids and are not active runtimes until a dedicated provider/runtime owner lands. This is a deployment/agent property, not a session property. agent_sessions.runtime_mode tracks conversation scope only.
 ### ddl
 
 ```sql
@@ -1617,7 +1617,7 @@ CREATE TABLE agents (
     agent_id          TEXT PRIMARY KEY,
     flow_instance     TEXT,
     role              TEXT NOT NULL,
-    model_tier        TEXT NOT NULL,
+    model             TEXT NOT NULL,
     llm_backend       TEXT NOT NULL DEFAULT 'anthropic' CHECK (llm_backend IN ('anthropic', 'claude_cli', 'openai_compatible', 'mock', 'local')),
     conversation_mode TEXT NOT NULL CHECK (conversation_mode IN ('task', 'session', 'session_per_entity')),
     parent_agent_id   TEXT,
@@ -2058,7 +2058,7 @@ Defines the filesystem contract for agent sessions. The platform provides three 
 - `/data is the SAME mount point across all workspace classes. An agent in any class sees identical /data contents.`
 - `/workspace isolation follows the workspace_scope declared by the agent's workspace class. per-agent workspaces are never visible to other agents. per-flow-instance workspaces are visible to all agents in that flow instance only.`
 - `Read-only mounts are enforced at the filesystem level (read-only bind mount, or equivalent). Agents cannot write to /data or /opt/swarm/contracts.`
-- `The runtime MUST NOT vary mount availability based on conversation_mode, model_tier, or any other agent property. Workspace class is the sole determinant of /workspace scope.`
+- `The runtime MUST NOT vary mount availability based on conversation_mode, model, or any other agent property. Workspace class is the sole determinant of /workspace scope.`
 
 ## boot_validation
 


### PR DESCRIPTION
## Summary

Closes #1130.

Refreshes active operator-facing docs to match the shipped LLM backend/profile/model-alias authority after #1128 and #1129:

- README now documents `anthropic`, `claude_cli`, and `openai_compatible`, `--backend > llm.backend > default anthropic`, config discovery, required credential env vars, and `llm.models` model aliases.
- Developer/platform docs and rendered/public markdown now use authored `model` aliases instead of `model_tier` in current examples.
- Builder API examples now show `model` instead of `model_tier`.

## Governing refs / context

Exact governing spec refs:

- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`
- `platform-spec.yaml#engine.agent_session_management.llm_provider_adapter_contract`

Binding issue/gate context:

- #1130 pre-audit and approved gate: `runtime.llm_provider_docs_config_secrets_model_alias_cleanup`
- #1128 / PR #1133 supplied backend selection/config discovery behavior.
- #1129 / PR #1156 supplied authored `model` alias runtime/store/verify/audit behavior.

## Semantic migration documentation

- New canonical owner: `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority` plus `internal/runtime/llm/selection` for backend profile and model alias resolution.
- Old active docs paths now invalid: `SWARM_LLM_BACKEND`, `api`/`cli_test` as operator backend IDs, authored `model_tier`, retired OpenAI-compatible model/base URL env keys, and retired per-provider model config keys.
- Production paths checked for surviving old behavior: CLI help, docker-compose backend flag test, config/backend precedence tests, OpenRPC generation, and broad tracked-docs search.
- Migration completeness for this PR: complete for active tracked docs/prose in the approved #1130 boundary. A non-doc bundle CLI/read-surface regression found on current master is split to #1164 and is not absorbed here.

## Proof

- `git ls-files README.md 'docs/**/*.md' 'docs/**/*.yaml' | rg -v 'docs/specs/swarm-platform/platform/contracts/' | xargs rg -n 'SWARM_LLM_BACKEND|model_tier|SWARM_OPENAI_COMPATIBLE|llm\.openai_compatible\.(default_model|low_cost_model)|llm\.claude_api\.(default_model|haiku_model)|SWARM_CLAUDE_(DEFAULT|HAIKU)_MODEL|OPENAI_COMPATIBLE_(DEFAULT|LOW_COST)_MODEL'`
  - Remaining hits are historical changelog entries, watchlist/source-authority split context, and root spec migration/fail-closed authority, not active setup docs.
- `go run ./cmd/swarm-openrpc-gen --check`
- `go run ./cmd/swarm serve --help | rg -- '--config|--backend|anthropic|claude_cli|openai_compatible|SWARM_LLM_BACKEND'`
- `go test ./cmd/swarm -run 'Test(DockerComposeUsesBackendFlagNotRetiredLLMBackendEnv|RunServeCommand_HelpIncludesServeFlags|DefaultRuntimeConfig_RejectsRetiredLLMBackendEnv|LoadRuntimeConfigWithOptions_UsesSharedDiscoveryAndBackendPrecedence)' -count=1`
- `go test ./...`