### PR TITLE
[agent-g][issue #1149] Add backend-neutral tool persistence stores

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -131,6 +131,8 @@ type storeBundle struct {
 	ManagerStore        runtimemanager.ManagerPersistence
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	MailboxStore        runtimetools.MailboxPersistence
+	ToolEntityStore     runtimetools.EntityPersistence
+	HumanTaskStore      runtimetools.HumanTaskPersistence
 	BudgetSpendStore    budgetspend.Store
 	MailboxAPIStore     apiv1.MailboxAPIStore
 	ObservabilityStore  apiv1.ObservabilityReadStore
@@ -152,6 +154,8 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ScheduleStore:       s.ScheduleStore,
 		StartupOwnership:    s.StartupOwnership,
 		MailboxStore:        s.MailboxStore,
+		ToolEntityStore:     s.ToolEntityStore,
+		HumanTaskStore:      s.HumanTaskStore,
 		BudgetSpendStore:    s.BudgetSpendStore,
 		RuntimeIngressStore: s.RuntimeIngressStore,
 		TurnStore:           s.TurnStore,
@@ -613,7 +617,8 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
 			AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
 				Config:            cfg,
-				SQLDB:             stores.SQLDB,
+				EntityStore:       stores.ToolEntityStore,
+				HumanTaskStore:    stores.HumanTaskStore,
 				SessionRegistry:   stores.SessionRegistry,
 				ConversationStore: stores.ConversationStore,
 				TurnStore:         stores.TurnStore,
@@ -1110,7 +1115,8 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
 			AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
 				Config:            cfg,
-				SQLDB:             stores.SQLDB,
+				EntityStore:       stores.ToolEntityStore,
+				HumanTaskStore:    stores.HumanTaskStore,
 				SessionRegistry:   stores.SessionRegistry,
 				ConversationStore: stores.ConversationStore,
 				TurnStore:         stores.TurnStore,
@@ -2039,6 +2045,8 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ManagerStore:        pg,
 			ScheduleStore:       pg,
 			MailboxStore:        pg,
+			ToolEntityStore:     pg,
+			HumanTaskStore:      pg,
 			BudgetSpendStore:    pg,
 			MailboxAPIStore:     pg,
 			ObservabilityStore:  pg,
@@ -2063,7 +2071,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 gate-promoted raw-SQL consumers (tool executor entity/human-task persistence and diagnostics, runtime diagnostics/logging) move to backend-neutral store owners or receive an explicit lead-approved split",
+			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1150 runtime diagnostics/logging moves to a backend-neutral store owner or receives an explicit lead-approved split",
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
 			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB),
@@ -2072,6 +2080,8 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ManagerStore:        sqliteStore,
 			ScheduleStore:       sqliteStore,
 			MailboxStore:        sqliteStore,
+			ToolEntityStore:     sqliteStore,
+			HumanTaskStore:      sqliteStore,
 			BudgetSpendStore:    sqliteStore,
 			MailboxAPIStore:     sqliteStore,
 			ObservabilityStore:  sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -191,8 +191,8 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
 	}
-	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 gate-promoted raw-SQL consumers") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1087 raw-SQL consumer fail-closed blocker", runtimeStores.ConstructionBlocker)
+	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics fail-closed blocker", runtimeStores.ConstructionBlocker)
 	}
 	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
@@ -202,6 +202,12 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 	if runtimeStores.BudgetSpendStore == nil {
 		t.Fatal("sqlite runtimeStores BudgetSpendStore missing backend-neutral budget/spend owner")
+	}
+	if runtimeStores.ToolEntityStore == nil {
+		t.Fatal("sqlite runtimeStores ToolEntityStore missing backend-neutral entity tool owner")
+	}
+	if runtimeStores.HumanTaskStore == nil {
+		t.Fatal("sqlite runtimeStores HumanTaskStore missing backend-neutral human-task owner")
 	}
 	if runtimeStores.PipelineStore == nil || !runtimeStores.PipelineStore.Enabled() {
 		t.Fatal("sqlite runtimeStores PipelineStore missing enabled backend-neutral pipeline owner")
@@ -230,10 +236,10 @@ func TestBuildStoresSQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit(t *testing
 		Options: runtime.RuntimeOptions{SelfCheck: true},
 	})
 	if err == nil {
-		t.Fatal("NewRuntime(sqlite) succeeded, want fail-closed blocker while #1087 raw-SQL consumers remain unsplit")
+		t.Fatal("NewRuntime(sqlite) succeeded, want fail-closed blocker while #1150 diagnostics remains split")
 	}
-	if !strings.Contains(err.Error(), "#1087 gate-promoted raw-SQL consumers") {
-		t.Fatalf("NewRuntime(sqlite) error = %v, want #1087 raw-SQL consumer blocker", err)
+	if !strings.Contains(err.Error(), "#1150 runtime diagnostics/logging") {
+		t.Fatalf("NewRuntime(sqlite) error = %v, want #1150 diagnostics blocker", err)
 	}
 }
 

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -188,6 +188,8 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		ScheduleStore:       pg,
 		StartupOwnership:    pg,
 		MailboxStore:        pg,
+		ToolEntityStore:     pg,
+		HumanTaskStore:      pg,
 		RuntimeIngressStore: pg,
 		ConversationStore:   nil,
 		TurnStore:           nil,

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -77,7 +77,8 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 		ContractSelection: selection,
 		AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
 			Config:            cfg,
