### PR TITLE
[agent-b][issue #1167] Add prepared bundle register CLI

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -67,6 +67,8 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 		"store.NewPostgresStore",
 		"SWARM_BUILDER_AUTH_TOKEN",
 		"SWARM_OPERATOR_AUTH_TOKEN",
+		"BuildBundleCatalogProjection",
+		"UpsertBundleCatalog",
 	}
 	for name := range wantAPIConsumers {
 		source := sources[name]
@@ -121,6 +123,10 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 	if err := os.WriteFile(payloadPath, []byte(`{"topic":"sample"}`), 0o600); err != nil {
 		t.Fatalf("write payload: %v", err)
 	}
+	envelopePath := filepath.Join(t.TempDir(), "bundle-register.yaml")
+	if err := os.WriteFile(envelopePath, []byte("api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n"), 0o600); err != nil {
+		t.Fatalf("write bundle register envelope: %v", err)
+	}
 
 	for _, tc := range []struct {
 		name string
@@ -158,6 +164,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "bundle list", args: []string{"bundle", "list"}},
 		{name: "bundle show", args: []string{"bundle", "show", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
 		{name: "bundle agents", args: []string{"bundle", "agents", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+		{name: "bundle register", args: []string{"bundle", "register", envelopePath}},
 		{name: "conversations list", args: []string{"conversations", "list"}},
 		{name: "conversation view", args: []string{"conversation", "view", "session-1"}},
 		{name: "conversation turn", args: []string{"conversation", "turn", "session-1", "1"}},

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -12,9 +13,10 @@ import (
 )
 
 const (
-	bundleListMethod   = "bundle.list"
-	bundleGetMethod    = "bundle.get"
-	bundleAgentsMethod = "bundle.agents"
+	bundleListMethod     = "bundle.list"
+	bundleGetMethod      = "bundle.get"
+	bundleAgentsMethod   = "bundle.agents"
+	bundleRegisterMethod = "bundle.register"
 )
 
 type bundleListCommandOptions struct {
@@ -31,6 +33,16 @@ type bundleListCommandOptions struct {
 type bundleHashCommandOptions struct {
 	apiOptions rootCommandOptions
 	output     cliOutputOptions
+}
+
+type bundleRegisterCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+
+	dataBlobPath      string
+	idempotencyKey    string
+	dataBlobSet       bool
+	idempotencyKeySet bool
 }
 
 type bundleListResult struct {
@@ -62,6 +74,13 @@ type bundleAgentsResult struct {
 	Agents []bundleAgentDefinition `json:"agents"`
 }
 
+type bundleRegistrationResult struct {
+	BundleHash    string `json:"bundle_hash"`
+	Registered    *bool  `json:"registered"`
+	HasData       *bool  `json:"has_data"`
+	DataSizeBytes *int64 `json:"data_size_bytes"`
+}
+
 type bundleAgentDefinition struct {
 	AgentID          string   `json:"agent_id"`
 	FlowInstance     string   `json:"flow_instance,omitempty"`
@@ -89,6 +108,7 @@ func newBundleCommand(opts rootCommandOptions) *cobra.Command {
 		newBundleListCommand(opts),
 		newBundleShowCommand(opts),
 		newBundleAgentsCommand(opts),
+		newBundleRegisterCommand(opts),
 	)
 	return cmd
 }
@@ -148,6 +168,28 @@ func newBundleAgentsCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	bindCLIOutputFlags(cmd, &agentsOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &agentsOpts.apiOptions)
+	return cmd
+}
+
+func newBundleRegisterCommand(opts rootCommandOptions) *cobra.Command {
+	registerOpts := bundleRegisterCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "register <registration-envelope-yaml>",
+		Short: "Register a prepared bundle envelope through /v1/rpc bundle.register.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registerOpts.dataBlobSet = cmd.Flags().Changed("data-blob")
+			registerOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			if err := registerOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runBundleRegisterCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), registerOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&registerOpts.dataBlobPath, "data-blob", "", "Path to a BundleRegisterDataBlobV1 JSON document")
+	cmd.Flags().StringVar(&registerOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.register")
+	bindCLIOutputFlags(cmd, &registerOpts.output)
+	bindCLIAPIConnectionFlags(cmd, &registerOpts.apiOptions)
 	return cmd
 }
 
@@ -228,6 +270,29 @@ func runBundleAgentsCommand(ctx context.Context, out, errOut io.Writer, opts bun
 	})
 }
 
+func runBundleRegisterCommand(ctx context.Context, out, errOut io.Writer, opts bundleRegisterCommandOptions, envelopePath string) error {
+	params, err := opts.params(envelopePath)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+	}
+	var result bundleRegistrationResult
+	if err := client.call(ctx, bundleRegisterMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+	}
+	if err := validateBundleRegistrationResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeBundleRegistrationHuman(w, result)
+	}, func() ([]string, error) {
+		return []string{result.BundleHash}, nil
+	})
+}
+
 func (opts bundleListCommandOptions) params() (map[string]any, error) {
 	params := map[string]any{}
 	if opts.limitSet {
@@ -246,8 +311,32 @@ func (opts bundleListCommandOptions) params() (map[string]any, error) {
 	return params, nil
 }
 
+func (opts bundleRegisterCommandOptions) params(envelopePath string) (map[string]any, error) {
+	contentYAML, err := readBundleRegisterTextFile("registration envelope", envelopePath)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{"content_yaml": contentYAML}
+	if opts.dataBlobSet {
+		dataBlob, err := readBundleRegisterDataBlob(opts.dataBlobPath)
+		if err != nil {
+			return nil, err
+		}
+		params["data_blob"] = dataBlob
+	}
+	if idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet); err != nil {
+		return nil, err
+	} else if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params, nil
+}
+
 func bundleAPIErrorClassifier() cliAPIErrorClassifier {
-	return cliAPIErrorClassifier{notFoundCodes: []string{"BUNDLE_NOT_FOUND"}}
+	return cliAPIErrorClassifier{
+		notFoundCodes: []string{"BUNDLE_NOT_FOUND"},
+		conflictCodes: []string{"BUNDLE_REGISTER_CONFLICT", "IDEMPOTENCY_CONFLICT"},
+	}
 }
 
 func validateBundleHashArg(name, raw string) (string, error) {
@@ -330,6 +419,66 @@ func validateBundleAgentsResult(result bundleAgentsResult) error {
 	return nil
 }
 
+func validateBundleRegistrationResult(result bundleRegistrationResult) error {
+	if _, err := validateBundleHashArg("bundle_hash", result.BundleHash); err != nil {
+		return fmt.Errorf("malformed bundle.register result: %w", err)
+	}
+	if result.Registered == nil {
+		return fmt.Errorf("malformed bundle.register result: registered is required")
+	}
+	if result.HasData == nil {
+		return fmt.Errorf("malformed bundle.register result: has_data is required")
+	}
+	if result.DataSizeBytes == nil {
+		return fmt.Errorf("malformed bundle.register result: data_size_bytes is required")
+	}
+	if *result.DataSizeBytes < 0 {
+		return fmt.Errorf("malformed bundle.register result: data_size_bytes must be non-negative")
+	}
+	return nil
+}
+
+func readBundleRegisterTextFile(label, path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("%s path is required", label)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", label, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s must be a file", label)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", label, err)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		return "", fmt.Errorf("%s must be non-empty", label)
+	}
+	return string(raw), nil
+}
+
+func readBundleRegisterDataBlob(path string) (map[string]any, error) {
+	raw, err := readBundleRegisterTextFile("data blob", path)
+	if err != nil {
+		return nil, err
+	}
+	var dataBlob map[string]any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	if err := decoder.Decode(&dataBlob); err != nil {
+		return nil, fmt.Errorf("--data-blob must contain one BundleRegisterDataBlobV1 JSON object: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("--data-blob must contain one BundleRegisterDataBlobV1 JSON object")
+	}
+	if dataBlob == nil {
+		return nil, fmt.Errorf("--data-blob must contain one BundleRegisterDataBlobV1 JSON object")
+	}
+	return dataBlob, nil
+}
+
 func writeBundleListHuman(w io.Writer, result bundleListResult) {
 	if w == nil {
 		return
@@ -396,6 +545,14 @@ func writeBundleAgentsHuman(w io.Writer, result bundleAgentsResult) {
 		}
 		fmt.Fprintln(w, strings.Join(fields, " "))
 	}
+}
+
+func writeBundleRegistrationHuman(w io.Writer, result bundleRegistrationResult) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "bundle %s registered=%t has_data=%t data_size_bytes=%d\n",
+		result.BundleHash, *result.Registered, *result.HasData, *result.DataSizeBytes)
 }
 
 func compactJSONValue(value any) string {

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -157,6 +159,107 @@ func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
 	}
 }
 
