### PR TITLE
[agent-c][issue #1117] Defer terminal lifecycle teardown until commit

### DIFF
--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -36,6 +37,15 @@ type flowInstanceRouteInstaller interface {
 
 type flowInstanceRouteRemover interface {
 	RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error
+}
+
+type terminalFlowInstanceSideEffectPlan struct {
+	EntityID   string
+	FlowPath   string
+	AgentIDs   []string
+	Route      runtimeflowidentity.Route
+	Remover    flowInstanceRouteRemover
+	FinalState string
 }
 
 func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
@@ -466,15 +476,61 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 	}
 	am.mu.RUnlock()
 	sort.Strings(agentIDs)
-	for _, agentID := range agentIDs {
+	remover, ok := am.bus.(flowInstanceRouteRemover)
+	if !ok || remover == nil {
+		return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", canonicalFlowPath)
+	}
+	plan := terminalFlowInstanceSideEffectPlan{
+		EntityID:   entityID,
+		FlowPath:   canonicalFlowPath,
+		AgentIDs:   agentIDs,
+		Route:      canonicalRoute,
+		Remover:    remover,
+		FinalState: req.FinalState,
+	}
+	if runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
+		if err := am.applyTerminalFlowInstanceSideEffects(plan); err != nil {
+			am.logTerminalFlowInstanceSideEffectFailure(plan, err)
+		}
+	}) {
+		return nil
+	}
+	return am.applyTerminalFlowInstanceSideEffects(plan)
+}
+
+func (am *AgentManager) applyTerminalFlowInstanceSideEffects(plan terminalFlowInstanceSideEffectPlan) error {
+	var errs []error
+	for _, agentID := range plan.AgentIDs {
 		if err := am.TeardownAgent(agentID); err != nil && !strings.Contains(err.Error(), "not found") {
-			return err
+			errs = append(errs, fmt.Errorf("teardown flow instance agent %s: %w", agentID, err))
 		}
 	}
-	if remover, ok := am.bus.(flowInstanceRouteRemover); ok && remover != nil {
-		return remover.RemoveFlowInstanceRoute(canonicalRoute)
+	if plan.Remover == nil {
+		errs = append(errs, fmt.Errorf("event bus does not support derived flow-instance route removal for %s", plan.FlowPath))
+	} else if err := plan.Remover.RemoveFlowInstanceRoute(plan.Route); err != nil {
+		errs = append(errs, fmt.Errorf("remove flow instance route %s: %w", plan.FlowPath, err))
 	}
-	return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", canonicalFlowPath)
+	return errors.Join(errs...)
+}
+
+func (am *AgentManager) logTerminalFlowInstanceSideEffectFailure(plan terminalFlowInstanceSideEffectPlan, err error) {
+	if am == nil || am.bus == nil || err == nil {
+		return
+	}
+	_ = am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "Terminal flow instance side-effect teardown failed after commit",
+		Component: "flow_activation",
+		Action:    "terminal_flow_instance_side_effects_failed",
+		EntityID:  plan.EntityID,
+		Detail: map[string]any{
+			"flow_path":   plan.FlowPath,
+			"agent_ids":   append([]string(nil), plan.AgentIDs...),
+			"route":       plan.Route.InstancePath,
+			"final_state": plan.FinalState,
+		},
+		Error: err.Error(),
+	})
 }
 
 func buildFlowAgentConfig(

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -499,18 +499,21 @@ func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req run
 }
 
 func (am *AgentManager) applyTerminalFlowInstanceSideEffects(plan terminalFlowInstanceSideEffectPlan) error {
-	var errs []error
+	var agentErrs []error
 	for _, agentID := range plan.AgentIDs {
 		if err := am.TeardownAgent(agentID); err != nil && !strings.Contains(err.Error(), "not found") {
-			errs = append(errs, fmt.Errorf("teardown flow instance agent %s: %w", agentID, err))
+			agentErrs = append(agentErrs, fmt.Errorf("teardown flow instance agent %s: %w", agentID, err))
 		}
 	}
-	if plan.Remover == nil {
-		errs = append(errs, fmt.Errorf("event bus does not support derived flow-instance route removal for %s", plan.FlowPath))
-	} else if err := plan.Remover.RemoveFlowInstanceRoute(plan.Route); err != nil {
-		errs = append(errs, fmt.Errorf("remove flow instance route %s: %w", plan.FlowPath, err))
+	if len(agentErrs) > 0 {
+		return errors.Join(agentErrs...)
 	}
-	return errors.Join(errs...)
+	if plan.Remover == nil {
+		return fmt.Errorf("event bus does not support derived flow-instance route removal for %s", plan.FlowPath)
+	} else if err := plan.Remover.RemoveFlowInstanceRoute(plan.Route); err != nil {
+		return fmt.Errorf("remove flow instance route %s: %w", plan.FlowPath, err)
+	}
+	return nil
 }
 
 func (am *AgentManager) logTerminalFlowInstanceSideEffectFailure(plan terminalFlowInstanceSideEffectPlan, err error) {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,6 +33,8 @@ type flowActivationTestBus struct {
 	removedPairs []string
 	published    []events.Event
 	runtimeLogs  []runtimepipeline.RuntimeLogEntry
+	unsubscribed []string
+	removeErr    error
 	routeStore   flowActivationRouteStore
 }
 
@@ -47,7 +51,9 @@ type flowActivationTestInstanceStore struct {
 }
 
 type flowActivationTestStore struct {
-	upserts []PersistedAgent
+	upserts      []PersistedAgent
+	terminated   []string
+	terminateErr error
 }
 
 func newFlowActivationManager(bus Bus, instances flowInstancePersistence, stores ...ManagerPersistence) *AgentManager {
@@ -133,8 +139,11 @@ func (s *flowActivationTestStore) UpsertAgent(_ context.Context, rec PersistedAg
 func (*flowActivationTestStore) LoadAgents(context.Context) ([]PersistedAgent, error) {
 	return nil, nil
 }
-func (*flowActivationTestStore) MarkAgentTerminated(context.Context, string) error { return nil }
-func (*flowActivationTestStore) EnsureEntitySchema(context.Context, string) error  { return nil }
+func (s *flowActivationTestStore) MarkAgentTerminated(_ context.Context, agentID string) error {
+	s.terminated = append(s.terminated, strings.TrimSpace(agentID))
+	return s.terminateErr
+}
+func (*flowActivationTestStore) EnsureEntitySchema(context.Context, string) error { return nil }
 func (*flowActivationTestStore) UpsertEventReceipt(context.Context, string, string, ReceiptStatus, string) error {
 	return nil
 }
@@ -159,7 +168,9 @@ func (*flowActivationTestBus) PublishPersistedRecipients(context.Context, events
 func (*flowActivationTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
-func (*flowActivationTestBus) Unsubscribe(string)           {}
+func (b *flowActivationTestBus) Unsubscribe(agentID string) {
+	b.unsubscribed = append(b.unsubscribed, agentID)
+}
 func (*flowActivationTestBus) Store() runtimebus.EventStore { return nil }
 func (*flowActivationTestBus) ResetInMemoryState() error    { return nil }
 func (b *flowActivationTestBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
@@ -183,6 +194,9 @@ func (b *flowActivationTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNo
 
 func (b *flowActivationTestBus) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error {
 	b.removedPairs = append(b.removedPairs, identity.ScopeKey+"/"+identity.InstanceID)
+	if b.removeErr != nil {
+		return b.removeErr
+	}
 	if b.routeStore != nil {
 		return b.routeStore.DeleteFlowInstanceRoute(context.Background(), identity)
 	}
@@ -794,6 +808,101 @@ func TestDeactivateFlowInstanceRemovesAgentsAndRoutes(t *testing.T) {
 	}
 }
 
+func TestDeactivateFlowInstanceQueuesTerminalSideEffectsUntilPostCommitWhenAvailable(t *testing.T) {
+	routeStore := &flowActivationTestRouteStore{}
+	bus := &flowActivationTestBus{routeStore: routeStore}
+	instances := &flowActivationTestInstanceStore{}
+	managerStore := &flowActivationTestStore{}
+	am := newFlowActivationManager(bus, instances, managerStore)
+	bundle := testFlowBundle("")
+
+	if err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	if err := am.DeactivateFlowInstance(ctx, "review", "inst-1", "review/inst-1", "ent-1"); err != nil {
+		t.Fatalf("DeactivateFlowInstance: %v", err)
+	}
+
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); !ok {
+		t.Fatal("flow agent was torn down before post-commit flush")
+	}
+	if len(bus.unsubscribed) != 0 {
+		t.Fatalf("unsubscribed before post-commit flush = %#v, want none", bus.unsubscribed)
+	}
+	if len(managerStore.terminated) != 0 {
+		t.Fatalf("agent terminations before post-commit flush = %#v, want none", managerStore.terminated)
+	}
+	if len(bus.removedPairs) != 0 {
+		t.Fatalf("removed routes before post-commit flush = %#v, want none", bus.removedPairs)
+	}
+	if got := routeStore.statusByPath["review/inst-1"]; got != "active" {
+		t.Fatalf("route status before post-commit flush = %q, want active", got)
+	}
+	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "review/inst-1" {
+		t.Fatalf("flow instance terminal state = %#v, want committed owner entry", instances.terminatedPaths)
+	}
+	if len(postCommit) != 1 {
+		t.Fatalf("post-commit actions = %d, want 1", len(postCommit))
+	}
+
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("expected flow agent teardown after post-commit flush")
+	}
+	if len(bus.unsubscribed) != 1 || bus.unsubscribed[0] != "reviewer-inst-1" {
+		t.Fatalf("unsubscribed after post-commit flush = %#v, want reviewer-inst-1", bus.unsubscribed)
+	}
+	if len(managerStore.terminated) != 1 || managerStore.terminated[0] != "reviewer-inst-1" {
+		t.Fatalf("agent terminations after post-commit flush = %#v, want reviewer-inst-1", managerStore.terminated)
+	}
+	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "review/inst-1" {
+		t.Fatalf("removed routes after post-commit flush = %#v, want [review/inst-1]", bus.removedPairs)
+	}
+	if got := routeStore.statusByPath["review/inst-1"]; got != "inactive" {
+		t.Fatalf("route status after post-commit flush = %q, want inactive", got)
+	}
+	if len(bus.runtimeLogs) != 0 {
+		t.Fatalf("runtime logs = %#v, want none", bus.runtimeLogs)
+	}
+}
+
+func TestDeactivateFlowInstanceLogsPostCommitTerminalSideEffectFailures(t *testing.T) {
+	bus := &flowActivationTestBus{removeErr: errors.New("route removal failed")}
+	instances := &flowActivationTestInstanceStore{}
+	managerStore := &flowActivationTestStore{terminateErr: errors.New("agent terminate failed")}
+	am := newFlowActivationManager(bus, instances, managerStore)
+	bundle := testFlowBundle("")
+
+	if err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	if err := am.DeactivateFlowInstance(ctx, "review", "inst-1", "review/inst-1", "ent-1"); err != nil {
+		t.Fatalf("DeactivateFlowInstance returned pre-commit error: %v", err)
+	}
+
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	if len(bus.runtimeLogs) != 1 {
+		t.Fatalf("runtime logs = %#v, want one post-commit failure log", bus.runtimeLogs)
+	}
+	log := bus.runtimeLogs[0]
+	if log.Action != "terminal_flow_instance_side_effects_failed" || log.Level != "warn" {
+		t.Fatalf("runtime log = %#v, want warning terminal_flow_instance_side_effects_failed", log)
+	}
+	if !strings.Contains(log.Error, "agent terminate failed") || !strings.Contains(log.Error, "route removal failed") {
+		t.Fatalf("runtime log error = %q, want both side-effect failures", log.Error)
+	}
+	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "review/inst-1" {
+		t.Fatalf("removed routes after failure = %#v, want route attempt after agent failure", bus.removedPairs)
+	}
+	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "review/inst-1" {
+		t.Fatalf("flow terminal state = %#v, want preserved terminal transition", instances.terminatedPaths)
+	}
+}
+
 func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	instances := &flowActivationTestInstanceStore{}
@@ -904,6 +1013,97 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 	}
 	if _, ok := am.GetAgentConfig("shared-subject-agent"); !ok {
 		t.Fatal("expected unrelated flow agent to remain active")
+	}
+}
+
+func TestDeactivateFlowInstanceModel_PostCommitSideEffectsFollowTerminalCommit(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	const runID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	routeStore := &flowActivationTestRouteStore{}
+	bus := &flowActivationTestBus{routeStore: routeStore}
+	managerStore := &flowActivationTestStore{}
+	store := runtimepipeline.NewWorkflowInstanceStore(db)
+	am := newFlowActivationManager(bus, store, managerStore)
+	bundle := testFlowBundle("")
+	const subjectID = "22222222-2222-2222-2222-222222222222"
+	req := testActivationRequest(bundle, "review", "inst-1", subjectID, "review/inst-1")
+
+	if err := am.ActivateFlowInstance(ctx, req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if err := store.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		if err := store.Mutate(txctx, req.Instance.EntityID, func(instance *runtimepipeline.WorkflowInstance) {
+			instance.CurrentState = "completed"
+		}); err != nil {
+			return err
+		}
+		if err := am.DeactivateFlowInstanceModel(txctx, runtimepipeline.FlowInstanceDeactivationRequest{
+			ContractBundle: semanticview.Wrap(bundle),
+			Instance:       req.Instance,
+			FinalState:     "completed",
+		}); err != nil {
+			return err
+		}
+		if _, ok := am.GetAgentConfig("reviewer-inst-1"); !ok {
+			t.Fatal("flow agent was torn down before terminal transaction commit")
+		}
+		if len(managerStore.terminated) != 0 || len(bus.unsubscribed) != 0 || len(bus.removedPairs) != 0 {
+			t.Fatalf("side effects before commit: terminated=%#v unsubscribed=%#v routes=%#v", managerStore.terminated, bus.unsubscribed, bus.removedPairs)
+		}
+		if got := routeStore.statusByPath["review/inst-1"]; got != "active" {
+			t.Fatalf("route status before commit = %q, want active", got)
+		}
+		var externalStatus string
+		if err := db.QueryRowContext(context.Background(), `
+			SELECT status
+			FROM flow_instances
+			WHERE instance_id = $1
+		`, "review/inst-1").Scan(&externalStatus); err != nil {
+			t.Fatalf("external flow_instances status before commit: %v", err)
+		}
+		if strings.TrimSpace(externalStatus) != "active" {
+			t.Fatalf("external flow_instances status before commit = %q, want active", externalStatus)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunInPipelineTransaction: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT status
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, "review/inst-1").Scan(&status); err != nil {
+		t.Fatalf("external flow_instances status after commit: %v", err)
+	}
+	if strings.TrimSpace(status) != "terminated" {
+		t.Fatalf("external flow_instances status after commit = %q, want terminated", status)
+	}
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("expected flow agent teardown after terminal transaction commit")
+	}
+	if len(managerStore.terminated) != 1 || managerStore.terminated[0] != "reviewer-inst-1" {
+		t.Fatalf("agent terminations after commit = %#v, want reviewer-inst-1", managerStore.terminated)
+	}
+	if len(bus.unsubscribed) != 1 || bus.unsubscribed[0] != "reviewer-inst-1" {
+		t.Fatalf("unsubscribed after commit = %#v, want reviewer-inst-1", bus.unsubscribed)
+	}
+	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "review/inst-1" {
+		t.Fatalf("removed routes after commit = %#v, want review/inst-1", bus.removedPairs)
+	}
+	if got := routeStore.statusByPath["review/inst-1"]; got != "inactive" {
+		t.Fatalf("route status after commit = %q, want inactive", got)
 	}
 }
 

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -868,8 +868,8 @@ func TestDeactivateFlowInstanceQueuesTerminalSideEffectsUntilPostCommitWhenAvail
 	}
 }
 
-func TestDeactivateFlowInstanceLogsPostCommitTerminalSideEffectFailures(t *testing.T) {
-	bus := &flowActivationTestBus{removeErr: errors.New("route removal failed")}
+func TestDeactivateFlowInstanceLogsPostCommitAgentFailureWithoutRouteRemoval(t *testing.T) {
+	bus := &flowActivationTestBus{}
 	instances := &flowActivationTestInstanceStore{}
 	managerStore := &flowActivationTestStore{terminateErr: errors.New("agent terminate failed")}
 	am := newFlowActivationManager(bus, instances, managerStore)
@@ -892,11 +892,49 @@ func TestDeactivateFlowInstanceLogsPostCommitTerminalSideEffectFailures(t *testi
 	if log.Action != "terminal_flow_instance_side_effects_failed" || log.Level != "warn" {
 		t.Fatalf("runtime log = %#v, want warning terminal_flow_instance_side_effects_failed", log)
 	}
-	if !strings.Contains(log.Error, "agent terminate failed") || !strings.Contains(log.Error, "route removal failed") {
-		t.Fatalf("runtime log error = %q, want both side-effect failures", log.Error)
+	if !strings.Contains(log.Error, "agent terminate failed") {
+		t.Fatalf("runtime log error = %q, want agent termination failure", log.Error)
+	}
+	if len(bus.removedPairs) != 0 {
+		t.Fatalf("removed routes after agent failure = %#v, want no route removal", bus.removedPairs)
+	}
+	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "review/inst-1" {
+		t.Fatalf("flow terminal state = %#v, want preserved terminal transition", instances.terminatedPaths)
+	}
+}
+
+func TestDeactivateFlowInstanceLogsPostCommitRouteFailureAfterAgentTeardown(t *testing.T) {
+	bus := &flowActivationTestBus{removeErr: errors.New("route removal failed")}
+	instances := &flowActivationTestInstanceStore{}
+	managerStore := &flowActivationTestStore{}
+	am := newFlowActivationManager(bus, instances, managerStore)
+	bundle := testFlowBundle("")
+
+	if err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	if err := am.DeactivateFlowInstance(ctx, "review", "inst-1", "review/inst-1", "ent-1"); err != nil {
+		t.Fatalf("DeactivateFlowInstance returned pre-commit error: %v", err)
+	}
+
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	if len(bus.runtimeLogs) != 1 {
+		t.Fatalf("runtime logs = %#v, want one post-commit failure log", bus.runtimeLogs)
+	}
+	log := bus.runtimeLogs[0]
+	if log.Action != "terminal_flow_instance_side_effects_failed" || log.Level != "warn" {
+		t.Fatalf("runtime log = %#v, want warning terminal_flow_instance_side_effects_failed", log)
+	}
+	if !strings.Contains(log.Error, "route removal failed") {
+		t.Fatalf("runtime log error = %q, want route removal failure", log.Error)
+	}
+	if len(managerStore.terminated) != 1 || managerStore.terminated[0] != "reviewer-inst-1" {
+		t.Fatalf("agent terminations after route failure = %#v, want reviewer-inst-1", managerStore.terminated)
 	}
 	if len(bus.removedPairs) != 1 || bus.removedPairs[0] != "review/inst-1" {
-		t.Fatalf("removed routes after failure = %#v, want route attempt after agent failure", bus.removedPairs)
+		t.Fatalf("removed routes after route failure = %#v, want one route attempt", bus.removedPairs)
 	}
 	if len(instances.terminatedPaths) != 1 || instances.terminatedPaths[0] != "review/inst-1" {
 		t.Fatalf("flow terminal state = %#v, want preserved terminal transition", instances.terminatedPaths)

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -374,15 +374,56 @@ func (s *SQLiteRuntimeStore) MarkAgentTerminated(ctx context.Context, agentID st
 	if agentID == "" {
 		return fmt.Errorf("agent_id is required")
 	}
-	_, err := s.DB.ExecContext(ctx, `
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite mark agent terminated tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	now := s.now()
+	if _, err := tx.ExecContext(ctx, `
 		UPDATE agents
 		SET status = 'terminated',
 		    last_active_at = ?
 		WHERE agent_id = ?
-	`, time.Now().UTC(), agentID)
-	if err != nil {
+	`, now, agentID); err != nil {
 		return fmt.Errorf("mark sqlite agent terminated: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET status = 'terminated',
+		    termination_reason = 'cancelled',
+		    terminated_at = COALESCE(terminated_at, ?),
+		    lease_holder = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE agent_id = ?
+		  AND status IN ('active', 'suspended')
+	`, now, now, agentID); err != nil {
+		return fmt.Errorf("mark sqlite agent terminated sessions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_conversation_audits
+		SET status = 'terminated',
+		    updated_at = ?
+		WHERE agent_id = ?
+		  AND status = 'active'
+	`, now, agentID); err != nil {
+		return fmt.Errorf("mark sqlite agent terminated conversation audits: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite mark agent terminated tx: %w", err)
+	}
+	committed = true
 	return nil
 }
 

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -667,6 +667,116 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	}
 }
 
+func TestSQLiteRuntimeStoreMarkAgentTerminatedCleansRuntimeState(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	store.SetNowFnForTest(func() time.Time { return now })
+
+	if err := store.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:                    "agent-cleanup-1",
+			Role:                  "operator",
+			Mode:                  "global",
+			Model:                 "regular",
+			LLMBackend:            "anthropic",
+			ConversationMode:      "session",
+			SessionScope:          "global",
+			SessionScopeAuthority: runtimeactors.SessionScopeAuthorityPlatformInternal,
+			Config:                json.RawMessage(`{"system_prompt":"test","tools":[]}`),
+		},
+		Status:    "active",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	lease, err := store.Acquire(ctx, "agent-cleanup-1", runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "owner-1", "")
+	if err != nil {
+		t.Fatalf("Acquire session: %v", err)
+	}
+	if err := store.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID:    lease.SessionID,
+		AgentID:      "agent-cleanup-1",
+		SessionScope: "global",
+		ScopeKey:     "global",
+		Mode:         "session",
+		Messages:     []runtimellm.Message{{Role: "user", Content: "hello"}},
+		Summary:      "session",
+		TurnCount:    1,
+		Status:       "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(session): %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, agent_id, scope_key, scope, conversation, turn_count,
+			runtime_mode, runtime_state, status, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, '[]', 0, 'task', '{}', 'active', ?, ?)
+	`, uuid.NewString(), "agent-cleanup-1", "global", "global", now, now); err != nil {
+		t.Fatalf("seed task audit: %v", err)
+	}
+
+	if err := store.MarkAgentTerminated(ctx, "agent-cleanup-1"); err != nil {
+		t.Fatalf("MarkAgentTerminated: %v", err)
+	}
+
+	var (
+		agentStatus      string
+		sessionStatus    string
+		sessionReason    string
+		terminatedRaw    any
+		auditStatus      string
+		activeAuditCount int
+	)
+	if err := store.DB.QueryRowContext(ctx, `SELECT status FROM agents WHERE agent_id = ?`, "agent-cleanup-1").Scan(&agentStatus); err != nil {
+		t.Fatalf("read agent status: %v", err)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(termination_reason, ''), terminated_at
+		FROM agent_sessions
+		WHERE agent_id = ?
+	`, "agent-cleanup-1").Scan(&sessionStatus, &sessionReason, &terminatedRaw); err != nil {
+		t.Fatalf("read session status: %v", err)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status
+		FROM agent_conversation_audits
+		WHERE agent_id = ?
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, "agent-cleanup-1").Scan(&auditStatus); err != nil {
+		t.Fatalf("read audit status: %v", err)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_conversation_audits
+		WHERE agent_id = ?
+		  AND status = 'active'
+	`, "agent-cleanup-1").Scan(&activeAuditCount); err != nil {
+		t.Fatalf("count active audits: %v", err)
+	}
+	terminatedAt, ok, err := sqliteTimeValue(terminatedRaw)
+	if err != nil {
+		t.Fatalf("scan terminated_at: %v", err)
+	}
+	if agentStatus != "terminated" {
+		t.Fatalf("agent status = %q, want terminated", agentStatus)
+	}
+	if sessionStatus != "terminated" {
+		t.Fatalf("session status = %q, want terminated", sessionStatus)
+	}
+	if sessionReason != "cancelled" {
+		t.Fatalf("session termination_reason = %q, want cancelled", sessionReason)
+	}
+	if !ok || terminatedAt.IsZero() {
+		t.Fatalf("session terminated_at = %v ok=%v, want non-zero", terminatedAt, ok)
+	}
+	if auditStatus != "terminated" || activeAuditCount != 0 {
+		t.Fatalf("audit status = %q active_count=%d, want terminated and no active audits", auditStatus, activeAuditCount)
+	}
+}
+
 func operatorDeliveriesContain(deliveries []OperatorEventDelivery, subscriberType, subscriberID string) bool {
 	for _, delivery := range deliveries {
 		if delivery.SubscriberType == subscriberType && delivery.SubscriberID == subscriberID {


### PR DESCRIPTION
Closes #1117

## Summary

This PR closes the approved #1117 failure class: `terminal_flow_instance_lifecycle_side_effects_post_commit_ordering`.

It changes terminal flow-instance deactivation so that, when deactivation runs inside the pipeline transaction/post-commit owner, terminal lifecycle side effects are queued until after commit:

- flow-scoped agent teardown
- bus unsubscribe / in-memory agent removal through `TeardownAgent`
- persisted agent/session/conversation-audit termination through `MarkAgentTerminated`
- flow-instance route removal through the event bus / route store / route table

Non-transactional deactivation remains immediate. Post-commit teardown failures are logged as recoverable runtime warnings and do not roll back the already committed terminal state.

## Governing Context

Exact adjacent spec references:

- `platform-spec.yaml` `runtime.dynamic_instance_lifecycle.termination`
- `platform-spec.yaml` `runtime.event_loop.atomicity`
- `platform-spec.yaml` `runtime.state_management.terminal_state_behavior`
- `platform-spec.yaml` `data_model.routing_rules.lifecycle`
- `platform-spec.yaml` `data_model.flow_instances`

The binding issue/gate context is #1117, the repaired Pre-Implementation Coverage Audit, and the approved gate comment approving `terminal_flow_instance_lifecycle_side_effects_post_commit_ordering`.

## Semantic Migration

New canonical owner:

- `AgentManager.DeactivateFlowInstanceModel` now consumes the existing pipeline post-commit owner (`runtimepipeline.QueuePipelinePostCommitAction`) for terminal flow-instance lifecycle side effects when a pipeline post-commit queue is present.

Old producer / reader / writer path now invalid:

- Synchronous `TeardownAgent` and `RemoveFlowInstanceRoute` from `DeactivateFlowInstanceModel` while inside a pipeline transaction/post-commit context.
- SQLite `MarkAgentTerminated` terminating only `agents` without also terminating active sessions and conversation audits.

Production paths checked for surviving old behavior:

- Transactional deactivation path through `WorkflowInstanceStore.RunInPipelineTransaction`.
- Non-transactional `DeactivateFlowInstance` path.
- EventBus route teardown path.
- Postgres and SQLite agent/session cleanup owners.

Migration completeness:

- Complete for the approved #1117 widened class. Broader #1025 / Empire #87 siblings remain split as tracked separately.

## Validation

- `go test ./internal/runtime/manager -run 'TestDeactivateFlowInstance|TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable|TestRecoverRestoresPersistedFlowInstanceRoutes' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusFlowInstanceRoutesPersistAcrossAddAndRemove|TestEventBusAddFlowInstanceRouteRollsBackPersistedRouteOnActiveInstallFailure' -count=1`
- `go test ./internal/store -run 'TestSQLiteRuntimeStoreMarkAgentTerminatedCleansRuntimeState|TestPostgresStore_MarkAgentTerminated_CleansRuntimeState|TestPostgresStoreFlowInstanceRouteDeletionRequiresCanonicalTermination' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestMaybeDeactivateTerminalFlowInstance|TestExecuteNodeContractHandler' -count=1`
- `go test ./...`