### PR TITLE
[agent-a][issue #1113] Resolve create_flow_instance event config refs

### DIFF
--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -753,7 +753,7 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 			InstanceIDPath: action.InstanceIDPath,
 			ConfigFrom:     action.ConfigFrom,
 		}
-		if err := pc.createFlowInstance(ctx, engineTriggerContext(execCtx.Request), plan); err != nil {
+		if err := pc.createFlowInstance(ctx, engineTriggerContext(execCtx.Request), plan, execCtx.Base); err != nil {
 			return true, err
 		}
 		return true, nil

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -572,6 +572,76 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 	}
 }
 
+func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextForConfigFrom(t *testing.T) {
+	var captured FlowInstanceActivationRequest
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			captured = req
+			return nil
+		},
+	}
+	runner := pipelineEngineActionRunner{coordinator: pc}
+	evt := (events.Event{
+		ID:            "evt-123",
+		Type:          "spawn.requested",
+		ParentEventID: "source-evt-1",
+		Payload:       []byte(`{"instance_id":"inst-42","name":"alpha"}`),
+	}).WithEnvelope(events.EventEnvelope{
+		EntityID: "ent-1",
+		Source: events.RouteIdentity{
+			FlowID:       "parent-flow",
+			FlowInstance: "parent-flow/source-1",
+			EntityID:     "ent-parent",
+		},
+	})
+	base := values.NewContext()
+	base.Event = values.Wrap(evt.ContextMap("ready"))
+	base.Payload = values.Wrap(parsePayloadMap(evt.Payload))
+	base.Entity = values.Wrap(map[string]any{"entity_id": "ent-1"})
+	action := runtimecontracts.ActionSpec{
+		ID:             "create_flow_instance",
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"source_event_id": "event.id",
+				"event_type":      "event.type",
+				"source_flow":     "event.source.flow_id",
+				"correlation_id":  "event.source_event_id",
+				"name":            "payload.name",
+				"parent_entity":   "entity.entity_id",
+			},
+		},
+	}
+
+	ok, err := runner.ExecuteAction(context.Background(), action, runtimeregistry.ActionInstruction{Builtin: "create_flow_instance"}, runtimeengine.ExecutionContext{
+		Base: base,
+		Request: runtimeengine.ExecutionRequest{
+			EntityID: identity.NormalizeEntityID("ent-1"),
+			NodeID:   identity.NormalizeNodeID("spawner"),
+			Event:    evt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAction: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected create_flow_instance action to be claimed")
+	}
+	for key, want := range map[string]any{
+		"source_event_id": "evt-123",
+		"event_type":      "spawn.requested",
+		"source_flow":     "parent-flow",
+		"correlation_id":  "source-evt-1",
+		"name":            "alpha",
+		"parent_entity":   "ent-1",
+	} {
+		if got := captured.Config[key]; got != want {
+			t.Fatalf("config[%s] = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
 func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -9,6 +9,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -30,7 +31,17 @@ type FlowInstanceDeactivationRequest struct {
 
 type FlowInstanceDeactivator func(context.Context, FlowInstanceDeactivationRequest) error
 
-func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCtx workflowTriggerContext, plan handlerExecutionPlan) error {
+type flowInstanceConfigRefError struct {
+	Key    string
+	Ref    string
+	Reason string
+}
+
+func (e flowInstanceConfigRefError) Error() string {
+	return fmt.Sprintf("create_flow_instance config_from %q ref %q %s", e.Key, e.Ref, e.Reason)
+}
+
+func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCtx workflowTriggerContext, plan handlerExecutionPlan, handlerContext values.Context) error {
 	if pc == nil || pc.instanceActivator == nil {
 		return fmt.Errorf("flow instance activator is not configured")
 	}
@@ -71,7 +82,11 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 		Config:         map[string]any{},
 		TriggerEvent:   triggerCtx.Event,
 	}
-	req.Config = resolveFlowInstanceConfig(plan.ConfigFrom, payload, entity)
+	config, err := resolveFlowInstanceConfig(plan.ConfigFrom, handlerContext)
+	if err != nil {
+		return err
+	}
+	req.Config = config
 	if len(req.Config) == 0 {
 		return fmt.Errorf("create_flow_instance config_from resolved empty")
 	}
@@ -91,9 +106,17 @@ func hasRequiredCreateFlowInstanceSiblings(plan handlerExecutionPlan) bool {
 	return len(plan.ConfigFrom.ConfigEntries()) > 0
 }
 
-func resolveFlowInstanceConfig(spec *runtimecontracts.ConfigFromSpec, payload, entity map[string]any) map[string]any {
+func createFlowInstanceHandlerContext(triggerCtx workflowTriggerContext, payload, entity map[string]any) values.Context {
+	handlerContext := values.NewContext()
+	handlerContext.Event = values.Wrap(triggerCtx.Event.ContextMap(string(triggerCtx.State.Stage)))
+	handlerContext.Payload = values.Wrap(payload)
+	handlerContext.Entity = values.Wrap(entity)
+	return handlerContext
+}
+
+func resolveFlowInstanceConfig(spec *runtimecontracts.ConfigFromSpec, handlerContext values.Context) (map[string]any, error) {
 	if spec == nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
 	out := map[string]any{}
 	for _, entry := range spec.ConfigEntries() {
@@ -101,11 +124,48 @@ func resolveFlowInstanceConfig(spec *runtimecontracts.ConfigFromSpec, payload, e
 		if key == "" {
 			continue
 		}
-		if value, ok := resolveFlowInstanceValue(entry.RefPath, entry.Ref, payload, entity); ok {
-			out[key] = value
+		value, err := resolveFlowInstanceConfigValue(entry, handlerContext)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handlerContext values.Context) (any, error) {
+	key := strings.TrimSpace(entry.Key)
+	ref := strings.TrimSpace(entry.Ref)
+	if ref == "" {
+		return nil, flowInstanceConfigRefError{Key: key, Ref: entry.Ref, Reason: "is empty"}
+	}
+	if entry.RefPath.HasExplicitRoot() {
+		switch entry.RefPath.Root {
+		case paths.RootPayload, paths.RootEntity, paths.RootEvent:
+			value, ok := handlerContext.Lookup(entry.RefPath)
+			if !ok {
+				return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "resolved empty"}
+			}
+			return value, nil
+		default:
+			root := entry.RefPath.Root.String()
+			if root == "" {
+				root = strings.Split(ref, ".")[0]
+			}
+			return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: fmt.Sprintf("uses unsupported root %q", root)}
 		}
 	}
-	return out
+	segments := strings.Split(ref, ".")
+	if len(segments) == 1 {
+		if value, ok := handlerContext.Payload.Lookup(paths.Path{Root: paths.RootPayload, Segments: segments, Raw: ref}); ok {
+			return value, nil
+		}
+		if value, ok := handlerContext.Entity.Lookup(paths.Path{Root: paths.RootEntity, Segments: segments, Raw: ref}); ok {
+			return value, nil
+		}
+		return ref, nil
+	}
+	return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "requires supported root payload, entity, or event"}
 }
 
 func resolveFlowInstanceID(pathSpec paths.Path, expr string, payload, entity map[string]any) string {

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -174,7 +174,7 @@ func lookupFlowInstanceConfigPath(handlerContext values.Context, path paths.Path
 	}
 	current := any(handlerContext.Bucket(path.Root).Raw())
 	for _, segment := range path.Segments {
-		object, ok := current.(map[string]any)
+		object, ok := flowInstanceConfigObject(current)
 		if !ok {
 			return nil, false
 		}
@@ -184,6 +184,17 @@ func lookupFlowInstanceConfigPath(handlerContext values.Context, path paths.Path
 		}
 	}
 	return current, true
+}
+
+func flowInstanceConfigObject(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case values.Bucket:
+		return typed.Raw(), true
+	default:
+		return nil, false
+	}
 }
 
 func resolveFlowInstanceID(pathSpec paths.Path, expr string, payload, entity map[string]any) string {

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -142,7 +142,7 @@ func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handle
 	if entry.RefPath.HasExplicitRoot() {
 		switch entry.RefPath.Root {
 		case paths.RootPayload, paths.RootEntity, paths.RootEvent:
-			value, ok := handlerContext.Lookup(entry.RefPath)
+			value, ok := lookupFlowInstanceConfigPath(handlerContext, entry.RefPath)
 			if !ok {
 				return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "resolved empty"}
 			}
@@ -157,15 +157,33 @@ func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handle
 	}
 	segments := strings.Split(ref, ".")
 	if len(segments) == 1 {
-		if value, ok := handlerContext.Payload.Lookup(paths.Path{Root: paths.RootPayload, Segments: segments, Raw: ref}); ok {
+		if value, ok := lookupFlowInstanceConfigPath(handlerContext, paths.Path{Root: paths.RootPayload, Segments: segments, Raw: ref}); ok {
 			return value, nil
 		}
-		if value, ok := handlerContext.Entity.Lookup(paths.Path{Root: paths.RootEntity, Segments: segments, Raw: ref}); ok {
+		if value, ok := lookupFlowInstanceConfigPath(handlerContext, paths.Path{Root: paths.RootEntity, Segments: segments, Raw: ref}); ok {
 			return value, nil
 		}
 		return ref, nil
 	}
 	return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "requires supported root payload, entity, or event"}
+}
+
+func lookupFlowInstanceConfigPath(handlerContext values.Context, path paths.Path) (any, bool) {
+	if path.IsZero() || !path.HasExplicitRoot() {
+		return nil, false
+	}
+	current := any(handlerContext.Bucket(path.Root).Raw())
+	for _, segment := range path.Segments {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[strings.TrimSpace(segment)]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
 }
 
 func resolveFlowInstanceID(pathSpec paths.Path, expr string, payload, entity map[string]any) string {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -101,6 +101,45 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 	}
 }
 
+func TestCreateFlowInstancePreservesNullConfigFromValues(t *testing.T) {
+	var captured FlowInstanceActivationRequest
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			captured = req
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","optional_setting":null}`),
+	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
+
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		InstanceIDPath: paths.Parse("payload.instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"optional_setting": "payload.optional_setting",
+				"bare_optional":    "optional_setting",
+			},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	if err != nil {
+		t.Fatalf("expected createFlowInstance to preserve explicit null config values: %v", err)
+	}
+	for _, key := range []string{"optional_setting", "bare_optional"} {
+		value, ok := captured.Config[key]
+		if !ok {
+			t.Fatalf("config[%s] missing; want explicit nil value", key)
+		}
+		if value != nil {
+			t.Fatalf("config[%s] = %#v, want nil", key, value)
+		}
+	}
+}
+
 func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
 	var captured FlowInstanceActivationRequest
 	pc := &PipelineCoordinator{

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,8 +12,17 @@ import (
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/paths"
+	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/semanticview"
 )
+
+func testCreateFlowInstanceContext(trigger workflowTriggerContext) values.Context {
+	payload := parsePayloadMap(trigger.Event.Payload)
+	entity := map[string]any{
+		"entity_id": workflowEventEntityID(trigger.Event),
+	}
+	return createFlowInstanceHandlerContext(trigger, payload, entity)
+}
 
 func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 	var captured FlowInstanceActivationRequest
@@ -26,8 +36,9 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 		Type:    events.EventType("custom.triggered"),
 		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	ok := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	ok := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template:       "review",
 		InstanceIDFrom: "payload.desired_instance_id",
 		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
@@ -36,7 +47,7 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 				"name": "payload.name",
 			},
 		},
-	})
+	}, testCreateFlowInstanceContext(triggerCtx))
 	if ok != nil {
 		t.Fatalf("expected createFlowInstance to succeed: %v", ok)
 	}
@@ -63,8 +74,9 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 		Type:    events.EventType("spawn.requested"),
 		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha","priority":1}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template:       "review",
 		InstanceIDFrom: "payload.instance_id",
 		InstanceIDPath: paths.Parse("payload.instance_id"),
@@ -74,7 +86,7 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 				"priority": "payload.priority",
 			},
 		},