+func TestBundleRegisterHelpDocumentsPreparedEnvelopeBoundary(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "register", "--help"}, &stdout, &stderr, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		"register <registration-envelope-yaml>",
+		"--data-blob",
+		"--idempotency-key",
+		"--api-server",
+		"--json",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"contracts-directory", "archive"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("help contains unapproved packaging term %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestBundleRegisterPreparedEnvelopeUsesCanonicalRPCAndRenders(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("e")
+	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
+	dataBlobPath := writeBundleRegisterFixture(t, "bundle-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[{"path":"flows/alpha/data/payload.bin","data_base64":"AQI="}]}`)
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validBundleRegistrationResult(bundleHash))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"bundle", "register", envelopePath,
+		"--data-blob", dataBlobPath,
+		"--idempotency-key", "idem-register",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertBundleRequest(t, captured, bundleRegisterMethod, map[string]any{
+		"content_yaml":    "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n",
+		"data_blob":       map[string]any{"api_version": "swarm.bundle.data.v1", "entries": []any{map[string]any{"path": "flows/alpha/data/payload.bin", "data_base64": "AQI="}}},
+		"idempotency_key": "idem-register",
+	})
+	for _, want := range []string{"bundle " + bundleHash, "registered=true", "has_data=true", "data_size_bytes=7"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestBundleRegisterJSONPreservesAPIShape(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("f")
+	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validBundleRegistrationResult(bundleHash))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "register", envelopePath, "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertBundleRequest(t, captured, bundleRegisterMethod, map[string]any{
+		"content_yaml": "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n",
+	})
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode stdout json: %v\n%s", err, stdout.String())
+	}
+	if decoded["bundle_hash"] != bundleHash || decoded["registered"] != true || decoded["has_data"] != true || decoded["data_size_bytes"] != float64(7) {
+		t.Fatalf("json registration result = %#v", decoded)
+	}
+}
+
 func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	var calls atomic.Int32
