### PR TITLE
[agent-f][issue #1018] Implement non-force bundle delete

### DIFF
--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -23,8 +23,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.SchemaCount != 104 {
 		t.Fatalf("schema count = %d, want 104", report.SchemaCount)
 	}
-	if report.ErrorCodeCount != 38 {
-		t.Fatalf("error code count = %d, want 38", report.ErrorCodeCount)
+	if report.ErrorCodeCount != 39 {
+		t.Fatalf("error code count = %d, want 39", report.ErrorCodeCount)
 	}
 	if report.MutatingMethodCount != 22 {
 		t.Fatalf("mutating method count = %d, want 22", report.MutatingMethodCount)
@@ -73,8 +73,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Components.Schemas) != 104 {
 		t.Fatalf("generated OpenRPC schemas = %d, want 104", len(doc.Components.Schemas))
 	}
-	if len(doc.Components.Errors) != 38 {
-		t.Fatalf("generated OpenRPC errors = %d, want 38", len(doc.Components.Errors))
+	if len(doc.Components.Errors) != 39 {
+		t.Fatalf("generated OpenRPC errors = %d, want 39", len(doc.Components.Errors))
 	}
 	assertGeneratedMethodsOmitExamplesUnderPolicy(t, api, artifact)
 	assertGeneratedMethodsOmitRPCDiscoverUnderPolicy(t, api, doc)
@@ -282,7 +282,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
 
 	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
-	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_run_fork_and_force_delete_methods_published")
+	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_run_fork_and_delete_methods_published")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.list")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "run.fork")
 	assertScalarContains(t, mustMappingValue(t, generatedPolicy, "rule"), "bundle.register")
@@ -344,12 +344,12 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	apiSurface := mustMappingValue(t, multi, "api_surface")
-	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "bundle_read_catalog_register_run_fork_and_force_delete_generated_openrpc")
+	assertScalarValue(t, mustMappingValue(t, apiSurface, "publication_status"), "bundle_read_catalog_register_run_fork_and_delete_generated_openrpc")
 
 	bundleDelete := mustMappingValue(t, multi, "bundle_delete")
 	phaseFive := mustMappingValue(t, bundleDelete, "phase_5_atomicity")
 	assertScalarValue(t, mustMappingValue(t, phaseFive, "tracker"), "#1009")
-	assertScalarValue(t, mustMappingValue(t, phaseFive, "implementation_status"), "implemented_for_force_delete_runtime_non_force_pending")
+	assertScalarValue(t, mustMappingValue(t, phaseFive, "implementation_status"), "implemented_for_force_and_non_force_delete_runtime")
 	assertScalarValue(t, mustMappingValue(t, phaseFive, "canonical_runtime_owner"), "internal/store.PostgresStore.ApplyBundleDeleteFinalMutation")
 	appliesTo := mustMappingValue(t, phaseFive, "applies_to")
 	if !sequenceContainsScalar(appliesTo, "#1018 non-force bundle.delete final bundle availability mutation") {
@@ -379,7 +379,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_UNAVAILABLE")
 	assertScalarContains(t, mustMappingValue(t, phaseFive, "reader_invariant"), "BUNDLE_DATA_INTEGRITY_ERROR")
 	postDeleteAdmission := mustMappingValue(t, phaseFive, "post_delete_new_work_admission")
-	assertScalarValue(t, mustMappingValue(t, postDeleteAdmission, "status"), "implemented_for_force_delete_runtime")
+	assertScalarValue(t, mustMappingValue(t, postDeleteAdmission, "status"), "implemented_for_force_and_non_force_delete_runtime")
 	assertScalarValue(t, mustMappingValue(t, postDeleteAdmission, "canonical_owner"), "internal/store/runlifecycle.EnsureActive")
 	admissionConsumers := mustMappingValue(t, postDeleteAdmission, "consumed_by")
 	if !sequenceContainsScalar(admissionConsumers, "/v1/rpc event.publish") {
@@ -432,8 +432,8 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	bundleCommand := mustMappingValue(t, commandCatalog, "bundle")
 	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents")
 	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_read_only_inventory")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "bundle.register API is live")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "swarm bundle register CLI consumer remains split")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "bundle.register and bundle.delete APIs are live")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "swarm bundle register/delete CLI consumers remain split")
 	runForkCatalog := mustMappingValue(t, commandCatalog, "run_fork")
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "command"), runForkCommand)
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "implementation_status"), "implemented_public_cli_consumer")
@@ -468,11 +468,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	}
 
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
-	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_run_fork_and_force_delete_method_catalog")
+	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_run_fork_and_delete_method_catalog")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.register is also published")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "does not imply a swarm bundle register CLI consumer")
-	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "Force-only bundle.delete is promoted")
-	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "split to #1018")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.delete is promoted")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "omitted or false force performs non-force deletion")
 
 	for _, relPath := range []string{
 		filepath.Join("cmd", "swarm", "main.go"),

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -568,6 +568,17 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		{Method: "runtime.nuke", Params: map[string]any{"dry_run": false, "idempotency_key": "idem-error"}, Code: RuntimeNukeInProgressCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.nuke.planErr = destructivereset.ErrOperationInProgress }}},
 		{Method: "bundle.delete", Params: map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "idempotency_key": "idem-error"}, Code: BundleNotFoundCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.bundleDelete.err = store.ErrBundleNotFound }}},
 		{Method: "bundle.delete", Params: map[string]any{"bundle_hash": runStartTestBundleHash, "force": true, "idempotency_key": "idem-error"}, Code: BundleDeleteInProgressCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) { s.bundleDelete.err = bundledelete.ErrOperationInProgress }}},
+		{Method: "bundle.delete", Params: map[string]any{"bundle_hash": runStartTestBundleHash, "idempotency_key": "idem-error"}, Code: BundleHasActiveRunsCode, WantEffects: 1, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
+			s.bundleDelete.err = &bundledelete.ActiveRunsRemainError{
+				BundleHash: runStartTestBundleHash,
+				ActiveRuns: []bundledelete.RunRef{{
+					RunID:        "00000000-0000-0000-0000-000000000101",
+					Status:       "running",
+					BundleHash:   runStartTestBundleHash,
+					BundleSource: "persisted",
+				}},
+			}
+		}}},
 	}
 }
 
@@ -880,25 +891,49 @@ func (e *recordingBundleDeleteExecutor) Execute(_ context.Context, req bundledel
 	if bundleHash == "" {
 		bundleHash = strings.TrimSpace(e.bundleHash)
 	}
+	status := "completed"
+	if req.DryRun {
+		status = "dry_run"
+	}
+	activeRunsStopped := 0
+	deliveriesCancelled := 0
+	containersStopped := 0
+	var activeRuns []bundledelete.RunRef
+	var nonActiveRuns []bundledelete.RunRef
+	if req.Force {
+		activeRunsStopped = 1
+		deliveriesCancelled = 1
+		containersStopped = 1
+		activeRuns = []bundledelete.RunRef{{
+			RunID:        "00000000-0000-0000-0000-000000000101",
+			Status:       "running",
+			BundleHash:   bundleHash,
+			BundleSource: "persisted",
+		}}
+	} else {
+		nonActiveRuns = []bundledelete.RunRef{{
+			RunID:        "00000000-0000-0000-0000-000000000102",
+			Status:       "completed",
+			BundleHash:   bundleHash,
+			BundleSource: "persisted",
+		}}
+	}
 	return bundledelete.Result{
 		OK:                  true,
-		Status:              "completed",
+		Status:              status,
 		OperationName:       bundledelete.DefaultOperationName,
 		BundleHash:          bundleHash,
 		Force:               req.Force,
-		Deleted:             true,
+		Deleted:             !req.DryRun,
 		DryRun:              req.DryRun,
-		ActiveRunsStopped:   1,
-		DeliveriesCancelled: 1,
-		ContainersStopped:   1,
+		ActiveRunsStopped:   activeRunsStopped,
+		DeliveriesCancelled: deliveriesCancelled,
+		ContainersStopped:   containersStopped,
 		Plan: bundledelete.Plan{
-			BundleHash: bundleHash,
-			ActiveRuns: []bundledelete.RunRef{{
-				RunID:        "00000000-0000-0000-0000-000000000101",
-				Status:       "running",
-				BundleHash:   bundleHash,
-				BundleSource: "persisted",
-			}},
+			BundleHash:    bundleHash,
+			ActiveRuns:    activeRuns,
+			NonActiveRuns: nonActiveRuns,
+			AffectedRuns:  append(activeRuns, nonActiveRuns...),
 		},
 	}, nil
 }

--- a/internal/apiv1/operator_bundle_delete.go
+++ b/internal/apiv1/operator_bundle_delete.go
@@ -38,13 +38,6 @@ func executeBundleDelete(ctx context.Context, req Request, opts OperatorReadOpti
 	if err != nil {
 		return nil, err
 	}
-	if !force {
-		return nil, NewInvalidParamsError(map[string]any{
-			"field":      "force",
-			"reason":     "non-force bundle.delete remains split to #1018; force=true is required for #1019",
-			"tracked_by": "#1018",
-		})
-	}
 	dryRun, err := optionalBoolParam(req.Params, "dry_run", false)
 	if err != nil {
 		return nil, err
@@ -115,12 +108,29 @@ func bundleDeleteError(bundleHash string, err error) error {
 			"operation_name": bundledelete.DefaultOperationName,
 		})
 	}
