### PR TITLE
[agent-e][issue #1120] Externalize output events from source route

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -13,6 +13,7 @@ import (
 	"swarm/internal/events"
 	"swarm/internal/runtime/accprojection"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeeventidentity "swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
@@ -941,9 +942,12 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 		if eventType == "" {
 			continue
 		}
+		eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
+		emitSpec := spec.Emit
+		emitSpec.Event = eventType
 		frame.state.SetFanOut("item", item)
 		payload := map[string]any{}
-		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, spec.Emit, workflowexpr.ValueExpressionOptions{AllowBareItem: true})
+		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{AllowBareItem: true})
 		if err != nil {
 			return false, err
 		}
@@ -954,7 +958,7 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if _, err := e.queueEmitIntentForSpec(frame, spec.Emit, eventType, shaped); err != nil {
+		if _, err := e.queueEmitIntentForSpec(frame, emitSpec, eventType, shaped); err != nil {
 			return false, err
 		}
 	}
@@ -1311,6 +1315,8 @@ func (e *Executor) stepEmits(frame *executionFrame) error {
 	if eventType == "" {
 		return nil
 	}
+	eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
+	emitSpec.Event = eventType
 	payload := map[string]any{}
 	if len(frame.state.Transformed) > 0 {
 		payload = frame.state.Transformed
@@ -1930,6 +1936,79 @@ func (e *Executor) shapeEmitPayloadWithContext(ctx context.Context, frame *execu
 	return e.deps.PayloadShaper.ShapeEmitPayload(ctx, req, strings.TrimSpace(eventType), cloned)
 }
 
+func (e *Executor) resolveDeclarativeEmitEventType(frame *executionFrame, eventType string) string {
+	eventType = runtimeeventidentity.Normalize(eventType)
+	if eventType == "" || e == nil || e.deps.Source == nil || frame == nil {
+		return eventType
+	}
+	flowID := strings.TrimSpace(frame.req.FlowID.String())
+	if flowID == "" {
+		return eventType
+	}
+	scope, ok := semanticview.FlowScopeByID(e.deps.Source, flowID)
+	if !ok {
+		return eventType
+	}
+	sourceRoute := emitSourceRoute(frame)
+	namespacePath := emitNamespaceSourcePath(scope, sourceRoute.FlowInstance)
+	localEvent := emitScopeLocalEventName(scope, namespacePath, eventType)
+	if localEvent == "" {
+		return eventType
+	}
+	if namespacePath == "" {
+		return localEvent
+	}
+	return namespacePath + "/" + localEvent
+}
+
+func emitNamespaceSourcePath(scope semanticview.FlowScope, sourcePath string) string {
+	scopePath := runtimeeventidentity.Normalize(scope.Path)
+	sourcePath = runtimeeventidentity.Normalize(sourcePath)
+	if scopePath == "" {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(scope.Mode), "template") || sourcePath == "" {
+		return scopePath
+	}
+	if sourcePath == scopePath || strings.HasPrefix(sourcePath, scopePath+"/") {
+		return sourcePath
+	}
+	return scopePath
+}
+
+func emitScopeLocalEventName(scope semanticview.FlowScope, sourcePath, eventType string) string {
+	eventType = runtimeeventidentity.Normalize(eventType)
+	if eventType == "" {
+		return ""
+	}
+	localEvents := emitScopeLocalEvents(scope)
+	if _, ok := localEvents[eventType]; ok {
+		return eventType
+	}
+	for _, prefix := range []string{sourcePath, scope.Path} {
+		prefix = runtimeeventidentity.Normalize(prefix)
+		if prefix == "" || !strings.HasPrefix(eventType, prefix+"/") {
+			continue
+		}
+		local := strings.TrimPrefix(eventType, prefix+"/")
+		if _, ok := localEvents[local]; ok {
+			return local
+		}
+	}
+	return ""
+}
+
+func emitScopeLocalEvents(scope semanticview.FlowScope) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, eventType := range scope.OutputEvents {
+		eventType = runtimeeventidentity.Normalize(eventType)
+		if eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	return out
+}
+
 func (e *Executor) newEmitIntent(frame *executionFrame, spec runtimecontracts.EmitSpec, eventType string, payload map[string]any, chainDepth int) (EmitIntent, error) {
 	encoded, err := encodePayload(payload)
 	if err != nil {
@@ -1942,9 +2021,9 @@ func (e *Executor) newEmitIntent(frame *executionFrame, spec runtimecontracts.Em
 			createdAt = last.Add(time.Nanosecond)
 		}
 	}
-	entityID := strings.TrimSpace(firstNonEmpty(
-		frame.req.EntityID.String(),
-	))
+	sourceRoute := emitSourceRoute(frame)
+	entityID := sourceRoute.EntityID
+	flowInstance := sourceRoute.FlowInstance
 	evt := events.Event{
 		Type:       events.EventType(strings.TrimSpace(eventType)),
 		Payload:    encoded,
@@ -1954,18 +2033,9 @@ func (e *Executor) newEmitIntent(frame *executionFrame, spec runtimecontracts.Em
 	if entityID != "" {
 		evt = evt.WithEntityID(entityID)
 	}
-	flowInstance := firstNonEmpty(
-		normalizedFlowInstanceCandidate(asString(frame.req.State.StateCarrier.Metadata["flow_path"])),
-		normalizedFlowInstanceCandidate(frame.req.Event.FlowInstance()),
-	)
 	if flowInstance != "" {
 		evt = evt.WithFlowInstance(flowInstance)
 	}
-	sourceRoute := events.RouteIdentity{
-		FlowID:       strings.TrimSpace(frame.req.FlowID.String()),
-		FlowInstance: flowInstance,
-		EntityID:     entityID,
-	}.Normalized()
 	if !sourceRoute.Empty() {
 		evt = evt.WithSourceRoute(sourceRoute)
 	}
@@ -2061,6 +2131,21 @@ func parentRouteFromState(metadata map[string]any) events.RouteIdentity {
 		FlowID:       asString(metadata["parent_flow_id"]),
 		FlowInstance: flowInstance,
 		EntityID:     entityID,
+	}.Normalized()
+}
+
+func emitSourceRoute(frame *executionFrame) events.RouteIdentity {
+	if frame == nil {
+		return events.RouteIdentity{}
+	}
+	flowInstance := firstNonEmpty(
+		normalizedFlowInstanceCandidate(asString(frame.req.State.StateCarrier.Metadata["flow_path"])),
+		normalizedFlowInstanceCandidate(frame.req.Event.FlowInstance()),
+	)
+	return events.RouteIdentity{
+		FlowID:       strings.TrimSpace(frame.req.FlowID.String()),
+		FlowInstance: flowInstance,
+		EntityID:     strings.TrimSpace(frame.req.EntityID.String()),
 	}.Normalized()
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -15,11 +15,60 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/identity"
 	runtimeregistry "swarm/internal/runtime/core/registry"
+	"swarm/internal/runtime/flowmodel"
 	"swarm/internal/runtime/semanticview"
 )
 
 func stubSource() semanticview.Source {
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+}
+
+func sourceWithDeclarativeEmitExternalizationFlows() semanticview.Source {
+	component := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "component-scaffold", Flow: "component-scaffold", Mode: "template"},
+		Path:  "component-scaffold",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs:  runtimecontracts.FlowInputPins{Events: []string{"repo_scaffold.repo_scaffolded"}},
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"component.scaffolded"}},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"component.scaffolded": {},
+		},
+	}
+	repo := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "repo-scaffold", Flow: "repo-scaffold"},
+		Path:  "repo-scaffold",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"repo_scaffold.repo_scaffolded"}},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"repo_scaffold.repo_scaffolded": {},
+		},
+	}
+	operating := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "operating", Flow: "operating"},
+		Path:  "operating",
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{component, repo, operating}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"component-scaffold": &root.Children[0],
+				"repo-scaffold":      &root.Children[1],
+				"operating":          &root.Children[2],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"component-scaffold": &root.Children[0],
+				"repo-scaffold":      &root.Children[1],
+				"operating":          &root.Children[2],
+			},
+		},
+	})
 }
 
 func sourceWithPolicy(values map[string]any) semanticview.Source {
@@ -1752,6 +1801,231 @@ func TestExecutor_EmitIntentFallsBackToInboundFlowWhenStateFlowPathNormalizesEmp
 	}
 	if got := result.EmitIntents[0].Event.FlowInstance(); got != "source/inst-1" {
 		t.Fatalf("emitted flow_instance = %q, want inbound fallback source/inst-1", got)
+	}
+}
+
+func TestExecutor_DeclarativeEmitSurfacesUseProducerSourceRouteNamespace(t *testing.T) {
+	source := sourceWithDeclarativeEmitExternalizationFlows()
+	parentRoute := events.RouteIdentity{
+		FlowID:       "operating",
+		FlowInstance: "operating/opco-1",
+		EntityID:     "opco-entity",
+	}.Normalized()
+	cases := []struct {
+		name      string
+		eventType string
+		payload   json.RawMessage
+		handler   runtimecontracts.SystemNodeEventHandler
+	}{
+		{
+			name: "top-level emit",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Emit: runtimecontracts.EmitSpec{Event: "component-scaffold/component.scaffolded"},
+			},
+		},
+		{
+			name: "rule emit",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Rules: []runtimecontracts.HandlerRuleEntry{{
+					Condition: "else",
+					Emit:      runtimecontracts.EmitSpec{Event: "component-scaffold/component.scaffolded"},
+				}},
+			},
+		},
+		{
+			name: "on-complete emit",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				OnComplete: []runtimecontracts.HandlerRuleEntry{{
+					Emit: runtimecontracts.EmitSpec{Event: "component-scaffold/component.scaffolded"},
+				}},
+			},
+		},
+		{
+			name: "accumulate on-complete emit",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnComplete: []runtimecontracts.HandlerRuleEntry{{
+						Emit: runtimecontracts.EmitSpec{Event: "component-scaffold/component.scaffolded"},
+					}},
+				},
+			},
+		},
+		{
+			name:      "accumulate on-timeout emit",
+			eventType: "accumulate.timeout",
+			payload: json.RawMessage(`{
+				"timer_handle": {
+					"kind": "accumulation_timeout",
+					"bucket": {
+						"node_id": "component-node",
+						"event_type": "repo-scaffold/repo_scaffold.repo_scaffolded"
+					}
+				}
+			}`),
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnTimeout: &runtimecontracts.HandlerRuleEntry{
+						Emit: runtimecontracts.EmitSpec{Event: "component-scaffold/component.scaffolded"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source:     source,
+				StateRepo:  stubStateRepo{},
+				TxRunner:   stubRunner{},
+				Locker:     stubLocker{},
+				Outbox:     stubOutbox{},
+				Dispatcher: stubDispatcher{},
+			}, nil)
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+			eventType := tc.eventType
+			if eventType == "" {
+				eventType = "repo-scaffold/repo_scaffold.repo_scaffolded"
+			}
+			payload := tc.payload
+			if len(payload) == 0 {
+				payload = json.RawMessage(`{}`)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: "component-entity",
+				NodeID:   "component-node",
+				FlowID:   "component-scaffold",
+				Event:    events.Event{ID: "evt-1", Type: events.EventType(eventType), Payload: payload},
+				Handler:  tc.handler,
+				State: testStateSnapshot("ready", map[string]any{
+					"flow_path":            "component-scaffold/component-1",
+					"parent_flow_id":       parentRoute.FlowID,
+					"parent_flow_instance": parentRoute.FlowInstance,
+					"parent_entity_id":     parentRoute.EntityID,
+				}, nil, map[string]map[string]any{}),
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if got := len(result.EmitIntents); got != 1 {
+				t.Fatalf("EmitIntents count = %d, want 1", got)
+			}
+			emitted := result.EmitIntents[0].Event
+			if got, want := string(emitted.Type), "component-scaffold/component-1/component.scaffolded"; got != want {
+				t.Fatalf("emitted type = %q, want %q", got, want)
+			}
+			if got := emitted.SourceRoute().FlowInstance; got != "component-scaffold/component-1" {
+				t.Fatalf("source flow_instance = %q, want component-scaffold/component-1", got)
+			}
+			if got := emitted.TargetRoute().FlowInstance; got != parentRoute.FlowInstance {
+				t.Fatalf("target flow_instance = %q, want %s", got, parentRoute.FlowInstance)
+			}
+		})
+	}
+}
+
+func TestExecutor_FanOutEmitUsesProducerSourceRouteNamespace(t *testing.T) {
+	source := sourceWithDeclarativeEmitExternalizationFlows()
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "component-entity",
+		NodeID:   "component-node",
+		FlowID:   "component-scaffold",
+		Event:    events.Event{ID: "evt-1", Type: "repo-scaffold/repo_scaffold.repo_scaffolded", Payload: json.RawMessage(`{"items":[{"id":"a"},{"id":"b"}]}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			FanOut: &runtimecontracts.FanOutSpec{
+				ItemsFrom: "payload.items",
+				Emit: runtimecontracts.EmitSpec{
+					Event: "component-scaffold/component.scaffolded",
+				},
+			},
+		},
+		State: testStateSnapshot("ready", map[string]any{
+			"flow_path":            "component-scaffold/component-1",
+			"parent_flow_id":       "operating",
+			"parent_flow_instance": "operating/opco-1",
+			"parent_entity_id":     "opco-entity",
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 2 {
+		t.Fatalf("EmitIntents count = %d, want 2", got)
+	}
+	for i, intent := range result.EmitIntents {
+		if got, want := string(intent.Event.Type), "component-scaffold/component-1/component.scaffolded"; got != want {
+			t.Fatalf("emit %d type = %q, want %q", i, got, want)
+		}
+		if got := intent.Event.SourceRoute().FlowInstance; got != "component-scaffold/component-1" {
+			t.Fatalf("emit %d source flow_instance = %q, want component-scaffold/component-1", i, got)
+		}
+	}
+}
+
+func TestExecutor_StaticProducerTargetRouteDoesNotOwnEventNamespace(t *testing.T) {
+	source := sourceWithDeclarativeEmitExternalizationFlows()
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "repo-entity",
+		NodeID:   "repo-node",
+		FlowID:   "repo-scaffold",
+		Event:    events.Event{ID: "evt-1", Type: "repo.commit_ready", Payload: json.RawMessage(`{}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Emit: runtimecontracts.EmitSpec{
+				Event: "repo-scaffold/repo_scaffold.repo_scaffolded",
+				Target: runtimecontracts.EmitTargetSpec{
+					Kind:       runtimecontracts.EmitTargetKindInstanceID,
+					Flow:       "component-scaffold",
+					InstanceID: "component-1",
+				},
+			},
+		},
+		State: testStateSnapshot("ready", map[string]any{
+			"flow_path": "repo-scaffold",
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", got)
+	}
+	emitted := result.EmitIntents[0].Event
+	if got, want := string(emitted.Type), "repo-scaffold/repo_scaffold.repo_scaffolded"; got != want {
+		t.Fatalf("emitted type = %q, want %q", got, want)
+	}
+	if got := emitted.SourceRoute().FlowInstance; got != "repo-scaffold" {
+		t.Fatalf("source flow_instance = %q, want repo-scaffold", got)
+	}
+	if got := emitted.TargetRoute().FlowInstance; got != "component-scaffold/component-1" {
+		t.Fatalf("target flow_instance = %q, want component-scaffold/component-1", got)
+	}
+	if got := emitted.FlowInstance(); got != "component-scaffold/component-1" {
+		t.Fatalf("legacy flow_instance projection = %q, want target component-scaffold/component-1", got)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -2187,6 +2187,53 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface
 	}
 }
 
+func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsForConcreteTemplateOutput(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml":             "name: template-output-required\nversion: 1.0.0\ndescription: Template output required-field proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: template\n",
+		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n",
+		"events.yaml":              "parent.trigger:\n  entity_id: string\n",
+		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=1.1.0\"\nflows: []\n",
+		"flows/child/schema.yaml":  "name: child\nmode: template\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.done]\n",
+		"flows/child/events.yaml":  "child.start:\n  entity_id: string\nchild.done:\n  step: string\n  required: [step]\n",
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected workflow fixture bundle")
+	}
+	shaper := pipelineEnginePayloadShaper{
+		coordinator: &PipelineCoordinator{
+			module: &previewWorkflowModule{
+				bundle: bundle,
+			},
+		},
+	}
+
+	req := runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("ent-child"),
+		FlowID:   identity.NormalizeFlowID("child"),
+		Event: events.Event{
+			Type:    events.EventType("child/child.start"),
+			Payload: json.RawMessage(`{"entity_id":"ent-child"}`),
+		}.WithEntityID("ent-child"),
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("ent-child"),
+			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
+		},
+	}
+
+	_, err := shaper.ShapeEmitPayload(context.Background(), req, "child/inst-1/child.done", map[string]any{})
+	if err == nil {
+		t.Fatal("expected concrete template output missing required field to fail closed")
+	}
+	if !errors.Is(err, runtimeengine.ErrEmitPayloadContractViolation) {
+		t.Fatalf("ShapeEmitPayload concrete template output error = %v, want %v", err, runtimeengine.ErrEmitPayloadContractViolation)
+	}
+
+	if _, err := shaper.ShapeEmitPayload(context.Background(), req, "child/inst-1/child.done", map[string]any{"step": "done"}); err != nil {
+		t.Fatalf("ShapeEmitPayload concrete template output with required field: %v", err)
+	}
+}
+
 func TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSurface(t *testing.T) {
 	source := loadWorkflowTempSource(t, map[string]string{
 		"package.yaml":             "name: action-emit-envelope-required\nversion: 1.0.0\ndescription: Action emit envelope-required proof.\nplatform_version: \">=1.1.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",

--- a/internal/runtime/semanticview/event_proof.go
+++ b/internal/runtime/semanticview/event_proof.go
@@ -1,6 +1,7 @@
 package semanticview
 
 import (
+	"sort"
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -116,6 +117,14 @@ func localizeFlowEventForProof(source Source, flowID, canonical string) string {
 	if !ok {
 		return canonical
 	}
+	localNames := flowScopeEventNamesForProof(scope)
+	if local := concreteTemplateInstanceLocalEventForProof(source, scope, canonical, localNames); local != "" {
+		return local
+	}
+	return runtimeeventidentity.LocalizeForFlow(scope.Path, localNames, canonical)
+}
+
+func flowScopeEventNamesForProof(scope FlowScope) []string {
 	localNames := make([]string, 0, len(scope.Events))
 	for name := range scope.Events {
 		name = runtimeeventidentity.Normalize(name)
@@ -124,7 +133,62 @@ func localizeFlowEventForProof(source Source, flowID, canonical string) string {
 		}
 		localNames = append(localNames, name)
 	}
-	return runtimeeventidentity.LocalizeForFlow(scope.Path, localNames, canonical)
+	sort.SliceStable(localNames, func(i, j int) bool {
+		if len(localNames[i]) != len(localNames[j]) {
+			return len(localNames[i]) > len(localNames[j])
+		}
+		return localNames[i] < localNames[j]
+	})
+	return localNames
+}
+
+func concreteTemplateInstanceLocalEventForProof(source Source, scope FlowScope, canonical string, localNames []string) string {
+	if !strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+		return ""
+	}
+	scopePath := runtimeeventidentity.Normalize(scope.Path)
+	canonical = runtimeeventidentity.Normalize(canonical)
+	if scopePath == "" || canonical == "" || !strings.HasPrefix(canonical, scopePath+"/") {
+		return ""
+	}
+	remainder := strings.TrimPrefix(canonical, scopePath+"/")
+	if remainder == "" || !strings.Contains(remainder, "/") {
+		return ""
+	}
+	if eventProofRemainderTargetsDescendantScope(source, scopePath, remainder) {
+		return ""
+	}
+	for _, local := range localNames {
+		if local == "" {
+			continue
+		}
+		if remainder == local || strings.HasSuffix(remainder, "/"+local) {
+			return local
+		}
+	}
+	return ""
+}
+
+func eventProofRemainderTargetsDescendantScope(source Source, scopePath, remainder string) bool {
+	if source == nil {
+		return false
+	}
+	scopePath = runtimeeventidentity.Normalize(scopePath)
+	remainder = runtimeeventidentity.Normalize(remainder)
+	if scopePath == "" || remainder == "" {
+		return false
+	}
+	for _, descendant := range source.FlowScopes() {
+		descendantPath := runtimeeventidentity.Normalize(descendant.Path)
+		if descendantPath == "" || descendantPath == scopePath || !strings.HasPrefix(descendantPath, scopePath+"/") {
+			continue
+		}
+		relativePath := strings.TrimPrefix(descendantPath, scopePath+"/")
+		if relativePath != "" && (remainder == relativePath || strings.HasPrefix(remainder, relativePath+"/")) {
+			return true
+		}
+	}
+	return false
 }
 
 func uniqueNormalizedProofCandidates(values ...string) []string {

--- a/internal/runtime/semanticview/event_schema_test.go
+++ b/internal/runtime/semanticview/event_schema_test.go
@@ -38,3 +38,93 @@ func TestResolveEventSchema_ReportsUnresolvedTypesAfterBundleResolution(t *testi
 		t.Fatalf("UnresolvedTypeError = %v, want NotDeclared", err)
 	}
 }
+
+func TestResolveFlowEventProof_TemplateInstanceOutputUsesTemplateCatalog(t *testing.T) {
+	root := runtimecontracts.FlowContractView{}
+	root.Children = []runtimecontracts.FlowContractView{{
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", Mode: "template"},
+		Path:  "child",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"child.done"}},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child.done": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"step": {Type: "string"},
+					},
+					Required: []string{"step"},
+				},
+			},
+		},
+	}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child": &root.Children[0],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"child": &root.Children[0],
+			},
+		},
+	}
+
+	proof := ResolveFlowEventProof(Wrap(bundle), "child", "child/inst-1/child.done")
+	if !proof.HasSchema {
+		t.Fatal("expected concrete template instance event to resolve template schema proof")
+	}
+	if proof.Local != "child.done" {
+		t.Fatalf("Local = %q, want child.done", proof.Local)
+	}
+	if proof.CatalogKey != "child.done" {
+		t.Fatalf("CatalogKey = %q, want child.done", proof.CatalogKey)
+	}
+	if proof.EventKey() != "child/inst-1/child.done" {
+		t.Fatalf("EventKey = %q, want concrete event identity", proof.EventKey())
+	}
+	if proof.Entry.Payload.Properties["step"].Type != "string" {
+		t.Fatalf("Entry payload = %#v, want step string", proof.Entry.Payload)
+	}
+}
+
+func TestResolveFlowEventProof_TemplateDescendantPathDoesNotBecomeInstanceLocalEvent(t *testing.T) {
+	root := runtimecontracts.FlowContractView{}
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", Mode: "template"},
+		Path:  "child",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"micro.done": {},
+		},
+	}
+	grandchild := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild", Mode: "static"},
+		Path:  "child/grandchild",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"micro.done": {},
+		},
+	}
+	child.Children = []runtimecontracts.FlowContractView{grandchild}
+	root.Children = []runtimecontracts.FlowContractView{child}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child":      &root.Children[0],
+				"grandchild": &root.Children[0].Children[0],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"child":            &root.Children[0],
+				"child/grandchild": &root.Children[0].Children[0],
+			},
+		},
+	}
+
+	proof := ResolveFlowEventProof(Wrap(bundle), "child", "child/grandchild/micro.done")
+	if proof.Local == "micro.done" {
+		t.Fatalf("Local = %q, want descendant path to remain non-local for child proof", proof.Local)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6377,8 +6377,12 @@ observation_model:
     - Agent fixture emissions (agents are independent, their emissions route through the event loop separately)
     - Dead-lettered events (intercepted before delivery, recorded in dead_letters table instead)
     - Child flow auto_emit events (visible within the child, not in parent emission log)
-    naming: Events are recorded with their fully-qualified URI in the parent flow context. When a child flow node emits order.completed,
-      the parent sees child-flow-id/order.completed. Within the same flow, events use local names (no prefix).
+    naming: Events are recorded with the producer/source route as the event namespace authority. When a template child flow
+      instance emits order.completed, observers see the concrete producer instance path, for example
+      child-flow-id/child-instance-id/order.completed. When a static service flow emits a local output event targeted at a
+      template child, observers see the static producer flow path, for example service-flow/service.completed. Target routes
+      remain event.target or event.target_set delivery metadata and do not rewrite the emitted event name. Within the same
+      root flow, events use local names (no prefix).
     payload_rules:
       description: Rules for constructing emitted event payloads on supported system-node runtime emit surfaces.
       declarative_system_node_emit_surface:


### PR DESCRIPTION
## Summary

Closes #1120.

- Externalizes declarative system-node output emits at the runtime emit boundary using the producer/source route, so template producer outputs can use the concrete producer instance path.
- Keeps static producer output namespaces static even when the output is targeted at a template instance.
- Preserves target route / target_set as delivery metadata and legacy receiver projection only.
- Clarifies `platform-spec.yaml` emitted-event naming to make producer/source route the event namespace authority.

## Governing Refs / Context

- #1120 body and gate comment: source route owns emitted event namespace; target route remains delivery metadata.
- `platform-spec.yaml`:
  - `contract_formats.event_schema.strict_payload_contract.envelope_split`
  - `contract_formats.event_schema.strict_payload_contract.envelope_identity`
  - `engine.event_identity`
  - `engine.cross_flow_routing`
  - `observation_model.emitted_events.naming`
- Split siblings remain out of scope: #1118 wildcard route resolution, #1119 accumulator bucket identity, #1122 query_entities context, final #1025 matrix.

## Semantic Migration

- New canonical runtime owner: `internal/runtime/engine.Executor.resolveDeclarativeEmitEventType` at the emit-intent boundary, consuming `semanticview` flow scope and `internal/runtime/core/eventidentity` normalization.
- Old non-authoritative path now invalid: treating pre-externalized static contract emit strings as final for template producer instance outputs.
- Checked production paths: top-level emit, rule emit, on_complete emit, accumulate on_complete/on_timeout emit, fan_out emit, target route persistence, catalog fixture non-regression.
- Migration complete for the approved #1120 declarative output emit class.

## Verification

- `go test ./internal/runtime/engine -run 'TestExecutor_(DeclarativeEmitSurfacesUseProducerSourceRouteNamespace|FanOutEmitUsesProducerSourceRouteNamespace|StaticProducerTargetRouteDoesNotOwnEventNamespace)' -count=1`
- `GOMAXPROCS=2 go test -p 1 ./internal/runtime/cataloge2e -run 'TestTier(7|11)FlowCompositionCatalogFixtures_RealRuntime' -count=1`
- `go test ./internal/runtime/core/eventidentity ./internal/runtime/engine ./internal/runtime/pipeline ./internal/runtime/bus ./internal/runtime/tools ./internal/runtime/manager -run 'Test(Externalize|ScopeResolveEvent|WorkflowNodeExternalEventType|Executor_EmitIntent|Executor_DeclarativeEmitSurfacesUseProducerSourceRouteNamespace|Executor_FanOutEmitUsesProducerSourceRouteNamespace|Executor_StaticProducerTargetRouteDoesNotOwnEventNamespace|.*Target|.*FlowInstance|.*ParentRoute|.*Pin|.*Output|DeliveryPlanner|EventBusPublish_Target|DeriveRouteTable|RouteTable|GenerateEmitToolsForActor_ResolvesInstanceScopedFlowEmitEventsThroughOwningFlowProof|HandleEmit|ActivateFlowInstance.*AutoEmit|buildAutoEmit)' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check HEAD~1..HEAD`
- `go test ./...`