@@ -165,6 +268,16 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
 	}))
 	defer server.Close()
+
+	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
+	emptyEnvelopePath := writeBundleRegisterFixture(t, "empty.yaml", " \n")
+	dataBlobPath := writeBundleRegisterFixture(t, "bundle-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[]}`)
+	badDataBlobPath := writeBundleRegisterFixture(t, "bad-data.json", `{bad json`)
+	multipleDataBlobPath := writeBundleRegisterFixture(t, "multi-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[]}{}`)
+	dirPath := filepath.Join(t.TempDir(), "bundle-dir")
+	if err := os.Mkdir(dirPath, 0o700); err != nil {
+		t.Fatalf("mkdir bundle dir: %v", err)
+	}
 
 	for _, tc := range []struct {
 		name       string
@@ -178,7 +291,14 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "show invalid hash", args: []string{"bundle", "show", "sha256:abc"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "agents invalid hash", args: []string{"bundle", "agents", "bad"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "get alias not promoted", args: []string{"bundle", "get", validBundleHash("a")}, wantStderr: "unknown command"},
-		{name: "register not promoted", args: []string{"bundle", "register"}, wantStderr: "unknown command"},
+		{name: "register missing envelope", args: []string{"bundle", "register"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "register missing file", args: []string{"bundle", "register", filepath.Join(t.TempDir(), "missing.yaml")}, wantStderr: "read registration envelope"},
+		{name: "register directory", args: []string{"bundle", "register", dirPath}, wantStderr: "registration envelope must be a file"},
+		{name: "register empty envelope", args: []string{"bundle", "register", emptyEnvelopePath}, wantStderr: "registration envelope must be non-empty"},
+		{name: "register missing data blob", args: []string{"bundle", "register", envelopePath, "--data-blob", filepath.Join(t.TempDir(), "missing.json")}, wantStderr: "read data blob"},
+		{name: "register malformed data blob", args: []string{"bundle", "register", envelopePath, "--data-blob", badDataBlobPath}, wantStderr: "--data-blob must contain one BundleRegisterDataBlobV1 JSON object"},
+		{name: "register multiple data blob documents", args: []string{"bundle", "register", envelopePath, "--data-blob", multipleDataBlobPath}, wantStderr: "--data-blob must contain one BundleRegisterDataBlobV1 JSON object"},
+		{name: "register blank idempotency", args: []string{"bundle", "register", envelopePath, "--data-blob", dataBlobPath, "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "delete not promoted", args: []string{"bundle", "delete", validBundleHash("a")}, wantStderr: "unknown command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -200,6 +320,7 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 
 func TestBundleCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 	bundleHash := validBundleHash("c")
+	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -253,6 +374,65 @@ func TestBundleCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantCode:   cliExitRuntime,
 			wantStderr: "malformed bundle.agents result: agents is required",
 		},
+		{
+			name: "bundle register conflict",
+			args: []string{"bundle", "register", envelopePath},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "BUNDLE_REGISTER_CONFLICT")
+			},
+			wantCode:   cliExitConflict,
+			wantStderr: "BUNDLE_REGISTER_CONFLICT: Application error: BUNDLE_REGISTER_CONFLICT",
+		},
+		{
+			name: "bundle register idempotency conflict",
+			args: []string{"bundle", "register", envelopePath, "--idempotency-key", "idem-register"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   cliExitConflict,
+			wantStderr: "IDEMPOTENCY_CONFLICT: Application error: IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "bundle register invalid params",
+			args: []string{"bundle", "register", envelopePath},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleInvalidParamsJSONRPCError(t, w, req.ID, "Invalid params: content_yaml")
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "Invalid params: content_yaml",
+		},
+		{
+			name: "malformed register missing registered",
+			args: []string{"bundle", "register", envelopePath},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validBundleRegistrationResult(bundleHash)
+				delete(result, "registered")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed bundle.register result: registered is required",
+		},
+		{
+			name: "malformed register negative data size",
+			args: []string{"bundle", "register", envelopePath},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validBundleRegistrationResult(bundleHash)
+				result["data_size_bytes"] = -1
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed bundle.register result: data_size_bytes must be non-negative",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -269,6 +449,15 @@ func TestBundleCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeBundleRegisterFixture(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
 }
 
 func assertBundleRequest(t *testing.T, req jsonRPCRequest, wantMethod string, wantParams map[string]any) {
@@ -319,6 +508,15 @@ func validBundleAgent(agentID string) map[string]any {
 	}
 }
 
+func validBundleRegistrationResult(bundleHash string) map[string]any {
+	return map[string]any{
+		"bundle_hash":     bundleHash,
+		"registered":      true,
+		"has_data":        true,
+		"data_size_bytes": 7,
+	}
+}
+
 func writeBundleJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {
 	t.Helper()
 	w.Header().Set("content-type", "application/json")
@@ -334,6 +532,21 @@ func writeBundleJSONRPCError(t *testing.T, w http.ResponseWriter, id string, cod
 				"retryable":      false,
 				"correlation_id": "corr-bundle",
 			},
+		},
+	}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func writeBundleInvalidParamsJSONRPCError(t *testing.T, w http.ResponseWriter, id string, message string) {
+	t.Helper()
+	w.Header().Set("content-type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32602,
+			"message": message,
 		},
 	}); err != nil {
 		t.Fatalf("encode response: %v", err)

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -54,6 +54,7 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		{"bundle", "list"},
 		{"bundle", "show"},
 		{"bundle", "agents"},
+		{"bundle", "register"},
 		{"agents", "list"},
 		{"agent", "view"},
 		{"agent", "restart"},

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -387,7 +387,7 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 	withFlags := []string{
 		"runs", "status", "trace", "health", "logs", "incidents",
 		"events list", "events follow", "event view", "event publish", "event replay",
-		"bundle list", "bundle show", "bundle agents",
+		"bundle list", "bundle show", "bundle agents", "bundle register",
 		"agents list", "agent view", "agent diagnose", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
 		"entities list", "entity view", "entity aggregate",
 		"mailbox list", "mailbox view", "mailbox approve", "mailbox reject", "mailbox defer",

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -430,10 +430,10 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	cli := mustMappingValue(t, root, "cli_specification")
 	commandCatalog := mustMappingValue(t, cli, "command_catalog")
 	bundleCommand := mustMappingValue(t, commandCatalog, "bundle")
-	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents")
-	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_read_only_inventory")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "bundle.register and bundle.delete APIs are live")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "swarm bundle register/delete CLI consumers remain split")
+	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents|register")
+	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_inventory_and_prepared_envelope_register")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Prepared-envelope swarm bundle register is implemented")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Directory/archive packaging and bundle.delete CLI remain split")
 	runForkCatalog := mustMappingValue(t, commandCatalog, "run_fork")
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "command"), runForkCommand)
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "implementation_status"), "implemented_public_cli_consumer")
@@ -459,7 +459,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 		t.Fatal("remaining_should_have_not_implemented still includes implemented swarm bundle inventory commands")
 	}
 	for _, want := range []string{
-		"swarm bundle register <path-or-archive>",
+		"swarm bundle register <contracts-directory-or-archive>",
 		"swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]",
 	} {
 		if !sequenceContainsScalar(remaining, want) {
@@ -470,7 +470,8 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")
 	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_run_fork_and_delete_method_catalog")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.register is also published")
-	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "does not imply a swarm bundle register CLI consumer")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "prepared-envelope swarm")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "contracts-directory/archive packaging remains split")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.delete is promoted")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "omitted or false force performs non-force deletion")
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6020,13 +6020,14 @@ multi_bundle_persistence:
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
   cli_surface:
