### PR TITLE
[agent-c][issue #1116] Dispatch publishes after commit

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -540,7 +540,7 @@ func (eb *EventBus) publishTransactional(
 	passthrough, deferred, err := eb.runInterceptors(dispatchCtx, evt)
 	if err != nil {
 		eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
-		return nil
+		return err
 	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	if deferredTransitions != nil {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -460,9 +460,9 @@ func (eb *EventBus) publishTransactional(
 	if err != nil {
 		return fmt.Errorf("begin publish tx: %w", err)
 	}
-	postCommitActions := make([]func(), 0, 8)
+	txPostCommitActions := make([]func(), 0, 8)
 	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
-	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommitActions)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &txPostCommitActions)
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
 	txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
 	committed := false
@@ -509,7 +509,7 @@ func (eb *EventBus) publishTransactional(
 			return fmt.Errorf("commit publish tx: %w", err)
 		}
 		committed = true
-		runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
 		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
@@ -527,47 +527,54 @@ func (eb *EventBus) publishTransactional(
 		return nil
 	}
 
-	passthrough, deferred, err := eb.runInterceptors(txctx, evt)
-	if err != nil {
-		return err
-	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit publish tx: %w", err)
 	}
 	committed = true
+	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+
+	postCommitActions := make([]func(), 0, 8)
+	dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
+	dispatchCtx = runtimepipeline.WithPipelinePostCommitActions(dispatchCtx, &postCommitActions)
+	dispatchCtx = runtimepipeline.WithPipelineReceiptOverride(dispatchCtx, receiptOverride)
+	passthrough, deferred, err := eb.runInterceptors(dispatchCtx, evt)
+	if err != nil {
+		eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
+		return nil
+	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	if deferredTransitions != nil {
-		runtimepipeline.FlushDeferredPipelineTransitions(ctx, *deferredTransitions)
+		runtimepipeline.FlushDeferredPipelineTransitions(dispatchCtx, *deferredTransitions)
 	}
 
 	if passthrough {
 		if len(inboundPlan.Recipients) > 0 {
-			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
-			if err := eb.deliverToRecipientsWithRoutes(ctx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
-				eb.recordCommittedPublishReceipt(ctx, evt, err)
+			eb.logQueuedDeliveries(dispatchCtx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
+			if err := eb.deliverToRecipientsWithRoutes(dispatchCtx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
+				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
 				return nil
 			}
-			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
+			eb.logDelivery(dispatchCtx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
 		}
 		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
-			if err := eb.publishDeferred(ctx, *inboundPlan.CycleEscalation); err != nil {
-				eb.recordCommittedPublishReceipt(ctx, evt, err)
+			if err := eb.publishDeferred(dispatchCtx, *inboundPlan.CycleEscalation); err != nil {
+				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
 				return nil
 			}
 		}
 		if strings.TrimSpace(inboundPlan.ContradictionReason) != "" {
-			_ = eb.emitContradiction(ctx, evt, inboundPlan.ContradictionReason)
+			_ = eb.emitContradiction(dispatchCtx, evt, inboundPlan.ContradictionReason)
 		}
 	}
-	eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
+	eb.logPublished(dispatchCtx, evt, int(time.Since(start)/time.Microsecond))
 
 	for _, d := range deferred {
-		if err := eb.publishDeferred(ctx, d); err != nil {
-			eb.recordCommittedPublishReceipt(ctx, evt, err)
+		if err := eb.publishDeferred(dispatchCtx, d); err != nil {
+			eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
 			return nil
 		}
 	}
-	eb.recordCommittedPublishReceipt(ctx, evt, nil)
+	eb.recordCommittedPublishReceipt(dispatchCtx, evt, nil)
 	return nil
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -202,6 +202,28 @@ func (i postCommitTxAbsentInterceptor) Intercept(ctx context.Context, _ events.E
 	return true, nil, nil
 }
 
+type postCommitErrorInterceptor struct {
+	t       *testing.T
+	store   *store.PostgresStore
+	eventID string
+	err     error
+}
+
+func (i postCommitErrorInterceptor) Intercept(ctx context.Context, _ events.Event) (bool, []events.Event, error) {
+	i.t.Helper()
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		i.t.Fatal("post-commit error interceptor ran with sql tx still in context")
+	}
+	ok, err := i.store.EventExists(ctx, i.eventID)
+	if err != nil {
+		i.t.Fatalf("EventExists(%s): %v", i.eventID, err)
+	}
+	if !ok {
+		i.t.Fatalf("expected event %s to be committed before interceptor error", i.eventID)
+	}
+	return false, nil, i.err
+}
+
 type deferredEventVisibleInterceptor struct {
 	t        *testing.T
 	store    *store.PostgresStore
@@ -1270,6 +1292,49 @@ func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) 
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for post-commit delivery")
+	}
+}
+
+func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecordsReceipt(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	eventID := "11111111-1111-1111-1111-111111111112"
+	wantErr := errors.New("post-commit interceptor failure")
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{postCommitErrorInterceptor{
+			t:       t,
+			store:   pg,
+			eventID: eventID,
+			err:     wantErr,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	err = eb.Publish(ctx, events.Event{
+		ID:        eventID,
+		RunID:     eventBusTestRunID,
+		Type:      events.EventType("task.failed"),
+		CreatedAt: time.Now().UTC(),
+		Payload:   []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`),
+	}.WithEntityID("11111111-1111-1111-1111-111111111114"))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Publish error = %v, want %v", err, wantErr)
+	}
+	var outcome, reasonCode, receiptError string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, ''), COALESCE(side_effects->>'error', '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&outcome, &reasonCode, &receiptError); err != nil {
+		t.Fatalf("load pipeline receipt: %v", err)
+	}
+	if outcome != "dead_letter" || reasonCode != "pipeline_error" || receiptError != wantErr.Error() {
+		t.Fatalf("pipeline receipt = outcome:%q reason:%q error:%q, want dead_letter/pipeline_error/%q", outcome, reasonCode, receiptError, wantErr.Error())
 	}
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -139,38 +139,38 @@ func (singleDeferredInterceptor) Intercept(_ context.Context, evt events.Event) 
 	}).WithEntityID(evt.EntityID())}, nil
 }
 
-type eventVisibleInTxInterceptor struct {
-	t       *testing.T
-	eventID string
+type nonTransactionalPersistedBeforeInterceptor struct {
+	t     *testing.T
+	store *recordingEventStore
 }
 
-func (i eventVisibleInTxInterceptor) Intercept(ctx context.Context, _ events.Event) (bool, []events.Event, error) {
+func (i nonTransactionalPersistedBeforeInterceptor) Intercept(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
 	i.t.Helper()
-	tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx)
-	if !ok || tx == nil {
-		i.t.Fatal("expected transactional publish context to expose sql tx")
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		i.t.Fatal("non-transactional interceptor unexpectedly ran with sql tx")
 	}
-	var count int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = $1::uuid`, i.eventID).Scan(&count); err != nil {
-		i.t.Fatalf("query inbound event inside interceptor tx: %v", err)
+	for _, got := range i.store.eventTypes() {
+		if got == string(evt.Type) {
+			return true, nil, nil
+		}
 	}
-	if count != 1 {
-		i.t.Fatalf("inbound event visible inside interceptor tx count=%d, want 1", count)
-	}
+	i.t.Fatalf("event type %s was not persisted before non-transactional interceptor ran; persisted=%v", evt.Type, i.store.eventTypes())
 	return true, nil, nil
 }
 
 type postCommitTxAbsentInterceptor struct {
-	t       *testing.T
-	store   *store.PostgresStore
-	eventID string
-	called  chan struct{}
+	t              *testing.T
+	store          *store.PostgresStore
+	eventID        string
+	called         chan struct{}
+	wantRecipients []string
+	wantScope      runtimereplayclaim.CommittedReplayScope
 }
 
 func (i postCommitTxAbsentInterceptor) Intercept(ctx context.Context, _ events.Event) (bool, []events.Event, error) {
 	i.t.Helper()
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
-		i.t.Fatal("transactional PublishTx interceptor ran with caller sql tx still in context")
+		i.t.Fatal("post-commit interceptor ran with sql tx still in context")
 	}
 	ok, err := i.store.EventExists(ctx, i.eventID)
 	if err != nil {
@@ -178,6 +178,22 @@ func (i postCommitTxAbsentInterceptor) Intercept(ctx context.Context, _ events.E
 	}
 	if !ok {
 		i.t.Fatalf("expected event %s to be committed before interceptor ran", i.eventID)
+	}
+	if i.wantRecipients != nil {
+		got, err := i.store.ListEventDeliveryRecipients(ctx, i.eventID)
+		if err != nil {
+			i.t.Fatalf("ListEventDeliveryRecipients(%s): %v", i.eventID, err)
+		}
+		assertSortedStringsEqual(i.t, got, i.wantRecipients)
+	}
+	if i.wantScope != "" {
+		got, err := i.store.LoadCommittedReplayScope(ctx, i.eventID)
+		if err != nil {
+			i.t.Fatalf("LoadCommittedReplayScope(%s): %v", i.eventID, err)
+		}
+		if got != i.wantScope {
+			i.t.Fatalf("committed replay scope = %q, want %q", got, i.wantScope)
+		}
 	}
 	select {
 	case i.called <- struct{}{}:
@@ -205,6 +221,9 @@ func (i deferredEventVisibleInterceptor) Intercept(ctx context.Context, evt even
 	}
 	if evt.Type != i.checkFor {
 		return true, nil, nil
+	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		i.t.Fatal("deferred event interceptor ran with sql tx still in context")
 	}
 	ok, err := i.store.EventExists(ctx, i.eventID)
 	if err != nil {
@@ -1189,23 +1208,68 @@ func TestEventBusPublish_InterceptsMultiHopDeferredChains(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishTransactional_PersistsInboundEventBeforeInterceptorsRun(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
-	pg := &store.PostgresStore{DB: db}
-	eventID := "11111111-1111-1111-1111-111111111111"
-	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
-		Interceptors: []runtimebus.EventInterceptor{eventVisibleInTxInterceptor{t: t, eventID: eventID}},
+func TestEventBusPublishNonTransactional_PersistsBeforeInterceptorsRun(t *testing.T) {
+	store := &recordingEventStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{nonTransactionalPersistedBeforeInterceptor{t: t, store: store}},
 	})
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.Event{
-		ID:        eventID,
-		Type:      events.EventType("task.completed"),
+	if err := eb.Publish(context.Background(), (events.Event{
+		Type:      events.EventType("custom.non_transactional"),
 		CreatedAt: time.Now().UTC(),
-		Payload:   []byte(`{}`),
-	}); err != nil {
+	}).WithEntityID("ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
+	}
+}
+
+func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	eventID := "11111111-1111-1111-1111-111111111111"
+	agentID := "agent-post-commit-publish"
+	seedActiveRuntimeBusAgent(t, ctx, pg, agentID)
+	called := make(chan struct{}, 1)
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{postCommitTxAbsentInterceptor{
+			t:              t,
+			store:          pg,
+			eventID:        eventID,
+			called:         called,
+			wantRecipients: []string{agentID},
+			wantScope:      runtimereplayclaim.CommittedReplayScopeSubscribed,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.Subscribe(agentID, events.EventType("task.completed"))
+	defer eb.Unsubscribe(agentID)
+	if err := eb.Publish(ctx, events.Event{
+		ID:          eventID,
+		RunID:       eventBusTestRunID,
+		Type:        events.EventType("task.completed"),
+		SourceAgent: "api.v1",
+		CreatedAt:   time.Now().UTC(),
+		Payload:     []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`),
+	}.WithEntityID("11111111-1111-1111-1111-111111111114")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for post-commit interceptor")
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event id = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for post-commit delivery")
 	}
 }
 
@@ -1401,7 +1465,7 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishDeferred_PersistsInboundEventBeforeInterceptorsRun(t *testing.T) {
+func TestEventBusPublishDeferred_RunsInterceptorsAfterDeferredEventCommit(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	eventID := "22222222-2222-2222-2222-222222222222"

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -120,7 +120,7 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 		return nil
 	}
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
-		queuedIntents := append([]runtimeengine.EmitIntent(nil), intents...)
+		queuedIntents := clonePostCommitEmitIntents(intents)
 		if !runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
 			postCommitActions := make([]func(), 0, 4)
 			dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(ctx))
@@ -151,6 +151,33 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 		d.bus.markPipelineReceipt(ctx, intent.Event.ID, "processed", "")
 	}
 	return nil
+}
+
+func clonePostCommitEmitIntents(intents []runtimeengine.EmitIntent) []runtimeengine.EmitIntent {
+	if len(intents) == 0 {
+		return nil
+	}
+	cloned := make([]runtimeengine.EmitIntent, 0, len(intents))
+	for _, intent := range intents {
+		copyIntent := intent
+		copyIntent.Event = clonePostCommitEvent(intent.Event)
+		if intent.Recipients != nil {
+			copyIntent.Recipients = append([]string(nil), intent.Recipients...)
+		}
+		cloned = append(cloned, copyIntent)
+	}
+	return cloned
+}
+
+func clonePostCommitEvent(evt events.Event) events.Event {
+	cloned := evt
+	if evt.Payload != nil {
+		cloned.Payload = append([]byte(nil), evt.Payload...)
+	}
+	if evt.Envelope.TargetSet != nil {
+		cloned.Envelope.TargetSet = append([]events.RouteIdentity(nil), evt.Envelope.TargetSet...)
+	}
+	return cloned
 }
 
 func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengine.EmitIntent) (bool, error) {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -119,6 +119,24 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 	if runtimepipeline.CollectPipelineEmitIntents(ctx, intents) {
 		return nil
 	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		queuedIntents := append([]runtimeengine.EmitIntent(nil), intents...)
+		if !runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
+			postCommitActions := make([]func(), 0, 4)
+			dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(ctx))
+			dispatchCtx = runtimepipeline.WithPipelinePostCommitActions(dispatchCtx, &postCommitActions)
+			if err := d.DispatchPostCommit(dispatchCtx, queuedIntents); err != nil {
+				d.bus.logRuntime(dispatchCtx, "error", "Post-commit outbox dispatch failed", "eventbus", "post_commit_outbox_dispatch_failed", "", "", "", "", "", nil, map[string]any{
+					"error":         err.Error(),
+					"intents_count": len(queuedIntents),
+				}, err.Error(), 0)
+			}
+			runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+		}) {
+			return errors.New("post-commit dispatch requires pipeline post-commit actions when a SQL transaction is active")
+		}
+		return nil
+	}
 	for _, intent := range intents {
 		queued, err := d.dispatchIntent(ctx, intent)
 		if err != nil {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -210,6 +210,87 @@ func TestEngineDispatcherQueuesWhenPipelineSQLTxActive(t *testing.T) {
 	}
 }
 
+func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	originalCh := eb.Subscribe("agent-original", events.EventType("custom.snapshot"))
+	defer eb.Unsubscribe("agent-original")
+	mutatedCh := eb.Subscribe("agent-mutated", events.EventType("custom.snapshot"))
+	defer eb.Unsubscribe("agent-mutated")
+
+	payload := []byte(`{"value":"original"}`)
+	targetSet := []events.RouteIdentity{{FlowInstance: "flow-original", EntityID: "entity-original"}}
+	recipients := []string{"agent-original"}
+	intents := []runtimeengine.EmitIntent{{
+		Event: events.Event{
+			ID:        "evt-queued-snapshot",
+			Type:      events.EventType("custom.snapshot"),
+			Payload:   payload,
+			Envelope:  events.EventEnvelope{TargetSet: targetSet},
+			CreatedAt: time.Now().UTC(),
+		},
+		Recipients: recipients,
+	}}
+	postCommitActions := make([]func(), 0, 1)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommitActions)
+
+	if err := eb.EngineDispatcher().DispatchPostCommit(txctx, intents); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	if len(postCommitActions) != 1 {
+		_ = tx.Rollback()
+		t.Fatalf("post-commit actions = %d, want 1", len(postCommitActions))
+	}
+	copy(payload, []byte(`{"value":"mutated!"}`))
+	targetSet[0] = events.RouteIdentity{FlowInstance: "flow-mutated", EntityID: "entity-mutated"}
+	recipients[0] = "agent-mutated"
+	intents[0].Event.Payload = []byte(`{"value":"reassigned"}`)
+	intents[0].Event.Envelope.TargetSet = []events.RouteIdentity{{FlowInstance: "flow-reassigned", EntityID: "entity-reassigned"}}
+	intents[0].Recipients = []string{"agent-reassigned"}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	select {
+	case got := <-originalCh:
+		if string(got.Payload) != `{"value":"original"}` {
+			t.Fatalf("delivered payload = %s, want original snapshot", string(got.Payload))
+		}
+		routes := got.TargetRoutes()
+		if len(routes) != 1 || routes[0].FlowInstance != "flow-original" || routes[0].EntityID != "entity-original" {
+			t.Fatalf("delivered target routes = %#v, want original snapshot", routes)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for original recipient delivery")
+	}
+	select {
+	case got := <-mutatedCh:
+		t.Fatalf("unexpected delivery to mutated recipient: %#v", got)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestEngineDispatcherFailsClosedWithSQLTxAndNoPostCommitQueue(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -136,6 +136,122 @@ func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
 	}
 }
 
+func TestEngineDispatcherQueuesWhenPipelineSQLTxActive(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{
+		descriptors: []runtimebus.ActiveAgentDescriptor{
+			{AgentID: "agent-a", EntityID: "ent-1"},
+		},
+	}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("agent-a", events.EventType("custom.emitted"))
+	defer eb.Unsubscribe("agent-a")
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-post-commit-dispatch",
+			Type:      events.EventType("custom.emitted"),
+			Payload:   []byte(`{"entity_id":"ent-1"}`),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+	}
+	postCommitActions := make([]func(), 0, 1)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommitActions)
+
+	if err := eb.EngineOutbox().WriteOutbox(txctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := eb.EngineDispatcher().DispatchPostCommit(txctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	if len(postCommitActions) != 1 {
+		_ = tx.Rollback()
+		t.Fatalf("post-commit actions = %d, want 1", len(postCommitActions))
+	}
+	select {
+	case got := <-ch:
+		_ = tx.Rollback()
+		t.Fatalf("event delivered before post-commit flush: %#v", got)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	select {
+	case got := <-ch:
+		if got.ID != intent.Event.ID {
+			t.Fatalf("delivered event id = %s, want %s", got.ID, intent.Event.ID)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for post-commit outbox dispatch")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestEngineDispatcherFailsClosedWithSQLTxAndNoPostCommitQueue(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	err = eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{{
+		Event: events.Event{
+			ID:        "evt-no-post-commit-queue",
+			Type:      events.EventType("custom.emitted"),
+			CreatedAt: time.Now().UTC(),
+		}.WithEntityID("ent-1"),
+	}})
+	if err == nil {
+		_ = tx.Rollback()
+		t.Fatal("expected DispatchPostCommit to fail closed without post-commit queue")
+	}
+	if !strings.Contains(err.Error(), "post-commit dispatch requires pipeline post-commit actions") {
+		_ = tx.Rollback()
+		t.Fatalf("DispatchPostCommit error = %q, want post-commit queue failure", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -494,6 +494,9 @@ func (h *runtimeHarness) waitForExpectedEmittedEvents(expected catalogExpectedDo
 	defer ticker.Stop()
 	for {
 		if h.hasExpectedEmittedEvents(ctx, entityID, expected.Expected.EmittedEvents, flowPrefix, source) {
+			if err := h.rt.WaitForQuiescence(ctx); err != nil {
+				h.t.Fatalf("WaitForQuiescence(after emitted events): %v", err)
+			}
 			return
 		}
 		select {


### PR DESCRIPTION
## Summary

Closes #1116.

This PR closes the approved first-slice class `post_commit_publish_outbox_dispatch_ordering`: transactional EventBus publish and engine outbox dispatch can no longer invoke downstream interceptors or delivery before canonical event, delivery/route, and replay-scope evidence is committed.

## Governing Refs

Exact governing spec refs:

- `platform-spec.yaml` `event_lifecycle.lifecycle`
- `platform-spec.yaml` `event_lifecycle.atomicity`
- `platform-spec.yaml` `engine.cross_flow_routing.delivery_filter`
- `platform-spec.yaml` `platform_actions.artifact_repo_commit.behavior`
- `platform-spec.yaml` `api_specification.method_catalog.mailbox.approve.approval_transaction_boundary`

No `platform-spec.yaml` update is included because this PR aligns runtime behavior to the existing root spec rather than introducing new platform semantics.

## Semantic Migration

New canonical owner:

- `internal/runtime/bus/eventbus_publish.go`: transactional `EventBus.Publish` persists event/delivery/replay-scope evidence, commits, then runs interceptors/delivery from a no-SQL-tx post-commit context.
- `internal/runtime/bus/outbox.go`: `EngineDispatcher.DispatchPostCommit` queues dispatch when called with a live pipeline SQL tx, or fails closed when no post-commit queue is present.
- `internal/runtime/pipeline/runtime_support.go` and pipeline transaction runners remain the post-commit queue/flush owners.

Old invalid paths:

- `publishTransactional` running interceptors before `tx.Commit()`.
- `EngineDispatcher.DispatchPostCommit` directly dispatching/intercepting while `PipelineSQLTxFromContext` is live.
- The old test expectation that transactional publish interceptors should see tx-local event rows.

Production paths checked:

- transactional `EventBus.Publish`
- caller-owned `EventBus.PublishTx`
- non-transactional `EventBus.Publish`
- deferred publish from transactional paths
- `EngineOutbox.WriteOutbox`
- `EngineDispatcher.DispatchPostCommit`
- engine/pipeline post-commit dispatch consumers
- catalog end-to-end runtime harness behavior after event visibility

Migration status: complete for the approved #1116 child class. Sibling issues #1117, #1118, #1119, #1120, #1122, and final parent proof #1025 remain separate.

## Validation

- `go test ./internal/runtime/cataloge2e -run 'TestTier5LifecycleCatalogFixtures_RealRuntime/test-timer-fire' -count=1 -v`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./...`