### PR TITLE
[agent-f][issue #1175] Add boot-pinned runtime contexts

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -121,13 +121,12 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 				return fmt.Errorf("--dev cannot be combined with --require-bundle-match")
 			}
 			if cmd.Flags().Changed("bundle-hash") {
-				opts.BundleHash = strings.TrimSpace(opts.BundleHash)
-				if opts.BundleHash == "" {
-					return fmt.Errorf("--bundle-hash must be non-empty")
+				hashes, err := serveBundleHashes(opts)
+				if err != nil {
+					return err
 				}
-				if !cliBundleHashPattern.MatchString(opts.BundleHash) {
-					return fmt.Errorf("--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>")
-				}
+				opts.BundleHash = hashes[0]
+				opts.BundleHashes = append([]string(nil), hashes[1:]...)
 				if cmd.Flags().Changed("contracts") {
 					return fmt.Errorf("--bundle-hash is mutually exclusive with --contracts")
 				}
@@ -188,7 +187,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, or openai_compatible")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
-	cmd.Flags().StringVar(&opts.BundleHash, "bundle-hash", opts.BundleHash, "Load a persisted bundle catalog row by canonical bundle_hash (serial single-bundle process)")
+	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -178,6 +178,7 @@ type serveOptions struct {
 	ContractsPath        string
 	DataSource           string
 	BundleHash           string
+	BundleHashes         []string
 	PlatformSpecPath     string
 	StoreMode            string
 	StoreModeSet         bool
@@ -205,6 +206,32 @@ type serveRuntimeBundle struct {
 	cleanup          func() error
 }
 
+type serveRuntimeBundleContext struct {
+	loaded            serveRuntimeBundle
+	stateStoreSummary string
+	bundleSourceFact  runtimecorrelation.BundleSourceFact
+	bootIdentity      runtimecontracts.BundleIdentity
+	workspaces        serveWorkspaceLifecycle
+	validation        runtime.WorkflowContractValidationResult
+	runtime           *runtime.Runtime
+}
+
+type serveRuntimeBundleContextRequest struct {
+	Ctx                    context.Context
+	Stores                 storeBundle
+	Config                 *config.Config
+	Loaded                 serveRuntimeBundle
+	Options                serveOptions
+	MountSources           workspaceMountSources
+	Credentials            runtimecredentials.Store
+	BootStartedAt          time.Time
+	BootProgress           func(runtime.BootProgressEvent)
+	EnableToolGateway      bool
+	UseStartupOwnership    bool
+	UseStartupRecovery     bool
+	RequireBundleScopeName bool
+}
+
 func defaultServeOptions() serveOptions {
 	return serveOptions{
 		StoreMode:          storebackend.ActiveDefaultBackend().String(),
@@ -223,19 +250,127 @@ func (b serveRuntimeBundle) serveIdentityDetail() string {
 	return strings.TrimSpace(b.bootIdentity.Fingerprint)
 }
 
+func serveRuntimeBundleIdentitiesDetail(bundles []serveRuntimeBundle) string {
+	parts := make([]string, 0, len(bundles))
+	for _, bundle := range bundles {
+		if detail := bundle.serveIdentityDetail(); detail != "" {
+			parts = append(parts, detail)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func servePinnedBundleHashes(bundles []serveRuntimeBundle) []string {
+	out := []string{}
+	for _, bundle := range bundles {
+		if bundle.dbLoaded {
+			if hash := strings.TrimSpace(bundle.bundleSourceFact.BundleHash); hash != "" {
+				out = append(out, hash)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func serveRuntimeStateStoreSummary(contexts []serveRuntimeBundleContext) string {
+	seen := map[string]struct{}{}
+	parts := []string{}
+	for _, contextDef := range contexts {
+		summary := strings.TrimSpace(contextDef.stateStoreSummary)
+		if summary == "" {
+			continue
+		}
+		if _, ok := seen[summary]; ok {
+			continue
+		}
+		seen[summary] = struct{}{}
+		parts = append(parts, summary)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "; ")
+}
+
 func serveConfigLoadDetail(configDetail string, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) string {
 	parts := []string{"config=" + strings.TrimSpace(configDetail)}
-	if hash := strings.TrimSpace(opts.BundleHash); hash != "" {
-		parts = append(parts, "bundle_hash="+hash)
+	hashes, _ := serveBundleHashes(opts)
+	if len(hashes) == 1 {
+		parts = append(parts, "bundle_hash="+hashes[0])
+	} else if len(hashes) > 1 {
+		parts = append(parts, "bundle_hashes="+strings.Join(hashes, ","))
 	} else {
 		parts = append(parts, "contracts="+filepath.Clean(resolvedPaths.ContractsPath))
 	}
 	return strings.Join(parts, " ")
 }
 
+func serveBundleHashes(opts serveOptions) ([]string, error) {
+	candidates := []string{}
+	if hash := strings.TrimSpace(opts.BundleHash); hash != "" {
+		candidates = append(candidates, hash)
+	}
+	candidates = append(candidates, opts.BundleHashes...)
+	out := make([]string, 0, len(candidates))
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		hash := strings.TrimSpace(candidate)
+		if hash == "" {
+			return nil, fmt.Errorf("--bundle-hash must be non-empty")
+		}
+		if err := runtimecontracts.ValidateBundleHash(hash); err != nil {
+			return nil, fmt.Errorf("--bundle-hash must be bundle-v1:sha256:<64 lowercase hex>")
+		}
+		if _, ok := seen[hash]; ok {
+			return nil, fmt.Errorf("--bundle-hash values must be unique")
+		}
+		seen[hash] = struct{}{}
+		out = append(out, hash)
+	}
+	return out, nil
+}
+
+func loadServeRuntimeBundles(ctx context.Context, repo string, stores storeBundle, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) ([]serveRuntimeBundle, error) {
+	hashes, err := serveBundleHashes(opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(hashes) > 0 {
+		out := make([]serveRuntimeBundle, 0, len(hashes))
+		for _, hash := range hashes {
+			loaded, err := loadServeRuntimeBundleFromCatalog(ctx, repo, stores, hash)
+			if err != nil {
+				for _, prior := range out {
+					if prior.cleanup != nil {
+						_ = prior.cleanup()
+					}
+				}
+				return nil, err
+			}
+			out = append(out, loaded)
+		}
+		return out, nil
+	}
+	loaded, err := loadServeRuntimeBundle(ctx, repo, stores, resolvedPaths, opts)
+	if err != nil {
+		return nil, err
+	}
+	return []serveRuntimeBundle{loaded}, nil
+}
+
 func loadServeRuntimeBundle(ctx context.Context, repo string, stores storeBundle, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) (serveRuntimeBundle, error) {
-	if bundleHash := strings.TrimSpace(opts.BundleHash); bundleHash != "" {
-		return loadServeRuntimeBundleFromCatalog(ctx, repo, stores, bundleHash)
+	hashes, err := serveBundleHashes(opts)
+	if err != nil {
+		return serveRuntimeBundle{}, err
+	}
+	if len(hashes) > 1 {
+		return serveRuntimeBundle{}, fmt.Errorf("loadServeRuntimeBundle supports one bundle_hash; use loadServeRuntimeBundles for multi-context boot")
+	}
+	if len(hashes) == 1 {
+		return loadServeRuntimeBundleFromCatalog(ctx, repo, stores, hashes[0])
 	}
 	contractsRoot, err := normalizeContractsRoot(resolvedPaths.ContractsPath)
 	if err != nil {
@@ -328,6 +463,79 @@ func prepareLoadedServeBundleSource(ctx context.Context, stores storeBundle, loa
 	return prepareServeBundleSource(ctx, stores, loaded.bundle, loaded.bootIdentity.Fingerprint, dev)
 }
 
+func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serveRuntimeBundleContext, error) {
+	loaded := req.Loaded
+	stateStoreSummary, err := initializeStateStores(req.Ctx, req.Stores, loaded.bundle)
+	if err != nil {
+		return serveRuntimeBundleContext{}, err
+	}
+	bundleSourceFact, err := prepareLoadedServeBundleSource(req.Ctx, req.Stores, loaded, req.Options.Dev)
+	if err != nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("prepare bundle source: %w", err)
+	}
+	bootIdentity := loaded.bootIdentity
+	bootIdentity.BundleHash = strings.TrimSpace(bundleSourceFact.BundleHash)
+	workspaces, err := configuredWorkspaceLifecycleForServe(req.Stores.SQLDB, loaded.contractsRoot, loaded.source, req.MountSources)
+	if err != nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("configure workspaces: %w", err)
+	}
+	if workspaces == nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("workspace lifecycle is not configured")
+	}
+	if req.RequireBundleScopeName {
+		if scoper, ok := workspaces.(interface{ SetBundleScope(string) }); ok && scoper != nil {
+			scoper.SetBundleScope(bundleSourceFact.BundleHash)
+		}
+	}
+	if err := workspaces.ValidateSource(req.Ctx, loaded.source); err != nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("validate workspaces: %w", err)
+	}
+	if err := workspaces.EnsurePrereqs(req.Ctx); err != nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("prepare workspaces: %w", err)
+	}
+	if err := workspaces.EnsureSystemWorkspaces(req.Ctx); err != nil {
+		return serveRuntimeBundleContext{}, fmt.Errorf("ensure system workspaces: %w", err)
+	}
+	validation, err := runtime.ValidateWorkflowContractSurface(req.Ctx, loaded.source, runtime.DefaultWorkflowContractValidationOptions(req.Credentials))
+	if err != nil {
+		return serveRuntimeBundleContext{}, err
+	}
+	runtimeStores := req.Stores.runtimeStores()
+	if !req.UseStartupOwnership {
+		runtimeStores.StartupOwnership = nil
+	}
+	rt, err := runtime.NewRuntime(req.Ctx, runtime.RuntimeDeps{
+		Config: req.Config,
+		Stores: runtimeStores,
+		Options: runtime.RuntimeOptions{
+			SelfCheck:                        req.Options.SelfCheck,
+			WorkflowModule:                   loaded.module,
+			WorkspaceLifecycle:               workspaces,
+			EnableToolGateway:                req.EnableToolGateway,
+			ToolGatewayToken:                 strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
+			BundleFingerprint:                bootIdentity.Fingerprint,
+			BundleSourceFact:                 bundleSourceFact,
+			Credentials:                      req.Credentials,
+			BootStartedAt:                    req.BootStartedAt,
+			BootProgress:                     req.BootProgress,
+			SystemContainers:                 systemWorkspaceContainers(workspaces),
+			DisablePersistentStartupRecovery: !req.UseStartupRecovery,
+		},
+	})
+	if err != nil {
+		return serveRuntimeBundleContext{}, err
+	}
+	return serveRuntimeBundleContext{
+		loaded:            loaded,
+		stateStoreSummary: stateStoreSummary,
+		bundleSourceFact:  bundleSourceFact,
+		bootIdentity:      bootIdentity,
+		workspaces:        workspaces,
+		validation:        validation,
+		runtime:           rt,
+	}, nil
+}
+
 func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver) (runtimellm.Runtime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
@@ -400,31 +608,29 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
-	loadedBundle, err := loadServeRuntimeBundle(ctx, repo, stores, resolvedPaths, opts)
+	loadedBundles, err := loadServeRuntimeBundles(ctx, repo, stores, resolvedPaths, opts)
 	if err != nil {
 		reporter.emit(4, "bundle_load", "FAILED", err.Error())
 		log.Printf("load Swarm contracts: %v", err)
 		return 1
 	}
-	if loadedBundle.cleanup != nil {
-		defer func() {
-			if err := loadedBundle.cleanup(); err != nil {
-				log.Printf("cleanup DB-loaded bundle runtime source failed: %v", err)
-			}
-		}()
-	}
-	module := loadedBundle.module
-	bundle := loadedBundle.bundle
-	source := loadedBundle.source
-	contractsRoot := loadedBundle.contractsRoot
-	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
-	bootBundleIdentity := loadedBundle.bootIdentity
-	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(loadedBundle.serveIdentityDetail(), source))
-	stateStoreSummary, err := initializeStateStores(ctx, stores, bundle)
-	if err != nil {
-		slog.Error("initialize state stores", "error", err)
+	if len(loadedBundles) == 0 {
+		reporter.emit(4, "bundle_load", "FAILED", "no bundle contexts loaded")
 		return 1
 	}
+	defer func() {
+		for _, loaded := range loadedBundles {
+			if loaded.cleanup != nil {
+				if err := loaded.cleanup(); err != nil {
+					log.Printf("cleanup DB-loaded bundle runtime source failed: %v", err)
+				}
+			}
+		}
+	}()
+	loadedBundle := loadedBundles[0]
+	source := loadedBundle.source
+	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
+	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
 	if opts.AbandonActiveRuns {
 		if stores.Postgres == nil {
 			slog.Error("abandon active runs failed", "error", "postgres store is required")
@@ -437,20 +643,20 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		}
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
-	workspaces, err := configuredWorkspaceLifecycleForServe(stores.SQLDB, contractsRoot, source, mountSources)
-	if err != nil {
-		slog.Error("configure workspaces", "error", err)
-		return 1
-	}
-	if workspaces == nil {
-		slog.Error("workspace lifecycle is not configured")
-		return 1
-	}
 	if stores.Postgres != nil {
+		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(stores.SQLDB, loadedBundle.contractsRoot, source, mountSources)
+		if err != nil {
+			slog.Error("configure recovery workspaces", "error", err)
+			return 1
+		}
+		if recoveryWorkspaces == nil {
+			slog.Error("workspace lifecycle is not configured")
+			return 1
+		}
 		recovery, err := runtimestartuprecovery.Recover(ctx, runtimestartuprecovery.Request{
 			AvailabilityReader: stores.Postgres,
 			CleanupStore:       stores.Postgres,
-			Containers:         serveStartupRecoveryContainers{lifecycle: workspaces},
+			Containers:         serveStartupRecoveryContainers{lifecycle: recoveryWorkspaces},
 			RequestedAt:        time.Now().UTC(),
 		})
 		if err != nil {
@@ -471,50 +677,48 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			)
 		}
 	}
-	pinnedBundleHash := ""
-	if loadedBundle.dbLoaded {
-		pinnedBundleHash = strings.TrimSpace(loadedBundle.bundleSourceFact.BundleHash)
-	}
-	if err := enforceServeBundleMatchAdmission(ctx, stores.Postgres, loadedBundle.serveIdentityDetail(), opts.RequireBundleMatch, pinnedBundleHash); err != nil {
+	pinnedBundleHashes := servePinnedBundleHashes(loadedBundles)
+	if err := enforceServeBundleMatchAdmissionForHashes(ctx, stores.Postgres, serveRuntimeBundleIdentitiesDetail(loadedBundles), opts.RequireBundleMatch, pinnedBundleHashes); err != nil {
 		slog.Error("bundle match admission failed", "error", err)
 		return 3
 	}
-	bundleSourceFact, err := prepareLoadedServeBundleSource(ctx, stores, loadedBundle, opts.Dev)
-	if err != nil {
-		slog.Error("prepare bundle source", "error", err)
-		return 3
-	}
-	bootBundleIdentity.BundleHash = strings.TrimSpace(bundleSourceFact.BundleHash)
-	if err := workspaces.ValidateSource(ctx, source); err != nil {
-		slog.Error("validate workspaces", "error", err)
-		return 1
-	}
-	if err := workspaces.EnsurePrereqs(ctx); err != nil {
-		slog.Error("prepare workspaces", "error", err)
-		return 1
-	}
-	if err := workspaces.EnsureSystemWorkspaces(ctx); err != nil {
-		slog.Error("ensure system workspaces", "error", err)
-		return 1
-	}
-	systemContainers := systemWorkspaceContainers(workspaces)
 	credentialStore, err := buildCredentialStore()
 	if err != nil {
 		slog.Error("configure credentials", "error", err)
 		return 1
 	}
-	validation, err := runtime.ValidateWorkflowContractSurface(ctx, source, runtime.DefaultWorkflowContractValidationOptions(credentialStore))
-	bootReport := validation.BootReport
-	if err != nil {
-		if bootReport.HasErrors() {
-			for _, finding := range bootReport.Errors() {
-				slog.Error("swarm boot verification failed", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
-			}
-		} else {
-			slog.Error("workflow contract validation failed", "error", err)
+	runtimeContexts := make([]serveRuntimeBundleContext, 0, len(loadedBundles))
+	for i, loaded := range loadedBundles {
+		contextDef, err := buildServeRuntimeBundleContext(serveRuntimeBundleContextRequest{
+			Ctx:                    ctx,
+			Stores:                 stores,
+			Config:                 cfg,
+			Loaded:                 loaded,
+			Options:                opts,
+			MountSources:           mountSources,
+			Credentials:            credentialStore,
+			BootStartedAt:          bootStartedAt,
+			BootProgress:           reporter.runtimeSink(),
+			EnableToolGateway:      i == 0,
+			UseStartupOwnership:    len(loadedBundles) == 1 && i == 0,
+			UseStartupRecovery:     len(loadedBundles) == 1,
+			RequireBundleScopeName: len(loadedBundles) > 1,
+		})
+		if err != nil {
+			slog.Error("build runtime context", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
+			return 1
 		}
-		return 1
+		runtimeContexts = append(runtimeContexts, contextDef)
 	}
+	primaryContext := runtimeContexts[0]
+	source = primaryContext.loaded.source
+	bundle := primaryContext.loaded.bundle
+	contractsRoot := primaryContext.loaded.contractsRoot
+	bootBundleIdentity := primaryContext.bootIdentity
+	workspaces := primaryContext.workspaces
+	rt := primaryContext.runtime
+	bootReport := primaryContext.validation.BootReport
+	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
 
 	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
 	if err != nil {
@@ -541,28 +745,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	defer restoreGatewayEnv()
 
-	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{
-		Config: cfg,
-		Stores: stores.runtimeStores(),
-		Options: runtime.RuntimeOptions{
-			SelfCheck:          opts.SelfCheck,
-			WorkflowModule:     module,
-			WorkspaceLifecycle: workspaces,
-			EnableToolGateway:  true,
-			ToolGatewayToken:   strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
-			BundleFingerprint:  bootBundleIdentity.Fingerprint,
-			BundleSourceFact:   bundleSourceFact,
-			Credentials:        credentialStore,
-			BootStartedAt:      bootStartedAt,
-			BootProgress:       reporter.runtimeSink(),
-			SystemContainers:   systemContainers,
-		},
-	})
-
-	if err != nil {
-		log.Printf("init runtime: %v", err)
-		return 1
-	}
 	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces)
 	if err != nil {
 		log.Printf("init forkchat sandbox runtime: %v", err)
@@ -571,10 +753,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, contractsRoot, bundle, source, rt, opts.Dev)
-	if loadedBundle.dbLoaded {
-		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins one persisted bundle for the process; dynamic project reload is split to RuntimeContextManager work")
+	if len(pinnedBundleHashes) > 0 {
+		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is split to RuntimeContextManager Load/Unload work")
 	}
 	defer func() {
+		if err := closeAdditionalServeRuntimeContexts(context.Background(), runtimeContexts[1:], opts); err != nil {
+			log.Printf("additional runtime context shutdown failed: %v", err)
+		}
 		if err := closeServeRuntime(context.Background(), supervisor, opts, workspaces); err != nil {
 			log.Printf("runtime shutdown failed: %v", err)
 		}
@@ -608,6 +793,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			RepoRoot: repo,
 			Store:    stores.Postgres,
 		}
+	}
+	apiRuntimeContexts, err := serveRuntimeContextManager(stores.Postgres, runtimeContexts)
+	if err != nil {
+		log.Printf("init runtime context manager: %v", err)
+		return 1
 	}
 	apiReadOptions := apiv1.OperatorReadOptions{
 		RepoRoot:         repo,
@@ -650,12 +840,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 				Credentials:       credentialStore,
 			},
 		},
-		AgentControl:   dashboardDynamicAgentControl{supervisor: supervisor},
-		Mailbox:        stores.MailboxAPIStore,
-		Idempotency:    stores.IdempotencyStore,
-		Events:         rt.Bus,
-		RunControl:     rt.RunControl,
-		RuntimeIngress: rt.RuntimeIngress,
+		AgentControl:    dashboardDynamicAgentControl{supervisor: supervisor},
+		Mailbox:         stores.MailboxAPIStore,
+		Idempotency:     stores.IdempotencyStore,
+		Events:          rt.Bus,
+		RunControl:      rt.RunControl,
+		RuntimeIngress:  rt.RuntimeIngress,
+		RuntimeContexts: apiRuntimeContexts,
 		ResetCoordinator: &runtimedestructivereset.Coordinator{
 			Planner: resetPlanner,
 			Locks:   stores.Postgres,
@@ -684,7 +875,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	defer shutdownHTTPServer("mcp", mcpServer)
 	defer shutdownHTTPServer("api", apiServer)
 	logBootWarnings(bootReport)
-	if err := rt.Start(ctx); err != nil {
+	if err := startServeRuntimeContexts(ctx, runtimeContexts); err != nil {
 		reporter.emit(22, "ready", "FAILED", err.Error())
 		log.Printf("start runtime: %v", err)
 		return 1
@@ -723,6 +914,60 @@ func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor
 		}
 	}
 	return errors.Join(shutdownErr, cleanupErr)
+}
+
+func serveRuntimeContextManager(reader runtime.RunBundleAvailabilityReader, contexts []serveRuntimeBundleContext) (*runtime.RuntimeContextManager, error) {
+	hasDBLoaded := false
+	managerContexts := make([]runtime.BundleContext, 0, len(contexts))
+	for _, contextDef := range contexts {
+		if !contextDef.loaded.dbLoaded {
+			continue
+		}
+		hasDBLoaded = true
+		managerContexts = append(managerContexts, runtime.BundleContext{
+			BundleHash:       contextDef.bundleSourceFact.BundleHash,
+			BundleSourceFact: contextDef.bundleSourceFact,
+			BundleIdentity:   contextDef.bootIdentity,
+			Source:           contextDef.loaded.source,
+			ContractsRoot:    contextDef.loaded.contractsRoot,
+			PlatformSpecPath: contextDef.loaded.platformSpecPath,
+			Runtime:          contextDef.runtime,
+		})
+	}
+	if !hasDBLoaded {
+		return nil, nil
+	}
+	return runtime.NewRuntimeContextManager(reader, managerContexts...)
+}
+
+func startServeRuntimeContexts(ctx context.Context, contexts []serveRuntimeBundleContext) error {
+	started := make([]*runtime.Runtime, 0, len(contexts))
+	for _, contextDef := range contexts {
+		if contextDef.runtime == nil {
+			continue
+		}
+		if err := contextDef.runtime.Start(ctx); err != nil {
+			for i := len(started) - 1; i >= 0; i-- {
+				_ = started[i].Shutdown()
+			}
+			return err
+		}
+		started = append(started, contextDef.runtime)
+	}
+	return nil
+}
+
+func closeAdditionalServeRuntimeContexts(ctx context.Context, contexts []serveRuntimeBundleContext, opts serveOptions) error {
+	var shutdownErr error
+	for _, contextDef := range contexts {
+		if contextDef.runtime == nil {
+			continue
+		}
+		if err := contextDef.runtime.ShutdownWithOptions(runtime.ShutdownOptions{Grace: opts.ShutdownGrace}); err != nil {
+			shutdownErr = errors.Join(shutdownErr, err)
+		}
+	}
+	return shutdownErr
 }
 
 type verifyCommandResult struct {
@@ -2133,12 +2378,20 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 }
 
 func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresStore, bootIdentity string, requireMatch bool, pinnedBundleHash string) error {
+	var pinned []string
+	if hash := strings.TrimSpace(pinnedBundleHash); hash != "" {
+		pinned = []string{hash}
+	}
+	return enforceServeBundleMatchAdmissionForHashes(ctx, pg, bootIdentity, requireMatch, pinned)
+}
+
+func enforceServeBundleMatchAdmissionForHashes(ctx context.Context, pg *store.PostgresStore, bootIdentity string, requireMatch bool, pinnedBundleHashes []string) error {
 	bootIdentity = strings.TrimSpace(bootIdentity)
-	pinnedBundleHash = strings.TrimSpace(pinnedBundleHash)
+	pinnedBundleHashes = uniqueTrimmedServeBundleHashes(pinnedBundleHashes)
 	if !requireMatch {
 		log.Printf("legacy bundle match admission disabled by --no-require-bundle-match; startup recovery has already consumed active run bundle source state")
 	}
-	enforceActiveAvailability := requireMatch || pinnedBundleHash != ""
+	enforceActiveAvailability := requireMatch || len(pinnedBundleHashes) > 0
 	if enforceActiveAvailability && bootIdentity == "" {
 		return fmt.Errorf("boot bundle identity is required")
 	}
@@ -2158,10 +2411,10 @@ func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresSto
 			return fmt.Errorf("active run bundle availability conflict: boot bundle %s cannot resume %d active run(s): %s", bootIdentity, len(conflicts), strings.Join(details, "; "))
 		}
 	}
-	if pinnedBundleHash == "" {
+	if len(pinnedBundleHashes) == 0 {
 		return nil
 	}
-	mismatches, err := activeRunPinnedBundleHashConflicts(ctx, pg, pinnedBundleHash)
+	mismatches, err := activeRunPinnedBundleHashesConflicts(ctx, pg, pinnedBundleHashes)
 	if err != nil {
 		return err
 	}
@@ -2172,7 +2425,7 @@ func enforceServeBundleMatchAdmission(ctx context.Context, pg *store.PostgresSto
 	for _, mismatch := range mismatches {
 		details = append(details, mismatch.DetailString())
 	}
-	return fmt.Errorf("active run pinned bundle_hash conflict: DB-loaded serve bundle_hash %s cannot resume %d active run(s) with different bundle_hash: %s", pinnedBundleHash, len(mismatches), strings.Join(details, "; "))
+	return fmt.Errorf("active run pinned bundle_hash conflict: DB-loaded serve bundle_hash set %s cannot resume %d active run(s) with different bundle_hash: %s", strings.Join(pinnedBundleHashes, ","), len(mismatches), strings.Join(details, "; "))
 }
 
 func activeRunPinnedBundleHashConflicts(ctx context.Context, pg *store.PostgresStore, pinnedBundleHash string) ([]runbundle.Availability, error) {
@@ -2194,6 +2447,48 @@ func activeRunPinnedBundleHashConflicts(ctx context.Context, pg *store.PostgresS
 		}
 	}
 	return conflicts, nil
+}
+
+func activeRunPinnedBundleHashesConflicts(ctx context.Context, pg *store.PostgresStore, pinnedBundleHashes []string) ([]runbundle.Availability, error) {
+	allowed := map[string]struct{}{}
+	for _, hash := range uniqueTrimmedServeBundleHashes(pinnedBundleHashes) {
+		allowed[hash] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return nil, nil
+	}
+	availabilities, err := pg.ActiveRunBundleAvailabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conflicts := make([]runbundle.Availability, 0, len(availabilities))
+	for _, availability := range availabilities {
+		if !availability.Available() {
+			continue
+		}
+		if _, ok := allowed[strings.TrimSpace(availability.BundleHash)]; !ok {
+			conflicts = append(conflicts, availability)
+		}
+	}
+	return conflicts, nil
+}
+
+func uniqueTrimmedServeBundleHashes(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -370,6 +371,18 @@ func TestCLI_ServeBundleHashValidationAndSerialScope(t *testing.T) {
 			wantCode: 0,
 			wantHash: "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
+		{
+			name:       "duplicate pinned bundle hash rejected",
+			args:       []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			wantCode:   2,
+			wantStderr: "--bundle-hash values must be unique",
+		},
+		{
+			name:     "repeated canonical bundle hashes accepted",
+			args:     []string{"serve", "--bundle-hash", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--bundle-hash", "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:0"},
+			wantCode: 0,
+			wantHash: "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
 	}
 
 	for _, tc := range tests {
@@ -402,6 +415,12 @@ func TestCLI_ServeBundleHashValidationAndSerialScope(t *testing.T) {
 			}
 			if captured.BundleHash != tc.wantHash {
 				t.Fatalf("BundleHash = %q, want %q", captured.BundleHash, tc.wantHash)
+			}
+			if tc.name == "repeated canonical bundle hashes accepted" {
+				wantExtra := []string{"bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+				if !reflect.DeepEqual(captured.BundleHashes, wantExtra) {
+					t.Fatalf("BundleHashes = %#v, want %#v", captured.BundleHashes, wantExtra)
+				}
 			}
 		})
 	}

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -280,6 +280,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 
 	sourceEvidence := mustMappingValue(t, multi, "source_evidence")
 	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "run_fork_cli_authority_absorbed_from"), "#1038")
+	assertScalarValue(t, mustMappingValue(t, sourceEvidence, "boot_pinned_runtime_context_manager"), "#1175")
 
 	generatedPolicy := mustMappingValue(t, multi, "generated_artifact_policy")
 	assertScalarValue(t, mustMappingValue(t, generatedPolicy, "current_openrpc_status"), "bundle_read_catalog_register_run_fork_and_delete_methods_published")
@@ -323,6 +324,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarContains(t, mustMappingValue(t, serveIngest, "data_blob"), "raw bytes as base64")
 	assertScalarContains(t, mustMappingValue(t, serveIngest, "parsed_json"), "Runtime-owned fields")
 	assertScalarContains(t, mustMappingValue(t, serveIngest, "idempotency"), "fails closed before runtime construction")
+	serveDBLoaded := mustMappingValue(t, persistence, "serve_db_loaded_runtime_source")
+	assertScalarValue(t, mustMappingValue(t, serveDBLoaded, "status"), "implemented_for_boot_pinned_postgres_serve_bundle_hash_contexts")
+	assertScalarContains(t, mustMappingValue(t, serveDBLoaded, "cli_flag"), "[--bundle-hash")
+	assertScalarValue(t, mustMappingValue(t, serveDBLoaded, "runtime_context_manager_owner"), "internal/runtime.RuntimeContextManager")
+	assertScalarValue(t, mustMappingValue(t, serveDBLoaded, "bundle_context_owner"), "internal/runtime.BundleContext")
 	platformTables := mustMappingValue(t, mustMappingValue(t, root, "platform_tables"), "tables")
 	if mappingValue(platformTables, "bundles") == nil {
 		t.Fatal("bundles table must be live in platform_tables after the DB migration child lands")

--- a/internal/apiv1/operator_agent_control.go
+++ b/internal/apiv1/operator_agent_control.go
@@ -79,7 +79,20 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 		TTL:            agentControlIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		result, err := opts.AgentControl.SendDirective(ctx, runtimeagentcontrol.SendDirectiveRequest{
+		selectedOpts := opts
+		if runtimeContextManager(opts) != nil {
+			if strings.TrimSpace(runID) == "" && multiRuntimeContextMode(opts) {
+				return store.APIIdempotencyCompletion{}, runtimeContextRequiredError(req.Method, "run_id is required to select a runtime context in multi-context DB-loaded mode")
+			}
+			if strings.TrimSpace(runID) != "" {
+				var err error
+				ctx, selectedOpts, _, err = runtimeBundleContextByRun(ctx, opts, runID)
+				if err != nil {
+					return store.APIIdempotencyCompletion{}, err
+				}
+			}
+		}
+		result, err := selectedOpts.AgentControl.SendDirective(ctx, runtimeagentcontrol.SendDirectiveRequest{
 			AgentID:    agentID,
 			Directive:  directive,
 			RunID:      runID,
@@ -116,6 +129,9 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 }
 
 func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	if multiRuntimeContextMode(opts) {
+		return nil, runtimeContextRequiredError(req.Method, "agent restart is ambiguous in multi-context DB-loaded mode; per-context agent control is split to #1176")
+	}
 	agentID, err := requiredStringParam(req.Params, "agent_id")
 	if err != nil {
 		return nil, err
@@ -157,6 +173,9 @@ func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOpti
 }
 
 func executeAgentReplayBacklog(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	if multiRuntimeContextMode(opts) {
+		return nil, runtimeContextRequiredError(req.Method, "agent backlog replay is ambiguous in multi-context DB-loaded mode; per-context agent control is split to #1176")
+	}
 	agentID, err := requiredStringParam(req.Params, "agent_id")
 	if err != nil {
 		return nil, err

--- a/internal/apiv1/operator_bundle_admission.go
+++ b/internal/apiv1/operator_bundle_admission.go
@@ -25,21 +25,33 @@ func resolveEventPublicationBundleScope(
 	params eventPublicationParams,
 	identity bundleIdentityParam,
 	cfg eventPublicationConfig,
-) (context.Context, eventPublicationParams, error) {
+) (context.Context, OperatorReadOptions, eventPublicationParams, error) {
 	requestedHash := strings.TrimSpace(identity.BundleHash)
-	currentFact, hasCurrentFact := eventPublicationRuntimeSourceFact(ctx, opts.Events)
 	runAvailability, hasRunContext, err := eventPublicationRunBundleContext(ctx, opts, params, cfg)
 	if err != nil {
-		return ctx, params, err
+		return ctx, opts, params, err
 	}
 
 	resolvedHash := requestedHash
 	if hasRunContext {
 		if requestedHash != "" && runAvailability.BundleHash != "" && requestedHash != runAvailability.BundleHash {
-			return ctx, params, NewApplicationError(BundleMismatchCode, false, bundleMismatchDetails(params.RunID, requestedHash, runAvailability))
+			return ctx, opts, params, NewApplicationError(BundleMismatchCode, false, bundleMismatchDetails(params.RunID, requestedHash, runAvailability))
+		}
+		if runtimeContextManager(opts) != nil {
+			var selectedOpts OperatorReadOptions
+			ctx, selectedOpts, runAvailability, err = runtimeBundleContextByRun(ctx, opts, params.RunID)
+			if err != nil {
+				return ctx, opts, params, err
+			}
+			currentFact, _ := runtimecorrelation.BundleSourceFactFromContext(ctx)
+			currentFact = currentFact.Normalized()
+			params.BundleHash = runAvailability.BundleHash
+			params.BundleSource = currentFact.BundleSource
+			params.BundleFingerprint = currentFact.BundleFingerprint
+			return ctx, selectedOpts, params, nil
 		}
 		if err := eventPublicationRunBundleAvailable(runAvailability); err != nil {
-			return ctx, params, err
+			return ctx, opts, params, err
 		}
 		resolvedHash = runAvailability.BundleHash
 		params.BundleSource = runAvailability.BundleSource
@@ -52,10 +64,32 @@ func resolveEventPublicationBundleScope(
 		if params.RunIDProvided {
 			details["run_id"] = strings.TrimSpace(params.RunID)
 		}
-		return ctx, params, NewApplicationError(BundleScopeRequiredCode, false, details)
+		return ctx, opts, params, NewApplicationError(BundleScopeRequiredCode, false, details)
 	}
+	if runtimeContextManager(opts) != nil {
+		var selectedOpts OperatorReadOptions
+		var contextDef any
+		ctx, selectedOpts, contextDef, err = runtimeBundleContextByHash(ctx, opts, resolvedHash, params.RunID)
+		if err != nil {
+			return ctx, opts, params, err
+		}
+		if contextDef == nil {
+			return ctx, opts, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+				"bundle_hash": resolvedHash,
+				"run_id":      strings.TrimSpace(params.RunID),
+				"cause":       "runtime_context_not_loaded",
+			})
+		}
+		currentFact, _ := runtimecorrelation.BundleSourceFactFromContext(ctx)
+		currentFact = currentFact.Normalized()
+		params.BundleHash = resolvedHash
+		params.BundleSource = currentFact.BundleSource
+		params.BundleFingerprint = currentFact.BundleFingerprint
+		return ctx, selectedOpts, params, nil
+	}
+	currentFact, hasCurrentFact := eventPublicationRuntimeSourceFact(ctx, opts.Events)
 	if !hasCurrentFact || strings.TrimSpace(currentFact.BundleHash) == "" {
-		return ctx, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+		return ctx, opts, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
 			"bundle_hash": resolvedHash,
 			"run_id":      strings.TrimSpace(params.RunID),
 			"cause":       "runtime_source_fact_missing",
@@ -63,7 +97,7 @@ func resolveEventPublicationBundleScope(
 	}
 	currentFact = currentFact.Normalized()
 	if currentFact.BundleHash != resolvedHash {
-		return ctx, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+		return ctx, opts, params, NewApplicationError(BundleUnavailableCode, false, map[string]any{
 			"bundle_hash":        resolvedHash,
 			"run_id":             strings.TrimSpace(params.RunID),
 			"active_bundle_hash": currentFact.BundleHash,
@@ -74,7 +108,7 @@ func resolveEventPublicationBundleScope(
 	params.BundleHash = resolvedHash
 	params.BundleSource = currentFact.BundleSource
 	params.BundleFingerprint = currentFact.BundleFingerprint
-	return runtimecorrelation.WithBundleSourceFact(ctx, currentFact), params, nil
+	return runtimecorrelation.WithBundleSourceFact(ctx, currentFact), opts, params, nil
 }
 
 func eventPublicationRuntimeSourceFact(ctx context.Context, publisher EventPublisher) (runtimecorrelation.BundleSourceFact, bool) {

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -170,21 +170,22 @@ func executeOperatorEventPublication(
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
-		ctx, params, err = resolveEventPublicationBundleScope(ctx, opts, params, bundleIdentity, cfg)
+		selectedOpts := opts
+		ctx, selectedOpts, params, err = resolveEventPublicationBundleScope(ctx, opts, params, bundleIdentity, cfg)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
 		if !cfg.rootInputOnly {
-			resolvedEventName, err := resolveEventPublicationEventName(opts.Source, params.EventName)
+			resolvedEventName, err := resolveEventPublicationEventName(selectedOpts.Source, params.EventName)
 			if err != nil {
 				return store.APIIdempotencyCompletion{}, err
 			}
 			params.EventName = resolvedEventName
 		}
-		if err := validateEventPublication(ctx, opts, params, cfg); err != nil {
+		if err := validateEventPublication(ctx, selectedOpts, params, cfg); err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}
-		if err := opts.Events.Publish(ctx, events.Event{
+		if err := selectedOpts.Events.Publish(ctx, events.Event{
 			ID:            params.EventID,
 			RunID:         params.RunID,
 			ParentEventID: params.SourceEventID,
@@ -198,7 +199,7 @@ func executeOperatorEventPublication(
 			}
 			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
 		}
-		result, resourceID, err := cfg.buildCompletion(ctx, opts, params)
+		result, resourceID, err := cfg.buildCompletion(ctx, selectedOpts, params)
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, err
 		}

--- a/internal/apiv1/operator_event_replay.go
+++ b/internal/apiv1/operator_event_replay.go
@@ -12,6 +12,7 @@ import (
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
 	"swarm/internal/store"
+	"swarm/internal/store/runbundle"
 )
 
 const (
@@ -96,7 +97,13 @@ func OperatorEventReplayHandlers(opts OperatorReadOptions) map[string]MethodHand
 }
 
 func eventReplayConfigured(opts OperatorReadOptions) bool {
-	if opts.Observability == nil || opts.Idempotency == nil || opts.Events == nil {
+	if opts.Observability == nil || opts.Idempotency == nil {
+		return false
+	}
+	if runtimeContextManager(opts) != nil {
+		return true
+	}
+	if opts.Events == nil {
 		return false
 	}
 	_, ok := opts.Events.(eventReplayPublisher)
@@ -219,6 +226,19 @@ func performEventReplay(
 	if err != nil {
 		return eventReplayPerformed{}, err
 	}
+	if runtimeContextManager(opts) != nil {
+		var availability runbundle.Availability
+		ctx, opts, availability, err = runtimeBundleContextByRun(ctx, opts, original.RunID)
+		if err != nil {
+			return eventReplayPerformed{}, err
+		}
+		_ = availability
+		selectedPublisher, ok := opts.Events.(eventReplayPublisher)
+		if !ok || selectedPublisher == nil {
+			return eventReplayPerformed{}, errors.New("event replay publisher is required for selected runtime context")
+		}
+		publisher = selectedPublisher
+	}
 	_, selectedSubscribers, err := eventReplayTargets(original, requestedSubscribers)
 	if err != nil {
 		return eventReplayPerformed{}, err
@@ -296,6 +316,19 @@ func ensureEventReplayAudit(
 	}
 	if err != nil {
 		return err
+	}
+	if runtimeContextManager(opts) != nil {
+		var availability runbundle.Availability
+		ctx, opts, availability, err = runtimeBundleContextByRun(ctx, opts, original.RunID)
+		if err != nil {
+			return err
+		}
+		_ = availability
+		selectedPublisher, ok := opts.Events.(eventReplayPublisher)
+		if !ok || selectedPublisher == nil {
+			return errors.New("event replay publisher is required for selected runtime context")
+		}
+		publisher = selectedPublisher
 	}
 	originalDeliveries, _, err := eventReplayTargets(original, stored.SubscribersReplayed)
 	if err != nil {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -206,6 +206,9 @@ func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadO
 	idempotencyKey := stringParam(req.Params, "idempotency_key")
 	action := strings.ToLower(strings.TrimSpace(decision.Action))
 	if action == "approved" || action == "approve" {
+		if multiRuntimeContextMode(opts) {
+			return nil, runtimeContextRequiredError(req.Method, "mailbox approval event publishing is ambiguous in multi-context DB-loaded mode; per-context mailbox approval routing is split to #1176")
+		}
 		txPublisher, ok := opts.Events.(TransactionalEventPublisher)
 		if !ok || txPublisher == nil {
 			return nil, errors.New("transactional event publisher is required for mailbox approval")

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	swruntime "swarm/internal/runtime"
 	"swarm/internal/runtime/bundledelete"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/semanticview"
@@ -85,6 +86,7 @@ type OperatorReadOptions struct {
 	Events                EventPublisher
 	RunControl            RunControlController
 	RuntimeIngress        RuntimeIngressController
+	RuntimeContexts       *swruntime.RuntimeContextManager
 	ResetCoordinator      DestructiveResetCoordinator
 	ResetQuiescer         DestructiveResetQuiescer
 	ResetCleaner          DestructiveResetCleaner

--- a/internal/apiv1/operator_run_control.go
+++ b/internal/apiv1/operator_run_control.go
@@ -60,6 +60,14 @@ func executeRunControl(ctx context.Context, req Request, opts OperatorReadOption
 		TTL:            runControlIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
+		selectedOpts := opts
+		if runtimeContextManager(opts) != nil {
+			var err error
+			ctx, selectedOpts, _, err = runtimeBundleContextByRun(ctx, opts, runID)
+			if err != nil {
+				return store.APIIdempotencyCompletion{}, err
+			}
+		}
 		controlReq := runtimeruncontrol.TransitionRequest{
 			RunID:        runID,
 			Reason:       "operator_request",
@@ -70,11 +78,11 @@ func executeRunControl(ctx context.Context, req Request, opts OperatorReadOption
 		var err error
 		switch action {
 		case "stop":
-			result, err = opts.RunControl.Stop(ctx, controlReq)
+			result, err = selectedOpts.RunControl.Stop(ctx, controlReq)
 		case "pause":
-			result, err = opts.RunControl.Pause(ctx, controlReq)
+			result, err = selectedOpts.RunControl.Pause(ctx, controlReq)
 		case "continue":
-			result, err = opts.RunControl.Continue(ctx, controlReq)
+			result, err = selectedOpts.RunControl.Continue(ctx, controlReq)
 		default:
 			err = fmt.Errorf("unsupported run control action %q", action)
 		}

--- a/internal/apiv1/operator_run_fork.go
+++ b/internal/apiv1/operator_run_fork.go
@@ -96,6 +96,13 @@ func OperatorRunForkHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 }
 
 func executeRunFork(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
+	if multiRuntimeContextMode(opts) {
+		return nil, NewApplicationError(UnsupportedBundleHashForkCode, false, map[string]any{
+			"tracked_follow_up":  "#976/#1025",
+			"unsupported_reason": "run.fork runtime dispatch in multi-context DB-loaded mode is split from the pinned RuntimeContextManager boot slice",
+			"supported_selector": "single DB-loaded runtime context or same source bundle_hash in serial mode",
+		})
+	}
 	params, err := runForkParamsFromRequest(req.Params)
 	if err != nil {
 		return nil, err

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -46,9 +46,14 @@ func OperatorRunStartHandlers(opts OperatorReadOptions) map[string]MethodHandler
 }
 
 func runStartConfigured(opts OperatorReadOptions) bool {
+	if opts.Idempotency == nil {
+		return false
+	}
+	if runtimeContextManager(opts) != nil {
+		return true
+	}
 	return opts.Source != nil &&
 		opts.Events != nil &&
-		opts.Idempotency != nil &&
 		strings.TrimSpace(opts.Bundle.Fingerprint) != ""
 }
 

--- a/internal/apiv1/operator_runtime_context.go
+++ b/internal/apiv1/operator_runtime_context.go
@@ -1,0 +1,106 @@
+package apiv1
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	swruntime "swarm/internal/runtime"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/store"
+	"swarm/internal/store/runbundle"
+)
+
+func runtimeContextManager(opts OperatorReadOptions) *swruntime.RuntimeContextManager {
+	if opts.RuntimeContexts == nil || opts.RuntimeContexts.Len() == 0 {
+		return nil
+	}
+	return opts.RuntimeContexts
+}
+
+func multiRuntimeContextMode(opts OperatorReadOptions) bool {
+	manager := runtimeContextManager(opts)
+	return manager != nil && manager.MultiContext()
+}
+
+func operatorOptionsForBundleContext(opts OperatorReadOptions, contextDef *swruntime.BundleContext) OperatorReadOptions {
+	if contextDef == nil || contextDef.Runtime == nil {
+		return opts
+	}
+	selected := opts
+	selected.Source = contextDef.Source
+	selected.Bundle = contextDef.BundleIdentity
+	selected.Events = contextDef.Runtime.Bus
+	selected.RuntimeIngress = contextDef.Runtime.RuntimeIngress
+	selected.RunControl = contextDef.Runtime.RunControl
+	if contextDef.Runtime.Manager != nil {
+		selected.AgentControl = contextDef.Runtime.Manager
+	}
+	return selected
+}
+
+func runtimeBundleContextByHash(ctx context.Context, opts OperatorReadOptions, bundleHash, runID string) (context.Context, OperatorReadOptions, *swruntime.BundleContext, error) {
+	manager := runtimeContextManager(opts)
+	if manager == nil {
+		return ctx, opts, nil, nil
+	}
+	bundleHash = strings.TrimSpace(bundleHash)
+	if bundleHash == "" {
+		return ctx, opts, nil, NewApplicationError(BundleScopeRequiredCode, false, map[string]any{
+			"field":  "bundle_hash",
+			"reason": "bundle_hash is required to select a runtime context",
+		})
+	}
+	contextDef, ok := manager.LookupBundleHash(bundleHash)
+	if !ok || contextDef == nil {
+		return ctx, opts, nil, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+			"bundle_hash": bundleHash,
+			"run_id":      strings.TrimSpace(runID),
+			"cause":       "runtime_context_not_loaded",
+		})
+	}
+	selected := operatorOptionsForBundleContext(opts, contextDef)
+	fact := contextDef.BundleSourceFact.Normalized()
+	if fact.BundleHash == "" {
+		fact.BundleHash = bundleHash
+	}
+	return runtimecorrelation.WithBundleSourceFact(ctx, fact), selected, contextDef, nil
+}
+
+func runtimeBundleContextByRun(ctx context.Context, opts OperatorReadOptions, runID string) (context.Context, OperatorReadOptions, runbundle.Availability, error) {
+	manager := runtimeContextManager(opts)
+	if manager == nil {
+		return ctx, opts, runbundle.Availability{}, nil
+	}
+	contextDef, availability, loaded, err := manager.LookupRun(ctx, strings.TrimSpace(runID))
+	if errors.Is(err, store.ErrRunNotFound) {
+		return ctx, opts, runbundle.Availability{}, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": strings.TrimSpace(runID)})
+	}
+	if err != nil {
+		return ctx, opts, runbundle.Availability{}, err
+	}
+	if availability.ErrorCode == BundleDataIntegrityErrorCode {
+		return ctx, opts, availability, NewApplicationError(BundleDataIntegrityErrorCode, false, bundleAvailabilityDetails(availability))
+	}
+	if !availability.Available() {
+		return ctx, opts, availability, NewApplicationError(BundleUnavailableCode, false, bundleAvailabilityDetails(availability))
+	}
+	if !loaded || contextDef == nil {
+		details := bundleAvailabilityDetails(availability)
+		details["cause"] = "runtime_context_not_loaded"
+		return ctx, opts, availability, NewApplicationError(BundleUnavailableCode, false, details)
+	}
+	selected := operatorOptionsForBundleContext(opts, contextDef)
+	fact := contextDef.BundleSourceFact.Normalized()
+	if fact.BundleHash == "" {
+		fact.BundleHash = availability.BundleHash
+	}
+	return runtimecorrelation.WithBundleSourceFact(ctx, fact), selected, availability, nil
+}
+
+func runtimeContextRequiredError(method, reason string) error {
+	return NewApplicationError(BundleScopeRequiredCode, false, map[string]any{
+		"method": strings.TrimSpace(method),
+		"reason": strings.TrimSpace(reason),
+	})
+}

--- a/internal/apiv1/operator_runtime_context_test.go
+++ b/internal/apiv1/operator_runtime_context_test.go
@@ -1,0 +1,657 @@
+package apiv1
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	swruntime "swarm/internal/runtime"
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimeingress "swarm/internal/runtime/ingress"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimeruncontrol "swarm/internal/runtime/runcontrol"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store"
+	"swarm/internal/store/runbundle"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/testutil"
+)
+
+const runtimeContextTestBundleHashB = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+const runtimeContextTestBundleHashC = "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+func TestOperatorRuntimeContextManagerRoutesCreateNewWorkToSelectedBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	handler := fixture.handler(t)
+	chPrimary := fixture.busA.Subscribe("scan-orchestrator", events.EventType("triage.requested"))
+	defer fixture.busA.Unsubscribe("scan-orchestrator")
+	chSelected := fixture.busB.Subscribe("scan-orchestrator", events.EventType("triage.requested"))
+	defer fixture.busB.Unsubscribe("scan-orchestrator")
+
+	published := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runtimeContextTestBundleHashB, "triage.requested", `{"topic":"context-b"}`, "", "idem-context-publish"))
+	if published.Error != nil {
+		t.Fatalf("event.publish error = %#v", published.Error)
+	}
+	publishedResult := asMap(t, published.Result)
+	publishedRunID := stringValue(t, publishedResult["run_id"], "run_id")
+	publishedEventID := stringValue(t, publishedResult["event_id"], "event_id")
+	assertRunBundleIdentity(t, fixture.db, publishedRunID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+	if got := countEventsByName(t, fixture.db, "triage.requested"); got != 1 {
+		t.Fatalf("triage.requested count after event.publish = %d, want 1", got)
+	}
+	select {
+	case got := <-chSelected:
+		if got.ID != publishedEventID {
+			t.Fatalf("selected context delivered event = %s, want %s", got.ID, publishedEventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for selected context delivery")
+	}
+	select {
+	case got := <-chPrimary:
+		t.Fatalf("primary context unexpectedly delivered selected bundle event %s", got.ID)
+	default:
+	}
+
+	runID := uuid.NewString()
+	started := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runtimeContextTestBundleHashB, "triage.requested", `{"topic":"context-b-start"}`, "idem-context-start"))
+	if started.Error != nil {
+		t.Fatalf("run.start error = %#v", started.Error)
+	}
+	assertRunBundleIdentity(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+	if got := countEventsByName(t, fixture.db, "triage.requested"); got != 2 {
+		t.Fatalf("triage.requested count after run.start = %d, want 2", got)
+	}
+}
+
+func TestOperatorRuntimeContextManagerRoutesExistingRunByStoredBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	handler := fixture.handler(t)
+	runID := uuid.NewString()
+	started := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runtimeContextTestBundleHashB, "triage.requested", `{"topic":"seed-existing"}`, "idem-existing-seed"))
+	if started.Error != nil {
+		t.Fatalf("seed run.start error = %#v", started.Error)
+	}
+
+	body := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"publish-existing","method":"event.publish","params":{"run_id":%q,"event_name":"triage.requested","payload":{"topic":"existing-run"},"idempotency_key":"idem-existing-context"}}`,
+		runID,
+	)
+	resp := rpcCall(t, handler, body)
+	if resp.Error != nil {
+		t.Fatalf("event.publish existing run error = %#v", resp.Error)
+	}
+	if got := countEventRowsByRunID(t, fixture.db, runID); got != 2 {
+		t.Fatalf("event rows for existing run = %d, want 2", got)
+	}
+	assertRunBundleIdentity(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+}
+
+func TestOperatorRuntimeContextManagerRejectsExistingRunUnavailableSourceStates(t *testing.T) {
+	tests := []struct {
+		name          string
+		bundleHash    string
+		bundleSource  string
+		fingerprint   string
+		seedBundleRow bool
+		wantCode      string
+		wantCause     string
+	}{
+		{
+			name:         "ephemeral",
+			bundleHash:   runtimeContextTestBundleHashB,
+			bundleSource: storerunlifecycle.BundleSourceEphemeral,
+			fingerprint:  runStartTestFingerprint,
+			wantCode:     BundleUnavailableCode,
+			wantCause:    storerunlifecycle.BundleSourceEphemeral,
+		},
+		{
+			name:         "deleted",
+			bundleHash:   runtimeContextTestBundleHashB,
+			bundleSource: storerunlifecycle.BundleSourceDeleted,
+			fingerprint:  runStartTestFingerprint,
+			wantCode:     BundleUnavailableCode,
+			wantCause:    storerunlifecycle.BundleSourceDeleted,
+		},
+		{
+			name:         "legacy",
+			bundleHash:   "",
+			bundleSource: storerunlifecycle.BundleSourceLegacy,
+			fingerprint:  runStartTestFingerprint,
+			wantCode:     BundleUnavailableCode,
+			wantCause:    storerunlifecycle.BundleSourceLegacy,
+		},
+		{
+			name:         "persisted missing bundle row",
+			bundleHash:   runtimeContextTestBundleHashC,
+			bundleSource: storerunlifecycle.BundleSourcePersisted,
+			wantCode:     BundleDataIntegrityErrorCode,
+			wantCause:    "persisted_missing_bundle_row",
+		},
+		{
+			name:          "persisted unloaded context",
+			bundleHash:    runtimeContextTestBundleHashC,
+			bundleSource:  storerunlifecycle.BundleSourcePersisted,
+			seedBundleRow: true,
+			wantCode:      BundleUnavailableCode,
+			wantCause:     "runtime_context_not_loaded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newOperatorRuntimeContextFixture(t)
+			if tt.seedBundleRow {
+				seedOperatorBundleDeleteBundle(t, context.Background(), fixture.db, tt.bundleHash)
+			}
+			handler := fixture.handler(t)
+			runID := uuid.NewString()
+			seedRuntimeContextRunBundle(t, fixture.db, runID, tt.bundleHash, tt.bundleSource, tt.fingerprint)
+			keyName := strings.ReplaceAll(tt.name, " ", "-")
+
+			calls := []struct {
+				method string
+				body   string
+			}{
+				{
+					method: "event.publish",
+					body:   eventPublishExistingRunBody(runID, "", "idem-context-publish-"+keyName),
+				},
+				{
+					method: "run.start",
+					body:   runStartBodyWithoutBundle(runID, "triage.requested", `{"topic":"blocked"}`, "idem-context-start-"+keyName),
+				},
+			}
+			for _, call := range calls {
+				resp := rpcCall(t, handler, call.body)
+				assertRuntimeContextBundleError(t, resp, call.method, tt.wantCode, tt.wantCause)
+				if got := countEventRowsByRunID(t, fixture.db, runID); got != 0 {
+					t.Fatalf("%s event rows for unavailable run = %d, want 0", call.method, got)
+				}
+			}
+		})
+	}
+}
+
+func TestOperatorRuntimeContextManagerRejectsExistingRunRequestedHashMismatch(t *testing.T) {
+	tests := []struct {
+		method string
+		body   func(string) string
+	}{
+		{
+			method: "event.publish",
+			body: func(runID string) string {
+				return eventPublishExistingRunBody(runID, runStartTestBundleHash, "idem-context-publish-mismatch")
+			},
+		},
+		{
+			method: "run.start",
+			body: func(runID string) string {
+				return runStartBodyWithBundleHash(runID, runStartTestBundleHash, "triage.requested", `{"topic":"mismatch"}`, "idem-context-start-mismatch")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			fixture := newOperatorRuntimeContextFixture(t)
+			handler := fixture.handler(t)
+			runID := uuid.NewString()
+			seedRuntimeContextRunBundle(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+
+			resp := rpcCall(t, handler, tt.body(runID))
+			assertRuntimeContextBundleError(t, resp, tt.method, BundleMismatchCode, "")
+			if got := countEventRowsByRunID(t, fixture.db, runID); got != 0 {
+				t.Fatalf("%s event rows for mismatched run = %d, want 0", tt.method, got)
+			}
+		})
+	}
+}
+
+func TestOperatorRuntimeContextManagerRoutesEventReplayByOriginalRunBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	handler := fixture.handler(t)
+	ctx := context.Background()
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, fixture.pg, "agent-a")
+	chPrimary := fixture.busA.Subscribe("agent-a")
+	defer fixture.busA.Unsubscribe("agent-a")
+	chSelected := fixture.busB.Subscribe("agent-a")
+	defer fixture.busB.Unsubscribe("agent-a")
+	original := seedReplayableOperatorEvent(t, ctx, fixture.pg, "triage.requested", []string{"agent-a"}, eventReplayStatusDelivered)
+	seedRuntimeContextRunBundle(t, fixture.db, original.RunID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+
+	resp := rpcCall(t, handler, eventReplayBody(original.EventID, []string{"agent-a"}, "idem-context-event-replay"))
+	if resp.Error != nil {
+		t.Fatalf("event.replay error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	replayEventID := stringValue(t, result["replay_event_id"], "replay_event_id")
+	auditEventID := stringValue(t, result["audit_event_id"], "audit_event_id")
+	assertReplayEventDelivered(t, chSelected, replayEventID, original.EventID)
+	assertNoReplayEvent(t, chPrimary)
+	assertReplayPersistence(t, fixture.db, original.EventID, replayEventID, auditEventID, 1)
+}
+
+func TestOperatorRuntimeContextManagerRoutesRunControlByStoredBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	baseStore := &recordingRuntimeContextRunControlStore{}
+	selectedStore := &recordingRuntimeContextRunControlStore{}
+	baseControl := runtimeruncontrol.NewController(baseStore, nil, runtimeruncontrol.Options{})
+	selectedControl := runtimeruncontrol.NewController(selectedStore, nil, runtimeruncontrol.Options{})
+	manager := runtimeContextManagerWithRuntimes(t, fixture,
+		&swruntime.Runtime{Bus: fixture.busA, RunControl: baseControl},
+		&swruntime.Runtime{Bus: fixture.busB, RunControl: selectedControl},
+	)
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:              func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Idempotency:      fixture.pg,
+			RunBundleContext: fixture.pg,
+			RunControl:       baseControl,
+			RuntimeContexts:  manager,
+		}),
+	})
+
+	for _, method := range []string{"run.pause", "run.continue", "run.stop"} {
+		runID := uuid.NewString()
+		seedRuntimeContextRunBundle(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+		resp := rpcCall(t, handler, runControlBody(method, runID, "idem-context-"+method))
+		if resp.Error != nil {
+			t.Fatalf("%s error = %#v", method, resp.Error)
+		}
+	}
+	if baseStore.totalCalls() != 0 {
+		t.Fatalf("base run control calls = %d, want 0", baseStore.totalCalls())
+	}
+	if selectedStore.pauseCalls != 1 || selectedStore.continueCalls != 1 || selectedStore.stopCalls != 1 {
+		t.Fatalf("selected run control calls pause/continue/stop = %d/%d/%d, want 1/1/1", selectedStore.pauseCalls, selectedStore.continueCalls, selectedStore.stopCalls)
+	}
+}
+
+func TestOperatorRuntimeContextManagerRoutesAgentDirectiveByStoredBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	baseAgent := &directiveIntegrationAgent{id: "agent-1"}
+	selectedAgent := &directiveIntegrationAgent{id: "agent-1"}
+	baseManager := runtimeContextTestAgentManager(t, fixture.pg, fixture.busA, baseAgent)
+	selectedManager := runtimeContextTestAgentManager(t, fixture.pg, fixture.busB, selectedAgent)
+	manager := runtimeContextManagerWithRuntimes(t, fixture,
+		&swruntime.Runtime{Bus: fixture.busA, Manager: baseManager},
+		&swruntime.Runtime{Bus: fixture.busB, Manager: selectedManager},
+	)
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:              func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Idempotency:      fixture.pg,
+			RunBundleContext: fixture.pg,
+			AgentControl:     baseManager,
+			RuntimeContexts:  manager,
+		}),
+	})
+	runID := uuid.NewString()
+	seedRuntimeContextRunBundle(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
+
+	resp := rpcCall(t, handler, agentDirectiveBodyWithRun("agent-1", runID, "inspect context", "idem-context-agent-directive"))
+	if resp.Error != nil {
+		t.Fatalf("agent.send_directive error = %#v", resp.Error)
+	}
+	if selectedAgent.calls != 1 {
+		t.Fatalf("selected agent calls = %d, want 1", selectedAgent.calls)
+	}
+	if baseAgent.calls != 0 {
+		t.Fatalf("base agent calls = %d, want 0", baseAgent.calls)
+	}
+}
+
+func TestOperatorRuntimeContextManagerFailsClosedForUnloadedBundle(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	handler := fixture.handler(t)
+	resp := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runtimeContextTestBundleHashC, "triage.requested", `{"topic":"missing"}`, "", "idem-unloaded-context"))
+	if resp.Error == nil {
+		t.Fatal("event.publish unloaded bundle error = nil")
+	}
+	data := asMap(t, resp.Error.Data)
+	details := asMap(t, data["details"])
+	if data["code"] != BundleUnavailableCode || details["cause"] != "runtime_context_not_loaded" {
+		t.Fatalf("event.publish unloaded bundle error data = %#v", data)
+	}
+	if got := countAllRunRows(t, fixture.db); got != 0 {
+		t.Fatalf("run rows after unloaded bundle = %d, want 0", got)
+	}
+}
+
+func TestOperatorRuntimeContextManagerFailsClosedForAmbiguousRuntimeConsumers(t *testing.T) {
+	fixture := newOperatorRuntimeContextFixture(t)
+	ingress := &recordingRuntimeIngress{}
+	runtimeHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:             func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			RuntimeIngress:  ingress,
+			Idempotency:     newMutatingProbeIdempotencyStore(),
+			RuntimeContexts: fixture.manager,
+		}),
+	})
+	for _, method := range []string{"runtime.pause", "runtime.resume"} {
+		runtimeResp := rpcCall(t, runtimeHandler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"runtime-control","method":%q,"params":{"idempotency_key":%q}}`, method, "idem-"+method))
+		if runtimeResp.Error == nil {
+			t.Fatalf("%s error = nil", method)
+		}
+		if data := asMap(t, runtimeResp.Error.Data); data["code"] != BundleScopeRequiredCode {
+			t.Fatalf("%s error data = %#v, want %s", method, data, BundleScopeRequiredCode)
+		}
+	}
+	if ingress.called {
+		t.Fatal("runtime control called singleton ingress in multi-context mode")
+	}
+
+	executor := &recordingRunForkExecutor{}
+	forkHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:                 func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			RunForkAvailability: &recordingRunForkAvailability{rows: map[string]runbundle.Availability{}},
+			RunFork:             executor,
+			Idempotency:         newMutatingProbeIdempotencyStore(),
+			RuntimeContexts:     fixture.manager,
+		}),
+	})
+	forkResp := rpcCall(t, forkHandler, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"idempotency_key":"fork-context"}}`,
+		runForkTestSourceRunID,
+	))
+	if forkResp.Error == nil {
+		t.Fatal("run.fork error = nil")
+	}
+	if data := asMap(t, forkResp.Error.Data); data["code"] != UnsupportedBundleHashForkCode {
+		t.Fatalf("run.fork error data = %#v, want %s", data, UnsupportedBundleHashForkCode)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("run.fork executor calls = %d, want 0", executor.calls)
+	}
+
+	agentControl := &fakeAgentControlController{}
+	agentHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:             func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			AgentControl:    agentControl,
+			Idempotency:     newMutatingProbeIdempotencyStore(),
+			RuntimeContexts: fixture.manager,
+		}),
+	})
+	for _, method := range []string{"agent.restart", "agent.replay_backlog"} {
+		resp := rpcCall(t, agentHandler, agentControlBody(method, "agent-1", "idem-"+method))
+		if resp.Error == nil {
+			t.Fatalf("%s error = nil", method)
+		}
+		if data := asMap(t, resp.Error.Data); data["code"] != BundleScopeRequiredCode {
+			t.Fatalf("%s error data = %#v, want %s", method, data, BundleScopeRequiredCode)
+		}
+	}
+	if agentControl.restartCalls != 0 || agentControl.replayCalls != 0 {
+		t.Fatalf("agent singleton calls restart/replay = %d/%d, want 0/0", agentControl.restartCalls, agentControl.replayCalls)
+	}
+
+	mailbox := &recordingRuntimeContextMailboxStore{}
+	mailboxHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Mailbox:         mailbox,
+			RuntimeContexts: fixture.manager,
+		}),
+	})
+	mailboxResp := rpcCall(t, mailboxHandler, `{"jsonrpc":"2.0","id":"mailbox-approve","method":"mailbox.approve","params":{"mailbox_id":"mailbox-1","decision_payload":{"approved":true},"idempotency_key":"idem-mailbox-context"}}`)
+	if mailboxResp.Error == nil {
+		t.Fatal("mailbox.approve error = nil")
+	}
+	if data := asMap(t, mailboxResp.Error.Data); data["code"] != BundleScopeRequiredCode {
+		t.Fatalf("mailbox.approve error data = %#v, want %s", data, BundleScopeRequiredCode)
+	}
+	if mailbox.decideCalls != 0 {
+		t.Fatalf("mailbox decision calls = %d, want 0", mailbox.decideCalls)
+	}
+}
+
+type operatorRuntimeContextFixture struct {
+	db      *sql.DB
+	pg      *store.PostgresStore
+	sourceA semanticview.Source
+	sourceB semanticview.Source
+	busA    *runtimebus.EventBus
+	busB    *runtimebus.EventBus
+	manager *swruntime.RuntimeContextManager
+}
+
+func newOperatorRuntimeContextFixture(t *testing.T) operatorRuntimeContextFixture {
+	t.Helper()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	ctx := context.Background()
+	seedOperatorBundleDeleteBundle(t, ctx, db, runStartTestBundleHash)
+	seedOperatorBundleDeleteBundle(t, ctx, db, runtimeContextTestBundleHashB)
+	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "scan-orchestrator")
+
+	sourceA := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	sourceB := semanticview.Wrap(runStartTestBundle("triage.requested"))
+	busA := newRuntimeContextTestBus(t, pg, sourceA, runStartTestBundleHash)
+	busB := newRuntimeContextTestBus(t, pg, sourceB, runtimeContextTestBundleHashB)
+	manager, err := swruntime.NewRuntimeContextManager(pg,
+		swruntime.BundleContext{
+			BundleHash:       runStartTestBundleHash,
+			BundleSourceFact: runtimeContextTestSourceFact(runStartTestBundleHash),
+			BundleIdentity:   runtimecontracts.BundleIdentity{WorkflowName: "review", WorkflowVersion: "1.0.0"},
+			Source:           sourceA,
+			Runtime:          &swruntime.Runtime{Bus: busA},
+		},
+		swruntime.BundleContext{
+			BundleHash:       runtimeContextTestBundleHashB,
+			BundleSourceFact: runtimeContextTestSourceFact(runtimeContextTestBundleHashB),
+			BundleIdentity:   runtimecontracts.BundleIdentity{WorkflowName: "review", WorkflowVersion: "1.0.0"},
+			Source:           sourceB,
+			Runtime:          &swruntime.Runtime{Bus: busB},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManager: %v", err)
+	}
+	return operatorRuntimeContextFixture{
+		db:      db,
+		pg:      pg,
+		sourceA: sourceA,
+		sourceB: sourceB,
+		busA:    busA,
+		busB:    busB,
+		manager: manager,
+	}
+}
+
+func (f operatorRuntimeContextFixture) handler(t *testing.T) *Handler {
+	t.Helper()
+	return testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:              func() time.Time { return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC) },
+			Ready:            func() bool { return true },
+			Database:         fakePinger{},
+			Runs:             f.pg,
+			Observability:    f.pg,
+			Idempotency:      f.pg,
+			Events:           f.busA,
+			Source:           f.sourceA,
+			RunBundleContext: f.pg,
+			RuntimeContexts:  f.manager,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName:    "review",
+				WorkflowVersion: "1.0.0",
+				Fingerprint:     runStartTestFingerprint,
+			},
+		}),
+	})
+}
+
+func seedRuntimeContextRunBundle(t *testing.T, db *sql.DB, runID, bundleHash, bundleSource, fingerprint string) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO runs (run_id, status, bundle_hash, bundle_source, bundle_fingerprint)
+		VALUES ($1::uuid, 'running', NULLIF($2, ''), $3, NULLIF($4, ''))
+		ON CONFLICT (run_id) DO UPDATE SET
+			bundle_hash = EXCLUDED.bundle_hash,
+			bundle_source = EXCLUDED.bundle_source,
+			bundle_fingerprint = EXCLUDED.bundle_fingerprint
+	`, runID, strings.TrimSpace(bundleHash), strings.TrimSpace(bundleSource), strings.TrimSpace(fingerprint)); err != nil {
+		t.Fatalf("seed runtime context run bundle: %v", err)
+	}
+}
+
+func runtimeContextManagerWithRuntimes(t *testing.T, fixture operatorRuntimeContextFixture, runtimeA, runtimeB *swruntime.Runtime) *swruntime.RuntimeContextManager {
+	t.Helper()
+	manager, err := swruntime.NewRuntimeContextManager(fixture.pg,
+		swruntime.BundleContext{
+			BundleHash:       runStartTestBundleHash,
+			BundleSourceFact: runtimeContextTestSourceFact(runStartTestBundleHash),
+			BundleIdentity:   runtimecontracts.BundleIdentity{WorkflowName: "review", WorkflowVersion: "1.0.0"},
+			Source:           fixture.sourceA,
+			Runtime:          runtimeA,
+		},
+		swruntime.BundleContext{
+			BundleHash:       runtimeContextTestBundleHashB,
+			BundleSourceFact: runtimeContextTestSourceFact(runtimeContextTestBundleHashB),
+			BundleIdentity:   runtimecontracts.BundleIdentity{WorkflowName: "review", WorkflowVersion: "1.0.0"},
+			Source:           fixture.sourceB,
+			Runtime:          runtimeB,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManager with runtimes: %v", err)
+	}
+	return manager
+}
+
+func runtimeContextTestAgentManager(t *testing.T, pg *store.PostgresStore, bus *runtimebus.EventBus, agent *directiveIntegrationAgent) *runtimemanager.AgentManager {
+	t.Helper()
+	manager := runtimemanager.NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return agent, nil
+	}, pg)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{ID: agent.id, Model: "regular"}); err != nil {
+		t.Fatalf("SpawnAgent(%s): %v", agent.id, err)
+	}
+	return manager
+}
+
+func eventPublishExistingRunBody(runID, bundleHash, idempotencyKey string) string {
+	parts := []string{
+		fmt.Sprintf(`"run_id":%q`, runID),
+		`"event_name":"triage.requested"`,
+		`"payload":{"topic":"blocked"}`,
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(bundleHash) != "" {
+		parts = append(parts, fmt.Sprintf(`"bundle_hash":%q`, bundleHash))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
+}
+
+func assertRuntimeContextBundleError(t *testing.T, resp rpcResponse, method, wantCode, wantCause string) {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("%s error = nil, want %s", method, wantCode)
+	}
+	data := asMap(t, resp.Error.Data)
+	if data["code"] != wantCode {
+		t.Fatalf("%s error data = %#v, want code %s", method, data, wantCode)
+	}
+	if strings.TrimSpace(wantCause) == "" {
+		return
+	}
+	details := asMap(t, data["details"])
+	if details["cause"] != wantCause {
+		t.Fatalf("%s error details = %#v, want cause %s", method, details, wantCause)
+	}
+}
+
+type recordingRuntimeContextRunControlStore struct {
+	stopCalls     int
+	pauseCalls    int
+	continueCalls int
+}
+
+func (s *recordingRuntimeContextRunControlStore) StopRunControl(_ context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	s.stopCalls++
+	return runtimeruncontrol.State{RunID: req.RunID, Status: runtimeruncontrol.StatusCancelled, ControlStatus: runtimeruncontrol.StatusStopped}, nil
+}
+
+func (s *recordingRuntimeContextRunControlStore) PauseRunControl(_ context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	s.pauseCalls++
+	return runtimeruncontrol.State{RunID: req.RunID, Status: runtimeruncontrol.StatusPaused, ControlStatus: runtimeruncontrol.StatusPaused}, nil
+}
+
+func (s *recordingRuntimeContextRunControlStore) ContinueRunControl(_ context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+	s.continueCalls++
+	return runtimeruncontrol.State{RunID: req.RunID, Status: runtimeruncontrol.StatusRunning, ControlStatus: runtimeruncontrol.StatusRunning}, nil
+}
+
+func (*recordingRuntimeContextRunControlStore) RunDispatchBlocked(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (s *recordingRuntimeContextRunControlStore) totalCalls() int {
+	return s.stopCalls + s.pauseCalls + s.continueCalls
+}
+
+type recordingRuntimeContextMailboxStore struct {
+	decideCalls int
+}
+
+func (*recordingRuntimeContextMailboxStore) ListV1MailboxItems(context.Context, store.MailboxV1ListOptions) ([]store.MailboxV1Item, string, error) {
+	return nil, "", nil
+}
+
+func (*recordingRuntimeContextMailboxStore) GetV1MailboxItem(context.Context, string) (store.MailboxV1ItemDetail, error) {
+	return store.MailboxV1ItemDetail{}, store.ErrMailboxV1NotFound
+}
+
+func (s *recordingRuntimeContextMailboxStore) DecideV1MailboxItem(context.Context, store.MailboxV1DecisionRequest) (store.MailboxV1DecisionOutcome, error) {
+	s.decideCalls++
+	return store.MailboxV1DecisionOutcome{Result: store.MailboxV1DecisionResult{OK: true, MailboxDecisionID: uuid.NewString(), Status: "approved"}}, nil
+}
+
+func newRuntimeContextTestBus(t *testing.T, pg *store.PostgresStore, source semanticview.Source, bundleHash string) *runtimebus.EventBus {
+	t.Helper()
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle:   source,
+		BundleSourceFact: runtimeContextTestSourceFact(bundleHash),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	return bus
+}
+
+func runtimeContextTestSourceFact(bundleHash string) runtimecorrelation.BundleSourceFact {
+	return runtimecorrelation.BundleSourceFact{
+		BundleHash:   strings.TrimSpace(bundleHash),
+		BundleSource: storerunlifecycle.BundleSourcePersisted,
+	}
+}
+
+type recordingRuntimeIngress struct {
+	called bool
+}
+
+func (r *recordingRuntimeIngress) Pause(context.Context, runtimeingress.TransitionRequest) (runtimeingress.TransitionResult, error) {
+	r.called = true
+	return runtimeingress.TransitionResult{Status: runtimeingress.StatusPaused}, nil
+}
+
+func (r *recordingRuntimeIngress) Resume(context.Context, runtimeingress.TransitionRequest) (runtimeingress.TransitionResult, error) {
+	r.called = true
+	return runtimeingress.TransitionResult{Status: runtimeingress.StatusRunning}, nil
+}

--- a/internal/apiv1/operator_runtime_control.go
+++ b/internal/apiv1/operator_runtime_control.go
@@ -41,6 +41,9 @@ func OperatorRuntimeControlHandlers(opts OperatorReadOptions) map[string]MethodH
 }
 
 func executeRuntimeIngressControl(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time, pause bool) (any, error) {
+	if multiRuntimeContextMode(opts) {
+		return nil, runtimeContextRequiredError(req.Method, "runtime ingress control is ambiguous in multi-context DB-loaded mode; dynamic per-context runtime control is split to #1176")
+	}
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {
 		return nil, err

--- a/internal/runtime/containeridentity/identity.go
+++ b/internal/runtime/containeridentity/identity.go
@@ -13,6 +13,7 @@ const (
 	LabelCreationSource = "dev.swarm.creation_source"
 	LabelContainerName  = "dev.swarm.container.name"
 	LabelWorkspaceScope = "dev.swarm.workspace.scope"
+	LabelBundleHash     = "dev.swarm.bundle_hash"
 	LabelRunID          = "dev.swarm.run_id"
 	LabelEntityID       = "dev.swarm.entity_id"
 	LabelAgentID        = "dev.swarm.agent_id"
@@ -34,6 +35,7 @@ type Identity struct {
 	CreationSource string
 	ContainerName  string
 	WorkspaceScope string
+	BundleHash     string
 	RunID          string
 	EntityID       string
 	AgentID        string
@@ -46,6 +48,7 @@ func (i Identity) Normalized() Identity {
 	i.CreationSource = strings.TrimSpace(i.CreationSource)
 	i.ContainerName = strings.TrimSpace(i.ContainerName)
 	i.WorkspaceScope = strings.TrimSpace(i.WorkspaceScope)
+	i.BundleHash = strings.TrimSpace(i.BundleHash)
 	i.RunID = strings.TrimSpace(i.RunID)
 	i.EntityID = strings.TrimSpace(i.EntityID)
 	i.AgentID = strings.TrimSpace(i.AgentID)
@@ -63,6 +66,7 @@ func (i Identity) Labels() map[string]string {
 		LabelContainerName:  i.ContainerName,
 		LabelWorkspaceScope: i.WorkspaceScope,
 	}
+	addOptionalLabel(labels, LabelBundleHash, i.BundleHash)
 	addOptionalLabel(labels, LabelRunID, i.RunID)
 	addOptionalLabel(labels, LabelEntityID, i.EntityID)
 	addOptionalLabel(labels, LabelAgentID, i.AgentID)
@@ -139,6 +143,7 @@ func FromLabels(labels map[string]string) (Identity, bool, error) {
 		CreationSource: labels[LabelCreationSource],
 		ContainerName:  labels[LabelContainerName],
 		WorkspaceScope: labels[LabelWorkspaceScope],
+		BundleHash:     labels[LabelBundleHash],
 		RunID:          labels[LabelRunID],
 		EntityID:       labels[LabelEntityID],
 		AgentID:        labels[LabelAgentID],

--- a/internal/runtime/context_manager.go
+++ b/internal/runtime/context_manager.go
@@ -1,0 +1,175 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store/runbundle"
+)
+
+// RunBundleAvailabilityReader resolves persisted run identity before a request
+// is dispatched to a bundle-bound runtime graph.
+type RunBundleAvailabilityReader interface {
+	LoadRunBundleAvailability(context.Context, string) (runbundle.Availability, error)
+}
+
+type BundleContext struct {
+	BundleHash        string
+	BundleSourceFact  runtimecorrelation.BundleSourceFact
+	BundleIdentity    runtimecontracts.BundleIdentity
+	Source            semanticview.Source
+	ContractsRoot     string
+	PlatformSpecPath  string
+	Runtime           *Runtime
+	WorkspaceScopeKey string
+}
+
+func (c BundleContext) normalized() BundleContext {
+	c.BundleHash = strings.TrimSpace(c.BundleHash)
+	c.BundleSourceFact = c.BundleSourceFact.Normalized()
+	if c.BundleHash == "" {
+		c.BundleHash = strings.TrimSpace(c.BundleSourceFact.BundleHash)
+	}
+	c.ContractsRoot = strings.TrimSpace(c.ContractsRoot)
+	c.PlatformSpecPath = strings.TrimSpace(c.PlatformSpecPath)
+	c.WorkspaceScopeKey = strings.TrimSpace(c.WorkspaceScopeKey)
+	return c
+}
+
+type RuntimeContextManager struct {
+	mu           sync.RWMutex
+	availability RunBundleAvailabilityReader
+	contexts     map[string]*BundleContext
+	order        []string
+}
+
+func NewRuntimeContextManager(availability RunBundleAvailabilityReader, contexts ...BundleContext) (*RuntimeContextManager, error) {
+	manager := &RuntimeContextManager{
+		availability: availability,
+		contexts:     map[string]*BundleContext{},
+	}
+	for _, contextDef := range contexts {
+		if err := manager.Register(contextDef); err != nil {
+			return nil, err
+		}
+	}
+	return manager, nil
+}
+
+func (m *RuntimeContextManager) Register(contextDef BundleContext) error {
+	if m == nil {
+		return fmt.Errorf("runtime context manager is required")
+	}
+	contextDef = contextDef.normalized()
+	if err := runtimecontracts.ValidateBundleHash(contextDef.BundleHash); err != nil {
+		return fmt.Errorf("runtime context bundle_hash: %w", err)
+	}
+	if contextDef.BundleSourceFact.BundleHash != "" && contextDef.BundleSourceFact.BundleHash != contextDef.BundleHash {
+		return fmt.Errorf("runtime context source fact hash %q does not match bundle_hash %q", contextDef.BundleSourceFact.BundleHash, contextDef.BundleHash)
+	}
+	if contextDef.Source == nil {
+		return fmt.Errorf("runtime context %s source is required", contextDef.BundleHash)
+	}
+	if contextDef.Runtime == nil {
+		return fmt.Errorf("runtime context %s runtime is required", contextDef.BundleHash)
+	}
+	if contextDef.Runtime.Bus == nil {
+		return fmt.Errorf("runtime context %s event bus is required", contextDef.BundleHash)
+	}
+	if contextDef.BundleSourceFact.BundleHash == "" {
+		contextDef.BundleSourceFact.BundleHash = contextDef.BundleHash
+	}
+	contextDef.BundleSourceFact = contextDef.BundleSourceFact.Normalized()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.contexts == nil {
+		m.contexts = map[string]*BundleContext{}
+	}
+	if _, exists := m.contexts[contextDef.BundleHash]; exists {
+		return fmt.Errorf("duplicate runtime context bundle_hash %s", contextDef.BundleHash)
+	}
+	copied := contextDef
+	m.contexts[contextDef.BundleHash] = &copied
+	m.order = append(m.order, contextDef.BundleHash)
+	sort.Strings(m.order)
+	return nil
+}
+
+func (m *RuntimeContextManager) Len() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.contexts)
+}
+
+func (m *RuntimeContextManager) MultiContext() bool {
+	return m.Len() > 1
+}
+
+func (m *RuntimeContextManager) BundleHashes() []string {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := append([]string(nil), m.order...)
+	sort.Strings(out)
+	return out
+}
+
+func (m *RuntimeContextManager) Primary() (*BundleContext, bool) {
+	if m == nil {
+		return nil, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.order) == 0 {
+		return nil, false
+	}
+	ctx := m.contexts[m.order[0]]
+	if ctx == nil {
+		return nil, false
+	}
+	return ctx, true
+}
+
+func (m *RuntimeContextManager) LookupBundleHash(bundleHash string) (*BundleContext, bool) {
+	if m == nil {
+		return nil, false
+	}
+	bundleHash = strings.TrimSpace(bundleHash)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ctx := m.contexts[bundleHash]
+	if ctx == nil {
+		return nil, false
+	}
+	return ctx, true
+}
+
+func (m *RuntimeContextManager) LookupRun(ctx context.Context, runID string) (*BundleContext, runbundle.Availability, bool, error) {
+	if m == nil {
+		return nil, runbundle.Availability{}, false, nil
+	}
+	if m.availability == nil {
+		return nil, runbundle.Availability{}, false, fmt.Errorf("run bundle availability reader is required")
+	}
+	availability, err := m.availability.LoadRunBundleAvailability(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		return nil, runbundle.Availability{}, false, err
+	}
+	if strings.TrimSpace(availability.BundleHash) == "" {
+		return nil, availability, false, nil
+	}
+	contextDef, ok := m.LookupBundleHash(availability.BundleHash)
+	return contextDef, availability, ok, nil
+}

--- a/internal/runtime/context_manager_test.go
+++ b/internal/runtime/context_manager_test.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	"swarm/internal/runtime/semanticview"
+	"swarm/internal/store/runbundle"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+const (
+	runtimeContextTestHashA = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	runtimeContextTestHashB = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestRuntimeContextManagerRegistersAndLooksUpPinnedContexts(t *testing.T) {
+	availability := fakeRunBundleAvailability{
+		rows: map[string]runbundle.Availability{
+			"run-b": {
+				RunID:            "run-b",
+				BundleHash:       runtimeContextTestHashB,
+				BundleSource:     storerunlifecycle.BundleSourcePersisted,
+				BundleRowPresent: true,
+			},
+		},
+	}
+	manager, err := NewRuntimeContextManager(availability,
+		testBundleContext(t, runtimeContextTestHashB, "beta.requested"),
+		testBundleContext(t, runtimeContextTestHashA, "alpha.requested"),
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManager: %v", err)
+	}
+	if manager.Len() != 2 || !manager.MultiContext() {
+		t.Fatalf("manager Len/MultiContext = %d/%v, want 2/true", manager.Len(), manager.MultiContext())
+	}
+	if got, want := manager.BundleHashes(), []string{runtimeContextTestHashA, runtimeContextTestHashB}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("BundleHashes = %#v, want %#v", got, want)
+	}
+	primary, ok := manager.Primary()
+	if !ok || primary.BundleHash != runtimeContextTestHashA {
+		t.Fatalf("Primary = %#v/%v, want %s", primary, ok, runtimeContextTestHashA)
+	}
+	contextDef, availabilityResult, loaded, err := manager.LookupRun(context.Background(), "run-b")
+	if err != nil {
+		t.Fatalf("LookupRun: %v", err)
+	}
+	if !loaded || contextDef == nil || contextDef.BundleHash != runtimeContextTestHashB {
+		t.Fatalf("LookupRun context = %#v loaded=%v, want %s", contextDef, loaded, runtimeContextTestHashB)
+	}
+	if availabilityResult.BundleHash != runtimeContextTestHashB || !availabilityResult.Available() {
+		t.Fatalf("LookupRun availability = %#v, want available %s", availabilityResult, runtimeContextTestHashB)
+	}
+}
+
+func TestRuntimeContextManagerRejectsDuplicateBundleHashes(t *testing.T) {
+	if _, err := NewRuntimeContextManager(nil,
+		testBundleContext(t, runtimeContextTestHashA, "alpha.requested"),
+		testBundleContext(t, runtimeContextTestHashA, "alpha.requested"),
+	); err == nil {
+		t.Fatal("NewRuntimeContextManager duplicate error = nil")
+	}
+}
+
+func testBundleContext(t *testing.T, bundleHash, eventName string) BundleContext {
+	t.Helper()
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{Name: "review", Version: "1.0.0"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			eventName: {},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	bus, err := runtimebus.NewEventBusWithOptions(nil, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		BundleSourceFact: runtimecorrelation.BundleSourceFact{
+			BundleHash:   bundleHash,
+			BundleSource: storerunlifecycle.BundleSourcePersisted,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	return BundleContext{
+		BundleHash: bundleHash,
+		BundleSourceFact: runtimecorrelation.BundleSourceFact{
+			BundleHash:   bundleHash,
+			BundleSource: storerunlifecycle.BundleSourcePersisted,
+		},
+		BundleIdentity: runtimecontracts.BundleIdentity{WorkflowName: "review", WorkflowVersion: "1.0.0"},
+		Source:         source,
+		Runtime:        &Runtime{Bus: bus},
+	}
+}
+
+type fakeRunBundleAvailability struct {
+	rows map[string]runbundle.Availability
+}
+
+func (f fakeRunBundleAvailability) LoadRunBundleAvailability(_ context.Context, runID string) (runbundle.Availability, error) {
+	row, ok := f.rows[runID]
+	if !ok {
+		return runbundle.Availability{}, runbundle.ErrRunNotFound
+	}
+	if row.ErrorCode == "" && row.BundleSource == storerunlifecycle.BundleSourcePersisted && !row.BundleRowPresent {
+		return row, errors.New("invalid fake persisted row without bundle")
+	}
+	return row, nil
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -63,18 +63,19 @@ type eventReceiptSchemaCapabilityProvider interface {
 }
 
 type RuntimeOptions struct {
-	SelfCheck          bool
-	WorkspaceLifecycle workspace.Lifecycle
-	EnableToolGateway  bool
-	ToolGatewayToken   string
-	BundleFingerprint  string
-	BundleSourceFact   runtimecorrelation.BundleSourceFact
-	WorkflowModule     runtimepipeline.WorkflowModule
-	LLMRuntime         llm.Runtime
-	Credentials        runtimecredentials.Store
-	BootStartedAt      time.Time
-	BootProgress       func(BootProgressEvent)
-	SystemContainers   []string
+	SelfCheck                        bool
+	WorkspaceLifecycle               workspace.Lifecycle
+	EnableToolGateway                bool
+	ToolGatewayToken                 string
+	BundleFingerprint                string
+	BundleSourceFact                 runtimecorrelation.BundleSourceFact
+	WorkflowModule                   runtimepipeline.WorkflowModule
+	LLMRuntime                       llm.Runtime
+	Credentials                      runtimecredentials.Store
+	BootStartedAt                    time.Time
+	BootProgress                     func(BootProgressEvent)
+	SystemContainers                 []string
+	DisablePersistentStartupRecovery bool
 }
 
 // RuntimeDeps is the canonical dependency graph for NewRuntime boot wiring.
@@ -701,13 +702,23 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		rt.cleanupStartFailure()
 	}()
 
-	startupRecoverySnapshot, err := rt.inspectStartupRecoverySnapshot(ctx)
-	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
-	if err != nil {
-		rt.emitBootProgress(6, "recovery_snapshot_inspection", "FAILED", err.Error())
-	} else {
-		rt.emitBootProgress(6, "recovery_snapshot_inspection", "ok", startupRecoverySnapshot.summary())
+	skipPersistentStartupRecovery := rt.Options.DisablePersistentStartupRecovery
+	startupRecoverySnapshot := startupRecoverySnapshot{
+		RecoveryOnStartup:  rt != nil && rt.Config != nil && rt.Config.Runtime.RecoveryOnStartup && !skipPersistentStartupRecovery,
+		InspectionComplete: true,
 	}
+	var err error
+	if skipPersistentStartupRecovery {
+		rt.emitBootProgress(6, "recovery_snapshot_inspection", "skipped", "persistent startup recovery disabled")
+	} else {
+		startupRecoverySnapshot, err = rt.inspectStartupRecoverySnapshot(ctx)
+		if err != nil {
+			rt.emitBootProgress(6, "recovery_snapshot_inspection", "FAILED", err.Error())
+		} else {
+			rt.emitBootProgress(6, "recovery_snapshot_inspection", "ok", startupRecoverySnapshot.summary())
+		}
+	}
+	startupRecoveryDecision := newStartupRecoveryDecisionReport(startupRecoverySnapshot)
 	if err != nil && !startupRecoverySnapshot.RecoveryOnStartup {
 		return err
 	}
@@ -723,7 +734,11 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		rt.emitBootProgress(7, "recovery_decision", "FAILED", denyErr.Error())
 		return denyErr
 	}
-	rt.emitBootProgress(7, "recovery_decision", string(startupRecoveryDecision.Outcome), string(startupRecoveryDecision.ReasonCode))
+	if skipPersistentStartupRecovery {
+		rt.emitBootProgress(7, "recovery_decision", "skipped", "persistent startup recovery disabled")
+	} else {
+		rt.emitBootProgress(7, "recovery_decision", string(startupRecoveryDecision.Outcome), string(startupRecoveryDecision.ReasonCode))
+	}
 
 	if rt.Pipeline != nil {
 		if _, err := rt.Pipeline.RepairContractEntityTypes(ctx); err != nil {
@@ -743,7 +758,9 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		}
 	}
 	rt.emitBootProgress(9, "system_nodes_start", "ok", fmt.Sprintf("%d nodes started", systemNodeCount))
-	if rt.Scheduler != nil && rt.Stores.ScheduleStore != nil {
+	if skipPersistentStartupRecovery {
+		rt.emitBootProgress(10, "schedule_restoration", "skipped", "persistent startup recovery disabled")
+	} else if rt.Scheduler != nil && rt.Stores.ScheduleStore != nil {
 		schedules, err := rt.Stores.ScheduleStore.LoadActiveSchedules(ctx)
 		if err != nil {
 			rt.emitBootProgress(10, "schedule_restoration", "FAILED", err.Error())
@@ -778,7 +795,9 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	} else {
 		rt.emitBootProgress(10, "schedule_restoration", "skipped", "scheduler or schedule store unavailable")
 	}
-	if rt.Config.Runtime.RecoveryOnStartup && rt.Manager != nil {
+	if skipPersistentStartupRecovery {
+		rt.emitBootProgress(11, "manager_recovery_if_enabled", "skipped", "persistent startup recovery disabled")
+	} else if rt.Config.Runtime.RecoveryOnStartup && rt.Manager != nil {
 		startupRecoveryDecision.ManagerRecoveryAttempted = true
 		managerReplaySummary, err := rt.Manager.RecoverWithStartupReplayDiagnostics(ctx)
 		startupRecoveryDecision.ManagerReplayCount = managerReplaySummary.ReplayedCount

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -82,6 +83,26 @@ func (*minimalRuntimeEventStore) InsertEventDeliveries(context.Context, string, 
 }
 func (*minimalRuntimeEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return nil, nil
+}
+
+type recoveryDisabledScheduleStore struct {
+	recordingRuntimeScheduleStore
+	loadCalls atomic.Int32
+}
+
+func (s *recoveryDisabledScheduleStore) LoadActiveSchedules(ctx context.Context) ([]runtimepipeline.Schedule, error) {
+	s.loadCalls.Add(1)
+	return s.recordingRuntimeScheduleStore.LoadActiveSchedules(ctx)
+}
+
+type recoveryDisabledManagerStore struct {
+	recoveryGuardManagerStore
+	loadCalls atomic.Int32
+}
+
+func (s *recoveryDisabledManagerStore) LoadAgents(ctx context.Context) ([]runtimemanager.PersistedAgent, error) {
+	s.loadCalls.Add(1)
+	return s.recoveryGuardManagerStore.LoadAgents(ctx)
 }
 
 func testOperationalRuntimeConfig() *config.Config {
@@ -218,6 +239,56 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithNonReplayEventStore(t *testing.T
 	}
 	if err := rt.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestRuntimeStart_DisablePersistentStartupRecoverySkipsUnscopedStoreReads(t *testing.T) {
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	cfg := testOperationalRuntimeConfig()
+	cfg.Runtime.RecoveryOnStartup = true
+	scheduleStore := &recoveryDisabledScheduleStore{
+		recordingRuntimeScheduleStore: recordingRuntimeScheduleStore{
+			active: []runtimepipeline.Schedule{{
+				AgentID:   "runtime",
+				EventType: "timer.check",
+				Mode:      "once",
+				At:        time.Now().Add(time.Minute),
+				TaskID:    "other-bundle",
+			}},
+		},
+	}
+	managerStore := &recoveryDisabledManagerStore{
+		recoveryGuardManagerStore: recoveryGuardManagerStore{
+			agents: []runtimemanager.PersistedAgent{{
+				Config: runtimeactors.AgentConfig{ID: "persisted-agent"},
+			}},
+		},
+	}
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{
+		EventStore:    &recoveryGuardEventStore{},
+		ManagerStore:  managerStore,
+		ScheduleStore: scheduleStore,
+	}, Options: RuntimeOptions{
+		SelfCheck:                        false,
+		WorkflowModule:                   module,
+		LLMRuntime:                       noopLLMRuntime{},
+		DisablePersistentStartupRecovery: true,
+	}})
+
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got := scheduleStore.loadCalls.Load(); got != 0 {
+		t.Fatalf("LoadActiveSchedules calls = %d, want 0", got)
+	}
+	if got := managerStore.loadCalls.Load(); got != 0 {
+		t.Fatalf("LoadAgents calls = %d, want 0", got)
 	}
 	if err := rt.Shutdown(); err != nil {
 		t.Fatalf("Shutdown: %v", err)

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -77,6 +77,8 @@ type DockerConfig struct {
 	SystemSystemdVolume   string
 	EntityContainerPrefix string
 	EntityWorkdir         string
+	BundleHash            string
+	BundleScope           string
 }
 
 func DefaultDockerConfig() DockerConfig {
@@ -196,6 +198,24 @@ func (m *DockerManager) SystemWorkspaceContainers() []string {
 	return out
 }
 
+func (m *DockerManager) SetBundleScope(bundleHash string) {
+	if m == nil {
+		return
+	}
+	cfg := m.cfg
+	cfg.BundleHash = strings.TrimSpace(bundleHash)
+	cfg.BundleScope = bundleScopeKey(bundleHash)
+	if cfg.BundleScope != "" {
+		cfg.ScaffoldContainer = scopedRuntimeName(cfg.BundleScope, cfg.ScaffoldContainer, "scaffold")
+		cfg.SystemContainer = scopedRuntimeName(cfg.BundleScope, cfg.SystemContainer, "system")
+		cfg.ScaffoldVolume = scopedRuntimeName(cfg.BundleScope, cfg.ScaffoldVolume, "scaffold")
+		cfg.SystemEntitiesVolume = scopedRuntimeName(cfg.BundleScope, cfg.SystemEntitiesVolume, "entities")
+		cfg.SystemNginxVolume = scopedRuntimeName(cfg.BundleScope, cfg.SystemNginxVolume, "nginx")
+		cfg.SystemSystemdVolume = scopedRuntimeName(cfg.BundleScope, cfg.SystemSystemdVolume, "systemd")
+	}
+	m.cfg = cfg
+}
+
 func (m *DockerManager) ValidateSource(ctx context.Context, source semanticview.Source) error {
 	if m == nil {
 		return fmt.Errorf("workspace manager is required")
@@ -257,6 +277,9 @@ func (m *DockerManager) EnsureEntityWorkspace(ctx context.Context, entityID stri
 	}
 	container := m.EntityContainerName(slug)
 	volume := fmt.Sprintf("entities_%s", slug)
+	if strings.TrimSpace(m.cfg.BundleScope) != "" {
+		volume = "entities_" + volumeScopeKey(m.bundleScopedPrefix()+"entity_"+slug)
+	}
 	runID, err := workspaceRunID(ctx)
 	if err != nil {
 		return err
@@ -269,6 +292,7 @@ func (m *DockerManager) EnsureEntityWorkspace(ctx context.Context, entityID stri
 		CreationSource: "workspace.EnsureEntityWorkspace",
 		ContainerName:  container,
 		WorkspaceScope: "entity",
+		BundleHash:     m.bundleHashLabel(),
 		RunID:          runID,
 		EntityID:       strings.TrimSpace(entityID),
 	}, append(m.standardMountArgs(),
@@ -571,11 +595,20 @@ func (m *DockerManager) workspaceScopeForActor(actor models.AgentConfig) (string
 func (m *DockerManager) workspaceContainerAndVolume(scope, scopeKey string) (string, string) {
 	scope = strings.TrimSpace(scope)
 	scopeKey = SanitizeSlug(scopeKey)
+	if strings.TrimSpace(m.cfg.BundleScope) == "" {
+		switch scope {
+		case "per-flow-instance":
+			return "swarm-flow-" + scopeKey, "workspaces_flow_" + scopeKey
+		default:
+			return "swarm-agent-" + scopeKey, "workspaces_agent_" + scopeKey
+		}
+	}
+	containerPrefix := m.bundleScopedPrefix()
 	switch scope {
 	case "per-flow-instance":
-		return "swarm-flow-" + scopeKey, "workspaces_flow_" + scopeKey
+		return containerPrefix + "flow-" + scopeKey, "workspaces_" + volumeScopeKey(containerPrefix+"flow_"+scopeKey)
 	default:
-		return "swarm-agent-" + scopeKey, "workspaces_agent_" + scopeKey
+		return containerPrefix + "agent-" + scopeKey, "workspaces_" + volumeScopeKey(containerPrefix+"agent_"+scopeKey)
 	}
 }
 
@@ -593,6 +626,7 @@ func (m *DockerManager) systemContainerIdentity(source, kind string) runtimecont
 		CreationSource: strings.TrimSpace(source),
 		ContainerName:  name,
 		WorkspaceScope: scope,
+		BundleHash:     m.bundleHashLabel(),
 	}
 }
 
@@ -607,6 +641,7 @@ func (m *DockerManager) workspaceContainerIdentity(ctx context.Context, containe
 		CreationSource: "workspace.ResolveWorkspace",
 		ContainerName:  strings.TrimSpace(container),
 		WorkspaceScope: strings.TrimSpace(scope),
+		BundleHash:     m.bundleHashLabel(),
 		RunID:          runID,
 	}
 	switch strings.TrimSpace(scope) {
@@ -1106,7 +1141,61 @@ func (m *DockerManager) LookupEntitySlug(ctx context.Context, entityID string) (
 }
 
 func (m *DockerManager) EntityContainerName(slug string) string {
-	return m.cfg.EntityContainerPrefix + SanitizeSlug(slug)
+	slug = SanitizeSlug(slug)
+	if strings.TrimSpace(m.cfg.BundleScope) == "" {
+		return m.cfg.EntityContainerPrefix + slug
+	}
+	return m.bundleScopedPrefix() + strings.TrimPrefix(m.cfg.EntityContainerPrefix, "swarm-") + slug
+}
+
+func (m *DockerManager) bundleScopedPrefix() string {
+	if m == nil {
+		return "swarm-"
+	}
+	scope := strings.TrimSpace(m.cfg.BundleScope)
+	if scope == "" {
+		return "swarm-"
+	}
+	return "swarm-" + SanitizeSlug(scope) + "-"
+}
+
+func (m *DockerManager) bundleHashLabel() string {
+	if m == nil {
+		return ""
+	}
+	return strings.TrimSpace(m.cfg.BundleHash)
+}
+
+func bundleScopeKey(bundleHash string) string {
+	bundleHash = strings.TrimSpace(bundleHash)
+	if bundleHash == "" {
+		return ""
+	}
+	const prefix = "bundle-v1:sha256:"
+	hash := strings.TrimPrefix(bundleHash, prefix)
+	if len(hash) > 12 {
+		hash = hash[:12]
+	}
+	return "bundle-" + hash
+}
+
+func volumeScopeKey(raw string) string {
+	raw = strings.Trim(SanitizeSlug(raw), "-")
+	raw = strings.ReplaceAll(raw, "-", "_")
+	return raw
+}
+
+func scopedRuntimeName(scope, current, fallback string) string {
+	scope = SanitizeSlug(scope)
+	current = strings.TrimSpace(current)
+	if current == "" {
+		current = fallback
+	}
+	current = strings.TrimPrefix(SanitizeSlug(current), "swarm-")
+	if current == "" {
+		current = fallback
+	}
+	return "swarm-" + scope + "-" + current
 }
 
 func SanitizeSlug(raw string) string {

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -135,6 +135,84 @@ func TestResolveWorkspace_PerAgentMountsStandardPaths(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspace_BundleScopeDisambiguatesContainersVolumesAndLabels(t *testing.T) {
+	const bundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.SharedDataSource = dataDir
+	cfg.ContractsSource = contractsDir
+	cfg.WorkspaceNetwork = ""
+	cfg.WorkspaceImage = "test-image"
+	manager.SetConfig(cfg)
+	manager.SetBundleScope(bundleHash)
+	manager.SetSemanticSource(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"workspace_classes": {
+				Value: map[string]any{
+					"dedicated": map[string]any{"workspace_scope": "per-agent"},
+				},
+			},
+		}},
+	}))
+
+	var creates [][]string
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		switch args[0] {
+		case "inspect":
+			return "", fmt.Errorf("no such object")
+		case "create":
+			creates = append(creates, append([]string{}, args...))
+			return "", nil
+		case "start":
+			return "", nil
+		default:
+			return "", nil
+		}
+	})
+	ctx := runtimecorrelation.WithRunID(context.Background(), "11111111-1111-1111-1111-111111111111")
+	target, err := manager.ResolveWorkspace(ctx, models.AgentConfig{
+		ID:             "dedicated-agent",
+		WorkspaceClass: "dedicated",
+	})
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	if target == nil || target.Container != "swarm-bundle-aaaaaaaaaaaa-agent-dedicated-agent" {
+		t.Fatalf("target = %#v, want bundle-scoped agent container", target)
+	}
+	joined := flattenDockerCalls(creates)
+	for _, expected := range []string{
+		"workspaces_swarm_bundle_aaaaaaaaaaaa_agent_dedicated_agent:/workspace",
+		"--label dev.swarm.bundle_hash=" + bundleHash,
+		"--label dev.swarm.container.name=swarm-bundle-aaaaaaaaaaaa-agent-dedicated-agent",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("bundle-scoped agent workspace create args missing %q:\n%s", expected, joined)
+		}
+	}
+
+	creates = nil
+	if err := manager.EnsureEntityWorkspace(ctx, "acme"); err != nil {
+		t.Fatalf("EnsureEntityWorkspace: %v", err)
+	}
+	joined = flattenDockerCalls(creates)
+	for _, expected := range []string{
+		"create --name swarm-bundle-aaaaaaaaaaaa-acme",
+		"entities_swarm_bundle_aaaaaaaaaaaa_entity_acme:/workspace",
+		"--label dev.swarm.bundle_hash=" + bundleHash,
+		"--label dev.swarm.container.name=swarm-bundle-aaaaaaaaaaaa-acme",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("bundle-scoped entity workspace create args missing %q:\n%s", expected, joined)
+		}
+	}
+}
+
 func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 	dataDir := t.TempDir()
 	contractsDir := t.TempDir()

--- a/openrpc.json
+++ b/openrpc.json
@@ -3110,7 +3110,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when run_id is omitted. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE. cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
+          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when run_id is omitted. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. In DB-loaded RuntimeContextManager mode, the resolved hash must select a loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE. cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -5999,12 +5999,12 @@
     {
       "name": "run.start",
       "deprecated": true,
-      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a run by injecting an event into the runtime bus. Create-new-work admission follows event.publish bundle_hash semantics: if no existing run row provides bundle context, bundle_hash is required. If run_id is supplied but no run row exists, the call is still create-new-work and run_id alone is not bundle scope. If caller bundle_hash and existing run context disagree, the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved bundle_hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE. Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with bundle_hash.\n",
+      "description": "Deprecated wrapper over event.publish retained for older Builder/API callers. New clients should call event.publish directly.\nStart a run by injecting an event into the runtime bus. Create-new-work admission follows event.publish bundle_hash semantics: if no existing run row provides bundle context, bundle_hash is required. If run_id is supplied but no run row exists, the call is still create-new-work and run_id alone is not bundle scope. If caller bundle_hash and existing run context disagree, the method fails closed with BUNDLE_MISMATCH. In DB-loaded RuntimeContextManager mode, the resolved bundle_hash must select a loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE. Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with bundle_hash.\n",
       "params": [
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when no existing run row supplies bundle context. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must match the single active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE; cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
+          "description": "Canonical #1001 bundle identity scope. Must be bundle-v1:sha256:\u003c64 lowercase hex\u003e. Required when no existing run row supplies bundle context. When run_id identifies an existing run, optional bundle_hash must match that run's canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH. In DB-loaded RuntimeContextManager mode, the resolved hash must select a loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE; cannot be combined with legacy bundle_ref; malformed or combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5583,11 +5583,12 @@ multi_bundle_persistence:
     bundle_hash_naming: '#1001'
     run_fork_cli_authority_absorbed_from: '#1038'
     serve_db_loaded_runtime_source: '#1020'
+    boot_pinned_runtime_context_manager: '#1175'
   authority_rule: >
     This section is the merge-bearing source authority for multi-bundle persistence, bundle identity, bundle-aware
     resume/delete/fork semantics, planned bundle API methods, and planned CLI command shape. The draft is now evidence
-    only. Database foundation, read-only bundle catalog APIs, supported local serve ingest/source stamping, and serial
-    Postgres-backed `swarm serve --bundle-hash` DB-loaded boot now have
+    only. Database foundation, read-only bundle catalog APIs, supported local serve ingest/source stamping, and boot-pinned
+    Postgres-backed `swarm serve --bundle-hash` DB-loaded boot and RuntimeContextManager dispatch now have
     promoted implementation owners in this section. Remaining runtime, API handler, CLI, delete/fork/recovery, and
     generated OpenRPC publication work stays separately gated unless a later PR explicitly promotes and proves it.
   generated_artifact_policy:
@@ -5738,9 +5739,9 @@ multi_bundle_persistence:
       platform_tables.tables is the current runtime DDL source. #1013 promotes the bundles table and
       runs.bundle_hash/runs.bundle_source into the live schema foundation. Serve ingest/source stamping for local
       `swarm serve --contracts` is promoted by multi_bundle_persistence.persistence_model.serve_ingest_projection;
-      serial Postgres-backed `swarm serve --bundle-hash` boot is promoted by
-      multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source. Reader migration, API routing,
-      CLI/fork behavior beyond this serve flag, delete/runtime cleanup, multi-bundle concurrency, and public
+      boot-pinned Postgres-backed `swarm serve --bundle-hash` runtime boot and dispatch are promoted by
+      multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source. Reader migration,
+      CLI/fork behavior beyond this serve flag, dynamic runtime Load/Unload, delete/runtime cleanup, and public
       dual-accept naming remain separately gated implementation work unless a later PR explicitly promotes and proves them.
     bundles_table:
       planned_live_owner_after_migration: platform_tables.tables.bundles
@@ -5799,26 +5800,34 @@ multi_bundle_persistence:
         - Bundle register/delete APIs remain #1017/#1018/#1019.
         - SQLite runtime support remains blocked by #1087/#1088 unless separately gated.
     serve_db_loaded_runtime_source:
-      status: implemented_for_serial_postgres_serve_bundle_hash
-      cli_flag: 'swarm serve --bundle-hash <bundle-v1:sha256:<64 lowercase hex>>'
+      status: implemented_for_boot_pinned_postgres_serve_bundle_hash_contexts
+      cli_flag: 'swarm serve --bundle-hash <bundle-v1:sha256:<64 lowercase hex>> [--bundle-hash <bundle-v1:sha256:<64 lowercase hex>> ...]'
       canonical_store_owner: internal/store.PostgresStore.LoadBundleCatalogRuntimeRecord
       runtime_source_owner: internal/runtime/contracts.LoadBundleCatalogRuntimeSource
       serve_boot_owner: cmd/swarm.loadServeRuntimeBundleFromCatalog
       source_fact_owner: cmd/swarm.prepareLoadedServeBundleSource
+      runtime_context_manager_owner: internal/runtime.RuntimeContextManager
+      bundle_context_owner: internal/runtime.BundleContext
       source_replacement_guard: cmd/swarm.runtimeProjectSupervisor.DisableSourceReplacement
       supported_surface:
-        - Exactly one canonical bundle_hash is pinned for the process. The flag is mutually exclusive with --contracts and --dev.
-        - The mode is Postgres-only. SQLite, no-store, missing store, missing bundle row, malformed archive, missing bytes, hash mismatch, and noncanonical hash fail closed before runtime readiness.
+        - One or more canonical bundle_hash values may be pinned at process boot by repeating --bundle-hash. Values must be canonical, non-empty, duplicate-free, and mutually exclusive with --contracts and --dev.
+        - The mode is Postgres-only and all-or-nothing before API readiness. SQLite, no-store, missing store, missing bundle row, malformed archive, missing bytes, hash mismatch, duplicate hash, and noncanonical hash fail closed before any runtime context is served.
         - The runtime loader consumes stored bundles.content_yaml and raw bundles.data_blob bytes only; parsed_json is inspection output and is never a runtime source.
         - The loader reconstructs platform spec, contract definition files, prompts, and flow data/ raw bytes into a process-owned temporary source, then recomputes BundleHash and requires it to equal the requested bundle_hash before runtime construction.
-        - Every run writer reachable under the booted runtime consumes BundleSourceFact with bundle_source=persisted and bundle_hash equal to the requested canonical hash.
+        - Each pinned bundle is registered as a BundleContext under RuntimeContextManager. The BundleContext owns its source, BundleSourceFact, EventBus, route table, pipeline/coordinator, agent manager, subscriptions, and source-bound runtime components.
+        - event.publish and run.start select a loaded BundleContext by explicit canonical bundle_hash for create-new work or by runs.bundle_hash/runs.bundle_source for existing-run work. Missing, deleted, legacy, or unloaded contexts fail closed rather than falling back to ambient boot state.
+        - Existing-run controls that can be resolved by run_id dispatch through the selected BundleContext. Ambiguous singleton controls such as runtime.pause/resume, mailbox approval event publication, and broad agent restart/backlog replay fail closed in multi-context mode pending dynamic lifecycle work.
+        - When more than one bundle is pinned in the same process, unscoped startup ownership, active schedule restoration, and manager pending-event recovery are disabled for every context until bundle-scoped recovery filters are promoted. Single-bundle DB-loaded serve may keep the existing startup recovery owner.
+        - Every run writer reachable under the selected runtime context consumes BundleSourceFact with bundle_source=persisted and bundle_hash equal to that context's canonical hash.
         - Runtime project OpenProject/ReloadProject source replacement is disabled while the process is pinned to a DB-loaded bundle source.
+        - Workspace/container names, volumes, and managed identity labels for executable context paths include bundle-disambiguated identity when more than one context can be loaded.
         - External executable code, tools, container images, credentials, and host environment dependencies remain environment-owned and are not stored in the bundles row.
       split_boundaries:
-        - Parallel multi-bundle runtime contexts and dispatcher/store isolation remain #981.
+        - Dynamic post-boot RuntimeContextManager Load/Unload remains #1176.
         - Same-bundle selected-contract fork execution from DB bytes consumes the persisted bundle catalog runtime source owner.
         - Cross-bundle fork routing remains #976.
-        - Create-new-work bundle_hash routing/admission remains #1022.
+        - Final lifecycle/scoped API conformance matrix remains #1025.
+        - Ambient CLI bundle context remains #1028.
         - Bundle CLI inventory and swarm fork consumers remain #1023/#989.
         - Delete/runtime.nuke/lifecycle cleanup remains #987/#988/#998/#1008/#1009.
     runs_table:
@@ -5990,10 +5999,10 @@ multi_bundle_persistence:
         rule: >
           New-run publication requires canonical bundle_hash when run_id is absent. Existing-run publication resolves bundle
           context from runs.bundle_hash/runs.bundle_source. If caller bundle_hash and existing run context disagree, the
-          method fails closed with BUNDLE_MISMATCH before mutation or idempotency completion. Until RuntimeContextManager
-          lands, the reduced supported scope routes only to the single active runtime whose BundleSourceFact bundle_hash
-          matches the resolved/requested bundle_hash; other valid hashes fail closed with BUNDLE_UNAVAILABLE rather than
-          falling back to ambient boot state. Legacy bundle_ref/bundle_fingerprint wrappers are transition-only parser inputs
+          method fails closed with BUNDLE_MISMATCH before mutation or idempotency completion. In DB-loaded pinned
+          RuntimeContextManager mode, the resolved/requested bundle_hash must select a loaded BundleContext; valid but
+          unloaded or unavailable hashes fail closed with BUNDLE_UNAVAILABLE rather than falling back to ambient boot
+          state. Legacy bundle_ref/bundle_fingerprint wrappers are transition-only parser inputs
           and are not authoritative for create-new-work scope.
       run.start:
         rule: Deprecated wrapper follows event.publish bundle_hash semantics while it remains present.
@@ -6041,7 +6050,7 @@ multi_bundle_persistence:
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
   cli_surface:
-    publication_status: bundle_inventory_register_envelope_run_fork_and_serial_serve_bundle_hash_implemented_other_cli_children_pending
+    publication_status: bundle_inventory_register_envelope_run_fork_and_boot_pinned_serve_bundle_hash_implemented_other_cli_children_pending
     bundle_commands_supported:
       - swarm bundle list
       - swarm bundle show <bundle-hash>
@@ -6051,7 +6060,7 @@ multi_bundle_persistence:
       - swarm bundle register <contracts-directory-or-archive>
       - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     modified_commands_planned:
-      - swarm serve --bundle-hash <bundle_hash> (implemented serial Postgres DB-loaded process mode)
+      - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev
       - swarm agents list --run-id <run-id>
       - swarm event publish <event-name> --bundle-hash <bundle_hash>
@@ -6099,18 +6108,20 @@ multi_bundle_persistence:
       reason: Forced bundle.delete preservation cleanup, mutex, quiescence, delivery/session/timer/container cleanup, and result projection are destructive-runtime implementation.
     serve_db_loaded_bundle:
       tracker: '#1020'
-      implementation_status: serial_postgres_single_bundle_process_promoted
+      implementation_status: boot_pinned_postgres_context_process_promoted
       runtime_owners:
         - internal/store.PostgresStore.LoadBundleCatalogRuntimeRecord
         - internal/runtime/contracts.LoadBundleCatalogRuntimeSource
         - cmd/swarm.loadServeRuntimeBundleFromCatalog
         - cmd/swarm.prepareLoadedServeBundleSource
         - cmd/swarm.runtimeProjectSupervisor.DisableSourceReplacement
+        - internal/runtime.RuntimeContextManager
+        - internal/runtime.BundleContext
       reason: >
-        swarm serve --bundle-hash DB-loaded YAML/data runtime boot mode is implemented for one canonical
-        Postgres-backed bundle_hash per process. Multi-bundle runtime concurrency and selected-contract fork
-        reuse remain split to #981; same-bundle selected-contract fork source reuse consumes the persisted
-        bundle catalog runtime source owner.
+        swarm serve --bundle-hash DB-loaded YAML/data runtime boot mode is implemented for one or more canonical
+        Postgres-backed bundle_hash values pinned at process boot. RuntimeContextManager owns loaded BundleContext
+        dispatch for the boot-pinned surface. Dynamic post-boot Load/Unload remains split to #1176; same-bundle
+        selected-contract fork source reuse consumes the persisted bundle catalog runtime source owner.
     bundle_safe_list_read_scoping:
       tracker: '#1021'
       reason: agent/event/run/log/incident read/list method scoping and generated OpenRPC shape are API read-model implementation.
@@ -6142,7 +6153,12 @@ multi_bundle_persistence:
       reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
     runtime_context_isolation:
       tracker: '#981'
-      reason: Hosting multiple bundles in one runtime process requires explicit per-run/bundle context isolation and dispatcher/store filtering proof.
+      implementation_status: boot_pinned_first_slice_implemented_by_1175_parent_remains_open
+      runtime_owners:
+        - internal/runtime.RuntimeContextManager
+        - internal/runtime.BundleContext
+        - internal/apiv1.OperatorReadOptions.RuntimeContexts
+      reason: Boot-pinned multi-context serve now routes supported runtime mutations through loaded BundleContext ownership and disables unscoped startup recovery/restore in multi-context processes; dynamic Load/Unload, scoped recovery filters, final matrix, ambient CLI context, cross-bundle fork, and cleanup siblings remain separately gated.
     lifecycle_cleanup:
       trackers:
         - '#987'
@@ -13897,8 +13913,8 @@ api_specification:
           Required when run_id is omitted. When run_id
           identifies an existing run, optional bundle_hash must match that run's
           canonical runs.bundle_hash or the method fails closed with BUNDLE_MISMATCH.
-          Until RuntimeContextManager lands, the resolved hash must match the single
-          active runtime source fact or the method fails closed with BUNDLE_UNAVAILABLE.
+          In DB-loaded RuntimeContextManager mode, the resolved hash must select a
+          loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE.
           cannot be combined with legacy bundle_ref; malformed or combined inputs fail
           closed with UNSUPPORTED_BUNDLE_HASH.
         schema:
@@ -14023,9 +14039,9 @@ api_specification:
         Start a run by injecting an event into the runtime bus. Create-new-work admission follows event.publish bundle_hash
         semantics: if no existing run row provides bundle context, bundle_hash is required. If run_id is supplied but no
         run row exists, the call is still create-new-work and run_id alone is not bundle scope. If caller bundle_hash and
-        existing run context disagree, the method fails closed with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the
-        resolved bundle_hash must match the single active runtime source fact or the method fails closed with
-        BUNDLE_UNAVAILABLE. Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with
+        existing run context disagree, the method fails closed with BUNDLE_MISMATCH. In DB-loaded RuntimeContextManager mode, the
+        resolved bundle_hash must select a loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE.
+        Legacy bundle_ref.fingerprint is deprecated transition input only and cannot be combined with
         bundle_hash.
 
         '
@@ -14041,9 +14057,9 @@ api_specification:
           Required when no existing run row supplies
           bundle context. When run_id identifies an existing run, optional bundle_hash
           must match that run's canonical runs.bundle_hash or the method fails closed
-          with BUNDLE_MISMATCH. Until RuntimeContextManager lands, the resolved hash must
-          match the single active runtime source fact or the method fails closed with
-          BUNDLE_UNAVAILABLE; cannot be combined with legacy bundle_ref; malformed or
+          with BUNDLE_MISMATCH. In DB-loaded RuntimeContextManager mode, the resolved hash must
+          select a loaded BundleContext or the method fails closed with BUNDLE_UNAVAILABLE;
+          cannot be combined with legacy bundle_ref; malformed or
           combined inputs fail closed with UNSUPPORTED_BUNDLE_HASH.
         schema:
           $ref: '#/components/schemas/BundleHash'


### PR DESCRIPTION
## Summary

Closes #1175.

Implements the approved first-slice boot-pinned RuntimeContextManager boundary for multi-bundle DB-loaded serve mode:

- Adds `internal/runtime.RuntimeContextManager` and `BundleContext` as the canonical runtime context owners for pinned bundle processes.
- Allows repeated canonical `swarm serve --bundle-hash` values, loads each persisted bundle all-or-nothing, and starts isolated runtime graphs for each bundle.
- Routes `event.publish`, `run.start`, `event.replay`, run control, agent control, runtime control, mailbox approval, and run fork through explicit context selection or fail-closed behavior.
- Adds bundle-scoped workspace/container identity labels and names for executable scoped paths.
- Ratifies the implemented #1175 authority in `platform-spec.yaml` and regenerates `openrpc.json`.

## Governing refs / context

- `platform-spec.yaml#multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source`
- `platform-spec.yaml#multi_bundle_persistence.explicit_splits.runtime_context_isolation`
- `platform-spec.yaml#api_specification.methods.event.publish`
- `platform-spec.yaml#api_specification.methods.run.start`
- `openrpc.json`
- #1175 pre-audit and lead gate outcome

## Semantic migration

New canonical owner:

- `internal/runtime.RuntimeContextManager`
- `internal/runtime.BundleContext`

Old non-authoritative paths now invalid for the approved #1175 surface:

- Treating the process-global runtime graph as the only active context when multiple persisted bundles are boot-pinned.
- Using the base API `BundleSourceFact` / event bus / runtime ingress without first selecting the loaded bundle context.
- Unscoped workspace/container names and labels for executable bundle-scoped runtime paths.

Production paths checked for surviving old behavior:

- `event.publish`, `run.start`, `event.replay`
- `run.stop`, `run.pause`, `run.continue`, `run.fork`
- `agent.send_directive`, `agent.restart`, `agent.replay_backlog`
- `runtime.pause`, `runtime.resume`
- mailbox approval event publishing
- `swarm serve --bundle-hash` boot and loaded bundle admission
- workspace/container identity generation

Migration status:

- Complete for the approved boot-pinned #1175 first slice.
- Dynamic Load/Unload (#1176), cross-bundle fork (#976), final supported matrix (#1025), ambient CLI context (#1028), Option B (#1026), and destructive cleanup / runtime.nuke residuals (#1008/#1009/#1027) remain outside this PR.

## Proof

- `go test ./...`