### PR TITLE
[agent-h][issue #1139] Promote workspace data source authority

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ SWARM_API_TOKEN=replace-with-random-token
 # bundle mounted at /opt/swarm/contracts.
 SWARM_CONTRACTS_HOST_DIR=/absolute/path/to/your/contracts
 
+# Optional fallback for plain local `swarm serve` when --data and
+# workspace.data_source are not set. Do not combine this with
+# SWARM_WORKSPACE_VOLUMES_FROM.
+SWARM_WORKSPACE_DATA_SOURCE=
+
 # Backend credentials. Set the one required by the backend you run.
 CLAUDE_CODE_OAUTH_TOKEN=
 ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ not user isolation on a shared host.
 
 See [`.env.example`](.env.example) for the public local environment template.
 
+### Workspace Reference Data
+
+Agents see shared reference files at `/data`. For plain local `swarm serve`,
+choose that host source explicitly:
+
+```bash
+swarm serve --contracts ./my-flow --data ./reference-data
+```
+
+The source order is `--data > workspace.data_source >
+SWARM_WORKSPACE_DATA_SOURCE > no path source`. The runtime no longer treats a
+repo-local `data/` directory as the implicit source of truth. `/data` remains
+read-only and opaque to Swarm; contract-owned `flows/<flow>/data/` files are a
+separate bundled contract input.
+
 ### LLM Backend Profiles
 
 Outside the Compose quickstart, select a shipped backend with `--backend` or

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -27,12 +27,13 @@ type runtimeProjectSupervisor struct {
 	stores           storeBundle
 	ready            *atomic.Bool
 	dev              bool
+	mountSources     workspaceMountSources
 	startRuntime     func(context.Context, *runtime.Runtime) error
 	shutdownRuntime  func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
 	validateSource   func(context.Context, semanticview.Source) error
 	initStateStores  func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
-	newWorkspaces    func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle
+	newWorkspaces    func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error)
 	createRuntime    func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
 
 	mu                              sync.RWMutex
@@ -49,6 +50,7 @@ func newRuntimeProjectSupervisor(
 	cfg *config.Config,
 	stores storeBundle,
 	ready *atomic.Bool,
+	mountSources workspaceMountSources,
 	initialRoot string,
 	initialBundle *runtimecontracts.WorkflowContractBundle,
 	initialSource semanticview.Source,
@@ -66,6 +68,7 @@ func newRuntimeProjectSupervisor(
 		stores:           stores,
 		ready:            ready,
 		dev:              dev,
+		mountSources:     mountSources,
 		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
 			return rt.Start(ctx)
 		},
@@ -79,8 +82,8 @@ func newRuntimeProjectSupervisor(
 			return verifyBundle(ctx, source)
 		},
 		initStateStores: initializeStateStores,
-		newWorkspaces: func(stores storeBundle, repoRoot, contractsRoot string, source semanticview.Source) workspace.Lifecycle {
-			return configuredWorkspaceLifecycle(stores.SQLDB, repoRoot, contractsRoot, source)
+		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
+			return configuredWorkspaceLifecycle(stores.SQLDB, contractsRoot, source, mountSources)
 		},
 		createRuntime: func(ctx context.Context, deps runtime.RuntimeDeps) (*runtime.Runtime, error) {
 			return runtime.NewRuntime(ctx, deps)
@@ -176,7 +179,10 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if err != nil {
 		return builderpkg.ProjectStatus{}, fmt.Errorf("prepare project bundle source: %w", err)
 	}
-	workspaces := s.newWorkspaces(s.stores, s.repoRoot, resolvedRoot, source)
+	workspaces, err := s.newWorkspaces(s.stores, resolvedRoot, source, s.mountSources)
+	if err != nil {
+		return builderpkg.ProjectStatus{}, err
+	}
 	if err := workspaces.ValidateSource(ctx, source); err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -207,7 +207,7 @@ func newSupervisorForLoadProjectFailureTest(
 	bundle := testBuilderSupervisorBundle(t)
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
-	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), "", nil, nil, nil)
+	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, "", nil, nil, nil)
 	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {
@@ -219,13 +219,41 @@ func newSupervisorForLoadProjectFailureTest(
 	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
 		return "store wiring ready", nil
 	}
-	supervisor.newWorkspaces = func(storeBundle, string, string, semanticview.Source) workspace.Lifecycle {
-		return lifecycle
+	supervisor.newWorkspaces = func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error) {
+		return lifecycle, nil
 	}
 	if createRuntime != nil {
 		supervisor.createRuntime = createRuntime
 	}
 	return supervisor
+}
+
+func TestRuntimeProjectSupervisorLoadProjectUsesResolvedWorkspaceMountSources(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	dataDir := t.TempDir()
+	wantMountSources := workspaceMountSources{
+		DataSource:       dataDir,
+		DataSourceSource: "--data",
+	}
+
+	var gotMountSources workspaceMountSources
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		return &runtimepkg.Runtime{}, nil
+	})
+	supervisor.mountSources = wantMountSources
+	supervisor.newWorkspaces = func(_ storeBundle, _ string, _ semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
+		gotMountSources = mountSources
+		return stubWorkspaceLifecycle{}, nil
+	}
+	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
+
+	if _, err := supervisor.OpenProject(context.Background(), projectRoot); err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	if gotMountSources != wantMountSources {
+		t.Fatalf("workspace mount sources = %#v, want %#v", gotMountSources, wantMountSources)
+	}
 }
 
 func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailures(t *testing.T) {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -138,6 +138,12 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 					return fmt.Errorf("--bundle-hash requires --store postgres")
 				}
 			}