-			SQLDB:             h.db,
+			EntityStore:       h.pg,
+			HumanTaskStore:    h.pg,
 			SessionRegistry:   sessions.NewPostgresRegistry(h.db, cfg.LLM.Session.LockTTL),
 			ConversationStore: h.pg,
 			TurnStore:         h.pg,

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -2321,8 +2321,10 @@ func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetoo
 	`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
+	pg := &store.PostgresStore{DB: db}
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:                          db,
+		EntityStore:                    pg,
+		HumanTaskStore:                 pg,
 		AllowInternalLegacyEntityTools: true,
 		WorkflowSource: runtimesemanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 			RootEntities: runtimecontracts.EntityContractsDocument{

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -2,7 +2,6 @@ package runforkexecution
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -37,7 +36,8 @@ var selectedContractAgentRuntimeGatewayEnvMu sync.Mutex
 
 type SelectedContractAgentRuntimeOptions struct {
 	Config            *config.Config
-	SQLDB             *sql.DB
+	EntityStore       runtimetools.EntityPersistence
+	HumanTaskStore    runtimetools.HumanTaskPersistence
 	SessionRegistry   runtimesessions.Registry
 	ConversationStore runtimellm.ConversationPersistence
 	TurnStore         runtimellm.TurnPersistence
@@ -272,7 +272,8 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 		Credentials:       credentials,
 		MailboxStore:      options.MailboxStore,
 		MCPClient:         options.MCPClient,
-		SQLDB:             options.SQLDB,
+		EntityStore:       options.EntityStore,
+		HumanTaskStore:    options.HumanTaskStore,
 		WorkflowSource:    source,
 		WorkspaceResolver: options.Workspace,
 		AuthorityProvider: authority,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -49,6 +49,8 @@ type Stores struct {
 	ScheduleStore       runtimepipeline.SchedulePersistence
 	StartupOwnership    runtimestartupownership.Store
 	MailboxStore        runtimetools.MailboxPersistence
+	ToolEntityStore     runtimetools.EntityPersistence
+	HumanTaskStore      runtimetools.HumanTaskPersistence
 	BudgetSpendStore    budgetspend.Store
 	InboundStore        InboundPersistence
 	RuntimeIngressStore runtimeingress.Store
@@ -510,7 +512,8 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		Config:            cfg,
 		Credentials:       rt.Credentials,
 		MailboxStore:      stores.MailboxStore,
-		SQLDB:             stores.SQLDB,
+		EntityStore:       stores.ToolEntityStore,
+		HumanTaskStore:    stores.HumanTaskStore,
 		WorkflowSource:    source,
 		WorkspaceResolver: rt.Workspace,
 		AuthorityProvider: rt.Authority,

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 
 	"swarm/internal/config"
 	"swarm/internal/events"
@@ -44,8 +43,9 @@ type ExecutorOptions struct {
 	Config            *config.Config
 	Credentials       runtimecredentials.Store
 	MailboxStore      MailboxPersistence
+	EntityStore       EntityPersistence
+	HumanTaskStore    HumanTaskPersistence
 	MCPClient         *runtimemcp.Client
-	SQLDB             *sql.DB
 	WorkflowSource    semanticview.Source
 	WorkspaceResolver workspace.Resolver
 	AuthorityProvider runtimeauthority.Provider

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -2,8 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"regexp"
-	"sort"
 	"strings"
 
 	"swarm/internal/runtime/entityruntime"
@@ -14,17 +12,6 @@ type entityToolSchema struct {
 	Defined  bool
 	Contract entityruntime.Contract
 }
-
-type entityFilterCondition struct {
-	Field    entityruntime.Field
-	Operator string
-	Value    any
-}
-
-var (
-	entityFilterSplitter = regexp.MustCompile(`(?i)\s+AND\s+`)
-	entityFilterPattern  = regexp.MustCompile(`^\s*([a-z_][a-z0-9_.]*)\s*(=|!=|>=|<=|>|<)\s*(.+?)\s*$`)
-)
 
 func entityToolSchemaForActor(source semanticview.Source, actorID string) (entityToolSchema, error) {
 	if source == nil {
@@ -98,114 +85,6 @@ func normalizeEntityFieldValue(schema entityToolSchema, field entityruntime.Fiel
 	return entityruntime.NormalizeFieldValue(schema.Contract, field.Path, value)
 }
 
-func parseEntityFilter(schema entityToolSchema, filter string, paramStart int) (string, []any, error) {
-	filter = strings.TrimSpace(filter)
-	if filter == "" {
-		return "", nil, nil
-	}
-	parts := entityFilterSplitter.Split(filter, -1)
-	clauses := make([]string, 0, len(parts))
-	args := make([]any, 0, len(parts))
-	paramIndex := paramStart
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		match := entityFilterPattern.FindStringSubmatch(part)
-		if len(match) != 4 {
-			return "", nil, fmt.Errorf("invalid filter expression %q", part)
-		}
-		field, err := schema.field(match[1])
-		if err != nil {
-			return "", nil, err
-		}
-		value, err := parseEntityFilterValue(schema, field, match[3])
-		if err != nil {
-			return "", nil, err
-		}
-		clauses = append(clauses, fmt.Sprintf("%s %s $%d", entityFilterSQLPath(field.Path), strings.TrimSpace(match[2]), paramIndex))
-		args = append(args, value)
-		paramIndex++
-	}
-	if len(clauses) == 0 {
-		return "", nil, nil
-	}
-	return " WHERE " + strings.Join(clauses, " AND "), args, nil
-}
-
-func parseEntityFilterValue(schema entityToolSchema, field entityruntime.Field, raw string) (any, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, fmt.Errorf("filter value for field %s is required", strings.TrimSpace(field.Path))
-	}
-	if strings.EqualFold(raw, "null") {
-		return normalizeEntityFieldValue(schema, field, nil)
-	}
-	if unquoted, ok := unquoteEntityFilterValue(raw); ok {
-		return normalizeEntityFieldValue(schema, field, unquoted)
-	}
-	switch strings.ToLower(field.Type) {
-	case "boolean":
-		switch strings.ToLower(raw) {
-		case "true":
-			return true, nil
-		case "false":
-			return false, nil
-		}
-	case "integer":
-		var v int64
-		if _, err := fmt.Sscanf(raw, "%d", &v); err == nil {
-			return normalizeEntityFieldValue(schema, field, v)
-		}
-	default:
-		if f := parseLooseNumeric(raw); f != raw {
-			return normalizeEntityFieldValue(schema, field, f)
-		}
-	}
-	return normalizeEntityFieldValue(schema, field, raw)
-}
-
-func unquoteEntityFilterValue(raw string) (string, bool) {
-	if len(raw) < 2 {
-		return "", false
-	}
-	if (strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'")) || (strings.HasPrefix(raw, `"`) && strings.HasSuffix(raw, `"`)) {
-		return raw[1 : len(raw)-1], true
-	}
-	return "", false
-}
-
-func parseLooseNumeric(raw string) any {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return raw
-	}
-	var floatValue float64
-	if _, err := fmt.Sscanf(raw, "%f", &floatValue); err == nil {
-		return floatValue
-	}
-	return raw
-}
-
-func metricExpression(metric string, field entityruntime.Field) (string, error) {
-	metric = strings.ToLower(strings.TrimSpace(metric))
-	switch metric {
-	case "count":
-		return "COUNT(*)", nil
-	case "sum", "avg":
-		fieldType := strings.ToLower(strings.TrimSpace(field.Type))
-		if fieldType != "integer" && !strings.HasPrefix(fieldType, "numeric") {
-			return "", fmt.Errorf("metric %s requires numeric field, got %s", metric, field.Type)
-		}
-		return strings.ToUpper(metric) + "(" + entityFilterSQLPath(field.Path) + ")", nil
-	case "min", "max":
-		return strings.ToUpper(metric) + "(" + entityFilterSQLPath(field.Path) + ")", nil
-	default:
-		return "", fmt.Errorf("unsupported metric %q", metric)
-	}
-}
-
 func defaultEntitySearchLimit(value int) int {
 	if value <= 0 {
 		return 100
@@ -214,42 +93,4 @@ func defaultEntitySearchLimit(value int) int {
 		return 1000
 	}
 	return value
-}
-
-func orderedEntityFieldNames(fields map[string]entityruntime.Field) []string {
-	out := make([]string, 0, len(fields))
-	for name := range fields {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func entityFilterSQLPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return `COALESCE(fields, '{}'::jsonb)`
-	}
-	segments := strings.Split(path, ".")
-	if len(segments) == 1 {
-		return fmt.Sprintf("COALESCE(fields, '{}'::jsonb) -> %s", entitySQLLiteral(segments[0]))
-	}
-	sqlPath := make([]string, 0, len(segments))
-	for _, segment := range segments {
-		segment = strings.TrimSpace(segment)
-		if segment == "" {
-			continue
-		}
-		sqlPath = append(sqlPath, entitySQLLiteral(segment))
-	}
-	return fmt.Sprintf("COALESCE(fields, '{}'::jsonb) #> ARRAY[%s]", strings.Join(sqlPath, ", "))
-}
-
-func entitySQLLiteral(value string) string {
-	value = strings.ReplaceAll(strings.TrimSpace(value), `'`, `''`)
-	return "'" + value + "'"
-}
-
-func entityQuoteIdent(v string) string {
-	return `"` + strings.ReplaceAll(v, `"`, `""`) + `"`
 }

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,11 +29,12 @@ type Executor struct {
 	mu                             sync.RWMutex
 	manager                        Manager
 	managerProvider                ManagerProvider
-	sqlDB                          *sql.DB
 	bus                            EventPublisher
 	scheduler                      Scheduler
 	scheduleStore                  SchedulePersistence
 	mailboxStore                   MailboxPersistence
+	entityStore                    EntityPersistence
+	humanTaskStore                 HumanTaskPersistence
 	cfg                            *config.Config
 	credentials                    runtimecredentials.Store
 	httpClient                     *http.Client
@@ -71,7 +71,8 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		scheduler:                      scheduler,
 		scheduleStore:                  scheduleStore,
 		mailboxStore:                   opts.MailboxStore,
-		sqlDB:                          opts.SQLDB,
+		entityStore:                    opts.EntityStore,
+		humanTaskStore:                 opts.HumanTaskStore,
 		cfg:                            opts.Config,
 		credentials:                    opts.Credentials,
 		httpClient:                     &http.Client{Timeout: 30 * time.Second},
@@ -659,14 +660,24 @@ func (e *Executor) mailboxStoreDependency() (MailboxPersistence, error) {
 	return store, nil
 }
 
-func (e *Executor) sqlDBDependency() (*sql.DB, error) {
+func (e *Executor) entityStoreDependency() (EntityPersistence, error) {
 	e.mu.RLock()
-	db := e.sqlDB
+	store := e.entityStore
 	e.mu.RUnlock()
-	if db == nil {
-		return nil, errors.New("sql db is not configured")
+	if store == nil {
+		return nil, errors.New("entity persistence store is not configured")
 	}
-	return db, nil
+	return store, nil
+}
+
+func (e *Executor) humanTaskStoreDependency() (HumanTaskPersistence, error) {
+	e.mu.RLock()
+	store := e.humanTaskStore
+	e.mu.RUnlock()
+	if store == nil {
+		return nil, errors.New("human task persistence store is not configured")
+	}
+	return store, nil
 }
 
 func (e *Executor) ValidateRuntimeToolInputForTest(name string, input any) error {

--- a/internal/runtime/tools/executor_dependency_test.go
+++ b/internal/runtime/tools/executor_dependency_test.go
@@ -2,9 +2,9 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"testing"
+	"time"
 
 	models "swarm/internal/runtime/core/actors"
 )
@@ -54,6 +54,34 @@ func (*mailboxStoreStub) ListUnnotifiedCriticalMailboxItems(context.Context, int
 }
 func (*mailboxStoreStub) MarkMailboxItemNotified(context.Context, string) error { return nil }
 
+type entityPersistenceStub struct{}
+
+func (*entityPersistenceStub) LoadEntityState(context.Context, EntityIdentity) (map[string]any, bool, error) {
+	return nil, false, nil
+}
+func (*entityPersistenceStub) QueryEntityStates(context.Context, EntityStateQuery) ([]map[string]any, error) {
+	return nil, nil
+}
+func (*entityPersistenceStub) SaveEntityField(context.Context, EntityFieldUpdate) (int, error) {
+	return 0, nil
+}
+func (*entityPersistenceStub) CreateEntity(context.Context, EntityCreateRecord) error { return nil }
+
+type humanTaskPersistenceStub struct{}
+
+func (*humanTaskPersistenceStub) CreateHumanTask(context.Context, HumanTaskCreateRecord) (string, error) {
+	return "task-1", nil
+}
+func (*humanTaskPersistenceStub) HumanTaskRequeueCount(context.Context, string) (int, error) {
+	return 0, nil
+}
+func (*humanTaskPersistenceStub) CountApprovedHumanTasksSince(context.Context, time.Time) (int, error) {
+	return 0, nil
+}
+func (*humanTaskPersistenceStub) DecideHumanTask(context.Context, HumanTaskDecisionRecord) error {
+	return nil
+}
+
 func TestExecutorMailboxSendFailsWithoutMailboxStore(t *testing.T) {
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{AuthorityProvider: allowMailboxAuthority{}})
 
@@ -91,24 +119,46 @@ func TestExecutorMailboxSendUsesConstructorOwnedMailboxStore(t *testing.T) {
 	}
 }
 
-func TestExecutorSQLDBDependencyFailsWithoutConstructorOwnedDB(t *testing.T) {
+func TestExecutorEntityStoreDependencyFailsWithoutConstructorOwnedStore(t *testing.T) {
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
 
-	db, err := exec.sqlDBDependency()
-	if db != nil || err == nil || !strings.Contains(err.Error(), "sql db is not configured") {
-		t.Fatalf("sqlDBDependency = (%v, %v), want nil sql db error", db, err)
+	store, err := exec.entityStoreDependency()
+	if store != nil || err == nil || !strings.Contains(err.Error(), "entity persistence store is not configured") {
+		t.Fatalf("entityStoreDependency = (%v, %v), want nil store error", store, err)
 	}
 }
 
-func TestExecutorSQLDBDependencyUsesConstructorOwnedDB(t *testing.T) {
-	db := &sql.DB{}
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{SQLDB: db})
+func TestExecutorEntityStoreDependencyUsesConstructorOwnedStore(t *testing.T) {
+	store := &entityPersistenceStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{EntityStore: store})
 
-	got, err := exec.sqlDBDependency()
+	got, err := exec.entityStoreDependency()
 	if err != nil {
-		t.Fatalf("sqlDBDependency: %v", err)
+		t.Fatalf("entityStoreDependency: %v", err)
 	}
-	if got != db {
-		t.Fatalf("sqlDBDependency db = %p, want %p", got, db)
+	if got != store {
+		t.Fatalf("entityStoreDependency store = %p, want %p", got, store)
+	}
+}
+
+func TestExecutorHumanTaskStoreDependencyFailsWithoutConstructorOwnedStore(t *testing.T) {
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
+
+	store, err := exec.humanTaskStoreDependency()
+	if store != nil || err == nil || !strings.Contains(err.Error(), "human task persistence store is not configured") {
+		t.Fatalf("humanTaskStoreDependency = (%v, %v), want nil store error", store, err)
+	}
+}
+
+func TestExecutorHumanTaskStoreDependencyUsesConstructorOwnedStore(t *testing.T) {
+	store := &humanTaskPersistenceStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{HumanTaskStore: store})
+
+	got, err := exec.humanTaskStoreDependency()
+	if err != nil {
+		t.Fatalf("humanTaskStoreDependency: %v", err)
+	}
+	if got != store {
+		t.Fatalf("humanTaskStoreDependency store = %p, want %p", got, store)
 	}
 }

--- a/internal/runtime/tools/executor_entity.go
+++ b/internal/runtime/tools/executor_entity.go
@@ -2,12 +2,10 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
@@ -31,10 +29,10 @@ var entityStateTopLevelFields = map[string]struct{}{
 	"updated_at":       {},
 }
 
-func (e *Executor) entityToolDependencies(input any) (*sql.DB, semanticview.Source, map[string]any, error) {
-	db, err := e.sqlDBDependency()
+func (e *Executor) entityToolDependencies(input any) (EntityPersistence, semanticview.Source, map[string]any, error) {
+	store, err := e.entityStoreDependency()
 	if err != nil {
-		return nil, nil, nil, NewRuntimeError("dependency_unavailable", "tool-executor", "entity_tool.db", true, "sql database is not configured")
+		return nil, nil, nil, NewRuntimeError("dependency_unavailable", "tool-executor", "entity_tool.store", true, "entity persistence store is not configured")
 	}
 	e.mu.RLock()
 	source := e.workflowSource
@@ -46,7 +44,7 @@ func (e *Executor) entityToolDependencies(input any) (*sql.DB, semanticview.Sour
 	if payload == nil {
 		payload = map[string]any{}
 	}
-	return db, source, payload, nil
+	return store, source, payload, nil
 }
 
 func parseEntityID(raw any) (string, error) {
@@ -60,24 +58,18 @@ func parseEntityID(raw any) (string, error) {
 	return entityID, nil
 }
 
-func loadEntityState(ctx context.Context, db *sql.DB, entityID string) (map[string]any, bool, error) {
+func loadEntityState(ctx context.Context, store EntityPersistence, entityID string) (map[string]any, bool, error) {
 	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
 	if err != nil {
 		return nil, false, err
 	}
-	row := db.QueryRowContext(ctx, entityStateRowQuery(" WHERE run_id = $1::uuid AND entity_id = $2::uuid"), identity.RunID, identity.EntityID)
-	var raw []byte
-	if err := row.Scan(&raw); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, false, nil
-		}
-		return nil, false, err
+	if store == nil {
+		return nil, false, fmt.Errorf("entity persistence store is not configured")
 	}
-	entity, err := decodeEntityJSONMap(raw)
-	if err != nil {
-		return nil, false, err
-	}
-	return entity, true, nil
+	return store.LoadEntityState(ctx, EntityIdentity{
+		RunID:    identity.RunID,
+		EntityID: identity.EntityID,
+	})
 }
 
 func materializeEntityStateRow(source semanticview.Source, row map[string]any) (map[string]any, error) {
@@ -96,96 +88,6 @@ func materializeEntityStateRow(source semanticview.Source, row map[string]any) (
 		cloned["entity_type"] = contract.EntityType
 	}
 	return cloned, nil
-}
-
-func entityStateRowQuery(suffix string) string {
-	return `
-		SELECT row_to_json(t)
-		FROM (
-			SELECT
-				entity_id::text AS entity_id,
-				run_id::text AS run_id,
-				COALESCE(flow_instance, '') AS flow_instance,
-				COALESCE(entity_type, '') AS entity_type,
-				name,
-				current_state,
-				COALESCE(gates, '{}'::jsonb) AS gates,
-				COALESCE(fields, '{}'::jsonb) AS fields,
-				COALESCE(accumulator, '{}'::jsonb) AS accumulator,
-				revision,
-				entered_state_at,
-				created_at,
-				updated_at
-			FROM entity_state` + suffix + `
-		) AS t
-	`
-}
-
-func queryEntityStateRows(ctx context.Context, db *sql.DB, suffix string, args ...any) ([]map[string]any, error) {
-	rows, err := db.QueryContext(ctx, `
-		SELECT entity_id::text, run_id::text, COALESCE(flow_instance, ''), COALESCE(entity_type, ''), name, current_state,
-		       COALESCE(gates, '{}'::jsonb), COALESCE(fields, '{}'::jsonb), COALESCE(accumulator, '{}'::jsonb),
-		       revision, entered_state_at, created_at, updated_at
-		FROM entity_state`+suffix, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	out := make([]map[string]any, 0)
-	for rows.Next() {
-		var entityID, runID, flowInstance, entityType, currentState string
-		var name sql.NullString
-		var gatesRaw, fieldsRaw, accumulatorRaw []byte
-		var revision int
-		var enteredStateAt, createdAt, updatedAt time.Time
-		if err := rows.Scan(
-			&entityID,
-			&runID,
-			&flowInstance,
-			&entityType,
-			&name,
-			&currentState,
-			&gatesRaw,
-			&fieldsRaw,
-			&accumulatorRaw,
-			&revision,
-			&enteredStateAt,
-			&createdAt,
-			&updatedAt,
-		); err != nil {
-			return nil, err
-		}
-		gates, err := decodeEntityJSONMap(gatesRaw)
-		if err != nil {
-			return nil, err
-		}
-		fields, err := decodeEntityJSONMap(fieldsRaw)
-		if err != nil {
-			return nil, err
-		}
-		accumulator, err := decodeEntityJSONMap(accumulatorRaw)
-		if err != nil {
-			return nil, err
-		}
-		row := map[string]any{
-			"entity_id":        entityID,
-			"run_id":           runID,
-			"flow_instance":    flowInstance,
-			"entity_type":      entityType,
-			"name":             nullStringValue(name),
-			"current_state":    currentState,
-			"gates":            gates,
-			"fields":           fields,
-			"accumulator":      accumulator,
-			"revision":         revision,
-			"entered_state_at": enteredStateAt.Format(time.RFC3339Nano),
-			"created_at":       createdAt.Format(time.RFC3339Nano),
-			"updated_at":       updatedAt.Format(time.RFC3339Nano),
-		}
-		out = append(out, row)
-	}
-	return out, rows.Err()
 }
 
 func materializeEntityStateRows(source semanticview.Source, rows []map[string]any) ([]map[string]any, error) {
@@ -228,13 +130,6 @@ func orderedEntityFieldNamesFromInput(names []string) []string {
 		deduped = append(deduped, name)
 	}
 	return deduped
-}
-
-func nullStringValue(value sql.NullString) any {
-	if !value.Valid {
-		return nil
-	}
-	return strings.TrimSpace(value.String)
 }
 
 func numericEntityValue(value any) (float64, bool) {

--- a/internal/runtime/tools/executor_entity_helpers_test.go
+++ b/internal/runtime/tools/executor_entity_helpers_test.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	models "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/entityruntime"
 )
 
 func TestOrderedEntityFieldNamesFromInput_NormalizesSortsAndDedupes(t *testing.T) {
@@ -16,27 +17,31 @@ func TestOrderedEntityFieldNamesFromInput_NormalizesSortsAndDedupes(t *testing.T
 	}
 }
 
-func TestEntityStateBaseQuery_OptionallyIncludesFlowInstance(t *testing.T) {
+func TestEntityStateQuery_OptionallyIncludesFlowInstance(t *testing.T) {
+	t.Parallel()
+
 	payload := map[string]any{
 		"flow_instance": " review/inst-1 ",
 	}
+	ctx := runtimecorrelation.WithRunID(t.Context(), "00000000-0000-0000-0000-000000000001")
 
-	clausesWithoutFlow, argsWithoutFlow := entityStateBaseQuery(nil, models.AgentConfig{}, payload, false)
-	whereWithoutFlow := joinEntityStateWhere(clausesWithoutFlow)
-	if whereWithoutFlow != "" {
-		t.Fatalf("where without flow = %q", whereWithoutFlow)
+	queryWithoutFlow, err := entityStateQueryForContractRun(ctx, nil, entityruntime.Contract{}, payload, false)
+	if err != nil {
+		t.Fatalf("query without flow: %v", err)
 	}
-	if !reflect.DeepEqual(argsWithoutFlow, []any{}) {
-		t.Fatalf("args without flow = %#v", argsWithoutFlow)
+	if queryWithoutFlow.RunID != "00000000-0000-0000-0000-000000000001" {
+		t.Fatalf("run_id without flow = %q", queryWithoutFlow.RunID)
+	}
+	if queryWithoutFlow.RequestedFlowExact != "" || queryWithoutFlow.RequestedFlowScope.Root != "" {
+		t.Fatalf("query without flow should not include requested flow: %#v", queryWithoutFlow)
 	}
 
-	clausesWithFlow, argsWithFlow := entityStateBaseQuery(nil, models.AgentConfig{}, payload, true)
-	whereWithFlow := joinEntityStateWhere(clausesWithFlow)
-	if whereWithFlow != " WHERE flow_instance = $1" {
-		t.Fatalf("where with flow = %q", whereWithFlow)
+	queryWithFlow, err := entityStateQueryForContractRun(ctx, nil, entityruntime.Contract{}, payload, true)
+	if err != nil {
+		t.Fatalf("query with flow: %v", err)
 	}
-	if !reflect.DeepEqual(argsWithFlow, []any{"review/inst-1"}) {
-		t.Fatalf("args with flow = %#v", argsWithFlow)
+	if queryWithFlow.RequestedFlowExact != "review/inst-1" {
+		t.Fatalf("requested flow exact = %q", queryWithFlow.RequestedFlowExact)
 	}
 }
 

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,7 +17,7 @@ import (
 )
 
 func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -26,14 +25,13 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_search_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	query, err := entityStateQueryForContractRun(ctx, source, schema.Contract, payload, true)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_search_entities.run_context", true, err, "resolve entity_state run context")
 	}
 	currentStateFilter := strings.TrimSpace(asString(payload["current_state"]))
 	if currentStateFilter != "" {
-		args = append(args, currentStateFilter)
-		filterSQL = append(filterSQL, fmt.Sprintf("current_state = $%d", len(args)))
+		query.CurrentState = currentStateFilter
 	}
 	if rawFilter, ok := payload["filter"]; ok && rawFilter != nil {
 		filterObject := map[string]any{}
@@ -51,21 +49,16 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 			if err != nil {
 				return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_search_entities.filter", false, err, "validate filter field %s", fieldName)
 			}
-			filterJSON, err := json.Marshal(value)
-			if err != nil {
-				return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_search_entities.filter", false, err, "marshal filter field %s", fieldName)
-			}
-			args = append(args, string(filterJSON))
-			filterSQL = append(filterSQL, fmt.Sprintf("%s = $%d::jsonb", entityFilterSQLPath(field.Path), len(args)))
+			query.FieldEquals = append(query.FieldEquals, EntityFieldEquals{Path: field.Path, Value: value})
 		}
 	}
-	whereClause := joinEntityStateWhere(filterSQL)
 	limit := defaultEntitySearchLimit(asInt(payload["limit"]))
 	offset := asInt(payload["offset"])
 	if offset < 0 {
 		offset = 0
 	}
-	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
+	query.OrderByCreatedDesc = true
+	rows, err := store.QueryEntityStates(ctx, query)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_search_entities.query", true, err, "search entity_state")
 	}
@@ -91,7 +84,7 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 }
 
 func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -99,12 +92,12 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_entities.schema", false, err, "resolve entity contract")
 	}
-	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	query, err := entityStateQueryForContractRun(ctx, source, schema.Contract, payload, true)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_entities.run_context", true, err, "resolve entity_state run context")
 	}
-	whereClause := joinEntityStateWhere(filterSQL)
-	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
+	query.OrderByCreatedDesc = true
+	rows, err := store.QueryEntityStates(ctx, query)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_entities.query", true, err, "query entity_state")
 	}
@@ -138,7 +131,7 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 }
 
 func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -165,12 +158,12 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 			return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_query_metrics.group_by", false, err, "validate group_by")
 		}
 	}
-	filterSQL, args, err := entityStateBaseQueryForContractRun(ctx, source, schema.Contract, payload, true)
+	query, err := entityStateQueryForContractRun(ctx, source, schema.Contract, payload, true)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_metrics.run_context", true, err, "resolve entity_state run context")
 	}
-	whereClause := joinEntityStateWhere(filterSQL)
-	rows, err := queryEntityStateRows(ctx, db, whereClause+" ORDER BY created_at DESC", args...)
+	query.OrderByCreatedDesc = true
+	rows, err := store.QueryEntityStates(ctx, query)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_query_metrics.query", true, err, "query entity_state metrics")
 	}
