### PR TITLE
[agent-g][issue #1157] Add backend-neutral agent usage read owner

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -139,6 +139,7 @@ type storeBundle struct {
 	BudgetSpendStore    budgetspend.Store
 	MailboxAPIStore     apiv1.MailboxAPIStore
 	ObservabilityStore  apiv1.ObservabilityReadStore
+	AgentUsageStore     apiv1.AgentUsageReadStore
 	RuntimeIngressStore runtimeingress.Store
 	IdempotencyStore    apiv1.APIIdempotencyStore
 	TurnStore           runtimellm.TurnPersistence
@@ -622,6 +623,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Observability:      apiObservability,
 		Entities:           apiEntities,
 		AgentConversations: apiAgentConversations,
+		AgentUsage:         stores.AgentUsageStore,
 		BundleCatalog:      stores.Postgres,
 		BundleDelete: &runtimebundledelete.Coordinator{
 			Planner:            stores.Postgres,
@@ -2089,6 +2091,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			BudgetSpendStore:    pg,
 			MailboxAPIStore:     pg,
 			ObservabilityStore:  pg,
+			AgentUsageStore:     pg,
 			RuntimeIngressStore: pg,
 			IdempotencyStore:    pg,
 			TurnStore:           pg,
@@ -2125,6 +2128,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			BudgetSpendStore:    sqliteStore,
 			MailboxAPIStore:     sqliteStore,
 			ObservabilityStore:  sqliteStore,
+			AgentUsageStore:     sqliteStore,
 			RuntimeIngressStore: sqliteStore,
 			IdempotencyStore:    sqliteStore,
 			TurnStore:           sqliteStore,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -185,7 +185,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxMaterializer == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxMaterializer == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.AgentUsageStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {

--- a/docs/watchlists/runtime-operations.yaml
+++ b/docs/watchlists/runtime-operations.yaml
@@ -446,8 +446,9 @@ nodes:
       - "#1086 must port core runtime persistence stores behind backend-neutral SQLite/Postgres contracts."
       - "#1087 must port session, locking, delivery, replay, trace-stream, and runtime diagnostics/log semantics for the SQLite local runtime path; #1147-#1150 are the focused runtime-construction children under that parent."
       - "#1186 promotes backend-neutral mailbox_write materialization through runtimepipeline.MailboxWriteMaterializationStore and removes the residual raw-SQL runtime construction blocker for explicit SQLite selection."
+      - "#1157 promotes backend-neutral public agent.usage read parity through internal/store.OperatorAgentUsageReadStore over canonical spend_ledger facts for Postgres and explicit SQLite."
       - "#1088 must flip the active local/dev default to SQLite only after zero-service swarm run and explicit Postgres opt-in are proven together."
-      - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes; #1157 agent.usage read parity and production SQLite multi-writer semantics remain explicitly split until separately closed."
+      - "#1089 must close docs, CI, repo-wide stale-default audit, and parent proof before #1066 closes; production SQLite multi-writer semantics remain explicitly split until separately closed."
     representative_issues:
       - 1066
       - 1084
@@ -456,6 +457,7 @@ nodes:
       - 1087
       - 1088
       - 1089
+      - 1157
       - 1186
     common_framing_mistakes:
       too_broad:

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -333,7 +333,7 @@ func readOnlyHTTPRuntimeErrorProbes() []readOnlyHTTPRuntimeErrorProbe {
 			Code:   AgentNotFoundCode,
 			Options: func(t *testing.T) OperatorReadOptions {
 				opts := readOnlyRuntimeProbeOptions(t)
-				opts.AgentConversations = &fakeAgentConversationReadStore{agentUsageErr: store.ErrAgentNotFound}
+				opts.AgentUsage = &fakeAgentConversationReadStore{agentUsageErr: store.ErrAgentNotFound}
 				return opts
 			},
 		},
@@ -810,6 +810,60 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 			currentConversationResult: &store.OperatorConversationDetail{
 				Conversation: store.OperatorConversationSummary{SessionID: sessionID, AgentID: "agent-1", RunID: runID, StartedAt: now, Status: "active"},
 				Turns:        []store.OperatorConversationTurn{{TurnIndex: 1, TurnID: "turn-current-1", TriggerEventID: eventID, TriggerEventType: "scan.requested", ParseOK: true}},
+			},
+		},
+		AgentUsage: &fakeAgentConversationReadStore{
+			agentUsageResult: store.OperatorAgentUsage{
+				AgentID: "agent-1",
+				Window: store.OperatorAgentUsageWindow{
+					Since: ptrTime(now.Add(-time.Hour)),
+					Until: ptrTime(now),
+				},
+				Usage: store.OperatorAgentUsageByAccounting{
+					Exact: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      100,
+						OutputTokens:     25,
+						EstimatedCostUSD: 0.000675,
+					},
+					Estimated: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      50,
+						OutputTokens:     10,
+						EstimatedCostUSD: 0.000300,
+					},
+				},
+				Breakdown: []store.OperatorAgentUsageBreakdown{{
+					UsageAccounting: store.AgentUsageAccountingExact,
+					InvocationType:  "anthropic",
+					Model:           "claude-3-5-sonnet",
+					ModelAlias:      "regular",
+					BackendProfile:  "anthropic",
+					Provider:        "anthropic",
+					Transport:       "api",
+					ResolvedModel:   "claude-3-5-sonnet",
+					Totals: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      100,
+						OutputTokens:     25,
+						EstimatedCostUSD: 0.000675,
+					},
+				}, {
+					UsageAccounting: store.AgentUsageAccountingEstimated,
+					InvocationType:  "claude_cli",
+					Model:           "sonnet",
+					ModelAlias:      "regular",
+					BackendProfile:  "claude_cli",
+					Provider:        "claude",
+					Transport:       "cli",
+					ResolvedModel:   "sonnet",
+					Totals: store.OperatorAgentUsageTotals{
+						LedgerEntries:    1,
+						InputTokens:      50,
+						OutputTokens:     10,
+						EstimatedCostUSD: 0.000300,
+					},
+				}},
 			},
 		},
 		ConversationForks: &fakeConversationForkLifecycleStore{

--- a/internal/apiv1/operator_agent_conversation_test.go
+++ b/internal/apiv1/operator_agent_conversation_test.go
@@ -303,6 +303,7 @@ func TestOperatorAgentConversationHandlersExposeReadOwner(t *testing.T) {
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			AgentConversations: reads,
+			AgentUsage:         reads,
 		}),
 	})
 