+			if cmd.Flags().Changed("data") {
+				opts.DataSource = strings.TrimSpace(opts.DataSource)
+				if opts.DataSource == "" {
+					return fmt.Errorf("--data must be non-empty")
+				}
+			}
 			if opts.Dev {
 				opts.AbandonActiveRuns = true
 				opts.NoRequireBundleMatch = true
@@ -181,6 +187,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", opts.ConfigPath, "Optional path to Swarm runtime config")
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, or openai_compatible")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
+	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringVar(&opts.BundleHash, "bundle-hash", opts.BundleHash, "Load a persisted bundle catalog row by canonical bundle_hash (serial single-bundle process)")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -72,8 +72,8 @@ const (
 var (
 	buildStoresForServe                  = buildStores
 	runtimeConfigExecutablePath          = os.Executable
-	configuredWorkspaceLifecycleForServe = func(db *sql.DB, repoRoot, contractsRoot string, source semanticview.Source) serveWorkspaceLifecycle {
-		return configuredWorkspaceLifecycle(db, repoRoot, contractsRoot, source)
+	configuredWorkspaceLifecycleForServe = func(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (serveWorkspaceLifecycle, error) {
+		return configuredWorkspaceLifecycle(db, contractsRoot, source, mountSources)
 	}
 )
 
@@ -174,6 +174,7 @@ type serveOptions struct {
 	ConfigPath           string
 	Backend              string
 	ContractsPath        string
+	DataSource           string
 	BundleHash           string
 	PlatformSpecPath     string
 	StoreMode            string
@@ -377,6 +378,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	cfg := cfgResult.Config
 	reporter.emit(2, "config_load", "ok", serveConfigLoadDetail(cfgResult.Detail(), resolvedPaths, opts))
+	mountSources, err := resolveWorkspaceMountSources(repo, opts.DataSource, cfg)
+	if err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
+		log.Printf("resolve workspace data source: %v", err)
+		return 1
+	}
 	storeSelection, err := resolveRuntimeStoreSelection(repo, opts.StoreMode, opts.StoreModeSet, cfg)
 	if err != nil {
 		reporter.emit(3, "db_connection", "FAILED", err.Error())
@@ -428,7 +435,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		}
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
-	workspaces := configuredWorkspaceLifecycleForServe(stores.SQLDB, repo, contractsRoot, source)
+	workspaces, err := configuredWorkspaceLifecycleForServe(stores.SQLDB, contractsRoot, source, mountSources)
+	if err != nil {
+		slog.Error("configure workspaces", "error", err)
+		return 1
+	}
 	if workspaces == nil {
 		slog.Error("workspace lifecycle is not configured")
 		return 1
@@ -557,7 +568,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, contractsRoot, bundle, source, rt, opts.Dev)
 	if loadedBundle.dbLoaded {
 		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins one persisted bundle for the process; dynamic project reload is split to RuntimeContextManager work")
 	}
@@ -1112,7 +1123,20 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
-		workspaces := configuredWorkspaceLifecycle(stores.SQLDB, repo, contractsRoot, source)
+		mountSources, err := resolveWorkspaceMountSources(repo, "", cfg)
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: resolve workspace data source: %v\n", err)
+			}
+			return 1
+		}
+		workspaces, err := configuredWorkspaceLifecycle(stores.SQLDB, contractsRoot, source, mountSources)
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: configure workspaces: %v\n", err)
+			}
+			return 1
+		}
 		result, err := runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
 			SourceRunID: strings.TrimSpace(*runID),
 			At:          strings.TrimSpace(*at),
@@ -2704,18 +2728,25 @@ func buildCredentialStore() (runtimecredentials.Store, error) {
 	return runtimecredentials.NewOverlayStore(runtimecredentials.NewEnvStore(), fileStore), nil
 }
 
-func configuredWorkspaceLifecycle(db *sql.DB, repoRoot, contractsRoot string, source semanticview.Source) *workspace.DockerManager {
+func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.DockerManager, error) {
 	manager := workspace.NewDockerManager(db)
 	cfg := workspace.DefaultDockerConfig()
-	if root := strings.TrimSpace(repoRoot); root != "" {
-		cfg.SharedDataSource = filepath.Join(root, "data")
+	if dataSource := strings.TrimSpace(mountSources.DataSource); dataSource != "" {
+		if volumesFrom := strings.TrimSpace(cfg.WorkspaceVolumesFrom); volumesFrom != "" {
+			sourceLabel := strings.TrimSpace(mountSources.DataSourceSource)
+			if sourceLabel == "" {
+				sourceLabel = "explicit data source"
+			}
+			return nil, fmt.Errorf("workspace data source from %s cannot be combined with SWARM_WORKSPACE_VOLUMES_FROM=%s", sourceLabel, volumesFrom)
+		}
+		cfg.SharedDataSource = dataSource
 	}
 	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {
 		cfg.ContractsSource = contractsDir
 	}
 	manager.SetConfig(cfg)
 	manager.SetSemanticSource(source)
-	return manager
+	return manager, nil
 }
 
 func repoRoot() string {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -314,7 +314,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--data", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -683,6 +683,36 @@ func TestCLI_ServeRuntimeConfigDoesNotFeedListenerConfig(t *testing.T) {
 	}
 	if captured.MCPListenAddr != defaultMCPListenAddr {
 		t.Fatalf("mcp listen addr = %q, want default %q", captured.MCPListenAddr, defaultMCPListenAddr)
+	}
+}
+
+func TestCLI_ServeDataFlagFeedsServeOptions(t *testing.T) {
+	dataDir := t.TempDir()
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--data", dataDir}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.DataSource != dataDir {
+		t.Fatalf("data source = %q, want %q", captured.DataSource, dataDir)
+	}
+}
+
+func TestCLI_ServeDataFlagRejectsEmptySource(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--data", ""}, &stdout, &stderr, defaultRootCommandOptions())
+	if code == 0 {
+		t.Fatalf("serve code = 0, want failure stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--data must be non-empty") {
+		t.Fatalf("serve stderr = %q, want --data validation error", stderr.String())
 	}
 }
 
@@ -1325,28 +1355,236 @@ func TestConfiguredWorkspaceLifecycleDoesNotInventSourceRootDataSource(t *testin
 		t.Fatalf("write package.yaml: %v", err)
 	}
 
-	manager := configuredWorkspaceLifecycle(nil, "", contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
-	err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{})
+	if err != nil {
+		t.Fatalf("configuredWorkspaceLifecycle: %v", err)
+	}
+	err = manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
 	if err == nil || !strings.Contains(err.Error(), "/data source is not configured") {
 		t.Fatalf("ValidateSource error = %v, want explicit /data source requirement", err)
 	}
 }
 