@@ -197,41 +190,26 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 	return map[string]any{"groups": groups}, nil
 }
 
-func entityStateBaseQuery(source semanticview.Source, actor models.AgentConfig, payload map[string]any, includeFlowInstance bool) ([]string, []any) {
-	contract, _ := entityruntime.ResolveForActor(source, actor.ID)
-	return entityStateBaseQueryForContract(source, contract, payload, includeFlowInstance)
-}
-
-func entityStateBaseQueryForContract(source semanticview.Source, contract entityruntime.Contract, payload map[string]any, includeFlowInstance bool) ([]string, []any) {
-	clauses := make([]string, 0, 4)
-	args := make([]any, 0, 4)
-	flowRoot := entityReadFlowScopeRoot(source, contract)
-	if flowRoot != "" {
-		args = append(args, flowRoot, flowRoot+"/%")
-		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
-	}
-	if includeFlowInstance {
-		clauses, args = appendEntityToolExistingFlowInstanceFilter(source, clauses, args, asString(payload["flow_instance"]))
-	}
-	return clauses, args
-}
-
-func entityStateBaseQueryForContractRun(ctx context.Context, source semanticview.Source, contract entityruntime.Contract, payload map[string]any, includeFlowInstance bool) ([]string, []any, error) {
+func entityStateQueryForContractRun(ctx context.Context, source semanticview.Source, contract entityruntime.Contract, payload map[string]any, includeFlowInstance bool) (EntityStateQuery, error) {
 	runID, err := runtimecurrentstate.RequireRunID(ctx)
 	if err != nil {
-		return nil, nil, err
+		return EntityStateQuery{}, err
 	}
-	clauses := []string{"run_id = $1::uuid"}
-	args := []any{runID}
-	flowRoot := entityReadFlowScopeRoot(source, contract)
-	if flowRoot != "" {
-		args = append(args, flowRoot, flowRoot+"/%")
-		clauses = append(clauses, fmt.Sprintf("(flow_instance = $%d OR flow_instance LIKE $%d)", len(args)-1, len(args)))
+	query := EntityStateQuery{RunID: runID}
+	if flowRoot := entityReadFlowScopeRoot(source, contract); flowRoot != "" {
+		query.FlowScope = EntityFlowScope{Root: flowRoot, IncludeDescendants: true}
 	}
 	if includeFlowInstance {
-		clauses, args = appendEntityToolExistingFlowInstanceFilter(source, clauses, args, asString(payload["flow_instance"]))
+		requested := normalizeEntityToolFlowInstance(asString(payload["flow_instance"]))
+		if requested != "" {
+			if root, ok := entityToolDeclaredFlowScopeRoot(source, requested); ok {
+				query.RequestedFlowScope = EntityFlowScope{Root: root, IncludeDescendants: true}
+			} else {
+				query.RequestedFlowExact = requested
+			}
+		}
 	}
-	return clauses, args, nil
+	return query, nil
 }
 
 func entityReadFlowScopeRoot(source semanticview.Source, contract entityruntime.Contract) string {
@@ -240,13 +218,6 @@ func entityReadFlowScopeRoot(source semanticview.Source, contract entityruntime.
 		return ""
 	}
 	return runtimeflowidentity.ScopeKey(source, flowID)
-}
-
-func joinEntityStateWhere(clauses []string) string {
-	if len(clauses) == 0 {
-		return ""
-	}
-	return " WHERE " + strings.Join(clauses, " AND ")
 }
 
 func filterEntityStateRowsCEL(expression string, rows []map[string]any, schema entityToolSchema) ([]map[string]any, error) {

--- a/internal/runtime/tools/executor_entity_read.go
+++ b/internal/runtime/tools/executor_entity_read.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (e *Executor) execGetEntity(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -15,7 +15,7 @@ func (e *Executor) execGetEntity(ctx context.Context, actor models.AgentConfig, 
 	if err != nil {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_get_entity.entity_id", false, err.Error())
 	}
-	entity, found, err := loadEntityState(ctx, db, entityID)
+	entity, found, err := loadEntityState(ctx, store, entityID)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_get_entity.lookup", true, err, "load entity %s", entityID)
 	}

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -1218,7 +1218,7 @@ accounts:
 		t.Fatalf("MaterializeRunFork: %v", err)
 	}
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:                          db,
+		EntityStore:                    pg,
 		WorkflowSource:                 semanticview.Wrap(bundle),
 		AllowInternalLegacyEntityTools: true,
 	})
@@ -1323,7 +1323,7 @@ accounts:
 	}
 
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:                          db,
+		EntityStore:                    pg,
 		WorkflowSource:                 semanticview.Wrap(bundle),
 		AllowInternalLegacyEntityTools: true,
 	})
@@ -2102,8 +2102,9 @@ foreign:
 	_, db, _ := testutil.StartPostgres(t)
 	ensureEntityToolTestRun(t, db)
 	bus := &entityToolRuntimeLogBus{}
+	pg := &store.PostgresStore{DB: db}
 	exec := runtimetools.NewExecutorWithOptions(bus, nil, runtimetools.ExecutorOptions{
-		SQLDB:                          db,
+		EntityStore:                    pg,
 		WorkflowSource:                 semanticview.Wrap(bundle),
 		AllowInternalLegacyEntityTools: true,
 	})
@@ -2607,9 +2608,10 @@ func newEntityToolTestHarnessWithBundleAndLegacyAccess(t *testing.T, actor model
 	t.Helper()
 	_, db, _ := testutil.StartPostgres(t)
 	ensureEntityToolTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
-		SQLDB:                          db,
+		EntityStore:                    pg,
 		WorkflowSource:                 semanticview.Wrap(bundle),
 		AllowInternalLegacyEntityTools: allowInternalLegacy,
 	})

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -2,25 +2,22 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	models "swarm/internal/runtime/core/actors"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecurrentstate "swarm/internal/runtime/currentstate"
 	"swarm/internal/runtime/entityruntime"
-	runtimemutationlog "swarm/internal/runtime/mutationlog"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
 func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -32,10 +29,10 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.run_context", true, err, "resolve entity_state run context")
 	}
-	if err := enforceEntityWriteOwnership(ctx, db, source, actor, entityID, e.runtimeLogSink()); err != nil {
+	if err := enforceEntityWriteOwnership(ctx, store, source, actor, entityID, e.runtimeLogSink()); err != nil {
 		return nil, err
 	}
-	row, found, err := loadEntityState(ctx, db, entityID)
+	row, found, err := loadEntityState(ctx, store, entityID)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "exec_save_entity_field.lookup", true, err, "load entity %s", entityID)
 	}
