### PR TITLE
[agent-e][issue #1118] Resolve wildcard route subscribers dynamically

### DIFF
--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -99,7 +99,23 @@ func (rt *RouteTable) Resolve(eventType string) []Subscriber {
 	}
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
-	return cloneSubscribers(rt.routes[eventType])
+	out := cloneSubscribers(rt.routes[eventType])
+	if _, active := rt.eventPath[eventType]; !active {
+		return out
+	}
+	for _, pattern := range rt.patterns {
+		eventPattern := strings.Trim(strings.TrimSpace(pattern.EventPattern), "/")
+		if eventPattern == "" || !strings.Contains(eventPattern, "*") {
+			continue
+		}
+		if !RouteMatches(eventPattern, eventType) {
+			continue
+		}
+		subscriber := pattern.Subscriber
+		subscriber.MatchPattern = eventPattern
+		out = appendUniqueSubscriber(out, subscriber)
+	}
+	return out
 }
 
 func (rt *RouteTable) AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
@@ -368,6 +384,13 @@ func routeProjectLocalEventSet(scope semanticview.ProjectScope) map[string]struc
 
 func routeFlowLocalEventSet(source semanticview.Source, scope semanticview.FlowScope) map[string]struct{} {
 	out := routeEventKeys(scope.Events)
+	for _, eventType := range scope.OutputEvents {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			continue
+		}
+		out[eventType] = struct{}{}
+	}
 	for _, eventType := range scope.InputEvents {
 		eventType = strings.TrimSpace(eventType)
 		if eventType == "" || routeFlowInputHasExternalProducer(source, scope.ID, eventType) {

--- a/internal/runtime/bus/routing_derivation_internal_test.go
+++ b/internal/runtime/bus/routing_derivation_internal_test.go
@@ -1,0 +1,179 @@
+package bus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+)
+
+func TestRouteTableResolve_WildcardSubscriberMatchesActiveConcreteChildEventWithoutMaterializedKey(t *testing.T) {
+	const pattern = "component-scaffold/*/component.scaffolded"
+	const eventType = "component-scaffold/component-a/component.scaffolded"
+	rt := newRouteTable(nil)
+	rt.eventPath[eventType] = struct{}{}
+	rt.patterns = []routePattern{{
+		EventPattern: pattern,
+		Subscriber: Subscriber{
+			ID:   "operating-accumulator",
+			Type: "node",
+		},
+	}}
+	rt.rebuildLocked()
+	delete(rt.routes, eventType)
+
+	got := rt.Resolve(eventType)
+	if len(got) != 1 {
+		t.Fatalf("Resolve concrete child event = %#v, want one wildcard subscriber", got)
+	}
+	if got[0].ID != "operating-accumulator" || got[0].Type != "node" {
+		t.Fatalf("resolved subscriber = %#v, want operating-accumulator node", got[0])
+	}
+	if got[0].MatchPattern != pattern {
+		t.Fatalf("matched pattern = %q, want %q", got[0].MatchPattern, pattern)
+	}
+	if got := rt.Resolve("component-scaffold/component-a/component.failed"); len(got) != 0 {
+		t.Fatalf("Resolve unrelated event = %#v, want none", got)
+	}
+	if got := rt.Resolve("component-scaffold/component-b/component.scaffolded"); len(got) != 0 {
+		t.Fatalf("Resolve never-added instance event = %#v, want none", got)
+	}
+	if got := rt.Resolve("other-scaffold/component-a/component.scaffolded"); len(got) != 0 {
+		t.Fatalf("Resolve unrelated path = %#v, want none", got)
+	}
+}
+
+func TestRouteTableResolve_WildcardSubscriberDoesNotMatchRemovedConcreteChildEvent(t *testing.T) {
+	const pattern = "component-scaffold/*/component.scaffolded"
+	const eventType = "component-scaffold/component-a/component.scaffolded"
+	rt := newRouteTable(nil)
+	rt.eventPath[eventType] = struct{}{}
+	rt.patterns = []routePattern{{
+		EventPattern: pattern,
+		Subscriber: Subscriber{
+			ID:   "operating-accumulator",
+			Type: "node",
+		},
+	}}
+	rt.rebuildLocked()
+	if got := rt.Resolve(eventType); len(got) != 1 {
+		t.Fatalf("Resolve active event = %#v, want one subscriber before removal", got)
+	}
+
+	delete(rt.eventPath, eventType)
+	rt.rebuildLocked()
+
+	if got := rt.Resolve(eventType); len(got) != 0 {
+		t.Fatalf("Resolve removed event = %#v, want none", got)
+	}
+}
+
+func TestRouteTableResolve_ExactAndWildcardMatchesDeduplicateSameSubscriber(t *testing.T) {
+	const (
+		exact   = "component-scaffold/component-a/component.scaffolded"
+		pattern = "component-scaffold/*/component.scaffolded"
+	)
+	rt := newRouteTable(nil)
+	rt.eventPath[exact] = struct{}{}
+	rt.patterns = []routePattern{
+		{
+			EventPattern: exact,
+			Subscriber: Subscriber{
+				ID:   "dual-listener",
+				Type: "node",
+			},
+		},
+		{
+			EventPattern: pattern,
+			Subscriber: Subscriber{
+				ID:   "dual-listener",
+				Type: "node",
+			},
+		},
+		{
+			EventPattern: pattern,
+			Subscriber: Subscriber{
+				ID:   "wildcard-listener",
+				Type: "node",
+			},
+		},
+		{
+			EventPattern: exact,
+			Subscriber: Subscriber{
+				ID:   "exact-listener",
+				Type: "node",
+			},
+		},
+	}
+	rt.rebuildLocked()
+
+	got := rt.Resolve(exact)
+	if len(got) != 3 {
+		t.Fatalf("Resolve exact child event = %#v, want three distinct subscribers", got)
+	}
+	ids := subscriberIDsForTest(got)
+	for _, want := range []string{"dual-listener", "wildcard-listener", "exact-listener"} {
+		if ids[want] != 1 {
+			t.Fatalf("subscriber %q count = %d in %#v, want 1", want, ids[want], got)
+		}
+	}
+}
+
+func TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution(t *testing.T) {
+	const pattern = "component-scaffold/*/component.scaffolded"
+	const eventType = "component-scaffold/component-a/component.scaffolded"
+	rt := newRouteTable(nil)
+	rt.eventPath[eventType] = struct{}{}
+	rt.patterns = []routePattern{{
+		EventPattern: pattern,
+		Subscriber: Subscriber{
+			ID:          "operating-observer",
+			Type:        "agent",
+			RouteSource: "subscription",
+		},
+	}}
+	rt.rebuildLocked()
+	delete(rt.routes, eventType)
+	eb, err := NewEventBusWithOptions(InMemoryEventStore{}, EventBusOptions{RouteTable: rt})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.Subscribe("operating-observer")
+	defer eb.Unsubscribe("operating-observer")
+	recorder := NewEmittedEventsRecorder()
+	ctx := WithEmittedEventsRecorder(context.Background(), recorder)
+
+	if err := eb.Publish(ctx, events.Event{
+		Type: eventType,
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case evt := <-ch:
+		if evt.Type != events.EventType(eventType) {
+			t.Fatalf("delivered event type = %q, want concrete child event", evt.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for routed wildcard delivery")
+	}
+
+	diags := recorder.SnapshotPublishes()
+	if len(diags) != 1 || len(diags[0].RoutedRecipients) != 1 {
+		t.Fatalf("publish diagnostics = %#v, want one routed recipient", diags)
+	}
+	if got := diags[0].RoutedRecipients[0].ID; got != "operating-observer" {
+		t.Fatalf("routed recipient = %q, want operating-observer", got)
+	}
+	if got := diags[0].RoutedRecipients[0].MatchedPattern; got != pattern {
+		t.Fatalf("matched pattern = %q, want %q", got, pattern)
+	}
+}
+
+func subscriberIDsForTest(in []Subscriber) map[string]int {
+	out := make(map[string]int, len(in))
+	for _, subscriber := range in {
+		out[subscriber.ID]++
+	}
+	return out
+}

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -221,6 +221,64 @@ func TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryP
 	}
 }
 
+func TestRouteTableTemplateOutputPinWildcardSubscriberResolvesThroughDerivedInstance(t *testing.T) {
+	root := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "root", Flow: "root"},
+		Path:  "",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"operating-accumulator": {
+				ID:           "operating-accumulator",
+				SubscribesTo: []string{"component-scaffold/*/component.scaffolded"},
+			},
+		},
+		Children: []runtimecontracts.FlowContractView{
+			{
+				Paths: runtimecontracts.FlowContractPaths{ID: "component-scaffold", Flow: "component-scaffold"},
+				Path:  "component-scaffold",
+				Schema: runtimecontracts.FlowSchemaDocument{
+					Mode: "template",
+					Pins: runtimecontracts.FlowPins{
+						Outputs: runtimecontracts.FlowOutputPins{Events: []string{"component.scaffolded"}},
+					},
+				},
+			},
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"root":               &root,
+				"component-scaffold": &root.Children[0],
+			},
+		},
+	}
+	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	identity := runtimeflowidentity.DeriveRoute("component-scaffold", "component-a")
+	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, identity); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+
+	got := rt.Resolve("component-scaffold/component-a/component.scaffolded")
+	if len(got) != 1 {
+		t.Fatalf("resolved subscribers = %#v, want one operating-accumulator route", got)
+	}
+	if got[0].ID != "operating-accumulator" || got[0].Type != "node" || got[0].MatchPattern != "component-scaffold/*/component.scaffolded" {
+		t.Fatalf("resolved subscriber = %#v, want operating-accumulator wildcard route", got[0])
+	}
+
+	rt.RemoveFlowInstanceRoute(identity)
+	if got := rt.Resolve("component-scaffold/component-a/component.scaffolded"); len(got) != 0 {
+		t.Fatalf("resolved subscribers after remove = %#v, want none", got)
+	}
+	if got := rt.Resolve("component-scaffold/component-b/component.scaffolded"); len(got) != 0 {
+		t.Fatalf("resolved subscribers for never-added instance = %#v, want none", got)
+	}
+}
+
 func TestDeriveRouteTable_InputPinsAutoWireFromProducerOutput(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},