-	})
+	}, testCreateFlowInstanceContext(triggerCtx))
 	if err != nil {
 		t.Fatalf("expected createFlowInstance to succeed: %v", err)
 	}
@@ -89,6 +101,160 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 	}
 }
 
+func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
+	var captured FlowInstanceActivationRequest
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			captured = req
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		ID:            "evt-123",
+		Type:          events.EventType("spawn.requested"),
+		ParentEventID: "source-evt-1",
+		Payload:       []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+	}).WithEnvelope(events.EventEnvelope{
+		EntityID: "ent-1",
+		Source: events.RouteIdentity{
+			FlowID:       "parent-flow",
+			FlowInstance: "parent-flow/source-1",
+			EntityID:     "ent-parent",
+		},
+	})
+	triggerCtx := workflowTriggerContext{Event: trigger}
+
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		InstanceIDPath: paths.Parse("payload.instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"source_event_id": "event.id",
+				"event_type":      "event.type",
+				"source_flow":     "event.source.flow_id",
+				"correlation_id":  "event.source_event_id",
+				"name":            "payload.name",
+				"parent_entity":   "entity.entity_id",
+			},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	if err != nil {
+		t.Fatalf("expected createFlowInstance to succeed: %v", err)
+	}
+	for key, want := range map[string]any{
+		"source_event_id": "evt-123",
+		"event_type":      "spawn.requested",
+		"source_flow":     "parent-flow",
+		"correlation_id":  "source-evt-1",
+		"name":            "alpha",
+		"parent_entity":   "ent-1",
+	} {
+		if got := captured.Config[key]; got != want {
+			t.Fatalf("config[%s] = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+func TestCreateFlowInstanceRejectsUnknownEventConfigRef(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		ID:      "evt-123",
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`),
+	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
+
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		InstanceIDPath: paths.Parse("payload.instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"missing_event": "event.missing",
+			},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	var refErr flowInstanceConfigRefError
+	if !errors.As(err, &refErr) {
+		t.Fatalf("createFlowInstance error = %T %v, want flowInstanceConfigRefError", err, err)
+	}
+	for _, want := range []string{`config_from "missing_event"`, `ref "event.missing"`, "resolved empty"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("createFlowInstance error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestCreateFlowInstanceRejectsUnsupportedConfigRefRoot(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		ID:      "evt-123",
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`),
+	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
+
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		InstanceIDPath: paths.Parse("payload.instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"policy_value": "policy.value",
+			},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	var refErr flowInstanceConfigRefError
+	if !errors.As(err, &refErr) {
+		t.Fatalf("createFlowInstance error = %T %v, want flowInstanceConfigRefError", err, err)
+	}
+	for _, want := range []string{`config_from "policy_value"`, `ref "policy.value"`, `unsupported root "policy"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("createFlowInstance error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestCreateFlowInstanceDoesNotResolveInstanceIDFromEventRef(t *testing.T) {
+	pc := &PipelineCoordinator{
+		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
+			t.Fatalf("unexpected activation request: %#v", req)
+			return nil
+		},
+	}
+	trigger := (events.Event{
+		ID:      "evt-123",
+		Type:    events.EventType("spawn.requested"),
+		Payload: []byte(`{"entity_id":"ent-1","name":"alpha"}`),
+	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
+
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "event.id",
+		InstanceIDPath: paths.Parse("event.id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{
+				"name": "payload.name",
+			},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	if err == nil || !strings.Contains(err.Error(), "create_flow_instance instance_id_from resolved empty") {
+		t.Fatalf("createFlowInstance error = %v, want instance_id_from split behavior", err)
+	}
+}
+
 func TestCreateFlowInstanceRejectsMissingRequiredSiblingFields(t *testing.T) {
 	pc := &PipelineCoordinator{
 		instanceActivator: func(_ context.Context, req FlowInstanceActivationRequest) error {
@@ -100,10 +266,11 @@ func TestCreateFlowInstanceRejectsMissingRequiredSiblingFields(t *testing.T) {
 		Type:    events.EventType("spawn.requested"),
 		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template: "review",
-	})
+	}, testCreateFlowInstanceContext(triggerCtx))
 	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
 		t.Fatalf("createFlowInstance error = %v, want missing required siblings", err)
 	}
@@ -120,15 +287,16 @@ func TestCreateFlowInstanceRejectsGeneratedFallbackWithoutInstanceIDFrom(t *test
 		Type:    events.EventType("spawn.requested"),
 		Payload: []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template: "review",
 		ConfigFrom: &runtimecontracts.ConfigFromSpec{
 			Bindings: map[string]string{
 				"name": "payload.name",
 			},
 		},
-	})
+	}, testCreateFlowInstanceContext(triggerCtx))
 	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
 		t.Fatalf("createFlowInstance error = %v, want missing instance_id_from failure", err)
 	}
@@ -145,15 +313,16 @@ func TestCreateFlowInstanceRejectsEmptyConfigFromBindings(t *testing.T) {
 		Type:    events.EventType("spawn.requested"),
 		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template:       "review",
 		InstanceIDFrom: "payload.desired_instance_id",
 		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
 		ConfigFrom: &runtimecontracts.ConfigFromSpec{
 			Bindings: map[string]string{},
 		},
-	})
+	}, testCreateFlowInstanceContext(triggerCtx))
 	if err == nil || !strings.Contains(err.Error(), "requires non-empty instance_id_from and config_from") {
 		t.Fatalf("createFlowInstance error = %v, want missing config_from failure", err)
 	}
@@ -170,8 +339,9 @@ func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
 		Type:    events.EventType("spawn.requested"),
 		Payload: []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
 	}).WithEntityID("ent-1")
+	triggerCtx := workflowTriggerContext{Event: trigger}
 
-	err := pc.createFlowInstance(context.Background(), workflowTriggerContext{Event: trigger}, handlerExecutionPlan{
+	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
 		Template:       "review",
 		InstanceIDFrom: "payload.desired_instance_id",
 		InstanceIDPath: paths.Parse("payload.desired_instance_id"),
@@ -180,9 +350,9 @@ func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
 				"name": "payload.missing_name",
 			},
 		},
-	})
-	if err == nil || !strings.Contains(err.Error(), "config_from resolved empty") {
-		t.Fatalf("createFlowInstance error = %v, want empty resolved config failure", err)
+	}, testCreateFlowInstanceContext(triggerCtx))
+	if err == nil || !strings.Contains(err.Error(), `config_from "name" ref "payload.missing_name" resolved empty`) {
+		t.Fatalf("createFlowInstance error = %v, want missing config ref failure", err)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1334,8 +1334,9 @@ handler_specification:
           required_sibling_fields:
             template: 'string — flow template ID (must be mode: template)'
             instance_id_from: string — payload field containing the unique instance ID
-            config_from: object — maps instance variable names to payload field paths. Platform reads payload values and passes
-              them as config to the new flow instance.
+            config_from: object — maps instance variable names to supported handler context refs (`payload.*`, `entity.*`,
+              and `event.*`). Platform resolves those refs from the canonical handler context and passes the values as config
+              to the new flow instance.
         record_evidence:
           description: Append event payload to entity accumulator state.
           behavior: Reads the event payload and appends it as a new entry in the entity's evidence accumulator (from state_schema).
@@ -3205,8 +3206,9 @@ engine:
     - id: config_from_payload_alignment
       severity: error
       scope: per-node
-      trigger: A create_flow_instance action's config_from references payload fields not present in the triggering event's
-        schema.
+      trigger: A create_flow_instance action's config_from payload.* refs name payload fields not present in the triggering
+        event's schema. Non-payload handler-context refs, including supported event-envelope refs through event.*, are not
+        payload schema fields and are governed by runtime config_from ref resolution.
       when: boot-only
     - id: phantom_produces
       severity: warning


### PR DESCRIPTION
## Summary

Closes #1113.

This PR closes the approved first-slice class `runtime.create_flow_instance_config_from_handler_context_event_ref_consumption`:

- moves `create_flow_instance.config_from` resolution onto the handler/base context for approved roots `payload.*`, `entity.*`, and `event.*`
- preserves explicit `null` config_from values while still failing closed for absent supported refs
- preserves the existing `instance_id_from` payload/entity-only behavior and adds proof that `event.*` did not silently widen there
- fails closed with a typed config_from diagnostic for unresolved/unsupported explicit refs
- updates `platform-spec.yaml` so the `create_flow_instance.config_from` leaf and payload-alignment rule no longer contradict event-envelope `event.*` semantics

## Governing Refs / Context

- #1113 issue body and gate comment: `create_flow_instance.config_from` event-envelope refs through canonical handler context only; do not absorb #1114-#1122 or Empire-local patches.
- `platform-spec.yaml#handler_specification.system_node_handlers.action.valid_values.create_flow_instance.required_sibling_fields.config_from`
- `platform-spec.yaml#engine.compliance_checks.config_from_payload_alignment`
- `platform-spec.yaml#event_contract_strictness` envelope-surface sections that state runtime-owned envelope fields remain on the event carrier and are read through `event.*`.

## Semantic Migration Accounting

- New canonical consumer: `create_flow_instance.config_from` now consumes the handler/base context for approved explicit roots.
- Canonical owners consumed: `events.Event.ContextMap`, `paths.RootEvent`, `paths.RootPayload`, `paths.RootEntity`, and the corresponding `values.Context` buckets.
- Local execution detail: config_from uses a presence-preserving lookup over context buckets so explicit nil leaves remain valid values; this avoids using `values.Context.Lookup` as the semantic test for presence because that helper treats nil as not found.
- Old path now invalid: local config_from resolution that silently dropped explicit roots outside payload/entity.
- Production paths checked: `pipelineEngineActionRunner.ExecuteAction` now passes `execCtx.Base`; direct pipeline tests use the same context shape.
- Migration completeness: complete for `config_from`; not claimed for `instance_id_from` or broader handler-action expression cleanup.

## Tests

- `go test ./internal/runtime/pipeline -run 'TestCreateFlowInstance|TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextForConfigFrom' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier1PrimitiveCatalogFixtures_RealRuntime/test-on-complete-with-state' -count=1 -p 1`
- `git diff --check`
- Whole-suite attempt after the review fix progressed through many passing packages, including `cmd/swarm`, `internal/apiv1`, `internal/dashboard/server`, `internal/runtime`, and `internal/runtime/bus`, then the tool harness returned code `-1` without a failing test line.