@@ -80,68 +77,26 @@ func (e *Executor) execSaveEntityField(ctx context.Context, actor models.AgentCo
 	if err != nil {
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.value", false, err, "marshal value")
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.begin", true, err, "begin save entity field tx")
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
 	pathSegments, err := entityJSONPathSegments(field.Path)
 	if err != nil {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "exec_save_entity_field.field", false, err.Error())
 	}
-	pathArray := pq.Array(pathSegments)
 
-	var oldValue []byte
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $3::text[], 'null'::jsonb)
-		FROM entity_state
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-		FOR UPDATE
-	`, identity.RunID, identity.EntityID, pathArray).Scan(&oldValue); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, NewRuntimeError("not_found", "tool-executor", "exec_save_entity_field.lookup", false, "entity %s not found", entityID)
-		}
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.lookup", true, err, "load current entity field %s", fieldName)
-	}
-
-	var revision int
-	if err := tx.QueryRowContext(ctx, `
-		UPDATE entity_state
-		SET
-			fields = jsonb_set(COALESCE(fields, '{}'::jsonb), $2::text[], $3::jsonb, true),
-			revision = revision + 1,
-			updated_at = now()
-		WHERE entity_id = $1::uuid
-		  AND run_id = $4::uuid
-		RETURNING revision
-	`, identity.EntityID, pathArray, string(valueJSON), identity.RunID).Scan(&revision); err != nil {
+	revision, err := store.SaveEntityField(ctx, EntityFieldUpdate{
+		RunID:        identity.RunID,
+		EntityID:     identity.EntityID,
+		FieldPath:    field.Path,
+		PathSegments: pathSegments,
+		ValueJSON:    json.RawMessage(valueJSON),
+		Writer: EntityMutationWriter{
+			Type:        "agent",
+			ID:          strings.TrimSpace(actor.ID),
+			HandlerStep: "save_entity_field",
+		},
+	})
+	if err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.update", true, err, "save entity field %s", fieldName)
 	}
-	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{
-			field.Path: nullableJSONBytes(oldValue),
-		},
-	}, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{
-			field.Path: json.RawMessage(valueJSON),
-		},
-	}, runtimemutationlog.Writer{
-		Type:        "agent",
-		ID:          strings.TrimSpace(actor.ID),
-		HandlerStep: "save_entity_field",
-	}); err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.mutation_log", true, err, "record entity mutation %s", fieldName)
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_save_entity_field.commit", true, err, "commit save entity field")
-	}
-	committed = true
 	return map[string]any{
 		"entity_id": entityID,
 		"field":     field.Path,
@@ -169,31 +124,19 @@ func entityJSONPathSegments(path string) ([]string, error) {
 	return segments, nil
 }
 
-func nullableJSONBytes(raw []byte) any {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed == "null" {
-		return nil
-	}
-	return json.RawMessage(append([]byte(nil), raw...))
-}
-
-func enforceEntityWriteOwnership(ctx context.Context, db *sql.DB, source semanticview.Source, actor models.AgentConfig, entityID string, logger runtimeToolLogSink) error {
+func enforceEntityWriteOwnership(ctx context.Context, store EntityPersistence, source semanticview.Source, actor models.AgentConfig, entityID string, logger runtimeToolLogSink) error {
 	flowRoot := actorFlowOwnershipRoot(source, actor.ID)
-	if flowRoot == "" || db == nil {
+	if flowRoot == "" || store == nil {
 		return nil
 	}
-	identity, err := runtimecurrentstate.RequireIdentity(ctx, entityID)
+	row, found, err := loadEntityState(ctx, store, entityID)
 	if err != nil {
-		return WrapRuntimeError("query_failed", "tool-executor", "entity_write_ownership.run_context", true, err, "resolve entity_state run context")
-	}
-	var flowInstance sql.NullString
-	if err := db.QueryRowContext(ctx, `SELECT COALESCE(flow_instance, '') FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, identity.RunID, identity.EntityID).Scan(&flowInstance); err != nil {
-		if err == sql.ErrNoRows {
-			return nil
-		}
 		return WrapRuntimeError("query_failed", "tool-executor", "entity_write_ownership.lookup", true, err, "load entity ownership")
 	}
-	targetFlow := strings.Trim(flowInstance.String, "/")
+	if !found {
+		return nil
+	}
+	targetFlow := strings.Trim(asString(row["flow_instance"]), "/")
 	if targetFlow == "" || entityFlowOwnedBy(flowRoot, targetFlow) {
 		return nil
 	}