-    publication_status: read_only_bundle_inventory_run_fork_and_serial_serve_bundle_hash_implemented_other_cli_children_pending
+    publication_status: bundle_inventory_register_envelope_run_fork_and_serial_serve_bundle_hash_implemented_other_cli_children_pending
     bundle_commands_supported:
       - swarm bundle list
       - swarm bundle show <bundle-hash>
       - swarm bundle agents <bundle-hash>
+      - swarm bundle register <registration-envelope-yaml> [--data-blob <data-blob-json>] [--idempotency-key <key>]
     bundle_commands_split:
-      - swarm bundle register <path-or-archive>
+      - swarm bundle register <contracts-directory-or-archive>
       - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> (implemented serial Postgres DB-loaded process mode)
@@ -6113,8 +6114,8 @@ multi_bundle_persistence:
       reason: swarm fork consumes /v1/rpc run.fork only; same-bundle DB-loaded source loading is supported by #1024, and cross-bundle fork routing remains split to #976.
     multi_bundle_cli_inventory:
       tracker: '#1023'
-      implementation_status: read_only_inventory_implemented
-      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only; bundle.register and bundle.delete APIs are live but their CLI commands remain split from this read-only inventory slice.
+      implementation_status: inventory_and_prepared_envelope_register_implemented
+      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only, and prepared-envelope swarm bundle register consumes /v1/rpc bundle.register only. Contracts-directory/archive register packaging and bundle.delete CLI remain split until their exact CLI/runtime/packaging owners land.
     bundle_hash_dual_accept_migration:
       tracker: '#1001'
       reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