-func TestConfiguredWorkspaceLifecycleUsesExplicitRepoAndContractsSources(t *testing.T) {
+func TestConfiguredWorkspaceLifecycleUsesExplicitDataAndContractsSources(t *testing.T) {
 	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
 	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
-	repoRoot := t.TempDir()
-	if err := os.Mkdir(filepath.Join(repoRoot, "data"), 0o755); err != nil {
-		t.Fatalf("mkdir data: %v", err)
-	}
+	dataDir := t.TempDir()
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 
-	manager := configuredWorkspaceLifecycle(nil, repoRoot, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+		DataSource:       dataDir,
+		DataSourceSource: "--data",
+	})
+	if err != nil {
+		t.Fatalf("configuredWorkspaceLifecycle: %v", err)
+	}
 	if err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})); err != nil {
 		t.Fatalf("ValidateSource: %v", err)
+	}
+}
+
+func TestConfiguredWorkspaceLifecycleFailsClosedForUnreadableDataSource(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
+	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
+	missingDataDir := filepath.Join(t.TempDir(), "missing-data")
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+
+	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+		DataSource:       missingDataDir,
+		DataSourceSource: "--data",
+	})
+	if err != nil {
+		t.Fatalf("configuredWorkspaceLifecycle: %v", err)
+	}
+	err = manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	if err == nil || !strings.Contains(err.Error(), "/data source") || !strings.Contains(err.Error(), missingDataDir) {
+		t.Fatalf("ValidateSource error = %v, want missing explicit /data source", err)
+	}
+}
+
+func TestConfiguredWorkspaceLifecycleRejectsExplicitDataSourceWithVolumesFrom(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "swarm-orchestrator")
+	_, err := configuredWorkspaceLifecycle(nil, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+		DataSource:       t.TempDir(),
+		DataSourceSource: "workspace.data_source",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with SWARM_WORKSPACE_VOLUMES_FROM") {
+		t.Fatalf("configuredWorkspaceLifecycle error = %v, want volumes-from conflict", err)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
+	repoRoot := t.TempDir()
+	flagDir := filepath.Join(repoRoot, "flag-data")
+	configDir := filepath.Join(repoRoot, "config-data")
+	envDir := filepath.Join(repoRoot, "env-data")
+	for _, dir := range []string{flagDir, configDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		FlagDataSource:   "flag-data",
+		ConfigDataSource: "config-data",
+		EnvDataSource:    "env-data",
+		EnvDataSourceSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve workspace mount sources: %v", err)
+	}
+	if result.DataSource != flagDir || result.DataSourceSource != "--data" {
+		t.Fatalf("flag precedence result = %#v, want source %q from --data", result, flagDir)
+	}
+
+	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		ConfigDataSource: "config-data",
+		EnvDataSource:    "env-data",
+		EnvDataSourceSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve config workspace mount source: %v", err)
+	}
+	if result.DataSource != configDir || result.DataSourceSource != "workspace.data_source" {
+		t.Fatalf("config precedence result = %#v, want source %q from workspace.data_source", result, configDir)
+	}
+
+	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		EnvDataSource:    "env-data",
+		EnvDataSourceSet: true,
+		ConfigDataSource: " ",
+		FlagDataSource:   " ",
+	})
+	if err != nil {
+		t.Fatalf("resolve env workspace mount source: %v", err)
+	}
+	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
+		t.Fatalf("env precedence result = %#v, want source %q from %s", result, envDir, envWorkspaceDataSource)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesDoesNotInventRepoDataDefault(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, "data"), 0o755); err != nil {
+		t.Fatalf("mkdir repo data: %v", err)
+	}
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{RepoRoot: repoRoot})
+	if err != nil {
+		t.Fatalf("resolve workspace mount sources: %v", err)
+	}
+	if result.DataSource != "" || result.DataSourceSource != "" {
+		t.Fatalf("workspace mount sources = %#v, want no source without explicit owner", result)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing.T) {
+	repoRoot := t.TempDir()
+	configDir := t.TempDir()
+	envDir := t.TempDir()
+	t.Setenv(envWorkspaceDataSource, envDir)
+
+	result, err := resolveWorkspaceMountSources(repoRoot, "", &config.Config{
+		Workspace: config.WorkspaceConfig{DataSource: configDir},
+	})
+	if err != nil {
+		t.Fatalf("resolve config workspace mount sources: %v", err)
+	}
+	if result.DataSource != configDir || result.DataSourceSource != "workspace.data_source" {
+		t.Fatalf("config-backed workspace mount sources = %#v, want %q from workspace.data_source", result, configDir)
+	}
+
+	result, err = resolveWorkspaceMountSources(repoRoot, "", &config.Config{})
+	if err != nil {
+		t.Fatalf("resolve env workspace mount sources: %v", err)
+	}
+	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
+		t.Fatalf("env-backed workspace mount sources = %#v, want %q from %s", result, envDir, envWorkspaceDataSource)
+	}
+}
+
+func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
+	var spec struct {
+		WorkspaceModel struct {
+			DataSourceAuthority struct {
+				PromotedBy                     string   `yaml:"promoted_by"`
+				ImplementationStatus           string   `yaml:"implementation_status"`
+				CanonicalOwner                 string   `yaml:"canonical_owner"`
+				CLIFlag                        string   `yaml:"cli_flag"`
+				ConfigKey                      string   `yaml:"config_key"`
+				EnvVar                         string   `yaml:"env_var"`
+				SourceOrder                    []string `yaml:"source_order"`
+				DefaultBehavior                string   `yaml:"default_behavior"`
+				FailureBehavior                string   `yaml:"failure_behavior"`
+				VolumesFromConflictRule        string   `yaml:"volumes_from_conflict_rule"`
+				ReadPolicy                     string   `yaml:"read_policy"`
+				RetiredNonAuthoritativeSources []string `yaml:"retired_non_authoritative_sources"`
+				SplitScope                     []string `yaml:"split_scope"`
+			} `yaml:"data_source_authority"`
+		} `yaml:"workspace_model"`
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					WorkspaceDataSourceAuthority struct {
+						PromotedBy string   `yaml:"promoted_by"`
+						Owner      string   `yaml:"owner"`
+						Flag       string   `yaml:"flag"`
+						ConfigKey  string   `yaml:"config_key"`
+						EnvVar     string   `yaml:"env_var"`
+						Consumers  []string `yaml:"consumers"`
+					} `yaml:"workspace_data_source_authority"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	authority := spec.WorkspaceModel.DataSourceAuthority
+	if strings.TrimSpace(authority.PromotedBy) != "#1139" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+		t.Fatalf("workspace data source authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
+	}
+	if !strings.Contains(authority.CanonicalOwner, "workspace_model.data_source_authority") {
+		t.Fatalf("workspace data source canonical owner = %q", authority.CanonicalOwner)
+	}
+	if authority.CLIFlag != "--data" || authority.ConfigKey != "workspace.data_source" || authority.EnvVar != envWorkspaceDataSource {
+		t.Fatalf("workspace data source selectors = %#v", authority)
+	}
+	for _, want := range []string{"--data", "workspace.data_source", envWorkspaceDataSource, "no path source"} {
+		if !stringSliceContains(authority.SourceOrder, want) {
+			t.Fatalf("workspace data source order missing %q: %#v", want, authority.SourceOrder)
+		}
+	}
+	for _, want := range []string{"repo-local `data/`", "fail closed", "SWARM_WORKSPACE_VOLUMES_FROM", "read-only", "opaque"} {
+		if !strings.Contains(authority.DefaultBehavior+authority.FailureBehavior+authority.VolumesFromConflictRule+authority.ReadPolicy+strings.Join(authority.RetiredNonAuthoritativeSources, "\n"), want) {
+			t.Fatalf("workspace data source spec missing %q:\n%#v", want, authority)
+		}
+	}
+	for _, want := range []string{"#1137", "#1138", "SWARM_WORKSPACE_DATA_MOUNT"} {
+		if !joinedContains(authority.SplitScope, want) {
+			t.Fatalf("workspace data source split scope missing %q: %#v", want, authority.SplitScope)
+		}
+	}
+	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceDataSourceAuthority
+	if command.PromotedBy != "#1139" || command.Owner != "workspace_model.data_source_authority" || command.Flag != "--data <path>" {
+		t.Fatalf("serve command data authority = %#v", command)
+	}
+	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+		if !joinedContains(command.Consumers, want) {
+			t.Fatalf("serve command data authority consumers missing %q: %#v", want, command.Consumers)
+		}
 	}
 }
 
@@ -1790,6 +2028,64 @@ func TestRuntimeOperationsWatchlistMapsLLMProviderModelSelectionSourceAuthority(
 	}
 	if !joinedContains(node.CommonFramingMistakes.TooBroad, "#1128") || !joinedContains(node.CommonFramingMistakes.TooNarrow, "model alongside model") {
 		t.Fatalf("watchlist framing mistakes do not guard #1127 split: %#v", node.CommonFramingMistakes)
+	}
+}
+
+func TestRuntimeOperationsWatchlistMapsWorkspaceDataSourceAuthority(t *testing.T) {
+	var watchlist struct {
+		ActiveIssues []struct {
+			ID     int      `yaml:"id"`
+			MapsTo []string `yaml:"maps_to"`
+		} `yaml:"active_issues"`
+		Nodes []struct {
+			ID                    string   `yaml:"id"`
+			KnownManifestations   []string `yaml:"known_manifestations"`
+			RepresentativeIssues  []int    `yaml:"representative_issues"`
+			CommonFramingMistakes struct {
+				TooNarrow []string `yaml:"too_narrow"`
+			} `yaml:"common_framing_mistakes"`
+		} `yaml:"nodes"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), "docs", "watchlists", "runtime-operations.yaml"))
+	if err != nil {
+		t.Fatalf("read runtime operations watchlist: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &watchlist); err != nil {
+		t.Fatalf("parse runtime operations watchlist: %v", err)
+	}
+	if !watchlistIssueMapsTo(watchlist.ActiveIssues, 1139, "fail_closed_operational_config") {
+		t.Fatalf("issue 1139 does not map to fail_closed_operational_config: %#v", watchlist.ActiveIssues)
+	}
+	var node struct {
+		ID                    string
+		KnownManifestations   []string
+		RepresentativeIssues  []int
+		CommonFramingMistakes struct {
+			TooNarrow []string `yaml:"too_narrow"`
+		} `yaml:"common_framing_mistakes"`
+	}
+	for _, candidate := range watchlist.Nodes {
+		if candidate.ID == "fail_closed_operational_config" {
+			node.ID = candidate.ID
+			node.KnownManifestations = candidate.KnownManifestations
+			node.RepresentativeIssues = candidate.RepresentativeIssues
+			node.CommonFramingMistakes = candidate.CommonFramingMistakes
+			break
+		}
+	}
+	if node.ID == "" {
+		t.Fatalf("fail_closed_operational_config node not found")
+	}
+	for _, want := range []string{"#1139", "--data", "workspace.data_source", envWorkspaceDataSource, "repoRoot/data"} {
+		if !joinedContains(node.KnownManifestations, want) {
+			t.Fatalf("watchlist known manifestations missing %q: %#v", want, node.KnownManifestations)
+		}
+	}
+	if !intSliceContains(node.RepresentativeIssues, 1139) {
+		t.Fatalf("representative issues missing 1139: %#v", node.RepresentativeIssues)
+	}
+	if !joinedContains(node.CommonFramingMistakes.TooNarrow, "repo-local data directory") {
+		t.Fatalf("watchlist framing mistakes missing repo-local data guard: %#v", node.CommonFramingMistakes)
 	}
 }
 