@@ -251,7 +194,7 @@ func entityFlowOwnedBy(flowRoot, targetFlow string) bool {
 }
 
 func (e *Executor) execCreateEntity(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -310,44 +253,23 @@ func (e *Executor) execCreateEntity(ctx context.Context, actor models.AgentConfi
 		return nil, WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_create_entity.fields", false, err, "marshal fields")
 	}
 	now := time.Now().UTC()
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.begin", true, err, "begin create entity tx")
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO entity_state (
-			run_id, entity_id, flow_instance, entity_type, name,
-			current_state, gates, fields, accumulator, revision,
-			entered_state_at, created_at, updated_at
-		)
-		VALUES (
-			$1::uuid, $2::uuid, $3, $4, NULLIF($5, ''),
-			$6, '{}'::jsonb, $7::jsonb, '{}'::jsonb, 1,
-			$8, $8, $8
-		)
-	`, runID, entityID, flowInstance, contract.EntityType, name, currentState, string(fieldsJSON), now); err != nil {
+	if err := store.CreateEntity(ctx, EntityCreateRecord{
+		RunID:        runID,
+		EntityID:     entityID,
+		FlowInstance: flowInstance,
+		EntityType:   contract.EntityType,
+		Name:         name,
+		CurrentState: currentState,
+		FieldsJSON:   json.RawMessage(fieldsJSON),
+		CreatedAt:    now,
+		Writer: EntityMutationWriter{
+			Type:        "platform",
+			ID:          "create_entity",
+			HandlerStep: "create_entity",
+		},
+	}); err != nil {
 		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.insert", false, err, "create entity %s", entityID)
 	}
-	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
-		CurrentState: currentState,
-		Fields:       normalizedFields,
-	}, runtimemutationlog.Writer{
-		Type:        "platform",
-		ID:          "create_entity",
-		HandlerStep: "create_entity",
-	}); err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.mutation_log", true, err, "record initial entity mutations")
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, WrapRuntimeError("write_failed", "tool-executor", "exec_create_entity.commit", true, err, "commit create entity")
-	}
-	committed = true
 	return map[string]any{
 		"entity_id":     entityID,
 		"current_state": currentState,

--- a/internal/runtime/tools/executor_human_tasks.go
+++ b/internal/runtime/tools/executor_human_tasks.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +13,7 @@ import (
 )
 
 func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, err := e.sqlDBDependency()
+	store, err := e.humanTaskStoreDependency()
 	if err != nil {
 		return nil, err
 	}
@@ -69,24 +68,33 @@ func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentC
 		in.Priority = "medium"
 	}
 
-	var deadline sql.NullTime
+	var deadline time.Time
 	if deadlineStr != "" {
 		t, err := time.Parse(time.RFC3339, deadlineStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid deadline (expected RFC3339): %w", err)
 		}
-		deadline = sql.NullTime{Time: t, Valid: true}
+		deadline = t.UTC()
 	}
 
-	talkingJSON := []byte("null")
+	talkingJSON := json.RawMessage("null")
 	if in.TalkingPoints != nil {
 		if b, err := json.Marshal(in.TalkingPoints); err == nil && len(b) > 0 {
 			talkingJSON = b
 		}
 	}
 
-	var taskID string
-	if err := insertHumanTaskMailboxSpec(ctx, db, actor.ID, in.EntityID, in.Category, in.Description, talkingJSON, in.ExpectedValue, in.Priority, deadline, &taskID); err != nil {
+	taskID, err := store.CreateHumanTask(ctx, HumanTaskCreateRecord{
+		ActorID:       actor.ID,
+		EntityID:      in.EntityID,
+		Category:      in.Category,
+		Description:   in.Description,
+		TalkingPoints: talkingJSON,
+		ExpectedValue: in.ExpectedValue,
+		Priority:      in.Priority,
+		Deadline:      deadline,
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -97,7 +105,7 @@ func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentC
 }
 
 func (e *Executor) execHumanTaskDecide(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-	db, err := e.sqlDBDependency()
+	store, err := e.humanTaskStoreDependency()
 	if err != nil {
 		return nil, err
 	}
@@ -141,27 +149,16 @@ func (e *Executor) execHumanTaskDecide(ctx context.Context, actor models.AgentCo
 	}
 
 	if newStatus == "approved" && cfg != nil && cfg.Budget().HumanTasks.MaxTasksPerWeek > 0 {
-		var requeueCount int
-		if err := db.QueryRowContext(ctx, `
-			SELECT COALESCE((payload->>'requeue_count')::int, 0)
-			FROM mailbox
-			WHERE item_id = $1::uuid
-			  AND item_type = 'human_task'
-		`, in.TaskID).Scan(&requeueCount); err != nil {
+		requeueCount, err := store.HumanTaskRequeueCount(ctx, in.TaskID)
+		if err != nil {
 			return nil, fmt.Errorf("load human task requeue count: %w", err)
 		}
 		if requeueCount > 0 {
 			goto skipBudget
 		}
 		weekStart := WeekStartUTC(time.Now(), cfg.Budget().HumanTasks.BudgetReset)
-		var approvedThisWeek int
-		if err := db.QueryRowContext(ctx, `
-			SELECT COALESCE(count(*), 0)
-			FROM mailbox
-			WHERE item_type = 'human_task'
-			  AND decided_at >= $1
-			  AND decision IN ('approved', 'assigned', 'completed')
-		`, weekStart).Scan(&approvedThisWeek); err != nil {
+		approvedThisWeek, err := store.CountApprovedHumanTasksSince(ctx, weekStart)
+		if err != nil {
 			return nil, fmt.Errorf("count approved human tasks this week: %w", err)
 		}
 		if approvedThisWeek >= cfg.Budget().HumanTasks.MaxTasksPerWeek {
@@ -178,19 +175,15 @@ func (e *Executor) execHumanTaskDecide(ctx context.Context, actor models.AgentCo
 	}
 skipBudget:
 
-	decisionObj := map[string]any{
-		"decision":      newStatus,
-		"reason":        in.Reason,
-		"decided_by":    actor.ID,
-		"decided_at":    time.Now().UTC().Format(time.RFC3339),
-		"priority_rank": in.PriorityRank,
-	}
-	if in.RequeueDate != "" {
-		decisionObj["requeue_date"] = in.RequeueDate
-	}
-	decisionJSON, _ := json.Marshal(decisionObj)
-
-	if err := updateHumanTaskMailboxSpec(ctx, db, in.TaskID, newStatus, actor.ID, decisionJSON, nil, nil); err != nil {
+	if err := store.DecideHumanTask(ctx, HumanTaskDecisionRecord{
+		TaskID:       in.TaskID,
+		Status:       newStatus,
+		ActorID:      actor.ID,
+		Reason:       in.Reason,
+		PriorityRank: in.PriorityRank,
+		RequeueDate:  in.RequeueDate,
+		DecidedAt:    time.Now().UTC(),
+	}); err != nil {
 		return nil, err
 	}
 
@@ -198,66 +191,6 @@ skipBudget:
 		"task_id": in.TaskID,
 		"status":  newStatus,
 	}, nil
-}
-
-func insertHumanTaskMailboxSpec(ctx context.Context, db *sql.DB, actorID, entityID, category, description string, talkingJSON []byte, expectedValue, priority string, deadline sql.NullTime, taskID *string) error {
-	payload := map[string]any{
-		"category":       strings.TrimSpace(category),
-		"description":    strings.TrimSpace(description),
-		"expected_value": strings.TrimSpace(expectedValue),
-		"priority":       strings.TrimSpace(priority),
-		"requeue_count":  0,
-	}
-	if len(talkingJSON) > 0 && string(talkingJSON) != "null" {
-		var talking any
-		if json.Unmarshal(talkingJSON, &talking) == nil {
-			payload["talking_points"] = talking
-		}
-	}
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("insert human task: marshal payload: %w", err)
-	}
-	var expiresAt any
-	if deadline.Valid {
-		expiresAt = deadline.Time
-	}
-	return db.QueryRowContext(ctx, `
-		INSERT INTO mailbox (
-			item_id, entity_id, flow_instance, scope, item_type, from_agent,
-			severity, summary, payload, status, notified, expires_at, created_at
-		)
-		VALUES (
-			gen_random_uuid(), NULLIF($1,'')::uuid, NULL,
-			CASE WHEN NULLIF($1,'') IS NULL THEN 'global' ELSE 'entity' END,
-			'human_task', $2, $3, $4, $5::jsonb, 'pending', false, $6, now()
-		)
-		RETURNING item_id::text
-	`, entityID, actorID, humanTaskSeverity(priority), description, string(payloadJSON), expiresAt).Scan(taskID)
-}
-
-func updateHumanTaskMailboxSpec(ctx context.Context, db *sql.DB, taskID, newStatus, actorID string, decisionJSON []byte, requestingAgent, entityID *string) error {
-	return db.QueryRowContext(ctx, `
-		UPDATE mailbox
-		SET status = CASE WHEN $2 = 'timed_out' THEN 'expired' ELSE 'decided' END,
-		    decision = $2,
-		    decision_notes = COALESCE(NULLIF(($3::jsonb)->>'reason', ''), decision_notes),
-		    decided_by = NULLIF($4,''),
-		    decided_at = now(),
-		    payload = CASE
-				WHEN $2 = 'deferred' THEN
-					jsonb_set(
-						COALESCE(payload, '{}'::jsonb),
-						'{requeue_count}',
-						to_jsonb(COALESCE((payload->>'requeue_count')::int, 0) + 1),
-						true
-					)
-				ELSE payload
-			END
-		WHERE item_id = $1::uuid
-		  AND item_type = 'human_task'
-		RETURNING COALESCE(from_agent, ''), COALESCE(entity_id::text, '')
-	`, taskID, newStatus, string(decisionJSON), actorID).Scan(requestingAgent, entityID)
 }
 
 func humanTaskSeverity(priority string) string {

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -135,6 +135,46 @@ accounts:
 	}
 }
 
+func TestSQLiteEntityPersistence_MarshalsStructuredFilterValues(t *testing.T) {
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	ensureSQLiteEntityToolTestRun(t, sqliteStore)
+	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)
+	entityID := uuid.NewString()
+	if err := sqliteStore.CreateEntity(ctx, runtimetools.EntityCreateRecord{
+		RunID:        entityToolTestRunID,
+		EntityID:     entityID,
+		FlowInstance: "review/inst-structured",
+		EntityType:   "account",
+		CurrentState: "queued",
+		FieldsJSON: json.RawMessage(`{
+			"business_brief":{"summary":"validated"},
+			"tags":["alpha","beta"]
+		}`),
+		CreatedAt: time.Now().UTC(),
+		Writer: runtimetools.EntityMutationWriter{
+			Type:        "platform",
+			ID:          "sqlite-structured-filter-test",
+			HandlerStep: "seed",
+		},
+	}); err != nil {
+		t.Fatalf("seed sqlite structured entity: %v", err)
+	}
+
+	rows, err := sqliteStore.QueryEntityStates(ctx, runtimetools.EntityStateQuery{
+		RunID: entityToolTestRunID,
+		FieldEquals: []runtimetools.EntityFieldEquals{
+			{Path: "business_brief", Value: map[string]any{"summary": "validated"}},
+			{Path: "tags", Value: []any{"alpha", "beta"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("query sqlite structured field filters: %v", err)
+	}
+	if len(rows) != 1 || strings.TrimSpace(asString(rows[0]["entity_id"])) != entityID {
+		t.Fatalf("structured filter rows = %#v, want seeded entity %s", rows, entityID)
+	}
+}
+
 func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"save_entity_field"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -1,0 +1,332 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	models "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
+	runtimetools "swarm/internal/runtime/tools"
+	"swarm/internal/store"
+	"swarm/internal/testutil"
+)
+
+type humanTaskToolStore interface {
+	runtimetools.HumanTaskPersistence
+	runtimetools.MailboxPersistence
+}
+
+type allowHumanTaskAuthority struct{}
+
+func (allowHumanTaskAuthority) CanonicalRole(role string) string { return strings.TrimSpace(role) }
+func (allowHumanTaskAuthority) ProducerRoles() []string          { return nil }
+func (allowHumanTaskAuthority) ProducerEventsForRole(string) []string {
+	return nil
+}
+func (allowHumanTaskAuthority) HasMessageAuthority(actor, target models.AgentConfig) bool {
+	return false
+}
+func (allowHumanTaskAuthority) AuthorizeRouting(actor, target models.AgentConfig, status string) error {
+	return nil
+}
+func (allowHumanTaskAuthority) AuthorizeManagement(actor, target models.AgentConfig) error {
+	return nil
+}
+func (allowHumanTaskAuthority) AuthorizeMailboxSend(actor models.AgentConfig) error {
+	return nil
+}
+func (allowHumanTaskAuthority) CanDecideHumanTasks(role string) bool { return true }
+
+func TestEntityTools_SQLiteBackendNeutralEntityPersistence(t *testing.T) {
+	actor := models.AgentConfig{
+		ID:    "tester",
+		Type:  "internal",
+		Role:  "operator",
+		Tools: []string{"create_entity", "get_entity", "save_entity_field", "query_entities", "query_metrics", "search_entities"},
+	}
+	bundle := loadWave1EntityToolBundle(t, actor, "review", "accounts", `
+types: {}
+`, `
+accounts:
+  status: text
+  score: numeric
+  priority: integer
+`)
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	ensureSQLiteEntityToolTestRun(t, sqliteStore)
+	ctx := runtimetools.WithActor(runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID), actor)
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		EntityStore:                    sqliteStore,
+		WorkflowSource:                 semanticview.Wrap(bundle),
+		AllowInternalLegacyEntityTools: true,
+	})
+
+	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
+		"flow_instance": "review/inst-1",
+		"name":          "Acme",
+		"fields": map[string]any{
+			"status":   "open",
+			"score":    42.0,
+			"priority": 3,
+		},
+	})
+	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
+		"entity_id": entityID,
+		"field":     "status",
+		"value":     "closed",
+	}); err != nil {
+		t.Fatalf("sqlite save_entity_field: %v", err)
+	}
+	searchOut, err := exec.Execute(ctx, "search_entities", map[string]any{
+		"flow_instance": "review/inst-1",
+		"current_state": "queued",
+		"filter":        map[string]any{"status": "closed"},
+	})
+	if err != nil {
+		t.Fatalf("sqlite search_entities: %v", err)
+	}
+	searchResult := searchOut.(map[string]any)
+	if got := len(searchResult["results"].([]map[string]any)); got != 1 {
+		t.Fatalf("sqlite search result count = %d, want 1", got)
+	}
+	queryOut, err := exec.Execute(ctx, "query_entities", map[string]any{
+		"filter": `status == "closed"`,
+		"select": []string{"status"},
+	})
+	if err != nil {
+		t.Fatalf("sqlite query_entities: %v", err)
+	}
+	if got := len(queryOut.(map[string]any)["results"].([]map[string]any)); got != 1 {
+		t.Fatalf("sqlite query result count = %d, want 1", got)
+	}
+	metricOut, err := exec.Execute(ctx, "query_metrics", map[string]any{
+		"metric": "sum",
+		"field":  "score",
+	})
+	if err != nil {
+		t.Fatalf("sqlite query_metrics: %v", err)
+	}
+	if got := testNumericValue(metricOut.(map[string]any)["value"]); got != 42.0 {
+		t.Fatalf("sqlite metric sum = %v, want 42", got)
+	}
+	var mutationCount int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM entity_mutations
+		WHERE run_id = ? AND entity_id = ?
+	`, entityToolTestRunID, entityID).Scan(&mutationCount); err != nil {
+		t.Fatalf("count sqlite entity mutations: %v", err)
+	}
+	if mutationCount < 2 {
+		t.Fatalf("sqlite entity mutation count = %d, want create and update mutations", mutationCount)
+	}
+}
+
+func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"save_entity_field"}}
+	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	ensureSQLiteEntityToolTestRun(t, sqliteStore)
+	ctx := runtimecorrelation.WithRunID(context.Background(), entityToolTestRunID)
+	entityID := uuid.NewString()
+	if err := sqliteStore.CreateEntity(ctx, runtimetools.EntityCreateRecord{
+		RunID:        entityToolTestRunID,
+		EntityID:     entityID,
+		FlowInstance: "validation/inst-1",
+		EntityType:   "validation_case",
+		CurrentState: "queued",
+		FieldsJSON:   json.RawMessage(`{"status":"open","business_brief":{"summary":"before","confidence":1}}`),
+		CreatedAt:    time.Now().UTC(),
+		Writer: runtimetools.EntityMutationWriter{
+			Type:        "platform",
+			ID:          "sqlite-role-scoped-test",
+			HandlerStep: "seed",
+		},
+	}); err != nil {
+		t.Fatalf("seed sqlite role-scoped entity: %v", err)
+	}
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		EntityStore:       sqliteStore,
+		WorkflowSource:    semanticview.Wrap(bundle),
+		AuthorityProvider: allowHumanTaskAuthority{},
+	})
+	currentCtx := runtimetools.WithActor(runtimebus.WithInboundEvent(ctx, events.Event{
+		ID:    "evt-current",
+		Type:  events.EventType("validation.started"),
+		RunID: entityToolTestRunID,
+	}.WithEntityID(entityID).WithFlowInstance("validation/inst-1")), actor)
+
+	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(currentCtx, actor))
+	if _, ok := names["read_validation_case"]; !ok {
+		t.Fatalf("sqlite current entity did not enable generated read tool: %#v", sortedRoleScopedToolNames(names))
+	}
+	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
+		"value": map[string]any{"summary": "after", "confidence": 9},
+	}); err != nil {
+		t.Fatalf("sqlite save_validation_case_business_brief: %v", err)
+	}
+	got, err := exec.Execute(currentCtx, "read_validation_case_business_brief", map[string]any{})
+	if err != nil {
+		t.Fatalf("sqlite read_validation_case_business_brief: %v", err)
+	}
+	brief, ok := got.(map[string]any)
+	if !ok || strings.TrimSpace(asString(brief["summary"])) != "after" {
+		t.Fatalf("sqlite role-scoped brief = %#v, want updated summary", got)
+	}
+}
+
+func TestHumanTaskTools_BackendNeutralPersistence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		store humanTaskToolStore
+	}{
+		{name: "postgres", store: newPostgresHumanTaskToolStoreForTest(t)},
+		{name: "sqlite", store: newSQLiteRuntimeToolStoreForTest(t)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Extensions: map[string]any{
+				"budget": map[string]any{
+					"human_tasks": map[string]any{
+						"max_tasks_per_week": 1,
+						"budget_reset":       "monday",
+					},
+				},
+			}}
+			exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+				Config:            cfg,
+				HumanTaskStore:    tc.store,
+				AuthorityProvider: allowHumanTaskAuthority{},
+			})
+			requester := models.AgentConfig{ID: "requester", Role: "worker", EntityID: uuid.NewString()}
+			decider := models.AgentConfig{ID: "decider", Role: "operator"}
+
+			firstID := createHumanTaskWithExecutor(t, exec, requester)
+			firstItem, err := tc.store.GetMailboxItem(context.Background(), firstID)
+			if err != nil {
+				t.Fatalf("get first human task: %v", err)
+			}
+			if firstItem.Type != "human_task" || firstItem.EntityID != requester.EntityID {
+				t.Fatalf("first human task item = %#v", firstItem)
+			}
+			if _, err := exec.ExecHumanTaskDecideDirect(context.Background(), decider, map[string]any{
+				"task_id":  firstID,
+				"decision": "approve",
+				"reason":   "ok",
+			}); err != nil {
+				t.Fatalf("approve first human task: %v", err)
+			}
+
+			secondID := createHumanTaskWithExecutor(t, exec, requester)
+			out, err := exec.ExecHumanTaskDecideDirect(context.Background(), decider, map[string]any{
+				"task_id":  secondID,
+				"decision": "approve",
+			})
+			if err != nil {
+				t.Fatalf("budget-gated approve second human task: %v", err)
+			}
+			if got := strings.TrimSpace(asString(out.(map[string]any)["status"])); got != "deferred" {
+				t.Fatalf("second human task status = %q, want deferred", got)
+			}
+			requeueCount, err := tc.store.HumanTaskRequeueCount(context.Background(), secondID)
+			if err != nil {
+				t.Fatalf("load second human task requeue count: %v", err)
+			}
+			if requeueCount != 1 {
+				t.Fatalf("second human task requeue count = %d, want 1", requeueCount)
+			}
+			out, err = exec.ExecHumanTaskDecideDirect(context.Background(), decider, map[string]any{
+				"task_id":  secondID,
+				"decision": "approve",
+			})
+			if err != nil {
+				t.Fatalf("approve requeued human task: %v", err)
+			}
+			if got := strings.TrimSpace(asString(out.(map[string]any)["status"])); got != "approved" {
+				t.Fatalf("requeued human task status = %q, want approved", got)
+			}
+		})
+	}
+}
+
+func createHumanTaskWithExecutor(t *testing.T, exec *runtimetools.Executor, actor models.AgentConfig) string {
+	t.Helper()
+	out, err := exec.ExecHumanTaskRequestDirect(context.Background(), actor, map[string]any{
+		"category":       "review",
+		"description":    "Needs human review",
+		"expected_value": "approval",
+		"priority":       "high",
+		"talking_points": []string{"one", "two"},
+	})
+	if err != nil {
+		t.Fatalf("human_task_request: %v", err)
+	}
+	result, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("human_task_request output = %#v", out)
+	}
+	taskID := strings.TrimSpace(asString(result["task_id"]))
+	if taskID == "" {
+		t.Fatalf("human_task_request task_id missing in %#v", out)
+	}
+	return taskID
+}
+
+func newPostgresHumanTaskToolStoreForTest(t *testing.T) *store.PostgresStore {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	return &store.PostgresStore{DB: db}
+}
+
+func newSQLiteRuntimeToolStoreForTest(t *testing.T) *store.SQLiteRuntimeStore {
+	t.Helper()
+	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := store.GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	sqliteStore, err := store.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqliteStore.Close(); err != nil {
+			t.Fatalf("close sqlite runtime store: %v", err)
+		}
+	})
+	if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	return sqliteStore
+}
+
+func ensureSQLiteEntityToolTestRun(t *testing.T, sqliteStore *store.SQLiteRuntimeStore) {
+	t.Helper()
+	if _, err := sqliteStore.DB.ExecContext(context.Background(), `
+		INSERT INTO runs (run_id, status, bundle_source, started_at)
+		VALUES (?, 'running', 'legacy', ?)
+		ON CONFLICT(run_id) DO NOTHING
+	`, entityToolTestRunID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite entity tool test run: %v", err)
+	}
+}

--- a/internal/runtime/tools/persistence.go
+++ b/internal/runtime/tools/persistence.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"time"
 
 	corestate "swarm/internal/runtime/core/state"
 )
@@ -17,4 +19,95 @@ type MailboxPersistence interface {
 	ExpireMailboxItems(ctx context.Context, limit int) ([]MailboxItem, error)
 	ListUnnotifiedCriticalMailboxItems(ctx context.Context, limit int) ([]MailboxItem, error)
 	MarkMailboxItemNotified(ctx context.Context, id string) error
+}
+
+// EntityPersistence is the backend-neutral store owner for entity tool reads
+// and writes. Executor code owns tool semantics; store implementations own SQL.
+type EntityPersistence interface {
+	LoadEntityState(ctx context.Context, identity EntityIdentity) (map[string]any, bool, error)
+	QueryEntityStates(ctx context.Context, query EntityStateQuery) ([]map[string]any, error)
+	SaveEntityField(ctx context.Context, update EntityFieldUpdate) (int, error)
+	CreateEntity(ctx context.Context, rec EntityCreateRecord) error
+}
+
+type EntityIdentity struct {
+	RunID    string
+	EntityID string
+}
+
+type EntityFlowScope struct {
+	Root               string
+	IncludeDescendants bool
+}
+
+type EntityFieldEquals struct {
+	Path  string
+	Value any
+}
+
+type EntityStateQuery struct {
+	RunID              string
+	FlowScope          EntityFlowScope
+	RequestedFlowScope EntityFlowScope
+	RequestedFlowExact string
+	CurrentState       string
+	FieldEquals        []EntityFieldEquals
+	OrderByCreatedDesc bool
+}
+
+type EntityMutationWriter struct {
+	Type        string
+	ID          string
+	HandlerStep string
+}
+
+type EntityFieldUpdate struct {
+	RunID        string
+	EntityID     string
+	FieldPath    string
+	PathSegments []string
+	ValueJSON    json.RawMessage
+	Writer       EntityMutationWriter
+}
+
+type EntityCreateRecord struct {
+	RunID        string
+	EntityID     string
+	FlowInstance string
+	EntityType   string
+	Name         string
+	CurrentState string
+	FieldsJSON   json.RawMessage
+	CreatedAt    time.Time
+	Writer       EntityMutationWriter
+}
+
+// HumanTaskPersistence owns human_task_request / human_task_decide mailbox-row
+// semantics used by the runtime tool executor.
+type HumanTaskPersistence interface {
+	CreateHumanTask(ctx context.Context, rec HumanTaskCreateRecord) (string, error)
+	HumanTaskRequeueCount(ctx context.Context, taskID string) (int, error)
+	CountApprovedHumanTasksSince(ctx context.Context, since time.Time) (int, error)
+	DecideHumanTask(ctx context.Context, rec HumanTaskDecisionRecord) error
+}
+
+type HumanTaskCreateRecord struct {
+	ActorID       string
+	EntityID      string
+	Category      string
+	Description   string
+	TalkingPoints json.RawMessage
+	ExpectedValue string
+	Priority      string
+	Deadline      time.Time
+}
+
+type HumanTaskDecisionRecord struct {
+	TaskID       string
+	Status       string
+	ActorID      string
+	Reason       string
+	PriorityRank int
+	RequeueDate  string
+	DecidedAt    time.Time
 }

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
@@ -339,14 +338,14 @@ func (e *Executor) roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Conte
 		return false
 	}
 	e.mu.RLock()