### PR DESCRIPTION
## Summary

Closes #1118.

- Makes `RouteTable.Resolve(eventType)` return exact subscribers plus stored wildcard subscribers whose patterns match the concrete event type only when that concrete event path is active in the route table.
- Registers flow `pins.outputs.events` in the route table's active local event-path owner, so template output-pin completions become active after `AddFlowInstanceRoute` without duplicating them in `events.yaml`.
- Keeps wildcard matching on the canonical `RouteMatches` / `eventidentity.MatchPattern` path while preserving active-instance teardown semantics.
- Adds focused route-table proof for production `DeriveRouteTable` + `AddFlowInstanceRoute` output-pin wildcard resolution, active no-materialized-key wildcard matching, never-added/removed concrete-path non-match, exact/wildcard de-duplication, unrelated wildcard non-overmatch, and EventBus publish consumption of the corrected `Resolve` path.

## Governing Refs / Context

- #1118 body and approved gate comment: `runtime.route_table_wildcard_subscriber_resolution` approved as first slice.
- `platform-spec.yaml`:
  - `engine.event_identity`
  - `engine.cross_flow_routing.delivery_filter`
- Adjacent historical contract context used in the audit:
  - `docs/specs/swarm-platform/platform/platform-spec.md#wildcards`
  - `docs/specs/swarm-platform/platform/platform-spec.md#routing_rules`