+	var active *bundledelete.ActiveRunsRemainError
+	if errors.As(err, &active) {
+		return NewApplicationError(BundleHasActiveRunsCode, false, bundleDeleteActiveRunsDetails(bundleHash, active.ActiveRuns))
+	}
+	if errors.Is(err, bundledelete.ErrActiveRunsRemain) {
+		return NewApplicationError(BundleHasActiveRunsCode, false, bundleDeleteActiveRunsDetails(bundleHash, nil))
+	}
 	if errors.Is(err, bundledelete.ErrNonForceSplit) {
 		return NewInvalidParamsError(map[string]any{
-			"field":      "force",
-			"reason":     "non-force bundle.delete remains split to #1018; force=true is required for #1019",
-			"tracked_by": "#1018",
+			"field":  "force",
+			"reason": "bundle.delete mode is not supported by the configured bundle-delete owner",
 		})
 	}
 	return err
+}
+
+func bundleDeleteActiveRunsDetails(bundleHash string, activeRuns []bundledelete.RunRef) map[string]any {
+	details := map[string]any{
+		"bundle_hash":    bundleHash,
+		"active_run_ids": bundledelete.ActiveRunIDList(activeRuns),
+	}
+	if len(activeRuns) > 0 {
+		details["active_runs"] = activeRuns
+	}
+	return details
 }

--- a/internal/apiv1/operator_bundle_delete_test.go
+++ b/internal/apiv1/operator_bundle_delete_test.go
@@ -102,8 +102,8 @@ func TestOperatorBundleDeleteForceErrors(t *testing.T) {
 	}
 }
 
-func TestOperatorBundleDeleteNonForceFailsClosedBeforeOwner(t *testing.T) {
-	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash}
+func TestOperatorBundleDeleteNonForceMissingBundleError(t *testing.T) {
+	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash, err: store.ErrBundleNotFound}
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
@@ -114,99 +114,227 @@ func TestOperatorBundleDeleteNonForceFailsClosedBeforeOwner(t *testing.T) {
 		}),
 	})
 
-	for _, body := range []string{
-		`{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `"}}`,
-		`{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `","force":false}}`,
-	} {
-		resp := rpcCall(t, handler, body)
-		if resp.Error == nil {
-			t.Fatal("bundle.delete non-force error = nil")
-		}
-		if resp.Error.Code != codeInvalidParams {
-			t.Fatalf("bundle.delete non-force code = %d, want %d", resp.Error.Code, codeInvalidParams)
-		}
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","idempotency_key":"non-force-missing"}}`)
+	if resp.Error == nil {
+		t.Fatal("bundle.delete missing bundle error = nil")
 	}
-	if len(executor.calls) != 0 {
-		t.Fatalf("bundle.delete owner calls after non-force = %d, want 0", len(executor.calls))
+	if data := asMap(t, resp.Error.Data); data["code"] != BundleNotFoundCode {
+		t.Fatalf("bundle.delete missing bundle data = %#v, want %s", data, BundleNotFoundCode)
+	}
+	if len(executor.calls) != 1 || executor.calls[0].Force {
+		t.Fatalf("bundle.delete missing bundle request = %#v", executor.calls)
 	}
 }
 
-func TestOperatorBundleDeleteForceBlocksPostDeleteNewWorkFromPersistedRuntimeSource(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	pg := &store.PostgresStore{DB: db}
-	ctx := context.Background()
-	seedOperatorBundleDeleteBundle(t, ctx, db, runStartTestBundleHash)
-	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	sourceFact := runtimecorrelation.BundleSourceFact{
-		BundleHash:        runStartTestBundleHash,
-		BundleSource:      storerunlifecycle.BundleSourcePersisted,
-		BundleFingerprint: runStartTestFingerprint,
-	}
-	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
-		ContractBundle:   source,
-		BundleSourceFact: sourceFact,
+func TestOperatorBundleDeleteNonForceUsesOwnerChainAndIdempotency(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash}
+	idempotency := newRecordingAPIIdempotencyStore()
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:          func() time.Time { return now },
+			Ready:        func() bool { return true },
+			Database:     fakePinger{},
+			Idempotency:  idempotency,
+			BundleDelete: executor,
+		}),
 	})
-	if err != nil {
-		t.Fatalf("NewEventBusWithOptions: %v", err)
+
+	body := `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"` + runStartTestBundleHash + `","dry_run":true,"idempotency_key":"non-force-1"}}`
+	resp := rpcCall(t, handler, body)
+	if resp.Error != nil {
+		t.Fatalf("bundle.delete non-force error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["ok"] != true || result["status"] != "dry_run" || result["bundle_hash"] != runStartTestBundleHash || result["force"] != false || result["dry_run"] != true {
+		t.Fatalf("bundle.delete non-force result = %#v", result)
+	}
+	if len(executor.calls) != 1 {
+		t.Fatalf("bundle.delete owner calls = %d, want 1", len(executor.calls))
+	}
+	if executor.calls[0].BundleHash != runStartTestBundleHash || executor.calls[0].Force || !executor.calls[0].DryRun {
+		t.Fatalf("bundle.delete non-force request = %#v", executor.calls[0])
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("bundle.delete non-force replay error = %#v", replay.Error)
+	}
+	if len(executor.calls) != 1 {
+		t.Fatalf("bundle.delete owner calls after replay = %d, want unchanged 1", len(executor.calls))
+	}
+
+	explicitFalse := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete-false","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","force":false,"dry_run":true,"idempotency_key":"non-force-false"}}`)
+	if explicitFalse.Error != nil {
+		t.Fatalf("bundle.delete explicit force false error = %#v", explicitFalse.Error)
+	}
+	if len(executor.calls) != 2 {
+		t.Fatalf("bundle.delete owner calls after explicit force false = %d, want 2", len(executor.calls))
+	}
+	if executor.calls[1].BundleHash != runStartTestBundleHash || executor.calls[1].Force || !executor.calls[1].DryRun {
+		t.Fatalf("bundle.delete explicit force false request = %#v", executor.calls[1])
+	}
+}
+
+func TestOperatorBundleDeleteNonForceActiveRunsError(t *testing.T) {
+	activeRunID := "00000000-0000-0000-0000-000000000181"
+	executor := &recordingBundleDeleteExecutor{
+		bundleHash: runStartTestBundleHash,
+		err: &bundledelete.ActiveRunsRemainError{
+			BundleHash: runStartTestBundleHash,
+			ActiveRuns: []bundledelete.RunRef{{
+				RunID:        activeRunID,
+				Status:       "running",
+				BundleHash:   runStartTestBundleHash,
+				BundleSource: "persisted",
+			}},
+		},
 	}
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Now:              func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
-			Ready:            func() bool { return true },
-			Database:         fakePinger{},
-			Runs:             pg,
-			Observability:    pg,
-			Idempotency:      pg,
-			Events:           bus,
-			Source:           source,
-			RunBundleContext: pg,
-			Bundle: runtimecontracts.BundleIdentity{
-				WorkflowName:    "review",
-				WorkflowVersion: "1.0.0",
-				Fingerprint:     runStartTestFingerprint,
-			},
-			BundleDelete: &bundledelete.Coordinator{
-				Planner:            pg,
-				Cleaner:            pg,
-				Finalizer:          pg,
-				Locks:              pg,
-				ContainerInventory: emptyBundleDeleteContainerInventory{},
-				Containers:         noopBundleDeleteContainers{},
-				Now:                func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
-			},
+			Ready:        func() bool { return true },
+			Database:     fakePinger{},
+			Idempotency:  newRecordingAPIIdempotencyStore(),
+			BundleDelete: executor,
 		}),
 	})
 
-	deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","force":true,"idempotency_key":"force-delete-current-runtime"}}`)
-	if deleted.Error != nil {
-		t.Fatalf("bundle.delete error = %#v", deleted.Error)
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","idempotency_key":"non-force-active"}}`)
+	if resp.Error == nil {
+		t.Fatal("bundle.delete active-runs error = nil")
 	}
-	if result := asMap(t, deleted.Result); result["deleted"] != true {
-		t.Fatalf("bundle.delete result = %#v, want deleted", result)
+	data := asMap(t, resp.Error.Data)
+	if data["code"] != BundleHasActiveRunsCode {
+		t.Fatalf("bundle.delete active-runs data = %#v, want %s", data, BundleHasActiveRunsCode)
 	}
+	details := asMap(t, data["details"])
+	activeIDs := asSlice(t, details["active_run_ids"])
+	if len(activeIDs) != 1 || activeIDs[0] != activeRunID {
+		t.Fatalf("bundle.delete active run ids = %#v, want %s", activeIDs, activeRunID)
+	}
+	if len(executor.calls) != 1 || executor.calls[0].Force {
+		t.Fatalf("bundle.delete active owner calls = %#v", executor.calls)
+	}
+}
 
-	published := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "publish-after-delete"))
-	assertBundleUnavailableNewWork(t, published, "event.publish")
-	if count := countEventsByName(t, db, "scan.requested"); count != 0 {
-		t.Fatalf("scan.requested events after event.publish = %d, want 0", count)
-	}
-	if count := countAllRunRows(t, db); count != 0 {
-		t.Fatalf("run rows after event.publish = %d, want 0", count)
-	}
+func TestOperatorBundleDeleteActiveRunsSentinelErrorOmitsRunRefs(t *testing.T) {
+	executor := &recordingBundleDeleteExecutor{bundleHash: runStartTestBundleHash, err: bundledelete.ErrActiveRunsRemain}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:        func() bool { return true },
+			Database:     fakePinger{},
+			Idempotency:  newRecordingAPIIdempotencyStore(),
+			BundleDelete: executor,
+		}),
+	})
 
