### PR TITLE
[agent-g][issue #1150] Promote runtime log persistence owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -123,6 +123,7 @@ type storeBundle struct {
 	Postgres            *store.PostgresStore
 	SQLDB               *sql.DB
 	RuntimeSQLDB        *sql.DB
+	RuntimeLogStore     runtime.RuntimeLogPersistence
 	RuntimeBlocker      string
 	SchemaBootstrapper  store.SchemaBootstrapper
 	EventStore          runtimebus.EventStore
@@ -148,6 +149,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		SQLDB:               s.RuntimeSQLDB,
 		ConstructionBlocker: s.RuntimeBlocker,
 		EventStore:          s.EventStore,
+		RuntimeLogStore:     s.RuntimeLogStore,
 		PipelineStore:       s.PipelineStore,
 		SessionRegistry:     s.SessionRegistry,
 		ConversationStore:   s.ConversationStore,
@@ -2046,6 +2048,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			Postgres:            pg,
 			SQLDB:               pg.DB,
 			RuntimeSQLDB:        pg.DB,
+			RuntimeLogStore:     pg,
 			SchemaBootstrapper:  pg,
 			EventStore:          pg,
 			PipelineStore:       runtimepipeline.NewWorkflowInstanceStore(pg.DB),
@@ -2080,7 +2083,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1150 runtime diagnostics/logging moves to a backend-neutral store owner or receives an explicit lead-approved split",
+			RuntimeLogStore:     sqliteStore,
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
 			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB),

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2083,6 +2083,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
+			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 mailbox_write materialization moves off the raw pipeline SQL database or receives explicit lead-approved split/tracker repair",
 			RuntimeLogStore:     sqliteStore,
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2529,6 +2529,7 @@ func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func()
 			Postgres:            runtimePG,
 			SQLDB:               runtimePG.DB,
 			RuntimeSQLDB:        runtimePG.DB,
+			RuntimeLogStore:     runtimePG,
 			SchemaBootstrapper:  runtimePG,
 			EventStore:          runtimePG,
 			PipelineStore:       runtimepipeline.NewWorkflowInstanceStore(runtimePG.DB),
@@ -5520,6 +5521,8 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 		return storeBundle{
 			Postgres:           runtimePG,
 			SQLDB:              runtimePG.DB,
+			RuntimeSQLDB:       runtimePG.DB,
+			RuntimeLogStore:    runtimePG,
 			SchemaBootstrapper: runtimePG,
 			EventStore:         runtimePG,
 			SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
@@ -5611,6 +5614,8 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 				return storeBundle{
 					Postgres:           runtimePG,
 					SQLDB:              runtimePG.DB,
+					RuntimeSQLDB:       runtimePG.DB,
+					RuntimeLogStore:    runtimePG,
 					SchemaBootstrapper: runtimePG,
 					EventStore:         runtimePG,
 					SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
@@ -5776,6 +5781,8 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 		return storeBundle{
 			Postgres:           runtimePG,
 			SQLDB:              runtimePG.DB,
+			RuntimeSQLDB:       runtimePG.DB,
+			RuntimeLogStore:    runtimePG,
 			SchemaBootstrapper: runtimePG,
 			EventStore:         runtimePG,
 			SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -194,8 +194,11 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.RuntimeLogStore == nil {
 		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
 	}
-	if runtimeStores.ConstructionBlocker != "" {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want no #1150 diagnostics blocker", runtimeStores.ConstructionBlocker)
+	if strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics blocker removed", runtimeStores.ConstructionBlocker)
+	}
+	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 mailbox_write materialization") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want residual #1087 mailbox_write blocker", runtimeStores.ConstructionBlocker)
 	}
 	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
@@ -240,8 +243,11 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner(t *testin
 	if runtimeStores.RuntimeLogStore == nil {
 		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
 	}
-	if runtimeStores.ConstructionBlocker != "" {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want empty after #1150 owner", runtimeStores.ConstructionBlocker)
+	if strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics blocker removed", runtimeStores.ConstructionBlocker)
+	}
+	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 mailbox_write materialization") {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want residual #1087 mailbox_write blocker", runtimeStores.ConstructionBlocker)
 	}
 	_, err = runtime.NewRuntime(ctx, runtime.RuntimeDeps{
 		Config:  &config.Config{},
@@ -249,13 +255,13 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner(t *testin
 		Options: runtime.RuntimeOptions{SelfCheck: true},
 	})
 	if err == nil {
-		t.Fatal("NewRuntime(sqlite) succeeded without workflow module, want boot validation error")
+		t.Fatal("NewRuntime(sqlite) succeeded, want residual #1087 mailbox_write blocker")
 	}
 	if strings.Contains(err.Error(), "#1150 runtime diagnostics/logging") {
 		t.Fatalf("NewRuntime(sqlite) error = %v, want #1150 diagnostics blocker removed", err)
 	}
-	if !strings.Contains(err.Error(), "workflow module is required") {
-		t.Fatalf("NewRuntime(sqlite) error = %v, want later workflow-module validation after #1150 owner", err)
+	if !strings.Contains(err.Error(), "#1087 mailbox_write materialization") {
+		t.Fatalf("NewRuntime(sqlite) error = %v, want residual #1087 mailbox_write blocker after #1150 owner", err)
 	}
 }
 

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -181,7 +181,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -191,8 +191,11 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
 	}
-	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics fail-closed blocker", runtimeStores.ConstructionBlocker)
+	if runtimeStores.RuntimeLogStore == nil {
+		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
+	}
+	if runtimeStores.ConstructionBlocker != "" {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want no #1150 diagnostics blocker", runtimeStores.ConstructionBlocker)
 	}
 	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
@@ -217,7 +220,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 }
 