@@ -2341,6 +2637,55 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 	stopped = true
 }
 
+func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
+	dataDir := t.TempDir()
+	var capturedMountSources workspaceMountSources
+	_, _, _ = installServeRuntimePostgresTestStoresWithWorkspaceFactory(t, func(mountSources workspaceMountSources) serveWorkspaceLifecycle {
+		capturedMountSources = mountSources
+		return serveRuntimeWorkspaceStub{}
+	})
+
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(serveCtx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			DataSource:         dataDir,
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: false,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+	stopped := false
+	t.Cleanup(func() {
+		if stopped {
+			return
+		}
+		cancelServe()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out stopping runServeRuntime\noutput:\n%s", out.String())
+		}
+	})
+	waitForServeReadyLine(t, &out, done)
+	cancelServe()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	stopped = true
+	if capturedMountSources.DataSource != dataDir || capturedMountSources.DataSourceSource != "--data" {
+		t.Fatalf("workspace mount sources = %#v, want %q from --data", capturedMountSources, dataDir)
+	}
+}
+
 func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	_, _, _ = installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -2512,6 +2857,13 @@ const serveRuntimeLegacyRunIDForTest = "11111111-2222-3333-4444-555555555555"
 
 func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
+	return installServeRuntimePostgresTestStoresWithWorkspaceFactory(t, func(workspaceMountSources) serveWorkspaceLifecycle {
+		return workspaceFactory()
+	})
+}
+
+func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+	t.Helper()
 	oldBuildStores := buildStoresForServe
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
 	dsn, db, cleanup := testutil.StartPostgres(t)