@@ -9577,26 +9578,30 @@ cli_specification:
       - SESSION_NOT_FOUND, TURN_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, runtime.logs, run.trace, or forkchat usage
     bundle:
-      command: swarm bundle list|show|agents
+      command: swarm bundle list|show|agents|register
       tier: should_have
-      implementation_status: implemented_read_only_inventory
-      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. bundle.register and bundle.delete APIs are live, but the swarm bundle register/delete CLI consumers remain split/absent from this read-only inventory slice.'
+      implementation_status: implemented_inventory_and_prepared_envelope_register
+      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Prepared-envelope swarm bundle register is implemented over /v1/rpc bundle.register. Directory/archive packaging and bundle.delete CLI remain split until their exact owners are promoted.'
       owners:
       - multi_bundle_persistence.cli_surface.bundle_commands_supported
       - multi_bundle_persistence.api_surface.bundle_methods_planned
       behavior: >
-        Public CLI family for persisted bundle inventory and agent catalog inspection. The implemented list/show/agents
-        commands consume /v1/rpc bundle.list, bundle.get, and bundle.agents only. The CLI must not call internal
-        store/runtime helpers or infer bundle state from local files. The live mutating /v1/rpc bundle.register API is
-        intentionally not exposed by this CLI slice; swarm bundle register and swarm bundle delete remain split CLI consumers
-        even though the corresponding /v1/rpc APIs are live.
+        Public CLI family for persisted bundle inventory, agent catalog inspection, and prepared-envelope registration.
+        The implemented list/show/agents commands consume /v1/rpc bundle.list, bundle.get, and bundle.agents. The
+        implemented register command consumes /v1/rpc bundle.register with an already-prepared
+        BundleRegistrationEnvelopeV1 YAML file as content_yaml, optional BundleRegisterDataBlobV1 JSON from
+        --data-blob, and optional --idempotency-key. The CLI must not call internal store/runtime helpers, compute
+        bundle_hash, materialize a contract root, infer bundle state from local files, or implement contracts-directory
+        or archive packaging. Destructive bundle.delete has a live API owner but remains split as a CLI consumer until a
+        later gate promotes that command.
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
-      - invalid args and missing SWARM_API_TOKEN make zero API calls
+      - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
+      - invalid args, invalid local envelope/data blob files, and missing SWARM_API_TOKEN make zero API calls
       - human and --json output render only server-owned result fields