-func TestBuildStoresSQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit(t *testing.T) {
+func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "dev.db")
 	stores, err := buildStores(ctx, storebackend.Selection{
@@ -230,16 +233,29 @@ func TestBuildStoresSQLiteRuntimeFailsClosedUntilRawSQLConsumersSplit(t *testing
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
+	runtimeStores := stores.runtimeStores()
+	if runtimeStores.SQLDB != nil {
+		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
+	}
+	if runtimeStores.RuntimeLogStore == nil {
+		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
+	}
+	if runtimeStores.ConstructionBlocker != "" {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want empty after #1150 owner", runtimeStores.ConstructionBlocker)
+	}
 	_, err = runtime.NewRuntime(ctx, runtime.RuntimeDeps{
 		Config:  &config.Config{},
-		Stores:  stores.runtimeStores(),
+		Stores:  runtimeStores,
 		Options: runtime.RuntimeOptions{SelfCheck: true},
 	})
 	if err == nil {
-		t.Fatal("NewRuntime(sqlite) succeeded, want fail-closed blocker while #1150 diagnostics remains split")
+		t.Fatal("NewRuntime(sqlite) succeeded without workflow module, want boot validation error")
 	}
-	if !strings.Contains(err.Error(), "#1150 runtime diagnostics/logging") {
-		t.Fatalf("NewRuntime(sqlite) error = %v, want #1150 diagnostics blocker", err)
+	if strings.Contains(err.Error(), "#1150 runtime diagnostics/logging") {
+		t.Fatalf("NewRuntime(sqlite) error = %v, want #1150 diagnostics blocker removed", err)
+	}
+	if !strings.Contains(err.Error(), "workflow module is required") {
+		t.Fatalf("NewRuntime(sqlite) error = %v, want later workflow-module validation after #1150 owner", err)
 	}
 }
 

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -392,7 +392,7 @@ nodes:
       - "#1084 owns canonical backend ids postgres/sqlite, selector precedence flag > environment > runtime config > rollout default, SWARM_STORE_BACKEND, SWARM_SQLITE_PATH, store.backend, store.sqlite.path, and the staged SQLite path authority."
       - "#1085 must own SQLite dialect, schema bootstrap, and backend capability binding before SQLite can construct runtime stores."
       - "#1086 must port core runtime persistence stores behind backend-neutral SQLite/Postgres contracts."
-      - "#1087 must port session, locking, delivery, replay, and trace-stream semantics for the SQLite local runtime path."
+      - "#1087 must port session, locking, delivery, replay, trace-stream, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent."
       - "#1088 must flip the active local/dev default to SQLite only after zero-service swarm run and explicit Postgres opt-in are proven together."
       - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes."
     representative_issues:

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -392,7 +392,7 @@ nodes:
       - "#1084 owns canonical backend ids postgres/sqlite, selector precedence flag > environment > runtime config > rollout default, SWARM_STORE_BACKEND, SWARM_SQLITE_PATH, store.backend, store.sqlite.path, and the staged SQLite path authority."
       - "#1085 must own SQLite dialect, schema bootstrap, and backend capability binding before SQLite can construct runtime stores."
       - "#1086 must port core runtime persistence stores behind backend-neutral SQLite/Postgres contracts."
-      - "#1087 must port session, locking, delivery, replay, trace-stream, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent."
+      - "#1087 must port session, locking, delivery, replay, trace-stream, mailbox_write materialization, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent and mailbox_write remains a residual construction blocker until separately gated."
       - "#1088 must flip the active local/dev default to SQLite only after zero-service swarm run and explicit Postgres opt-in are proven together."
       - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes."
     representative_issues:

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -13,7 +13,9 @@ import (
 	"gopkg.in/yaml.v3"
 	"swarm/internal/events"
 	"swarm/internal/platform"
+	runtimepkg "swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	storepkg "swarm/internal/store"
 )
 
@@ -113,23 +115,35 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
 	}
 
-	logID := uuid.NewString()
-	if err := sqliteStore.AppendEvent(ctx, events.Event{
-		ID:          logID,
-		RunID:       runID,
-		Type:        events.EventType("platform.runtime_log"),
-		SourceAgent: "runtime",
-		Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","session_id":"session-1"}}`),
-		CreatedAt:   now.Add(time.Second),
+	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
+	logCtx := runtimecorrelation.WithRunID(ctx, runID)
+	if err := logger.Log(logCtx, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "runtime warning",
+		Component: "scheduler",
+		Action:    "supported_surface",
+		SessionID: "session-1",
 	}); err != nil {
-		t.Fatalf("AppendEvent runtime log: %v", err)
+		t.Fatalf("RuntimeLogger.Log sqlite runtime log: %v", err)
+	}
+	logs, err := sqliteStore.ListOperatorRuntimeLogs(ctx, storepkg.OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "scheduler",
+		Level:     "warn",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs after logger write: %v", err)
+	}
+	if len(logs.Logs) != 1 {
+		t.Fatalf("logger-written runtime logs = %#v, want one", logs.Logs)
 	}
 
 	return sqliteObservabilitySurfaceFixture{
 		store:   sqliteStore,
 		runID:   runID,
 		eventID: eventID,
-		logID:   logID,
+		logID:   logs.Logs[0].LogID,
 		now:     now,
 	}
 }

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -183,6 +183,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{Config: cfg, Stores: runtime.Stores{
 		SQLDB:               db,
 		EventStore:          pg,
+		RuntimeLogStore:     pg,
 		SessionRegistry:     sessions.NewPostgresRegistry(db, cfg.LLM.Session.LockTTL),
 		ManagerStore:        pg,
 		ScheduleStore:       pg,

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -681,7 +681,7 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 
 	entityID := uuid.NewString()
 	parentEventID := uuid.NewString()
-	logger := runtimepkg.NewRuntimeLogger(db, pg)
+	logger := runtimepkg.NewRuntimeLogger(pg)
 	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
 		Level:      "warn",
 		Message:    "Tool execution was denied for save_entity_field",
@@ -789,10 +789,11 @@ func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReade
 		Runtime: config.RuntimeConfig{},
 		LLM:     config.LLMConfig{Backend: "anthropic"},
 	}, Stores: runtimepkg.Stores{
-		SQLDB:         db,
-		EventStore:    pg,
-		ManagerStore:  pg,
-		ScheduleStore: pg,
+		SQLDB:           db,
+		EventStore:      pg,
+		RuntimeLogStore: pg,
+		ManagerStore:    pg,
+		ScheduleStore:   pg,
 	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -1168,10 +1169,11 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 			Backend: "anthropic",
 		},
 	}, Stores: runtimepkg.Stores{
-		SQLDB:         db,
-		EventStore:    pg,
-		ManagerStore:  pg,
-		ScheduleStore: pg,
+		SQLDB:           db,
+		EventStore:      pg,
+		RuntimeLogStore: pg,
+		ManagerStore:    pg,
+		ScheduleStore:   pg,
 	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
@@ -1255,9 +1257,10 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 			Backend: "anthropic",
 		},
 	}, Stores: runtimepkg.Stores{
-		SQLDB:        db,
-		EventStore:   eventStore,
-		ManagerStore: &conformanceManagerReplayStore{},
+		SQLDB:           db,
+		EventStore:      eventStore,
+		RuntimeLogStore: pg,
+		ManagerStore:    &conformanceManagerReplayStore{},
 	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -1354,10 +1357,11 @@ func TestStartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityRead
 			Backend: "anthropic",
 		},
 	}, Stores: runtimepkg.Stores{
-		SQLDB:         db,
-		EventStore:    conformanceTimerRecoveryEventStore{},
-		ManagerStore:  pg,
-		ScheduleStore: scheduleStore,
+		SQLDB:           db,
+		EventStore:      conformanceTimerRecoveryEventStore{},
+		RuntimeLogStore: pg,
+		ManagerStore:    pg,
+		ScheduleStore:   scheduleStore,
 	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: loadConformanceRuntimeWorkflowModule(t),
@@ -1472,7 +1476,7 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 	requireCanonicalRuntimeLogSurface(t, ctx, pg)
 	seedConformanceAgent(t, ctx, pg, "agent-1")
 
-	logger := runtimepkg.NewRuntimeLogger(db, pg)
+	logger := runtimepkg.NewRuntimeLogger(pg)
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
 		Logger: conformanceRuntimeLoggerHook{logger: logger},
 	})
