### PR TITLE
[agent-b][issue #1187] Add bundle register contracts packaging

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -67,6 +67,7 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 		"store.NewPostgresStore",
 		"SWARM_BUILDER_AUTH_TOKEN",
 		"SWARM_OPERATOR_AUTH_TOKEN",
+		"BundleHash(",
 		"BuildBundleCatalogProjection",
 		"UpsertBundleCatalog",
 	}
@@ -127,6 +128,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 	if err := os.WriteFile(envelopePath, []byte("api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n"), 0o600); err != nil {
 		t.Fatalf("write bundle register envelope: %v", err)
 	}
+	contractsDir := writeBundleRegisterContractsFixture(t)
 
 	for _, tc := range []struct {
 		name string
@@ -165,6 +167,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "bundle show", args: []string{"bundle", "show", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
 		{name: "bundle agents", args: []string{"bundle", "agents", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
 		{name: "bundle register", args: []string{"bundle", "register", envelopePath}},
+		{name: "bundle register contracts", args: []string{"bundle", "register", "--contracts", contractsDir}},
 		{name: "conversations list", args: []string{"conversations", "list"}},
 		{name: "conversation view", args: []string{"conversation", "view", "session-1"}},
 		{name: "conversation turn", args: []string{"conversation", "turn", "session-1", "1"}},

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
 )
 
 const (
@@ -40,9 +42,12 @@ type bundleRegisterCommandOptions struct {
 	output     cliOutputOptions
 
 	dataBlobPath      string
+	contractsDir      string
 	idempotencyKey    string
 	dataBlobSet       bool
+	contractsSet      bool
 	idempotencyKeySet bool
+	repoRoot          string
 }
 
 type bundleListResult struct {
@@ -95,7 +100,7 @@ type bundleAgentDefinition struct {
 	Tools            []string `json:"tools,omitempty"`
 }
 
-func newBundleCommand(opts rootCommandOptions) *cobra.Command {
+func newBundleCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
 		Short: "Inspect persisted bundle catalog entries through v1 RPC.",
@@ -108,7 +113,7 @@ func newBundleCommand(opts rootCommandOptions) *cobra.Command {
 		newBundleListCommand(opts),
 		newBundleShowCommand(opts),
 		newBundleAgentsCommand(opts),
-		newBundleRegisterCommand(opts),
+		newBundleRegisterCommand(repoRoot, opts),
 	)
 	return cmd
 }
@@ -171,22 +176,24 @@ func newBundleAgentsCommand(opts rootCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func newBundleRegisterCommand(opts rootCommandOptions) *cobra.Command {
-	registerOpts := bundleRegisterCommandOptions{apiOptions: opts}
+func newBundleRegisterCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
+	registerOpts := bundleRegisterCommandOptions{apiOptions: opts, repoRoot: repoRoot}
 	cmd := &cobra.Command{
-		Use:   "register <registration-envelope-yaml>",
-		Short: "Register a prepared bundle envelope through /v1/rpc bundle.register.",
-		Args:  cobra.ExactArgs(1),
+		Use:   "register <registration-envelope-yaml> | register --contracts <contracts-directory>",
+		Short: "Register a bundle through /v1/rpc bundle.register.",
+		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registerOpts.dataBlobSet = cmd.Flags().Changed("data-blob")
+			registerOpts.contractsSet = cmd.Flags().Changed("contracts")
 			registerOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
 			if err := registerOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
-			return runBundleRegisterCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), registerOpts, args[0])
+			return runBundleRegisterCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), registerOpts, args)
 		},
 	}
 	cmd.Flags().StringVar(&registerOpts.dataBlobPath, "data-blob", "", "Path to a BundleRegisterDataBlobV1 JSON document")
+	cmd.Flags().StringVar(&registerOpts.contractsDir, "contracts", "", "Package a local contracts directory into BundleRegistrationEnvelopeV1 before calling bundle.register")
 	cmd.Flags().StringVar(&registerOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.register")
 	bindCLIOutputFlags(cmd, &registerOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &registerOpts.apiOptions)
@@ -270,8 +277,8 @@ func runBundleAgentsCommand(ctx context.Context, out, errOut io.Writer, opts bun
 	})
 }
 
-func runBundleRegisterCommand(ctx context.Context, out, errOut io.Writer, opts bundleRegisterCommandOptions, envelopePath string) error {
-	params, err := opts.params(envelopePath)
+func runBundleRegisterCommand(ctx context.Context, out, errOut io.Writer, opts bundleRegisterCommandOptions, args []string) error {
+	params, err := opts.params(args)
 	if err != nil {
 		return returnCLIValidationError(errOut, err)
 	}
@@ -311,7 +318,17 @@ func (opts bundleListCommandOptions) params() (map[string]any, error) {
 	return params, nil
 }
 
-func (opts bundleRegisterCommandOptions) params(envelopePath string) (map[string]any, error) {
+func (opts bundleRegisterCommandOptions) params(args []string) (map[string]any, error) {
+	if opts.contractsSet {
+		return opts.contractsDirectoryParams(args)
+	}
+	if len(args) != 1 {
+		return nil, fmt.Errorf("register requires <registration-envelope-yaml> or --contracts <contracts-directory>")
+	}
+	return opts.preparedEnvelopeParams(args[0])
+}
+
+func (opts bundleRegisterCommandOptions) preparedEnvelopeParams(envelopePath string) (map[string]any, error) {
 	contentYAML, err := readBundleRegisterTextFile("registration envelope", envelopePath)
 	if err != nil {
 		return nil, err
@@ -323,6 +340,50 @@ func (opts bundleRegisterCommandOptions) params(envelopePath string) (map[string
 			return nil, err
 		}
 		params["data_blob"] = dataBlob
+	}
+	if idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet); err != nil {
+		return nil, err
+	} else if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params, nil
+}
+
+func (opts bundleRegisterCommandOptions) contractsDirectoryParams(args []string) (map[string]any, error) {
+	if len(args) != 0 {
+		return nil, fmt.Errorf("--contracts cannot be combined with a registration envelope argument")
+	}
+	if opts.dataBlobSet {
+		return nil, fmt.Errorf("--data-blob cannot be used with --contracts")
+	}
+	contractsDir, err := optionalNonEmptyFlag("--contracts", opts.contractsDir, opts.contractsSet)
+	if err != nil {
+		return nil, err
+	}
+	repoRoot := strings.TrimSpace(opts.repoRoot)
+	if repoRoot == "" {
+		repoRoot = discoverRepoRoot()
+	}
+	if repoRoot == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("resolve repo root: %w", err)
+		}
+		repoRoot = cwd
+	}
+	paths, err := resolveCLIContractPlatformSpecPaths(repoRoot, cliContractPlatformSpecPathOptions{
+		ContractsPath: contractsDir,
+	})
+	if err != nil {
+		return nil, err
+	}
+	upload, err := runtimecontracts.BuildBundleRegistrationDirectoryUpload(repoRoot, paths.ContractsPath, paths.PlatformSpecPath)
+	if err != nil {
+		return nil, fmt.Errorf("package contracts directory: %w", err)
+	}
+	params := map[string]any{"content_yaml": upload.ContentYAML}
+	if upload.DataBlob != nil && len(upload.DataBlob.Entries) > 0 {
+		params["data_blob"] = upload.DataBlob
 	}
 	if idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet); err != nil {
 		return nil, err

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -248,10 +248,16 @@ func TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders(t *testing.T
 	}
 	wantDataBlob := map[string]any{
 		"api_version": "swarm.bundle.data.v1",
-		"entries": []any{map[string]any{
-			"path":        "flows/alpha/data/payload.bin",
-			"data_base64": base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}),
-		}},
+		"entries": []any{
+			map[string]any{
+				"path":        "flows/alpha/data/empty.bin",
+				"data_base64": "",
+			},
+			map[string]any{
+				"path":        "flows/alpha/data/payload.bin",
+				"data_base64": base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}),
+			},
+		},
 	}
 	if !reflect.DeepEqual(captured.Params["data_blob"], wantDataBlob) {
 		t.Fatalf("data_blob = %#v, want %#v", captured.Params["data_blob"], wantDataBlob)
@@ -387,7 +393,6 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
 		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
 		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "package contracts directory"},