-	db := e.sqlDB
+	store := e.entityStore
 	source := e.workflowSource
 	e.mu.RUnlock()
-	return roleScopedEntityToolsEligibleForCurrentTurn(ctx, db, source, actor)
+	return roleScopedEntityToolsEligibleForCurrentTurn(ctx, store, source, actor)
 }
 
-func roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, db *sql.DB, source semanticview.Source, actor models.AgentConfig) bool {
-	if db == nil || source == nil {
+func roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, store EntityPersistence, source semanticview.Source, actor models.AgentConfig) bool {
+	if store == nil || source == nil {
 		return false
 	}
 	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
@@ -357,7 +356,7 @@ func roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, db *sql.DB
 	if entityID == "" {
 		return false
 	}
-	row, found, err := loadEntityState(ctx, db, entityID)
+	row, found, err := loadEntityState(ctx, store, entityID)
 	if err != nil || !found {
 		return false
 	}
@@ -379,7 +378,7 @@ func (e *Executor) dispatchRoleScopedEntityTool(ctx context.Context, actor model
 }
 
 func (e *Executor) execRoleScopedEntityTool(ctx context.Context, actor models.AgentConfig, name string, input any) (any, error) {
-	db, source, payload, err := e.entityToolDependencies(input)
+	store, source, payload, err := e.entityToolDependencies(input)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +396,7 @@ func (e *Executor) execRoleScopedEntityTool(ctx context.Context, actor models.Ag
 	if entityID == "" {
 		return nil, NewRuntimeError("invalid_tool_input", "tool-executor", "role_scoped_entity_tool.current_entity", false, "current turn entity_id is required for %s", strings.TrimSpace(name))
 	}
-	row, found, err := loadEntityState(ctx, db, entityID)
+	row, found, err := loadEntityState(ctx, store, entityID)
 	if err != nil {
 		return nil, WrapRuntimeError("query_failed", "tool-executor", "role_scoped_entity_tool.lookup", true, err, "load current entity %s", entityID)
 	}

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -702,8 +702,12 @@ func sqliteToolEntityWhere(query runtimetools.EntityStateQuery) (string, []any, 
 		if path == "" {
 			return "", nil, fmt.Errorf("entity field filter path is required")
 		}
-		clauses = append(clauses, "json_extract(COALESCE(fields, '{}'), ?) = ?")
-		args = append(args, sqliteToolJSONPath(path), sqliteToolJSONCompareValue(filter.Value))
+		clause, clauseArgs, err := sqliteToolEntityFieldEqualsClause(path, filter.Value)
+		if err != nil {
+			return "", nil, err
+		}
+		clauses = append(clauses, clause)
+		args = append(args, clauseArgs...)
 	}
 	return strings.Join(clauses, " AND "), args, nil
 }
@@ -742,6 +746,30 @@ func sqliteToolJSONPath(path string) string {
 		out += "." + segment
 	}
 	return out
+}
+
+func sqliteToolEntityFieldEqualsClause(path string, value any) (string, []any, error) {
+	jsonPath := sqliteToolJSONPath(path)
+	if sqliteToolStructuredJSONCompareValue(value) {
+		valueJSON, err := json.Marshal(value)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal sqlite entity field filter %s: %w", path, err)
+		}
+		return "json(json_extract(COALESCE(fields, '{}'), ?)) = json(?)", []any{jsonPath, string(valueJSON)}, nil
+	}
+	return "json_extract(COALESCE(fields, '{}'), ?) = ?", []any{jsonPath, sqliteToolJSONCompareValue(value)}, nil
+}
+
+func sqliteToolStructuredJSONCompareValue(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any, []any:
+		return true
+	case json.RawMessage:
+		trimmed := strings.TrimSpace(string(typed))
+		return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
+	default:
+		return false
+	}
 }
 
 func sqliteToolJSONCompareValue(value any) any {

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -1,0 +1,1016 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimemutationlog "swarm/internal/runtime/mutationlog"
+	runtimetools "swarm/internal/runtime/tools"
+)
+
+var _ runtimetools.EntityPersistence = (*PostgresStore)(nil)
+var _ runtimetools.EntityPersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimetools.HumanTaskPersistence = (*PostgresStore)(nil)
+var _ runtimetools.HumanTaskPersistence = (*SQLiteRuntimeStore)(nil)
+
+func (s *PostgresStore) LoadEntityState(ctx context.Context, identity runtimetools.EntityIdentity) (map[string]any, bool, error) {
+	if s == nil || s.DB == nil {
+		return nil, false, fmt.Errorf("postgres entity persistence store is required")
+	}
+	runID, entityID, err := normalizeToolEntityIdentity(identity)
+	if err != nil {
+		return nil, false, err
+	}
+	rows, err := s.DB.QueryContext(ctx, toolEntitySelectSQL(`run_id = $1::uuid AND entity_id = $2::uuid`), runID, entityID)
+	if err != nil {
+		return nil, false, fmt.Errorf("load postgres entity state: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanToolEntityRows(rows)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(items) == 0 {
+		return nil, false, nil
+	}
+	return items[0], true, nil
+}
+
+func (s *SQLiteRuntimeStore) LoadEntityState(ctx context.Context, identity runtimetools.EntityIdentity) (map[string]any, bool, error) {
+	if s == nil || s.DB == nil {
+		return nil, false, fmt.Errorf("sqlite entity persistence store is required")
+	}
+	runID, entityID, err := normalizeToolEntityIdentity(identity)
+	if err != nil {
+		return nil, false, err
+	}
+	rows, err := s.DB.QueryContext(ctx, toolEntitySelectSQL(`run_id = ? AND entity_id = ?`), runID, entityID)
+	if err != nil {
+		return nil, false, fmt.Errorf("load sqlite entity state: %w", err)
+	}
+	defer rows.Close()
+	items, err := scanToolEntityRows(rows)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(items) == 0 {
+		return nil, false, nil
+	}
+	return items[0], true, nil
+}
+
+func (s *PostgresStore) QueryEntityStates(ctx context.Context, query runtimetools.EntityStateQuery) ([]map[string]any, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres entity persistence store is required")
+	}
+	where, args, err := postgresToolEntityWhere(query)
+	if err != nil {
+		return nil, err
+	}
+	order := ""
+	if query.OrderByCreatedDesc {
+		order = " ORDER BY created_at DESC"
+	}
+	rows, err := s.DB.QueryContext(ctx, toolEntitySelectSQL(where)+order, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query postgres entity state: %w", err)
+	}
+	defer rows.Close()
+	return scanToolEntityRows(rows)
+}
+
+func (s *SQLiteRuntimeStore) QueryEntityStates(ctx context.Context, query runtimetools.EntityStateQuery) ([]map[string]any, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite entity persistence store is required")
+	}
+	where, args, err := sqliteToolEntityWhere(query)
+	if err != nil {
+		return nil, err
+	}
+	order := ""
+	if query.OrderByCreatedDesc {
+		order = " ORDER BY created_at DESC"
+	}
+	rows, err := s.DB.QueryContext(ctx, toolEntitySelectSQL(where)+order, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite entity state: %w", err)
+	}
+	defer rows.Close()
+	return scanToolEntityRows(rows)
+}
+
+func (s *PostgresStore) SaveEntityField(ctx context.Context, update runtimetools.EntityFieldUpdate) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("postgres entity persistence store is required")
+	}
+	runID, entityID, segments, valueJSON, err := normalizeToolEntityFieldUpdate(update)
+	if err != nil {
+		return 0, err
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin postgres entity field update: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	pathArray := pq.Array(segments)
+	var oldValue []byte
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $3::text[], 'null'::jsonb)
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		FOR UPDATE
+	`, runID, entityID, pathArray).Scan(&oldValue); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, fmt.Errorf("entity not found: %s", entityID)
+		}
+		return 0, fmt.Errorf("load postgres entity field: %w", err)
+	}
+	var revision int
+	if err := tx.QueryRowContext(ctx, `
+		UPDATE entity_state
+		SET
+			fields = jsonb_set(COALESCE(fields, '{}'::jsonb), $2::text[], $3::jsonb, true),
+			revision = revision + 1,
+			updated_at = now()
+		WHERE entity_id = $1::uuid
+		  AND run_id = $4::uuid
+		RETURNING revision
+	`, entityID, pathArray, string(valueJSON), runID).Scan(&revision); err != nil {
+		return 0, fmt.Errorf("update postgres entity field: %w", err)
+	}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{update.FieldPath: toolNullableJSONBytes(oldValue)},
+	}, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{update.FieldPath: json.RawMessage(valueJSON)},
+	}, mutationWriter(update.Writer)); err != nil {
+		return 0, fmt.Errorf("record postgres entity mutation: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit postgres entity field update: %w", err)
+	}
+	committed = true
+	return revision, nil
+}
+
+func (s *SQLiteRuntimeStore) SaveEntityField(ctx context.Context, update runtimetools.EntityFieldUpdate) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("sqlite entity persistence store is required")
+	}
+	runID, entityID, segments, valueJSON, err := normalizeToolEntityFieldUpdate(update)
+	if err != nil {
+		return 0, err
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin sqlite entity field update: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	var fieldsRaw any
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(fields, '{}')
+		FROM entity_state
+		WHERE run_id = ? AND entity_id = ?
+	`, runID, entityID).Scan(&fieldsRaw); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, fmt.Errorf("entity not found: %s", entityID)
+		}
+		return 0, fmt.Errorf("load sqlite entity fields: %w", err)
+	}
+	fields, err := toolDecodeJSONMap(fieldsRaw)
+	if err != nil {
+		return 0, fmt.Errorf("decode sqlite entity fields: %w", err)
+	}
+	oldValue, _ := toolPathValue(fields, segments)
+	newValue, err := toolDecodeJSONValue(valueJSON)
+	if err != nil {
+		return 0, fmt.Errorf("decode sqlite entity field value: %w", err)
+	}
+	toolSetPath(fields, segments, newValue)
+	fieldsJSON, err := json.Marshal(fields)
+	if err != nil {
+		return 0, fmt.Errorf("marshal sqlite entity fields: %w", err)
+	}
+	now := s.now()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE entity_state
+		SET fields = ?, revision = revision + 1, updated_at = ?
+		WHERE run_id = ? AND entity_id = ?
+	`, string(fieldsJSON), now, runID, entityID); err != nil {
+		return 0, fmt.Errorf("update sqlite entity field: %w", err)
+	}
+	var revision int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT revision
+		FROM entity_state
+		WHERE run_id = ? AND entity_id = ?
+	`, runID, entityID).Scan(&revision); err != nil {
+		return 0, fmt.Errorf("load sqlite entity revision: %w", err)
+	}
+	if err := insertSQLiteEntityStateDiff(ctx, tx, runID, entityID, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{update.FieldPath: oldValue},
+	}, runtimemutationlog.EntityStateProjection{
+		Fields: map[string]any{update.FieldPath: newValue},
+	}, mutationWriter(update.Writer), now); err != nil {
+		return 0, fmt.Errorf("record sqlite entity mutation: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit sqlite entity field update: %w", err)
+	}
+	committed = true
+	return revision, nil
+}
+
+func (s *PostgresStore) CreateEntity(ctx context.Context, rec runtimetools.EntityCreateRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres entity persistence store is required")
+	}
+	rec, fields, err := normalizeToolEntityCreateRecord(rec)
+	if err != nil {
+		return err
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin postgres entity create: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, $3, $4, NULLIF($5, ''),
+			$6, '{}'::jsonb, $7::jsonb, '{}'::jsonb, 1,
+			$8, $8, $8
+		)
+	`, rec.RunID, rec.EntityID, rec.FlowInstance, rec.EntityType, rec.Name, rec.CurrentState, string(rec.FieldsJSON), rec.CreatedAt); err != nil {
+		return fmt.Errorf("insert postgres entity: %w", err)
+	}
+	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
+		CurrentState: rec.CurrentState,
+		Fields:       fields,
+	}, mutationWriter(rec.Writer)); err != nil {
+		return fmt.Errorf("record postgres entity create mutation: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit postgres entity create: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) CreateEntity(ctx context.Context, rec runtimetools.EntityCreateRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite entity persistence store is required")
+	}
+	rec, fields, err := normalizeToolEntityCreateRecord(rec)
+	if err != nil {
+		return err
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite entity create: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, name,
+			current_state, gates, fields, accumulator, revision,
+			entered_state_at, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, '{}', ?, '{}', 1, ?, ?, ?)
+	`, rec.RunID, rec.EntityID, rec.FlowInstance, rec.EntityType, sqliteNullString(rec.Name),
+		rec.CurrentState, string(rec.FieldsJSON), rec.CreatedAt, rec.CreatedAt, rec.CreatedAt); err != nil {
+		return fmt.Errorf("insert sqlite entity: %w", err)
+	}
+	if err := insertSQLiteEntityStateDiff(ctx, tx, rec.RunID, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
+		CurrentState: rec.CurrentState,
+		Fields:       fields,
+	}, mutationWriter(rec.Writer), rec.CreatedAt); err != nil {
+		return fmt.Errorf("record sqlite entity create mutation: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite entity create: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *PostgresStore) CreateHumanTask(ctx context.Context, rec runtimetools.HumanTaskCreateRecord) (string, error) {
+	return createHumanTask(ctx, s, rec)
+}
+
+func (s *SQLiteRuntimeStore) CreateHumanTask(ctx context.Context, rec runtimetools.HumanTaskCreateRecord) (string, error) {
+	return createHumanTask(ctx, s, rec)
+}
+
+func (s *PostgresStore) HumanTaskRequeueCount(ctx context.Context, taskID string) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("postgres human-task persistence store is required")
+	}
+	taskID = strings.TrimSpace(taskID)
+	var n int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE((payload->>'requeue_count')::int, 0)
+		FROM mailbox
+		WHERE item_id = $1::uuid
+		  AND item_type = 'human_task'
+	`, taskID).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (s *SQLiteRuntimeStore) HumanTaskRequeueCount(ctx context.Context, taskID string) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("sqlite human-task persistence store is required")
+	}
+	taskID = strings.TrimSpace(taskID)
+	var payloadRaw any
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(payload, '{}')
+		FROM mailbox
+		WHERE item_id = ? AND item_type = 'human_task'
+	`, taskID).Scan(&payloadRaw); err != nil {
+		return 0, err
+	}
+	payload, err := toolDecodeJSONMap(payloadRaw)
+	if err != nil {
+		return 0, err
+	}
+	return toolIntValue(payload["requeue_count"]), nil
+}
+
+func (s *PostgresStore) CountApprovedHumanTasksSince(ctx context.Context, since time.Time) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("postgres human-task persistence store is required")
+	}
+	var n int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(count(*), 0)
+		FROM mailbox
+		WHERE item_type = 'human_task'
+		  AND decided_at >= $1
+		  AND decision IN ('approved', 'assigned', 'completed')
+	`, since).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (s *SQLiteRuntimeStore) CountApprovedHumanTasksSince(ctx context.Context, since time.Time) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, fmt.Errorf("sqlite human-task persistence store is required")
+	}
+	var n int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(count(*), 0)
+		FROM mailbox
+		WHERE item_type = 'human_task'
+		  AND decided_at >= ?
+		  AND decision IN ('approved', 'assigned', 'completed')
+	`, since.UTC()).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (s *PostgresStore) DecideHumanTask(ctx context.Context, rec runtimetools.HumanTaskDecisionRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres human-task persistence store is required")
+	}
+	rec = normalizeHumanTaskDecisionRecord(rec)
+	res, err := s.DB.ExecContext(ctx, `
+		UPDATE mailbox
+		SET status = CASE WHEN $2 = 'timed_out' THEN 'expired' ELSE 'decided' END,
+		    decision = $2,
+		    decision_notes = COALESCE(NULLIF($3, ''), decision_notes),
+		    decided_by = NULLIF($4,''),
+		    decided_at = $5,
+		    payload = CASE
+				WHEN $2 = 'deferred' THEN
+					jsonb_set(
+						COALESCE(payload, '{}'::jsonb),
+						'{requeue_count}',
+						to_jsonb(COALESCE((payload->>'requeue_count')::int, 0) + 1),
+						true
+					)
+				ELSE payload
+			END
+		WHERE item_id = $1::uuid
+		  AND item_type = 'human_task'
+	`, rec.TaskID, rec.Status, rec.Reason, rec.ActorID, rec.DecidedAt)
+	if err != nil {
+		return fmt.Errorf("decide postgres human task: %w", err)
+	}
+	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
+		return fmt.Errorf("human task not found: %s", rec.TaskID)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) DecideHumanTask(ctx context.Context, rec runtimetools.HumanTaskDecisionRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite human-task persistence store is required")
+	}
+	rec = normalizeHumanTaskDecisionRecord(rec)
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite human task decision: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	var payloadRaw any
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(payload, '{}')
+		FROM mailbox
+		WHERE item_id = ? AND item_type = 'human_task'
+	`, rec.TaskID).Scan(&payloadRaw); err != nil {
+		return fmt.Errorf("load sqlite human task payload: %w", err)
+	}
+	payload, err := toolDecodeJSONMap(payloadRaw)
+	if err != nil {
+		return fmt.Errorf("decode sqlite human task payload: %w", err)
+	}
+	if rec.Status == "deferred" {
+		payload["requeue_count"] = toolIntValue(payload["requeue_count"]) + 1
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal sqlite human task payload: %w", err)
+	}
+	rowStatus := "decided"
+	if rec.Status == "timed_out" {
+		rowStatus = "expired"
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE mailbox
+		SET status = ?,
+		    decision = ?,
+		    decision_notes = COALESCE(NULLIF(?, ''), decision_notes),
+		    decided_by = ?,
+		    decided_at = ?,
+		    payload = ?
+		WHERE item_id = ? AND item_type = 'human_task'
+	`, rowStatus, rec.Status, rec.Reason, sqliteNullString(rec.ActorID), rec.DecidedAt.UTC(), string(payloadJSON), rec.TaskID)
+	if err != nil {
+		return fmt.Errorf("decide sqlite human task: %w", err)
+	}
+	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
+		return fmt.Errorf("human task not found: %s", rec.TaskID)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite human task decision: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+type mailboxPersistence interface {
+	InsertMailboxItem(ctx context.Context, item runtimetools.MailboxItem) (string, error)
+}
+
+func createHumanTask(ctx context.Context, store mailboxPersistence, rec runtimetools.HumanTaskCreateRecord) (string, error) {
+	if store == nil {
+		return "", fmt.Errorf("human-task persistence store is required")
+	}
+	rec = normalizeHumanTaskCreateRecord(rec)
+	payload := map[string]any{
+		"category":       rec.Category,
+		"description":    rec.Description,
+		"expected_value": rec.ExpectedValue,
+		"priority":       rec.Priority,
+		"requeue_count":  0,
+	}
+	if len(rec.TalkingPoints) > 0 && strings.TrimSpace(string(rec.TalkingPoints)) != "null" {
+		var talking any
+		if json.Unmarshal(rec.TalkingPoints, &talking) == nil {
+			payload["talking_points"] = talking
+		}
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("create human task: marshal payload: %w", err)
+	}
+	return store.InsertMailboxItem(ctx, runtimetools.MailboxItem{
+		EntityID:  rec.EntityID,
+		FromAgent: rec.ActorID,
+		Type:      "human_task",
+		Priority:  rec.Priority,
+		Status:    "pending",
+		Summary:   rec.Description,
+		Context:   json.RawMessage(payloadJSON),
+		TimeoutAt: rec.Deadline,
+	})
+}
+
+func toolEntitySelectSQL(where string) string {
+	return `
+		SELECT entity_id, run_id, COALESCE(flow_instance, ''), COALESCE(entity_type, ''), name, current_state,
+		       COALESCE(gates, '{}'), COALESCE(fields, '{}'), COALESCE(accumulator, '{}'),
+		       revision, entered_state_at, created_at, updated_at
+		FROM entity_state
+		WHERE ` + where
+}
+
+func scanToolEntityRows(rows *sql.Rows) ([]map[string]any, error) {
+	out := make([]map[string]any, 0)
+	for rows.Next() {
+		var entityID, runID, flowInstance, entityType, currentState string
+		var name sql.NullString
+		var gatesRaw, fieldsRaw, accumulatorRaw any
+		var revision int
+		var enteredStateAtRaw, createdAtRaw, updatedAtRaw any
+		if err := rows.Scan(
+			&entityID,
+			&runID,
+			&flowInstance,
+			&entityType,
+			&name,
+			&currentState,
+			&gatesRaw,
+			&fieldsRaw,
+			&accumulatorRaw,
+			&revision,
+			&enteredStateAtRaw,
+			&createdAtRaw,
+			&updatedAtRaw,
+		); err != nil {
+			return nil, fmt.Errorf("scan entity state: %w", err)
+		}
+		gates, err := toolDecodeJSONMap(gatesRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity gates: %w", err)
+		}
+		fields, err := toolDecodeJSONMap(fieldsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity fields: %w", err)
+		}
+		accumulator, err := toolDecodeJSONMap(accumulatorRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity accumulator: %w", err)
+		}
+		enteredStateAt, err := toolTimeString(enteredStateAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity entered_state_at: %w", err)
+		}
+		createdAt, err := toolTimeString(createdAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity created_at: %w", err)
+		}
+		updatedAt, err := toolTimeString(updatedAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("decode entity updated_at: %w", err)
+		}
+		row := map[string]any{
+			"entity_id":        strings.TrimSpace(entityID),
+			"run_id":           strings.TrimSpace(runID),
+			"flow_instance":    strings.TrimSpace(flowInstance),
+			"entity_type":      strings.TrimSpace(entityType),
+			"name":             nil,
+			"current_state":    strings.TrimSpace(currentState),
+			"gates":            gates,
+			"fields":           fields,
+			"accumulator":      accumulator,
+			"revision":         revision,
+			"entered_state_at": enteredStateAt,
+			"created_at":       createdAt,
+			"updated_at":       updatedAt,
+		}
+		if name.Valid {
+			row["name"] = strings.TrimSpace(name.String)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate entity states: %w", err)
+	}
+	return out, nil
+}
+
+func postgresToolEntityWhere(query runtimetools.EntityStateQuery) (string, []any, error) {
+	runID := strings.TrimSpace(query.RunID)
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", nil, fmt.Errorf("run_id must be uuid")
+	}
+	clauses := []string{"run_id = $1::uuid"}
+	args := []any{runID}
+	addArg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	appendFlowScope := func(scope runtimetools.EntityFlowScope) {
+		root := strings.Trim(strings.TrimSpace(scope.Root), "/")
+		if root == "" {
+			return
+		}
+		if scope.IncludeDescendants {
+			eq := addArg(root)
+			like := addArg(root + "/%")
+			clauses = append(clauses, fmt.Sprintf("(flow_instance = %s OR flow_instance LIKE %s)", eq, like))
+			return
+		}
+		clauses = append(clauses, "flow_instance = "+addArg(root))
+	}
+	appendFlowScope(query.FlowScope)
+	appendFlowScope(query.RequestedFlowScope)
+	if exact := strings.Trim(strings.TrimSpace(query.RequestedFlowExact), "/"); exact != "" {
+		clauses = append(clauses, "flow_instance = "+addArg(exact))
+	}
+	if state := strings.TrimSpace(query.CurrentState); state != "" {
+		clauses = append(clauses, "current_state = "+addArg(state))
+	}
+	for _, filter := range query.FieldEquals {
+		path := strings.TrimSpace(filter.Path)
+		if path == "" {
+			return "", nil, fmt.Errorf("entity field filter path is required")
+		}
+		valueJSON, err := json.Marshal(filter.Value)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal entity field filter %s: %w", path, err)
+		}
+		clauses = append(clauses, fmt.Sprintf("%s = %s::jsonb", postgresToolEntityFieldExpr(path), addArg(string(valueJSON))))
+	}
+	return strings.Join(clauses, " AND "), args, nil
+}
+
+func sqliteToolEntityWhere(query runtimetools.EntityStateQuery) (string, []any, error) {
+	runID := strings.TrimSpace(query.RunID)
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", nil, fmt.Errorf("run_id must be uuid")
+	}
+	clauses := []string{"run_id = ?"}
+	args := []any{runID}
+	appendFlowScope := func(scope runtimetools.EntityFlowScope) {
+		root := strings.Trim(strings.TrimSpace(scope.Root), "/")
+		if root == "" {
+			return
+		}
+		if scope.IncludeDescendants {
+			clauses = append(clauses, "(flow_instance = ? OR flow_instance LIKE ?)")
+			args = append(args, root, root+"/%")
+			return
+		}
+		clauses = append(clauses, "flow_instance = ?")
+		args = append(args, root)
+	}
+	appendFlowScope(query.FlowScope)
+	appendFlowScope(query.RequestedFlowScope)
+	if exact := strings.Trim(strings.TrimSpace(query.RequestedFlowExact), "/"); exact != "" {
+		clauses = append(clauses, "flow_instance = ?")
+		args = append(args, exact)
+	}
+	if state := strings.TrimSpace(query.CurrentState); state != "" {
+		clauses = append(clauses, "current_state = ?")
+		args = append(args, state)
+	}
+	for _, filter := range query.FieldEquals {
+		path := strings.TrimSpace(filter.Path)
+		if path == "" {
+			return "", nil, fmt.Errorf("entity field filter path is required")
+		}
+		clauses = append(clauses, "json_extract(COALESCE(fields, '{}'), ?) = ?")
+		args = append(args, sqliteToolJSONPath(path), sqliteToolJSONCompareValue(filter.Value))
+	}
+	return strings.Join(clauses, " AND "), args, nil
+}
+
+func postgresToolEntityFieldExpr(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return `COALESCE(fields, '{}'::jsonb)`
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) == 1 {
+		return fmt.Sprintf("COALESCE(fields, '{}'::jsonb) -> %s", postgresStringLiteral(segments[0]))
+	}
+	sqlPath := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment != "" {
+			sqlPath = append(sqlPath, postgresStringLiteral(segment))
+		}
+	}
+	return fmt.Sprintf("COALESCE(fields, '{}'::jsonb) #> ARRAY[%s]", strings.Join(sqlPath, ", "))
+}
+
+func postgresStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func sqliteToolJSONPath(path string) string {
+	segments := strings.Split(strings.TrimSpace(path), ".")
+	out := "$"
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		out += "." + segment
+	}
+	return out
+}
+
+func sqliteToolJSONCompareValue(value any) any {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	default:
+		return v
+	}
+}
+
+func normalizeToolEntityIdentity(identity runtimetools.EntityIdentity) (string, string, error) {
+	runID := strings.TrimSpace(identity.RunID)
+	entityID := strings.TrimSpace(identity.EntityID)
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", "", fmt.Errorf("run_id must be uuid")
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return "", "", fmt.Errorf("entity_id must be uuid")
+	}
+	return runID, entityID, nil
+}
+
+func normalizeToolEntityFieldUpdate(update runtimetools.EntityFieldUpdate) (string, string, []string, json.RawMessage, error) {
+	runID, entityID, err := normalizeToolEntityIdentity(runtimetools.EntityIdentity{RunID: update.RunID, EntityID: update.EntityID})
+	if err != nil {
+		return "", "", nil, nil, err
+	}
+	segments := append([]string(nil), update.PathSegments...)
+	if len(segments) == 0 {
+		segments = strings.Split(strings.TrimSpace(update.FieldPath), ".")
+	}
+	clean := segments[:0]
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return "", "", nil, nil, fmt.Errorf("field path segment is required")
+		}
+		clean = append(clean, segment)
+	}
+	valueJSON := json.RawMessage(strings.TrimSpace(string(update.ValueJSON)))
+	if len(valueJSON) == 0 {
+		valueJSON = json.RawMessage("null")
+	}
+	return runID, entityID, clean, valueJSON, nil
+}
+
+func normalizeToolEntityCreateRecord(rec runtimetools.EntityCreateRecord) (runtimetools.EntityCreateRecord, map[string]any, error) {
+	runID, entityID, err := normalizeToolEntityIdentity(runtimetools.EntityIdentity{RunID: rec.RunID, EntityID: rec.EntityID})
+	if err != nil {
+		return runtimetools.EntityCreateRecord{}, nil, err
+	}
+	rec.RunID = runID
+	rec.EntityID = entityID
+	rec.FlowInstance = strings.Trim(strings.TrimSpace(rec.FlowInstance), "/")
+	rec.EntityType = strings.TrimSpace(rec.EntityType)
+	rec.Name = strings.TrimSpace(rec.Name)
+	rec.CurrentState = strings.TrimSpace(rec.CurrentState)
+	if rec.FlowInstance == "" || rec.EntityType == "" || rec.CurrentState == "" {
+		return runtimetools.EntityCreateRecord{}, nil, fmt.Errorf("flow_instance, entity_type, and current_state are required")
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now().UTC()
+	} else {
+		rec.CreatedAt = rec.CreatedAt.UTC()
+	}
+	if len(rec.FieldsJSON) == 0 {
+		rec.FieldsJSON = json.RawMessage("{}")
+	}
+	fields, err := toolDecodeJSONMap(rec.FieldsJSON)
+	if err != nil {
+		return runtimetools.EntityCreateRecord{}, nil, fmt.Errorf("decode entity fields: %w", err)
+	}
+	normalized, err := json.Marshal(fields)
+	if err != nil {
+		return runtimetools.EntityCreateRecord{}, nil, fmt.Errorf("marshal entity fields: %w", err)
+	}
+	rec.FieldsJSON = json.RawMessage(normalized)
+	return rec, fields, nil
+}
+
+func mutationWriter(writer runtimetools.EntityMutationWriter) runtimemutationlog.Writer {
+	return runtimemutationlog.Writer{
+		Type:        strings.TrimSpace(writer.Type),
+		ID:          strings.TrimSpace(writer.ID),
+		HandlerStep: strings.TrimSpace(writer.HandlerStep),
+	}
+}
+
+func toolDecodeJSONMap(raw any) (map[string]any, error) {
+	data := jsonRawMessageValue(raw)
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	if strings.TrimSpace(string(data)) == "" || strings.TrimSpace(string(data)) == "null" {
+		return map[string]any{}, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return map[string]any{}, nil
+	}
+	return out, nil
+}
+
+func toolDecodeJSONValue(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func toolTimeString(raw any) (string, error) {
+	if at, ok, err := sqliteTimeValue(raw); err != nil {
+		return "", err
+	} else if ok {
+		return at.Format(time.RFC3339Nano), nil
+	}
+	return "", nil
+}
+
+func toolNullableJSONBytes(raw []byte) any {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	return json.RawMessage(append([]byte(nil), raw...))
+}
+
+func toolPathValue(fields map[string]any, segments []string) (any, bool) {
+	var current any = fields
+	for _, segment := range segments {
+		next, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = next[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func toolSetPath(fields map[string]any, segments []string, value any) {
+	if len(segments) == 0 {
+		return
+	}
+	current := fields
+	for _, segment := range segments[:len(segments)-1] {
+		next, _ := current[segment].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[segment] = next
+		}
+		current = next
+	}
+	current[segments[len(segments)-1]] = value
+}
+
+func insertSQLiteEntityStateDiff(ctx context.Context, tx *sql.Tx, runID string, entityID string, before, after runtimemutationlog.EntityStateProjection, writer runtimemutationlog.Writer, createdAt time.Time) error {
+	records, err := runtimemutationlog.BuildEntityStateDiffRecords(entityID, before, after, writer)
+	if err != nil {
+		return err
+	}
+	causedByEvent := ""
+	if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+		causedByEvent = nullUUIDString(inbound.ID)
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	for _, rec := range records {
+		oldValue, err := toolJSONSQLArg(rec.OldValue)
+		if err != nil {
+			return err
+		}
+		newValue, err := toolJSONSQLArg(rec.NewValue)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO entity_mutations (
+				mutation_id, run_id, entity_id, field, old_value, new_value,
+				caused_by_event, writer_type, writer_id, handler_step, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, uuid.NewString(), runID, rec.EntityID, rec.Field, oldValue, newValue,
+			sqliteNullUUID(causedByEvent), rec.WriterType, rec.WriterID, sqliteNullString(rec.HandlerStep), createdAt.UTC()); err != nil {
+			return fmt.Errorf("insert sqlite entity mutation: %w", err)
+		}
+	}
+	return nil
+}
+
+func toolJSONSQLArg(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch typed := value.(type) {
+	case json.RawMessage:
+		if len(typed) == 0 {
+			return nil, nil
+		}
+		return string(typed), nil
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return nil, err
+		}
+		return string(data), nil
+	}
+}
+
+func normalizeHumanTaskCreateRecord(rec runtimetools.HumanTaskCreateRecord) runtimetools.HumanTaskCreateRecord {
+	rec.ActorID = strings.TrimSpace(rec.ActorID)
+	rec.EntityID = strings.TrimSpace(rec.EntityID)
+	rec.Category = strings.TrimSpace(rec.Category)
+	rec.Description = strings.TrimSpace(rec.Description)
+	rec.ExpectedValue = strings.TrimSpace(rec.ExpectedValue)
+	rec.Priority = strings.TrimSpace(rec.Priority)
+	if rec.Priority == "" {
+		rec.Priority = "medium"
+	}
+	if !rec.Deadline.IsZero() {
+		rec.Deadline = rec.Deadline.UTC()
+	}
+	return rec
+}
+
+func normalizeHumanTaskDecisionRecord(rec runtimetools.HumanTaskDecisionRecord) runtimetools.HumanTaskDecisionRecord {
+	rec.TaskID = strings.TrimSpace(rec.TaskID)
+	rec.Status = strings.TrimSpace(rec.Status)
+	rec.ActorID = strings.TrimSpace(rec.ActorID)
+	rec.Reason = strings.TrimSpace(rec.Reason)
+	rec.RequeueDate = strings.TrimSpace(rec.RequeueDate)
+	if rec.DecidedAt.IsZero() {
+		rec.DecidedAt = time.Now().UTC()
+	} else {
+		rec.DecidedAt = rec.DecidedAt.UTC()
+	}
+	return rec
+}
+
+func toolIntValue(raw any) int {
+	switch v := raw.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	case string:
+		var n int
+		_, _ = fmt.Sscanf(strings.TrimSpace(v), "%d", &n)
+		return n
+	default:
+		return 0
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2259,12 +2259,12 @@ engine:
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
         - >
           May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
-          observability semantics, and #1148 budget/spend rows, but must not be treated as a construction-ready runtime
-          backend while the remaining #1087 raw-SQL consumer blocker remains unresolved.
+          observability semantics, #1148 budget/spend rows, and #1149 tool entity/human-task persistence rows, but must
+          not be treated as a construction-ready runtime backend while the remaining #1087 diagnostics raw-SQL consumer
+          blocker remains unresolved.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
-        - Must keep runtime construction fail-closed until tool-executor entity/human-task persistence and diagnostics, and
-          runtime diagnostics/logging either gain backend-neutral owners for SQLite or receive explicit lead-approved
-          split/tracker repair.
+        - Must keep runtime construction fail-closed until runtime diagnostics/logging either gains a backend-neutral owner
+          for SQLite or receives explicit lead-approved split/tracker repair.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2299,7 +2299,7 @@ engine:
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
         replay scope consumption. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
       excludes:
-      - tool executor entity and human-task persistence/diagnostics owned by #1149
+      - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150
     - name: runtime_budget_spend_rows
       owner: internal/runtime/budgetspend.Store consumed through runtime.Stores.BudgetSpendStore and internal/runtime.BudgetTracker
@@ -2312,10 +2312,27 @@ engine:
         budget/spend semantics. SQLite must not substitute an in-memory spend ledger for persisted local runtime budget truth.
       excludes:
       - public operator agent.usage reads over spend_ledger owned by #1157
-      - tool executor entity and human-task persistence/diagnostics owned by #1149
+      - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - production multi-writer SQLite budget concurrency semantics
+    - name: runtime_tool_entity_and_human_task_rows
+      owner: runtimetools.EntityPersistence and runtimetools.HumanTaskPersistence consumed through runtime.Stores and ExecutorOptions
+      promoted_by: '#1149'
+      sqlite_owner: internal/store.SQLiteRuntimeStore tool entity and human-task persistence methods
+      postgres_owner: internal/store.PostgresStore tool entity and human-task persistence methods
+      scope: >
+        SQLite supports explicit local-dev runtime tool entity reads, searches, CEL-backed query/metrics filtering, entity
+        creation, entity field updates with mutation-log rows, generated role-scoped current-entity tools, human_task_request
+        mailbox row creation, and human_task_decide decision/requeue/weekly-budget reads through the same executor behavior
+        owner used by Postgres. Backend-specific SQL belongs to the store implementations; the runtime tool executor must
+        not receive a raw SQLite SQL handle as a compatibility seam for these surfaces.
+      excludes:
+      - public operator mailbox API decisions owned by api_specification.method_catalog.mailbox.*
+      - public operator agent.usage reads over spend_ledger owned by #1157
+      - runtime diagnostics/logging owned by #1150
+      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - production multi-writer SQLite concurrency semantics
     - name: mailbox_rows
       owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
       sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
@@ -2369,9 +2386,9 @@ engine:
       runtime_sql_handle_for_sqlite: omitted
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
-        accidentally treated as SQLite owners. Because tool-executor SQL diagnostics/entity helpers and SQL runtime logging
-        are still gate-promoted #1087 consumers, runtime.NewRuntime must fail closed for SQLite until those consumers move
-        to backend-neutral store owners or receive explicit lead-approved split/tracker repair.
+        accidentally treated as SQLite owners. Because SQL runtime diagnostics/logging remains a gate-promoted #1087 consumer,
+        runtime.NewRuntime must fail closed for SQLite until that consumer moves to a backend-neutral store owner or receives
+        explicit lead-approved split/tracker repair.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."


### PR DESCRIPTION
## Summary

Closes #1149.

This PR closes `runtime.sqlite_tool_entity_human_task_backend_neutral_owner` by promoting backend-neutral runtime tool persistence owners for entity tools and human-task tools. `runtime.NewRuntime` and selected-contract run-fork executor construction now consume typed owners instead of `ExecutorOptions.SQLDB`; backend-specific SQL is confined to `internal/store` implementations for Postgres and SQLite.

SQLite runtime construction remains fail-closed on #1150 runtime diagnostics/logging. This does not claim #1087, #1066, #1088, #1089, or #1157 closure.

## Governing Refs

- #1149 pre-audit and approved gate: `runtime.sqlite_tool_entity_human_task_backend_neutral_owner` first slice.
- `platform-spec.yaml` `contract_formats.persistence_model.role_scoped_entity_tools`.
- `platform-spec.yaml` `engine.runtime_store_backend_selection`.
- `platform-spec.yaml` `engine.runtime_core_persistence_store_contracts`.
- Adjacent split refs: mailbox API methods are separate; `agent.usage` is #1157; runtime diagnostics/logging is #1150; default flip is #1088.

## Semantic Migration

- New canonical owners: `runtimetools.EntityPersistence` and `runtimetools.HumanTaskPersistence`.
- Implementations: `internal/store.PostgresStore` and `internal/store.SQLiteRuntimeStore`.
- Consumers moved: `runtime.Stores`, `runtime.NewRuntime`, selected-contract run-fork executor wiring, `ExecutorOptions`, legacy internal entity handlers, generated role-scoped entity tools, `human_task_request`, and `human_task_decide`.
- Old path now invalid for this class: `ExecutorOptions.SQLDB`, `Executor.sqlDB`, `sqlDBDependency`, and raw executor SQL helpers for entity/human-task persistence.
- Surviving old behavior: `runtime.Stores.SQLDB` / raw runtime SQL remains only for #1150 diagnostics/logging and is not authoritative for entity/human-task tool persistence.
- Migration completeness: complete for #1149; parent chain remains blocked by #1150.

## Proof

- `go test -p 1 ./...`
- `go test ./internal/runtime/tools ./cmd/swarm -run 'TestSQLiteEntityPersistence_MarshalsStructuredFilterValues|TestEntityTools_SQLiteBackendNeutralEntityPersistence|TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence|TestHumanTaskTools_BackendNeutralPersistence|TestBuildStoresSQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit' -count=1`
- `go test ./internal/runtime/runforkexecution ./internal/runtime/cataloge2e ./internal/runtime/conformance -run 'TestEntity|TestTier12RuntimeFork_SelectedContractForkExecutionFixture|Test.*SelectedContract|Test.*Human|Test.*Persisted' -count=1`