@@ -1624,9 +1628,10 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 			Backend: "anthropic",
 		},
 	}, Stores: runtimepkg.Stores{
-		SQLDB:        db,
-		EventStore:   conformanceTimerRecoveryEventStore{},
-		ManagerStore: managerStore,
+		SQLDB:           db,
+		EventStore:      conformanceTimerRecoveryEventStore{},
+		RuntimeLogStore: pg,
+		ManagerStore:    managerStore,
 	}, Options: runtimepkg.RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -1722,7 +1727,7 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 
 	requireCanonicalRuntimeLogSurface(t, ctx, pg)
 
-	logger := runtimepkg.NewRuntimeLogger(db, pg)
+	logger := runtimepkg.NewRuntimeLogger(pg)
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
 		Logger: conformanceRuntimeLoggerHook{logger: logger},
 	})

--- a/internal/runtime/diagnostics.go
+++ b/internal/runtime/diagnostics.go
@@ -2,16 +2,13 @@ package runtime
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	runtimebus "swarm/internal/runtime/bus"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	"swarm/internal/runtime/diaglog"
-	storerunlifecycle "swarm/internal/store/runlifecycle"
 )
 
 // RuntimeLogEntry is a structured runtime operation record (spec v2.0.14).
@@ -47,12 +44,21 @@ func (e *RuntimeLogEntry) NormalizeEntityID() {
 }
 
 type RuntimeLogger struct {
-	db           *sql.DB
-	capabilities runtimeLogCapabilityResolver
+	persistence RuntimeLogPersistence
 }
 