No `platform-spec.yaml` change is included because this PR implements the existing canonical resolver / publish-time recipient-construction contract; it does not introduce a new platform API, architecture surface, or runtime semantic category.

Split siblings remain out of scope: #1119, #1122, #1117, #1116, #1115, #1114, and final #1025 / Empire #87 proof closure.

## Semantic Migration

- Canonical owner after this change: `internal/runtime/bus.RouteTable.Resolve`, consuming stored `routePattern` entries, active concrete event-path state, and `internal/runtime/bus.RouteMatches`.
- Active route-event owner repaired: `routeFlowLocalEventSet` now includes `FlowScope.OutputEvents`, so output-pin completions are installed into `RouteTable.eventPath` during derivation/instance activation.
- Old non-authoritative path now invalid: treating `rt.routes[eventType]` as the exhaustive subscriber-resolution truth when active wildcard subscriber patterns exist.
- Old over-broad path rejected by review and fixed: treating syntactic wildcard match alone as sufficient when the concrete event path was never added or was removed.
- Checked production paths: EventBus publish/delivery planning, runfork admission route-derived recipients, selected route history, and runstart root-input checks all consume `RouteTable.Resolve` or remain different concepts.
- Migration complete for the approved #1118 child class.

## Verification

Passed on rebased head `e0fb5704`:
- `go test ./internal/runtime/bus -run 'TestRouteTableTemplateOutputPinWildcardSubscriberResolvesThroughDerivedInstance|TestRouteTableResolve_(WildcardSubscriberMatchesActiveConcreteChildEventWithoutMaterializedKey|WildcardSubscriberDoesNotMatchRemovedConcreteChildEvent|ExactAndWildcardMatchesDeduplicateSameSubscriber)|TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution' -count=1`
- `go test ./internal/runtime/core/eventidentity ./internal/runtime/bus ./internal/runtime/runforkadmission ./internal/runtime/runstart -count=1`
- `go test ./internal/store -run TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2 -count=1 -timeout 20m`
- `git diff --check`

Whole-suite note:
- `go test ./...` was attempted after the output-pin repair before the final rebase. It passed visible packages through `internal/runtime/...`, then `internal/store` hit Go's 10m package timeout in `TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2` while multiple local whole-suite runs were active. The exact timed-out store test passed separately on the rebased head with a 20m timeout.