@@ -2544,8 +2896,8 @@ func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func()
 			TurnStore:           runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
-		return workspaceFactory()
+	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources) (serveWorkspaceLifecycle, error) {
+		return workspaceFactory(mountSources), nil
 	}
 	t.Cleanup(func() {
 		buildStoresForServe = oldBuildStores
@@ -5529,8 +5881,8 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 			TurnStore:          runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
-		return serveRuntimeWorkspaceStub{}
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
 		buildStoresForServe = oldBuildStores
@@ -5620,8 +5972,8 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 					TurnStore:          runtimePG,
 				}, nil
 			}
-			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
-				return serveRuntimeWorkspaceStub{}
+			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+				return serveRuntimeWorkspaceStub{}, nil
 			}
 			t.Cleanup(func() {
 				buildStoresForServe = oldBuildStores
@@ -5785,8 +6137,8 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 			TurnStore:          runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, string, semanticview.Source) serveWorkspaceLifecycle {
-		return serveRuntimeWorkspaceStub{}
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
 		buildStoresForServe = oldBuildStores

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1445,10 +1445,11 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	}
 
 	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:         repoRoot,
-		ConfigDataSource: "config-data",
-		EnvDataSource:    "env-data",
-		EnvDataSourceSet: true,
+		RepoRoot:            repoRoot,
+		ConfigDataSource:    "config-data",
+		ConfigDataSourceSet: true,
+		EnvDataSource:       "env-data",
+		EnvDataSourceSet:    true,
 	})
 	if err != nil {
 		t.Fatalf("resolve config workspace mount source: %v", err)
@@ -1469,6 +1470,24 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	}
 	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
 		t.Fatalf("env precedence result = %#v, want source %q from %s", result, envDir, envWorkspaceDataSource)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeEnvFallback(t *testing.T) {
+	repoRoot := t.TempDir()
+	envDir := t.TempDir()
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:            repoRoot,
+		ConfigDataSource:    " \t ",
+		ConfigDataSourceSet: true,
+		EnvDataSource:       envDir,
+		EnvDataSourceSet:    true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "workspace.data_source") || !strings.Contains(err.Error(), "must be non-empty") {
+		t.Fatalf("resolve workspace mount sources error = %v, want empty workspace.data_source rejection", err)
+	}
+	if result.DataSource != "" || result.DataSourceSource != "workspace.data_source" {
+		t.Fatalf("workspace mount sources = %#v, want no env fallback and workspace.data_source source label", result)
 	}
 }
 
@@ -1508,6 +1527,31 @@ func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing
 	}
 	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
 		t.Fatalf("env-backed workspace mount sources = %#v, want %q from %s", result, envDir, envWorkspaceDataSource)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "swarm.yaml")
+	writeRuntimeConfigText(t, configPath, strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  data_source: \"   \"",
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n")+"\n")
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config with empty workspace.data_source: %v", err)
+	}
+	result, err = resolveWorkspaceMountSources(repoRoot, "", cfg)
+	if err == nil || !strings.Contains(err.Error(), "workspace.data_source") || !strings.Contains(err.Error(), "must be non-empty") {
+		t.Fatalf("resolve empty configured workspace source error = %v, want fail-closed config rejection before env fallback", err)
+	}
+	if result.DataSource != "" || result.DataSourceSource != "workspace.data_source" {
+		t.Fatalf("empty configured workspace source result = %#v, want no env fallback", result)
 	}
 }
 