-type runtimeLogCapabilityResolver interface {
+// RuntimeLogPersistence owns backend-specific platform.runtime_log persistence
+// and lineage lookup while RuntimeLogger owns canonical payload construction.
+type RuntimeLogPersistence interface {
 	CanonicalRuntimeLogCapability(context.Context) (bool, bool, error)
+	RuntimeLogLineageParentEventID(ctx context.Context, runID, explicitParentEventID, subjectEventID string) (string, error)
+	PersistRuntimeLog(ctx context.Context, record RuntimeLogPersistenceRecord) error
+}
+
+type RuntimeLogPersistenceRecord struct {
+	RunID         string
+	Payload       []byte
+	ParentEventID string
 }
 
 type InstanceDigestRow struct {
@@ -67,8 +73,8 @@ type DigestPersistence interface {
 	ListInstanceDigestRows(ctx context.Context, limit int) ([]InstanceDigestRow, error)
 }
 
-func NewRuntimeLogger(db *sql.DB, capabilities runtimeLogCapabilityResolver) *RuntimeLogger {
-	return &RuntimeLogger{db: db, capabilities: capabilities}
+func NewRuntimeLogger(persistence RuntimeLogPersistence) *RuntimeLogger {
+	return &RuntimeLogger{persistence: persistence}
 }
 
 func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
@@ -85,19 +91,16 @@ func (l *RuntimeLogger) Log(ctx context.Context, e RuntimeLogEntry) error {
 		action = "unknown"
 	}
 	e.NormalizeEntityID()
-	if l.db == nil {
+	if l.persistence == nil {
 		return nil
 	}
-	if l.capabilities == nil {
-		return nil
-	}
-	enabled, hasRunID, err := l.capabilities.CanonicalRuntimeLogCapability(withoutSQLTxContext(ctx))
+	enabled, hasRunID, err := l.persistence.CanonicalRuntimeLogCapability(withoutSQLTxContext(ctx))
 	if err != nil || !enabled {
 		return nil
 	}
 
 	detail := marshalJSONOrEmpty(e.Detail)
-	payload, err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.db, hasRunID, level.String(), component, action, e, detail)
+	payload, err := logRuntimeEventSpec(withoutSQLTxContext(ctx), l.persistence, hasRunID, level.String(), component, action, e, detail)
 	if err != nil {
 		return err
 	}
@@ -201,8 +204,8 @@ func sanitizeStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) (CanonicalRuntimeLogPayload, error) {
-	if db == nil {
+func logRuntimeEventSpec(ctx context.Context, persistence RuntimeLogPersistence, hasRunID bool, level, component, action string, e RuntimeLogEntry, detail []byte) (CanonicalRuntimeLogPayload, error) {
+	if persistence == nil {
 		return CanonicalRuntimeLogPayload{}, nil
 	}
 	detailMap := map[string]any{}
@@ -228,7 +231,7 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 		}
 		runtimeLogAddLineageDetails(detailMap, lineage)
 	}
-	parentEventID, err := runtimeLogLineageParentEventID(ctx, db, lineageRunID, explicitParentEventID, subjectEventID)
+	parentEventID, err := runtimeLogLineageParentEventID(ctx, persistence, lineageRunID, explicitParentEventID, subjectEventID)
 	if err != nil {
 		return CanonicalRuntimeLogPayload{}, err
 	}
@@ -245,62 +248,17 @@ func logRuntimeEventSpec(ctx context.Context, db *sql.DB, hasRunID bool, level, 
 	if err != nil {
 		return CanonicalRuntimeLogPayload{}, err
 	}
-	if hasRunID {
-		if err := persistRunScopedRuntimeLog(ctx, db, runID, string(encoded), parentEventID); err != nil {
-			return CanonicalRuntimeLogPayload{}, err
-		}
-		return canonicalPayload, nil
+	record := RuntimeLogPersistenceRecord{
+		Payload:       encoded,
+		ParentEventID: parentEventID,
 	}
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO events (
-			event_id, event_name, entity_id, flow_instance, scope, payload,
-			chain_depth, produced_by, produced_by_type, source_event_id, created_at
-		)
-		VALUES (
-			gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $1::jsonb,
-			0, 'runtime', 'platform', NULLIF($2,'')::uuid, now()
-		)
-	`, string(encoded), parentEventID)
-	if err != nil {
+	if hasRunID {
+		record.RunID = runID
+	}
+	if err := persistence.PersistRuntimeLog(ctx, record); err != nil {
 		return CanonicalRuntimeLogPayload{}, err
 	}
 	return canonicalPayload, nil
-}
-
-func persistRunScopedRuntimeLog(ctx context.Context, db *sql.DB, runID, encodedPayload, parentEventID string) error {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := ensureRuntimeLogRunRow(ctx, tx, runID); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO events (
-			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
-			chain_depth, produced_by, produced_by_type, source_event_id, created_at
-		)
-		VALUES (
-			NULLIF($1,'')::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
-			0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
-		)
-	`, runID, encodedPayload, parentEventID); err != nil {
-		return err
-	}
-	if err := storerunlifecycle.SyncCounts(ctx, tx, runID); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	committed = true
-	return nil
 }
 
 func runtimeLogRecorderEntry(payload CanonicalRuntimeLogPayload) diaglog.RunEntry {
@@ -373,60 +331,11 @@ func runtimeLogAddLineageDetails(detailMap map[string]any, lineage runtimecorrel
 	}
 }
 
-func runtimeLogLineageParentEventID(ctx context.Context, db *sql.DB, runID, explicitParentEventID, subjectEventID string) (string, error) {
-	explicitParentEventID = strings.TrimSpace(explicitParentEventID)
-	if explicitParentEventID != "" {
-		return explicitParentEventID, nil
-	}
-	runID = strings.TrimSpace(runID)
-	subjectEventID = strings.TrimSpace(subjectEventID)
-	if db == nil || runID == "" || subjectEventID == "" {
+func runtimeLogLineageParentEventID(ctx context.Context, persistence RuntimeLogPersistence, runID, explicitParentEventID, subjectEventID string) (string, error) {
+	if persistence == nil {
 		return "", nil
 	}
-	if _, err := uuid.Parse(runID); err != nil {
-		return "", err
-	}
-	if _, err := uuid.Parse(subjectEventID); err != nil {
-		return "", nil
-	}
-	var exists bool
-	if err := db.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM events
-			WHERE run_id = $1::uuid
-			  AND event_id = $2::uuid
-		)
-	`, runID, subjectEventID).Scan(&exists); err != nil {
-		return "", err
-	}
-	if !exists {
-		return "", nil
-	}
-	return subjectEventID, nil
-}
-
-func ensureRuntimeLogRunRow(ctx context.Context, db storerunlifecycle.DBTX, runID string) error {
-	if db == nil {
-		return nil
-	}
-	runID = strings.TrimSpace(runID)
-	if runID == "" {
-		return nil
-	}
-	if _, err := uuid.Parse(runID); err != nil {
-		return err
-	}
-	opts := storerunlifecycle.EnsureActiveOptions{}
-	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
-		opts.HasBundleHashCol = true
-		opts.HasBundleSourceCol = true
-		opts.HasBundleFingerprintCol = true
-		opts.BundleHash = fact.BundleHash
-		opts.BundleSource = fact.BundleSource
-		opts.BundleFingerprint = fact.BundleFingerprint
-	}
-	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "", opts)
+	return persistence.RuntimeLogLineageParentEventID(ctx, runID, explicitParentEventID, subjectEventID)
 }
 
 func runtimeLogPayload(level, component, action string, e RuntimeLogEntry, detailMap map[string]any, runID, parentEventID, handlerID string) map[string]any {

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -21,10 +21,103 @@ type runtimeLogCapabilityStub struct {
 	enabled  bool
 	hasRunID bool
 	err      error
+	db       *sql.DB
 }
 
 func (s runtimeLogCapabilityStub) CanonicalRuntimeLogCapability(context.Context) (bool, bool, error) {
 	return s.enabled, s.hasRunID, s.err
+}
+
+func (s runtimeLogCapabilityStub) RuntimeLogLineageParentEventID(ctx context.Context, runID, explicitParentEventID, subjectEventID string) (string, error) {
+	explicitParentEventID = strings.TrimSpace(explicitParentEventID)
+	if explicitParentEventID != "" {
+		return explicitParentEventID, nil
+	}
+	runID = strings.TrimSpace(runID)
+	subjectEventID = strings.TrimSpace(subjectEventID)
+	if s.db == nil || runID == "" || subjectEventID == "" {
+		return "", nil
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", err
+	}
+	if _, err := uuid.Parse(subjectEventID); err != nil {
+		return "", nil
+	}
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_id = $2::uuid
+		)
+	`, runID, subjectEventID).Scan(&exists); err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+	return subjectEventID, nil
+}
+
+func (s runtimeLogCapabilityStub) PersistRuntimeLog(ctx context.Context, record RuntimeLogPersistenceRecord) error {
+	if s.db == nil {
+		return nil
+	}
+	runID := strings.TrimSpace(record.RunID)
+	parentEventID := strings.TrimSpace(record.ParentEventID)
+	if runID == "" {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, event_name, entity_id, flow_instance, scope, payload,
+				chain_depth, produced_by, produced_by_type, source_event_id, created_at
+			)
+			VALUES (
+				gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $1::jsonb,
+				0, 'runtime', 'platform', NULLIF($2,'')::uuid, now()
+			)
+		`, string(record.Payload), parentEventID)
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := ensureRuntimeLogRunRowForTest(ctx, tx, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			NULLIF($1,'')::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
+			0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
+		)
+	`, runID, string(record.Payload), parentEventID); err != nil {
+		return err
+	}
+	if err := storerunlifecycle.SyncCounts(ctx, tx, runID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func newTestRuntimeLogger(db *sql.DB, stub runtimeLogCapabilityStub) *RuntimeLogger {
+	stub.db = db
+	return NewRuntimeLogger(stub)
 }
 
 func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
@@ -55,7 +148,7 @@ func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 
@@ -135,7 +228,7 @@ func TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults(t *testing.T) 
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 
@@ -215,7 +308,7 @@ func TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner(t *testin
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	if err := logger.Log(context.Background(), RuntimeLogEntry{
 		Level:      "warn",
 		Message:    "Tool execution was denied for save_entity_field",
@@ -265,7 +358,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	if err := logger.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
 		Message:   "runtime log",
@@ -293,7 +386,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	sourceFact := runtimecorrelation.BundleSourceFact{
 		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
@@ -328,7 +421,7 @@ func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
 func TestRuntimeLogger_LogRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	sourceFact := runtimecorrelation.BundleSourceFact{
 		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
@@ -371,7 +464,7 @@ func TestRuntimeLogger_Log_ReturnsPersistenceFailure(t *testing.T) {
 
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
 		Message:   "Persisting the pipeline receipt failed",
@@ -415,7 +508,7 @@ func TestRuntimeLogger_Log_AllowsEmptyCanonicalMessageWhenDetailsExist(t *testin
 		}, "").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	if err := logger.Log(context.Background(), RuntimeLogEntry{
 		Level:     "debug",
 		Message:   "",
@@ -452,14 +545,13 @@ func TestDecodeCanonicalRuntimeLogPayload_FailsClosedOnMissingMessageField(t *te
 func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
 	capabilityErr := errors.New("capability unavailable")
 	tests := []struct {
-		name         string
-		db           bool
-		capabilities runtimeLogCapabilityResolver
+		name        string
+		db          bool
+		persistence RuntimeLogPersistence
 	}{
-		{name: "missing database", capabilities: runtimeLogCapabilityStub{enabled: true}},
-		{name: "missing resolver", db: true},
-		{name: "disabled", db: true, capabilities: runtimeLogCapabilityStub{}},
-		{name: "resolver error", db: true, capabilities: runtimeLogCapabilityStub{err: capabilityErr}},
+		{name: "missing persistence", db: true},
+		{name: "disabled", db: true, persistence: runtimeLogCapabilityStub{}},
+		{name: "resolver error", db: true, persistence: runtimeLogCapabilityStub{err: capabilityErr}},
 	}
 
 	for _, tt := range tests {
@@ -479,7 +571,12 @@ func TestRuntimeLogger_Log_FailsClosedWithoutCanonicalCapability(t *testing.T) {
 
 			recorder := runtimebus.NewEmittedEventsRecorder()
 			ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-			logger := NewRuntimeLogger(db, tt.capabilities)
+			persistence := tt.persistence
+			if stub, ok := persistence.(runtimeLogCapabilityStub); ok {
+				stub.db = db
+				persistence = stub
+			}
+			logger := NewRuntimeLogger(persistence)
 			if err := logger.Log(ctx, RuntimeLogEntry{
 				Level:   "info",
 				Message: "runtime log",
@@ -508,7 +605,7 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnPayloadValidationFailure
 
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true})
 	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "warn",
 		Message:   "runtime log",
@@ -546,7 +643,7 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnLineageLookupFailure(t *
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "warn",
 		Message:   "runtime log",
@@ -583,7 +680,7 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnRunRowFailure(t *testing
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
 		Message:   "runtime log",
@@ -625,7 +722,7 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnSyncCountsFailure(t *tes
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	err = logger.Log(ctx, RuntimeLogEntry{
 		Level:     "error",
 		Message:   "runtime log",
@@ -647,7 +744,7 @@ func TestRuntimeLogger_Log_PersistsCanonicalRunOwnershipFromContext(t *testing.T
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	spoofedRunID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
@@ -683,7 +780,7 @@ func TestRuntimeLogger_Log_DoesNotInferRunOwnershipFromDetailPayload(t *testing.
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	payloadRunID := uuid.NewString()
 
 	if err := logger.Log(ctx, RuntimeLogEntry{
@@ -716,11 +813,11 @@ func TestRuntimeLogger_Log_DerivesLineageFromPersistedSubjectEvent(t *testing.T)
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	subjectEventID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	if err := ensureRuntimeLogRunRow(ctx, db, runID); err != nil {
+	if err := ensureRuntimeLogRunRowForTest(ctx, db, runID); err != nil {
 		t.Fatalf("ensure run row: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -765,7 +862,7 @@ func TestRuntimeLogger_Log_DoesNotDeriveLineageFromUnpersistedSubjectEvent(t *te
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
@@ -797,7 +894,7 @@ func TestRuntimeLogger_Log_PersistsTypedRuntimeLineage(t *testing.T) {
 	ctx := context.Background()
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	logger := NewRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
+	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
 	subjectEventID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
@@ -812,7 +909,7 @@ func TestRuntimeLogger_Log_PersistsTypedRuntimeLineage(t *testing.T) {
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	if err := ensureRuntimeLogRunRow(ctx, db, runID); err != nil {
+	if err := ensureRuntimeLogRunRowForTest(ctx, db, runID); err != nil {
 		t.Fatalf("ensure run row: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -927,6 +1024,29 @@ func countRuntimeLogRowsForRun(t *testing.T, db *sql.DB, runID string) int {
 		t.Fatalf("count runtime log rows for %s: %v", runID, err)
 	}
 	return count
+}
+
+func ensureRuntimeLogRunRowForTest(ctx context.Context, db storerunlifecycle.DBTX, runID string) error {
+	if db == nil {
+		return nil
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return err
+	}
+	opts := storerunlifecycle.EnsureActiveOptions{}
+	if fact, ok := runtimecorrelation.BundleSourceFactFromContext(ctx); ok {
+		opts.HasBundleHashCol = true
+		opts.HasBundleSourceCol = true
+		opts.HasBundleFingerprintCol = true
+		opts.BundleHash = fact.BundleHash
+		opts.BundleSource = fact.BundleSource
+		opts.BundleFingerprint = fact.BundleFingerprint
+	}
+	return storerunlifecycle.EnsureActive(ctx, db, runID, "", "", opts)
 }
 
 type runtimeLogPayloadArg struct {

--- a/internal/runtime/runforkexecution/runtime_container.go
+++ b/internal/runtime/runforkexecution/runtime_container.go
@@ -218,7 +218,7 @@ func selectedContractRuntimeContainerLogger(pg *store.PostgresStore) runtimebus.
 	if pg == nil || pg.DB == nil {
 		return nil
 	}
-	return selectedContractRuntimeContainerLoggerHook{logger: runtimepkg.NewRuntimeLogger(pg.DB, pg)}
+	return selectedContractRuntimeContainerLoggerHook{logger: runtimepkg.NewRuntimeLogger(pg)}
 }
 
 func (h selectedContractRuntimeContainerLoggerHook) Log(ctx context.Context, level diaglog.Level, message, component, action, eventID, eventType, agentID, entityID, sessionID string, correlation map[string]string, detail any, errText string, durationUS int) error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -42,6 +42,7 @@ type Stores struct {
 	SQLDB               *sql.DB
 	ConstructionBlocker string
 	EventStore          runtimebus.EventStore
+	RuntimeLogStore     RuntimeLogPersistence
 	PipelineStore       *runtimepipeline.WorkflowInstanceStore
 	SessionRegistry     sessions.Registry
 	ConversationStore   llm.ConversationPersistence
@@ -55,10 +56,6 @@ type Stores struct {
 	InboundStore        InboundPersistence
 	RuntimeIngressStore runtimeingress.Store
 	TurnStore           llm.TurnPersistence
-}
-
-type runtimeLogSchemaCapabilityProvider interface {
-	CanonicalRuntimeLogCapability(context.Context) (bool, bool, error)
 }
 
 type eventReceiptSchemaCapabilityProvider interface {
@@ -96,7 +93,6 @@ type validatedRuntimeDeps struct {
 	Credentials              runtimecredentials.Store
 	Authority                runtimeauthority.Provider
 	EmitRegistry             *runtimetools.EmitRegistry
-	RuntimeLogCapabilities   runtimeLogCapabilityResolver
 	EventReceiptCapability   func(context.Context) (bool, error)
 	TrimmedBundleFingerprint string
 	BundleSourceFact         runtimecorrelation.BundleSourceFact
@@ -334,7 +330,6 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 		Credentials:              credentials,
 		Authority:                authorityProvider,
 		EmitRegistry:             emitRegistry,
-		RuntimeLogCapabilities:   runtimeLogSchemaCapabilities(stores),
 		EventReceiptCapability:   canonicalEventReceiptCapabilities(stores),
 		TrimmedBundleFingerprint: strings.TrimSpace(opts.BundleFingerprint),
 		BundleSourceFact:         opts.BundleSourceFact.Normalized(),
@@ -380,8 +375,8 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		Credentials:    boot.Credentials,
 	}
 
-	if stores.SQLDB != nil {
-		rt.Logger = NewRuntimeLogger(stores.SQLDB, boot.RuntimeLogCapabilities)
+	if stores.RuntimeLogStore != nil {
+		rt.Logger = NewRuntimeLogger(stores.RuntimeLogStore)
 	}
 	payloadValidator := boot.payloadValidator(rt.Logger)
 	boot.bindPayloadValidator(payloadValidator)
@@ -597,22 +592,6 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	}
 
 	return rt, nil
-}
-
-func runtimeLogSchemaCapabilities(stores Stores) runtimeLogCapabilityResolver {
-	candidates := []any{
-		stores.EventStore,
-		stores.ManagerStore,
-		stores.ScheduleStore,
-		stores.MailboxStore,
-		stores.InboundStore,
-	}
-	for _, candidate := range candidates {
-		if provider, ok := candidate.(runtimeLogSchemaCapabilityProvider); ok && provider != nil {
-			return provider
-		}
-	}
-	return nil
 }
 
 func canonicalEventReceiptCapabilities(stores Stores) func(context.Context) (bool, error) {

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -365,10 +365,11 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *t
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(false), Stores: Stores{
-		SQLDB:         db,
-		EventStore:    startupRecoveryCapabilityEventStore{},
-		ManagerStore:  &recoveryGuardManagerStore{},
-		ScheduleStore: scheduleStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    &recoveryGuardManagerStore{},
+		ScheduleStore:   scheduleStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -423,9 +424,10 @@ func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testin
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(false), Stores: Stores{
-		SQLDB:        db,
-		EventStore:   eventStore,
-		ManagerStore: managerStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      eventStore,
+		ManagerStore:    managerStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -498,10 +500,11 @@ func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:         db,
-		EventStore:    startupRecoveryCapabilityEventStore{},
-		ManagerStore:  &recoveryGuardManagerStore{},
-		ScheduleStore: scheduleStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    &recoveryGuardManagerStore{},
+		ScheduleStore:   scheduleStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -585,10 +588,11 @@ func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *te
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:         db,
-		EventStore:    startupRecoveryCapabilityEventStore{},
-		ManagerStore:  &recoveryGuardManagerStore{},
-		ScheduleStore: scheduleStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    &recoveryGuardManagerStore{},
+		ScheduleStore:   scheduleStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -710,9 +714,10 @@ func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *te
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:        db,
-		EventStore:   startupRecoveryCapabilityEventStore{},
-		ManagerStore: managerStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    managerStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -809,9 +814,10 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:        db,
-		EventStore:   eventStore,
-		ManagerStore: &recoveryGuardManagerStore{},
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      eventStore,
+		ManagerStore:    &recoveryGuardManagerStore{},
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -859,9 +865,10 @@ func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartu
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:        db,
-		EventStore:   startupRecoveryCapabilityEventStore{},
-		ManagerStore: startupRecoveryManagerStore{loadErr: errors.New("load agents failed")},
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    startupRecoveryManagerStore{loadErr: errors.New("load agents failed")},
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,
@@ -937,10 +944,11 @@ func TestRuntimeStart_InspectionFailurePreservesDecisionErrorAcrossTimerSkipAndD
 	}
 
 	rt, err := NewRuntime(ctx, RuntimeDeps{Config: testRecoveryDiagnosticsConfig(true), Stores: Stores{
-		SQLDB:         db,
-		EventStore:    startupRecoveryCapabilityEventStore{},
-		ManagerStore:  managerStore,
-		ScheduleStore: scheduleStore,
+		SQLDB:           db,
+		RuntimeLogStore: runtimeLogCapabilityStub{enabled: true, hasRunID: true, db: db},
+		EventStore:      startupRecoveryCapabilityEventStore{},
+		ManagerStore:    managerStore,
+		ScheduleStore:   scheduleStore,
 	}, Options: RuntimeOptions{
 		SelfCheck:      false,
 		WorkflowModule: module,

--- a/internal/store/runtime_log_persistence.go
+++ b/internal/store/runtime_log_persistence.go
@@ -1,0 +1,157 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimepkg "swarm/internal/runtime"
+)
+
+const runtimeLogEventName = "platform.runtime_log"
+
+func runtimeLogEvent(record runtimepkg.RuntimeLogPersistenceRecord) events.Event {
+	return events.Event{
+		ID:            uuid.NewString(),
+		Type:          events.EventType(runtimeLogEventName),
+		SourceAgent:   "runtime",
+		Payload:       json.RawMessage(record.Payload),
+		RunID:         strings.TrimSpace(record.RunID),
+		ParentEventID: strings.TrimSpace(record.ParentEventID),
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+func (s *PostgresStore) RuntimeLogLineageParentEventID(ctx context.Context, runID, explicitParentEventID, subjectEventID string) (string, error) {
+	explicitParentEventID = strings.TrimSpace(explicitParentEventID)
+	if explicitParentEventID != "" {
+		return explicitParentEventID, nil
+	}
+	runID = strings.TrimSpace(runID)
+	subjectEventID = strings.TrimSpace(subjectEventID)
+	if s == nil || s.DB == nil || runID == "" || subjectEventID == "" {
+		return "", nil
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", err
+	}
+	if _, err := uuid.Parse(subjectEventID); err != nil {
+		return "", nil
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_id = $2::uuid
+		)
+	`, runID, subjectEventID).Scan(&exists); err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+	return subjectEventID, nil
+}
+
+func (s *PostgresStore) PersistRuntimeLog(ctx context.Context, record runtimepkg.RuntimeLogPersistenceRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	enabled, _, err := s.CanonicalRuntimeLogCapability(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return unsupportedSchemaCapability("events", SchemaFlavorUnavailable)
+	}
+	if err := s.validateEventPayload(runtimeLogEventName, record.Payload); err != nil {
+		return err
+	}
+	if strings.TrimSpace(record.RunID) != "" {
+		return s.AppendEvent(ctx, runtimeLogEvent(record))
+	}
+	_, err = s.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (
+			gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $1::jsonb,
+			0, 'runtime', 'platform', NULLIF($2,'')::uuid, now()
+		)
+	`, string(record.Payload), strings.TrimSpace(record.ParentEventID))
+	if err != nil {
+		return fmt.Errorf("persist postgres runtime log: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) RuntimeLogLineageParentEventID(ctx context.Context, runID, explicitParentEventID, subjectEventID string) (string, error) {
+	explicitParentEventID = strings.TrimSpace(explicitParentEventID)
+	if explicitParentEventID != "" {
+		return explicitParentEventID, nil
+	}
+	runID = strings.TrimSpace(runID)
+	subjectEventID = strings.TrimSpace(subjectEventID)
+	if s == nil || s.DB == nil || runID == "" || subjectEventID == "" {
+		return "", nil
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", err
+	}
+	if _, err := uuid.Parse(subjectEventID); err != nil {
+		return "", nil
+	}
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events
+			WHERE run_id = ?
+			  AND event_id = ?
+		)
+	`, runID, subjectEventID).Scan(&exists); err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+	return subjectEventID, nil
+}
+
+func (s *SQLiteRuntimeStore) PersistRuntimeLog(ctx context.Context, record runtimepkg.RuntimeLogPersistenceRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	enabled, _, err := s.CanonicalRuntimeLogCapability(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return unsupportedSchemaCapability("events", SchemaFlavorUnavailable)
+	}
+	if err := s.validateEventPayload(runtimeLogEventName, record.Payload); err != nil {
+		return err
+	}
+	if strings.TrimSpace(record.RunID) != "" {
+		return s.AppendEvent(ctx, runtimeLogEvent(record))
+	}
+	_, err = s.DB.ExecContext(ctx, `
+		INSERT OR IGNORE INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
+			scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (?, NULL, 'platform.runtime_log', NULL, NULL, '{}', '{}', '[]',
+			'global', ?, 0, 'runtime', 'platform', ?, ?)
+	`, uuid.NewString(), string(record.Payload), sqliteNullUUID(record.ParentEventID), time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("persist sqlite runtime log: %w", err)
+	}
+	return nil
+}

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimepkg "swarm/internal/runtime"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
+)
+
+func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	subjectEventID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	if err := store.AppendEvent(ctx, events.Event{
+		ID:          subjectEventID,
+		RunID:       runID,
+		Type:        events.EventType("validation/validation.package_ready"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"ready":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed sqlite subject event: %v", err)
+	}
+
+	logger := runtimepkg.NewRuntimeLogger(store)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "sqlite diagnostic persisted",
+		Component: "eventbus",
+		Action:    "lineage_lookup",
+		EventID:   subjectEventID,
+		EventType: "validation/validation.package_ready",
+		SessionID: "session-1",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log sqlite: %v", err)
+	}
+
+	logs, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "eventbus",
+		Level:     "warn",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs sqlite: %v", err)
+	}
+	if len(logs.Logs) != 1 {
+		t.Fatalf("sqlite runtime logs = %#v, want one logger-written row", logs.Logs)
+	}
+	log := logs.Logs[0]
+	if log.RunID != runID || log.SessionID != "session-1" || log.Message != "sqlite diagnostic persisted" {
+		t.Fatalf("sqlite runtime log = %#v, want run/session/message", log)
+	}
+	gotParentEventID, _ := log.Details["parent_event_id"].(string)
+	if got := strings.TrimSpace(gotParentEventID); got != subjectEventID {
+		t.Fatalf("sqlite runtime log parent_event_id = %q, want %q", got, subjectEventID)
+	}
+	var sourceEventID string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(source_event_id, '')
+		FROM events
+		WHERE event_id = ?
+	`, log.LogID).Scan(&sourceEventID); err != nil {
+		t.Fatalf("load sqlite runtime log source_event_id: %v", err)
+	}
+	if sourceEventID != subjectEventID {
+		t.Fatalf("sqlite source_event_id = %q, want %q", sourceEventID, subjectEventID)
+	}
+}
+
+func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &PostgresStore{DB: db}
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+
+	runID := uuid.NewString()
+	subjectEventID := uuid.NewString()
+	sourceFact := runtimecorrelation.BundleSourceFact{
+		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BundleSource:      storerunlifecycle.BundleSourcePersisted,
+		BundleFingerprint: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: test', '{}'::jsonb)
+	`, sourceFact.BundleHash); err != nil {
+		t.Fatalf("seed bundle row: %v", err)
+	}
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
+	if err := pg.AppendEvent(ctx, events.Event{
+		ID:          subjectEventID,
+		RunID:       runID,
+		Type:        events.EventType("validation/validation.package_ready"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"ready":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed postgres subject event: %v", err)
+	}
+
+	logger := runtimepkg.NewRuntimeLogger(pg)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "postgres diagnostic persisted",
+		Component: "eventbus",
+		Action:    "lineage_lookup",
+		EventID:   subjectEventID,
+		EventType: "validation/validation.package_ready",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log postgres: %v", err)
+	}
+
+	var gotHash, gotSource, gotFingerprint, sourceEventID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(bundle_hash, ''), bundle_source, COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&gotHash, &gotSource, &gotFingerprint); err != nil {
+		t.Fatalf("load postgres run bundle source: %v", err)
+	}
+	if gotHash != sourceFact.BundleHash || gotSource != sourceFact.BundleSource || gotFingerprint != sourceFact.BundleFingerprint {
+		t.Fatalf("postgres run bundle source = hash:%q source:%q fingerprint:%q, want %#v", gotHash, gotSource, gotFingerprint, sourceFact)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(source_event_id::text, '')
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&sourceEventID); err != nil {
+		t.Fatalf("load postgres runtime log source_event_id: %v", err)
+	}
+	if sourceEventID != subjectEventID {
+		t.Fatalf("postgres source_event_id = %q, want %q", sourceEventID, subjectEventID)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2109,12 +2109,13 @@ engine:
         status: active_supported_runtime_backend
         meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
       sqlite:
-        status: explicit_local_store_backend_until_default_flip
+        status: explicit_local_store_backend_until_runtime_construction_gate
         meaning: >
           Local/dev SQLite runtime store selection. Explicit sqlite selection may construct the selected typed SQLite store
           owners promoted by #1086 and staged by #1087, including backend-neutral runtime diagnostics/log persistence
-          promoted by #1150. SQLite remains staged until the public default flip is separately proven by #1088; it does
-          not promote production multi-writer SQLite semantics.
+          promoted by #1150, but runtime boot remains fail-closed while mailbox_write materialization still depends on
+          the raw pipeline SQL database. SQLite remains staged until the public default flip is separately proven by
+          #1088; it does not promote production multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2171,8 +2172,9 @@ engine:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
       Explicit sqlite selection is recognized as a canonical backend id. It may construct the selected typed SQLite store
-      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers. Surfaces split to #1088/#1089
-      must still fail closed or remain unavailable until their owning children land.
+      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers. runtime.NewRuntime must
+      continue to fail closed while mailbox_write materialization still requires the raw pipeline SQL database. Surfaces
+      split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2186,7 +2188,7 @@ engine:
     split_boundaries:
     - "SQLite dialect/schema/bootstrap remains split to #1085."
     - "Backend-neutral core runtime persistence stores remain split to #1086."
-    - "SQLite runtime construction semantics remain under #1087 parent closeout until the parent is refreshed after the promoted child owners land."
+    - "SQLite runtime construction semantics remain under #1087 parent closeout; mailbox_write materialization must move off the raw pipeline SQL database or receive explicit split/tracker repair before runtime construction is unblocked."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
@@ -2258,11 +2260,14 @@ engine:
         - >
           May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
           observability semantics, #1148 budget/spend rows, #1149 tool entity/human-task persistence rows, and #1150
-          runtime diagnostics/log rows. SQLite remains staged for local/dev use until #1088 proves the public default flip.
+          runtime diagnostics/log rows, but must not be treated as construction-ready while mailbox_write materialization
+          still requires the raw pipeline SQL database.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
         - >
-          Must keep public default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit
-          Postgres opt-in together.
+          Must keep explicit SQLite runtime construction fail-closed until the residual #1087 mailbox_write materialization
+          raw-SQL seam is promoted to a backend-neutral owner or explicitly split by tracker repair, and must keep public
+          default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit Postgres opt-in
+          together.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2401,8 +2406,10 @@ engine:
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
         accidentally treated as SQLite owners. Runtime diagnostics/logging consumes the promoted backend-neutral
-        RuntimeLogPersistence owner instead of a raw SQL handle. Any future raw-SQL runtime consumer must receive a
-        separately gated backend-neutral owner before it can participate in explicit SQLite runtime construction.
+        RuntimeLogPersistence owner instead of a raw SQL handle. mailbox_write materialization remains a residual #1087
+        raw-SQL runtime consumer and must continue to block explicit SQLite runtime construction until promoted or split.
+        Any future raw-SQL runtime consumer must receive a separately gated backend-neutral owner before it can participate
+        in explicit SQLite runtime construction.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2109,13 +2109,12 @@ engine:
         status: active_supported_runtime_backend
         meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
       sqlite:
-        status: explicit_local_store_backend_until_runtime_construction_gate
+        status: explicit_local_store_backend_until_default_flip
         meaning: >
           Local/dev SQLite runtime store selection. Explicit sqlite selection may construct the selected typed SQLite store
-          owners promoted by #1086 and staged by #1087, but runtime boot remains fail-closed while the #1087 gate-promoted
-          raw-SQL runtime consumers are not migrated to backend-neutral owners or explicitly split by lead-approved tracker
-          repair. SQLite remains staged until the public default flip is separately proven by #1088; it does not promote
-          production multi-writer SQLite semantics.
+          owners promoted by #1086 and staged by #1087, including backend-neutral runtime diagnostics/log persistence
+          promoted by #1150. SQLite remains staged until the public default flip is separately proven by #1088; it does
+          not promote production multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2172,9 +2171,8 @@ engine:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
       Explicit sqlite selection is recognized as a canonical backend id. It may construct the selected typed SQLite store
-      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers, but runtime.NewRuntime must
-      continue to fail closed until the #1087 raw-SQL consumer blocker is migrated or receives explicit split/tracker
-      approval. Surfaces split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
+      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers. Surfaces split to #1088/#1089
+      must still fail closed or remain unavailable until their owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2188,7 +2186,7 @@ engine:
     split_boundaries:
     - "SQLite dialect/schema/bootstrap remains split to #1085."
     - "Backend-neutral core runtime persistence stores remain split to #1086."
-    - "SQLite runtime construction remains blocked by #1087 until gate-promoted raw-SQL runtime consumers are migrated or explicitly split."
+    - "SQLite runtime construction semantics remain under #1087 parent closeout until the parent is refreshed after the promoted child owners land."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
@@ -2259,12 +2257,12 @@ engine:
         - Must not silently replace missing unsupported sibling semantics with in-memory state.
         - >
           May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
-          observability semantics, #1148 budget/spend rows, and #1149 tool entity/human-task persistence rows, but must
-          not be treated as a construction-ready runtime backend while the remaining #1087 diagnostics raw-SQL consumer
-          blocker remains unresolved.
+          observability semantics, #1148 budget/spend rows, #1149 tool entity/human-task persistence rows, and #1150
+          runtime diagnostics/log rows. SQLite remains staged for local/dev use until #1088 proves the public default flip.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
-        - Must keep runtime construction fail-closed until runtime diagnostics/logging either gains a backend-neutral owner
-          for SQLite or receives explicit lead-approved split/tracker repair.
+        - >
+          Must keep public default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit
+          Postgres opt-in together.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2333,6 +2331,22 @@ engine:
       - runtime diagnostics/logging owned by #1150
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - production multi-writer SQLite concurrency semantics
+    - name: runtime_diagnostics_log_rows
+      owner: internal/runtime.RuntimeLogPersistence consumed by internal/runtime.RuntimeLogger through runtime.Stores.RuntimeLogStore
+      promoted_by: '#1150'
+      sqlite_owner: internal/store.SQLiteRuntimeStore runtime-log persistence and lineage lookup methods
+      postgres_owner: internal/store.PostgresStore runtime-log persistence and lineage lookup methods
+      scope: >
+        RuntimeLogger owns canonical platform.runtime_log payload construction. Backend-specific stores own capability
+        checks, global and run-scoped runtime-log persistence, source_event_id lineage lookup, and run-row preservation
+        behavior for their backend. Explicit SQLite local/dev runtime construction consumes SQLiteRuntimeStore without
+        passing a raw SQLite *sql.DB into RuntimeLogger. Postgres remains authoritative for production runtime-log
+        persistence, bundle-source fail-closed run creation, and run counter synchronization.
+      excludes:
+      - public operator agent.usage reads over spend_ledger owned by #1157
+      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - docs/CI/repo-wide closeout owned by #1089
+      - production multi-writer SQLite concurrency semantics
     - name: mailbox_rows
       owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
       sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
@@ -2382,13 +2396,13 @@ engine:
       scope: >
         SQLite exposes persisted local-runtime event, delivery, session, turn, and log rows through the same API read owner.
         Cursor-rich production read semantics remain Postgres-owned unless separately promoted for SQLite.
-    raw_sql_runtime_consumer_blocker_for_sqlite:
+    raw_sql_runtime_consumer_boundary_for_sqlite:
       runtime_sql_handle_for_sqlite: omitted
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
-        accidentally treated as SQLite owners. Because SQL runtime diagnostics/logging remains a gate-promoted #1087 consumer,
-        runtime.NewRuntime must fail closed for SQLite until that consumer moves to a backend-neutral store owner or receives
-        explicit lead-approved split/tracker repair.
+        accidentally treated as SQLite owners. Runtime diagnostics/logging consumes the promoted backend-neutral
+        RuntimeLogPersistence owner instead of a raw SQL handle. Any future raw-SQL runtime consumer must receive a
+        separately gated backend-neutral owner before it can participate in explicit SQLite runtime construction.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."


### PR DESCRIPTION
## Summary

Closes #1150.

This PR promotes runtime diagnostics/log persistence to a backend-neutral owner so explicit SQLite runtime construction no longer fails closed on the #1150 diagnostics/logging blocker while preserving Postgres runtime-log behavior. Explicit SQLite runtime construction remains fail-closed on the residual #1087 `mailbox_write` raw pipeline SQL seam.

## Governing refs / context

- Binding issue/gate: #1150 Pre-Implementation Coverage Audit and approved gate outcome for `runtime.sqlite_runtime_diagnostics_log_owner`.
- Authoritative spec updated in this PR: `platform-spec.yaml` `engine.runtime_store_backend_selection` and `engine.runtime_core_persistence_store_contracts`.
- Adjacent supported read surfaces used as proof: API runtime logs/subscribe logs and trace-related observability surfaces remain store-backed.

## Semantic migration

- New canonical owner: `internal/runtime.RuntimeLogPersistence`, consumed by `internal/runtime.RuntimeLogger` through `runtime.Stores.RuntimeLogStore`.
- Backend owners: `internal/store.PostgresStore` and `internal/store.SQLiteRuntimeStore` implement runtime-log capability, lineage lookup, and persistence.
- Old non-authoritative path invalidated: `RuntimeLogger` no longer accepts or owns a raw `*sql.DB`, and `internal/runtime/diagnostics.go` no longer contains Postgres-specific runtime-log SQL persistence helpers.
- SQLite construction path checked: `cmd/swarm` selected SQLite store wiring now provides `RuntimeLogStore` while leaving `runtime.Stores.SQLDB` nil and preserving a fail-closed `ConstructionBlocker` for residual #1087 `mailbox_write` materialization.
- Postgres path checked: Postgres still owns runtime-log persistence, run-row sync, bundle-source lineage, and selected-fork logger construction.
- Migration complete for #1150 only. Parent #1087/#1066 remain open; #1088 default flip, #1089 docs/CI, #1157 agent.usage reads, residual #1087 mailbox materialization, and production SQLite multi-writer semantics remain split.

## Verification

- `go test ./cmd/swarm -run 'TestBuildStores(SQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner|AcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./internal/store -run 'Test(SQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability|PostgresRuntimeLogPersistencePreservesRunSourceAndLineage)$' -count=1`
- `go test ./internal/apiv1 -run TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces -count=1`
- `go test ./internal/store -count=1`
- `go test ./internal/store -run TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires -count=1`
- `go test ./...` passed before the review follow-up; post-review exact full-suite retries were interrupted by shared Docker-backed store test contention from concurrent worktrees, while the affected paths above passed.