-		{name: "register contracts empty data", args: []string{"bundle", "register", "--contracts", writeBundleRegisterContractsFixtureWithEmptyData(t)}, wantStderr: "cannot be represented in BundleRegisterDataBlobV1"},
 		{name: "delete not promoted", args: []string{"bundle", "delete", validBundleHash("a")}, wantStderr: "unknown command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -602,16 +607,10 @@ states:
   - done
 `)
 	writeBundleRegisterFixtureFile(t, filepath.Join(root, "prompts", "root.md"), "root prompt\n")
+	writeBundleRegisterFixtureBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
 	writeBundleRegisterFixtureBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
 	writeBundleRegisterFixtureFile(t, filepath.Join(root, ".DS_Store"), "ignored\n")
 	writeBundleRegisterFixtureFile(t, filepath.Join(root, "prompts", ".#ignored.md"), "ignored\n")
-	return root
-}
-
-func writeBundleRegisterContractsFixtureWithEmptyData(t *testing.T) string {
-	t.Helper()
-	root := writeBundleRegisterContractsFixture(t)
-	writeBundleRegisterFixtureBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
 	return root
 }
 

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
@@ -159,7 +162,7 @@ func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
 	}
 }
 
-func TestBundleRegisterHelpDocumentsPreparedEnvelopeBoundary(t *testing.T) {
+func TestBundleRegisterHelpDocumentsPreparedEnvelopeAndContractsBoundary(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "register", "--help"}, &stdout, &stderr, rootCommandOptions{})
 	if code != 0 {
@@ -167,6 +170,7 @@ func TestBundleRegisterHelpDocumentsPreparedEnvelopeBoundary(t *testing.T) {
 	}
 	for _, want := range []string{
 		"register <registration-envelope-yaml>",
+		"--contracts",
 		"--data-blob",
 		"--idempotency-key",
 		"--api-server",
@@ -176,9 +180,88 @@ func TestBundleRegisterHelpDocumentsPreparedEnvelopeBoundary(t *testing.T) {
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}
 	}
-	for _, notWant := range []string{"contracts-directory", "archive"} {
+	for _, notWant := range []string{"archive"} {
 		if strings.Contains(stdout.String(), notWant) {
 			t.Fatalf("help contains unapproved packaging term %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("9")
+	contractsDir := writeBundleRegisterContractsFixture(t)
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validBundleRegistrationResult(bundleHash))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"bundle", "register",
+		"--contracts", contractsDir,
+		"--idempotency-key", "idem-contracts",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != bundleRegisterMethod {
+		t.Fatalf("method = %q, want %q", captured.Method, bundleRegisterMethod)
+	}
+	if _, ok := captured.Params["bundle_hash"]; ok {
+		t.Fatalf("bundle_hash must not be sent by CLI: %#v", captured.Params)
+	}
+	contentYAML, ok := captured.Params["content_yaml"].(string)
+	if !ok || strings.TrimSpace(contentYAML) == "" {
+		t.Fatalf("content_yaml = %#v", captured.Params["content_yaml"])
+	}
+	var envelope bundleRegistrationEnvelopeForTest
+	if err := yaml.Unmarshal([]byte(contentYAML), &envelope); err != nil {
+		t.Fatalf("decode content_yaml: %v\n%s", err, contentYAML)
+	}
+	if envelope.APIVersion != "swarm.bundle.register.v1" {
+		t.Fatalf("content_yaml api_version = %q", envelope.APIVersion)
+	}
+	var paths []string
+	for _, file := range envelope.Files {
+		paths = append(paths, file.Path)
+		if strings.Contains(file.Text, "ignored") {
+			t.Fatalf("ignored content leaked through %s", file.Path)
+		}
+	}
+	wantPaths := []string{"flows/alpha/schema.yaml", "package.yaml", "prompts/root.md"}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("content_yaml files = %#v, want %#v\n%s", paths, wantPaths, contentYAML)
+	}
+	wantDataBlob := map[string]any{
+		"api_version": "swarm.bundle.data.v1",
+		"entries": []any{map[string]any{
+			"path":        "flows/alpha/data/payload.bin",
+			"data_base64": base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}),
+		}},
+	}
+	if !reflect.DeepEqual(captured.Params["data_blob"], wantDataBlob) {
+		t.Fatalf("data_blob = %#v, want %#v", captured.Params["data_blob"], wantDataBlob)
+	}
+	if captured.Params["idempotency_key"] != "idem-contracts" {
+		t.Fatalf("idempotency_key = %#v", captured.Params["idempotency_key"])
+	}
+	for _, want := range []string{"bundle " + bundleHash, "registered=true", "has_data=true", "data_size_bytes=7"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
@@ -274,6 +357,8 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 	dataBlobPath := writeBundleRegisterFixture(t, "bundle-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[]}`)
 	badDataBlobPath := writeBundleRegisterFixture(t, "bad-data.json", `{bad json`)
 	multipleDataBlobPath := writeBundleRegisterFixture(t, "multi-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[]}{}`)
+	contractsDir := writeBundleRegisterContractsFixture(t)
+	invalidContractsDir := t.TempDir()
 	dirPath := filepath.Join(t.TempDir(), "bundle-dir")
 	if err := os.Mkdir(dirPath, 0o700); err != nil {
 		t.Fatalf("mkdir bundle dir: %v", err)
@@ -291,7 +376,7 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "show invalid hash", args: []string{"bundle", "show", "sha256:abc"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "agents invalid hash", args: []string{"bundle", "agents", "bad"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "get alias not promoted", args: []string{"bundle", "get", validBundleHash("a")}, wantStderr: "unknown command"},
-		{name: "register missing envelope", args: []string{"bundle", "register"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "register missing envelope", args: []string{"bundle", "register"}, wantStderr: "register requires <registration-envelope-yaml> or --contracts <contracts-directory>"},
 		{name: "register missing file", args: []string{"bundle", "register", filepath.Join(t.TempDir(), "missing.yaml")}, wantStderr: "read registration envelope"},
 		{name: "register directory", args: []string{"bundle", "register", dirPath}, wantStderr: "registration envelope must be a file"},
 		{name: "register empty envelope", args: []string{"bundle", "register", emptyEnvelopePath}, wantStderr: "registration envelope must be non-empty"},
@@ -299,6 +384,10 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register malformed data blob", args: []string{"bundle", "register", envelopePath, "--data-blob", badDataBlobPath}, wantStderr: "--data-blob must contain one BundleRegisterDataBlobV1 JSON object"},
 		{name: "register multiple data blob documents", args: []string{"bundle", "register", envelopePath, "--data-blob", multipleDataBlobPath}, wantStderr: "--data-blob must contain one BundleRegisterDataBlobV1 JSON object"},
 		{name: "register blank idempotency", args: []string{"bundle", "register", envelopePath, "--data-blob", dataBlobPath, "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
+		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
+		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
+		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "package contracts directory"},
+		{name: "register contracts empty data", args: []string{"bundle", "register", "--contracts", writeBundleRegisterContractsFixtureWithEmptyData(t)}, wantStderr: "cannot be represented in BundleRegisterDataBlobV1"},
 		{name: "delete not promoted", args: []string{"bundle", "delete", validBundleHash("a")}, wantStderr: "unknown command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -315,6 +404,32 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 				t.Fatalf("RPC calls = %d, want 0", calls.Load())
 			}
 		})
+	}
+}
+
+func TestBundleRegisterContractsDirectoryRejectsSymlinkBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	contractsDir := writeBundleRegisterContractsFixture(t)
+	if err := os.Symlink(filepath.Join(contractsDir, "prompts", "root.md"), filepath.Join(contractsDir, "prompts", "link.md")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"bundle", "register", "--contracts", contractsDir}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "symlink") {
+		t.Fatalf("stderr = %q, want symlink rejection", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
 	}
 }
 
