### PR TITLE
[agent-a][issue #1114] Preserve flow instance parent routes

### DIFF
--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -28,6 +28,53 @@ type ParentRoute struct {
 	FlowID       string
 }
 
+func (r ParentRoute) Normalized() ParentRoute {
+	return ParentRoute{
+		FlowInstance: normalizeRef(r.FlowInstance),
+		EntityID:     strings.TrimSpace(r.EntityID),
+		FlowID:       strings.TrimSpace(r.FlowID),
+	}
+}
+
+func (r ParentRoute) Empty() bool {
+	r = r.Normalized()
+	return r.FlowInstance == "" && r.EntityID == "" && r.FlowID == ""
+}
+
+func (r ParentRoute) Complete() bool {
+	r = r.Normalized()
+	return r.FlowInstance != "" && r.EntityID != "" && r.FlowID != ""
+}
+
+func ParentRouteFromMetadata(metadata map[string]any) ParentRoute {
+	if len(metadata) == 0 {
+		return ParentRoute{}
+	}
+	return ParentRoute{
+		FlowID:       metadataString(metadata, "parent_flow_id"),
+		FlowInstance: metadataString(metadata, "parent_flow_instance"),
+		EntityID:     metadataString(metadata, "parent_entity_id"),
+	}.Normalized()
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	value, ok := metadata[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+}
+
 type Persisted struct {
 	Instance
 	StorageRef string

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -50,6 +50,10 @@ type ResolutionInput struct {
 	MatchValues  map[string]string
 	Descriptors  []Descriptor
 	AllowMissing bool
+	// Static child flows have no persisted ParentRoute row; they may route back to
+	// the current delivery entity, but template/dynamic ParentRoute metadata must
+	// remain complete and fail closed when partial.
+	AllowEntityOnlyParentRoute bool
 }
 
 type Resolution struct {
@@ -106,6 +110,12 @@ func Resolve(input ResolutionInput, evt events.Event) Resolution {
 	if target.Empty() {
 		parentRoute := input.ParentRoute.Normalized()
 		if !parentRoute.Empty() {
+			if input.AllowEntityOnlyParentRoute && parentRoute.FlowID == "" && parentRoute.FlowInstance == "" && parentRoute.EntityID != "" {
+				return Resolution{Event: evt.WithTargetRoute(parentRoute), Target: parentRoute}
+			}
+			if parentRoute.FlowID == "" || parentRoute.FlowInstance == "" || parentRoute.EntityID == "" {
+				return Resolution{Event: evt, Failure: FailureParentRouteIncomplete}
+			}
 			return Resolution{Event: evt.WithTargetRoute(parentRoute), Target: parentRoute}
 		}
 		return Resolution{Event: evt, Failure: FailureTargetRequiredMissing}

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -1,0 +1,109 @@
+package pinrouting
+
+import (
+	"testing"
+
+	"swarm/internal/events"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/flowmodel"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestResolveTargetsCompleteParentRouteForPinDeclaredOutput(t *testing.T) {
+	source := testPinRoutingSource()
+	parent := events.RouteIdentity{
+		FlowID:       "root",
+		FlowInstance: "root/inst-1",
+		EntityID:     "parent-ent",
+	}
+
+	result := Resolve(ResolutionInput{
+		Source:      source,
+		FlowID:      "child",
+		EventType:   "child.done",
+		ParentRoute: parent,
+	}, events.Event{Type: "child.done"})
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if result.Target != parent {
+		t.Fatalf("Target = %#v, want %#v", result.Target, parent)
+	}
+	if got := result.Event.TargetRoute(); got != parent {
+		t.Fatalf("Event target = %#v, want %#v", got, parent)
+	}
+}
+
+func TestResolveFailsClosedOnIncompleteParentRouteForPinDeclaredOutput(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testPinRoutingSource(),
+		FlowID:    "child",
+		EventType: "child.done",
+		ParentRoute: events.RouteIdentity{
+			FlowID:   "root",
+			EntityID: "parent-ent",
+		},
+	}, events.Event{Type: "child.done"})
+
+	if result.Failure != FailureParentRouteIncomplete {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureParentRouteIncomplete)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on failed parent route", got)
+	}
+}
+
+func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.T) {
+	parent := events.RouteIdentity{EntityID: "parent-ent"}
+	blocked := Resolve(ResolutionInput{
+		Source:      testPinRoutingSource(),
+		FlowID:      "child",
+		EventType:   "child.done",
+		ParentRoute: parent,
+	}, events.Event{Type: "child.done"})
+	if blocked.Failure != FailureParentRouteIncomplete {
+		t.Fatalf("blocked Failure = %q, want %q", blocked.Failure, FailureParentRouteIncomplete)
+	}
+
+	allowed := Resolve(ResolutionInput{
+		Source:                     testPinRoutingSource(),
+		FlowID:                     "child",
+		EventType:                  "child.done",
+		ParentRoute:                parent,
+		AllowEntityOnlyParentRoute: true,
+	}, events.Event{Type: "child.done"})
+	if allowed.Failure != "" {
+		t.Fatalf("allowed Failure = %q, want empty", allowed.Failure)
+	}
+	if got := allowed.Event.TargetRoute(); got != parent {
+		t.Fatalf("allowed target = %#v, want %#v", got, parent)
+	}
+}
+
+func testPinRoutingSource() semanticview.Source {
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "child",
+			Flow: "child",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"child.done"},
+				},
+			},
+		},
+		Path: "child",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{child},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child": &child,
+			},
+		},
+	})
+}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -2116,21 +2116,11 @@ func (e *Executor) resolveEmitTargetMatchValues(frame *executionFrame, match map
 }
 
 func parentRouteFromState(metadata map[string]any) events.RouteIdentity {
-	if len(metadata) == 0 {
-		return events.RouteIdentity{}
-	}
-	flowInstance := firstNonEmpty(
-		asString(metadata["parent_flow_instance"]),
-		asString(metadata["parent_flow_path"]),
-	)
-	entityID := firstNonEmpty(
-		asString(metadata["parent_entity_id"]),
-		runtimeflowidentity.EntityID(flowInstance),
-	)
+	route := runtimeflowidentity.ParentRouteFromMetadata(metadata).Normalized()
 	return events.RouteIdentity{
-		FlowID:       asString(metadata["parent_flow_id"]),
-		FlowInstance: flowInstance,
-		EntityID:     entityID,
+		FlowID:       route.FlowID,
+		FlowInstance: route.FlowInstance,
+		EntityID:     route.EntityID,
 	}.Normalized()
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2029,6 +2029,91 @@ func TestExecutor_StaticProducerTargetRouteDoesNotOwnEventNamespace(t *testing.T
 	}
 }
 
