### PR TITLE
[agent-a][issue #1115] Preserve activation auto-emit run ids

### DIFF
--- a/internal/runtime/correlation/context_test.go
+++ b/internal/runtime/correlation/context_test.go
@@ -47,6 +47,20 @@ func TestCorrelateEvent_GeneratesRunWithoutGeneratingTrace(t *testing.T) {
 	}
 }
 
+func TestCorrelateEvent_PreservesExplicitEventRunID(t *testing.T) {
+	ctx, evt := CorrelateEvent(context.Background(), events.Event{
+		ID:    "evt-child",
+		Type:  events.EventType("task.started"),
+		RunID: "run-explicit",
+	})
+	if got := evt.RunID; got != "run-explicit" {
+		t.Fatalf("event run_id = %q, want run-explicit", got)
+	}
+	if got := RunIDFromContext(ctx); got != "run-explicit" {
+		t.Fatalf("context run_id = %q, want run-explicit", got)
+	}
+}
+
 func TestCorrelateEvent_UsesTypedRuntimeLineageParent(t *testing.T) {
 	ctx := WithRuntimeLineage(context.Background(), RuntimeLineage{
 		Owner:               "runtime.run_fork.selected_contract_execution.fork_local_runtime_typed_lineage",

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -15,6 +15,7 @@ import (
 	models "swarm/internal/runtime/core/actors"
 	"swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimeeventpayload "swarm/internal/runtime/eventpayload"
 	runtimeeventschema "swarm/internal/runtime/eventschema"
 	runtimepipeline "swarm/internal/runtime/pipeline"
@@ -78,6 +79,11 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	autoEmitEvent, autoEmitName, err := buildAutoEmitOnCreateEvent(req.ContractBundle, schema, templateID, flowPath, instanceID, flowEntityID, parentEntityID, req.Config)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(autoEmitName) != "" {
+		if runID := runtimecorrelation.RunIDFromContext(ctx); runID != "" {
+			autoEmitEvent.RunID = runID
+		}
 	}
 	if err := am.workflowInstances.Create(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      instanceID,

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -397,8 +397,10 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
+	const runID = "11111111-1111-1111-1111-111111111115"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
-	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
+	err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -415,14 +417,19 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	if got := autoEmit.EntityID(); got != runtimepipeline.FlowInstanceEntityID("review/inst-1") {
 		t.Fatalf("published entity_id = %q, want %q", got, runtimepipeline.FlowInstanceEntityID("review/inst-1"))
 	}
+	if got := strings.TrimSpace(autoEmit.RunID); got != runID {
+		t.Fatalf("published run_id = %q, want active run %q", got, runID)
+	}
 }
 
 func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
+	const runID = "22222222-2222-2222-2222-222222222215"
 	postCommit := make([]func(), 0, 1)
-	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	ctx = runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommit)
 
 	err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
 	if err != nil {
@@ -441,6 +448,9 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	}
 	if got := string(bus.published[0].Type); got != "review/inst-1/task.started" {
 		t.Fatalf("auto-emitted type = %q, want review/inst-1/task.started", got)
+	}
+	if got := strings.TrimSpace(bus.published[0].RunID); got != runID {
+		t.Fatalf("auto-emitted run_id = %q, want active run %q", got, runID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stamp runtime-generated template activation `auto_emit_on_create` events with the active run id before the queued post-commit path drops the handler context.
- Add direct and queued activation proofs that auto-emits preserve the active run id.
- Add canonical correlation proof that an explicit event `run_id` is preserved rather than replaced with a new run.

Closes #1115

## Governing Context

Binding refs:

- `platform-spec.yaml#runtime.dynamic_instance_lifecycle.creation.auto_emit`
- `platform-spec.yaml#platform_tables.runs.lifecycle.run_id_propagation`
- `platform-spec.yaml#run_model.lineage.run_id`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`
- #1115 pre-audit and approved gate: https://github.com/yazzaoui/Swarm/issues/1115#issuecomment-4588299648

No platform-spec change is included because this PR implements the existing run-id propagation rule for activation auto-emits; it does not introduce a new platform semantic.

## Semantic Migration

- New canonical consumer: `internal/runtime/manager/flow_activation.go` consumes `internal/runtime/correlation.RunIDFromContext` before activation auto-emits enter the post-commit closure.
- Canonical owner remains `internal/runtime/correlation` (`RunIDFromContext`, `CorrelateEvent`).
- Old invalid path: queued activation auto-emit publishing an event with empty `RunID` through `context.Background()`, allowing `CorrelateEvent` to allocate a new run.
- Production paths checked: direct activation publish, queued post-commit activation publish, duplicate-create suppression, and external public `event.publish` omitted-run behavior.
- Migration completeness: complete for #1115 run-id inheritance. Source-event causal-parent lineage is not claimed closed and remains split to #1025 / Empire #87 tracking as noted by the gate.

## Verification

- `go test ./internal/runtime/manager -run 'TestActivateFlowInstance(PublishesAutoEmitEvent|QueuesAutoEmitUntilPostCommitWhenAvailable|RejectsDuplicateInstanceIDBeforeSideEffects)' -count=1`
- `go test ./internal/runtime/correlation -run 'TestCorrelateEvent_(PreservesExplicitEventRunID|GeneratesRunWithoutGeneratingTrace|InheritsRunAndParentWithoutGeneratingTrace)' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency' -count=1`
- `go test ./internal/store -run TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHistory -count=1 -timeout 20m`
- `go test ./... -count=1 -timeout 20m`

Note: one rebased `go test ./... -count=1` run hit Go's default 10-minute package timeout in `internal/store` while bootstrapping Postgres for an unrelated store test. The isolated test passed in 4s, and the final current-base full-suite run passed with `-timeout 20m`.
