### PR TITLE
[agent-g][issue #1186] Promote mailbox write materialization owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -132,6 +132,7 @@ type storeBundle struct {
 	ConversationStore   runtimellm.ConversationPersistence
 	ManagerStore        runtimemanager.ManagerPersistence
 	ScheduleStore       runtimepipeline.SchedulePersistence
+	MailboxMaterializer runtimepipeline.MailboxWriteMaterializationStore
 	MailboxStore        runtimetools.MailboxPersistence
 	ToolEntityStore     runtimetools.EntityPersistence
 	HumanTaskStore      runtimetools.HumanTaskPersistence
@@ -155,6 +156,7 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 		ConversationStore:   s.ConversationStore,
 		ManagerStore:        s.ManagerStore,
 		ScheduleStore:       s.ScheduleStore,
+		MailboxMaterializer: s.MailboxMaterializer,
 		StartupOwnership:    s.StartupOwnership,
 		MailboxStore:        s.MailboxStore,
 		ToolEntityStore:     s.ToolEntityStore,
@@ -2080,6 +2082,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ConversationStore:   pg,
 			ManagerStore:        pg,
 			ScheduleStore:       pg,
+			MailboxMaterializer: pg,
 			MailboxStore:        pg,
 			ToolEntityStore:     pg,
 			HumanTaskStore:      pg,
@@ -2107,7 +2110,6 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
 			SQLDB:               sqliteStore.DB,
-			RuntimeBlocker:      "sqlite runtime construction remains fail-closed until #1087 mailbox_write materialization moves off the raw pipeline SQL database or receives explicit lead-approved split/tracker repair",
 			RuntimeLogStore:     sqliteStore,
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
@@ -2116,6 +2118,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ConversationStore:   sqliteStore,
 			ManagerStore:        sqliteStore,
 			ScheduleStore:       sqliteStore,
+			MailboxMaterializer: sqliteStore,
 			MailboxStore:        sqliteStore,
 			ToolEntityStore:     sqliteStore,
 			HumanTaskStore:      sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -11,6 +11,10 @@ import (
 
 	"swarm/internal/config"
 	"swarm/internal/runtime"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimellm "swarm/internal/runtime/llm"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/runtime/semanticview"
 	storebackend "swarm/internal/store/backendselection"
 )
 
@@ -181,7 +185,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxMaterializer == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -194,11 +198,11 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if runtimeStores.RuntimeLogStore == nil {
 		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
 	}
-	if strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics blocker removed", runtimeStores.ConstructionBlocker)
+	if runtimeStores.MailboxMaterializer == nil {
+		t.Fatal("sqlite runtimeStores MailboxMaterializer missing backend-neutral mailbox_write owner")
 	}
-	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 mailbox_write materialization") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want residual #1087 mailbox_write blocker", runtimeStores.ConstructionBlocker)
+	if runtimeStores.ConstructionBlocker != "" {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want explicit sqlite construction unblocked after mailbox_write owner", runtimeStores.ConstructionBlocker)
 	}
 	if strings.Contains(runtimeStores.ConstructionBlocker, "pipeline coordination/background nodes") {
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1147 pipeline/background owner removed from residual blocker", runtimeStores.ConstructionBlocker)
@@ -223,7 +227,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 }
 