+func TestExecutor_ChildPinOutputTargetsStoredParentRoute(t *testing.T) {
+	source := sourceWithChildOutputPin()
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     source,
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	parentRoute := events.RouteIdentity{
+		FlowID:       "root",
+		FlowInstance: "root/inst-1",
+		EntityID:     "parent-ent",
+	}
+	state := testStateSnapshot("running", map[string]any{
+		"flow_path":            "child/inst-1",
+		"parent_flow_id":       parentRoute.FlowID,
+		"parent_flow_instance": parentRoute.FlowInstance,
+		"parent_entity_id":     parentRoute.EntityID,
+	}, nil, map[string]map[string]any{})
+	state.EntityID = identity.NormalizeEntityID("child-ent")
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "child-ent",
+		NodeID:   "child-node",
+		FlowID:   "child",
+		Event: (events.Event{
+			ID:      "evt-1",
+			Type:    "child/requested",
+			Payload: json.RawMessage(`{}`),
+		}).WithEntityID("wrong-parent").WithFlowInstance("wrong/root").WithSourceRoute(events.RouteIdentity{
+			FlowID:       "wrong",
+			FlowInstance: "wrong/root",
+			EntityID:     "wrong-parent",
+		}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Emit: runtimecontracts.EmitSpec{Event: "child.done"},
+		},
+		State: state,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", got)
+	}
+	if got := result.EmitIntents[0].Event.TargetRoute(); got != parentRoute {
+		t.Fatalf("target route = %#v, want %#v", got, parentRoute)
+	}
+}
+
+func sourceWithChildOutputPin() semanticview.Source {
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "child",
+			Flow: "child",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"child.done"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child.done": {},
+		},
+		Path: "child",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{child},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child": &child,
+			},
+		},
+	})
+}
+
 func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSourceWithRootEntityContract(),

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -86,12 +86,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		WorkflowVersion: strings.TrimSpace(req.ContractBundle.WorkflowVersion()),
 		CurrentState:    initialState,
 		Config:          cloneFlowConfig(req.Config),
-		Metadata: map[string]any{
-			"entity_id":        flowEntityID,
-			"instance_id":      instanceID,
-			"flow_path":        flowPath,
-			"parent_entity_id": parentEntityID,
-		},
+		Metadata:        flowInstanceActivationMetadata(instance, flowEntityID, instanceID, flowPath, parentEntityID),
 	}); err != nil {
 		return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
 	}
@@ -154,6 +149,26 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		}
 	}
 	return nil
+}
+
+func flowInstanceActivationMetadata(instance runtimeflowidentity.Instance, flowEntityID, instanceID, flowPath, parentEntityID string) map[string]any {
+	metadata := map[string]any{
+		"entity_id":        strings.TrimSpace(flowEntityID),
+		"instance_id":      strings.TrimSpace(instanceID),
+		"flow_path":        strings.Trim(strings.TrimSpace(flowPath), "/"),
+		"parent_entity_id": strings.TrimSpace(parentEntityID),
+	}
+	parentRoute := instance.ParentRoute.Normalized()
+	if strings.TrimSpace(parentRoute.FlowID) != "" {
+		metadata["parent_flow_id"] = strings.TrimSpace(parentRoute.FlowID)
+	}
+	if strings.TrimSpace(parentRoute.FlowInstance) != "" {
+		metadata["parent_flow_instance"] = strings.Trim(strings.TrimSpace(parentRoute.FlowInstance), "/")
+	}
+	if strings.TrimSpace(parentRoute.EntityID) != "" {
+		metadata["parent_entity_id"] = strings.TrimSpace(parentRoute.EntityID)
+	}
+	return metadata
 }
 
 func buildAutoEmitOnCreateEvent(source semanticview.Source, schema runtimecontracts.FlowSchemaDocument, templateID, flowPath, instanceID, flowEntityID, parentEntityID string, config map[string]any) (events.Event, string, error) {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -703,6 +703,36 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	}
 }
 