--- a/cmd/swarm/workspace_data_source.go
+++ b/cmd/swarm/workspace_data_source.go
@@ -21,7 +21,8 @@ type workspaceDataSourceInput struct {
 
 	FlagDataSource string
 
-	ConfigDataSource string
+	ConfigDataSource    string
+	ConfigDataSourceSet bool
 
 	EnvDataSource    string
 	EnvDataSourceSet bool
@@ -29,12 +30,14 @@ type workspaceDataSourceInput struct {
 
 func resolveWorkspaceMountSources(repoRoot string, flagDataSource string, cfg *config.Config) (workspaceMountSources, error) {
 	envDataSource, envDataSourceSet := os.LookupEnv(envWorkspaceDataSource)
+	configDataSource, configDataSourceSet := runtimeConfigWorkspaceDataSource(cfg)
 	return resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:         repoRoot,
-		FlagDataSource:   flagDataSource,
-		ConfigDataSource: runtimeConfigWorkspaceDataSource(cfg),
-		EnvDataSource:    envDataSource,
-		EnvDataSourceSet: envDataSourceSet,
+		RepoRoot:            repoRoot,
+		FlagDataSource:      flagDataSource,
+		ConfigDataSource:    configDataSource,
+		ConfigDataSourceSet: configDataSourceSet,
+		EnvDataSource:       envDataSource,
+		EnvDataSourceSet:    envDataSourceSet,
 	})
 }
 
@@ -43,7 +46,7 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 	case strings.TrimSpace(in.FlagDataSource) != "":
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.FlagDataSource, "--data")
 		return workspaceMountSources{DataSource: path, DataSourceSource: "--data"}, err
-	case strings.TrimSpace(in.ConfigDataSource) != "":
+	case in.ConfigDataSourceSet:
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.ConfigDataSource, "workspace.data_source")
 		return workspaceMountSources{DataSource: path, DataSourceSource: "workspace.data_source"}, err
 	case in.EnvDataSourceSet && strings.TrimSpace(in.EnvDataSource) != "":
@@ -54,11 +57,11 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 	}
 }
 
-func runtimeConfigWorkspaceDataSource(cfg *config.Config) string {
+func runtimeConfigWorkspaceDataSource(cfg *config.Config) (string, bool) {
 	if cfg == nil {
-		return ""
+		return "", false
 	}
-	return cfg.Workspace.DataSource
+	return cfg.Workspace.DataSource, cfg.Workspace.DataSourceConfigured()
 }
 
 func normalizeWorkspaceDataSourcePath(repoRoot string, raw string, source string) (string, error) {

--- a/cmd/swarm/workspace_data_source.go
+++ b/cmd/swarm/workspace_data_source.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"swarm/internal/config"
+)
+
+const envWorkspaceDataSource = "SWARM_WORKSPACE_DATA_SOURCE"
+
+type workspaceMountSources struct {
+	DataSource       string
+	DataSourceSource string
+}
+
+type workspaceDataSourceInput struct {
+	RepoRoot string
+
+	FlagDataSource string
+
+	ConfigDataSource string
+
+	EnvDataSource    string
+	EnvDataSourceSet bool
+}
+
+func resolveWorkspaceMountSources(repoRoot string, flagDataSource string, cfg *config.Config) (workspaceMountSources, error) {
+	envDataSource, envDataSourceSet := os.LookupEnv(envWorkspaceDataSource)
+	return resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		FlagDataSource:   flagDataSource,
+		ConfigDataSource: runtimeConfigWorkspaceDataSource(cfg),
+		EnvDataSource:    envDataSource,
+		EnvDataSourceSet: envDataSourceSet,
+	})
+}
+
+func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspaceMountSources, error) {
+	switch {
+	case strings.TrimSpace(in.FlagDataSource) != "":
+		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.FlagDataSource, "--data")
+		return workspaceMountSources{DataSource: path, DataSourceSource: "--data"}, err
+	case strings.TrimSpace(in.ConfigDataSource) != "":
+		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.ConfigDataSource, "workspace.data_source")
+		return workspaceMountSources{DataSource: path, DataSourceSource: "workspace.data_source"}, err
+	case in.EnvDataSourceSet && strings.TrimSpace(in.EnvDataSource) != "":
+		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.EnvDataSource, envWorkspaceDataSource)
+		return workspaceMountSources{DataSource: path, DataSourceSource: envWorkspaceDataSource}, err
+	default:
+		return workspaceMountSources{}, nil
+	}
+}
+
+func runtimeConfigWorkspaceDataSource(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Workspace.DataSource
+}
+
+func normalizeWorkspaceDataSourcePath(repoRoot string, raw string, source string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("workspace data source from %s must be non-empty", source)
+	}
+	return filepath.Clean(resolvePath(repoRoot, path)), nil
+}

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -69,6 +69,10 @@ active_issues:
     title: Make operational config surfaces fail closed and remove inert controls
     maps_to:
       - fail_closed_operational_config
+  - id: 1139
+    title: Make agent /data source explicit via serve flag and config
+    maps_to:
+      - fail_closed_operational_config
   - id: 170
     title: Introduce an explicit runtime dependency graph object for boot wiring
     maps_to:
@@ -744,13 +748,16 @@ nodes:
     known_manifestations:
       - inert controls left exposed
       - operational config surfaces not fail-closed
+      - '#1139 runtime /data source authority requires --data > workspace.data_source > SWARM_WORKSPACE_DATA_SOURCE > no path source and must fail closed instead of deriving repoRoot/data'
     representative_issues:
       - 147
+      - 1139
     common_framing_mistakes:
       too_broad:
         - config is confusing
       too_narrow:
         - one flag is inert
