### PR TITLE
[agent-c][issue #1027] Add runtime.nuke bundle catalog inclusion

### DIFF
--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -375,7 +375,7 @@ func mutatingHTTPRuntimeFixtures() map[string]mutatingHTTPRuntimeFixture {
 		"runtime.nuke": {
 			Params:         map[string]any{"dry_run": false},
 			ConflictParams: map[string]any{"dry_run": true},
-			ResultKeys:     []string{"ok", "status", "operation_name", "plan", "quiescence", "cleanup", "containers"},
+			ResultKeys:     []string{"ok", "status", "dry_run", "include_bundles", "operation_name", "plan", "quiescence", "cleanup", "containers"},
 			SuccessEffects: 4,
 		},
 		"runtime.pause": {

--- a/internal/apiv1/operator_runtime_nuke.go
+++ b/internal/apiv1/operator_runtime_nuke.go
@@ -34,6 +34,7 @@ type runtimeNukeResult struct {
 	OK             bool                                  `json:"ok"`
 	Status         string                                `json:"status"`
 	DryRun         bool                                  `json:"dry_run"`
+	IncludeBundles bool                                  `json:"include_bundles"`
 	OperationName  string                                `json:"operation_name"`
 	Plan           destructivereset.Result               `json:"plan"`
 	Quiescence     destructivereset.QuiescenceResult     `json:"quiescence"`
@@ -68,6 +69,10 @@ func executeRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptio
 	if err != nil {
 		return nil, err
 	}
+	includeBundles, err := optionalBoolParam(req.Params, "include_bundles", true)
+	if err != nil {
+		return nil, err
+	}
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return nil, err
@@ -81,7 +86,7 @@ func executeRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptio
 		TTL:            runtimeNukeIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		result, err := performRuntimeNuke(ctx, req, opts, dryRun, now)
+		result, err := performRuntimeNuke(ctx, req, opts, dryRun, includeBundles, now)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
@@ -107,15 +112,17 @@ func executeRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptio
 	return stored, nil
 }
 
-func performRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptions, dryRun bool, now time.Time) (runtimeNukeResult, error) {
+func performRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptions, dryRun, includeBundles bool, now time.Time) (runtimeNukeResult, error) {
 	var quiescence destructivereset.QuiescenceResult
 	var cleanup destructivereset.CleanupResult
 	var containers destructivereset.ContainerResetResult
 	planResult, _, err := opts.ResetCoordinator.BuildPlanWithLock(ctx, destructivereset.Request{
-		ActorTokenID: req.ActorTokenID,
-		RequestHash:  req.RequestHash,
-		DryRun:       dryRun,
-		RequestedAt:  now,
+		ActorTokenID:      req.ActorTokenID,
+		RequestHash:       req.RequestHash,
+		DryRun:            dryRun,
+		IncludeBundles:    includeBundles,
+		IncludeBundlesSet: true,
+		RequestedAt:       now,
 	}, func(ctx context.Context, planResult destructivereset.Result) error {
 		var err error
 		quiescence, err = opts.ResetQuiescer.Apply(ctx, destructivereset.QuiescenceRequest{
@@ -147,14 +154,15 @@ func performRuntimeNuke(ctx context.Context, req Request, opts OperatorReadOptio
 		return runtimeNukeResult{}, err
 	}
 	result := runtimeNukeResult{
-		OK:            true,
-		Status:        "completed",
-		DryRun:        dryRun,
-		OperationName: strings.TrimSpace(planResult.OperationName),
-		Plan:          planResult,
-		Quiescence:    quiescence,
-		Cleanup:       cleanup,
-		Containers:    containers,
+		OK:             true,
+		Status:         "completed",
+		DryRun:         dryRun,
+		IncludeBundles: planResult.IncludeBundles,
+		OperationName:  strings.TrimSpace(planResult.OperationName),
+		Plan:           planResult,
+		Quiescence:     quiescence,
+		Cleanup:        cleanup,
+		Containers:     containers,
 	}
 	if result.OperationName == "" {
 		result.OperationName = destructivereset.DefaultOperationName

--- a/internal/apiv1/operator_runtime_nuke_test.go
+++ b/internal/apiv1/operator_runtime_nuke_test.go
@@ -35,7 +35,7 @@ func TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners(t *testing.T) {
 		t.Fatalf("runtime.nuke dry-run error = %#v", resp.Error)
 	}
 	result := asMap(t, resp.Result)
-	if result["ok"] != true || result["status"] != "dry_run" || result["dry_run"] != true || result["partial_failure"] != false {
+	if result["ok"] != true || result["status"] != "dry_run" || result["dry_run"] != true || result["include_bundles"] != true || result["partial_failure"] != false {
 		t.Fatalf("runtime.nuke dry-run result = %#v", result)
 	}
 	if got, want := strings.Join(owners.calls, ","), "plan,quiescence,cleanup,containers"; got != want {
@@ -45,6 +45,9 @@ func TestOperatorRuntimeNukeDryRunUsesDestructiveResetOwners(t *testing.T) {
 	assertRuntimeNukeContractStatus(t, result, destructivereset.ContractLegacyResetMigration, "split")
 	if owners.lastPlan.DryRun != true || owners.lastQuiescence.Result.DryRun != true || owners.lastCleanup.Result.DryRun != true || owners.lastContainers.Result.DryRun != true {
 		t.Fatalf("dry-run flag not propagated through owners: plan=%v quiescence=%v cleanup=%v containers=%v", owners.lastPlan.DryRun, owners.lastQuiescence.Result.DryRun, owners.lastCleanup.Result.DryRun, owners.lastContainers.Result.DryRun)
+	}
+	if !owners.lastPlan.IncludeBundles || !owners.lastPlan.IncludeBundlesSet || !owners.lastQuiescence.Result.IncludeBundles || !owners.lastCleanup.Result.IncludeBundles || !owners.lastContainers.Result.IncludeBundles {
+		t.Fatalf("include_bundles default not propagated through owners: plan=%#v quiescence=%v cleanup=%v containers=%v", owners.lastPlan, owners.lastQuiescence.Result.IncludeBundles, owners.lastCleanup.Result.IncludeBundles, owners.lastContainers.Result.IncludeBundles)
 	}
 }
 
@@ -66,15 +69,18 @@ func TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency(t *testing.
 			ResetContainers:  recordingRuntimeNukeContainerStopper{owners},
 		}),
 	})
-	body := `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"idempotency_key":"apply"}}`
+	body := `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"include_bundles":false,"idempotency_key":"apply"}}`
 
 	resp := rpcCall(t, handler, body)
 	if resp.Error != nil {
 		t.Fatalf("runtime.nuke apply error = %#v", resp.Error)
 	}
 	result := asMap(t, resp.Result)
-	if result["ok"] != false || result["status"] != "partial_failure" || result["partial_failure"] != true {
+	if result["ok"] != false || result["status"] != "partial_failure" || result["include_bundles"] != false || result["partial_failure"] != true {
 		t.Fatalf("runtime.nuke partial result = %#v", result)
+	}
+	if owners.lastPlan.IncludeBundles || !owners.lastPlan.IncludeBundlesSet || owners.lastCleanup.Result.IncludeBundles || owners.lastContainers.Result.IncludeBundles {
+		t.Fatalf("include_bundles=false not propagated through owners: plan=%#v cleanup=%v containers=%v", owners.lastPlan, owners.lastCleanup.Result.IncludeBundles, owners.lastContainers.Result.IncludeBundles)
 	}
 	if len(owners.calls) != 4 {
 		t.Fatalf("owner call count = %d, want 4", len(owners.calls))
@@ -88,7 +94,7 @@ func TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency(t *testing.
 		t.Fatalf("owner calls after replay = %d, want unchanged 4", len(owners.calls))
 	}
 
-	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"dry_run":true,"idempotency_key":"apply"}}`)
+	conflict := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"nuke","method":"runtime.nuke","params":{"include_bundles":true,"idempotency_key":"apply"}}`)
 	if conflict.Error == nil {
 		t.Fatal("runtime.nuke idempotency conflict error = nil")
 	}
@@ -177,11 +183,13 @@ func (o *recordingRuntimeNukeOwners) BuildPlan(_ context.Context, req destructiv
 		return destructivereset.Result{}, false, o.planErr
 	}
 	return destructivereset.Result{
-		OperationName: destructivereset.DefaultOperationName,
-		DryRun:        req.DryRun,
-		PlannedAt:     req.RequestedAt,
+		OperationName:  destructivereset.DefaultOperationName,
+		DryRun:         req.DryRun,
+		IncludeBundles: req.IncludeBundles,
+		PlannedAt:      req.RequestedAt,
 		Plan: destructivereset.Plan{
-			ActiveRuns: []destructivereset.RunRef{{RunID: "00000000-0000-0000-0000-000000000001", Status: "running"}},
+			IncludeBundles: req.IncludeBundles,
+			ActiveRuns:     []destructivereset.RunRef{{RunID: "00000000-0000-0000-0000-000000000001", Status: "running"}},
 			EntityContainers: []destructivereset.ContainerRef{{
 				Name:          "swarm-agent-1",
 				Kind:          "agent",
@@ -229,10 +237,11 @@ func (q recordingRuntimeNukeQuiescer) Apply(ctx context.Context, req destructive
 
 func (o *recordingRuntimeNukeOwners) ApplyCleanup(req destructivereset.CleanupRequest) destructivereset.CleanupResult {
 	return destructivereset.CleanupResult{
-		OperationName: req.Result.OperationName,
-		DryRun:        req.Result.DryRun,
-		AppliedAt:     req.RequestedAt,
-		RunIDs:        []string{"00000000-0000-0000-0000-000000000001"},
+		OperationName:  req.Result.OperationName,
+		DryRun:         req.Result.DryRun,
+		IncludeBundles: req.Result.IncludeBundles,
+		AppliedAt:      req.RequestedAt,
+		RunIDs:         []string{"00000000-0000-0000-0000-000000000001"},
 	}
 }
 

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -11,7 +11,12 @@ const (
 	CleanupDeleteMixedRowPolicy = "delete_mixed_row_policy"
 	CleanupPreserve             = "preserve"
 	CleanupSplitPreserve        = "split_preserve"
+	CleanupRequestScopedBundles = "request_scoped_bundle_catalog"
 )
+
+type CleanupPolicy struct {
+	IncludeBundles bool
+}
 
 func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 	return []CleanupCatalogEntry{
@@ -41,10 +46,18 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "agents", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "agent registry/config state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "flow_instances", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "product/config state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "routing_rules", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "routing/topology config", PreservationProof: "must survive destructive runtime cleanup"},
-		{Table: "bundles", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "global bundle catalog state", PreservationProof: "must survive destructive runtime cleanup"},
+		{Table: "bundles", TableKind: CleanupTableKindPlatform, Classification: CleanupRequestScopedBundles, PredicateOwner: "runtime.nuke include_bundles request policy", PreservationProof: "include_bundles=false preserves bundle catalog state; include_bundles=true deletes it as part of server-wide runtime.nuke"},
 		{Table: "mailbox", TableKind: CleanupTableKindPlatform, Classification: CleanupSplitPreserve, PredicateOwner: "no run_id; source_event_id policy split", PreservationProof: "preserve until a mailbox cleanup owner exists"},
 		{Table: "spend_ledger", TableKind: CleanupTableKindPlatform, Classification: CleanupSplitPreserve, PredicateOwner: "no run_id; cost audit policy split", PreservationProof: "preserve until a spend cleanup owner exists"},
 	}
+}
+
+func PlatformCleanupCatalogForPolicy(policy CleanupPolicy) []CleanupCatalogEntry {
+	catalog := DefaultPlatformCleanupCatalog()
+	for i := range catalog {
+		catalog[i] = CleanupEntryForPolicy(catalog[i], policy)
+	}
+	return catalog
 }
 
 func DefaultGeneratedCleanupCatalog() []CleanupCatalogEntry {
@@ -61,10 +74,42 @@ func DefaultCleanupCatalog() []CleanupCatalogEntry {
 	return out
 }
 
+func CleanupCatalogForPolicy(policy CleanupPolicy) []CleanupCatalogEntry {
+	out := PlatformCleanupCatalogForPolicy(policy)
+	out = append(out, DefaultGeneratedCleanupCatalog()...)
+	return out
+}
+
 func CleanupCatalogByTable() map[string]CleanupCatalogEntry {
 	out := map[string]CleanupCatalogEntry{}
 	for _, entry := range DefaultPlatformCleanupCatalog() {
 		out[entry.Table] = entry
 	}
 	return out
+}
+
+func CleanupCatalogByTableForPolicy(policy CleanupPolicy) map[string]CleanupCatalogEntry {
+	out := map[string]CleanupCatalogEntry{}
+	for _, entry := range PlatformCleanupCatalogForPolicy(policy) {
+		out[entry.Table] = entry
+	}
+	return out
+}
+
+func CleanupEntryForPolicy(entry CleanupCatalogEntry, policy CleanupPolicy) CleanupCatalogEntry {
+	if entry.Table != "bundles" || entry.Classification != CleanupRequestScopedBundles {
+		return entry
+	}
+	if policy.IncludeBundles {
+		entry.Classification = CleanupDeleteAll
+		entry.PredicateOwner = "runtime.nuke include_bundles=true server-wide bundle catalog deletion"
+		entry.DeleteOrderGroup = 6
+		entry.PreservationProof = ""
+		return entry
+	}
+	entry.Classification = CleanupPreserve
+	entry.PredicateOwner = "runtime.nuke include_bundles=false bundle catalog preservation"
+	entry.DeleteOrderGroup = 0
+	entry.PreservationProof = "bundle catalog rows must survive runtime.nuke when include_bundles=false"
+	return entry
 }

--- a/internal/runtime/destructivereset/cleanup_catalog_test.go
+++ b/internal/runtime/destructivereset/cleanup_catalog_test.go
@@ -71,6 +71,26 @@ func TestDefaultPlatformCleanupCatalogMatchesPlatformSpecPolicy(t *testing.T) {
 	}
 }
 
+func TestCleanupCatalogPolicyMapsRequestScopedBundles(t *testing.T) {
+	includeCatalog := CleanupCatalogByTableForPolicy(CleanupPolicy{IncludeBundles: true})
+	includeEntry, ok := includeCatalog["bundles"]
+	if !ok {
+		t.Fatal("include_bundles=true catalog missing bundles")
+	}
+	if includeEntry.Classification != CleanupDeleteAll || includeEntry.DeleteOrderGroup == 0 || includeEntry.PreservationProof != "" {
+		t.Fatalf("include_bundles=true bundles entry = %#v, want delete_all without preservation proof", includeEntry)
+	}
+
+	preserveCatalog := CleanupCatalogByTableForPolicy(CleanupPolicy{IncludeBundles: false})
+	preserveEntry, ok := preserveCatalog["bundles"]
+	if !ok {
+		t.Fatal("include_bundles=false catalog missing bundles")
+	}
+	if preserveEntry.Classification != CleanupPreserve || preserveEntry.DeleteOrderGroup != 0 || preserveEntry.PreservationProof == "" {
+		t.Fatalf("include_bundles=false bundles entry = %#v, want preserve with proof", preserveEntry)
+	}
+}
+
 func loadPlatformTableNamesForCleanupCatalogTest(t *testing.T) map[string]struct{} {
 	t.Helper()
 	repo := cleanupCatalogTestRepoRoot(t)

--- a/internal/runtime/destructivereset/coordinator.go
+++ b/internal/runtime/destructivereset/coordinator.go
@@ -83,10 +83,11 @@ func (c *Coordinator) BuildPlanWithLock(ctx context.Context, req Request, apply 
 		return Result{}, false, err
 	}
 	result := Result{
-		OperationName: operation,
-		DryRun:        req.DryRun,
-		PlannedAt:     req.RequestedAt,
-		Plan:          plan,
+		OperationName:  operation,
+		DryRun:         req.DryRun,
+		IncludeBundles: req.IncludeBundles,
+		PlannedAt:      req.RequestedAt,
+		Plan:           plan,
 	}
 	if apply != nil {
 		if err := apply(ctx, copyResult(result)); err != nil {

--- a/internal/runtime/destructivereset/coordinator_test.go
+++ b/internal/runtime/destructivereset/coordinator_test.go
@@ -44,6 +44,9 @@ func TestCoordinatorBuildPlanStoresAndReplaysIdempotentResult(t *testing.T) {
 	if result.OperationName != DefaultOperationName || !result.DryRun || !result.PlannedAt.Equal(now) {
 		t.Fatalf("result metadata = %#v, want operation/dry-run/time", result)
 	}
+	if !result.IncludeBundles || !result.Plan.IncludeBundles {
+		t.Fatalf("include_bundles = result:%v plan:%v, want default true through result and plan", result.IncludeBundles, result.Plan.IncludeBundles)
+	}
 	if len(result.Plan.ActiveRuns) != 1 || result.Plan.ActiveRuns[0].RunID != "run-1" {
 		t.Fatalf("active runs = %#v", result.Plan.ActiveRuns)
 	}
@@ -274,8 +277,11 @@ func TestInventoryPlannerCarriesImplementedContractsAndSplitResetSeams(t *testin
 		containsSeam(plan.ResetSeams, "scripts_private_reset_dev") {
 		t.Fatalf("reset seams = %#v, want retired dashboard/Builder and private reset helper seams omitted", plan.ResetSeams)
 	}
-	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || !plan.Preserved.BundleContracts {
-		t.Fatalf("preserved resources = %#v, want schema/auth/bundle preserved", plan.Preserved)
+	if !plan.IncludeBundles || !containsTableAction(plan.RunScopedTables, "bundles", CleanupDeleteAll) {
+		t.Fatalf("include_bundles plan = include:%v tables:%#v, want bundle catalog delete table", plan.IncludeBundles, plan.RunScopedTables)
+	}
+	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || plan.Preserved.BundleContracts {
+		t.Fatalf("preserved resources = %#v, want schema/auth preserved and bundle contracts not preserved when include_bundles defaults true", plan.Preserved)
 	}
 	if !slices.Contains(plan.Preserved.SystemContainers, "swarm-scaffold") || !slices.Contains(plan.Preserved.SystemContainers, "swarm-system") {
 		t.Fatalf("system containers = %#v, want scaffold/system preserved", plan.Preserved.SystemContainers)
@@ -288,7 +294,7 @@ func TestInventoryPlannerMergesPreservedResourceDefaultsByField(t *testing.T) {
 			SystemContainers: []string{"custom-system"},
 		},
 	}}
-	plan, err := (InventoryPlanner{Reader: reader}).BuildPlan(context.Background(), Request{})
+	plan, err := (InventoryPlanner{Reader: reader}).BuildPlan(context.Background(), Request{IncludeBundles: false, IncludeBundlesSet: true})
 	if err != nil {
 		t.Fatalf("BuildPlan error = %v", err)
 	}
@@ -300,6 +306,9 @@ func TestInventoryPlannerMergesPreservedResourceDefaultsByField(t *testing.T) {
 	}
 	if !plan.Preserved.SchemaMigrations || !plan.Preserved.AuthTokens || !plan.Preserved.BundleContracts {
 		t.Fatalf("preserved resources = %#v, want critical defaults merged", plan.Preserved)
+	}
+	if plan.IncludeBundles || containsTableAction(plan.RunScopedTables, "bundles", CleanupDeleteAll) {
+		t.Fatalf("include_bundles=false plan = include:%v tables:%#v, want bundle catalog preserved", plan.IncludeBundles, plan.RunScopedTables)
 	}
 }
 
@@ -459,5 +468,11 @@ func containsContractStatus(contracts []DownstreamContract, id, status string) b
 func containsSeam(seams []ResetSeam, id string) bool {
 	return slices.ContainsFunc(seams, func(seam ResetSeam) bool {
 		return seam.ID == id
+	})
+}
+
+func containsTableAction(tables []TableRef, name, action string) bool {
+	return slices.ContainsFunc(tables, func(table TableRef) bool {
+		return table.Name == name && table.Action == action
 	})
 }

--- a/internal/runtime/destructivereset/planner.go
+++ b/internal/runtime/destructivereset/planner.go
@@ -34,15 +34,17 @@ func (r CompositeInventoryReader) ReadResetInventory(ctx context.Context) (Inven
 	return inventory, nil
 }
 
-func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error) {
+func (p InventoryPlanner) BuildPlan(ctx context.Context, req Request) (Plan, error) {
 	if p.Reader == nil {
 		return Plan{}, ErrPlannerNotConfigured
 	}
+	includeBundles := req.includeBundles()
 	inventory, err := p.Reader.ReadResetInventory(ctx)
 	if err != nil {
 		return Plan{}, err
 	}
 	preserved := mergePreservedResources(inventory.Preserved)
+	preserved.BundleContracts = !includeBundles
 	contracts := p.DownstreamContracts
 	if len(contracts) == 0 {
 		contracts = DefaultDownstreamContracts()
@@ -55,13 +57,37 @@ func (p InventoryPlanner) BuildPlan(ctx context.Context, _ Request) (Plan, error
 		ActiveRuns:          append([]RunRef(nil), inventory.ActiveRuns...),
 		CleanupRuns:         append([]RunRef(nil), inventory.CleanupRuns...),
 		CleanupRunSetKnown:  inventory.CleanupRunSetKnown,
+		IncludeBundles:      includeBundles,
 		ActiveDeliveries:    append([]DeliveryRef(nil), inventory.ActiveDeliveries...),
-		RunScopedTables:     append([]TableRef(nil), inventory.RunScopedTables...),
+		RunScopedTables:     resetInventoryRunScopedTables(inventory.RunScopedTables, includeBundles),
 		EntityContainers:    append([]ContainerRef(nil), inventory.EntityContainers...),
 		Preserved:           copyPreservedResources(preserved),
 		DownstreamContracts: append([]DownstreamContract(nil), contracts...),
 		ResetSeams:          append([]ResetSeam(nil), seams...),
 	}, nil
+}
+
+func resetInventoryRunScopedTables(tables []TableRef, includeBundles bool) []TableRef {
+	out := append([]TableRef(nil), tables...)
+	if !includeBundles {
+		return out
+	}
+	entry, ok := CleanupCatalogByTableForPolicy(CleanupPolicy{IncludeBundles: true})["bundles"]
+	if !ok || entry.Classification != CleanupDeleteAll {
+		return out
+	}
+	for i := range out {
+		if out[i].Name == "bundles" {
+			out[i].Owner = ContractRunScopedTruncation
+			out[i].Action = entry.Classification
+			return out
+		}
+	}
+	return append(out, TableRef{
+		Name:   "bundles",
+		Owner:  ContractRunScopedTruncation,
+		Action: entry.Classification,
+	})
 }
 
 func copyPreservedResources(p PreservedResources) PreservedResources {

--- a/internal/runtime/destructivereset/types.go
+++ b/internal/runtime/destructivereset/types.go
@@ -35,18 +35,21 @@ var (
 )
 
 type Request struct {
-	ActorTokenID   string
-	IdempotencyKey string
-	RequestHash    string
-	DryRun         bool
-	RequestedAt    time.Time
+	ActorTokenID      string
+	IdempotencyKey    string
+	RequestHash       string
+	DryRun            bool
+	IncludeBundles    bool
+	IncludeBundlesSet bool
+	RequestedAt       time.Time
 }
 
 type Result struct {
-	OperationName string    `json:"operation_name"`
-	DryRun        bool      `json:"dry_run"`
-	PlannedAt     time.Time `json:"planned_at"`
-	Plan          Plan      `json:"plan"`
+	OperationName  string    `json:"operation_name"`
+	DryRun         bool      `json:"dry_run"`
+	IncludeBundles bool      `json:"include_bundles"`
+	PlannedAt      time.Time `json:"planned_at"`
+	Plan           Plan      `json:"plan"`
 }
 
 type QuiescenceRequest struct {
@@ -74,11 +77,12 @@ type CleanupRequest struct {
 }
 
 type CleanupResult struct {
-	OperationName string               `json:"operation_name"`
-	DryRun        bool                 `json:"dry_run"`
-	AppliedAt     time.Time            `json:"applied_at"`
-	RunIDs        []string             `json:"run_ids"`
-	Tables        []CleanupTableResult `json:"tables"`
+	OperationName  string               `json:"operation_name"`
+	DryRun         bool                 `json:"dry_run"`
+	IncludeBundles bool                 `json:"include_bundles"`
+	AppliedAt      time.Time            `json:"applied_at"`
+	RunIDs         []string             `json:"run_ids"`
+	Tables         []CleanupTableResult `json:"tables"`
 }
 
 type CleanupTableResult struct {
@@ -151,6 +155,7 @@ type Plan struct {
 	ActiveRuns          []RunRef             `json:"active_runs"`
 	CleanupRuns         []RunRef             `json:"cleanup_runs"`
 	CleanupRunSetKnown  bool                 `json:"cleanup_run_set_known"`
+	IncludeBundles      bool                 `json:"include_bundles"`
 	ActiveDeliveries    []DeliveryRef        `json:"active_deliveries"`
 	RunScopedTables     []TableRef           `json:"run_scoped_tables"`
 	EntityContainers    []ContainerRef       `json:"entity_containers"`
@@ -309,6 +314,10 @@ func (r Request) normalize(now time.Time) (Request, error) {
 	r.ActorTokenID = strings.TrimSpace(r.ActorTokenID)
 	r.IdempotencyKey = strings.TrimSpace(r.IdempotencyKey)
 	r.RequestHash = strings.TrimSpace(r.RequestHash)
+	if !r.IncludeBundlesSet {
+		r.IncludeBundles = true
+		r.IncludeBundlesSet = true
+	}
 	if r.ActorTokenID == "" {
 		return Request{}, fmt.Errorf("%w: actor token id is required", ErrInvalidRequest)
 	}
@@ -320,6 +329,13 @@ func (r Request) normalize(now time.Time) (Request, error) {
 	}
 	r.RequestedAt = r.RequestedAt.UTC()
 	return r, nil
+}
+
+func (r Request) includeBundles() bool {
+	if !r.IncludeBundlesSet {
+		return true
+	}
+	return r.IncludeBundles
 }
 
 func (k IdempotencyKey) normalized() IdempotencyKey {

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lib/pq"
 	"swarm/internal/runtime/destructivereset"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 type destructiveResetCleanupExecutor interface {
@@ -33,16 +34,17 @@ func (s *PostgresStore) ApplyDestructiveResetCleanup(ctx context.Context, req de
 		return destructivereset.CleanupResult{}, err
 	}
 	out := destructivereset.CleanupResult{
-		OperationName: strings.TrimSpace(req.Result.OperationName),
-		DryRun:        req.Result.DryRun,
-		AppliedAt:     now,
+		OperationName:  strings.TrimSpace(req.Result.OperationName),
+		DryRun:         req.Result.DryRun,
+		IncludeBundles: req.Result.IncludeBundles,
+		AppliedAt:      now,
 	}
 	if out.OperationName == "" {
 		out.OperationName = destructivereset.DefaultOperationName
 	}
 	if req.Result.DryRun {
 		out.RunIDs = runIDs
-		rows, err := destructiveResetCleanupTableResults(ctx, s.DB, runIDs)
+		rows, err := destructiveResetCleanupTableResults(ctx, s.DB, runIDs, req.Result.IncludeBundles)
 		if err != nil {
 			return destructivereset.CleanupResult{}, err
 		}
@@ -59,11 +61,16 @@ func (s *PostgresStore) ApplyDestructiveResetCleanup(ctx context.Context, req de
 	if err := lockDestructiveResetCleanupRuns(ctx, tx, runIDs); err != nil {
 		return destructivereset.CleanupResult{}, err
 	}
+	if req.Result.IncludeBundles {
+		if err := prepareDestructiveResetBundleCatalogDelete(ctx, tx, runIDs); err != nil {
+			return destructivereset.CleanupResult{}, err
+		}
+	}
 	if err := destructiveResetCleanupSeverPreservedReferences(ctx, tx, runIDs); err != nil {
 		return destructivereset.CleanupResult{}, err
 	}
 	out.RunIDs = runIDs
-	rows, err := destructiveResetCleanupTableResults(ctx, tx, runIDs)
+	rows, err := destructiveResetCleanupTableResults(ctx, tx, runIDs, req.Result.IncludeBundles)
 	if err != nil {
 		return destructivereset.CleanupResult{}, err
 	}
@@ -71,7 +78,7 @@ func (s *PostgresStore) ApplyDestructiveResetCleanup(ctx context.Context, req de
 		if rows[i].TableKind == destructivereset.CleanupTableKindGenerated {
 			continue
 		}
-		deleted, err := destructiveResetCleanupDeleteTable(ctx, tx, rows[i].Table, runIDs)
+		deleted, err := destructiveResetCleanupDeleteTable(ctx, tx, rows[i].Table, runIDs, req.Result.IncludeBundles)
 		if err != nil {
 			return destructivereset.CleanupResult{}, err
 		}
@@ -94,6 +101,9 @@ func validateDestructiveResetCleanupRequest(req destructivereset.CleanupRequest,
 	runIDs, err := destructiveResetCleanupRunIDsFromPlan(req.Result.Plan)
 	if err != nil {
 		return nil, err
+	}
+	if req.Result.Plan.IncludeBundles != req.Result.IncludeBundles {
+		return nil, fmt.Errorf("%w: destructive reset include_bundles result and plan mismatch", destructivereset.ErrInvalidRequest)
 	}
 	if req.Result.DryRun {
 		return runIDs, nil
@@ -188,6 +198,26 @@ func lockDestructiveResetCleanupRuns(ctx context.Context, exec destructiveResetC
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("lock destructive reset cleanup run ids: %w", err)
+	}
+	return nil
+}
+
+func prepareDestructiveResetBundleCatalogDelete(ctx context.Context, tx *sql.Tx, runIDs []string) error {
+	if err := lockBundleDeleteRunCreationTx(ctx, tx); err != nil {
+		return fmt.Errorf("lock runtime.nuke bundle catalog cleanup: %w", err)
+	}
+	var outOfPlan int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM runs
+		WHERE bundle_source = $2
+		  AND NULLIF(bundle_hash, '') IS NOT NULL
+		  AND NOT (run_id = ANY($1::uuid[]))
+	`, pq.Array(runIDs), storerunlifecycle.BundleSourcePersisted).Scan(&outOfPlan); err != nil {
+		return fmt.Errorf("validate runtime.nuke bundle catalog cleanup run snapshot: %w", err)
+	}
+	if outOfPlan > 0 {
+		return fmt.Errorf("%w: runtime.nuke include_bundles cannot delete bundle catalog with persisted bundle-source runs outside the cleanup plan", destructivereset.ErrInvalidRequest)
 	}
 	return nil
 }
@@ -296,8 +326,8 @@ func destructiveResetCleanupSeverPreservedReferences(ctx context.Context, exec d
 	return nil
 }
 
-func destructiveResetCleanupTableResults(ctx context.Context, exec destructiveResetCleanupExecutor, runIDs []string) ([]destructivereset.CleanupTableResult, error) {
-	catalog := destructivereset.DefaultCleanupCatalog()
+func destructiveResetCleanupTableResults(ctx context.Context, exec destructiveResetCleanupExecutor, runIDs []string, includeBundles bool) ([]destructivereset.CleanupTableResult, error) {
+	catalog := destructivereset.CleanupCatalogForPolicy(destructivereset.CleanupPolicy{IncludeBundles: includeBundles})
 	out := make([]destructivereset.CleanupTableResult, 0, len(catalog))
 	for _, entry := range catalog {
 		result := destructivereset.CleanupTableResult{
@@ -311,7 +341,7 @@ func destructiveResetCleanupTableResults(ctx context.Context, exec destructiveRe
 			out = append(out, result)
 			continue
 		}
-		count, err := destructiveResetCleanupCountTable(ctx, exec, entry, runIDs)
+		count, err := destructiveResetCleanupCountTable(ctx, exec, entry, runIDs, includeBundles)
 		if err != nil {
 			return nil, err
 		}
@@ -326,8 +356,8 @@ func destructiveResetCleanupTableResults(ctx context.Context, exec destructiveRe
 	return out, nil
 }
 
-func destructiveResetCleanupCountTable(ctx context.Context, exec destructiveResetCleanupExecutor, entry destructivereset.CleanupCatalogEntry, runIDs []string) (int64, error) {
-	query, args, err := destructiveResetCleanupQuery(entry.Table, "count", runIDs)
+func destructiveResetCleanupCountTable(ctx context.Context, exec destructiveResetCleanupExecutor, entry destructivereset.CleanupCatalogEntry, runIDs []string, includeBundles bool) (int64, error) {
+	query, args, err := destructiveResetCleanupQuery(entry.Table, "count", runIDs, includeBundles)
 	if err != nil {
 		return 0, err
 	}
@@ -338,8 +368,8 @@ func destructiveResetCleanupCountTable(ctx context.Context, exec destructiveRese
 	return count, nil
 }
 
-func destructiveResetCleanupDeleteTable(ctx context.Context, exec destructiveResetCleanupExecutor, table string, runIDs []string) (int64, error) {
-	query, args, err := destructiveResetCleanupQuery(table, "delete", runIDs)
+func destructiveResetCleanupDeleteTable(ctx context.Context, exec destructiveResetCleanupExecutor, table string, runIDs []string, includeBundles bool) (int64, error) {
+	query, args, err := destructiveResetCleanupQuery(table, "delete", runIDs, includeBundles)
 	if err != nil {
 		return 0, err
 	}
@@ -357,20 +387,26 @@ func destructiveResetCleanupDeleteTable(ctx context.Context, exec destructiveRes
 	return rows, nil
 }
 
-func destructiveResetCleanupQuery(table, mode string, runIDs []string) (string, []any, error) {
+func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBundles bool) (string, []any, error) {
 	table = strings.TrimSpace(table)
 	mode = strings.TrimSpace(mode)
 	if mode != "count" && mode != "delete" {
 		return "", nil, fmt.Errorf("unsupported destructive reset cleanup query mode %q", mode)
 	}
-	if len(runIDs) == 0 && mode == "delete" {
-		return "", nil, nil
-	}
-	if destructiveResetCleanupPreservesTable(table) {
+	if destructiveResetCleanupPreservesTable(table, includeBundles) {
 		if mode == "delete" {
 			return "", nil, nil
 		}
 		return fmt.Sprintf(`SELECT COUNT(*) FROM %s`, quoteIdent(table)), nil, nil
+	}
+	if table == "bundles" && includeBundles {
+		if mode == "count" {
+			return `SELECT COUNT(*) FROM bundles`, nil, nil
+		}
+		return `DELETE FROM bundles`, nil, nil
+	}
+	if len(runIDs) == 0 && mode == "delete" {
+		return "", nil, nil
 	}
 	if len(runIDs) == 0 {
 		return `SELECT 0`, nil, nil
@@ -514,8 +550,8 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string) (string, 
 	}
 }
 
-func destructiveResetCleanupPreservesTable(table string) bool {
-	entry, ok := destructivereset.CleanupCatalogByTable()[strings.TrimSpace(table)]
+func destructiveResetCleanupPreservesTable(table string, includeBundles bool) bool {
+	entry, ok := destructivereset.CleanupCatalogByTableForPolicy(destructivereset.CleanupPolicy{IncludeBundles: includeBundles})[strings.TrimSpace(table)]
 	if !ok {
 		return false
 	}

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -3,11 +3,13 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"swarm/internal/runtime/destructivereset"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
 	"swarm/internal/testutil"
 )
 
@@ -142,6 +144,170 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunCountsWithoutMutation(
 	}
 }
 
+func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesDeletesBundleCatalog(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	seed := seedDestructiveResetCleanupRows(t, ctx, pg)
+	seedDestructiveResetBundleRows(t, ctx, pg)
+
+	now := time.Date(2026, 5, 16, 18, 37, 0, 0, time.UTC)
+	result, err := pg.ApplyDestructiveResetCleanup(ctx, destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName:  destructivereset.DefaultOperationName,
+			IncludeBundles: true,
+			PlannedAt:      now.Add(-time.Minute),
+			Plan:           cleanupPlanForRunIDsIncludingBundles(seed.RunA, seed.RunB),
+		},
+		Quiescence: destructivereset.QuiescenceResult{
+			OperationName: destructivereset.DefaultOperationName,
+			AppliedAt:     now.Add(-30 * time.Second),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDestructiveResetCleanup include_bundles=true: %v", err)
+	}
+	if !result.IncludeBundles {
+		t.Fatalf("cleanup IncludeBundles = false, want true")
+	}
+	assertCleanupTableResult(t, result, "bundles", 2, 2)
+	if got := countRows(t, ctx, pg, "bundles"); got != 0 {
+		t.Fatalf("bundles after include_bundles=true cleanup = %d, want 0", got)
+	}
+	if got := countRows(t, ctx, pg, "runs"); got != 0 {
+		t.Fatalf("runs after include_bundles=true cleanup = %d, want existing cleanup still applied", got)
+	}
+}
+
+func TestPostgresStore_ApplyDestructiveResetCleanup_ExcludeBundlesPreservesBundleCatalog(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	seed := seedDestructiveResetCleanupRows(t, ctx, pg)
+	seedDestructiveResetBundleRows(t, ctx, pg)
+
+	now := time.Date(2026, 5, 16, 18, 38, 0, 0, time.UTC)
+	result, err := pg.ApplyDestructiveResetCleanup(ctx, destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName:  destructivereset.DefaultOperationName,
+			IncludeBundles: false,
+			PlannedAt:      now.Add(-time.Minute),
+			Plan:           cleanupPlanForRunIDs(seed.RunA, seed.RunB),
+		},
+		Quiescence: destructivereset.QuiescenceResult{
+			OperationName: destructivereset.DefaultOperationName,
+			AppliedAt:     now.Add(-30 * time.Second),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDestructiveResetCleanup include_bundles=false: %v", err)
+	}
+	if result.IncludeBundles {
+		t.Fatalf("cleanup IncludeBundles = true, want false")
+	}
+	assertCleanupTablePreserved(t, result, "bundles", 2)
+	if got := countRows(t, ctx, pg, "bundles"); got != 2 {
+		t.Fatalf("bundles after include_bundles=false cleanup = %d, want preserved", got)
+	}
+	if got := countRows(t, ctx, pg, "runs"); got != 0 {
+		t.Fatalf("runs after include_bundles=false cleanup = %d, want existing cleanup still applied", got)
+	}
+}
+
+func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunIncludeBundlesCountsWithoutMutation(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	seed := seedDestructiveResetCleanupRows(t, ctx, pg)
+	seedDestructiveResetBundleRows(t, ctx, pg)
+
+	now := time.Date(2026, 5, 16, 18, 39, 0, 0, time.UTC)
+	result, err := pg.ApplyDestructiveResetCleanup(ctx, destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName:  destructivereset.DefaultOperationName,
+			DryRun:         true,
+			IncludeBundles: true,
+			PlannedAt:      now.Add(-time.Minute),
+			Plan:           cleanupPlanForRunIDsIncludingBundles(seed.RunA, seed.RunB),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDestructiveResetCleanup dry-run include_bundles=true: %v", err)
+	}
+	assertCleanupTableResult(t, result, "bundles", 2, 0)
+	if got := countRows(t, ctx, pg, "bundles"); got != 2 {
+		t.Fatalf("bundles after dry-run include_bundles=true = %d, want preserved", got)
+	}
+	if got := countRows(t, ctx, pg, "runs"); got != 2 {
+		t.Fatalf("runs after dry-run include_bundles=true = %d, want preserved", got)
+	}
+}
+
+func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesRejectsOutOfPlanPersistedRun(t *testing.T) {
+	dsn, _, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.DB.Close() })
+	ctx := context.Background()
+	seedDestructiveResetBundleRows(t, ctx, pg)
+	outOfPlanRun := uuid.NewString()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, started_at)
+		VALUES ($1::uuid, 'completed', $2, $3, now())
+	`, outOfPlanRun, destructiveResetCleanupBundleHashA, storerunlifecycle.BundleSourcePersisted); err != nil {
+		t.Fatalf("seed out-of-plan persisted run: %v", err)
+	}
+
+	now := time.Date(2026, 5, 16, 18, 40, 0, 0, time.UTC)
+	_, err = pg.ApplyDestructiveResetCleanup(ctx, destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		RequestedAt:  now,
+		Result: destructivereset.Result{
+			OperationName:  destructivereset.DefaultOperationName,
+			IncludeBundles: true,
+			PlannedAt:      now.Add(-time.Minute),
+			Plan:           cleanupPlanForRunIDsIncludingBundles(),
+		},
+		Quiescence: destructivereset.QuiescenceResult{
+			OperationName: destructivereset.DefaultOperationName,
+			AppliedAt:     now.Add(-30 * time.Second),
+		},
+	})
+	if !errors.Is(err, destructivereset.ErrInvalidRequest) {
+		t.Fatalf("include_bundles=true out-of-plan error = %v, want ErrInvalidRequest", err)
+	}
+	if got := countRows(t, ctx, pg, "bundles"); got != 2 {
+		t.Fatalf("bundles after rejected include_bundles=true cleanup = %d, want rollback/preserved", got)
+	}
+	if got := countRowsWhere(t, ctx, pg, "runs", `run_id = $1::uuid`, outOfPlanRun); got != 1 {
+		t.Fatalf("out-of-plan run rows after rejected cleanup = %d, want preserved", got)
+	}
+}
+
 func TestPostgresStore_ApplyDestructiveResetCleanup_DoesNotDeleteRunsCreatedAfterPlan(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -152,7 +318,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DoesNotDeleteRunsCreatedAfte
 	t.Cleanup(func() { _ = pg.DB.Close() })
 	ctx := context.Background()
 	seedDestructiveResetCleanupRows(t, ctx, pg)
-	plan, err := (destructivereset.InventoryPlanner{Reader: pg}).BuildPlan(ctx, destructivereset.Request{ActorTokenID: "operator-token"})
+	plan, err := (destructivereset.InventoryPlanner{Reader: pg}).BuildPlan(ctx, destructivereset.Request{ActorTokenID: "operator-token", IncludeBundles: false, IncludeBundlesSet: true})
 	if err != nil {
 		t.Fatalf("BuildPlan: %v", err)
 	}
@@ -220,7 +386,7 @@ func TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanu
 	plan, err := (destructivereset.InventoryPlanner{Reader: destructivereset.CompositeInventoryReader{
 		Reader:     pg,
 		Containers: managedContainerInventoryFunc(func(context.Context) ([]destructivereset.ContainerRef, error) { return containerRefs, nil }),
-	}}).BuildPlan(ctx, destructivereset.Request{ActorTokenID: "operator-token"})
+	}}).BuildPlan(ctx, destructivereset.Request{ActorTokenID: "operator-token", IncludeBundles: false, IncludeBundlesSet: true})
 	if err != nil {
 		t.Fatalf("BuildPlan: %v", err)
 	}
@@ -683,10 +849,31 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RequiresPlannedCleanupRunSet
 	}
 }
 
+func TestValidateDestructiveResetCleanupRequestRejectsIncludeBundlesPlanMismatch(t *testing.T) {
+	now := time.Date(2026, 5, 16, 19, 2, 0, 0, time.UTC)
+	_, err := validateDestructiveResetCleanupRequest(destructivereset.CleanupRequest{
+		ActorTokenID: "operator-token",
+		Result: destructivereset.Result{
+			DryRun:         true,
+			IncludeBundles: true,
+			PlannedAt:      now.Add(-time.Minute),
+			Plan:           cleanupPlanForRunIDs(uuid.NewString()),
+		},
+	}, now)
+	if !errors.Is(err, destructivereset.ErrInvalidRequest) {
+		t.Fatalf("include_bundles plan mismatch error = %v, want ErrInvalidRequest", err)
+	}
+}
+
 type destructiveResetCleanupSeed struct {
 	RunA string
 	RunB string
 }
+
+const (
+	destructiveResetCleanupBundleHashA = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	destructiveResetCleanupBundleHashB = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
 
 type managedContainerInventoryFunc func(context.Context) ([]destructivereset.ContainerRef, error)
 
@@ -700,6 +887,12 @@ func cleanupPlanForRunIDs(runIDs ...string) destructivereset.Plan {
 		runs = append(runs, destructivereset.RunRef{RunID: runID})
 	}
 	return destructivereset.Plan{CleanupRuns: runs, CleanupRunSetKnown: true}
+}
+
+func cleanupPlanForRunIDsIncludingBundles(runIDs ...string) destructivereset.Plan {
+	plan := cleanupPlanForRunIDs(runIDs...)
+	plan.IncludeBundles = true
+	return plan
 }
 
 func seedDestructiveResetCleanupRows(t *testing.T, ctx context.Context, pg *PostgresStore) destructiveResetCleanupSeed {
@@ -899,12 +1092,36 @@ func seedDestructiveResetCleanupRows(t *testing.T, ctx context.Context, pg *Post
 	return destructiveResetCleanupSeed{RunA: runA, RunB: runB}
 }
 
+func seedDestructiveResetBundleRows(t *testing.T, ctx context.Context, pg *PostgresStore) {
+	t.Helper()
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, metadata) VALUES
+			($1, 'name: bundle-a', '{}'::jsonb, '{}'::jsonb),
+			($2, 'name: bundle-b', '{}'::jsonb, '{}'::jsonb)
+	`, destructiveResetCleanupBundleHashA, destructiveResetCleanupBundleHashB); err != nil {
+		t.Fatalf("seed bundles: %v", err)
+	}
+}
+
 func assertCleanupTableResult(t *testing.T, result destructivereset.CleanupResult, table string, matched, deleted int64) {
 	t.Helper()
 	for _, row := range result.Tables {
 		if row.Table == table {
 			if row.MatchedRows != matched || row.DeletedRows != deleted {
 				t.Fatalf("cleanup table %s result = matched %d deleted %d, want %d/%d", table, row.MatchedRows, row.DeletedRows, matched, deleted)
+			}
+			return
+		}
+	}
+	t.Fatalf("cleanup result missing table %s: %#v", table, result.Tables)
+}
+
+func assertCleanupTablePreserved(t *testing.T, result destructivereset.CleanupResult, table string, preserved int64) {
+	t.Helper()
+	for _, row := range result.Tables {
+		if row.Table == table {
+			if row.PreservedRows != preserved || row.MatchedRows != 0 || row.DeletedRows != 0 {
+				t.Fatalf("cleanup table %s result = preserved %d matched %d deleted %d, want preserved %d only", table, row.PreservedRows, row.MatchedRows, row.DeletedRows, preserved)
 			}
 			return
 		}

--- a/internal/store/destructive_reset_inventory.go
+++ b/internal/store/destructive_reset_inventory.go
@@ -32,7 +32,7 @@ func (s *PostgresStore) ReadResetInventory(ctx context.Context) (destructiverese
 	}
 	for _, entry := range destructivereset.DefaultPlatformCleanupCatalog() {
 		switch entry.Classification {
-		case destructivereset.CleanupPreserve, destructivereset.CleanupSplitPreserve:
+		case destructivereset.CleanupPreserve, destructivereset.CleanupSplitPreserve, destructivereset.CleanupRequestScopedBundles:
 			continue
 		default:
 			out.RunScopedTables = append(out.RunScopedTables, destructivereset.TableRef{

--- a/openrpc.json
+++ b/openrpc.json
@@ -7128,13 +7128,21 @@
     },
     {
       "name": "runtime.nuke",
-      "description": "Public destructive runtime reset wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the destructive-reset owner chain for execution: plan/result/lock, active-run and delivery quiescence, run-scoped cleanup/preservation, and managed entity-container selection/stop. It MUST NOT directly truncate tables, call raw Docker stop/list helpers, call AgentManager.ResetRuntimeStateWithSource, or migrate dashboard/Builder/CLI reset seams in this method implementation.\n\n`dry_run=true` returns the same top-level shape with side-effect-free previews from each owner. Apply mode sequences plan -\u003e quiescence -\u003e cleanup -\u003e managed-container stop. Managed-container stop failures are represented as `status=partial_failure`, `ok=false`, and explicit `errors`; they must not masquerade as complete success. Public final-response idempotency follows the v1 API idempotency convention.\n",
+      "description": "Public destructive runtime reset wrapper. The API layer owns only the v1 request/response/auth/idempotency contract and MUST consume the destructive-reset owner chain for execution: plan/result/lock, active-run and delivery quiescence, run-scoped cleanup/preservation, and managed entity-container selection/stop. It MUST NOT directly truncate tables, call raw Docker stop/list helpers, call AgentManager.ResetRuntimeStateWithSource, or migrate dashboard/Builder/CLI reset seams in this method implementation.\n\n`dry_run=true` returns the same top-level shape with side-effect-free previews from each owner. Apply mode sequences plan -\u003e quiescence -\u003e cleanup -\u003e managed-container stop. Managed-container stop failures are represented as `status=partial_failure`, `ok=false`, and explicit `errors`; they must not masquerade as complete success. `include_bundles` defaults true and is the only runtime.nuke control for whether server-wide bundle catalog state is deleted with the cleanup owner; false preserves bundle catalog rows. Public final-response idempotency follows the v1 API idempotency convention.\n",
       "params": [
         {
           "name": "dry_run",
           "required": false,
           "schema": {
             "default": false,
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "include_bundles",
+          "required": false,
+          "schema": {
+            "default": true,
             "type": "boolean"
           }
         },
@@ -10524,6 +10532,10 @@
             },
             "type": "array"
           },
+          "include_bundles": {
+            "description": "Echoes whether this runtime.nuke request includes server-wide bundle catalog deletion; defaults true.",
+            "type": "boolean"
+          },
           "ok": {
             "description": "True for dry-run or fully completed apply; false when the operation completed with explicit partial failures.",
             "type": "boolean"
@@ -10557,6 +10569,7 @@
           "ok",
           "status",
           "dry_run",
+          "include_bundles",
           "operation_name",
           "plan",
           "quiescence",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4088,6 +4088,7 @@ platform_tables:
       - Runtime-owned persisted facts that describe running or historical execution must carry an exact run_id, event lineage, or fork/source run lineage before destructive reset may delete them.
       - Generated product/entity/node-state tables remain split-preserved until a separate owner gives them exact run-scoped identity.
       - Schema, auth/idempotency-like, operator/system, product config, topology, global timers, mailbox, and spend/cost audit state must survive this internal cleanup slice unless a later gate defines an exact run-scoped owner.
+      - "The bundle catalog is request-scoped by `runtime.nuke.include_bundles`: `false` preserves `bundles`; `true` deletes `bundles` only inside the destructive-reset cleanup transaction after serializing persisted run creation and failing closed if any persisted bundle-source run remains outside the cleanup plan."
       - Apply executes in one database transaction, reports per-table dry-run/apply counts, rolls back on any SQL/FK/order error, and produces no successful result unless the transaction commits.
     classifications:
       delete_by_event_join:
@@ -4122,6 +4123,7 @@ platform_tables:
         - agents
         - flow_instances
         - routing_rules
+      request_scoped_bundle_catalog:
         - bundles
       split_preserve:
         - mailbox
@@ -12920,6 +12922,7 @@ api_specification:
         - ok
         - status
         - dry_run
+        - include_bundles
         - operation_name
         - plan
         - quiescence
@@ -12939,6 +12942,9 @@ api_specification:
             - partial_failure
           dry_run:
             type: boolean
+          include_bundles:
+            type: boolean
+            description: Echoes whether this runtime.nuke request includes server-wide bundle catalog deletion; defaults true.
           operation_name:
             type: string
           plan:
@@ -15631,7 +15637,9 @@ api_specification:
         \ reset seams in this method implementation.\n\n`dry_run=true` returns the same top-level shape with side-effect-free\
         \ previews from each owner. Apply mode sequences plan -> quiescence -> cleanup -> managed-container stop. Managed-container\
         \ stop failures are represented as `status=partial_failure`, `ok=false`, and explicit `errors`; they must not masquerade\
-        \ as complete success. Public final-response idempotency follows the v1 API idempotency convention.\n"
+        \ as complete success. `include_bundles` defaults true and is the only runtime.nuke control for whether server-wide\
+        \ bundle catalog state is deleted with the cleanup owner; false preserves bundle catalog rows. Public final-response\
+        \ idempotency follows the v1 API idempotency convention.\n"
       scope:
         required:
         - control:runtime
@@ -15642,6 +15650,11 @@ api_specification:
         schema:
           type: boolean
           default: false
+      - name: include_bundles
+        required: false
+        schema:
+          type: boolean
+          default: true
       - name: idempotency_key
         required: false
         schema:


### PR DESCRIPTION
## Summary
- Add `include_bundles` to `/v1/rpc runtime.nuke` parsing, response projection, destructive-reset request/result/plan state, and cleanup output.
- Make the `bundles` cleanup catalog classification request-scoped: `include_bundles=false` preserves the bundle catalog, while `include_bundles=true` deletes it in the destructive-reset cleanup transaction.
- Add the store-side fail-closed guard that serializes persisted run creation through the shared destructive lock path and rejects bundle catalog deletion if persisted bundle-source runs remain outside the cleanup plan.
- Update root `platform-spec.yaml` and regenerated root `openrpc.json` for the runtime.nuke parameter/result surface.

Closes #1027

## Governing Refs / Context
- Exact spec sections updated: `platform_tables.destructive_reset_cleanup_policy`, `api_specification.method_catalog.runtime.nuke`, and `api_specification.components.schemas.RuntimeNukeResult` in root `platform-spec.yaml`.
- Binding issue/gate context: #1027 Pre-Implementation Coverage Audit and gate outcome `approved as first slice`.
- Explicitly out of scope per gate: #1018 non-force `bundle.delete`, #981 RuntimeContextManager unload, CLI bundle delete, per-bundle nuke, and broader multi-bundle lifecycle cleanup.

## Semantic Migration
- New canonical owner: `/v1/rpc runtime.nuke include_bundles` -> `destructivereset.Request` / `Result` / `Plan` -> `destructivereset.CleanupPolicy` -> `PostgresStore.ApplyDestructiveResetCleanup`.
- Old invalid path: unconditional static `bundles` preservation in the destructive-reset cleanup catalog.
- Production paths checked for surviving old behavior: API param parsing/idempotency, destructive-reset planner/result, cleanup catalog policy mapping, store dry-run/apply mutation, shared destructive lock path, root OpenRPC generation, and existing CLI `control nuke` consumer behavior.
- Migration completeness: complete for the approved #1027 first slice; parent cleanup and bundle lifecycle siblings remain split as tracked.

## Validation
- `go test ./internal/runtime/destructivereset -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorRuntimeNuke|TestOpenRPCMutatingHTTPRuntimeProbes' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_ApplyDestructiveResetCleanup|TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanup|TestValidateDestructiveResetCleanupRequestRejectsIncludeBundlesPlanMismatch|TestPostgresStore_BundleDelete|TestPostgresStore_TryAcquireSerializesDestructiveResetLock' -count=1`
- `go test ./internal/store -count=1` with heartbeat: `ok swarm/internal/store 320.124s`
- `go test ./internal/apispec -count=1`
- `go test ./cmd/swarm -run TestControlNuke -count=1`
- `go test ./...` was rerun on `origin/master` `519701f4`; the local tool wrapper exited `-1` at the store-backed tail without Go failure output. All emitted packages passed, and `internal/store` passed separately as listed above.