+func TestActivateFlowInstancePersistsFullParentRouteMetadata(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
+	bundle := testFlowBundle("")
+
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-legacy", "review/inst-1")
+	req.Instance.ParentRoute = runtimeflowidentity.ParentRoute{
+		FlowID:       "operating",
+		FlowInstance: "operating/root",
+		EntityID:     "parent-ent",
+	}
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(instances.creates) != 1 {
+		t.Fatalf("creates = %d, want 1", len(instances.creates))
+	}
+	metadata := instances.creates[0].Metadata
+	if got := metadata["parent_flow_id"]; got != "operating" {
+		t.Fatalf("parent_flow_id = %#v, want operating", got)
+	}
+	if got := metadata["parent_flow_instance"]; got != "operating/root" {
+		t.Fatalf("parent_flow_instance = %#v, want operating/root", got)
+	}
+	if got := metadata["parent_entity_id"]; got != "parent-ent" {
+		t.Fatalf("parent_entity_id = %#v, want parent-ent", got)
+	}
+}
+
 func TestActivateFlowInstanceResolvesAgentPermissions(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -966,6 +966,12 @@ var workflowRuntimeControlMetadataKeys = []string{
 	"parent_entity_id",
 }
 
+var workflowRuntimeParentRouteMetadataKeys = []string{
+	"parent_flow_id",
+	"parent_flow_instance",
+	"parent_entity_id",
+}
+
 func workflowRuntimeControlMetadata(metadata map[string]any) map[string]any {
 	if len(metadata) == 0 {
 		return nil
@@ -981,7 +987,7 @@ func workflowRuntimeControlMetadata(metadata map[string]any) map[string]any {
 }
 
 func restoreWorkflowRuntimeControlMetadata(metadata map[string]any, control map[string]any) {
-	if metadata == nil || len(control) == 0 {
+	if metadata == nil {
 		return
 	}
 	for _, key := range workflowRuntimeControlMetadataKeys {
@@ -989,6 +995,12 @@ func restoreWorkflowRuntimeControlMetadata(metadata map[string]any, control map[
 		if ok {
 			metadata[key] = value
 		}
+	}
+	for _, key := range workflowRuntimeParentRouteMetadataKeys {
+		if _, ok := control[key]; ok {
+			continue
+		}
+		delete(metadata, key)
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -879,6 +879,7 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 	if instance.Metadata == nil {
 		instance.Metadata = map[string]any{}
 	}
+	controlMetadata := workflowRuntimeControlMetadata(instance.Metadata)
 	if strings.TrimSpace(instance.WorkflowName) == "" {
 		defaultWorkflowName := strings.TrimSpace(flowID)
 		if defaultWorkflowName == "" && source != nil {
@@ -924,6 +925,7 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 	}
 	if mutation.StateCarrier.Metadata != nil || len(mutation.StateCarrier.Gates) > 0 {
 		instance.Metadata = mutation.StateCarrier.PersistedMetadata()
+		restoreWorkflowRuntimeControlMetadata(instance.Metadata, controlMetadata)
 	}
 	if mutation.StateCarrier.StateBuckets != nil {
 		instance.StateBuckets = mutation.StateCarrier.PersistedStateBuckets()
@@ -948,6 +950,45 @@ func applyEngineStateMutation(instance *WorkflowInstance, mutation runtimeengine
 	}
 	if len(entityProjection) > 0 {
 		workflowSetStateBucket(instance, workflowStateBucketEntityProjection, entityProjection)
+	}
+}
+
+var workflowRuntimeControlMetadataKeys = []string{
+	"storage_ref",
+	"instance_id",
+	"flow_path",
+	"entity_id",
+	"workflow_version",
+	"template_version",
+	"instance_kind",
+	"parent_flow_id",
+	"parent_flow_instance",
+	"parent_entity_id",
+}
+
+func workflowRuntimeControlMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	control := make(map[string]any, len(workflowRuntimeControlMetadataKeys))
+	for _, key := range workflowRuntimeControlMetadataKeys {
+		value, ok := metadata[key]
+		if ok {
+			control[key] = value
+		}
+	}
+	return control
+}
+
+func restoreWorkflowRuntimeControlMetadata(metadata map[string]any, control map[string]any) {
+	if metadata == nil || len(control) == 0 {
+		return
+	}
+	for _, key := range workflowRuntimeControlMetadataKeys {
+		value, ok := control[key]
+		if ok {
+			metadata[key] = value
+		}
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -14,10 +14,13 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	"swarm/internal/runtime/core/identity"
+	runtimepinrouting "swarm/internal/runtime/core/pinrouting"
 	runtimeregistry "swarm/internal/runtime/core/registry"
 	"swarm/internal/runtime/core/values"
 	runtimeengine "swarm/internal/runtime/engine"
+	"swarm/internal/runtime/flowmodel"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
 )
@@ -173,6 +176,112 @@ func TestApplyEngineStateMutationPreservesRuntimeControlMetadata(t *testing.T) {
 	if got := instance.Metadata["business_status"]; got != "new" {
 		t.Fatalf("business_status = %#v, want new", got)
 	}
+}
+
+func TestApplyEngineStateMutationRejectsAuthoredParentRouteInsertion(t *testing.T) {
+	instance := &WorkflowInstance{
+		Metadata: map[string]any{
+			"business_status": "old",
+		},
+	}
+	mutation := testEngineStateMutation(map[string]any{
+		"business_status":      "new",
+		"parent_flow_id":       "root",
+		"parent_flow_instance": "root/inst-1",
+		"parent_entity_id":     "parent-ent",
+	}, nil, nil)
+
+	applyEngineStateMutation(instance, mutation, nil, nil, "")
+
+	for _, key := range []string{"parent_flow_id", "parent_flow_instance", "parent_entity_id"} {
+		if _, ok := instance.Metadata[key]; ok {
+			t.Fatalf("metadata[%s] = %#v, want absent", key, instance.Metadata[key])
+		}
+	}
+	if got := instance.Metadata["business_status"]; got != "new" {
+		t.Fatalf("business_status = %#v, want new", got)
+	}
+	assertMutationParentRoutePinOutputFailure(t, instance.Metadata, runtimepinrouting.FailureTargetRequiredMissing)
+}
+
+func TestApplyEngineStateMutationRejectsAuthoredParentRouteCompletion(t *testing.T) {
+	instance := &WorkflowInstance{
+		Metadata: map[string]any{
+			"parent_entity_id": "legacy-parent",
+			"business_status":  "old",
+		},
+	}
+	mutation := testEngineStateMutation(map[string]any{
+		"business_status":      "new",
+		"parent_flow_id":       "root",
+		"parent_flow_instance": "root/inst-1",
+		"parent_entity_id":     "wrong-parent",
+	}, nil, nil)
+
+	applyEngineStateMutation(instance, mutation, nil, nil, "")
+
+	if _, ok := instance.Metadata["parent_flow_id"]; ok {
+		t.Fatalf("parent_flow_id = %#v, want absent", instance.Metadata["parent_flow_id"])
+	}
+	if _, ok := instance.Metadata["parent_flow_instance"]; ok {
+		t.Fatalf("parent_flow_instance = %#v, want absent", instance.Metadata["parent_flow_instance"])
+	}
+	if got := instance.Metadata["parent_entity_id"]; got != "legacy-parent" {
+		t.Fatalf("parent_entity_id = %#v, want legacy-parent", got)
+	}
+	if got := instance.Metadata["business_status"]; got != "new" {
+		t.Fatalf("business_status = %#v, want new", got)
+	}
+	assertMutationParentRoutePinOutputFailure(t, instance.Metadata, runtimepinrouting.FailureParentRouteIncomplete)
+}
+
+func assertMutationParentRoutePinOutputFailure(t *testing.T, metadata map[string]any, want runtimepinrouting.TargetFailure) {
+	t.Helper()
+	route := runtimeflowidentity.ParentRouteFromMetadata(metadata).Normalized()
+	result := runtimepinrouting.Resolve(runtimepinrouting.ResolutionInput{
+		Source:    mutationParentRoutePinOutputSource(),
+		FlowID:    "child",
+		EventType: "child.done",
+		Emit:      runtimecontracts.EmitSpec{Event: "child.done"},
+		ParentRoute: events.RouteIdentity{
+			FlowID:       route.FlowID,
+			FlowInstance: route.FlowInstance,
+			EntityID:     route.EntityID,
+		},
+	}, events.Event{Type: events.EventType("child.done")})
+	if result.Failure != want {
+		t.Fatalf("pin output failure = %q, want %q (metadata=%#v)", result.Failure, want, metadata)
+	}
+}
+
+func mutationParentRoutePinOutputSource() semanticview.Source {
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "child",
+			Flow: "child",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"child.done"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child.done": {},
+		},
+		Path: "child",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{child},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child": &child,
+			},
+		},
+	})
 }
 
 func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testing.T) {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -129,6 +129,52 @@ func TestApplyEngineStateMutationPreservesExistingMetadataOnGateOnlyMutation(t *
 	}
 }
 
+func TestApplyEngineStateMutationPreservesRuntimeControlMetadata(t *testing.T) {
+	instance := &WorkflowInstance{
+		Metadata: map[string]any{
+			"storage_ref":          "review/inst-1",
+			"instance_id":          "inst-1",
+			"flow_path":            "review/inst-1",
+			"entity_id":            "child-ent",
+			"workflow_version":     "v1",
+			"template_version":     "tv1",
+			"instance_kind":        "materialized",
+			"parent_flow_id":       "operating",
+			"parent_flow_instance": "operating/root",
+			"parent_entity_id":     "parent-ent",
+			"business_status":      "old",
+		},
+	}
+	mutation := testEngineStateMutation(map[string]any{
+		"parent_flow_id":       "wrong",
+		"parent_flow_instance": "wrong/root",
+		"parent_entity_id":     "wrong-parent",
+		"business_status":      "new",
+	}, nil, nil)
+
+	applyEngineStateMutation(instance, mutation, nil, nil, "")
+
+	for key, want := range map[string]any{
+		"storage_ref":          "review/inst-1",
+		"instance_id":          "inst-1",
+		"flow_path":            "review/inst-1",
+		"entity_id":            "child-ent",
+		"workflow_version":     "v1",
+		"template_version":     "tv1",
+		"instance_kind":        "materialized",
+		"parent_flow_id":       "operating",
+		"parent_flow_instance": "operating/root",
+		"parent_entity_id":     "parent-ent",
+	} {
+		if got := instance.Metadata[key]; got != want {
+			t.Fatalf("metadata[%s] = %#v, want %#v", key, got, want)
+		}
+	}
+	if got := instance.Metadata["business_status"]; got != "new" {
+		t.Fatalf("business_status = %#v, want new", got)
+	}
+}
+
 func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/runtime/pipeline/flow_instance_identity.go
+++ b/internal/runtime/pipeline/flow_instance_identity.go
@@ -34,11 +34,7 @@ func StoredFlowInstance(source semanticview.Source, instance WorkflowInstance) r
 		entityID,
 		strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
 	)
-	stored.ParentRoute = runtimeflowidentity.ParentRoute{
-		FlowID:       strings.TrimSpace(asString(instance.Metadata["parent_flow_id"])),
-		FlowInstance: strings.Trim(strings.TrimSpace(asString(instance.Metadata["parent_flow_instance"])), "/"),
-		EntityID:     strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
-	}
+	stored.ParentRoute = runtimeflowidentity.ParentRouteFromMetadata(instance.Metadata)
 	return stored
 }
 
@@ -68,11 +64,7 @@ func workflowInstancePersistedIdentity(source semanticview.Source, instance Work
 	if err != nil {
 		return runtimeflowidentity.Persisted{}, err
 	}
-	persisted.ParentRoute = runtimeflowidentity.ParentRoute{
-		FlowID:       strings.TrimSpace(asString(instance.Metadata["parent_flow_id"])),
-		FlowInstance: strings.Trim(strings.TrimSpace(asString(instance.Metadata["parent_flow_instance"])), "/"),
-		EntityID:     strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
-	}
+	persisted.ParentRoute = runtimeflowidentity.ParentRouteFromMetadata(instance.Metadata)
 	return persisted, nil
 }
 
@@ -93,11 +85,7 @@ func workflowStateIdentity(source semanticview.Source, flowID string, state Work
 		strings.TrimSpace(state.EntityID),
 		asString(state.Metadata["parent_entity_id"]),
 	)
-	instance.ParentRoute = runtimeflowidentity.ParentRoute{
-		FlowID:       strings.TrimSpace(asString(state.Metadata["parent_flow_id"])),
-		FlowInstance: strings.Trim(strings.TrimSpace(asString(state.Metadata["parent_flow_instance"])), "/"),
-		EntityID:     strings.TrimSpace(asString(state.Metadata["parent_entity_id"])),
-	}
+	instance.ParentRoute = runtimeflowidentity.ParentRouteFromMetadata(state.Metadata)
 	return instance
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -77,18 +77,20 @@ type workflowInstancePersistedProjection struct {
 }
 
 type workflowInstancePersistedControl struct {
-	StorageRef        string
-	Slug              string
-	Name              string
-	EntityType        string
-	InstanceID        string
-	FlowPath          string
-	InstanceKind      string
-	TemplateVersion   string
-	LastSourceEvent   string
-	Status            string
-	ParentEntityID    string
-	TransitionHistory []WorkflowTransitionRecord
+	StorageRef         string
+	Slug               string
+	Name               string
+	EntityType         string
+	InstanceID         string
+	FlowPath           string
+	InstanceKind       string
+	TemplateVersion    string
+	LastSourceEvent    string
+	Status             string
+	ParentFlowID       string
+	ParentFlowInstance string
+	ParentEntityID     string
+	TransitionHistory  []WorkflowTransitionRecord
 }
 
 type WorkflowInstanceStore struct {
@@ -1283,23 +1285,25 @@ func workflowInstancePersistedProjectionFromInstance(instance WorkflowInstance, 
 		return workflowInstancePersistedProjection{}, fmt.Errorf("workflow instance storage_ref %q disagrees with canonical storage_ref %q", storageRef, persistedIdentity.StorageRef)
 	}
 	control := workflowInstancePersistedControl{
-		StorageRef:        strings.TrimSpace(persistedIdentity.StorageRef),
-		Slug:              strings.TrimSpace(asString(instance.Metadata["slug"])),
-		Name:              strings.TrimSpace(asString(instance.Metadata["name"])),
-		EntityType:        strings.TrimSpace(asString(instance.Metadata["entity_type"])),
-		InstanceID:        strings.TrimSpace(persistedIdentity.InstanceID),
-		InstanceKind:      strings.TrimSpace(asString(instance.Metadata["instance_kind"])),
-		TemplateVersion:   strings.TrimSpace(asString(instance.Metadata["template_version"])),
-		LastSourceEvent:   strings.TrimSpace(asString(instance.Metadata["last_source_event"])),
-		Status:            strings.TrimSpace(asString(instance.Config["status"])),
-		ParentEntityID:    strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
-		TransitionHistory: append([]WorkflowTransitionRecord{}, instance.TransitionHistory...),
+		StorageRef:         strings.TrimSpace(persistedIdentity.StorageRef),
+		Slug:               strings.TrimSpace(asString(instance.Metadata["slug"])),
+		Name:               strings.TrimSpace(asString(instance.Metadata["name"])),
+		EntityType:         strings.TrimSpace(asString(instance.Metadata["entity_type"])),
+		InstanceID:         strings.TrimSpace(persistedIdentity.InstanceID),
+		InstanceKind:       strings.TrimSpace(asString(instance.Metadata["instance_kind"])),
+		TemplateVersion:    strings.TrimSpace(asString(instance.Metadata["template_version"])),
+		LastSourceEvent:    strings.TrimSpace(asString(instance.Metadata["last_source_event"])),
+		Status:             strings.TrimSpace(asString(instance.Config["status"])),
+		ParentFlowID:       strings.TrimSpace(persistedIdentity.ParentRoute.FlowID),
+		ParentFlowInstance: strings.Trim(strings.TrimSpace(persistedIdentity.ParentRoute.FlowInstance), "/"),
+		ParentEntityID:     strings.TrimSpace(asString(instance.Metadata["parent_entity_id"])),
+		TransitionHistory:  append([]WorkflowTransitionRecord{}, instance.TransitionHistory...),
 	}
 	if persistedIdentity.HasStoredPath {
 		control.FlowPath = strings.TrimSpace(persistedIdentity.InstancePath)
 	}
 	for _, key := range []string{
-		"slug", "name", "entity_type", "parent_entity_id",
+		"slug", "name", "entity_type", "parent_flow_id", "parent_flow_instance", "parent_entity_id",
 		"instance_id", "storage_ref", "flow_path", "instance_kind",
 		"template_version", "workflow_version", "transition_history",
 	} {
@@ -1349,6 +1353,12 @@ func (p workflowInstancePersistedProjection) Metadata() map[string]any {
 	if strings.TrimSpace(p.Control.LastSourceEvent) != "" {
 		metadata["last_source_event"] = strings.TrimSpace(p.Control.LastSourceEvent)
 	}
+	if strings.TrimSpace(p.Control.ParentFlowID) != "" {
+		metadata["parent_flow_id"] = strings.TrimSpace(p.Control.ParentFlowID)
+	}
+	if strings.TrimSpace(p.Control.ParentFlowInstance) != "" {
+		metadata["parent_flow_instance"] = strings.Trim(strings.TrimSpace(p.Control.ParentFlowInstance), "/")
+	}
 	if strings.TrimSpace(p.Control.ParentEntityID) != "" {
 		metadata["parent_entity_id"] = strings.TrimSpace(p.Control.ParentEntityID)
 	}
@@ -1380,6 +1390,12 @@ func (p workflowInstancePersistedProjection) ConfigPayload(workflowVersion strin
 	}
 	if strings.TrimSpace(p.Control.Status) != "" {
 		config["status"] = strings.TrimSpace(p.Control.Status)
+	}
+	if strings.TrimSpace(p.Control.ParentFlowID) != "" {
+		config["parent_flow_id"] = strings.TrimSpace(p.Control.ParentFlowID)
+	}
+	if strings.TrimSpace(p.Control.ParentFlowInstance) != "" {
+		config["parent_flow_instance"] = strings.Trim(strings.TrimSpace(p.Control.ParentFlowInstance), "/")
 	}
 	if strings.TrimSpace(p.Control.ParentEntityID) != "" {
 		config["parent_entity_id"] = strings.TrimSpace(p.Control.ParentEntityID)
@@ -1470,6 +1486,14 @@ func decodeWorkflowInstanceConfigPayload(raw []byte, control workflowInstancePer
 	if err != nil {
 		return nil, workflowInstancePersistedControl{}, err
 	}
+	parentFlowID, err := workflowInstanceOptionalString(config, "parent_flow_id")
+	if err != nil {
+		return nil, workflowInstancePersistedControl{}, err
+	}
+	parentFlowInstance, err := workflowInstanceOptionalString(config, "parent_flow_instance")
+	if err != nil {
+		return nil, workflowInstancePersistedControl{}, err
+	}
 	parentEntityID, err := workflowInstanceOptionalString(config, "parent_entity_id")
 	if err != nil {
 		return nil, workflowInstancePersistedControl{}, err
@@ -1485,6 +1509,8 @@ func decodeWorkflowInstanceConfigPayload(raw []byte, control workflowInstancePer
 	delete(config, "instance_kind")
 	delete(config, "template_version")
 	delete(config, "last_source_event")
+	delete(config, "parent_flow_id")
+	delete(config, "parent_flow_instance")
 	delete(config, "parent_entity_id")
 	delete(config, "transition_history")
 	control.InstanceID = strings.TrimSpace(instanceID)
@@ -1499,6 +1525,8 @@ func decodeWorkflowInstanceConfigPayload(raw []byte, control workflowInstancePer
 	control.TemplateVersion = strings.TrimSpace(templateVersion)
 	control.LastSourceEvent = strings.TrimSpace(lastSourceEvent)
 	control.Status = strings.TrimSpace(status)
+	control.ParentFlowID = strings.TrimSpace(parentFlowID)
+	control.ParentFlowInstance = strings.Trim(strings.TrimSpace(parentFlowInstance), "/")
 	control.ParentEntityID = strings.TrimSpace(parentEntityID)
 	control.TransitionHistory = transitionHistory
 	return config, control, nil

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -19,6 +19,8 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	store := NewWorkflowInstanceStore(db)
 	storageRef := uuid.NewString()
 	parentID := uuid.NewString()
+	parentFlowID := "operating"
+	parentFlowInstance := "operating/root"
 	now := time.Now().UTC().Round(time.Microsecond)
 
 	instance := WorkflowInstance{
@@ -46,17 +48,19 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 			},
 		},
 		Metadata: map[string]any{
-			"business_brief":    map[string]any{"title": "hello"},
-			"status":            "open",
-			"slug":              "projection",
-			"name":              "Projection Flow",
-			"entity_type":       "workflow_subject",
-			"instance_id":       "inst-1",
-			"flow_path":         "review/inst-1",
-			"instance_kind":     "materialized",
-			"template_version":  "v1",
-			"last_source_event": "review.started",
-			"parent_entity_id":  parentID,
+			"business_brief":       map[string]any{"title": "hello"},
+			"status":               "open",
+			"slug":                 "projection",
+			"name":                 "Projection Flow",
+			"entity_type":          "workflow_subject",
+			"instance_id":          "inst-1",
+			"flow_path":            "review/inst-1",
+			"instance_kind":        "materialized",
+			"template_version":     "v1",
+			"last_source_event":    "review.started",
+			"parent_flow_id":       parentFlowID,
+			"parent_flow_instance": parentFlowInstance,
+			"parent_entity_id":     parentID,
 			"gates": map[string]any{
 				"g_ready": true,
 			},
@@ -88,6 +92,15 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	}
 	if got := strings.TrimSpace(asString(loaded.Metadata["flow_path"])); got != "review/inst-1" {
 		t.Fatalf("Metadata flow_path = %#v, want review/inst-1", loaded.Metadata["flow_path"])
+	}
+	if got := strings.TrimSpace(asString(loaded.Metadata["parent_flow_id"])); got != parentFlowID {
+		t.Fatalf("Metadata parent_flow_id = %#v, want %q", loaded.Metadata["parent_flow_id"], parentFlowID)
+	}
+	if got := strings.Trim(strings.TrimSpace(asString(loaded.Metadata["parent_flow_instance"])), "/"); got != parentFlowInstance {
+		t.Fatalf("Metadata parent_flow_instance = %#v, want %q", loaded.Metadata["parent_flow_instance"], parentFlowInstance)
+	}
+	if got := strings.TrimSpace(asString(loaded.Metadata["parent_entity_id"])); got != parentID {
+		t.Fatalf("Metadata parent_entity_id = %#v, want %q", loaded.Metadata["parent_entity_id"], parentID)
 	}
 	if got := strings.TrimSpace(asString(loaded.Metadata["storage_ref"])); got != storageRef {
 		t.Fatalf("Metadata storage_ref = %#v, want %q", loaded.Metadata["storage_ref"], storageRef)
@@ -127,6 +140,15 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 	}
 	if identity.EntityID != runtimeflowidentity.EntityID("review/inst-1") {
 		t.Fatalf("identity.EntityID = %q, want canonical id for review/inst-1", identity.EntityID)
+	}
+	if identity.ParentRoute.FlowID != parentFlowID {
+		t.Fatalf("identity.ParentRoute.FlowID = %q, want %q", identity.ParentRoute.FlowID, parentFlowID)
+	}
+	if identity.ParentRoute.FlowInstance != parentFlowInstance {
+		t.Fatalf("identity.ParentRoute.FlowInstance = %q, want %q", identity.ParentRoute.FlowInstance, parentFlowInstance)
+	}
+	if identity.ParentRoute.EntityID != parentID {
+		t.Fatalf("identity.ParentRoute.EntityID = %q, want %q", identity.ParentRoute.EntityID, parentID)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,9 +46,58 @@ func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRo
 	assertSQLiteMutationCount(t, db, entityID, "tier", "workflow_instance_store", "create", "1", "2", 1)
 }
 
+func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	storageRef := "review/inst-1"
+
+	if err := store.Create(ctx, WorkflowInstance{
+		InstanceID:      "inst-1",
+		StorageRef:      storageRef,
+		WorkflowName:    "review",
+		WorkflowVersion: "v1",
+		CurrentState:    "created",
+		EnteredStageAt:  time.Now().UTC(),
+		Metadata: map[string]any{
+			"flow_path":            storageRef,
+			"parent_flow_id":       "operating",
+			"parent_flow_instance": "operating/root",
+			"parent_entity_id":     "parent-ent",
+		},
+	}); err != nil {
+		t.Fatalf("Create workflow instance: %v", err)
+	}
+
+	loaded, ok, err := store.Load(ctx, storageRef)
+	if err != nil {
+		t.Fatalf("Load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to persist")
+	}
+	for key, want := range map[string]string{
+		"parent_flow_id":       "operating",
+		"parent_flow_instance": "operating/root",
+		"parent_entity_id":     "parent-ent",
+	} {
+		if got := strings.TrimSpace(asString(loaded.Metadata[key])); got != want {
+			t.Fatalf("loaded.Metadata[%s] = %#v, want %q", key, loaded.Metadata[key], want)
+		}
+	}
+	identity, err := workflowInstancePersistedIdentity(nil, loaded)
+	if err != nil {
+		t.Fatalf("workflowInstancePersistedIdentity: %v", err)
+	}
+	if identity.ParentRoute.FlowID != "operating" || identity.ParentRoute.FlowInstance != "operating/root" || identity.ParentRoute.EntityID != "parent-ent" {
+		t.Fatalf("ParentRoute = %#v, want operating/operating/root/parent-ent", identity.ParentRoute)
+	}
+}
+
 func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	db, err := sql.Open("sqlite", "file:"+name+"?mode=memory&cache=shared")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -509,6 +509,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		MailboxStore:      stores.MailboxStore,
 		EntityStore:       stores.ToolEntityStore,
 		HumanTaskStore:    stores.HumanTaskStore,
+		WorkflowInstances: pipelineStore,
 		WorkflowSource:    source,
 		WorkspaceResolver: rt.Workspace,
 		AuthorityProvider: rt.Authority,

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -18,6 +18,11 @@ type Schedule = runtimepipeline.Schedule
 
 type SchedulePersistence = runtimepipeline.SchedulePersistence
 
+type WorkflowInstanceLoader interface {
+	Enabled() bool
+	Load(ctx context.Context, instanceID string) (runtimepipeline.WorkflowInstance, bool, error)
+}
+
 type EventPublisher interface {
 	Publish(ctx context.Context, evt events.Event) error
 	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
@@ -45,6 +50,7 @@ type ExecutorOptions struct {
 	MailboxStore      MailboxPersistence
 	EntityStore       EntityPersistence
 	HumanTaskStore    HumanTaskPersistence
+	WorkflowInstances WorkflowInstanceLoader
 	MCPClient         *runtimemcp.Client
 	WorkflowSource    semanticview.Source
 	WorkspaceResolver workspace.Resolver

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -35,6 +35,7 @@ type Executor struct {
 	mailboxStore                   MailboxPersistence
 	entityStore                    EntityPersistence
 	humanTaskStore                 HumanTaskPersistence
+	workflowInstances              WorkflowInstanceLoader
 	cfg                            *config.Config
 	credentials                    runtimecredentials.Store
 	httpClient                     *http.Client
@@ -73,6 +74,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		mailboxStore:                   opts.MailboxStore,
 		entityStore:                    opts.EntityStore,
 		humanTaskStore:                 opts.HumanTaskStore,
+		workflowInstances:              opts.WorkflowInstances,
 		cfg:                            opts.Config,
 		credentials:                    opts.Credentials,
 		httpClient:                     &http.Client{Timeout: 30 * time.Second},

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
+	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "swarm/internal/runtime/core/pinrouting"
 	"swarm/internal/runtime/semanticview"
 )
@@ -108,14 +109,28 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 	}
 	if runtimepinrouting.PinDeclaredOutput(e.workflowSource, flowID, eventType) {
 		spec := runtimecontracts.EmitSpec{Event: eventType}
+		parentRoute, allowEntityOnlyParentRoute, err := e.emitParentRouteForActor(ctx, actor, flowID, flowInstance, inbound)
+		if err != nil {
+			wrapped := WrapRuntimeError(
+				"parent_route_lookup_failed",
+				"tool-executor",
+				"handle_emit_tool.parent_route",
+				true,
+				err,
+				"failed to resolve emit tool parent route",
+			)
+			e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "parent_route_lookup_failed", "publish", "parent_route", wrapped)
+			return nil, wrapped
+		}
 		resolution := runtimepinrouting.Resolve(runtimepinrouting.ResolutionInput{
-			Source:      e.workflowSource,
-			FlowID:      flowID,
-			EventType:   eventType,
-			Emit:        spec,
-			SourceRoute: sourceRoute,
-			Inbound:     inbound,
-			ParentRoute: emitParentRouteForActorEvent(inbound, flowInstance),
+			Source:                     e.workflowSource,
+			FlowID:                     flowID,
+			EventType:                  eventType,
+			Emit:                       spec,
+			SourceRoute:                sourceRoute,
+			Inbound:                    inbound,
+			ParentRoute:                parentRoute,
+			AllowEntityOnlyParentRoute: allowEntityOnlyParentRoute,
 		}, emitted)
 		if resolution.Failure != "" {
 			wrapped := NewRuntimeError(
@@ -162,16 +177,69 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 	}, nil
 }
 
-func emitParentRouteForActorEvent(inbound events.Event, flowInstance string) events.RouteIdentity {
-	parent := inbound.SourceRoute()
-	if parent.Empty() {
-		return events.RouteIdentity{}
+func (e *Executor) emitParentRouteForActor(ctx context.Context, actor models.AgentConfig, flowID, flowInstance string, inbound events.Event) (events.RouteIdentity, bool, error) {
+	if e == nil {
+		return events.RouteIdentity{}, false, nil
 	}
-	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
-	if flowInstance != "" && strings.Trim(strings.TrimSpace(parent.FlowInstance), "/") == flowInstance {
-		return events.RouteIdentity{}
+	if e.workflowInstances != nil && e.workflowInstances.Enabled() {
+		for _, ref := range emitWorkflowInstanceRefs(actor, flowInstance) {
+			instance, ok, err := e.workflowInstances.Load(ctx, ref)
+			if err != nil {
+				return events.RouteIdentity{}, false, err
+			}
+			if !ok {
+				continue
+			}
+			parent := runtimeflowidentity.ParentRouteFromMetadata(instance.Metadata).Normalized()
+			return events.RouteIdentity{
+				FlowID:       parent.FlowID,
+				FlowInstance: parent.FlowInstance,
+				EntityID:     parent.EntityID,
+			}.Normalized(), false, nil
+		}
 	}
-	return parent
+	if route, ok := e.staticFlowEntityParentRoute(flowID, inbound); ok {
+		return route, true, nil
+	}
+	return events.RouteIdentity{}, false, nil
+}
+
+func emitWorkflowInstanceRefs(actor models.AgentConfig, flowInstance string) []string {
+	candidates := []string{
+		actor.EffectiveEntityID(),
+		strings.Trim(strings.TrimSpace(flowInstance), "/"),
+		actor.CanonicalFlowPath(),
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func (e *Executor) staticFlowEntityParentRoute(flowID string, inbound events.Event) (events.RouteIdentity, bool) {
+	flowID = strings.TrimSpace(flowID)
+	if e == nil || e.workflowSource == nil || flowID == "" {
+		return events.RouteIdentity{}, false
+	}
+	scope, ok := e.workflowSource.FlowScopeByID(flowID)
+	if !ok || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+		return events.RouteIdentity{}, false
+	}
+	entityID := strings.TrimSpace(inbound.EntityID())
+	if entityID == "" {
+		return events.RouteIdentity{}, false
+	}
+	return events.RouteIdentity{EntityID: entityID}.Normalized(), true
 }
 
 func emitFlowInstanceForActorEvent(actor models.AgentConfig, inbound events.Event) string {

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -235,6 +235,10 @@ func (e *Executor) staticFlowEntityParentRoute(flowID string, inbound events.Eve
 	if !ok || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
 		return events.RouteIdentity{}, false
 	}
+	path := strings.Trim(strings.TrimSpace(e.workflowSource.FlowPath(flowID)), "/")
+	if !strings.Contains(path, "/") {
+		return events.RouteIdentity{}, false
+	}
 	entityID := strings.TrimSpace(inbound.EntityID())
 	if entityID == "" {
 		return events.RouteIdentity{}, false

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/flowmodel"
+	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 )
 
@@ -29,6 +30,21 @@ func (b *publishBusCapture) PublishDirect(_ context.Context, evt events.Event, _
 	b.event = evt
 	b.count++
 	return nil
+}
+
+type emitWorkflowInstanceLoader struct {
+	rows map[string]runtimepipeline.WorkflowInstance
+	err  error
+}
+
+func (l emitWorkflowInstanceLoader) Enabled() bool { return true }
+
+func (l emitWorkflowInstanceLoader) Load(_ context.Context, ref string) (runtimepipeline.WorkflowInstance, bool, error) {
+	if l.err != nil {
+		return runtimepipeline.WorkflowInstance{}, false, l.err
+	}
+	instance, ok := l.rows[strings.TrimSpace(ref)]
+	return instance, ok, nil
 }
 
 func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
@@ -318,27 +334,45 @@ func TestHandleEmitTool_TargetsParentRouteForChildPinOutput(t *testing.T) {
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
-	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
-	actor := models.AgentConfig{
-		ID:         "analyzer",
-		Role:       "analyzer",
-		Mode:       "analyzer-flow",
-		FlowPath:   "analyzer-flow",
-		EmitEvents: []string{"analyzer-flow/analysis.done"},
-	}
 	parentRoute := events.RouteIdentity{
 		FlowID:       "root",
 		FlowInstance: "root",
 		EntityID:     "11111111-1111-1111-1111-111111111111",
 	}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{
+		WorkflowSource: source,
+		EmitRegistry:   emitRegistry,
+		WorkflowInstances: emitWorkflowInstanceLoader{rows: map[string]runtimepipeline.WorkflowInstance{
+			"analyzer-flow/inst-1": {
+				Metadata: map[string]any{
+					"parent_flow_id":       parentRoute.FlowID,
+					"parent_flow_instance": parentRoute.FlowInstance,
+					"parent_entity_id":     parentRoute.EntityID,
+				},
+			},
+		}},
+	})
+	actor := models.AgentConfig{
+		ID:         "analyzer",
+		Role:       "analyzer",
+		Mode:       "analyzer-flow",
+		FlowPath:   "analyzer-flow/inst-1",
+		EntityID:   "22222222-2222-2222-2222-222222222222",
+		EmitEvents: []string{"analyzer-flow/analysis.done"},
+	}
 	childRoute := events.RouteIdentity{
 		FlowID:       "analyzer-flow",
-		FlowInstance: "analyzer-flow",
+		FlowInstance: "analyzer-flow/inst-1",
 		EntityID:     "22222222-2222-2222-2222-222222222222",
+	}
+	wrongInboundParent := events.RouteIdentity{
+		FlowID:       "wrong-root",
+		FlowInstance: "wrong-root",
+		EntityID:     "33333333-3333-3333-3333-333333333333",
 	}
 	inbound := (events.Event{
 		Type: events.EventType("analyzer-flow/analysis.requested"),
-	}).WithSourceRoute(parentRoute).WithTargetRoute(childRoute)
+	}).WithSourceRoute(wrongInboundParent).WithTargetRoute(childRoute)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -348,8 +382,145 @@ func TestHandleEmitTool_TargetsParentRouteForChildPinOutput(t *testing.T) {
 	if got := bus.event.TargetRoute(); got != parentRoute {
 		t.Fatalf("target route = %#v, want parent route %#v", got, parentRoute)
 	}
-	if got := bus.event.SourceRoute(); got.Empty() || got.FlowID != "analyzer-flow" {
-		t.Fatalf("source route = %#v, want analyzer-flow source", got)
+	if got := bus.event.SourceRoute(); got.Empty() || got.FlowID != "analyzer-flow" || got.FlowInstance != "analyzer-flow/inst-1" {
+		t.Fatalf("source route = %#v, want analyzer-flow/inst-1 source", got)
+	}
+}
+
+func TestHandleEmitTool_FailsClosedOnIncompleteStoredParentRoute(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
+			},
+		},
+	}
+	analyzerFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "analyzer-flow",
+			Flow: "analyzer-flow",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"analysis.done"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {},
+		},
+		Path: "analyzer-flow",
+	}
+	bundle.FlowTree = flowmodel.Tree[runtimecontracts.FlowContractView]{
+		Root: &runtimecontracts.FlowContractView{
+			Children: []runtimecontracts.FlowContractView{analyzerFlow},
+		},
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"analyzer-flow": &analyzerFlow,
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{
+		WorkflowSource: source,
+		EmitRegistry:   emitRegistry,
+		WorkflowInstances: emitWorkflowInstanceLoader{rows: map[string]runtimepipeline.WorkflowInstance{
+			"analyzer-flow/inst-1": {
+				Metadata: map[string]any{
+					"parent_flow_id":   "root",
+					"parent_entity_id": "11111111-1111-1111-1111-111111111111",
+				},
+			},
+		}},
+	})
+	actor := models.AgentConfig{
+		ID:         "analyzer",
+		Role:       "analyzer",
+		Mode:       "analyzer-flow",
+		FlowPath:   "analyzer-flow/inst-1",
+		EntityID:   "22222222-2222-2222-2222-222222222222",
+		EmitEvents: []string{"analyzer-flow/analysis.done"},
+	}
+	ctx := runtimebus.WithInboundEvent(context.Background(), events.Event{
+		Type: events.EventType("analyzer-flow/analysis.requested"),
+	})
+
+	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
+	if err == nil {
+		t.Fatal("handleEmitTool error = nil, want parent_route_incomplete")
+	}
+	if !strings.Contains(err.Error(), "parent_route_incomplete") {
+		t.Fatalf("handleEmitTool error = %v, want parent_route_incomplete", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
+	}
+}
+
+func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
+			},
+		},
+	}
+	analyzerFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "analyzer-flow",
+			Flow: "analyzer-flow",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"analysis.done"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {},
+		},
+		Path: "analyzer-flow",
+	}
+	bundle.FlowTree = flowmodel.Tree[runtimecontracts.FlowContractView]{
+		Root: &runtimecontracts.FlowContractView{
+			Children: []runtimecontracts.FlowContractView{analyzerFlow},
+		},
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"analyzer-flow": &analyzerFlow,
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "analyzer",
+		Role:       "analyzer",
+		Mode:       "analyzer-flow",
+		FlowPath:   "analyzer-flow",
+		EmitEvents: []string{"analyzer-flow/analysis.done"},
+	}
+	inbound := (events.Event{
+		Type: events.EventType("analyzer-flow/analysis.requested"),
+	}).WithEntityID("11111111-1111-1111-1111-111111111111").WithSourceRoute(events.RouteIdentity{
+		FlowID:       "wrong-root",
+		FlowInstance: "wrong-root",
+		EntityID:     "33333333-3333-3333-3333-333333333333",
+	})
+	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
+
+	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	want := events.RouteIdentity{EntityID: "11111111-1111-1111-1111-111111111111"}
+	if got := bus.event.TargetRoute(); got != want {
+		t.Fatalf("target route = %#v, want delivery entity route %#v", got, want)
 	}
 }
 

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -483,6 +483,70 @@ func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) 
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"analysis.done": {},
 		},