-	runID := uuid.NewString()
-	started := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "start-after-delete"))
-	assertBundleUnavailableNewWork(t, started, "run.start")
-	if count := countRunRowsByID(t, db, runID); count != 0 {
-		t.Fatalf("run rows after run.start = %d, want 0", count)
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{"bundle_hash":"`+runStartTestBundleHash+`","idempotency_key":"active-sentinel"}}`)
+	if resp.Error == nil {
+		t.Fatal("bundle.delete active-runs sentinel error = nil")
 	}
-	if count := countEventRowsByRunID(t, db, runID); count != 0 {
-		t.Fatalf("event rows after run.start = %d, want 0", count)
+	data := asMap(t, resp.Error.Data)
+	if data["code"] != BundleHasActiveRunsCode {
+		t.Fatalf("bundle.delete active-runs sentinel data = %#v, want %s", data, BundleHasActiveRunsCode)
 	}
-	if count := countAPIIdempotencyRows(t, db); count != 1 {
-		t.Fatalf("api_idempotency rows after rejected new work = %d, want only bundle.delete row", count)
+	details := asMap(t, data["details"])
+	activeIDs := asSlice(t, details["active_run_ids"])
+	if len(activeIDs) != 0 {
+		t.Fatalf("bundle.delete active run ids = %#v, want empty", activeIDs)
+	}
+	if _, ok := details["active_runs"]; ok {
+		t.Fatalf("bundle.delete active_runs details = %#v, want omitted without run refs", details["active_runs"])
+	}
+}
+
+func TestOperatorBundleDeleteBlocksPostDeleteNewWorkFromPersistedRuntimeSource(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		deleteParams string
+	}{
+		{name: "non_force", deleteParams: `"bundle_hash":"` + runStartTestBundleHash + `","idempotency_key":"non-force-delete-current-runtime"`},
+		{name: "force", deleteParams: `"bundle_hash":"` + runStartTestBundleHash + `","force":true,"idempotency_key":"force-delete-current-runtime"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			pg := &store.PostgresStore{DB: db}
+			ctx := context.Background()
+			seedOperatorBundleDeleteBundle(t, ctx, db, runStartTestBundleHash)
+			source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+			sourceFact := runtimecorrelation.BundleSourceFact{
+				BundleHash:        runStartTestBundleHash,
+				BundleSource:      storerunlifecycle.BundleSourcePersisted,
+				BundleFingerprint: runStartTestFingerprint,
+			}
+			bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+				ContractBundle:   source,
+				BundleSourceFact: sourceFact,
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			handler := testHandler(t, Options{
+				AuthTokens: []string{testToken},
+				Handlers: OperatorReadHandlers(OperatorReadOptions{
+					Now:              func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
+					Ready:            func() bool { return true },
+					Database:         fakePinger{},
+					Runs:             pg,
+					Observability:    pg,
+					Idempotency:      pg,
+					Events:           bus,
+					Source:           source,
+					RunBundleContext: pg,
+					Bundle: runtimecontracts.BundleIdentity{
+						WorkflowName:    "review",
+						WorkflowVersion: "1.0.0",
+						Fingerprint:     runStartTestFingerprint,
+					},
+					BundleDelete: &bundledelete.Coordinator{
+						Planner:            pg,
+						Cleaner:            pg,
+						Finalizer:          pg,
+						Locks:              pg,
+						ContainerInventory: emptyBundleDeleteContainerInventory{},
+						Containers:         noopBundleDeleteContainers{},
+						Now:                func() time.Time { return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC) },
+					},
+				}),
+			})
+
+			deleted := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"delete","method":"bundle.delete","params":{`+tc.deleteParams+`}}`)
+			if deleted.Error != nil {
+				t.Fatalf("bundle.delete error = %#v", deleted.Error)
+			}
+			if result := asMap(t, deleted.Result); result["deleted"] != true {
+				t.Fatalf("bundle.delete result = %#v, want deleted", result)
+			}
+
+			published := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "publish-after-delete"))
+			assertBundleUnavailableNewWork(t, published, "event.publish")
+			if count := countEventsByName(t, db, "scan.requested"); count != 0 {
+				t.Fatalf("scan.requested events after event.publish = %d, want 0", count)
+			}
+			if count := countAllRunRows(t, db); count != 0 {
+				t.Fatalf("run rows after event.publish = %d, want 0", count)
+			}
+
+			runID := uuid.NewString()
+			started := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "start-after-delete"))
+			assertBundleUnavailableNewWork(t, started, "run.start")
+			if count := countRunRowsByID(t, db, runID); count != 0 {
+				t.Fatalf("run rows after run.start = %d, want 0", count)
+			}
+			if count := countEventRowsByRunID(t, db, runID); count != 0 {
+				t.Fatalf("event rows after run.start = %d, want 0", count)
+			}
+			if count := countAPIIdempotencyRows(t, db); count != 1 {
+				t.Fatalf("api_idempotency rows after rejected new work = %d, want only bundle.delete row", count)
+			}
+		})
 	}
 }
 

--- a/internal/apiv1/registry.go
+++ b/internal/apiv1/registry.go
@@ -19,6 +19,7 @@ const (
 	BundleDataIntegrityErrorCode         = "BUNDLE_DATA_INTEGRITY_ERROR"
 	BundleRegisterConflictCode           = "BUNDLE_REGISTER_CONFLICT"
 	BundleDeleteInProgressCode           = "BUNDLE_DELETE_IN_PROGRESS"
+	BundleHasActiveRunsCode              = "BUNDLE_HAS_ACTIVE_RUNS"
 	UnsupportedBundleHashCode            = "UNSUPPORTED_BUNDLE_HASH"
 	UnsupportedBundleHashForkCode        = "UNSUPPORTED_BUNDLE_HASH_FORK"
 	UnsupportedBundleRefCode             = "UNSUPPORTED_BUNDLE_REF"

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -171,14 +171,14 @@ methods:
   - method: bundle.delete
     transport: http
     required_params: [bundle_hash]
-    declared_errors: [BUNDLE_NOT_FOUND, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT]
-    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
+    declared_errors: [BUNDLE_NOT_FOUND, BUNDLE_HAS_ACTIVE_RUNS, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT]
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}, {kind: go_test, name: TestOperatorBundleDeleteNonForceUsesOwnerChainAndIdempotency}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
     auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
-    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceErrors}]}
-    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
-    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}]}
+    declared_error_tests: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceErrors}, {kind: go_test, name: TestOperatorBundleDeleteNonForceMissingBundleError}, {kind: go_test, name: TestOperatorBundleDeleteNonForceActiveRunsError}]}
+    idempotency: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}, {kind: go_test, name: TestOperatorBundleDeleteNonForceUsesOwnerChainAndIdempotency}]}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorBundleDeleteForceUsesOwnerChainAndIdempotency}, {kind: go_test, name: TestOperatorBundleDeleteNonForceUsesOwnerChainAndIdempotency}]}
     notification_schema: {status: not_applicable}
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}

--- a/internal/runtime/bundledelete/coordinator.go
+++ b/internal/runtime/bundledelete/coordinator.go
@@ -37,20 +37,11 @@ func (c *Coordinator) Execute(ctx context.Context, req Request) (Result, error) 
 	if c.Planner == nil {
 		return Result{}, fmt.Errorf("bundle delete planner is required")
 	}
-	if c.Cleaner == nil {
-		return Result{}, fmt.Errorf("bundle delete preservation cleaner is required")
-	}
 	if c.Finalizer == nil {
 		return Result{}, fmt.Errorf("bundle delete finalizer is required")
 	}
 	if c.Locks == nil {
 		return Result{}, fmt.Errorf("bundle delete lock manager is required")
-	}
-	if c.ContainerInventory == nil {
-		return Result{}, fmt.Errorf("bundle delete managed container inventory is required")
-	}
-	if c.Containers == nil {
-		return Result{}, fmt.Errorf("bundle delete managed container stopper is required")
 	}
 
 	lease, acquired, err := c.Locks.TryAcquire(ctx, c.lockKey())
@@ -72,7 +63,6 @@ func (c *Coordinator) Execute(ctx context.Context, req Request) (Result, error) 
 		return Result{}, err
 	}
 	plan.PlannedAt = req.RequestedAt
-	containers, err := c.managedContainersForPlan(ctx, plan)
 	result := Result{
 		OK:            true,
 		Status:        "completed",
@@ -82,6 +72,19 @@ func (c *Coordinator) Execute(ctx context.Context, req Request) (Result, error) 
 		DryRun:        req.DryRun,
 		Plan:          plan,
 	}
+	if !req.Force {
+		return c.executeNonForce(ctx, req, result)
+	}
+	if c.Cleaner == nil {
+		return Result{}, fmt.Errorf("bundle delete preservation cleaner is required")
+	}
+	if c.ContainerInventory == nil {
+		return Result{}, fmt.Errorf("bundle delete managed container inventory is required")
+	}
+	if c.Containers == nil {
+		return Result{}, fmt.Errorf("bundle delete managed container stopper is required")
+	}
+	containers, err := c.managedContainersForPlan(ctx, plan)
 	if err != nil {
 		return result.withPartialFailure("managed_containers", err), nil
 	}
@@ -134,6 +137,30 @@ func (c *Coordinator) Execute(ctx context.Context, req Request) (Result, error) 
 	})
 	if err != nil {
 		return result.withPartialFailure("phase_5_bundle_delete", err), nil
+	}
+	result.FinalMutation = final
+	result.Deleted = final.Deleted
+	return result, nil
+}
+
+func (c *Coordinator) executeNonForce(ctx context.Context, req Request, result Result) (Result, error) {
+	if len(result.Plan.ActiveRuns) > 0 {
+		return Result{}, &ActiveRunsRemainError{
+			BundleHash: req.BundleHash,
+			ActiveRuns: result.Plan.ActiveRuns,
+		}
+	}
+	if req.DryRun {
+		result.Status = "dry_run"
+		return result, nil
+	}
+	final, err := c.Finalizer.ApplyBundleDeleteFinalMutation(ctx, FinalMutationRequest{
+		OperationName: c.operationName(),
+		BundleHash:    req.BundleHash,
+		RequestedAt:   req.RequestedAt,
+	})
+	if err != nil {
+		return Result{}, err
 	}
 	result.FinalMutation = final
 	result.Deleted = final.Deleted

--- a/internal/runtime/bundledelete/types.go
+++ b/internal/runtime/bundledelete/types.go
@@ -24,6 +24,29 @@ var (
 	ErrNonForceSplit       = errors.New("bundle delete non-force behavior is split")
 )
 
+type ActiveRunsRemainError struct {
+	BundleHash string
+	ActiveRuns []RunRef
+}
+
+func (e *ActiveRunsRemainError) Error() string {
+	if e == nil {
+		return ErrActiveRunsRemain.Error()
+	}
+	parts := []string{ErrActiveRunsRemain.Error()}
+	if bundleHash := strings.TrimSpace(e.BundleHash); bundleHash != "" {
+		parts = append(parts, "bundle_hash="+bundleHash)
+	}
+	if ids := ActiveRunIDList(e.ActiveRuns); len(ids) > 0 {
+		parts = append(parts, "active_run_ids="+strings.Join(ids, ","))
+	}
+	return strings.Join(parts, ": ")
+}
+
+func (e *ActiveRunsRemainError) Is(target error) bool {
+	return target == ErrActiveRunsRemain
+}
+
 type Request struct {
 	ActorTokenID string
 	RequestHash  string
@@ -152,9 +175,6 @@ func NormalizeRequest(req Request, now time.Time) (Request, error) {
 	if req.BundleHash == "" {
 		return Request{}, fmt.Errorf("%w: bundle_hash is required", ErrInvalidRequest)
 	}
-	if !req.Force {
-		return Request{}, ErrNonForceSplit
-	}
 	if req.RequestedAt.IsZero() {
 		req.RequestedAt = now.UTC()
 	}
@@ -190,8 +210,12 @@ func AffectedRunIDs(plan Plan) map[string]struct{} {
 }
 
 func AffectedRunIDList(plan Plan) []string {
-	out := make([]string, 0, len(plan.AffectedRuns))
-	for _, run := range plan.AffectedRuns {
+	return ActiveRunIDList(plan.AffectedRuns)
+}
+
+func ActiveRunIDList(runs []RunRef) []string {
+	out := make([]string, 0, len(runs))
+	for _, run := range runs {
 		if runID := strings.TrimSpace(run.RunID); runID != "" {
 			out = append(out, runID)
 		}

--- a/internal/store/bundle_delete.go
+++ b/internal/store/bundle_delete.go
@@ -136,7 +136,7 @@ func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req 
 	if err := lockBundleDeleteRunCreationTx(ctx, tx); err != nil {
 		return bundledelete.FinalMutationResult{}, err
 	}
-	activeRemaining, err := lockBundleDeleteReferencingRunsTx(ctx, tx, bundleHash)
+	activeRemainingRuns, err := lockBundleDeleteReferencingRunsTx(ctx, tx, bundleHash)
 	if err != nil {
 		return bundledelete.FinalMutationResult{}, err
 	}
@@ -144,7 +144,7 @@ func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req 
 		OperationName:        operationName,
 		BundleHash:           bundleHash,
 		AppliedAt:            now,
-		RemainingActiveRuns:  activeRemaining,
+		RemainingActiveRuns:  len(activeRemainingRuns),
 		SourceAuthorityOwner: "store.ApplyBundleDeleteFinalMutation",
 		TransactionOrderProof: []string{
 			"lock_runs_table_against_new_persisted_bundle_references",
@@ -152,8 +152,11 @@ func (s *PostgresStore) ApplyBundleDeleteFinalMutation(ctx context.Context, req 
 			"delete_matching_bundles_row",
 		},
 	}
-	if activeRemaining > 0 {
-		return result, bundledelete.ErrActiveRunsRemain
+	if len(activeRemainingRuns) > 0 {
+		return result, &bundledelete.ActiveRunsRemainError{
+			BundleHash: bundleHash,
+			ActiveRuns: activeRemainingRuns,
+		}
 	}
 	updateResult, err := tx.ExecContext(ctx, `
 		UPDATE runs