-func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner(t *testing.T) {
+func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "dev.db")
 	stores, err := buildStores(ctx, storebackend.Selection{
@@ -243,25 +247,86 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnDiagnosticsOwner(t *testin
 	if runtimeStores.RuntimeLogStore == nil {
 		t.Fatal("sqlite runtimeStores RuntimeLogStore missing backend-neutral runtime diagnostics owner")
 	}
-	if strings.Contains(runtimeStores.ConstructionBlocker, "#1150 runtime diagnostics/logging") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want #1150 diagnostics blocker removed", runtimeStores.ConstructionBlocker)
+	if runtimeStores.MailboxMaterializer == nil {
+		t.Fatal("sqlite runtimeStores MailboxMaterializer missing backend-neutral mailbox_write owner")
 	}
-	if !strings.Contains(runtimeStores.ConstructionBlocker, "#1087 mailbox_write materialization") {
-		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want residual #1087 mailbox_write blocker", runtimeStores.ConstructionBlocker)
+	if runtimeStores.ConstructionBlocker != "" {
+		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want construction blocker removed after mailbox_write owner", runtimeStores.ConstructionBlocker)
 	}
-	_, err = runtime.NewRuntime(ctx, runtime.RuntimeDeps{
-		Config:  &config.Config{},
-		Stores:  runtimeStores,
-		Options: runtime.RuntimeOptions{SelfCheck: true},
+	bundle := loadStoreBackendSelectionWorkflowBundle(t)
+	if _, err := initializeStateStores(ctx, stores, bundle); err != nil {
+		t.Fatalf("initializeStateStores(sqlite): %v", err)
+	}
+	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{
+		Config: &config.Config{},
+		Stores: runtimeStores,
+		Options: runtime.RuntimeOptions{
+			SelfCheck:      true,
+			WorkflowModule: stubWorkflowModule{source: semanticview.Wrap(bundle)},
+			LLMRuntime:     storeBackendSelectionNoopLLMRuntime{},
+		},
 	})
-	if err == nil {
-		t.Fatal("NewRuntime(sqlite) succeeded, want residual #1087 mailbox_write blocker")
+	if err != nil {
+		t.Fatalf("NewRuntime(sqlite): %v", err)
 	}
-	if strings.Contains(err.Error(), "#1150 runtime diagnostics/logging") {
-		t.Fatalf("NewRuntime(sqlite) error = %v, want #1150 diagnostics blocker removed", err)
+	if rt.Pipeline == nil {
+		t.Fatal("NewRuntime(sqlite) Pipeline = nil, want runtime construction to consume SQLite pipeline store")
 	}
-	if !strings.Contains(err.Error(), "#1087 mailbox_write materialization") {
-		t.Fatalf("NewRuntime(sqlite) error = %v, want residual #1087 mailbox_write blocker after #1150 owner", err)
+	if rt.Stores.SQLDB != nil {
+		t.Fatalf("NewRuntime(sqlite) raw SQLDB = %#v, want nil", rt.Stores.SQLDB)
+	}
+	if rt.Stores.MailboxMaterializer == nil {
+		t.Fatal("NewRuntime(sqlite) MailboxMaterializer missing")
+	}
+}
+
+type storeBackendSelectionNoopLLMRuntime struct{}
+
+func (storeBackendSelectionNoopLLMRuntime) StartSession(context.Context, string, string, []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	return &runtimellm.Session{}, nil
+}
+
+func (storeBackendSelectionNoopLLMRuntime) ContinueSession(context.Context, *runtimellm.Session, runtimellm.Message) (*runtimellm.Response, error) {
+	return &runtimellm.Response{}, nil
+}
+
+func loadStoreBackendSelectionWorkflowBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: store-backend-selection
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: store-backend-selection
+initial_state: idle
+states:
+  - idle
+terminal_states:
+  - idle
+`)
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeStoreBackendSelectionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func writeStoreBackendSelectionFixtureFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }
 

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -133,6 +133,10 @@ active_issues:
     title: Close SQLite-default rollout with docs, CI, repo-wide old-path audit, and parent proof
     maps_to:
       - runtime_store_backend_default_and_sqlite_portability
+  - id: 1186
+    title: Promote backend-neutral mailbox_write materialization for SQLite runtime construction
+    maps_to:
+      - runtime_store_backend_default_and_sqlite_portability
   - id: 175
     title: Add first-class launch, stalled-run, and long-running session observability
     maps_to:
@@ -434,15 +438,16 @@ nodes:
     canonical_owners:
       - platform-spec.yaml runtime_store_backend_selection
       - internal/store/backendselection runtime store backend resolver and SQLite path resolver
-      - "future SQLite schema/store/session/delivery/trace owners tracked by #1085-#1088 before public default flip"
+      - "SQLite schema/store/session/delivery/trace/mailbox materialization owners tracked by #1085-#1088 and #1186 before public default flip"
     why_this_node_exists: Runtime store semantics drift when CLI defaults, env/config loading, runtime store construction, schema bootstrap, session locking, event delivery/replay, trace reads, docs, and CI each infer Postgres or SQLite support independently.
     known_manifestations:
       - "#1084 owns canonical backend ids postgres/sqlite, selector precedence flag > environment > runtime config > rollout default, SWARM_STORE_BACKEND, SWARM_SQLITE_PATH, store.backend, store.sqlite.path, and the staged SQLite path authority."
       - "#1085 must own SQLite dialect, schema bootstrap, and backend capability binding before SQLite can construct runtime stores."
       - "#1086 must port core runtime persistence stores behind backend-neutral SQLite/Postgres contracts."
-      - "#1087 must port session, locking, delivery, replay, trace-stream, mailbox_write materialization, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent and mailbox_write remains a residual construction blocker until separately gated."
+      - "#1087 must port session, locking, delivery, replay, trace-stream, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent."
+      - "#1186 promotes backend-neutral mailbox_write materialization through runtimepipeline.MailboxWriteMaterializationStore and removes the residual raw-SQL runtime construction blocker for explicit SQLite selection."
       - "#1088 must flip the active local/dev default to SQLite only after zero-service swarm run and explicit Postgres opt-in are proven together."
-      - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes."
+      - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes; #1157 agent.usage read parity and production SQLite multi-writer semantics remain explicitly split until separately closed."
     representative_issues:
       - 1066
       - 1084
@@ -451,6 +456,7 @@ nodes:
       - 1087
       - 1088
       - 1089
+      - 1186
     common_framing_mistakes:
       too_broad:
         - make SQLite production-ready in the local/dev default rollout

--- a/internal/apiv1/operator_mailbox_materialization_test.go
+++ b/internal/apiv1/operator_mailbox_materialization_test.go
@@ -1,0 +1,101 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	"swarm/internal/events"
+	"swarm/internal/platform"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	storepkg "swarm/internal/store"
+)
+
+func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newSQLiteMailboxMaterializationAPIStore(t, ctx)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if err := sqliteStore.AppendEvent(ctx, (events.Event{
+		ID:        eventID,
+		RunID:     runID,
+		Type:      "mailbox.review_requested",
+		Payload:   json.RawMessage(`{"kind":"review"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	itemID := uuid.NewString()
+	tx, err := sqliteStore.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	for i := 0; i < 2; i++ {
+		if err := sqliteStore.MaterializeMailboxWrite(txctx, runtimepipeline.MailboxWriteMaterialization{
+			ItemID:        itemID,
+			EntityID:      entityID,
+			FlowInstance:  "validation/case-1",
+			Scope:         "entity",
+			ItemType:      "review_request",
+			SourceEventID: eventID,
+			FromAgent:     "system_node:mailbox-node",
+			Severity:      "urgent",
+			Summary:       "Review validation package",
+			Payload:       json.RawMessage(`{"review_kind":"validation"}`),
+		}); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("MaterializeMailboxWrite iteration %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Ready:    func() bool { return true },
+			Database: fakePinger{},
+			Mailbox:  sqliteStore,
+		}),
+	})
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"mailbox.list","params":{"status":"pending","run_id":"`+runID+`","entity_id":"`+entityID+`","type":"review_request","priority":"high","limit":1}}`)
+	if list.Error != nil {
+		t.Fatalf("mailbox.list error = %#v", list.Error)
+	}
+	items := asMap(t, list.Result)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("mailbox.list items = %#v", items)
+	}
+	got := asMap(t, items[0])
+	if got["mailbox_id"] != itemID || got["source_event_id"] != eventID || got["source_flow"] != "validation/case-1" || got["priority"] != "high" {
+		t.Fatalf("mailbox.list item = %#v, want materialized mailbox_write row", got)
+	}
+}
+
+func newSQLiteMailboxMaterializationAPIStore(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
+	t.Helper()
+	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() { _ = sqliteStore.Close() })
+	var platformSpec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	return sqliteStore
+}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -55,6 +55,7 @@ type PipelineCoordinator struct {
 	instanceDeactivator     FlowInstanceDeactivator
 	timerScheduler          *Scheduler
 	timerScheduleStore      SchedulePersistence
+	mailboxMaterializer     MailboxWriteMaterializationStore
 	eventReceiptsCapability func(context.Context) (bool, error)
 	artifactRoot            string
 	bundleFingerprint       string
@@ -71,6 +72,7 @@ type PipelineCoordinatorOptions struct {
 	InstanceDeactivator     FlowInstanceDeactivator
 	TimerScheduler          *Scheduler
 	TimerScheduleStore      SchedulePersistence
+	MailboxMaterializer     MailboxWriteMaterializationStore
 	EventReceiptsCapability func(context.Context) (bool, error)
 	ArtifactRoot            string
 	BundleFingerprint       string
@@ -98,6 +100,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		instanceDeactivator:     opts.InstanceDeactivator,
 		timerScheduler:          opts.TimerScheduler,
 		timerScheduleStore:      opts.TimerScheduleStore,
+		mailboxMaterializer:     opts.MailboxMaterializer,
 		eventReceiptsCapability: opts.EventReceiptsCapability,
 		artifactRoot:            strings.TrimSpace(opts.ArtifactRoot),
 		bundleFingerprint:       strings.TrimSpace(opts.BundleFingerprint),

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -643,16 +643,10 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 }
 
 func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	defer cleanup()
-	pc := &PipelineCoordinator{db: db}
+	materializer := &recordingMailboxWriteMaterializer{}
+	pc := &PipelineCoordinator{mailboxMaterializer: materializer}
 	runner := pipelineEngineActionRunner{coordinator: pc}
 	ctx := context.Background()
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("BeginTx: %v", err)
-	}
-	txctx := WithPipelineSQLTxContext(ctx, tx)
 	eventID := "11111111-1111-1111-1111-111111111111"
 	entityID := "22222222-2222-2222-2222-222222222222"
 	action := runtimecontracts.ActionSpec{
@@ -690,59 +684,46 @@ func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *tes
 		},
 	}
 	for i := 0; i < 2; i++ {
-		ok, err := runner.ExecuteAction(txctx, action, runtimeregistry.ActionInstruction{Builtin: "mailbox_write"}, execCtx)
+		ok, err := runner.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "mailbox_write"}, execCtx)
 		if err != nil {
-			_ = tx.Rollback()
 			t.Fatalf("ExecuteAction iteration %d: %v", i, err)
 		}
 		if !ok {
-			_ = tx.Rollback()
 			t.Fatalf("ExecuteAction iteration %d was not claimed", i)
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("Commit: %v", err)
+	if materializer.calls != 2 {
+		t.Fatalf("materializer calls = %d, want duplicate attempts to reach idempotent owner", materializer.calls)
 	}
-
-	var count int
-	var sourceEventID, gotEntityID, flowInstance, itemType, severity, summary, payloadKind, fromAgent, status string
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*),
-		       COALESCE(MAX(source_event_id::text), ''),
-		       COALESCE(MAX(entity_id::text), ''),
-		       COALESCE(MAX(flow_instance), ''),
-		       COALESCE(MAX(item_type), ''),
-		       COALESCE(MAX(severity), ''),
-		       COALESCE(MAX(summary), ''),
-		       COALESCE(MAX(payload->>'review_kind'), ''),
-		       COALESCE(MAX(from_agent), ''),
-		       COALESCE(MAX(status), '')
-		FROM mailbox
-		WHERE source_event_id = $1::uuid
-	`, eventID).Scan(&count, &sourceEventID, &gotEntityID, &flowInstance, &itemType, &severity, &summary, &payloadKind, &fromAgent, &status); err != nil {
-		t.Fatalf("query mailbox: %v", err)
+	rows := materializer.rows()
+	if len(rows) != 1 {
+		t.Fatalf("materialized rows = %d, want 1 idempotent row", len(rows))
 	}
-	if count != 1 {
-		t.Fatalf("mailbox row count = %d, want 1", count)
+	got := rows[0]
+	if got.ItemID != deterministicMailboxItemID(eventID, "mailbox-node") {
+		t.Fatalf("item_id = %q, want deterministic id", got.ItemID)
 	}
-	if sourceEventID != eventID || gotEntityID != entityID || flowInstance != "validation/case-1" {
-		t.Fatalf("mailbox identity = source %q entity %q flow %q", sourceEventID, gotEntityID, flowInstance)
+	if got.SourceEventID != eventID || got.EntityID != entityID || got.FlowInstance != "validation/case-1" || got.Scope != "entity" {
+		t.Fatalf("mailbox identity = source %q entity %q flow %q scope %q", got.SourceEventID, got.EntityID, got.FlowInstance, got.Scope)
 	}
-	if itemType != "review_request" || severity != "urgent" || summary != "Review validation package" || status != "pending" {
-		t.Fatalf("mailbox row fields type=%q severity=%q summary=%q status=%q", itemType, severity, summary, status)
+	if got.ItemType != "review_request" || got.Severity != "urgent" || got.Summary != "Review validation package" {
+		t.Fatalf("mailbox fields type=%q severity=%q summary=%q", got.ItemType, got.Severity, got.Summary)
 	}
-	if payloadKind != "validation" {
-		t.Fatalf("payload review_kind = %q", payloadKind)
+	var payload map[string]any
+	if err := json.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("decode materialized payload: %v", err)
 	}
-	if fromAgent != "system_node:mailbox-node" {
-		t.Fatalf("from_agent = %q", fromAgent)
+	if payload["review_kind"] != "validation" || payload["operator_hint"] != "inspect_package" {
+		t.Fatalf("payload = %#v, want review_kind/operator_hint", payload)
+	}
+	if got.FromAgent != "system_node:mailbox-node" {
+		t.Fatalf("from_agent = %q", got.FromAgent)
 	}
 }
 
 func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpression(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	defer cleanup()
-	runner := pipelineEngineActionRunner{coordinator: &PipelineCoordinator{db: db}}
+	materializer := &recordingMailboxWriteMaterializer{}
+	runner := pipelineEngineActionRunner{coordinator: &PipelineCoordinator{mailboxMaterializer: materializer}}
 	ctx := context.Background()
 	eventID := "33333333-3333-3333-3333-333333333333"
 	action := runtimecontracts.ActionSpec{
@@ -770,13 +751,38 @@ func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpr
 	if err == nil || !strings.Contains(err.Error(), "mailbox.summary resolved empty") {
 		t.Fatalf("ExecuteAction error = %v, want missing summary", err)
 	}
-	var count int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE source_event_id = $1::uuid`, eventID).Scan(&count); err != nil {
-		t.Fatalf("query mailbox count: %v", err)
+	if materializer.calls != 0 {
+		t.Fatalf("materializer calls = %d, want no persistence after validation failure", materializer.calls)
 	}
-	if count != 0 {
-		t.Fatalf("mailbox row count = %d, want 0", count)
+}
+
+type recordingMailboxWriteMaterializer struct {
+	mu    sync.Mutex
+	calls int
+	byID  map[string]MailboxWriteMaterialization
+}
+
+func (m *recordingMailboxWriteMaterializer) MaterializeMailboxWrite(_ context.Context, item MailboxWriteMaterialization) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.byID == nil {
+		m.byID = map[string]MailboxWriteMaterialization{}
 	}
+	if _, ok := m.byID[item.ItemID]; !ok {
+		m.byID[item.ItemID] = item
+	}
+	return nil
+}
+
+func (m *recordingMailboxWriteMaterializer) rows() []MailboxWriteMaterialization {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]MailboxWriteMaterialization, 0, len(m.byID))
+	for _, row := range m.byID {
+		out = append(out, row)
+	}
+	return out
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t *testing.T) {

--- a/internal/runtime/pipeline/mailbox_materialization.go
+++ b/internal/runtime/pipeline/mailbox_materialization.go
@@ -14,9 +14,26 @@ import (
 	"swarm/internal/runtime/workflowexpr"
 )
 
+type MailboxWriteMaterialization struct {
+	ItemID        string
+	EntityID      string
+	FlowInstance  string
+	Scope         string
+	ItemType      string
+	SourceEventID string
+	FromAgent     string
+	Severity      string
+	Summary       string
+	Payload       json.RawMessage
+}
+
+type MailboxWriteMaterializationStore interface {
+	MaterializeMailboxWrite(context.Context, MailboxWriteMaterialization) error
+}
+
 func (pc *PipelineCoordinator) materializeMailboxItem(ctx context.Context, action runtimecontracts.ActionSpec, execCtx runtimeengine.ExecutionContext) error {
-	if pc == nil || pc.db == nil {
-		return fmt.Errorf("mailbox_write requires pipeline database")
+	if pc == nil || pc.mailboxMaterializer == nil {
+		return fmt.Errorf("mailbox_write requires mailbox materialization store")
 	}
 	spec := action.Mailbox
 	if spec == nil {
@@ -90,19 +107,20 @@ func (pc *PipelineCoordinator) materializeMailboxItem(ctx context.Context, actio
 		scope = "flow"
 	}
 	itemID := deterministicMailboxItemID(sourceEventID, nodeID)
-	_, err = dbExecContext(ctx, pc.db, `
-		INSERT INTO mailbox (
-			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
-			from_agent, severity, summary, payload, status, notified, created_at
-		)
-		VALUES (
-			$1::uuid, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5, $6::uuid,
-			$7, $8, NULLIF($9,''), $10::jsonb, 'pending', false, now()
-		)
-		ON CONFLICT (item_id) DO NOTHING
-	`, itemID, strings.TrimSpace(entityID), flowInstance, scope, normalizedType, sourceEventID, "system_node:"+nodeID, severity, summary, string(payloadJSON))
-	if err != nil {
-		return fmt.Errorf("mailbox_write insert: %w", err)
+	record := MailboxWriteMaterialization{
+		ItemID:        itemID,
+		EntityID:      strings.TrimSpace(entityID),
+		FlowInstance:  flowInstance,
+		Scope:         scope,
+		ItemType:      normalizedType,
+		SourceEventID: sourceEventID,
+		FromAgent:     "system_node:" + nodeID,
+		Severity:      severity,
+		Summary:       summary,
+		Payload:       json.RawMessage(payloadJSON),
+	}
+	if err := pc.mailboxMaterializer.MaterializeMailboxWrite(ctx, record); err != nil {
+		return fmt.Errorf("mailbox_write materialize: %w", err)
 	}
 	return nil
 }

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -301,6 +301,7 @@ func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.
 func newSelectedContractPipeline(bus *runtimebus.EventBus, store *store.PostgresStore, loaded LoadedSelectedContractSource) *runtimepipeline.PipelineCoordinator {
 	return runtimepipeline.NewPipelineCoordinatorWithOptions(bus, store.DB, runtimepipeline.PipelineCoordinatorOptions{
 		Module:                  loaded.Module,
+		MailboxMaterializer:     store,
 		EventReceiptsCapability: store.CanonicalEventReceiptsCapability,
 	})
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -48,6 +48,7 @@ type Stores struct {
 	ConversationStore   llm.ConversationPersistence
 	ManagerStore        runtimemanager.ManagerPersistence
 	ScheduleStore       runtimepipeline.SchedulePersistence
+	MailboxMaterializer runtimepipeline.MailboxWriteMaterializationStore
 	StartupOwnership    runtimestartupownership.Store
 	MailboxStore        runtimetools.MailboxPersistence
 	ToolEntityStore     runtimetools.EntityPersistence
@@ -453,6 +454,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			},
 			TimerScheduler:          rt.Scheduler,
 			TimerScheduleStore:      stores.ScheduleStore,
+			MailboxMaterializer:     stores.MailboxMaterializer,
 			EventReceiptsCapability: boot.EventReceiptCapability,
 			ArtifactRoot:            artifactRoot,
 			BundleFingerprint:       opts.BundleFingerprint,

--- a/internal/store/mailbox_materialization.go
+++ b/internal/store/mailbox_materialization.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+)
+
+type mailboxMaterializationExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func (s *PostgresStore) MaterializeMailboxWrite(ctx context.Context, item runtimepipeline.MailboxWriteMaterialization) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	item, err = normalizeMailboxWriteMaterialization(item)
+	if err != nil {
+		return err
+	}
+	exec := mailboxMaterializationDBExecutor(ctx, s.DB)
+	_, err = exec.ExecContext(ctx, `
+		INSERT INTO mailbox (
+			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+			from_agent, severity, summary, payload, status, notified, created_at
+		)
+		VALUES (
+			$1::uuid, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5, $6::uuid,
+			$7, $8, NULLIF($9,''), $10::jsonb, 'pending', false, now()
+		)
+		ON CONFLICT (item_id) DO NOTHING
+	`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload))
+	if err != nil {
+		return fmt.Errorf("materialize postgres mailbox_write: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) MaterializeMailboxWrite(ctx context.Context, item runtimepipeline.MailboxWriteMaterialization) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Mailbox != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("mailbox", caps.Mailbox)
+	}
+	item, err = normalizeMailboxWriteMaterialization(item)
+	if err != nil {
+		return err
+	}
+	exec := mailboxMaterializationDBExecutor(ctx, s.DB)
+	_, err = exec.ExecContext(ctx, `
+		INSERT INTO mailbox (
+			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+			from_agent, severity, summary, payload, status, notified, created_at
+		)
+		VALUES (?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'pending', 0, ?)
+		ON CONFLICT(item_id) DO NOTHING
+	`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("materialize sqlite mailbox_write: %w", err)
+	}
+	return nil
+}
+
+func mailboxMaterializationDBExecutor(ctx context.Context, db *sql.DB) mailboxMaterializationExecutor {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return tx
+	}
+	return db
+}
+
+func normalizeMailboxWriteMaterialization(item runtimepipeline.MailboxWriteMaterialization) (runtimepipeline.MailboxWriteMaterialization, error) {
+	item.ItemID = strings.TrimSpace(item.ItemID)
+	item.EntityID = strings.TrimSpace(item.EntityID)
+	item.FlowInstance = strings.Trim(strings.TrimSpace(item.FlowInstance), "/")
+	item.Scope = strings.ToLower(strings.TrimSpace(item.Scope))
+	item.ItemType = strings.TrimSpace(item.ItemType)
+	item.SourceEventID = strings.TrimSpace(item.SourceEventID)
+	item.FromAgent = strings.TrimSpace(item.FromAgent)
+	item.Severity = normalizeMailboxSeverity(item.Severity)
+	item.Summary = strings.TrimSpace(item.Summary)
+	if item.ItemID == "" {
+		return item, fmt.Errorf("mailbox_write item_id is required")
+	}
+	if _, err := uuid.Parse(item.ItemID); err != nil {
+		return item, fmt.Errorf("mailbox_write item_id: %w", err)
+	}
+	if item.SourceEventID == "" {
+		return item, fmt.Errorf("mailbox_write source_event_id is required")
+	}
+	if _, err := uuid.Parse(item.SourceEventID); err != nil {
+		return item, fmt.Errorf("mailbox_write source_event_id: %w", err)
+	}
+	if item.EntityID != "" {
+		if _, err := uuid.Parse(item.EntityID); err != nil {
+			return item, fmt.Errorf("mailbox_write entity_id: %w", err)
+		}
+	}
+	if item.ItemType == "" {
+		return item, fmt.Errorf("mailbox_write item_type is required")
+	}
+	if item.FromAgent == "" {
+		return item, fmt.Errorf("mailbox_write from_agent is required")
+	}
+	if item.Summary == "" {
+		return item, fmt.Errorf("mailbox_write summary is required")
+	}
+	if len(item.Payload) == 0 || string(item.Payload) == "null" {
+		item.Payload = json.RawMessage(`{}`)
+	}
+	if !json.Valid(item.Payload) {
+		return item, fmt.Errorf("mailbox_write payload must be valid JSON")
+	}
+	derivedScope := "global"
+	switch {
+	case item.EntityID != "":
+		derivedScope = "entity"
+	case item.FlowInstance != "":
+		derivedScope = "flow"
+	}
+	if item.Scope == "" {
+		item.Scope = derivedScope
+	}
+	if item.Scope != derivedScope {
+		return item, fmt.Errorf("mailbox_write scope %q does not match materialization fields %q", item.Scope, derivedScope)
+	}
+	return item, nil
+}

--- a/internal/store/mailbox_materialization_test.go
+++ b/internal/store/mailbox_materialization_test.go
@@ -1,0 +1,197 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+	runtimepipeline "swarm/internal/runtime/pipeline"
+	"swarm/internal/testutil"
+)
+
+func TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := &PostgresStore{DB: db}
+	ctx := context.Background()
+	if _, err := store.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if err := store.AppendEvent(ctx, (events.Event{
+		ID:        eventID,
+		RunID:     runID,
+		Type:      "mailbox.review_requested",
+		Payload:   json.RawMessage(`{"kind":"review"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	item := runtimepipeline.MailboxWriteMaterialization{
+		ItemID:        uuid.NewString(),
+		EntityID:      entityID,
+		FlowInstance:  "validation/case-1",
+		Scope:         "entity",
+		ItemType:      "review_request",
+		SourceEventID: eventID,
+		FromAgent:     "system_node:mailbox-node",
+		Severity:      "urgent",
+		Summary:       "Review validation package",
+		Payload:       json.RawMessage(`{"review_kind":"validation"}`),
+	}
+
+	rollbackTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx rollback: %v", err)
+	}
+	if err := store.MaterializeMailboxWrite(runtimepipeline.WithPipelineSQLTxContext(ctx, rollbackTx), item); err != nil {
+		t.Fatalf("MaterializeMailboxWrite rollback: %v", err)
+	}
+	if err := rollbackTx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	assertPostgresMailboxMaterializationCount(t, ctx, db, item.ItemID, 0)
+
+	commitTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx commit: %v", err)
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, commitTx)
+	for i := 0; i < 2; i++ {
+		if err := store.MaterializeMailboxWrite(txctx, item); err != nil {
+			_ = commitTx.Rollback()
+			t.Fatalf("MaterializeMailboxWrite commit iteration %d: %v", i, err)
+		}
+	}
+	if err := commitTx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	assertPostgresMailboxMaterializationCount(t, ctx, db, item.ItemID, 1)
+	assertV1MailboxMaterializationRead(t, ctx, store, item, runID)
+}
+
+func TestSQLiteRuntimeStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *testing.T) {
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if err := store.AppendEvent(ctx, (events.Event{
+		ID:        eventID,
+		RunID:     runID,
+		Type:      "mailbox.review_requested",
+		Payload:   json.RawMessage(`{"kind":"review"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	item := runtimepipeline.MailboxWriteMaterialization{
+		ItemID:        uuid.NewString(),
+		EntityID:      entityID,
+		FlowInstance:  "validation/case-1",
+		Scope:         "entity",
+		ItemType:      "review_request",
+		SourceEventID: eventID,
+		FromAgent:     "system_node:mailbox-node",
+		Severity:      "urgent",
+		Summary:       "Review validation package",
+		Payload:       json.RawMessage(`{"review_kind":"validation"}`),
+	}
+
+	rollbackTx, err := store.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx rollback: %v", err)
+	}
+	if err := store.MaterializeMailboxWrite(runtimepipeline.WithPipelineSQLTxContext(ctx, rollbackTx), item); err != nil {
+		t.Fatalf("MaterializeMailboxWrite rollback: %v", err)
+	}
+	if err := rollbackTx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	assertSQLiteMailboxMaterializationCount(t, ctx, store, item.ItemID, 0)
+
+	commitTx, err := store.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx commit: %v", err)
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, commitTx)
+	for i := 0; i < 2; i++ {
+		if err := store.MaterializeMailboxWrite(txctx, item); err != nil {
+			_ = commitTx.Rollback()
+			t.Fatalf("MaterializeMailboxWrite commit iteration %d: %v", i, err)
+		}
+	}
+	if err := commitTx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	assertSQLiteMailboxMaterializationCount(t, ctx, store, item.ItemID, 1)
+	assertV1MailboxMaterializationRead(t, ctx, store, item, runID)
+}
+
+type mailboxV1ReadStore interface {
+	ListV1MailboxItems(context.Context, MailboxV1ListOptions) ([]MailboxV1Item, string, error)
+	GetV1MailboxItem(context.Context, string) (MailboxV1ItemDetail, error)
+}
+
+func assertV1MailboxMaterializationRead(t *testing.T, ctx context.Context, store mailboxV1ReadStore, item runtimepipeline.MailboxWriteMaterialization, runID string) {
+	t.Helper()
+	items, cursor, err := store.ListV1MailboxItems(ctx, MailboxV1ListOptions{
+		Status:   "pending",
+		RunID:    runID,
+		EntityID: item.EntityID,
+		Type:     item.ItemType,
+		Priority: item.Severity,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListV1MailboxItems: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("ListV1MailboxItems cursor = %q, want empty", cursor)
+	}
+	if len(items) != 1 {
+		t.Fatalf("ListV1MailboxItems len = %d, want 1: %#v", len(items), items)
+	}
+	got := items[0]
+	wantPriority := item.Severity
+	if wantPriority == "urgent" {
+		wantPriority = "high"
+	}
+	if got.MailboxID != item.ItemID || got.SourceEventID != item.SourceEventID || got.SourceRunID != runID || got.SourceEntityID != item.EntityID || got.SourceFlow != item.FlowInstance || got.Priority != wantPriority {
+		t.Fatalf("v1 mailbox item = %#v, want materialized identity", got)
+	}
+	detail, err := store.GetV1MailboxItem(ctx, item.ItemID)
+	if err != nil {
+		t.Fatalf("GetV1MailboxItem: %v", err)
+	}
+	if detail.Item.MailboxID != item.ItemID || detail.Payload["review_kind"] != "validation" {
+		t.Fatalf("v1 mailbox detail = %#v, want materialized payload", detail)
+	}
+}
+
+func assertPostgresMailboxMaterializationCount(t *testing.T, ctx context.Context, db execQueryer, itemID string, want int) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE item_id = $1::uuid`, itemID).Scan(&count); err != nil {
+		t.Fatalf("count postgres mailbox materializations: %v", err)
+	}
+	if count != want {
+		t.Fatalf("postgres mailbox materialization count = %d, want %d", count, want)
+	}
+}
+
+func assertSQLiteMailboxMaterializationCount(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, itemID string, want int) {
+	t.Helper()
+	var count int
+	if err := store.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM mailbox WHERE item_id = ?`, itemID).Scan(&count); err != nil {
+		t.Fatalf("count sqlite mailbox materializations: %v", err)
+	}
+	if count != want {
+		t.Fatalf("sqlite mailbox materialization count = %d, want %d", count, want)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2114,9 +2114,9 @@ engine:
         meaning: >
           Local/dev SQLite runtime store selection. Explicit sqlite selection may construct the selected typed SQLite store
           owners promoted by #1086 and staged by #1087, including backend-neutral runtime diagnostics/log persistence
-          promoted by #1150, but runtime boot remains fail-closed while mailbox_write materialization still depends on
-          the raw pipeline SQL database. SQLite remains staged until the public default flip is separately proven by
-          #1088; it does not promote production multi-writer SQLite semantics.
+          promoted by #1150 and backend-neutral mailbox_write materialization promoted by #1186, without exposing a raw
+          runtime SQL handle to Postgres-only consumers. SQLite remains staged until the public default flip is separately
+          proven by #1088; it does not promote production multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2174,8 +2174,8 @@ engine:
     - >
       Explicit sqlite selection is recognized as a canonical backend id. It may construct the selected typed SQLite store
       owners without passing a raw runtime SQL handle into Postgres-only runtime consumers. runtime.NewRuntime must
-      continue to fail closed while mailbox_write materialization still requires the raw pipeline SQL database. Surfaces
-      split to #1088/#1089 must still fail closed or remain unavailable until their owning children land.
+      consume backend-neutral owners for runtime construction, including #1186 mailbox_write materialization, while public
+      default selection and docs/CI surfaces split to #1088/#1089 remain unavailable until their owning children land.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
     required_consumers:
@@ -2189,7 +2189,7 @@ engine:
     split_boundaries:
     - "SQLite dialect/schema/bootstrap remains split to #1085."
     - "Backend-neutral core runtime persistence stores remain split to #1086."
-    - "SQLite runtime construction semantics remain under #1087 parent closeout; mailbox_write materialization must move off the raw pipeline SQL database or receive explicit split/tracker repair before runtime construction is unblocked."
+    - "SQLite runtime construction semantics remain under #1087 parent closeout; mailbox_write materialization is promoted by #1186 and must consume its backend-neutral owner rather than the raw pipeline SQL database."
     - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
@@ -2261,14 +2261,13 @@ engine:
         - >
           May expose typed SQLite store owners for the #1087 session, startup ownership, delivery/replay, conversation/turn,
           observability semantics, #1148 budget/spend rows, #1149 tool entity/human-task persistence rows, and #1150
-          runtime diagnostics/log rows, but must not be treated as construction-ready while mailbox_write materialization
-          still requires the raw pipeline SQL database.
+          runtime diagnostics/log rows, and #1186 mailbox_write materialization rows without passing raw SQLite SQL handles
+          to Postgres-only runtime consumers.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
         - >
-          Must keep explicit SQLite runtime construction fail-closed until the residual #1087 mailbox_write materialization
-          raw-SQL seam is promoted to a backend-neutral owner or explicitly split by tracker repair, and must keep public
-          default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit Postgres opt-in
-          together.
+          Must keep public default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit
+          Postgres opt-in together. Explicit SQLite construction remains local/dev selected-store support only; it does
+          not promote production multi-writer SQLite semantics.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2353,6 +2352,23 @@ engine:
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - docs/CI/repo-wide closeout owned by #1089
       - production multi-writer SQLite concurrency semantics
+    - name: mailbox_write_materialization_rows
+      owner: runtimepipeline.MailboxWriteMaterializationStore consumed by PipelineCoordinator mailbox_write actions through runtime.Stores.MailboxMaterializer
+      promoted_by: '#1186'
+      sqlite_owner: internal/store.SQLiteRuntimeStore.MaterializeMailboxWrite
+      postgres_owner: internal/store.PostgresStore.MaterializeMailboxWrite
+      scope: >
+        PipelineCoordinator owns mailbox_write expression evaluation, deterministic item_id derivation from source_event_id
+        and materializer node, source_event_id/from_agent/flow_instance/payload shaping, and handler transaction context
+        propagation. Backend-specific stores own idempotent persisted mailbox row materialization through the same typed
+        owner for explicit SQLite local/dev runtime construction and Postgres production runtime construction. SQLite must
+        keep runtime.Stores.SQLDB nil and must not receive a raw pipeline SQL handle as a mailbox_write compatibility seam.
+      excludes:
+      - broad public mailbox decision API behavior owned by api_specification.method_catalog.mailbox.*
+      - dashboard and digest mailbox read closure
+      - public local/dev default flip and zero-service swarm run proof owned by #1088
+      - docs/CI/repo-wide closeout owned by #1089
+      - production multi-writer SQLite concurrency semantics
     - name: mailbox_rows
       owner: runtimetools.MailboxPersistence plus apiv1.MailboxAPIStore for the v1 operator mailbox surface
       sqlite_owner: internal/store.SQLiteRuntimeStore mailbox and v1 mailbox API methods
@@ -2407,10 +2423,10 @@ engine:
       rule: >
         Explicit SQLite store construction must leave runtime.Stores.SQLDB nil so Postgres-only raw-SQL components are not
         accidentally treated as SQLite owners. Runtime diagnostics/logging consumes the promoted backend-neutral
-        RuntimeLogPersistence owner instead of a raw SQL handle. mailbox_write materialization remains a residual #1087
-        raw-SQL runtime consumer and must continue to block explicit SQLite runtime construction until promoted or split.
-        Any future raw-SQL runtime consumer must receive a separately gated backend-neutral owner before it can participate
-        in explicit SQLite runtime construction.
+        RuntimeLogPersistence owner instead of a raw SQL handle. mailbox_write materialization consumes the #1186
+        MailboxWriteMaterializationStore owner instead of the raw pipeline SQL database. Any future raw-SQL runtime
+        consumer must receive a separately gated backend-neutral owner before it can participate in explicit SQLite runtime
+        construction.
     split_boundaries:
     - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."


### PR DESCRIPTION
## Summary

Closes #1186.

Promotes `mailbox_write` row materialization from `PipelineCoordinator` raw SQL to the backend-neutral `runtimepipeline.MailboxWriteMaterializationStore` owner, wired through `runtime.Stores.MailboxMaterializer` for Postgres and explicit SQLite runtime construction.

## Governing Refs / Context

- `platform-spec.yaml` `action.valid_values.mailbox_write`
- `platform-spec.yaml` `engine.runtime_store_backend_selection`
- `platform-spec.yaml` `engine.runtime_core_persistence_store_contracts`
- `platform-spec.yaml` `api_specification.method_catalog.mailbox.list` / `mailbox.get`
- Approved #1186 gate: first slice `runtime.mailbox_write_materialization_backend_neutral_owner`

## Semantic Migration

- New canonical owner: `runtimepipeline.MailboxWriteMaterializationStore`, consumed by `PipelineCoordinator` through `runtime.Stores.MailboxMaterializer`.
- Old invalid path: `PipelineCoordinator.materializeMailboxItem` directly writing `INSERT INTO mailbox` through `pc.db` / raw pipeline SQL.
- Production paths checked: `cmd/swarm buildStores` for Postgres and SQLite, `runtime.NewRuntime`, selected-contract fork pipeline construction, pipeline action runner, Postgres/SQLite store implementations, and operator `mailbox.list` read surface.
- Migration complete for the chosen class: `mailbox_write` materialization no longer requires passing raw SQLite `*sql.DB` into runtime construction.
- Parent/residuals remain split: #1087/#1066 parent closeout, #1088 default flip, #1089 docs/CI, #1157 agent.usage read parity, and production multi-writer SQLite semantics.

## Tests

- `go test ./internal/runtime/pipeline -run 'MailboxWrite'`
- `go test ./internal/store -run 'MaterializeMailboxWrite|V1Mailbox'`
- `go test ./internal/apiv1 -run 'SQLiteReadsMaterializedMailboxWrite'`
- `go test ./cmd/swarm -run 'BuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner|BuildStoresAcceptsSQLiteSelectedCoreRuntimeStore'`
- `go test ./...`