@@ -458,6 +573,61 @@ func writeBundleRegisterFixture(t *testing.T, name, content string) string {
 		t.Fatalf("write %s: %v", name, err)
 	}
 	return path
+}
+
+type bundleRegistrationEnvelopeForTest struct {
+	APIVersion string                          `yaml:"api_version"`
+	Files      []bundleRegistrationFileForTest `yaml:"files"`
+}
+
+type bundleRegistrationFileForTest struct {
+	Path string `yaml:"path"`
+	Text string `yaml:"text"`
+}
+
+func writeBundleRegisterContractsFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBundleRegisterFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: cli-register-fixture
+version: "1.0.0"
+flows:
+  - id: alpha
+    flow: alpha
+`)
+	writeBundleRegisterFixtureFile(t, filepath.Join(root, "flows", "alpha", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleRegisterFixtureFile(t, filepath.Join(root, "prompts", "root.md"), "root prompt\n")
+	writeBundleRegisterFixtureBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
+	writeBundleRegisterFixtureFile(t, filepath.Join(root, ".DS_Store"), "ignored\n")
+	writeBundleRegisterFixtureFile(t, filepath.Join(root, "prompts", ".#ignored.md"), "ignored\n")
+	return root
+}
+
+func writeBundleRegisterContractsFixtureWithEmptyData(t *testing.T) string {
+	t.Helper()
+	root := writeBundleRegisterContractsFixture(t)
+	writeBundleRegisterFixtureBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
+	return root
+}
+
+func writeBundleRegisterFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	writeBundleRegisterFixtureBytes(t, path, []byte(content))
+}
+
+func writeBundleRegisterFixtureBytes(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }
 
 func assertBundleRequest(t *testing.T, req jsonRPCRequest, wantMethod string, wantParams map[string]any) {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -94,7 +94,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newAgentsCommand(opts),
 		newAgentCommand(opts),
 		newForkChatCommand(opts),
-		newBundleCommand(opts),
+		newBundleCommand(repo, opts),
 		newEntitiesCommand(opts),
 		newEntityCommand(opts),
 		newMailboxCommand(opts),

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -437,9 +437,9 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	commandCatalog := mustMappingValue(t, cli, "command_catalog")
 	bundleCommand := mustMappingValue(t, commandCatalog, "bundle")
 	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents|register")
-	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_inventory_and_prepared_envelope_register")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Prepared-envelope swarm bundle register is implemented")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Directory/archive packaging and bundle.delete CLI remain split")
+	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_inventory_prepared_envelope_and_directory_register")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "local directory swarm bundle register --contracts")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Archive packaging and bundle.delete CLI remain split")
 	runForkCatalog := mustMappingValue(t, commandCatalog, "run_fork")
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "command"), runForkCommand)
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "implementation_status"), "implemented_public_cli_consumer")
@@ -465,7 +465,7 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 		t.Fatal("remaining_should_have_not_implemented still includes implemented swarm bundle inventory commands")
 	}
 	for _, want := range []string{
-		"swarm bundle register <contracts-directory-or-archive>",
+		"swarm bundle register --archive <archive-file>",
 		"swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]",
 	} {
 		if !sequenceContainsScalar(remaining, want) {
@@ -477,7 +477,8 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	assertScalarValue(t, mustMappingValue(t, apiBoundary, "status"), "partial_bundle_read_catalog_register_run_fork_and_delete_method_catalog")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.register is also published")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "prepared-envelope swarm")
-	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "contracts-directory/archive packaging remains split")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "local contracts-directory packaging is implemented")
+	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "archive packaging remains split")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "bundle.delete is promoted")
 	assertScalarContains(t, mustMappingValue(t, apiBoundary, "rule"), "omitted or false force performs non-force deletion")
 

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -711,6 +711,34 @@ func TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempote
 	if got := withDataResult["data_size_bytes"].(float64); got <= 0 {
 		t.Fatalf("bundle.register data_size_bytes = %v, want >0", got)
 	}
+
+	localRoot := t.TempDir()
+	writeBundleRegistrationLocalContractsFixture(t, localRoot)
+	upload, err := runtimecontracts.BuildBundleRegistrationDirectoryUpload(t.TempDir(), localRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload: %v", err)
+	}
+	packagedParams := map[string]any{"content_yaml": upload.ContentYAML}
+	if upload.DataBlob != nil {
+		packagedParams["data_blob"] = upload.DataBlob
+	}
+	packagedRequest, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "packaged-directory",
+		"method":  "bundle.register",
+		"params":  packagedParams,
+	})
+	if err != nil {
+		t.Fatalf("marshal packaged directory request: %v", err)
+	}
+	packaged := rpcCall(t, handler, string(packagedRequest))
+	if packaged.Error != nil {
+		t.Fatalf("bundle.register packaged directory error = %#v\ncontent_yaml:\n%s", packaged.Error, upload.ContentYAML)
+	}
+	packagedResult := asMap(t, packaged.Result)
+	if packagedResult["registered"] != true || packagedResult["has_data"] != true {
+		t.Fatalf("bundle.register packaged directory result = %#v", packagedResult)
+	}
 }
 
 func TestOperatorBundleRegisterHandlersFailClosed(t *testing.T) {
@@ -822,6 +850,34 @@ files:
         - start
         - done
 `