@@ -801,6 +802,7 @@ func TestOperatorAgentConversationHandlersTypedErrors(t *testing.T) {
 				AuthTokens: []string{testToken},
 				Handlers: OperatorReadHandlers(OperatorReadOptions{
 					AgentConversations: tc.reads,
+					AgentUsage:         tc.reads,
 				}),
 			})
 			resp := rpcCall(t, handler, tc.body)
@@ -832,6 +834,7 @@ func TestOperatorAgentUsageFailsClosedOnMalformedOwnerData(t *testing.T) {
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			AgentConversations: reads,
+			AgentUsage:         reads,
 		}),
 	})
 
@@ -1104,7 +1107,7 @@ func TestOperatorAgentUsageRejectsInvalidWindow(t *testing.T) {
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			AgentConversations: &fakeAgentConversationReadStore{},
+			AgentUsage: &fakeAgentConversationReadStore{},
 		}),
 	})
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -44,12 +44,15 @@ type AgentConversationReadStore interface {
 	ListOperatorAgents(context.Context, store.OperatorAgentListOptions) (store.OperatorAgentListResult, error)
 	LoadOperatorAgent(context.Context, string) (store.OperatorAgentDetail, error)
 	LoadOperatorAgentDiagnosis(context.Context, string, store.OperatorAgentDiagnosisOptions) (store.OperatorAgentDiagnosis, error)
-	LoadOperatorAgentUsage(context.Context, string, store.OperatorAgentUsageOptions) (store.OperatorAgentUsage, error)
 	LoadOperatorAgentDeliveryDiagnostics(context.Context, string, store.OperatorAgentDeliveryDiagnosticsOptions) (store.OperatorAgentDeliveryDiagnostics, error)
 	ListOperatorConversations(context.Context, store.OperatorConversationListOptions) (store.OperatorConversationListResult, error)
 	LoadOperatorConversation(context.Context, string) (store.OperatorConversationDetail, error)
 	LoadOperatorConversationTurn(context.Context, string, int) (store.OperatorConversationTurnDetail, error)
 	LoadCurrentOperatorConversationForAgent(context.Context, string) (*store.OperatorConversationDetail, error)
+}
+
+type AgentUsageReadStore interface {
+	LoadOperatorAgentUsage(context.Context, string, store.OperatorAgentUsageOptions) (store.OperatorAgentUsage, error)
 }
 
 type BundleCatalogReadStore interface {
@@ -72,6 +75,7 @@ type OperatorReadOptions struct {
 	Observability         ObservabilityReadStore
 	Entities              EntityReadStore
 	AgentConversations    AgentConversationReadStore
+	AgentUsage            AgentUsageReadStore
 	BundleCatalog         BundleCatalogReadStore
 	BundleDelete          BundleDeleteExecutor
 	ConversationForks     ConversationForkLifecycleStore
@@ -299,6 +303,13 @@ func requireAgentConversationReadStore(reads AgentConversationReadStore) (AgentC
 	return reads, nil
 }
 
+func requireAgentUsageReadStore(reads AgentUsageReadStore) (AgentUsageReadStore, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("agent usage read store is required")
+	}
+	return reads, nil
+}
+
 func requireBundleCatalogReadStore(reads BundleCatalogReadStore) (BundleCatalogReadStore, error) {
 	if reads == nil {
 		return nil, fmt.Errorf("bundle catalog read store is required")
@@ -369,264 +380,273 @@ func OperatorBundleCatalogHandlers(opts OperatorReadOptions) map[string]MethodHa
 }
 
 func OperatorAgentConversationHandlers(opts OperatorReadOptions) map[string]MethodHandler {
-	if opts.AgentConversations == nil {
+	handlers := map[string]MethodHandler{}
+	usageHandler := func(ctx context.Context, req Request) (any, error) {
+		reads, err := requireAgentUsageReadStore(opts.AgentUsage)
+		if err != nil {
+			return nil, err
+		}
+		agentID, err := requiredStringParam(req.Params, "agent_id")
+		if err != nil {
+			return nil, err
+		}
+		usageOpts, err := operatorAgentUsageOptionsFromParams(req.Params)
+		if err != nil {
+			return nil, err
+		}
+		result, err := reads.LoadOperatorAgentUsage(ctx, agentID, usageOpts)
+		if errors.Is(err, store.ErrAgentNotFound) {
+			return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := validateAgentUsageResult(result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+	if opts.AgentConversations != nil {
+		for name, handler := range map[string]MethodHandler{
+			"agent.list": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				listOpts, err := operatorAgentListOptionsFromParams(req.Params)
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.ListOperatorAgents(ctx, listOpts)
+				if err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"agent.get": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				agentID, err := requiredStringParam(req.Params, "agent_id")
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadOperatorAgent(ctx, agentID)
+				if errors.Is(err, store.ErrAgentNotFound) {
+					return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+				}
+				if err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"agent.diagnose": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				agentID, err := requiredStringParam(req.Params, "agent_id")
+				if err != nil {
+					return nil, err
+				}
+				queueLimit, err := boundedIntegerParam(req.Params, "queue_limit", 1, store.MaxAgentDiagnosisQueueLimit)
+				if err != nil {
+					return nil, err
+				}
+				queueCursor, _, err := optionalStringParam(req.Params, "queue_cursor")
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadOperatorAgentDiagnosis(ctx, agentID, store.OperatorAgentDiagnosisOptions{
+					QueueLimit:  queueLimit,
+					QueueCursor: queueCursor,
+				})
+				if errors.Is(err, store.ErrAgentNotFound) {
+					return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+				}
+				if errors.Is(err, store.ErrInvalidPendingAgentDeliveryCursor) {
+					return nil, NewInvalidParamsError(map[string]any{"field": "queue_cursor", "reason": "invalid agent.diagnose queue cursor"})
+				}
+				if err != nil {
+					return nil, err
+				}
+				if err := validateAgentDiagnosisResult(result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"agent.delivery_diagnostics": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				agentID, err := requiredStringParam(req.Params, "agent_id")
+				if err != nil {
+					return nil, err
+				}
+				failureLimit, err := boundedIntegerParam(req.Params, "failure_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
+				if err != nil {
+					return nil, err
+				}
+				deadLetterLimit, err := boundedIntegerParam(req.Params, "dead_letter_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
+				if err != nil {
+					return nil, err
+				}
+				failureCursor, _, err := optionalStringParam(req.Params, "failure_cursor")
+				if err != nil {
+					return nil, err
+				}
+				deadLetterCursor, _, err := optionalStringParam(req.Params, "dead_letter_cursor")
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadOperatorAgentDeliveryDiagnostics(ctx, agentID, store.OperatorAgentDeliveryDiagnosticsOptions{
+					FailureLimit:     failureLimit,
+					FailureCursor:    failureCursor,
+					DeadLetterLimit:  deadLetterLimit,
+					DeadLetterCursor: deadLetterCursor,
+				})
+				if errors.Is(err, store.ErrAgentNotFound) {
+					return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+				}
+				var cursorErr store.AgentDeliveryDiagnosticsCursorError
+				if errors.As(err, &cursorErr) {
+					field := strings.TrimSpace(cursorErr.Field)
+					if field == "" {
+						field = "cursor"
+					}
+					return nil, NewInvalidParamsError(map[string]any{"field": field, "reason": "invalid agent.delivery_diagnostics cursor"})
+				}
+				if err != nil {
+					return nil, err
+				}
+				if err := validateAgentDeliveryDiagnosticsResult(result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"conversation.list": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				listOpts, err := operatorConversationListOptionsFromParams(req.Params)
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.ListOperatorConversations(ctx, listOpts)
+				if errors.Is(err, store.ErrInvalidConversationCursor) {
+					return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid conversation list cursor"})
+				}
+				if paramErr := entityReadParamError(err); paramErr != nil {
+					return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
+				}
+				if err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"conversation.get": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				sessionID, err := requiredStringParam(req.Params, "session_id")
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadOperatorConversation(ctx, sessionID)
+				if errors.Is(err, store.ErrSessionNotFound) {
+					return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
+				}
+				if err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+			"conversation.get_turn": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				sessionID, err := requiredStringParam(req.Params, "session_id")
+				if err != nil {
+					return nil, err
+				}
+				turnIndex, err := requiredBoundedIntegerParam(req.Params, "turn_index", 1, 1000000)
+				if err != nil {
+					return nil, err
+				}
+				includeLogs, err := optionalBoolParam(req.Params, "include_logs", true)
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadOperatorConversationTurn(ctx, sessionID, turnIndex)
+				if errors.Is(err, store.ErrSessionNotFound) {
+					return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
+				}
+				if errors.Is(err, store.ErrTurnNotFound) {
+					return nil, NewApplicationError(TurnNotFoundCode, false, map[string]any{"session_id": sessionID, "turn_index": turnIndex})
+				}
+				if err != nil {
+					return nil, err
+				}
+				if includeLogs {
+					observability, err := requireObservabilityReadStore(opts.Observability)
+					if err != nil {
+						return nil, err
+					}
+					logOpts := store.OperatorRuntimeLogListOptions{
+						SessionID: result.Session.SessionID,
+						Since:     &result.RuntimeLogWindowStart,
+						Until:     result.RuntimeLogWindowEnd,
+						Limit:     1000,
+						Order:     "asc",
+					}
+					logs, err := observability.ListOperatorRuntimeLogs(ctx, logOpts)
+					if errors.Is(err, store.ErrInvalidObservabilityCursor) {
+						return nil, NewInvalidParamsError(map[string]any{"field": "runtime_log_entries", "reason": "invalid runtime log cursor"})
+					}
+					if err != nil {
+						return nil, err
+					}
+					if logs.Logs == nil {
+						logs.Logs = []store.OperatorRuntimeLogEntry{}
+					}
+					result.Turn.RuntimeLogEntries = logs.Logs
+				}
+				return result, nil
+			},
+			"conversation.current_for_agent": func(ctx context.Context, req Request) (any, error) {
+				reads, err := requireAgentConversationReadStore(opts.AgentConversations)
+				if err != nil {
+					return nil, err
+				}
+				agentID, err := requiredStringParam(req.Params, "agent_id")
+				if err != nil {
+					return nil, err
+				}
+				result, err := reads.LoadCurrentOperatorConversationForAgent(ctx, agentID)
+				if errors.Is(err, store.ErrAgentNotFound) {
+					return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
+				}
+				if err != nil {
+					return nil, err
+				}
+				return result, nil
+			},
+		} {
+			handlers[name] = handler
+		}
+	}
+	if opts.AgentUsage != nil {
+		handlers["agent.usage"] = usageHandler
+	}
+	if len(handlers) == 0 {
 		return nil
 	}
-	return map[string]MethodHandler{
-		"agent.list": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			listOpts, err := operatorAgentListOptionsFromParams(req.Params)
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.ListOperatorAgents(ctx, listOpts)
-			if err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"agent.get": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			agentID, err := requiredStringParam(req.Params, "agent_id")
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorAgent(ctx, agentID)
-			if errors.Is(err, store.ErrAgentNotFound) {
-				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-			}
-			if err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"agent.diagnose": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			agentID, err := requiredStringParam(req.Params, "agent_id")
-			if err != nil {
-				return nil, err
-			}
-			queueLimit, err := boundedIntegerParam(req.Params, "queue_limit", 1, store.MaxAgentDiagnosisQueueLimit)
-			if err != nil {
-				return nil, err
-			}
-			queueCursor, _, err := optionalStringParam(req.Params, "queue_cursor")
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorAgentDiagnosis(ctx, agentID, store.OperatorAgentDiagnosisOptions{
-				QueueLimit:  queueLimit,
-				QueueCursor: queueCursor,
-			})
-			if errors.Is(err, store.ErrAgentNotFound) {
-				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-			}
-			if errors.Is(err, store.ErrInvalidPendingAgentDeliveryCursor) {
-				return nil, NewInvalidParamsError(map[string]any{"field": "queue_cursor", "reason": "invalid agent.diagnose queue cursor"})
-			}
-			if err != nil {
-				return nil, err
-			}
-			if err := validateAgentDiagnosisResult(result); err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"agent.usage": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			agentID, err := requiredStringParam(req.Params, "agent_id")
-			if err != nil {
-				return nil, err
-			}
-			usageOpts, err := operatorAgentUsageOptionsFromParams(req.Params)
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorAgentUsage(ctx, agentID, usageOpts)
-			if errors.Is(err, store.ErrAgentNotFound) {
-				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-			}
-			if err != nil {
-				return nil, err
-			}
-			if err := validateAgentUsageResult(result); err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"agent.delivery_diagnostics": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			agentID, err := requiredStringParam(req.Params, "agent_id")
-			if err != nil {
-				return nil, err
-			}
-			failureLimit, err := boundedIntegerParam(req.Params, "failure_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
-			if err != nil {
-				return nil, err
-			}
-			deadLetterLimit, err := boundedIntegerParam(req.Params, "dead_letter_limit", 1, store.MaxAgentDeliveryDiagnosticsLimit)
-			if err != nil {
-				return nil, err
-			}
-			failureCursor, _, err := optionalStringParam(req.Params, "failure_cursor")
-			if err != nil {
-				return nil, err
-			}
-			deadLetterCursor, _, err := optionalStringParam(req.Params, "dead_letter_cursor")
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorAgentDeliveryDiagnostics(ctx, agentID, store.OperatorAgentDeliveryDiagnosticsOptions{
-				FailureLimit:     failureLimit,
-				FailureCursor:    failureCursor,
-				DeadLetterLimit:  deadLetterLimit,
-				DeadLetterCursor: deadLetterCursor,
-			})
-			if errors.Is(err, store.ErrAgentNotFound) {
-				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-			}
-			var cursorErr store.AgentDeliveryDiagnosticsCursorError
-			if errors.As(err, &cursorErr) {
-				field := strings.TrimSpace(cursorErr.Field)
-				if field == "" {
-					field = "cursor"
-				}
-				return nil, NewInvalidParamsError(map[string]any{"field": field, "reason": "invalid agent.delivery_diagnostics cursor"})
-			}
-			if err != nil {
-				return nil, err
-			}
-			if err := validateAgentDeliveryDiagnosticsResult(result); err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"conversation.list": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			listOpts, err := operatorConversationListOptionsFromParams(req.Params)
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.ListOperatorConversations(ctx, listOpts)
-			if errors.Is(err, store.ErrInvalidConversationCursor) {
-				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid conversation list cursor"})
-			}
-			if paramErr := entityReadParamError(err); paramErr != nil {
-				return nil, NewInvalidParamsError(map[string]any{"field": paramErr.Field, "reason": paramErr.Reason})
-			}
-			if err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"conversation.get": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			sessionID, err := requiredStringParam(req.Params, "session_id")
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorConversation(ctx, sessionID)
-			if errors.Is(err, store.ErrSessionNotFound) {
-				return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
-			}
-			if err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-		"conversation.get_turn": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			sessionID, err := requiredStringParam(req.Params, "session_id")
-			if err != nil {
-				return nil, err
-			}
-			turnIndex, err := requiredBoundedIntegerParam(req.Params, "turn_index", 1, 1000000)
-			if err != nil {
-				return nil, err
-			}
-			includeLogs, err := optionalBoolParam(req.Params, "include_logs", true)
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadOperatorConversationTurn(ctx, sessionID, turnIndex)
-			if errors.Is(err, store.ErrSessionNotFound) {
-				return nil, NewApplicationError(SessionNotFoundCode, false, map[string]any{"session_id": sessionID})
-			}
-			if errors.Is(err, store.ErrTurnNotFound) {
-				return nil, NewApplicationError(TurnNotFoundCode, false, map[string]any{"session_id": sessionID, "turn_index": turnIndex})
-			}
-			if err != nil {
-				return nil, err
-			}
-			if includeLogs {
-				observability, err := requireObservabilityReadStore(opts.Observability)
-				if err != nil {
-					return nil, err
-				}
-				logOpts := store.OperatorRuntimeLogListOptions{
-					SessionID: result.Session.SessionID,
-					Since:     &result.RuntimeLogWindowStart,
-					Until:     result.RuntimeLogWindowEnd,
-					Limit:     1000,
-					Order:     "asc",
-				}
-				logs, err := observability.ListOperatorRuntimeLogs(ctx, logOpts)
-				if errors.Is(err, store.ErrInvalidObservabilityCursor) {
-					return nil, NewInvalidParamsError(map[string]any{"field": "runtime_log_entries", "reason": "invalid runtime log cursor"})
-				}
-				if err != nil {
-					return nil, err
-				}
-				if logs.Logs == nil {
-					logs.Logs = []store.OperatorRuntimeLogEntry{}
-				}
-				result.Turn.RuntimeLogEntries = logs.Logs
-			}
-			return result, nil
-		},
-		"conversation.current_for_agent": func(ctx context.Context, req Request) (any, error) {
-			reads, err := requireAgentConversationReadStore(opts.AgentConversations)
-			if err != nil {
-				return nil, err
-			}
-			agentID, err := requiredStringParam(req.Params, "agent_id")
-			if err != nil {
-				return nil, err
-			}
-			result, err := reads.LoadCurrentOperatorConversationForAgent(ctx, agentID)
-			if errors.Is(err, store.ErrAgentNotFound) {
-				return nil, NewApplicationError(AgentNotFoundCode, false, map[string]any{"agent_id": agentID})
-			}
-			if err != nil {
-				return nil, err
-			}
-			return result, nil
-		},
-	}
+	return handlers
 }
 
 func validateAgentDiagnosisResult(item store.OperatorAgentDiagnosis) error {

--- a/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
+++ b/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
@@ -1,0 +1,111 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+	"swarm/internal/platform"
+	"swarm/internal/runtime/budgetspend"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimemanager "swarm/internal/runtime/manager"
+	runtimesessions "swarm/internal/runtime/sessions"
+	storepkg "swarm/internal/store"
+)
+
+func TestSQLiteAgentUsageOwnerBacksSupportedAPISurface(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	seedSQLiteAgentUsageAgent(t, ctx, sqliteStore, "agent-1")
+	seedSQLiteAgentUsageAgent(t, ctx, sqliteStore, "agent-2")
+
+	since := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	for _, rec := range []budgetspend.SpendRecord{
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 100, OutputTokens: 25, CostUSD: 0.000675, InvocationType: "anthropic", UsageAccounting: storepkg.AgentUsageAccountingExact, RecordedAt: since},
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "sonnet", ModelAlias: "regular", BackendProfile: "claude_cli", Provider: "claude", Transport: "cli", ResolvedModel: "sonnet", InputTokens: 50, OutputTokens: 10, CostUSD: 0.000300, InvocationType: "claude_cli", UsageAccounting: storepkg.AgentUsageAccountingEstimated, RecordedAt: since.Add(time.Minute)},
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 7, OutputTokens: 3, CostUSD: 0.000010, InvocationType: "anthropic", UsageAccounting: storepkg.AgentUsageAccountingExact, RecordedAt: until},
+		{FlowInstance: "flow/a", AgentID: "agent-2", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 999, OutputTokens: 999, CostUSD: 1.000000, InvocationType: "anthropic", UsageAccounting: storepkg.AgentUsageAccountingExact, RecordedAt: since.Add(time.Minute)},
+	} {
+		if err := sqliteStore.RecordSpend(ctx, rec); err != nil {
+			t.Fatalf("RecordSpend(%s/%s): %v", rec.AgentID, rec.UsageAccounting, err)
+		}
+	}
+
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			AgentUsage: sqliteStore,
+		}),
+	})
+	resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"usage","method":"agent.usage","params":{"agent_id":"agent-1","since":"2026-05-21T09:00:00Z","until":"2026-05-21T10:00:00Z"}}`)
+	if resp.Error != nil {
+		t.Fatalf("agent.usage error = %#v", resp.Error)
+	}
+	result := asMap(t, resp.Result)
+	if result["agent_id"] != "agent-1" {
+		t.Fatalf("agent_id = %#v", result["agent_id"])
+	}
+	usage := asMap(t, result["usage"])
+	exact := asMap(t, usage["exact"])
+	estimated := asMap(t, usage["estimated"])
+	if exact["ledger_entries"] != float64(1) || exact["input_tokens"] != float64(100) || estimated["ledger_entries"] != float64(1) || estimated["input_tokens"] != float64(50) {
+		t.Fatalf("usage totals = %#v", usage)
+	}
+	breakdown, _ := result["breakdown"].([]any)
+	if len(breakdown) != 2 {
+		t.Fatalf("breakdown = %#v, want two rows", result["breakdown"])
+	}
+	first := asMap(t, breakdown[0])
+	if first["usage_accounting"] != storepkg.AgentUsageAccountingExact || first["model"] != "claude-3-5-sonnet" || first["provider"] != "anthropic" || first["transport"] != "api" || first["resolved_model"] != "claude-3-5-sonnet" {
+		t.Fatalf("first breakdown = %#v", first)
+	}
+	for _, forbidden := range []string{"prompt", "response", "raw_request", "raw_response"} {
+		if _, ok := result[forbidden]; ok {
+			t.Fatalf("agent.usage exposed forbidden field %q: %#v", forbidden, result)
+		}
+	}
+}
+
+func newSQLiteAgentUsageStoreFixture(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
+	t.Helper()
+	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() { _ = sqliteStore.Close() })
+	var platformSpec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	return sqliteStore
+}
+
+func seedSQLiteAgentUsageAgent(t *testing.T, ctx context.Context, sqliteStore *storepkg.SQLiteRuntimeStore, agentID string) {
+	t.Helper()
+	if err := sqliteStore.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               agentID,
+			Role:             "researcher",
+			Type:             "managed",
+			Model:            "cheap",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"usage"}`),
+		},
+		Status:    "active",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent %s: %v", agentID, err)
+	}
+}

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
+	"swarm/internal/runtime/budgetspend"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
@@ -707,6 +708,115 @@ func TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated(t *testin
 	}
 	if got := result.Breakdown[1]; got.UsageAccounting != AgentUsageAccountingEstimated || got.InvocationType != "claude_cli" || got.Model != "sonnet" || got.ModelAlias != "regular" || got.BackendProfile != "claude_cli" || got.Provider != "claude" || got.Transport != "cli" || got.ResolvedModel != "sonnet" {
 		t.Fatalf("second breakdown = %#v", got)
+	}
+}
+
+func TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-1", "active")
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-2", "active")
+
+	since := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	records := []budgetspend.SpendRecord{
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 100, OutputTokens: 25, CostUSD: 0.000675, InvocationType: "anthropic", UsageAccounting: AgentUsageAccountingExact, RecordedAt: since},
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "sonnet", ModelAlias: "regular", BackendProfile: "claude_cli", Provider: "claude", Transport: "cli", ResolvedModel: "sonnet", InputTokens: 50, OutputTokens: 10, CostUSD: 0.000300, InvocationType: "claude_cli", UsageAccounting: AgentUsageAccountingEstimated, RecordedAt: since.Add(time.Minute)},
+		{FlowInstance: "flow/a", AgentID: "agent-1", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 7, OutputTokens: 3, CostUSD: 0.000010, InvocationType: "anthropic", UsageAccounting: AgentUsageAccountingExact, RecordedAt: until},
+		{FlowInstance: "flow/a", AgentID: "agent-2", Model: "claude-3-5-sonnet", ModelAlias: "regular", BackendProfile: "anthropic", Provider: "anthropic", Transport: "api", ResolvedModel: "claude-3-5-sonnet", InputTokens: 999, OutputTokens: 999, CostUSD: 1.000000, InvocationType: "anthropic", UsageAccounting: AgentUsageAccountingExact, RecordedAt: since.Add(time.Minute)},
+	}
+	for _, rec := range records {
+		if err := sqliteStore.RecordSpend(ctx, rec); err != nil {
+			t.Fatalf("RecordSpend(%s/%s): %v", rec.AgentID, rec.UsageAccounting, err)
+		}
+	}
+
+	result, err := sqliteStore.LoadOperatorAgentUsage(ctx, "agent-1", OperatorAgentUsageOptions{Since: &since, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentUsage: %v", err)
+	}
+	if result.AgentID != "agent-1" {
+		t.Fatalf("agent_id = %q", result.AgentID)
+	}
+	if result.Window.Since == nil || !result.Window.Since.Equal(since) || result.Window.Until == nil || !result.Window.Until.Equal(until) {
+		t.Fatalf("window = %#v", result.Window)
+	}
+	if result.Usage.Exact.LedgerEntries != 1 || result.Usage.Exact.InputTokens != 100 || result.Usage.Exact.OutputTokens != 25 {
+		t.Fatalf("exact usage = %#v", result.Usage.Exact)
+	}
+	if result.Usage.Estimated.LedgerEntries != 1 || result.Usage.Estimated.InputTokens != 50 || result.Usage.Estimated.OutputTokens != 10 {
+		t.Fatalf("estimated usage = %#v", result.Usage.Estimated)
+	}
+	if len(result.Breakdown) != 2 {
+		t.Fatalf("breakdown = %#v, want two rows", result.Breakdown)
+	}
+	if got := result.Breakdown[0]; got.UsageAccounting != AgentUsageAccountingExact || got.InvocationType != "anthropic" || got.Model != "claude-3-5-sonnet" || got.ModelAlias != "regular" || got.BackendProfile != "anthropic" || got.Provider != "anthropic" || got.Transport != "api" || got.ResolvedModel != "claude-3-5-sonnet" {
+		t.Fatalf("first breakdown = %#v", got)
+	}
+	if got := result.Breakdown[1]; got.UsageAccounting != AgentUsageAccountingEstimated || got.InvocationType != "claude_cli" || got.Model != "sonnet" || got.ModelAlias != "regular" || got.BackendProfile != "claude_cli" || got.Provider != "claude" || got.Transport != "cli" || got.ResolvedModel != "sonnet" {
+		t.Fatalf("second breakdown = %#v", got)
+	}
+}
+
+func TestSQLiteRuntimeStoreLoadAgentUsageEmptyAndAgentExistence(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-empty", "active")
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-terminated", "terminated")
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-ephemeral", "ephemeral")
+
+	result, err := sqliteStore.LoadOperatorAgentUsage(ctx, "agent-empty", OperatorAgentUsageOptions{})
+	if err != nil {
+		t.Fatalf("LoadOperatorAgentUsage empty: %v", err)
+	}
+	if result.AgentID != "agent-empty" || result.Breakdown == nil || len(result.Breakdown) != 0 {
+		t.Fatalf("empty result = %#v", result)
+	}
+	if result.Usage.Exact.LedgerEntries != 0 || result.Usage.Estimated.LedgerEntries != 0 {
+		t.Fatalf("empty usage totals = %#v", result.Usage)
+	}
+	for _, agentID := range []string{"missing", "agent-terminated", "agent-ephemeral"} {
+		_, err := sqliteStore.LoadOperatorAgentUsage(ctx, agentID, OperatorAgentUsageOptions{})
+		if !errors.Is(err, ErrAgentNotFound) {
+			t.Fatalf("LoadOperatorAgentUsage(%s) error = %v, want ErrAgentNotFound", agentID, err)
+		}
+	}
+}
+
+func TestSQLiteRuntimeStoreLoadAgentUsageFailsClosedOnMalformedRows(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-1", "active")
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO spend_ledger (
+			flow_instance, agent_id, model, invocation_type, usage_accounting, created_at
+		) VALUES (
+			'flow/a', 'agent-1', '', 'anthropic', 'exact', ?
+		)
+	`, time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed malformed spend row: %v", err)
+	}
+	_, err := sqliteStore.LoadOperatorAgentUsage(ctx, "agent-1", OperatorAgentUsageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "empty model") {
+		t.Fatalf("LoadOperatorAgentUsage malformed error = %v, want empty model", err)
+	}
+}
+
+func seedOperatorAgentUsageAgent(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, agentID string, status string) {
+	t.Helper()
+	if err := store.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               agentID,
+			Role:             "researcher",
+			Type:             "managed",
+			Model:            "cheap",
+			ConversationMode: runtimesessions.RuntimeModeTask.String(),
+			Config:           json.RawMessage(`{"system_prompt":"usage"}`),
+		},
+		Status:    status,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent %s: %v", agentID, err)
 	}
 }
 

--- a/internal/store/operator_agent_usage_read_surface.go
+++ b/internal/store/operator_agent_usage_read_surface.go
@@ -12,6 +12,15 @@ const (
 	AgentUsageAccountingEstimated = "estimated"
 )
 
+// OperatorAgentUsageReadStore is the backend-neutral owner for the public
+// per-agent usage read surface over canonical spend_ledger facts.
+type OperatorAgentUsageReadStore interface {
+	LoadOperatorAgentUsage(context.Context, string, OperatorAgentUsageOptions) (OperatorAgentUsage, error)
+}
+
+var _ OperatorAgentUsageReadStore = (*PostgresStore)(nil)
+var _ OperatorAgentUsageReadStore = (*SQLiteRuntimeStore)(nil)
+
 type OperatorAgentUsageOptions struct {
 	Since *time.Time
 	Until *time.Time
@@ -54,10 +63,6 @@ type OperatorAgentUsageBreakdown struct {
 }
 
 func (s *PostgresStore) LoadOperatorAgentUsage(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) (OperatorAgentUsage, error) {
-	return NewOperatorAgentConversationReadSurface(s.DB, s, 0).LoadOperatorAgentUsage(ctx, agentID, opts)
-}
-
-func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentUsage(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) (OperatorAgentUsage, error) {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return OperatorAgentUsage{}, ErrAgentNotFound
@@ -65,17 +70,41 @@ func (r *OperatorAgentConversationReadSurface) LoadOperatorAgentUsage(ctx contex
 	if err := validateOperatorAgentUsageWindow(opts); err != nil {
 		return OperatorAgentUsage{}, err
 	}
-	if err := r.requireAgentUsageCapabilities(ctx); err != nil {
+	if err := s.requireAgentUsageCapabilities(ctx); err != nil {
 		return OperatorAgentUsage{}, err
 	}
-	if err := r.ensureAgentUsageAgentExists(ctx, agentID); err != nil {
+	if err := s.ensureAgentUsageAgentExists(ctx, agentID); err != nil {
 		return OperatorAgentUsage{}, err
 	}
-
-	breakdown, err := r.loadAgentUsageBreakdown(ctx, agentID, opts)
+	breakdown, err := s.loadAgentUsageBreakdown(ctx, agentID, opts)
 	if err != nil {
 		return OperatorAgentUsage{}, err
 	}
+	return buildOperatorAgentUsage(agentID, opts, breakdown)
+}
+
+func (s *SQLiteRuntimeStore) LoadOperatorAgentUsage(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) (OperatorAgentUsage, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return OperatorAgentUsage{}, ErrAgentNotFound
+	}
+	if err := validateOperatorAgentUsageWindow(opts); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	if err := s.requireAgentUsageCapabilities(ctx); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	if err := s.ensureAgentUsageAgentExists(ctx, agentID); err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	breakdown, err := s.loadAgentUsageBreakdown(ctx, agentID, opts)
+	if err != nil {
+		return OperatorAgentUsage{}, err
+	}
+	return buildOperatorAgentUsage(agentID, opts, breakdown)
+}
+
+func buildOperatorAgentUsage(agentID string, opts OperatorAgentUsageOptions, breakdown []OperatorAgentUsageBreakdown) (OperatorAgentUsage, error) {
 	result := OperatorAgentUsage{
 		AgentID:   agentID,
 		Window:    OperatorAgentUsageWindow{Since: copyTimePtr(opts.Since), Until: copyTimePtr(opts.Until)},
@@ -121,18 +150,18 @@ func addOperatorAgentUsageTotals(a, b OperatorAgentUsageTotals) OperatorAgentUsa
 	}
 }
 
-func (r *OperatorAgentConversationReadSurface) requireAgentUsageCapabilities(ctx context.Context) error {
-	if r == nil || r.db == nil {
+func (s *PostgresStore) requireAgentUsageCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
 		return fmt.Errorf("operator agent usage read owner requires postgres store")
 	}
-	caps, err := r.resolveConversationCapabilities(ctx)
+	caps, err := s.ResolveSchemaCapabilities(ctx)
 	if err != nil {
 		return err
 	}
 	if caps.Agents != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agents", caps.Agents)
 	}
-	catalog, err := loadSchemaColumnCatalog(ctx, r.db)
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
 	if err != nil {
 		return err
 	}
@@ -154,9 +183,42 @@ func (r *OperatorAgentConversationReadSurface) requireAgentUsageCapabilities(ctx
 	return nil
 }
 
-func (r *OperatorAgentConversationReadSurface) ensureAgentUsageAgentExists(ctx context.Context, agentID string) error {
+func (s *SQLiteRuntimeStore) requireAgentUsageCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("operator agent usage read owner requires sqlite runtime store")
+	}
+	caps, err := s.ResolveSchemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Agents != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("agents", caps.Agents)
+	}
+	catalog, err := loadSQLiteSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	required := map[string][]string{
+		"agents": {
+			"agent_id", "status",
+		},
+		"spend_ledger": {
+			"agent_id", "model", "input_tokens", "output_tokens", "cost_usd",
+			"invocation_type", "usage_accounting", "model_alias", "backend_profile",
+			"provider", "transport", "resolved_model", "created_at",
+		},
+	}
+	for table, columns := range required {
+		if !catalog.hasColumns(table, columns...) {
+			return fmt.Errorf("agent usage read owner requires canonical %s columns: %s", table, strings.Join(columns, ", "))
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStore) ensureAgentUsageAgentExists(ctx context.Context, agentID string) error {
 	var exists bool
-	if err := r.db.QueryRowContext(ctx, `
+	if err := s.DB.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM agents
@@ -172,7 +234,23 @@ func (r *OperatorAgentConversationReadSurface) ensureAgentUsageAgentExists(ctx c
 	return nil
 }
 
-func (r *OperatorAgentConversationReadSurface) loadAgentUsageBreakdown(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) ([]OperatorAgentUsageBreakdown, error) {
+func (s *SQLiteRuntimeStore) ensureAgentUsageAgentExists(ctx context.Context, agentID string) error {
+	var count int
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(1)
+		FROM agents
+		WHERE agent_id = ?
+		  AND status NOT IN ('terminated', 'ephemeral')
+	`, agentID).Scan(&count); err != nil {
+		return fmt.Errorf("load agent usage agent: %w", err)
+	}
+	if count == 0 {
+		return ErrAgentNotFound
+	}
+	return nil
+}
+
+func (s *PostgresStore) loadAgentUsageBreakdown(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) ([]OperatorAgentUsageBreakdown, error) {
 	args := []any{agentID}
 	windowClause := strings.Builder{}
 	if opts.Since != nil {
@@ -183,7 +261,7 @@ func (r *OperatorAgentConversationReadSurface) loadAgentUsageBreakdown(ctx conte
 		args = append(args, opts.Until.UTC())
 		windowClause.WriteString(fmt.Sprintf("\n		  AND created_at < $%d", len(args)))
 	}
-	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
 		WITH usage_rows AS (
 			SELECT
 				usage_accounting,
@@ -214,6 +292,95 @@ func (r *OperatorAgentConversationReadSurface) loadAgentUsageBreakdown(ctx conte
 			COALESCE(SUM(input_tokens), 0)::bigint,
 			COALESCE(SUM(output_tokens), 0)::bigint,
 			COALESCE(SUM(cost_usd), 0)::float8
+		FROM usage_rows
+		GROUP BY usage_accounting, invocation_type, model, model_alias, backend_profile, provider, transport, resolved_model
+		ORDER BY CASE usage_accounting WHEN 'exact' THEN 0 WHEN 'estimated' THEN 1 ELSE 2 END ASC, invocation_type ASC, model ASC, model_alias ASC
+	`, windowClause.String()), args...)
+	if err != nil {
+		return nil, fmt.Errorf("load agent usage breakdown: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OperatorAgentUsageBreakdown
+	for rows.Next() {
+		var row OperatorAgentUsageBreakdown
+		if err := rows.Scan(
+			&row.UsageAccounting,
+			&row.InvocationType,
+			&row.Model,
+			&row.ModelAlias,
+			&row.BackendProfile,
+			&row.Provider,
+			&row.Transport,
+			&row.ResolvedModel,
+			&row.Totals.LedgerEntries,
+			&row.Totals.InputTokens,
+			&row.Totals.OutputTokens,
+			&row.Totals.EstimatedCostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent usage breakdown: %w", err)
+		}
+		row.UsageAccounting = strings.TrimSpace(row.UsageAccounting)
+		row.InvocationType = strings.TrimSpace(row.InvocationType)
+		row.Model = strings.TrimSpace(row.Model)
+		row.ModelAlias = strings.TrimSpace(row.ModelAlias)
+		row.BackendProfile = strings.TrimSpace(row.BackendProfile)
+		row.Provider = strings.TrimSpace(row.Provider)
+		row.Transport = strings.TrimSpace(row.Transport)
+		row.ResolvedModel = strings.TrimSpace(row.ResolvedModel)
+		if err := validateOperatorAgentUsageBreakdown(row); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read agent usage breakdown: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) loadAgentUsageBreakdown(ctx context.Context, agentID string, opts OperatorAgentUsageOptions) ([]OperatorAgentUsageBreakdown, error) {
+	args := []any{agentID}
+	windowClause := strings.Builder{}
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		windowClause.WriteString("\n		  AND created_at >= ?")
+	}
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		windowClause.WriteString("\n		  AND created_at < ?")
+	}
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		WITH usage_rows AS (
+			SELECT
+				usage_accounting,
+				invocation_type,
+				model,
+				COALESCE(NULLIF(trim(model_alias), ''), 'unknown') AS model_alias,
+				COALESCE(NULLIF(trim(backend_profile), ''), 'unknown') AS backend_profile,
+				COALESCE(NULLIF(trim(provider), ''), 'unknown') AS provider,
+				COALESCE(NULLIF(trim(transport), ''), 'unknown') AS transport,
+				COALESCE(NULLIF(trim(resolved_model), ''), model) AS resolved_model,
+				input_tokens,
+				output_tokens,
+				cost_usd
+			FROM spend_ledger
+			WHERE agent_id = ?
+			  %s
+		)
+		SELECT
+			usage_accounting,
+			invocation_type,
+			model,
+			model_alias,
+			backend_profile,
+			provider,
+			transport,
+			resolved_model,
+			COUNT(*),
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(cost_usd), 0)
 		FROM usage_rows
 		GROUP BY usage_accounting, invocation_type, model, model_alias, backend_profile, provider, transport, resolved_model
 		ORDER BY CASE usage_accounting WHEN 'exact' THEN 0 WHEN 'estimated' THEN 1 ELSE 2 END ASC, invocation_type ASC, model ASC, model_alias ASC

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2320,11 +2320,29 @@ engine:
         side effects through the same BudgetTracker behavior owner. Postgres remains authoritative for production runtime
         budget/spend semantics. SQLite must not substitute an in-memory spend ledger for persisted local runtime budget truth.
       excludes:
-      - public operator agent.usage reads over spend_ledger owned by #1157
+      - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - production multi-writer SQLite budget concurrency semantics
+    - name: operator_agent_usage_read_rows
+      owner: internal/store.OperatorAgentUsageReadStore consumed by api_specification.method_catalog.agent.usage through apiv1.OperatorReadOptions.AgentUsage
+      promoted_by: '#1157'
+      sqlite_owner: internal/store.SQLiteRuntimeStore.LoadOperatorAgentUsage over canonical agents and spend_ledger rows
+      postgres_owner: internal/store.PostgresStore.LoadOperatorAgentUsage over canonical agents and spend_ledger rows
+      scope: >
+        The public agent.usage read surface consumes one backend-neutral per-agent usage read owner over canonical
+        spend_ledger facts for exact and estimated accounting. The owner validates active agent existence, applies
+        since-inclusive and until-exclusive created_at windows, aggregates exact and estimated totals, and returns
+        model, model_alias, backend_profile, provider, transport, resolved_model, and invocation_type breakdowns for
+        both explicit SQLite local/dev runtime stores and Postgres production stores. API handlers must not reconstruct
+        usage from runtime memory, dashboard-local SQL, diagnostics, trace streams, EventBus payloads, or tests.
+      excludes:
+      - spend writes, threshold evaluation, and runtime budget side effects owned by runtime_budget_spend_rows
+      - agent.diagnose, agent.delivery_diagnostics, conversation, dashboard, trace, and runtime diagnostics surfaces
+      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - docs/CI/repo-wide closeout owned by #1089
+      - production multi-writer SQLite concurrency semantics
     - name: runtime_tool_entity_and_human_task_rows
       owner: runtimetools.EntityPersistence and runtimetools.HumanTaskPersistence consumed through runtime.Stores and ExecutorOptions
       promoted_by: '#1149'
@@ -2338,7 +2356,7 @@ engine:
         not receive a raw SQLite SQL handle as a compatibility seam for these surfaces.
       excludes:
       - public operator mailbox API decisions owned by api_specification.method_catalog.mailbox.*
-      - public operator agent.usage reads over spend_ledger owned by #1157
+      - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
       - runtime diagnostics/logging owned by #1150
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - production multi-writer SQLite concurrency semantics
@@ -2354,7 +2372,7 @@ engine:
         passing a raw SQLite *sql.DB into RuntimeLogger. Postgres remains authoritative for production runtime-log
         persistence, bundle-source fail-closed run creation, and run counter synchronization.
       excludes:
-      - public operator agent.usage reads over spend_ledger owned by #1157
+      - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
       - local/dev default flip and zero-service swarm run proof owned by #1088
       - docs/CI/repo-wide closeout owned by #1089
       - production multi-writer SQLite concurrency semantics


### PR DESCRIPTION
Closes #1157

## Governing refs
- `platform-spec.yaml` `api_specification.method_catalog.agent.usage`
- `platform-spec.yaml` `components.schemas.AgentUsage*`
- `platform-spec.yaml` `platform_tables.tables.spend_ledger`
- `platform-spec.yaml` `engine.runtime_core_persistence_store_contracts`
- Issue #1157 pre-audit and approved gate comment
- `docs/IMPLEMENTER_GUIDELINES.md`
- `docs/SEMANTIC_DRIFT.md`

## Semantic migration
- New canonical owner: `internal/store.OperatorAgentUsageReadStore`.
- Owner consumers: `/v1/rpc agent.usage` via `apiv1.OperatorReadOptions.AgentUsage`; `cmd/swarm` wires Postgres and explicit SQLite store bundles to that owner.
- Old producer/reader path now invalid: `agent.usage` no longer consumes the broad `AgentConversationReadStore`; Postgres usage reads moved off `OperatorAgentConversationReadSurface` and onto the named usage store owner.
- Production paths checked for surviving old behavior: API handler registration, `cmd/swarm` store bundle construction, OpenRPC read-only probes, Postgres usage read tests, SQLite supported API surface test.
- Migration complete for the approved #1157 child. It does not flip SQLite default, does not close #1088/#1089/#1066/#1087, and does not add production multi-writer SQLite semantics.

## Tests
- `go test ./internal/store -run 'Test(SQLiteRuntimeStoreLoadAgentUsage|OperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated)' -count=1`
- `go test ./internal/apiv1 -run 'Test(SQLiteAgentUsageOwnerBacksSupportedAPISurface|OperatorAgentConversationHandlersExposeReadOwner|OperatorAgentUsageFailsClosedOnMalformedOwnerData|OperatorAgentUsageRejectsInvalidWindow|OperatorAgentDiagnoseRejectsQueueLimit|OpenRPC)' -count=1`
- `go test ./cmd/swarm -run 'TestBuildStores(SQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner|AcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./...`