+		Path: "root/analyzer-flow",
+	}
+	bundle.FlowTree = flowmodel.Tree[runtimecontracts.FlowContractView]{
+		Root: &runtimecontracts.FlowContractView{
+			Children: []runtimecontracts.FlowContractView{analyzerFlow},
+		},
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"analyzer-flow": &analyzerFlow,
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "analyzer",
+		Role:       "analyzer",
+		Mode:       "analyzer-flow",
+		FlowPath:   "root/analyzer-flow",
+		EmitEvents: []string{"analyzer-flow/analysis.done"},
+	}
+	inbound := (events.Event{
+		Type: events.EventType("analyzer-flow/analysis.requested"),
+	}).WithEntityID("11111111-1111-1111-1111-111111111111").WithSourceRoute(events.RouteIdentity{
+		FlowID:       "wrong-root",
+		FlowInstance: "wrong-root",
+		EntityID:     "33333333-3333-3333-3333-333333333333",
+	})
+	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
+
+	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	want := events.RouteIdentity{EntityID: "11111111-1111-1111-1111-111111111111"}
+	if got := bus.event.TargetRoute(); got != want {
+		t.Fatalf("target route = %#v, want delivery entity route %#v", got, want)
+	}
+}
+
+func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
+			},
+		},
+	}
+	analyzerFlow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "analyzer-flow",
+			Flow: "analyzer-flow",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"analysis.done"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"analysis.done": {},
+		},
 		Path: "analyzer-flow",
 	}
 	bundle.FlowTree = flowmodel.Tree[runtimecontracts.FlowContractView]{
@@ -507,20 +571,18 @@ func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) 
 	}
 	inbound := (events.Event{
 		Type: events.EventType("analyzer-flow/analysis.requested"),
-	}).WithEntityID("11111111-1111-1111-1111-111111111111").WithSourceRoute(events.RouteIdentity{
-		FlowID:       "wrong-root",
-		FlowInstance: "wrong-root",
-		EntityID:     "33333333-3333-3333-3333-333333333333",
-	})
+	}).WithEntityID("11111111-1111-1111-1111-111111111111")
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
-	if err != nil {
-		t.Fatalf("handleEmitTool: %v", err)
+	if err == nil {
+		t.Fatal("handleEmitTool error = nil, want target_required_missing")
 	}
-	want := events.RouteIdentity{EntityID: "11111111-1111-1111-1111-111111111111"}
-	if got := bus.event.TargetRoute(); got != want {
-		t.Fatalf("target route = %#v, want delivery entity route %#v", got, want)
+	if !strings.Contains(err.Error(), "target_required_missing") {
+		t.Fatalf("handleEmitTool error = %v, want target_required_missing", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1229,7 +1229,8 @@ handler_specification:
         rule: Pin routing activates if and only if the emitted event is declared in the emitter flow's schema.yaml pins.outputs.events.
         ad_hoc_emits: Emits not declared in pins.outputs.events are ordinary event-loop emits and do not require target or broadcast.
         target_requirement: A pin-declared output emit MUST resolve an explicit target, use structural child-to-parent ParentRoute
-          binding, or declare broadcast:true. No silent fallback to event-type broadcast is allowed.
+          binding, use the static no-instance child-flow delivery-entity route where eligible, or declare broadcast:true. No
+          silent fallback to event-type broadcast is allowed.
         explicit_target_precedence: Producer target wins over structural binding. Structural binding writes event.target only
           when the emit site has no explicit target and broadcast:true is absent.
       target_forms:
@@ -1678,6 +1679,10 @@ engine:
     structural_binding:
       child_to_parent: A child flow instance has exactly one parent in v1. Child pin-declared outputs without explicit target
         route to the recorded ParentRoute of the instance that created the child.
+      static_child_no_instance: Static child flows that are not template/dynamic instances have no persisted ParentRoute row.
+        When such a child emits a pin-declared output without explicit target or broadcast:true, the runtime may target only
+        the current delivery entity route. This exception must not read inbound event.source as structural parent authority
+        and does not satisfy ParentRoute metadata for template/dynamic instances.
       parent_to_child: Parent-to-child routing is never inferred structurally in v1. The parent must use target:{instance_id}
         or another explicit target form.
       grandchildren: A grandchild's structural pin output routes to its immediate parent only. Multi-level retargeting is v2.
@@ -6848,6 +6853,10 @@ static_analyzer:
       structural_parent_route:
         rule: Child-to-parent structural binding is valid only for child/template instances that will record full ParentRoute
           at create_flow_instance time.
+      static_child_delivery_entity:
+        rule: Static child flows without a materialized instance row may use the current delivery entity as the only implicit
+          target route for pin-declared outputs; this path is not ParentRoute metadata and must not fall back to inbound
+          event.source.
       explicit_broadcast:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output.
     static_failure_reasons:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1679,10 +1679,11 @@ engine:
     structural_binding:
       child_to_parent: A child flow instance has exactly one parent in v1. Child pin-declared outputs without explicit target
         route to the recorded ParentRoute of the instance that created the child.
-      static_child_no_instance: Static child flows that are not template/dynamic instances have no persisted ParentRoute row.
-        When such a child emits a pin-declared output without explicit target or broadcast:true, the runtime may target only
-        the current delivery entity route. This exception must not read inbound event.source as structural parent authority
-        and does not satisfy ParentRoute metadata for template/dynamic instances.
+      static_child_no_instance: Nested static child flows that are not template/dynamic instances have no persisted ParentRoute
+        row. When such a child emits a pin-declared output without explicit target or broadcast:true, the runtime may target
+        only the current delivery entity route. Eligibility requires the resolved flow scope path to be nested. This exception
+        must not read inbound event.source as structural parent authority and does not satisfy ParentRoute metadata for
+        template/dynamic instances.
       parent_to_child: Parent-to-child routing is never inferred structurally in v1. The parent must use target:{instance_id}
         or another explicit target form.
       grandchildren: A grandchild's structural pin output routes to its immediate parent only. Multi-level retargeting is v2.
@@ -6854,9 +6855,9 @@ static_analyzer:
         rule: Child-to-parent structural binding is valid only for child/template instances that will record full ParentRoute
           at create_flow_instance time.
       static_child_delivery_entity:
-        rule: Static child flows without a materialized instance row may use the current delivery entity as the only implicit
-          target route for pin-declared outputs; this path is not ParentRoute metadata and must not fall back to inbound
-          event.source.
+        rule: Nested static child flows without a materialized instance row may use the current delivery entity as the only
+          implicit target route for pin-declared outputs; root static flows still require an explicit target or broadcast:true.
+          This path is not ParentRoute metadata and must not fall back to inbound event.source.
       explicit_broadcast:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output.
     static_failure_reasons:

--- a/tests/tier11-flow-composition/test-required-agents-child/expected.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/expected.yaml
@@ -5,7 +5,7 @@ trigger:
 
 expected:
   handler_outcome: success
-  entity_state: done
-  emitted_events:
-    - analysis.done
-    - request.complete
+  entity_state: idle
+  agent_received:
+    analyzer:
+      - analyzer-flow/analysis.requested


### PR DESCRIPTION
## Summary

Closes #1114.

Preserves runtime-owned ParentRoute/control metadata across flow-instance activation, persisted projection/reload, and handler state mutation, then makes child pin-output routing consume that canonical metadata for both system-node and generated agent emit surfaces.

## Governing Refs

- `platform-spec.yaml` routing / pin routing sections: `event_routing.target_resolution.structural_binding.parent_route`, `dynamic_instance_lifecycle.creation.parent_route`, and the pin-routing failure taxonomy.
- Approved #1114 gate: `runtime.parent_route_control_metadata_preservation_across_system_node_and_agent_emit_surfaces`.
- This PR updates `platform-spec.yaml` to record the limited static child no-instance delivery-entity route used by existing static child-flow required-agent surfaces; template/dynamic ParentRoute remains strict and fails closed when incomplete.

## Semantic Migration

- New canonical owner: `internal/runtime/core/flowidentity.ParentRouteFromMetadata` plus `runtimeflowidentity.ParentRoute` for metadata interpretation; persisted ownership is in the shared workflow instance projection (`internal/runtime/pipeline/workflow_instance_store.go`).
- Old non-authoritative paths invalidated: `parent_flow_path` fallback in `runtimeengine.parentRouteFromState`; generated emit-tool routing no longer derives structural parent route from inbound `event.source`.
- Production paths checked: `AgentManager.ActivateFlowInstance`, workflow instance Postgres/SQLite projection and reload, `applyEngineStateMutation`, system-node emit routing, generated agent emit-tool routing, runtime construction wiring.
- Migration complete for #1114 chosen class. Existing children with partial legacy ParentRoute metadata fail closed with `parent_route_incomplete`; static non-instance child flows use only current delivery entity routing and do not satisfy ParentRoute metadata.

## Verification

- `go test ./internal/runtime/core/pinrouting ./internal/runtime/engine ./internal/runtime/tools ./internal/runtime/pipeline ./internal/runtime/manager -count=1`
- `go test ./internal/runtime/core/pinrouting ./internal/runtime/tools ./internal/runtime/cataloge2e -run 'TestResolve|TestHandleEmitTool|TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-required-agents-child' -count=1`
- `go test ./... -count=1`