+}
+
+func writeBundleRegistrationLocalContractsFixture(t *testing.T, root string) {
+	t.Helper()
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: registered-local-directory
+version: "1.0.0"
+flows:
+  - id: alpha
+    flow: alpha
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), "\x01\x02\x03")
+}
+
+func writeBundleRegistrationLocalFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }
 
 func testBundleRegistrationPlatformSpec(t *testing.T) string {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -857,6 +857,8 @@ func writeBundleRegistrationLocalContractsFixture(t *testing.T, root string) {
 	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: registered-local-directory
 version: "1.0.0"
+packages:
+  - path: packages/foo
 flows:
   - id: alpha
     flow: alpha
@@ -867,7 +869,36 @@ states:
   - start
   - done
 `)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "package.yaml"), `
+name: nested-flow-package
+version: "1.0.0"
+flows:
+  - id: gamma
+    flow: gamma
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "flows", "gamma", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "packages", "foo", "package.yaml"), `
+name: child-package
+version: "1.0.0"
+flows:
+  - id: beta
+    flow: beta
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "packages", "foo", "flows", "beta", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), "")
 	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), "\x01\x02\x03")
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "flows", "alpha", "flows", "gamma", "data", "nested.bin"), "\x09")
+	writeBundleRegistrationLocalFixtureFile(t, filepath.Join(root, "packages", "foo", "flows", "beta", "data", "child.bin"), "\x04\x05")
 }
 
 func writeBundleRegistrationLocalFixtureFile(t *testing.T, path, content string) {

--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -212,8 +212,8 @@ func bundleRegistrationDataBlobParam(params map[string]any) ([]bundleRegistratio
 		seen[folded] = path
 		previous = path
 		encoded, ok := entry["data_base64"].(string)
-		if !ok || strings.TrimSpace(encoded) == "" {
-			return nil, NewInvalidParamsError(map[string]any{"field": field + ".data_base64", "reason": "must be a non-empty base64 string"})
+		if !ok {
+			return nil, NewInvalidParamsError(map[string]any{"field": field + ".data_base64", "reason": "must be a base64 string"})
 		}
 		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
 		if err != nil {
@@ -358,10 +358,19 @@ func cleanBundleRegistrationPath(raw, field string) (string, error) {
 
 func validateBundleRegistrationDataPath(path, field string) error {
 	segments := strings.Split(path, "/")
-	if len(segments) < 4 || segments[0] != "flows" || segments[1] == "" || segments[2] != "data" {
-		return NewInvalidParamsError(map[string]any{"field": field, "reason": "data_blob entries must be under flows/<flow>/data/..."})
+	if !bundleRegistrationDataPathIsFlowData(segments) {
+		return NewInvalidParamsError(map[string]any{"field": field, "reason": "data_blob entries must be under a flow data directory (.../flows/<flow>/data/...)"})
 	}
 	return nil
+}
+
+func bundleRegistrationDataPathIsFlowData(segments []string) bool {
+	for i := 0; i+3 < len(segments); i++ {
+		if segments[i] == "flows" && segments[i+1] != "" && segments[i+2] == "data" {
+			return true
+		}
+	}
+	return false
 }
 
 func asciiFoldBundleRegistrationPath(path string) string {

--- a/internal/runtime/contracts/bundle_registration_upload.go
+++ b/internal/runtime/contracts/bundle_registration_upload.go
@@ -71,9 +71,6 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 			if err := validateBundleRegistrationUploadDataPath(rel); err != nil {
 				return BundleRegistrationUpload{}, err
 			}
-			if len(raw) == 0 {
-				return BundleRegistrationUpload{}, fmt.Errorf("raw data file %s is empty and cannot be represented in BundleRegisterDataBlobV1", rel)
-			}
 			dataEntries = append(dataEntries, BundleRegisterDataEntryV1{
 				Path:       rel,
 				DataBase64: base64.StdEncoding.EncodeToString(raw),
@@ -139,8 +136,17 @@ func encodeBundleRegistrationEnvelopeYAML(files []bundleRegistrationUploadFile) 
 
 func validateBundleRegistrationUploadDataPath(path string) error {
 	segments := strings.Split(path, "/")
-	if len(segments) < 4 || segments[0] != "flows" || segments[1] == "" || segments[2] != "data" {
-		return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under flows/<flow>/data/...", path)
+	if !bundleRegistrationUploadDataPathIsFlowData(segments) {
+		return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under a flow data directory (.../flows/<flow>/data/...)", path)
 	}
 	return nil
+}
+
+func bundleRegistrationUploadDataPathIsFlowData(segments []string) bool {
+	for i := 0; i+3 < len(segments); i++ {
+		if segments[i] == "flows" && segments[i+1] != "" && segments[i+2] == "data" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/contracts/bundle_registration_upload.go
+++ b/internal/runtime/contracts/bundle_registration_upload.go
@@ -1,0 +1,146 @@
+package contracts
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	bundleRegistrationEnvelopeAPIVersion = "swarm.bundle.register.v1"
+	bundleRegistrationDataAPIVersion     = "swarm.bundle.data.v1"
+)
+
+type BundleRegistrationUpload struct {
+	ContentYAML string
+	DataBlob    *BundleRegisterDataBlobV1
+}
+
+type BundleRegisterDataBlobV1 struct {
+	APIVersion string                      `json:"api_version"`
+	Entries    []BundleRegisterDataEntryV1 `json:"entries"`
+}
+
+type BundleRegisterDataEntryV1 struct {
+	Path       string `json:"path"`
+	DataBase64 string `json:"data_base64"`
+}
+
+type bundleRegistrationEnvelopeUploadV1 struct {
+	APIVersion string                         `yaml:"api_version"`
+	Files      []bundleRegistrationUploadFile `yaml:"files"`
+}
+
+type bundleRegistrationUploadFile struct {
+	Path string `yaml:"path"`
+	Text string `yaml:"text"`
+}
+
+// BuildBundleRegistrationDirectoryUpload packages a local contracts directory
+// into the public bundle.register request shape without computing bundle_hash
+// or building a catalog projection.
+func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpecPath string) (BundleRegistrationUpload, error) {
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, contractsRoot, platformSpecPath)
+	if err != nil {
+		return BundleRegistrationUpload{}, err
+	}
+	entries, err := bundleHashEntries(bundle)
+	if err != nil {
+		return BundleRegistrationUpload{}, err
+	}
+	files := make([]bundleRegistrationUploadFile, 0, len(entries))
+	var dataEntries []BundleRegisterDataEntryV1
+	for _, entry := range entries {
+		if entry.Label == "platform/platform-spec.yaml" {
+			continue
+		}
+		rel, ok := strings.CutPrefix(entry.Label, "bundle/")
+		if !ok {
+			return BundleRegistrationUpload{}, fmt.Errorf("bundle registration input %q is not under bundle/", entry.Label)
+		}
+		raw, err := os.ReadFile(entry.Path)
+		if err != nil {
+			return BundleRegistrationUpload{}, fmt.Errorf("read %s: %w", rel, err)
+		}
+		switch entry.Policy {
+		case bundleHashRaw:
+			if err := validateBundleRegistrationUploadDataPath(rel); err != nil {
+				return BundleRegistrationUpload{}, err
+			}
+			if len(raw) == 0 {
+				return BundleRegistrationUpload{}, fmt.Errorf("raw data file %s is empty and cannot be represented in BundleRegisterDataBlobV1", rel)
+			}
+			dataEntries = append(dataEntries, BundleRegisterDataEntryV1{
+				Path:       rel,
+				DataBase64: base64.StdEncoding.EncodeToString(raw),
+			})
+		case bundleHashYAML, bundleHashPrompt:
+			if !utf8.Valid(raw) {
+				return BundleRegistrationUpload{}, fmt.Errorf("text bundle input %s is not valid UTF-8", rel)
+			}
+			files = append(files, bundleRegistrationUploadFile{Path: rel, Text: string(raw)})
+		default:
+			return BundleRegistrationUpload{}, fmt.Errorf("unknown bundle registration input policy %d for %s", entry.Policy, rel)
+		}
+	}
+	if len(files) == 0 {
+		return BundleRegistrationUpload{}, fmt.Errorf("bundle registration directory has no text inputs")
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	sort.Slice(dataEntries, func(i, j int) bool {
+		return dataEntries[i].Path < dataEntries[j].Path
+	})
+	envelope, err := encodeBundleRegistrationEnvelopeYAML(files)
+	if err != nil {
+		return BundleRegistrationUpload{}, err
+	}
+	upload := BundleRegistrationUpload{ContentYAML: envelope}
+	if len(dataEntries) > 0 {
+		upload.DataBlob = &BundleRegisterDataBlobV1{
+			APIVersion: bundleRegistrationDataAPIVersion,
+			Entries:    dataEntries,
+		}
+	}
+	return upload, nil
+}
+
+func encodeBundleRegistrationEnvelopeYAML(files []bundleRegistrationUploadFile) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("api_version: ")
+	apiVersion, err := json.Marshal(bundleRegistrationEnvelopeAPIVersion)
+	if err != nil {
+		return "", err
+	}
+	builder.Write(apiVersion)
+	builder.WriteString("\nfiles:\n")
+	for _, file := range files {
+		path, err := json.Marshal(file.Path)
+		if err != nil {
+			return "", err
+		}
+		text, err := json.Marshal(file.Text)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString("  - path: ")
+		builder.Write(path)
+		builder.WriteString("\n    text: ")
+		builder.Write(text)
+		builder.WriteString("\n")
+	}
+	return builder.String(), nil
+}
+
+func validateBundleRegistrationUploadDataPath(path string) error {
+	segments := strings.Split(path, "/")
+	if len(segments) < 4 || segments[0] != "flows" || segments[1] == "" || segments[2] != "data" {
+		return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under flows/<flow>/data/...", path)
+	}
+	return nil
+}

--- a/internal/runtime/contracts/bundle_registration_upload_test.go
+++ b/internal/runtime/contracts/bundle_registration_upload_test.go
@@ -38,8 +38,12 @@ func TestBuildBundleRegistrationDirectoryUploadPackagesTextAndData(t *testing.T)
 		}
 	}
 	wantPaths := []string{
+		"flows/alpha/flows/gamma/schema.yaml",
+		"flows/alpha/package.yaml",
 		"flows/alpha/schema.yaml",
 		"package.yaml",
+		"packages/foo/flows/beta/schema.yaml",
+		"packages/foo/package.yaml",
 		"prompts/root.md",
 	}
 	if !reflect.DeepEqual(paths, wantPaths) {
@@ -51,15 +55,17 @@ func TestBuildBundleRegistrationDirectoryUploadPackagesTextAndData(t *testing.T)
 	if upload.DataBlob.APIVersion != bundleRegistrationDataAPIVersion {
 		t.Fatalf("data api_version = %q, want %q", upload.DataBlob.APIVersion, bundleRegistrationDataAPIVersion)
 	}
-	if got, want := len(upload.DataBlob.Entries), 1; got != want {
+	if got, want := len(upload.DataBlob.Entries), 4; got != want {
 		t.Fatalf("data entries = %d, want %d", got, want)
 	}
-	entry := upload.DataBlob.Entries[0]
-	if entry.Path != "flows/alpha/data/payload.bin" {
-		t.Fatalf("data path = %q", entry.Path)
+	wantData := []BundleRegisterDataEntryV1{
+		{Path: "flows/alpha/data/empty.bin", DataBase64: ""},
+		{Path: "flows/alpha/data/payload.bin", DataBase64: base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03})},
+		{Path: "flows/alpha/flows/gamma/data/nested.bin", DataBase64: base64.StdEncoding.EncodeToString([]byte{0x09})},
+		{Path: "packages/foo/flows/beta/data/child.bin", DataBase64: base64.StdEncoding.EncodeToString([]byte{0x04, 0x05})},
 	}
-	if want := base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}); entry.DataBase64 != want {
-		t.Fatalf("data_base64 = %q, want %q", entry.DataBase64, want)
+	if !reflect.DeepEqual(upload.DataBlob.Entries, wantData) {
+		t.Fatalf("data entries = %#v, want %#v", upload.DataBlob.Entries, wantData)
 	}
 }
 
@@ -100,13 +106,6 @@ func TestBuildBundleRegistrationDirectoryUploadFailsClosed(t *testing.T) {
 			},
 			wantErrSub: "not valid UTF-8",
 		},
-		{
-			name: "empty raw data",
-			mutate: func(t *testing.T, root string) {
-				writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
-			},
-			wantErrSub: "cannot be represented in BundleRegisterDataBlobV1",
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -126,6 +125,8 @@ func writeBundleRegistrationUploadFixture(t *testing.T, root string) {
 	writeBundleHashText(t, filepath.Join(root, "package.yaml"), `
 name: upload-fixture
 version: "1.0.0"
+packages:
+  - path: packages/foo
 flows:
   - id: alpha
     flow: alpha
@@ -137,5 +138,34 @@ states:
   - done
 `)
 	writeBundleHashText(t, filepath.Join(root, "prompts", "root.md"), "root prompt\n")
+	writeBundleHashText(t, filepath.Join(root, "flows", "alpha", "package.yaml"), `
+name: nested-flow-package
+version: "1.0.0"
+flows:
+  - id: gamma
+    flow: gamma
+`)
+	writeBundleHashText(t, filepath.Join(root, "flows", "alpha", "flows", "gamma", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleHashText(t, filepath.Join(root, "packages", "foo", "package.yaml"), `
+name: child-package
+version: "1.0.0"
+flows:
+  - id: beta
+    flow: beta
+`)
+	writeBundleHashText(t, filepath.Join(root, "packages", "foo", "flows", "beta", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
 	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
+	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "flows", "gamma", "data", "nested.bin"), []byte{0x09})
+	writeBundleHashBytes(t, filepath.Join(root, "packages", "foo", "flows", "beta", "data", "child.bin"), []byte{0x04, 0x05})
 }

--- a/internal/runtime/contracts/bundle_registration_upload_test.go
+++ b/internal/runtime/contracts/bundle_registration_upload_test.go
@@ -1,0 +1,141 @@
+package contracts
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestBuildBundleRegistrationDirectoryUploadPackagesTextAndData(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := t.TempDir()
+	writeBundleRegistrationUploadFixture(t, root)
+	writeBundleHashText(t, filepath.Join(root, ".DS_Store"), "ignored")
+	writeBundleHashText(t, filepath.Join(root, "prompts", ".#ignored.md"), "ignored")
+
+	upload, err := BuildBundleRegistrationDirectoryUpload(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload: %v", err)
+	}
+
+	var envelope bundleRegistrationEnvelopeUploadV1
+	if err := yaml.Unmarshal([]byte(upload.ContentYAML), &envelope); err != nil {
+		t.Fatalf("unmarshal content_yaml: %v\n%s", err, upload.ContentYAML)
+	}
+	if envelope.APIVersion != bundleRegistrationEnvelopeAPIVersion {
+		t.Fatalf("api_version = %q, want %q", envelope.APIVersion, bundleRegistrationEnvelopeAPIVersion)
+	}
+	var paths []string
+	for _, file := range envelope.Files {
+		paths = append(paths, file.Path)
+		if strings.Contains(file.Text, "ignored") {
+			t.Fatalf("ignored content leaked through %s", file.Path)
+		}
+	}
+	wantPaths := []string{
+		"flows/alpha/schema.yaml",
+		"package.yaml",
+		"prompts/root.md",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("files = %#v, want %#v\n%s", paths, wantPaths, upload.ContentYAML)
+	}
+	if upload.DataBlob == nil {
+		t.Fatal("DataBlob = nil, want one data entry")
+	}
+	if upload.DataBlob.APIVersion != bundleRegistrationDataAPIVersion {
+		t.Fatalf("data api_version = %q, want %q", upload.DataBlob.APIVersion, bundleRegistrationDataAPIVersion)
+	}
+	if got, want := len(upload.DataBlob.Entries), 1; got != want {
+		t.Fatalf("data entries = %d, want %d", got, want)
+	}
+	entry := upload.DataBlob.Entries[0]
+	if entry.Path != "flows/alpha/data/payload.bin" {
+		t.Fatalf("data path = %q", entry.Path)
+	}
+	if want := base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}); entry.DataBase64 != want {
+		t.Fatalf("data_base64 = %q, want %q", entry.DataBase64, want)
+	}
+}
+
+func TestBuildBundleRegistrationDirectoryUploadFailsClosed(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	for _, tc := range []struct {
+		name       string
+		mutate     func(t *testing.T, root string)
+		wantErrSub string
+	}{
+		{
+			name: "symlink",
+			mutate: func(t *testing.T, root string) {
+				target := filepath.Join(root, "prompts", "root.md")
+				link := filepath.Join(root, "prompts", "link.md")
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unsupported: %v", err)
+				}
+			},
+			wantErrSub: "symlink",
+		},
+		{
+			name: "ascii case collision",
+			mutate: func(t *testing.T, root string) {
+				writeBundleHashText(t, filepath.Join(root, "prompts", "Root.md"), "collision\n")
+				lower, errLower := os.Stat(filepath.Join(root, "prompts", "root.md"))
+				upper, errUpper := os.Stat(filepath.Join(root, "prompts", "Root.md"))
+				if errLower == nil && errUpper == nil && os.SameFile(lower, upper) {
+					t.Skip("case-insensitive filesystem cannot represent ASCII case collision fixture")
+				}
+			},
+			wantErrSub: "case-colliding",
+		},
+		{
+			name: "invalid prompt utf8",
+			mutate: func(t *testing.T, root string) {
+				writeBundleHashBytes(t, filepath.Join(root, "prompts", "bad.md"), []byte{0xff})
+			},
+			wantErrSub: "not valid UTF-8",
+		},
+		{
+			name: "empty raw data",
+			mutate: func(t *testing.T, root string) {
+				writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "empty.bin"), nil)
+			},
+			wantErrSub: "cannot be represented in BundleRegisterDataBlobV1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeBundleRegistrationUploadFixture(t, root)
+			tc.mutate(t, root)
+
+			_, err := BuildBundleRegistrationDirectoryUpload(repo, root, DefaultPlatformSpecFile(repo))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func writeBundleRegistrationUploadFixture(t *testing.T, root string) {
+	t.Helper()
+	writeBundleHashText(t, filepath.Join(root, "package.yaml"), `
+name: upload-fixture
+version: "1.0.0"
+flows:
+  - id: alpha
+    flow: alpha
+`)
+	writeBundleHashText(t, filepath.Join(root, "flows", "alpha", "schema.yaml"), `
+initial_state: start
+states:
+  - start
+  - done
+`)
+	writeBundleHashText(t, filepath.Join(root, "prompts", "root.md"), "root prompt\n")
+	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
+}

--- a/openrpc.json
+++ b/openrpc.json
@@ -8509,7 +8509,7 @@
                   "type": "string"
                 },
                 "path": {
-                  "description": "Strictly sorted slash-separated path under flows/\u003cflow\u003e/data/... with the same normalization and collision rules as BundleRegistrationFile.path.",
+                  "description": "Strictly sorted slash-separated path under a discovered flow data directory, such as flows/\u003cflow\u003e/data/..., packages/\u003cpackage\u003e/flows/\u003cflow\u003e/data/..., or a nested flow package path, with the same normalization and collision rules as BundleRegistrationFile.path.",
                   "minLength": 1,
                   "type": "string"
                 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6090,15 +6090,28 @@ multi_bundle_persistence:
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
   cli_surface:
-    publication_status: bundle_inventory_register_envelope_run_fork_and_boot_pinned_serve_bundle_hash_implemented_other_cli_children_pending
+    publication_status: bundle_inventory_register_envelope_directory_run_fork_and_boot_pinned_serve_bundle_hash_implemented_other_cli_children_pending
     bundle_commands_supported:
       - swarm bundle list
       - swarm bundle show <bundle-hash>
       - swarm bundle agents <bundle-hash>
       - swarm bundle register <registration-envelope-yaml> [--data-blob <data-blob-json>] [--idempotency-key <key>]
+      - swarm bundle register --contracts <contracts-directory> [--idempotency-key <key>]
     bundle_commands_split:
-      - swarm bundle register <contracts-directory-or-archive>
+      - swarm bundle register --archive <archive-file>
       - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
+    bundle_register_directory_packager:
+      owner: internal/runtime/contracts.BuildBundleRegistrationDirectoryUpload
+      status: implemented_local_directory_packager
+      cli_consumer: swarm bundle register --contracts <contracts-directory>
+      rule: >
+        The local directory packager converts a selected contracts directory into BundleRegistrationEnvelopeV1
+        content_yaml plus optional BundleRegisterDataBlobV1 entries without computing bundle_hash, building catalog
+        projection bytes, touching store/runtime writers, or sending server-local paths. It reuses canonical bundle input
+        discovery for traversal, ignored file/dir, symlink, normalized-label, duplicate, and ASCII case-collision behavior,
+        emits slash-relative NFC bundle paths in deterministic order, writes text inputs to content_yaml, and writes only
+        flows/<flow>/data/... raw inputs to data_blob. Archive packaging remains split until archive format and extraction
+        safety rules are promoted.
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev
@@ -6186,8 +6199,8 @@ multi_bundle_persistence:
       reason: swarm fork consumes /v1/rpc run.fork only; same-bundle DB-loaded source loading is supported by #1024, and cross-bundle fork routing remains split to #976.
     multi_bundle_cli_inventory:
       tracker: '#1023'
-      implementation_status: inventory_and_prepared_envelope_register_implemented
-      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only, and prepared-envelope swarm bundle register consumes /v1/rpc bundle.register only. Contracts-directory/archive register packaging and bundle.delete CLI remain split until their exact CLI/runtime/packaging owners land.
+      implementation_status: inventory_prepared_envelope_and_directory_register_implemented
+      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only, prepared-envelope swarm bundle register consumes /v1/rpc bundle.register only, and swarm bundle register --contracts packages a local contracts directory through the non-hashing registration upload owner before calling /v1/rpc bundle.register. Archive register packaging and bundle.delete CLI remain split until their exact CLI/runtime/packaging owners land.
     bundle_hash_dual_accept_migration:
       tracker: '#1001'
       reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
@@ -9727,28 +9740,31 @@ cli_specification:
     bundle:
       command: swarm bundle list|show|agents|register
       tier: should_have
-      implementation_status: implemented_inventory_and_prepared_envelope_register
-      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Prepared-envelope swarm bundle register is implemented over /v1/rpc bundle.register. Directory/archive packaging and bundle.delete CLI remain split until their exact owners are promoted.'
+      implementation_status: implemented_inventory_prepared_envelope_and_directory_register
+      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Prepared-envelope swarm bundle register and local directory swarm bundle register --contracts are implemented over /v1/rpc bundle.register. Archive packaging and bundle.delete CLI remain split until their exact owners are promoted.'
       owners:
       - multi_bundle_persistence.cli_surface.bundle_commands_supported
       - multi_bundle_persistence.api_surface.bundle_methods_planned
       behavior: >
-        Public CLI family for persisted bundle inventory, agent catalog inspection, and prepared-envelope registration.
+        Public CLI family for persisted bundle inventory, agent catalog inspection, prepared-envelope registration, and
+        local contracts-directory registration.
         The implemented list/show/agents commands consume /v1/rpc bundle.list, bundle.get, and bundle.agents. The
         implemented register command consumes /v1/rpc bundle.register with an already-prepared
         BundleRegistrationEnvelopeV1 YAML file as content_yaml, optional BundleRegisterDataBlobV1 JSON from
-        --data-blob, and optional --idempotency-key. The CLI must not call internal store/runtime helpers, compute
-        bundle_hash, materialize a contract root, infer bundle state from local files, or implement contracts-directory
-        or archive packaging. Destructive bundle.delete has a live API owner but remains split as a CLI consumer until a
-        later gate promotes that command.
+        --data-blob, and optional --idempotency-key, or with --contracts <contracts-directory> through the non-hashing
+        registration upload owner. The --contracts path may package local upload bytes but must not call internal
+        store/runtime helpers, compute bundle_hash, build catalog projection bytes, infer persisted bundle state from
+        local files, or send server-local path semantics. Archive packaging remains split. Destructive bundle.delete has
+        a live API owner but remains split as a CLI consumer until a later gate promotes that command.
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
       - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
-      - invalid args, invalid local envelope/data blob files, and missing SWARM_API_TOKEN make zero API calls
+      - local directory packaging proves traversal/root escape, symlink fail-closed behavior, ignored file/dir policy, slash-relative NFC paths, duplicate and ASCII case-collision failure, text-vs-flows-data split, deterministic ordering, and no bundle_hash param
+      - invalid args, invalid local envelope/data blob files, invalid local contracts directories, and missing SWARM_API_TOKEN make zero API calls
       - human and --json output render only server-owned result fields
       - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/hash-owner bundle reads or writes from CLI
-      - swarm bundle delete, unpromoted bundle.get alias, contracts-directory register packaging, and archive register packaging remain absent/unknown until later CLI gates
+      - swarm bundle delete, unpromoted bundle.get alias, and archive register packaging remain absent/unknown until later CLI gates
     run_fork:
       command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
       tier: should_have
@@ -10193,7 +10209,7 @@ cli_specification:
     - swarm control mailbox
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
-    - swarm bundle register <contracts-directory-or-archive>
+    - swarm bundle register --archive <archive-file>
     - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
@@ -10236,9 +10252,10 @@ api_specification:
       filters, and bundle_hash create-new-work params. The read-only bundle.list, bundle.get, and bundle.agents methods are
       now in method_catalog/OpenRPC with matching handlers and proof. Non-destructive bundle.register is also published
       in method_catalog/OpenRPC with its handler/store/idempotency owner proof by #1017; the prepared-envelope swarm
-      bundle register CLI consumer is implemented by #1167, while contracts-directory/archive packaging remains split.
+      bundle register CLI consumer is implemented by #1167, and local contracts-directory packaging is implemented by
+      #1187 through the non-hashing upload packager owner, while archive packaging remains split.
       run.fork is also promoted into method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by
-      #989. The swarm bundle list/show/agents/register and swarm fork CLI consumers are implemented by #1023/#1167 and
+      #989. The swarm bundle list/show/agents/register and swarm fork CLI consumers are implemented by #1023/#1167/#1187 and
       consume only those canonical /v1/rpc methods. bundle.delete is promoted into method_catalog/OpenRPC with matching
       API/runtime handler proof by #1018 and #1019: omitted or false force performs non-force deletion and force=true
       performs force cleanup. Remaining multi-bundle methods and shapes are

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6109,9 +6109,11 @@ multi_bundle_persistence:
         content_yaml plus optional BundleRegisterDataBlobV1 entries without computing bundle_hash, building catalog
         projection bytes, touching store/runtime writers, or sending server-local paths. It reuses canonical bundle input
         discovery for traversal, ignored file/dir, symlink, normalized-label, duplicate, and ASCII case-collision behavior,
-        emits slash-relative NFC bundle paths in deterministic order, writes text inputs to content_yaml, and writes only
-        flows/<flow>/data/... raw inputs to data_blob. Archive packaging remains split until archive format and extraction
-        safety rules are promoted.
+        emits slash-relative NFC bundle paths in deterministic order, writes text inputs to content_yaml, and writes raw
+        inputs under every discovered flow data directory to data_blob, including root flows/<flow>/data/...,
+        package flows such as packages/<package>/flows/<flow>/data/..., and nested flow packages such as
+        flows/<parent>/flows/<child>/data/.... Empty raw-data files are represented as empty base64 strings. Archive
+        packaging remains split until archive format and extraction safety rules are promoted.
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev
@@ -9759,7 +9761,7 @@ cli_specification:
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
       - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
-      - local directory packaging proves traversal/root escape, symlink fail-closed behavior, ignored file/dir policy, slash-relative NFC paths, duplicate and ASCII case-collision failure, text-vs-flows-data split, deterministic ordering, and no bundle_hash param
+      - local directory packaging proves traversal/root escape, symlink fail-closed behavior, ignored file/dir policy, slash-relative NFC paths, duplicate and ASCII case-collision failure, text-vs-every-discovered-flow-data split including empty raw data, deterministic ordering, and no bundle_hash param
       - invalid args, invalid local envelope/data blob files, invalid local contracts directories, and missing SWARM_API_TOKEN make zero API calls
       - human and --json output render only server-owned result fields
       - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
@@ -10954,7 +10956,7 @@ api_specification:
                 path:
                   type: string
                   minLength: 1
-                  description: Strictly sorted slash-separated path under flows/<flow>/data/... with the same normalization and collision rules as BundleRegistrationFile.path.
+                  description: Strictly sorted slash-separated path under a discovered flow data directory, such as flows/<flow>/data/..., packages/<package>/flows/<flow>/data/..., or a nested flow package path, with the same normalization and collision rules as BundleRegistrationFile.path.
                 data_base64:
                   type: string
                   contentEncoding: base64


### PR DESCRIPTION
Part of #1187

## Summary

- Adds `swarm bundle register --contracts <contracts-directory>` as the approved directory-only local packaging slice.
- Introduces `internal/runtime/contracts.BuildBundleRegistrationDirectoryUpload` as the non-hashing owner that emits `BundleRegistrationEnvelopeV1` content YAML and optional `BundleRegisterDataBlobV1` entries.
- Keeps prepared-envelope registration intact and keeps archive packaging, bundle.delete, serve/runtime routing, direct store/runtime registration, and hash/projection ownership out of scope.

## Governing refs / context

- `platform-spec.yaml#multi_bundle_persistence.cli_surface`
- `platform-spec.yaml#cli_specification.command_catalog.bundle`
- `platform-spec.yaml#api_specification.multi_bundle_publication_boundary`
- Generated root `openrpc.json` method: `/v1/rpc bundle.register`
- Binding issue/gate context: #1187 Pre-Implementation Coverage Audit and independent B-gate approval limited this PR to directory packaging only.

## Semantic migration

- New canonical owner: `internal/runtime/contracts.BuildBundleRegistrationDirectoryUpload` for local contracts-directory upload packaging.
- Old invalid path: treating a contracts directory as a prepared-envelope file or inferring archive/file type from a positional argument.
- Still invalid paths: CLI computing `bundle_hash`, building catalog projections, writing store/runtime state, or sending server-local filesystem paths.
- Production paths checked: prepared-envelope `swarm bundle register <registration-envelope-yaml>`, directory `swarm bundle register --contracts`, API-backed `bundle.register`, server materialization/hash/projection/store path, and CLI no-bypass guards.
- Migration completeness: complete for local contracts-directory packaging only; archive packaging remains split/spec-blocked.

## Verification

- `go test ./...`