-      - BUNDLE_NOT_FOUND, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
-      - no direct DB/store/runtime bundle reads or writes from CLI
-      - swarm bundle register, swarm bundle delete, and unpromoted bundle.get alias remain absent/unknown until later CLI gates, even though /v1/rpc bundle.register is already published
+      - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - no direct DB/store/runtime/hash-owner bundle reads or writes from CLI
+      - swarm bundle delete, unpromoted bundle.get alias, contracts-directory register packaging, and archive register packaging remain absent/unknown until later CLI gates
     run_fork:
       command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
       tier: should_have
@@ -10041,7 +10046,7 @@ cli_specification:
     - swarm control mailbox
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm bundle register <path-or-archive>
+    - swarm bundle register <contracts-directory-or-archive>
     - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
@@ -10083,12 +10088,13 @@ api_specification:
       #1012 promotes the multi-bundle API contract as source authority, including bundle.* methods, run.fork, bundle_hash
       filters, and bundle_hash create-new-work params. The read-only bundle.list, bundle.get, and bundle.agents methods are
       now in method_catalog/OpenRPC with matching handlers and proof. Non-destructive bundle.register is also published
-      in method_catalog/OpenRPC with its handler/store/idempotency owner proof by #1017; this does not imply a swarm
-      bundle register CLI consumer in #1023's read-only inventory slice. run.fork is also promoted into
-      method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by #989. The swarm bundle
-      list/show/agents and swarm fork CLI consumers are implemented by #1023 and consume only those canonical /v1/rpc
-      methods. bundle.delete is promoted into method_catalog/OpenRPC with matching API/runtime handler proof by #1018 and
-      #1019: omitted or false force performs non-force deletion and force=true performs force cleanup. Remaining multi-bundle methods and shapes are
+      in method_catalog/OpenRPC with its handler/store/idempotency owner proof by #1017; the prepared-envelope swarm
+      bundle register CLI consumer is implemented by #1167, while contracts-directory/archive packaging remains split.
+      run.fork is also promoted into method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by
+      #989. The swarm bundle list/show/agents/register and swarm fork CLI consumers are implemented by #1023/#1167 and
+      consume only those canonical /v1/rpc methods. bundle.delete is promoted into method_catalog/OpenRPC with matching
+      API/runtime handler proof by #1018 and #1019: omitted or false force performs non-force deletion and force=true
+      performs force cleanup. Remaining multi-bundle methods and shapes are
       not in method_catalog/OpenRPC until a later gated API/runtime implementation PR registers handlers and regenerates
       openrpc.json/proof artifacts in the same PR. Consumers must not treat docs/MULTI_BUNDLE_PERSISTENCE_DRAFT.md or
       #1038 prose as API authority after #1012.


