### PR TITLE
[agent-b][issue #1164] Align bundle agents model field

### DIFF
--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -67,7 +67,7 @@ type bundleAgentDefinition struct {
 	FlowInstance     string   `json:"flow_instance,omitempty"`
 	Role             string   `json:"role,omitempty"`
 	Type             string   `json:"type,omitempty"`
-	ModelTier        string   `json:"model_tier,omitempty"`
+	Model            string   `json:"model,omitempty"`
 	LLMBackend       string   `json:"llm_backend,omitempty"`
 	ConversationMode string   `json:"conversation_mode,omitempty"`
 	SessionScope     string   `json:"session_scope,omitempty"`
@@ -383,7 +383,7 @@ func writeBundleAgentsHuman(w io.Writer, result bundleAgentsResult) {
 		appendKV("flow_instance", agent.FlowInstance)
 		appendKV("role", agent.Role)
 		appendKV("type", agent.Type)
-		appendKV("model_tier", agent.ModelTier)
+		appendKV("model", agent.Model)
 		appendKV("llm_backend", agent.LLMBackend)
 		appendKV("conversation_mode", agent.ConversationMode)
 		appendKV("session_scope", agent.SessionScope)

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -53,7 +53,7 @@ func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
 	}{
 		{args: []string{"bundle", "list", "--limit", "2", "--cursor", "bundle-cursor-1"}, wantStdout: []string{"bundle " + bundleHash, "agents=2", "next_cursor=bundle-cursor-2"}},
 		{args: []string{"bundle", "show", bundleHash}, wantStdout: []string{"Bundle " + bundleHash, "content_yaml:", "agents:"}},
-		{args: []string{"bundle", "agents", bundleHash}, wantStdout: []string{"agent agent-alpha", "role=researcher", "subscriptions=scan.requested"}},
+		{args: []string{"bundle", "agents", bundleHash}, wantStdout: []string{"agent agent-alpha", "role=researcher", "model=regular", "subscriptions=scan.requested"}},
 	}
 	for _, command := range commands {
 		var stdout, stderr bytes.Buffer
@@ -68,6 +68,9 @@ func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
 		}
 		if strings.TrimSpace(stderr.String()) != "" {
 			t.Fatalf("%v stderr = %q, want empty", command.args, stderr.String())
+		}
+		if strings.Contains(stdout.String(), "model_tier") {
+			t.Fatalf("%v stdout contains retired model_tier field:\n%s", command.args, stdout.String())
 		}
 	}
 
@@ -111,6 +114,46 @@ func TestBundleCommandsJSONPreserveAPIShape(t *testing.T) {
 		if _, ok := decoded[wrapper]; ok {
 			t.Fatalf("json output contains CLI wrapper %q: %#v", wrapper, decoded)
 		}
+	}
+}
+
+func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("d")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"agents": []map[string]any{validBundleAgent("agent-alpha")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "agents", bundleHash, "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertBundleRequest(t, captured, bundleAgentsMethod, map[string]any{"bundle_hash": bundleHash})
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode stdout json: %v\n%s", err, stdout.String())
+	}
+	agents, ok := decoded["agents"].([]any)
+	if !ok || len(agents) != 1 {
+		t.Fatalf("json agents = %#v, want one agent", decoded["agents"])
+	}
+	agent, ok := agents[0].(map[string]any)
+	if !ok {
+		t.Fatalf("json agent = %#v, want object", agents[0])
+	}
+	if agent["model"] != "regular" {
+		t.Fatalf("json agent model = %#v, want regular; agent=%#v", agent["model"], agent)
+	}
+	if _, ok := agent["model_tier"]; ok {
+		t.Fatalf("json agent contains retired model_tier field: %#v", agent)
 	}
 }
 
@@ -266,7 +309,7 @@ func validBundleAgent(agentID string) map[string]any {
 		"flow_instance":     "default",
 		"role":              "researcher",
 		"type":              "business",
-		"model_tier":        "standard",
+		"model":             "regular",
 		"llm_backend":       "openai_compatible",
 		"conversation_mode": "task",
 		"session_scope":     "run",


### PR DESCRIPTION
Closes #1164

## Scope

This PR closes the approved #1164 first slice: `swarm bundle agents <bundle-hash>` now consumes and renders canonical `BundleAgentDefinition.model` instead of retired `model_tier`.

Out of scope: #1130 docs cleanup, #1167 `swarm bundle register`, #983 provider work, and any broader #1129 reopening.

## Governing Refs

- #1164 Pre-Implementation Coverage Audit and independent gate approval.
- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`: `model` replaces `model_tier`.
- `platform-spec.yaml#/components/schemas/BundleAgentDefinition`: public bundle agent rows expose `model`.
- Generated root `openrpc.json` `BundleAgentDefinition`: exposes `model`, not `model_tier`.
- `/v1/rpc bundle.agents` API/store owners in `internal/apiv1` and `internal/store` already return canonical `model`.

## Semantic Migration

- New canonical owner consumed by CLI: `BundleAgentDefinition.model` from platform spec/OpenRPC and `/v1/rpc bundle.agents`.
- Old invalid CLI path: `cmd/swarm` `bundleAgentDefinition.ModelTier`, `json:"model_tier"`, and human `model_tier=` rendering.
- Production paths checked for surviving old behavior: CLI decode/render/tests, OpenRPC schema, API handler/store projection, adjacent `swarm agents` output, and migration-only references.
- Migration is complete for the approved #1164 CLI consumer class. Store/API/spec were already canonical and are unchanged.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./cmd/swarm -run 'Bundle' -count=1`
- `rg -n 'ModelTier|json:"model_tier|appendKV\("model_tier"|"model_tier"\s*:' cmd/swarm/bundle.go cmd/swarm/bundle_test.go` returned no matches
- `git diff --check`
- `go test ./...`