+        - repo-local data directory happens to exist, so /data source authority is already safe
     current_action_pressure: active
   - id: runtime_lifecycle_observability
     title: Runtime Lifecycle Observability

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,11 +14,12 @@ import (
 
 // Config contains platform-generic runtime configuration.
 type Config struct {
-	Runtime    RuntimeConfig  `yaml:"runtime"`
-	Database   DatabaseConfig `yaml:"database"`
-	Store      StoreConfig    `yaml:"store"`
-	LLM        LLMConfig      `yaml:"llm"`
-	Extensions map[string]any `yaml:",inline"`
+	Runtime    RuntimeConfig   `yaml:"runtime"`
+	Database   DatabaseConfig  `yaml:"database"`
+	Store      StoreConfig     `yaml:"store"`
+	Workspace  WorkspaceConfig `yaml:"workspace"`
+	LLM        LLMConfig       `yaml:"llm"`
+	Extensions map[string]any  `yaml:",inline"`
 
 	typedExtensions ExtensionsConfig `yaml:"-"`
 	extensionsReady bool             `yaml:"-"`
@@ -48,6 +49,10 @@ type StoreConfig struct {
 
 type StoreSQLiteConfig struct {
 	Path string `yaml:"path"`
+}
+
+type WorkspaceConfig struct {
+	DataSource string `yaml:"data_source"`
 }
 
 type LLMConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,30 @@ type StoreSQLiteConfig struct {
 
 type WorkspaceConfig struct {
 	DataSource string `yaml:"data_source"`
+
+	dataSourceSet bool
+}
+
+func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
+	type raw WorkspaceConfig
+	var decoded raw
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*w = WorkspaceConfig(decoded)
+	if value.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			if value.Content[i].Value == "data_source" {
+				w.dataSourceSet = true
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (w WorkspaceConfig) DataSourceConfigured() bool {
+	return w.dataSourceSet || strings.TrimSpace(w.DataSource) != ""
 }
 
 type LLMConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,6 +64,9 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	if cfg.Workspace.DataSource != "./reference-data" {
 		t.Fatalf("workspace.data_source = %q, want ./reference-data", cfg.Workspace.DataSource)
 	}
+	if !cfg.Workspace.DataSourceConfigured() {
+		t.Fatal("workspace.data_source presence was not preserved")
+	}
 
 	var ext ExtensionsConfig
 	if err := cfg.DecodeExtensions(&ext); err != nil {
@@ -81,6 +84,35 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	}
 	if ext.Sharding.Stages["default"].TargetItemsPerShard != 10 {
 		t.Fatalf("expected default sharding.stages.default.target_items_per_shard=10, got %d", ext.Sharding.Stages["default"].TargetItemsPerShard)
+	}
+}
+
+func TestLoad_PreservesEmptyWorkspaceDataSourcePresence(t *testing.T) {
+	cfgText := strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  data_source: \"   \"",
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	p := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(p, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Workspace.DataSourceConfigured() {
+		t.Fatal("empty workspace.data_source presence was not preserved")
+	}
+	if cfg.Workspace.DataSource != "   " {
+		t.Fatalf("workspace.data_source = %q, want preserved whitespace", cfg.Workspace.DataSource)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,8 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 		"  password: postgres",
 		"  sslmode: disable",
 		"  pool_size: 5",
+		"workspace:",
+		"  data_source: ./reference-data",
 		"llm:",
 		"  backend: claude_cli",
 		"  session:",
@@ -58,6 +60,9 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	}
 	if cfg.LLM.Session.LockTTL <= 0*time.Second {
 		t.Fatalf("expected lock ttl > 0")
+	}
+	if cfg.Workspace.DataSource != "./reference-data" {
+		t.Fatalf("workspace.data_source = %q, want ./reference-data", cfg.Workspace.DataSource)
 	}
 
 	var ext ExtensionsConfig

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -85,7 +85,7 @@ func DefaultDockerConfig() DockerConfig {
 		WorkspaceImage:        ConfiguredWorkspaceImageFromEnv(),
 		WorkspaceNetwork:      EnvOrDefault("SWARM_WORKSPACE_NETWORK", "mas_default"),
 		WorkspaceVolumesFrom:  EnvOrDefault("SWARM_WORKSPACE_VOLUMES_FROM", ""),
-		SharedDataSource:      EnvOrDefault("SWARM_WORKSPACE_DATA_SOURCE", ""),
+		SharedDataSource:      "",
 		DataMountPoint:        EnvOrDefault("SWARM_WORKSPACE_DATA_MOUNT", "/data"),
 		ContractsSource:       EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", ""),
 		ContractsMountPoint:   EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_MOUNT", "/opt/swarm/contracts"),

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -303,15 +303,15 @@ func TestDefaultDockerConfigDoesNotDeriveSourceRootMounts(t *testing.T) {
 	}
 }
 
-func TestDefaultDockerConfigConsumesExplicitWorkspaceMountEnv(t *testing.T) {
+func TestDefaultDockerConfigLeavesDataSourceToCommandResolver(t *testing.T) {
 	dataDir := t.TempDir()
 	contractsDir := t.TempDir()
 	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", dataDir)
 	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", contractsDir)
 
 	cfg := DefaultDockerConfig()
-	if cfg.SharedDataSource != dataDir {
-		t.Fatalf("SharedDataSource = %q, want %q", cfg.SharedDataSource, dataDir)
+	if cfg.SharedDataSource != "" {
+		t.Fatalf("SharedDataSource = %q, want command-level resolver to own SWARM_WORKSPACE_DATA_SOURCE", cfg.SharedDataSource)
 	}
 	if cfg.ContractsSource != contractsDir {
 		t.Fatalf("ContractsSource = %q, want %q", cfg.ContractsSource, contractsDir)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6499,6 +6499,53 @@ workspace_model:
     split_scope: >
       Docker Compose setup and workspace image contents/default agent CLI availability remain tracked separately by #996 and
       #997 unless a future gate explicitly widens them.
+  data_source_authority:
+    promoted_by: '#1139'
+    implementation_status: implemented_first_slice
+    canonical_owner: platform-spec.yaml#workspace_model.data_source_authority
+    scope: >
+      Defines the host/source authority for the agent-visible `/data` mount for `swarm serve` and current Docker workspace
+      lifecycle consumers. Compose/Postgres onboarding (#1137), host workspace backend implementation (#1138), SQLite default,
+      and mount destination override cleanup remain split.
+    cli_flag: --data
+    config_key: workspace.data_source
+    env_var: SWARM_WORKSPACE_DATA_SOURCE
+    source_order:
+    - --data
+    - workspace.data_source
+    - SWARM_WORKSPACE_DATA_SOURCE
+    - no path source
+    default_behavior: >
+      The runtime MUST NOT synthesize a source path from the Swarm source checkout. In particular, a non-empty repo root or a
+      repo-local `data/` directory is not a valid `/data` source unless the operator selected it explicitly through the
+      authoritative source order.
+    path_resolution_rule: >
+      Non-empty relative path sources are resolved through the command path resolver with the active repo root when present;
+      absolute path sources are used as-is after cleaning. Empty explicit values are invalid.
+    failure_behavior: >
+      Missing or unreadable path sources fail closed during workspace boot validation. If no path source is selected,
+      workspace boot must still fail closed unless an explicit deployment alternate such as `SWARM_WORKSPACE_VOLUMES_FROM`
+      satisfies the invariant `/data` mount.
+    volumes_from_conflict_rule: >
+      `SWARM_WORKSPACE_VOLUMES_FROM` is an explicit deployment alternate, not a fallback path source. It MUST NOT be combined
+      with an explicit `/data` path source from `--data`, `workspace.data_source`, or `SWARM_WORKSPACE_DATA_SOURCE`; startup
+      must fail closed on that conflict.
+    read_policy: >
+      `/data` remains read-only, global, and opaque to the platform. Source authority does not permit indexing, mutating,
+      validating contents beyond mount readability, or folding runtime `/data` into workflow bundle identity.
+    consumers:
+    - swarm serve boot workspace lifecycle
+    - builder project supervisor reload workspace lifecycle
+    - selected-contract run-fork workspace lifecycle
+    - Docker workspace manager SharedDataSource mount consumer
+    retired_non_authoritative_sources:
+    - repoRoot/data derivation in cmd/swarm configuredWorkspaceLifecycle
+    - lower-level Docker default ownership of SWARM_WORKSPACE_DATA_SOURCE
+    split_scope:
+    - '#1137 Compose/Postgres onboarding and Compose ./data:/data:ro deployment shape'
+    - '#1138 host workspace backend'
+    - SQLite local default and broader local runtime onboarding
+    - mount destination override semantics such as SWARM_WORKSPACE_DATA_MOUNT
   standard_mounts:
     description: Three mount points are available to every agent session. Products cannot add new mount points — they configure
       access and scope for these three via workspace class definitions.
@@ -8230,6 +8277,21 @@ cli_specification:
           running binary second when present, built-in/default config last, then --backend overrides config llm.backend.
           SWARM_LLM_BACKEND, SWARM_LLM_RUNTIME_MODE, llm.runtime_mode, and SWARM_OPENAI_COMPATIBLE_BASE_URL are retired
           selector/connection-owner seams and must fail closed.
+      workspace_data_source_authority:
+        promoted_by: '#1139'
+        owner: workspace_model.data_source_authority
+        flag: --data <path>
+        config_key: workspace.data_source
+        env_var: SWARM_WORKSPACE_DATA_SOURCE
+        rule: >
+          `swarm serve` MUST resolve the agent-visible `/data` source through
+          `workspace_model.data_source_authority` before constructing any workspace lifecycle. The command MUST NOT
+          derive `/data` from the Swarm source checkout or from a repo-local `data/` directory unless that path was
+          explicitly selected by the operator through the promoted source order.
+        consumers:
+        - serve boot workspace lifecycle
+        - dynamic Builder project reload workspace lifecycle
+        - selected-contract run-fork workspace lifecycle
       unified_listener_bind_contract:
         implemented_by: '#853'
         superseded_by: '#992 listener_topology_v2_1 runtime bind implementation'


### PR DESCRIPTION
## Summary

Closes #1139.

This PR promotes explicit agent `/data` source authority for `swarm serve` and the current Docker workspace lifecycle consumers. It adds `swarm serve --data`, `workspace.data_source`, and `SWARM_WORKSPACE_DATA_SOURCE` resolution through one command-level owner with precedence `--data > workspace.data_source > SWARM_WORKSPACE_DATA_SOURCE > no path source`.

## Governing Refs / Context

- `platform-spec.yaml#workspace_model.data_source_authority`
- `platform-spec.yaml#workspace_model.runtime_image_packaging.mount_source_rule`
- `platform-spec.yaml#workspace_model.standard_mounts./data`
- `platform-spec.yaml#workspace_model.mount_guarantees`
- `platform-spec.yaml#workspace_model.boot_validation`
- `platform-spec.yaml#workspace_model.deployment_mapping`
- `platform-spec.yaml#entity_capabilities.flow_data_access.data_root`
- Issue #1139 Pre-Implementation Coverage Audit and independent gate comment approving first-slice implementation.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#workspace_model.data_source_authority`, implemented by `cmd/swarm/workspace_data_source.go` before workspace lifecycle construction.
- Old invalid path: `configuredWorkspaceLifecycle` no longer derives `repoRoot/data`; `DefaultDockerConfig` no longer owns `SWARM_WORKSPACE_DATA_SOURCE` directly.
- Checked production paths: serve boot, builder project supervisor reload, selected-contract run-fork, Docker workspace mount args/validation, config loading, CLI flag parsing, docs/env example, and runtime operations watchlist.
- Migration completeness: complete for the approved child class. #1137 Compose/Postgres, #1138 host workspace backend, SQLite default, and mount-destination override cleanup remain split.

## Validation

- `go test ./cmd/swarm ./internal/config ./internal/runtime/workspace`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`