### PR DESCRIPTION
## Summary

Adds the approved first-slice `swarm bundle register <registration-envelope-yaml>` CLI consumer over `/v1/rpc bundle.register`.

This closes only the prepared-envelope CLI-consumer class approved in the #1167 gate. Contracts-directory/archive packaging remains split under #1023/#1011 tracking and is not implemented here.

Closes #1167 under the approved prepared-envelope first-slice gate.

## Governing Refs

- #1167 Pre-Implementation Coverage Audit and Independent Gate B Review.
- `platform-spec.yaml` root `multi_bundle_persistence.cli_surface`, `cli_specification.command_catalog.bundle`, and `api_specification.multi_bundle_publication_boundary`.
- Root `openrpc.json` `/v1/rpc bundle.register` method and schemas: `BundleRegistrationEnvelopeV1`, `BundleRegisterDataBlobV1`, `BundleRegistrationResult`.

## Semantic Boundary

- New canonical CLI consumer: `cmd/swarm bundle register` calls `/v1/rpc bundle.register` exactly once on valid input.
- Old/non-authoritative paths invalid here: direct store/runtime/hash-owner calls, local bundle-hash computation, contract-root materialization, directory/archive packaging, direct DB/EventBus/dashboard/Builder reads.
- Production paths checked for surviving old behavior: `cmd/swarm` no-bypass tests, API flag placement tests, bundle list/show/agents regression tests, `swarm fork` regression coverage through the required command-family proof.
- Migration completeness: complete for prepared-envelope register; incomplete by design for contracts-directory/archive packaging and `bundle.delete` CLI, both split to later gates.

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./cmd/swarm -run 'Bundle|CLIAPIConnectionFlagsSurfaceAndIsolation|CLIRuntimeStateAPIConsumers|CLIRuntimeStateCommandsRequireSharedAPIToken' -count=1`
- `go test ./internal/apispec -run TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkMethods -count=1`
- `go test ./...`