@@ -321,30 +324,37 @@ func lockBundleDeleteRunCreationTx(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-func lockBundleDeleteReferencingRunsTx(ctx context.Context, tx *sql.Tx, bundleHash string) (int, error) {
+func lockBundleDeleteReferencingRunsTx(ctx context.Context, tx *sql.Tx, bundleHash string) ([]bundledelete.RunRef, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT COALESCE(status, '')
+		SELECT
+			run_id::text,
+			COALESCE(status, ''),
+			COALESCE(bundle_hash, ''),
+			COALESCE(bundle_source, ''),
+			COALESCE(bundle_fingerprint, '')
 		FROM runs
 		WHERE bundle_hash = $1
 		  AND bundle_source = $2
+		ORDER BY run_id::text
 		FOR UPDATE
 	`, bundleHash, storerunlifecycle.BundleSourcePersisted)
 	if err != nil {
-		return 0, fmt.Errorf("lock bundle delete referencing runs: %w", err)
+		return nil, fmt.Errorf("lock bundle delete referencing runs: %w", err)
 	}
 	defer rows.Close()
-	active := 0
+	active := []bundledelete.RunRef{}
 	for rows.Next() {
-		var status string
-		if err := rows.Scan(&status); err != nil {
-			return 0, fmt.Errorf("scan bundle delete referencing run: %w", err)
+		var run bundledelete.RunRef
+		if err := rows.Scan(&run.RunID, &run.Status, &run.BundleHash, &run.BundleSource, &run.BundleFingerprint); err != nil {
+			return nil, fmt.Errorf("scan bundle delete referencing run: %w", err)
 		}
-		if bundleDeleteRunStatusActive(status) {
-			active++
+		normalizeBundleDeleteRunRef(&run)
+		if bundleDeleteRunStatusActive(run.Status) {
+			active = append(active, run)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("read bundle delete referencing runs: %w", err)
+		return nil, fmt.Errorf("read bundle delete referencing runs: %w", err)
 	}
 	return active, nil
 }

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -144,6 +144,54 @@ func TestPostgresStore_BundleDeleteFinalMutationFailsBeforeDeletingWithActiveRun
 	assertBundleRowPresent(t, ctx, pg, bundleDeleteTestHash)
 }
 
+func TestPostgresStore_BundleDeleteFinalMutationMarksOnlyNonActivePersistedRunsDeleted(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+
+	ctx := context.Background()
+	seedBundleDeleteBundle(t, ctx, pg, bundleDeleteTestHash)
+
+	persisted := map[string]string{
+		uuid.NewString(): "completed",
+		uuid.NewString(): "failed",
+		uuid.NewString(): "cancelled",
+		uuid.NewString(): "forked",
+	}
+	for runID, status := range persisted {
+		seedBundleDeleteRunWithSource(t, ctx, pg, runID, status, bundleDeleteTestHash, storerunlifecycle.BundleSourcePersisted)
+	}
+	ephemeralRunID := uuid.NewString()
+	deletedRunID := uuid.NewString()
+	legacyRunID := uuid.NewString()
+	seedBundleDeleteRunWithSource(t, ctx, pg, ephemeralRunID, "completed", bundleDeleteTestHash, storerunlifecycle.BundleSourceEphemeral)
+	seedBundleDeleteRunWithSource(t, ctx, pg, deletedRunID, "completed", bundleDeleteTestHash, storerunlifecycle.BundleSourceDeleted)
+	seedBundleDeleteRunWithSource(t, ctx, pg, legacyRunID, "completed", bundleDeleteTestHash, storerunlifecycle.BundleSourceLegacy)
+
+	final, err := pg.ApplyBundleDeleteFinalMutation(ctx, bundledelete.FinalMutationRequest{
+		OperationName: bundledelete.DefaultOperationName,
+		BundleHash:    bundleDeleteTestHash,
+		RequestedAt:   time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ApplyBundleDeleteFinalMutation: %v", err)
+	}
+	if !final.Deleted || final.BundleRowsDeleted != 1 || final.RunsMarkedDeleted != len(persisted) {
+		t.Fatalf("final mutation = %#v, want deleted row and %d persisted run updates", final, len(persisted))
+	}
+	for runID, status := range persisted {
+		assertBundleDeleteRunBundle(t, ctx, pg, runID, status, storerunlifecycle.BundleSourceDeleted, bundleDeleteTestHash)
+	}
+	assertBundleDeleteRunBundle(t, ctx, pg, ephemeralRunID, "completed", storerunlifecycle.BundleSourceEphemeral, bundleDeleteTestHash)
+	assertBundleDeleteRunBundle(t, ctx, pg, deletedRunID, "completed", storerunlifecycle.BundleSourceDeleted, bundleDeleteTestHash)
+	assertBundleDeleteRunBundle(t, ctx, pg, legacyRunID, "completed", storerunlifecycle.BundleSourceLegacy, bundleDeleteTestHash)
+	assertBundleRowAbsent(t, ctx, pg, bundleDeleteTestHash)
+}
+
 func TestPostgresStore_BundleDeleteFinalMutationSerializesConcurrentRunCreation(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -265,11 +313,31 @@ func seedBundleDeleteBundle(t *testing.T, ctx context.Context, pg *PostgresStore
 
 func seedBundleDeleteRun(t *testing.T, ctx context.Context, pg *PostgresStore, runID, status, bundleHash string) {
 	t.Helper()
+	seedBundleDeleteRunWithSource(t, ctx, pg, runID, status, bundleHash, storerunlifecycle.BundleSourcePersisted)
+}
+
+func seedBundleDeleteRunWithSource(t *testing.T, ctx context.Context, pg *PostgresStore, runID, status, bundleHash, bundleSource string) {
+	t.Helper()
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, bundle_fingerprint, started_at)
 		VALUES ($1::uuid, $2, $3, $4, $5, now())
-	`, runID, status, bundleHash, storerunlifecycle.BundleSourcePersisted, testBootBundleFingerprint); err != nil {
+	`, runID, status, bundleHash, bundleSource, testBootBundleFingerprint); err != nil {
 		t.Fatalf("seed bundle delete run %s: %v", runID, err)
+	}
+}
+
+func assertBundleDeleteRunBundle(t *testing.T, ctx context.Context, pg *PostgresStore, runID, wantStatus, wantSource, wantHash string) {
+	t.Helper()
+	var status, source, bundleHash string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT status, bundle_source, COALESCE(bundle_hash, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&status, &source, &bundleHash); err != nil {
+		t.Fatalf("load run bundle %s: %v", runID, err)
+	}
+	if status != wantStatus || source != wantSource || bundleHash != wantHash {
+		t.Fatalf("run bundle %s = status:%s source:%s hash:%s, want %s/%s/%s", runID, status, source, bundleHash, wantStatus, wantSource, wantHash)
 	}
 }
 

--- a/openrpc.json
+++ b/openrpc.json
@@ -323,7 +323,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -399,7 +399,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -454,7 +454,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -514,7 +514,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -568,7 +568,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -626,7 +626,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -767,7 +767,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -893,7 +893,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1113,7 +1113,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1151,7 +1151,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -1254,7 +1254,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1411,7 +1411,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: BUNDLE_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1452,7 +1452,7 @@
     },
     {
       "name": "bundle.delete",
-      "description": "Force-only destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the bundle-delete owner chain for execution: shared destructive-operation mutex, bundle plan, preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and the #1009 source-first final store transaction. `force=false` and omitted force are intentionally fail-closed and split to #1018; this method MUST NOT implement non-force deletion, CLI behavior, runtime.nuke include_bundles, or broad multi-bundle lifecycle cleanup.\n",
+      "description": "Destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the bundle-delete owner chain for execution. Omitted or false force performs the #1018 non-force path: plan persisted run users, fail closed with BUNDLE_HAS_ACTIVE_RUNS when running or paused persisted users exist, and otherwise consume the #1009 source-first final store transaction to mark eligible persisted runs deleted before deleting the bundle row. force=true performs the #1019 force path: shared destructive-operation mutex, bundle plan, preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and the same final store transaction after cleanup succeeds. This method MUST NOT implement CLI behavior, runtime.nuke include_bundles, or broad multi-bundle lifecycle cleanup.\n",
       "params": [
         {
           "name": "bundle_hash",
@@ -1494,7 +1494,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: BUNDLE_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1515,6 +1515,58 @@
                 },
                 "required": [
                   "bundle_hash"
+                ],
+                "type": "object"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "details",
+              "retryable",
+              "correlation_id"
+            ],
+            "type": "object"
+          }
+        },
+        {
+          "code": -32005,
+          "message": "Application error: BUNDLE_HAS_ACTIVE_RUNS",
+          "data": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "const": "BUNDLE_HAS_ACTIVE_RUNS",
+                "type": "string"
+              },
+              "correlation_id": {
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": false,
+                "properties": {
+                  "active_run_ids": {
+                    "items": {
+                      "$ref": "#/components/schemas/OpaqueId"
+                    },
+                    "type": "array"
+                  },
+                  "active_runs": {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "bundle_hash": {
+                    "$ref": "#/components/schemas/BundleHash"
+                  }
+                },
+                "required": [
+                  "bundle_hash",
+                  "active_run_ids"
                 ],
                 "type": "object"
               },
@@ -1571,7 +1623,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1652,7 +1704,7 @@
       },
       "errors": [
         {
-          "code": -32006,
+          "code": -32007,
           "message": "Application error: BUNDLE_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1757,7 +1809,7 @@
       },
       "errors": [
         {
-          "code": -32007,
+          "code": -32008,
           "message": "Application error: BUNDLE_REGISTER_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1795,7 +1847,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -1958,7 +2010,7 @@
       },
       "errors": [
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -1996,7 +2048,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2039,7 +2091,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2077,7 +2129,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2173,7 +2225,7 @@
       },
       "errors": [
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2211,7 +2263,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2299,7 +2351,7 @@
       },
       "errors": [
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2337,7 +2389,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -2470,7 +2522,7 @@
       },
       "errors": [
         {
-          "code": -32018,
+          "code": -32019,
           "message": "Application error: FORK_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2530,7 +2582,7 @@
       },
       "errors": [
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2607,7 +2659,7 @@
       },
       "errors": [
         {
-          "code": -32033,
+          "code": -32034,
           "message": "Application error: SESSION_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2645,7 +2697,7 @@
           }
         },
         {
-          "code": -32034,
+          "code": -32035,
           "message": "Application error: TURN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2813,7 +2865,7 @@
       },
       "errors": [
         {
-          "code": -32010,
+          "code": -32011,
           "message": "Application error: ENTITY_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -2946,7 +2998,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3127,7 +3179,7 @@
       },
       "errors": [
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: BUNDLE_MISMATCH",
           "data": {
             "additionalProperties": false,
@@ -3177,7 +3229,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: BUNDLE_SCOPE_REQUIRED",
           "data": {
             "additionalProperties": false,
@@ -3222,7 +3274,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3325,7 +3377,7 @@
           }
         },
         {
-          "code": -32035,
+          "code": -32036,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -3360,7 +3412,7 @@
           }
         },
         {
-          "code": -32037,
+          "code": -32038,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -3395,7 +3447,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -3448,7 +3500,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3505,7 +3557,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -3563,7 +3615,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3601,7 +3653,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3639,7 +3691,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -3681,7 +3733,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -3780,7 +3832,7 @@
       },
       "errors": [
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -3818,7 +3870,7 @@
           }
         },
         {
-          "code": -32015,
+          "code": -32016,
           "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
           "data": {
             "additionalProperties": false,
@@ -3856,7 +3908,7 @@
           }
         },
         {
-          "code": -32016,
+          "code": -32017,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
           "data": {
             "additionalProperties": false,
@@ -3911,7 +3963,7 @@
           }
         },
         {
-          "code": -32017,
+          "code": -32018,
           "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -3971,7 +4023,7 @@
           }
         },
         {
-          "code": -32014,
+          "code": -32015,
           "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
           "data": {
             "additionalProperties": false,
@@ -4025,7 +4077,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -4083,7 +4135,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4264,7 +4316,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4302,7 +4354,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4354,7 +4406,7 @@
           }
         },
         {
-          "code": -32022,
+          "code": -32023,
           "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
           "data": {
             "additionalProperties": false,
@@ -4396,7 +4448,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4491,7 +4543,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4529,7 +4581,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4581,7 +4633,7 @@
           }
         },
         {
-          "code": -32020,
+          "code": -32021,
           "message": "Application error: INVALID_DEFER_UNTIL",
           "data": {
             "additionalProperties": false,
@@ -4626,7 +4678,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -4707,7 +4759,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4862,7 +4914,7 @@
       },
       "errors": [
         {
-          "code": -32023,
+          "code": -32024,
           "message": "Application error: MAILBOX_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -4900,7 +4952,7 @@
           }
         },
         {
-          "code": -32021,
+          "code": -32022,
           "message": "Application error: MAILBOX_ALREADY_DECIDED",
           "data": {
             "additionalProperties": false,
@@ -4952,7 +5004,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5060,7 +5112,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5098,7 +5150,7 @@
           }
         },
         {
-          "code": -32032,
+          "code": -32033,
           "message": "Application error: RUN_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5140,7 +5192,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5221,7 +5273,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5305,7 +5357,7 @@
       },
       "errors": [
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -5408,7 +5460,7 @@
           }
         },
         {
-          "code": -32036,
+          "code": -32037,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
           "data": {
             "additionalProperties": false,
@@ -5458,7 +5510,7 @@
           }
         },
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5496,7 +5548,7 @@
           }
         },
         {
-          "code": -32012,
+          "code": -32013,
           "message": "Application error: EVENT_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5534,7 +5586,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -5624,7 +5676,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5765,7 +5817,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -5803,7 +5855,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -5845,7 +5897,7 @@
           }
         },
         {
-          "code": -32029,
+          "code": -32030,
           "message": "Application error: RUN_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -5883,7 +5935,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6017,7 +6069,7 @@
       },
       "errors": [
         {
-          "code": -32005,
+          "code": -32006,
           "message": "Application error: BUNDLE_MISMATCH",
           "data": {
             "additionalProperties": false,
@@ -6067,7 +6119,7 @@
           }
         },
         {
-          "code": -32008,
+          "code": -32009,
           "message": "Application error: BUNDLE_SCOPE_REQUIRED",
           "data": {
             "additionalProperties": false,
@@ -6112,7 +6164,7 @@
           }
         },
         {
-          "code": -32009,
+          "code": -32010,
           "message": "Application error: BUNDLE_UNAVAILABLE",
           "data": {
             "additionalProperties": false,
@@ -6215,7 +6267,7 @@
           }
         },
         {
-          "code": -32035,
+          "code": -32036,
           "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
           "data": {
             "additionalProperties": false,
@@ -6250,7 +6302,7 @@
           }
         },
         {
-          "code": -32037,
+          "code": -32038,
           "message": "Application error: UNSUPPORTED_BUNDLE_REF",
           "data": {
             "additionalProperties": false,
@@ -6285,7 +6337,7 @@
           }
         },
         {
-          "code": -32011,
+          "code": -32012,
           "message": "Application error: EVENT_NOT_DECLARED",
           "data": {
             "additionalProperties": false,
@@ -6338,7 +6390,7 @@
           }
         },
         {
-          "code": -32013,
+          "code": -32014,
           "message": "Application error: EVENT_PUBLISH_FAILED",
           "data": {
             "additionalProperties": false,
@@ -6395,7 +6447,7 @@
           }
         },
         {
-          "code": -32025,
+          "code": -32026,
           "message": "Application error: PAYLOAD_VALIDATION_FAILED",
           "data": {
             "additionalProperties": false,
@@ -6453,7 +6505,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6541,7 +6593,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6579,7 +6631,7 @@
           }
         },
         {
-          "code": -32030,
+          "code": -32031,
           "message": "Application error: RUN_ALREADY_TERMINAL",
           "data": {
             "additionalProperties": false,
@@ -6621,7 +6673,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -6721,7 +6773,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -6822,7 +6874,7 @@
       },
       "errors": [
         {
-          "code": -32031,
+          "code": -32032,
           "message": "Application error: RUN_NOT_FOUND",
           "data": {
             "additionalProperties": false,
@@ -7102,7 +7154,7 @@
       },
       "errors": [
         {
-          "code": -32028,
+          "code": -32029,
           "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
           "data": {
             "additionalProperties": false,
@@ -7140,7 +7192,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7221,7 +7273,7 @@
       },
       "errors": [
         {
-          "code": -32026,
+          "code": -32027,
           "message": "Application error: RUNTIME_ALREADY_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -7252,7 +7304,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -7333,7 +7385,7 @@
       },
       "errors": [
         {
-          "code": -32027,
+          "code": -32028,
           "message": "Application error: RUNTIME_NOT_PAUSED",
           "data": {
             "additionalProperties": false,
@@ -7364,7 +7416,7 @@
           }
         },
         {
-          "code": -32019,
+          "code": -32020,
           "message": "Application error: IDEMPOTENCY_CONFLICT",
           "data": {
             "additionalProperties": false,
@@ -8278,7 +8330,6 @@
             "type": "object"
           },
           "force": {
-            "const": true,
             "type": "boolean"
           },
           "ok": {
@@ -10978,8 +11029,60 @@
           "type": "object"
         }
       },
-      "BUNDLE_MISMATCH": {
+      "BUNDLE_HAS_ACTIVE_RUNS": {
         "code": -32005,
+        "message": "Application error: BUNDLE_HAS_ACTIVE_RUNS",
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "const": "BUNDLE_HAS_ACTIVE_RUNS",
+              "type": "string"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": false,
+              "properties": {
+                "active_run_ids": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpaqueId"
+                  },
+                  "type": "array"
+                },
+                "active_runs": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "bundle_hash": {
+                  "$ref": "#/components/schemas/BundleHash"
+                }
+              },
+              "required": [
+                "bundle_hash",
+                "active_run_ids"
+              ],
+              "type": "object"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "details",
+            "retryable",
+            "correlation_id"
+          ],
+          "type": "object"
+        }
+      },
+      "BUNDLE_MISMATCH": {
+        "code": -32006,
         "message": "Application error: BUNDLE_MISMATCH",
         "data": {
           "additionalProperties": false,
@@ -11029,7 +11132,7 @@
         }
       },
       "BUNDLE_NOT_FOUND": {
-        "code": -32006,
+        "code": -32007,
         "message": "Application error: BUNDLE_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11067,7 +11170,7 @@
         }
       },
       "BUNDLE_REGISTER_CONFLICT": {
-        "code": -32007,
+        "code": -32008,
         "message": "Application error: BUNDLE_REGISTER_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -11105,7 +11208,7 @@
         }
       },
       "BUNDLE_SCOPE_REQUIRED": {
-        "code": -32008,
+        "code": -32009,
         "message": "Application error: BUNDLE_SCOPE_REQUIRED",
         "data": {
           "additionalProperties": false,
@@ -11150,7 +11253,7 @@
         }
       },
       "BUNDLE_UNAVAILABLE": {
-        "code": -32009,
+        "code": -32010,
         "message": "Application error: BUNDLE_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11203,7 +11306,7 @@
         }
       },
       "ENTITY_NOT_FOUND": {
-        "code": -32010,
+        "code": -32011,
         "message": "Application error: ENTITY_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11241,7 +11344,7 @@
         }
       },
       "EVENT_NOT_DECLARED": {
-        "code": -32011,
+        "code": -32012,
         "message": "Application error: EVENT_NOT_DECLARED",
         "data": {
           "additionalProperties": false,
@@ -11294,7 +11397,7 @@
         }
       },
       "EVENT_NOT_FOUND": {
-        "code": -32012,
+        "code": -32013,
         "message": "Application error: EVENT_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11332,7 +11435,7 @@
         }
       },
       "EVENT_PUBLISH_FAILED": {
-        "code": -32013,
+        "code": -32014,
         "message": "Application error: EVENT_PUBLISH_FAILED",
         "data": {
           "additionalProperties": false,
@@ -11389,7 +11492,7 @@
         }
       },
       "EVENT_REPLAY_NOT_ELIGIBLE": {
-        "code": -32014,
+        "code": -32015,
         "message": "Application error: EVENT_REPLAY_NOT_ELIGIBLE",
         "data": {
           "additionalProperties": false,
@@ -11443,7 +11546,7 @@
         }
       },
       "EVENT_REPLAY_NO_DELIVERY_HISTORY": {
-        "code": -32015,
+        "code": -32016,
         "message": "Application error: EVENT_REPLAY_NO_DELIVERY_HISTORY",
         "data": {
           "additionalProperties": false,
@@ -11481,7 +11584,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL": {
-        "code": -32016,
+        "code": -32017,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_NOT_ORIGINAL",
         "data": {
           "additionalProperties": false,
@@ -11536,7 +11639,7 @@
         }
       },
       "EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE": {
-        "code": -32017,
+        "code": -32018,
         "message": "Application error: EVENT_REPLAY_SUBSCRIBER_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11596,7 +11699,7 @@
         }
       },
       "FORK_NOT_FOUND": {
-        "code": -32018,
+        "code": -32019,
         "message": "Application error: FORK_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11634,7 +11737,7 @@
         }
       },
       "IDEMPOTENCY_CONFLICT": {
-        "code": -32019,
+        "code": -32020,
         "message": "Application error: IDEMPOTENCY_CONFLICT",
         "data": {
           "additionalProperties": false,
@@ -11693,7 +11796,7 @@
         }
       },
       "INVALID_DEFER_UNTIL": {
-        "code": -32020,
+        "code": -32021,
         "message": "Application error: INVALID_DEFER_UNTIL",
         "data": {
           "additionalProperties": false,
@@ -11738,7 +11841,7 @@
         }
       },
       "MAILBOX_ALREADY_DECIDED": {
-        "code": -32021,
+        "code": -32022,
         "message": "Application error: MAILBOX_ALREADY_DECIDED",
         "data": {
           "additionalProperties": false,
@@ -11790,7 +11893,7 @@
         }
       },
       "MAILBOX_APPROVAL_EVENT_UNCONFIGURED": {
-        "code": -32022,
+        "code": -32023,
         "message": "Application error: MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
         "data": {
           "additionalProperties": false,
@@ -11832,7 +11935,7 @@
         }
       },
       "MAILBOX_NOT_FOUND": {
-        "code": -32023,
+        "code": -32024,
         "message": "Application error: MAILBOX_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -11870,7 +11973,7 @@
         }
       },
       "METHOD_UNAVAILABLE": {
-        "code": -32024,
+        "code": -32025,
         "message": "Application error: METHOD_UNAVAILABLE",
         "data": {
           "additionalProperties": false,
@@ -11908,7 +12011,7 @@
         }
       },
       "PAYLOAD_VALIDATION_FAILED": {
-        "code": -32025,
+        "code": -32026,
         "message": "Application error: PAYLOAD_VALIDATION_FAILED",
         "data": {
           "additionalProperties": false,
@@ -11966,7 +12069,7 @@
         }
       },
       "RUNTIME_ALREADY_PAUSED": {
-        "code": -32026,
+        "code": -32027,
         "message": "Application error: RUNTIME_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -11997,7 +12100,7 @@
         }
       },
       "RUNTIME_NOT_PAUSED": {
-        "code": -32027,
+        "code": -32028,
         "message": "Application error: RUNTIME_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -12028,7 +12131,7 @@
         }
       },
       "RUNTIME_NUKE_IN_PROGRESS": {
-        "code": -32028,
+        "code": -32029,
         "message": "Application error: RUNTIME_NUKE_IN_PROGRESS",
         "data": {
           "additionalProperties": false,
@@ -12066,7 +12169,7 @@
         }
       },
       "RUN_ALREADY_PAUSED": {
-        "code": -32029,
+        "code": -32030,
         "message": "Application error: RUN_ALREADY_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -12104,7 +12207,7 @@
         }
       },
       "RUN_ALREADY_TERMINAL": {
-        "code": -32030,
+        "code": -32031,
         "message": "Application error: RUN_ALREADY_TERMINAL",
         "data": {
           "additionalProperties": false,
@@ -12146,7 +12249,7 @@
         }
       },
       "RUN_NOT_FOUND": {
-        "code": -32031,
+        "code": -32032,
         "message": "Application error: RUN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -12184,7 +12287,7 @@
         }
       },
       "RUN_NOT_PAUSED": {
-        "code": -32032,
+        "code": -32033,
         "message": "Application error: RUN_NOT_PAUSED",
         "data": {
           "additionalProperties": false,
@@ -12226,7 +12329,7 @@
         }
       },
       "SESSION_NOT_FOUND": {
-        "code": -32033,
+        "code": -32034,
         "message": "Application error: SESSION_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -12264,7 +12367,7 @@
         }
       },
       "TURN_NOT_FOUND": {
-        "code": -32034,
+        "code": -32035,
         "message": "Application error: TURN_NOT_FOUND",
         "data": {
           "additionalProperties": false,
@@ -12307,7 +12410,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH": {
-        "code": -32035,
+        "code": -32036,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH",
         "data": {
           "additionalProperties": false,
@@ -12342,7 +12445,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_HASH_FORK": {
-        "code": -32036,
+        "code": -32037,
         "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
         "data": {
           "additionalProperties": false,
@@ -12392,7 +12495,7 @@
         }
       },
       "UNSUPPORTED_BUNDLE_REF": {
-        "code": -32037,
+        "code": -32038,
         "message": "Application error: UNSUPPORTED_BUNDLE_REF",
         "data": {
           "additionalProperties": false,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5566,15 +5566,16 @@ multi_bundle_persistence:
     promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
     generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
-    current_openrpc_status: bundle_read_catalog_register_run_fork_and_force_delete_methods_published
+    current_openrpc_status: bundle_read_catalog_register_run_fork_and_delete_methods_published
     rule: >
       Generated openrpc.json is derived from api_specification.method_catalog and must continue to match the currently
       registered /v1/rpc handler set. The read-only bundle.list, bundle.get, and bundle.agents catalog methods are now
       published because their handlers and store owner are implemented in the same gated PR. run.fork is now published
       because its selected-contract API/runtime handler owner is implemented in the same gated PR. Mutating bundle.register
       is now published because its handler, idempotency behavior, shared bundle catalog writer, and generated artifacts are
-      implemented together. Force-only bundle.delete is now published because its API/runtime handler owner is implemented
-      in the same gated PR; omitted or false force remains fail-closed and split to #1018.
+      implemented together. bundle.delete is now published because its API/runtime handler owners are implemented in gated
+      PRs: omitted or false force performs the #1018 non-force delete path, while force=true performs the #1019 force-delete
+      cleanup path.
     proof_expectation: >
       Source-authority promotion proof must verify that generated OpenRPC methods are not silently published without
       implementation, and that future implementation PRs promote matching method_catalog entries and generated artifacts
@@ -5857,7 +5858,7 @@ multi_bundle_persistence:
       Without --force, deleting a bundle with any active run using that bundle fails closed with BUNDLE_HAS_ACTIVE_RUNS.
     phase_5_atomicity:
       tracker: '#1009'
-      implementation_status: implemented_for_force_delete_runtime_non_force_pending
+      implementation_status: implemented_for_force_and_non_force_delete_runtime
       canonical_runtime_owner: internal/store.PostgresStore.ApplyBundleDeleteFinalMutation
       applies_to:
         - '#1018 non-force bundle.delete final bundle availability mutation'
@@ -5882,7 +5883,7 @@ multi_bundle_persistence:
         existing bundle row or the post-delete deleted source with no row. They must not observe a legitimate delete as
         bundle_source=persisted with a missing bundle row.
       post_delete_new_work_admission:
-        status: implemented_for_force_delete_runtime
+        status: implemented_for_force_and_non_force_delete_runtime
         canonical_owner: internal/store/runlifecycle.EnsureActive
         consumed_by:
           - internal/store.PostgresStore.ensureRunRow
@@ -5895,8 +5896,8 @@ multi_bundle_persistence:
           New work or run-scoped runtime/mutation records stamped from a persisted runtime BundleSourceFact MUST serialize
           against the runs table, re-check that bundles still contains the source bundle_hash in the same transaction as
           the run-row creation, and fail closed before inserting a run, event, runtime-log row, or mutation-log row when
-          the bundle row has been deleted. A successful bundle.delete --force must therefore make later same-runtime
-          event.publish, run.start, runtime-log, and mutation-log attempts fail closed rather than recreating
+          the bundle row has been deleted. A successful bundle.delete, with or without --force, must therefore make later
+          same-runtime event.publish, run.start, runtime-log, and mutation-log attempts fail closed rather than recreating
           bundle_source=persisted with a missing bundle row.
       reader_invariant: >
         Bundle availability readers MUST read runs.bundle_source before consulting bundles. Readers only look up bundles
@@ -5930,7 +5931,7 @@ multi_bundle_persistence:
         - containers_stopped
         - dry_run
   api_surface:
-    publication_status: bundle_read_catalog_register_run_fork_and_force_delete_generated_openrpc
+    publication_status: bundle_read_catalog_register_run_fork_and_delete_generated_openrpc
     command_transport_owner: api_specification
     bundle_methods_planned:
       bundle.list:
@@ -6064,9 +6065,11 @@ multi_bundle_persistence:
       reason: bundle.list/get/agents/register method publication, store owners, OpenRPC artifacts, and handler tests are API implementation.
     bundle_delete_non_force:
       tracker: '#1018'
-      reason: Non-force bundle.delete active-run refusal and non-active deleted marking are API/store lifecycle implementation.
+      implementation_status: implemented_api_store_runtime
+      reason: Non-force bundle.delete active-run refusal and non-active deleted marking are implemented by the API handler and shared store transaction owner.
     bundle_delete_force:
       tracker: '#1019'
+      implementation_status: implemented_destructive_runtime
       reason: Forced bundle.delete preservation cleanup, mutex, quiescence, delivery/session/timer/container cleanup, and result projection are destructive-runtime implementation.
     serve_db_loaded_bundle:
       tracker: '#1020'
@@ -6107,7 +6110,7 @@ multi_bundle_persistence:
     multi_bundle_cli_inventory:
       tracker: '#1023'
       implementation_status: read_only_inventory_implemented
-      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only; bundle.register API is live but the CLI command remains split from this read-only inventory slice, and bundle.delete remains split until its API/runtime owner lands.
+      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only; bundle.register and bundle.delete APIs are live but their CLI commands remain split from this read-only inventory slice.
     bundle_hash_dual_accept_migration:
       tracker: '#1001'
       reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
@@ -9568,7 +9571,7 @@ cli_specification:
       command: swarm bundle list|show|agents
       tier: should_have
       implementation_status: implemented_read_only_inventory
-      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. bundle.register API is live, but the swarm bundle register CLI consumer remains split/absent from this read-only inventory slice; bundle.delete remains split until its API/runtime owner is promoted.'
+      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. bundle.register and bundle.delete APIs are live, but the swarm bundle register/delete CLI consumers remain split/absent from this read-only inventory slice.'
       owners:
       - multi_bundle_persistence.cli_surface.bundle_commands_supported
       - multi_bundle_persistence.api_surface.bundle_methods_planned
@@ -9576,8 +9579,8 @@ cli_specification:
         Public CLI family for persisted bundle inventory and agent catalog inspection. The implemented list/show/agents
         commands consume /v1/rpc bundle.list, bundle.get, and bundle.agents only. The CLI must not call internal
         store/runtime helpers or infer bundle state from local files. The live mutating /v1/rpc bundle.register API is
-        intentionally not exposed by this CLI slice; swarm bundle register remains a split CLI consumer. Destructive
-        bundle.delete remains split until its API/runtime owner lands.
+        intentionally not exposed by this CLI slice; swarm bundle register and swarm bundle delete remain split CLI consumers
+        even though the corresponding /v1/rpc APIs are live.
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
       - invalid args and missing SWARM_API_TOKEN make zero API calls
@@ -10066,7 +10069,7 @@ api_specification:
       downgraded to backlog before it can be used as implementation authority.
   multi_bundle_publication_boundary:
     owner: multi_bundle_persistence.api_surface
-    status: partial_bundle_read_catalog_register_run_fork_and_force_delete_method_catalog
+    status: partial_bundle_read_catalog_register_run_fork_and_delete_method_catalog
     rule: >
       #1012 promotes the multi-bundle API contract as source authority, including bundle.* methods, run.fork, bundle_hash
       filters, and bundle_hash create-new-work params. The read-only bundle.list, bundle.get, and bundle.agents methods are
@@ -10075,8 +10078,8 @@ api_specification:
       bundle register CLI consumer in #1023's read-only inventory slice. run.fork is also promoted into
       method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by #989. The swarm bundle
       list/show/agents and swarm fork CLI consumers are implemented by #1023 and consume only those canonical /v1/rpc
-      methods. Force-only bundle.delete is promoted into method_catalog/OpenRPC with matching API/runtime handler proof by
-      #1019; omitted or false force remains fail-closed and split to #1018. Remaining multi-bundle methods and shapes are
+      methods. bundle.delete is promoted into method_catalog/OpenRPC with matching API/runtime handler proof by #1018 and
+      #1019: omitted or false force performs non-force deletion and force=true performs force cleanup. Remaining multi-bundle methods and shapes are
       not in method_catalog/OpenRPC until a later gated API/runtime implementation PR registers handlers and regenerates
       openrpc.json/proof artifacts in the same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or
       #1038 prose as API authority after #1012.
@@ -10836,7 +10839,6 @@ api_specification:
             $ref: '#/components/schemas/BundleHash'
           force:
             type: boolean
-            const: true
           deleted:
             type: boolean
           dry_run:
@@ -13076,6 +13078,24 @@ api_specification:
           operation_name:
             type: string
             const: bundle.delete
+      BUNDLE_HAS_ACTIVE_RUNS:
+        type: object
+        additionalProperties: false
+        required:
+        - bundle_hash
+        - active_run_ids
+        properties:
+          bundle_hash:
+            $ref: '#/components/schemas/BundleHash'
+          active_run_ids:
+            type: array
+            items:
+              $ref: '#/components/schemas/OpaqueId'
+          active_runs:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
       BUNDLE_UNAVAILABLE:
         type: object
         additionalProperties: false
@@ -13670,12 +13690,14 @@ api_specification:
     bundle.delete:
       tier: should_have
       description: >
-        Force-only destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency
-        contract and MUST consume the bundle-delete owner chain for execution: shared destructive-operation mutex, bundle
-        plan, preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and
-        the #1009 source-first final store transaction. `force=false` and omitted force are intentionally fail-closed and
-        split to #1018; this method MUST NOT implement non-force deletion, CLI behavior, runtime.nuke include_bundles, or
-        broad multi-bundle lifecycle cleanup.
+        Destructive bundle delete wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and
+        MUST consume the bundle-delete owner chain for execution. Omitted or false force performs the #1018 non-force path:
+        plan persisted run users, fail closed with BUNDLE_HAS_ACTIVE_RUNS when running or paused persisted users exist, and
+        otherwise consume the #1009 source-first final store transaction to mark eligible persisted runs deleted before
+        deleting the bundle row. force=true performs the #1019 force path: shared destructive-operation mutex, bundle plan,
+        preservation cleanup for active affected runs, managed entity-container selection/stop by run identity, and the same
+        final store transaction after cleanup succeeds. This method MUST NOT implement CLI behavior, runtime.nuke
+        include_bundles, or broad multi-bundle lifecycle cleanup.
       scope:
         required:
         - control:runtime
@@ -13706,6 +13728,7 @@ api_specification:
           $ref: '#/components/schemas/BundleDeleteResult'
       errors:
       - BUNDLE_NOT_FOUND
+      - BUNDLE_HAS_ACTIVE_RUNS
       - BUNDLE_DELETE_IN_PROGRESS
       - IDEMPOTENCY_CONFLICT
     health.subscribe:
@@ -15684,8 +15707,8 @@ api_specification:
         Legacy dynamic bundle.open/reload/close remains deferred and is not the multi-bundle public API. #1012 promotes the
         authoritative multi-bundle source model under multi_bundle_persistence, with planned bundle.list/get/agents/register/delete,
         run.fork, and bundle_hash create-new-work semantics. The read-only bundle.list/get/agents catalog methods and
-        non-destructive bundle.register and run.fork are now published in method_catalog/OpenRPC with handlers;
-        bundle.delete remains withheld until its gated API/runtime implementation lands. Existing bundle_ref/bundle_fingerprint
+        non-destructive bundle.register, run.fork, and destructive bundle.delete are now published in method_catalog/OpenRPC
+        with handlers. Existing bundle_ref/bundle_fingerprint
         language is migration evidence only after the #1001 bundle_hash decision.
     verify:
       methods:


### PR DESCRIPTION
## Summary
- Implements non-force `bundle.delete` over the shared bundle-delete owner chain.
- Publishes the live non-force contract in `platform-spec.yaml` and regenerated `openrpc.json`, including `BUNDLE_HAS_ACTIVE_RUNS` and `BundleDeleteResult.force=false` support.
- Preserves the already-landed #1019 force-delete path and keeps CLI/runtime.nuke/RuntimeContextManager/cross-bundle work split.

Closes #1018

## Governing Refs
- `platform-spec.yaml#multi_bundle_persistence.bundle_delete`
- `platform-spec.yaml#multi_bundle_persistence.bundle_delete.phase_5_atomicity`
- `platform-spec.yaml#api_specification.method_catalog.bundle.delete`
- `platform-spec.yaml#api_specification.components.schemas.BundleDeleteResult`
- `platform-spec.yaml#api_specification.components.errors.BUNDLE_HAS_ACTIVE_RUNS`
- #1018 pre-audit and independent gate
- #1009 source-first final mutation owner
- #1019 force-delete cleanup path, already landed

## Semantic Migration
- Canonical owner: `internal/store.PostgresStore.ApplyBundleDeleteFinalMutation`, coordinated by `internal/runtime/bundledelete.Coordinator`.
- Old invalid path: `/v1/rpc bundle.delete` with omitted/false `force` no longer fails before the owner chain; it now invokes the non-force owner path.
- Production paths checked for surviving old behavior: API handler, runtime coordinator, store final mutation, generated OpenRPC, API compliance matrix, platform-spec publication tests, post-delete new-work admission tests.
- Migration complete for the #1018 class: non-force API/runtime/store behavior is live; force cleanup remains #1019; CLI bundle delete, runtime.nuke include_bundles, RuntimeContextManager unload, and broad lifecycle cleanup remain split.

## Proof
- `go test ./internal/runtime/bundledelete ./internal/store ./internal/apiv1 ./internal/apispec`
- `go test ./...`
- Rebased onto `origin/master` at `057b6192`; reran `go test ./...` after rebase.