### PR TITLE
[agent-g][issue #1088] Default local runtime store to SQLite

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -189,7 +189,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
-	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
+	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -67,6 +67,7 @@ const (
 	serveReadinessRoutes    = "/healthz /readyz"
 	serveGatewayTokenBytes  = 32
 	serveExitDataIntegrity  = 78
+	runtimeStoreBackendHelp = "Runtime store backend: sqlite (local/dev default) or postgres (explicit opt-in production/external backend)"
 )
 
 var (
@@ -144,6 +145,17 @@ type storeBundle struct {
 	IdempotencyStore    apiv1.APIIdempotencyStore
 	TurnStore           runtimellm.TurnPersistence
 	StartupOwnership    runtimestartupownership.Store
+}
+
+type sqlDBPinger struct {
+	db *sql.DB
+}
+
+func (p sqlDBPinger) Ping(ctx context.Context) error {
+	if p.db == nil {
+		return errors.New("sql database is not configured")
+	}
+	return p.db.PingContext(ctx)
 }
 
 func (s storeBundle) runtimeStores() runtime.Stores {
@@ -774,11 +786,22 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	var apiEntities apiv1.EntityReadStore
 	var apiAgentConversations apiv1.AgentConversationReadStore
+	var apiDatabase apiv1.Pinger
+	var apiRuns apiv1.RunReadStore
 	apiObservability := stores.ObservabilityStore
 	if stores.Postgres != nil {
+		apiDatabase = stores.Postgres
+		apiRuns = stores.Postgres
 		apiEntities = stores.Postgres
 		apiAgentConversations = stores.Postgres
 		apiObservability = stores.Postgres
+	} else if stores.SQLDB != nil {
+		apiDatabase = sqlDBPinger{db: stores.SQLDB}
+	}
+	if stores.Postgres == nil {
+		if runStore, ok := stores.ObservabilityStore.(apiv1.RunReadStore); ok {
+			apiRuns = runStore
+		}
 	}
 	resetPlanner := runtimedestructivereset.InventoryPlanner{
 		Reader: runtimedestructivereset.CompositeInventoryReader{
@@ -808,8 +831,8 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Ready: func() bool {
 			return ready.Load()
 		},
-		Database:           stores.Postgres,
-		Runs:               stores.Postgres,
+		Database:           apiDatabase,
+		Runs:               apiRuns,
 		Observability:      apiObservability,
 		Entities:           apiEntities,
 		AgentConversations: apiAgentConversations,
@@ -1197,7 +1220,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	backend := fs.String("backend", "", "LLM backend profile for local runtime startup")
 	contractsPath := fs.String("contracts", "", "Path to selected Swarm contract bundle root for fork planning or selected-contract execution")
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
-	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), "Runtime store backend: postgres (active default) or sqlite (selected core stores; default flip after #1088)")
+	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), runtimeStoreBackendHelp)
 	runID := fs.String("run", "", "Source run ID to plan from")
 	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3022,6 +3022,23 @@ func TestPrepareServeBundleSourceDevStampsEphemeralWithoutCatalogRow(t *testing.
 	}
 }
 
+func TestPrepareServeBundleSourceSQLiteStampsEphemeralWithoutPostgresCatalog(t *testing.T) {
+	ctx := context.Background()
+	bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier1-primitives/test-emits-single")
+	identity, err := runtimecontracts.BootBundleIdentity(bundle)
+	if err != nil {
+		t.Fatalf("BootBundleIdentity: %v", err)
+	}
+
+	fact, err := prepareServeBundleSource(ctx, storeBundle{}, bundle, identity.Fingerprint, false)
+	if err != nil {
+		t.Fatalf("prepareServeBundleSource(sqlite local): %v", err)
+	}
+	if fact.BundleSource != storerunlifecycle.BundleSourceEphemeral || fact.BundleHash == "" || fact.BundleFingerprint != identity.Fingerprint {
+		t.Fatalf("source fact = %#v", fact)
+	}
+}
+
 func TestCLI_NoArgCommandsRejectUnexpectedArgs(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -3480,6 +3497,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunUsesCanonicalPlannerJSON(t *testing.T)
 	}
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
+		"--store", "postgres",
 		"--dry-run",
 		"--run", runID,
 		"--at", eventID,
@@ -3544,6 +3562,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady(t 
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
+		"--store", "postgres",
 		"--dry-run",
 		"--run", runID,
 		"--at", eventID,
@@ -3597,6 +3616,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunContractsAddsContractFrontierAdmission
 	repo := repoRoot()
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--dry-run",
 		"--run", runID,
 		"--at", eventID,
@@ -3762,6 +3782,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteThroughCanonicalOwne
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(context.Background(), repo, []string{
+		"--store", "postgres",
 		"--contracts", contractsRoot,
 		"--run", sourceRunID,
 		"--at", sourceEventID,
@@ -3860,6 +3881,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteReportsSourceAdvance
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(context.Background(), repo, []string{
+		"--store", "postgres",
 		"--contracts", contractsRoot,
 		"--run", sourceRunID,
 		"--at", sourceEventID,
@@ -3938,6 +3960,7 @@ func TestRunForkRuntimeOwnerHarness_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t
 	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--materialize-only",
 		"--run", runID,
 		"--at", eventID,
@@ -4010,6 +4033,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateUsesCanonicalStoreOwnerJSON(t *testi
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
+		"--store", "postgres",
 		"--activate",
 		"--run", materialized.ForkRunID,
 		"--json",
@@ -4062,6 +4086,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateNonSelectedDoesNotRequireSelectedBin
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
+		"--store", "postgres",
 		"--activate",
 		"--run", materialized.ForkRunID,
 		"--json",
@@ -4092,6 +4117,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingConsumesRuntimeAdmiss
 
 	var materializeOut bytes.Buffer
 	materializeCode := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--materialize-only",
 		"--run", runID,
 		"--at", eventID,
@@ -4108,6 +4134,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingConsumesRuntimeAdmiss
 
 	var activateOut bytes.Buffer
 	activateCode := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--activate",
 		"--run", materialized.ForkRunID,
 		"--json",
@@ -4159,6 +4186,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSe
 
 	var materializeOut bytes.Buffer
 	materializeCode := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--materialize-only",
 		"--run", runID,
 		"--at", eventID,
@@ -4175,6 +4203,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSe
 
 	var activateOut bytes.Buffer
 	activateCode := runForkRuntimeOwnerHarness(ctx, repo, []string{
+		"--store", "postgres",
 		"--activate",
 		"--run", materialized.ForkRunID,
 		"--json",

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -139,8 +139,8 @@ func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	if serveOpts.MCPListenAddr != defaultMCPListenAddr {
 		t.Fatalf("mcp listen addr = %q, want unchanged default %q", serveOpts.MCPListenAddr, defaultMCPListenAddr)
 	}
-	if serveOpts.StoreMode != "postgres" || serveOpts.StoreModeSet {
-		t.Fatalf("store opts = mode %q set %v, want staged postgres default with no flag source", serveOpts.StoreMode, serveOpts.StoreModeSet)
+	if serveOpts.StoreMode != "sqlite" || serveOpts.StoreModeSet {
+		t.Fatalf("store opts = mode %q set %v, want sqlite default with no flag source", serveOpts.StoreMode, serveOpts.StoreModeSet)
 	}
 }
 

--- a/cmd/swarm/serve_bundle_source.go
+++ b/cmd/swarm/serve_bundle_source.go
@@ -17,7 +17,7 @@ func prepareServeBundleSource(ctx context.Context, stores storeBundle, bundle *r
 		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("derive canonical bundle hash: %w", err)
 	}
 	source := storerunlifecycle.BundleSourcePersisted
-	if dev {
+	if dev || stores.Postgres == nil {
 		source = storerunlifecycle.BundleSourceEphemeral
 	}
 	fact := runtimecorrelation.BundleSourceFact{
@@ -25,11 +25,8 @@ func prepareServeBundleSource(ctx context.Context, stores storeBundle, bundle *r
 		BundleSource:      source,
 		BundleFingerprint: strings.TrimSpace(legacyFingerprint),
 	}.Normalized()
-	if dev {
+	if source == storerunlifecycle.BundleSourceEphemeral {
 		return fact, nil
-	}
-	if stores.Postgres == nil {
-		return runtimecorrelation.BundleSourceFact{}, fmt.Errorf("postgres bundle catalog store is required for persisted serve bundle source")
 	}
 	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
 	if err != nil {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	apiv1 "swarm/internal/apiv1"
 	"swarm/internal/config"
 	"swarm/internal/runtime"
 	runtimecontracts "swarm/internal/runtime/contracts"
@@ -19,14 +20,18 @@ import (
 )
 
 func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
-	t.Run("staged default remains postgres", func(t *testing.T) {
+	t.Run("rollout default is sqlite", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
-		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
+		repo := t.TempDir()
+		got, err := resolveRuntimeStoreSelection(repo, storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
 		if err != nil {
 			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
 		}
-		if got.Backend != storebackend.BackendPostgres || got.BackendSource != storebackend.SourceRolloutDefault {
-			t.Fatalf("selection = %#v, want staged postgres rollout default", got)
+		if got.Backend != storebackend.BackendSQLite || got.BackendSource != storebackend.SourceRolloutDefault {
+			t.Fatalf("selection = %#v, want sqlite rollout default", got)
+		}
+		if want := filepath.Join(repo, ".swarm", "dev.db"); got.SQLitePath != want || got.SQLitePathSource != storebackend.SourceRolloutDefault {
+			t.Fatalf("sqlite path = %q source %q, want %q from rollout default", got.SQLitePath, got.SQLitePathSource, want)
 		}
 	})
 
@@ -76,6 +81,12 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 		wantBackend storebackend.Backend
 		wantSource  storebackend.Source
 	}{
+		{
+			name:        "rollout default sqlite reaches store construction",
+			storeMode:   storebackend.ActiveDefaultBackend().String(),
+			wantBackend: storebackend.BackendSQLite,
+			wantSource:  storebackend.SourceRolloutDefault,
+		},
 		{
 			name:        "flag postgres reaches store construction",
 			storeMode:   storebackend.BackendPostgres.String(),
@@ -160,13 +171,13 @@ func TestServeCommandCapturesStoreFlagForCanonicalResolver(t *testing.T) {
 	}
 }
 
-func TestServeHelpDocumentsStagedStoreBackends(t *testing.T) {
+func TestServeHelpDocumentsSQLiteDefaultAndPostgresOptIn(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--help"}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != 0 {
 		t.Fatalf("serve --help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Runtime store backend", "postgres (active default)", "sqlite (selected core stores; default flip after #1088)"} {
+	for _, want := range []string{"Runtime store backend", "sqlite (local/dev default)", "postgres (explicit opt-in production/external backend)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -190,6 +201,9 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 	if stores.Postgres != nil {
 		t.Fatalf("sqlite store bundle Postgres = %#v, want nil", stores.Postgres)
+	}
+	if _, ok := stores.ObservabilityStore.(apiv1.RunReadStore); !ok {
+		t.Fatalf("sqlite ObservabilityStore = %T, want selected run read store for run.get/list", stores.ObservabilityStore)
 	}
 	runtimeStores := stores.runtimeStores()
 	if runtimeStores.SQLDB != nil {

--- a/internal/apiv1/operator_bundle_admission.go
+++ b/internal/apiv1/operator_bundle_admission.go
@@ -56,6 +56,19 @@ func resolveEventPublicationBundleScope(
 		resolvedHash = runAvailability.BundleHash
 		params.BundleSource = runAvailability.BundleSource
 	}
+	if resolvedHash == "" && identity.LegacyFingerprint == "" && !hasRunContext && runtimeContextManager(opts) == nil {
+		currentFact, hasCurrentFact := eventPublicationRuntimeSourceFact(ctx, opts.Events)
+		currentFact = currentFact.Normalized()
+		if hasCurrentFact &&
+			currentFact.BundleHash != "" &&
+			currentFact.BundleSource == storerunlifecycle.BundleSourceEphemeral &&
+			currentFact.BundleFingerprint != "" {
+			params.BundleHash = currentFact.BundleHash
+			params.BundleSource = currentFact.BundleSource
+			params.BundleFingerprint = currentFact.BundleFingerprint
+			return runtimecorrelation.WithBundleSourceFact(ctx, currentFact), opts, params, nil
+		}
+	}
 	if resolvedHash == "" {
 		details := map[string]any{
 			"field":  "bundle_hash",

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -255,6 +255,40 @@ func TestOperatorEventPublishHandlersRequireCanonicalBundleHashForCreateNewWork(
 	assertNoEventPublishPersistence(t, db)
 }
 
+func TestOperatorEventPublishHandlersUseActiveEphemeralBundleScopeForCreateNewWork(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	seedActiveAPIV1RuntimeBusAgent(t, context.Background(), pg, "scan-orchestrator")
+	ch := bus.Subscribe("scan-orchestrator", events.EventType("scan.requested"))
+	defer bus.Unsubscribe("scan-orchestrator")
+	handler := eventPublishTestHandler(t, pg, bus, source)
+
+	published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "scan.requested", `{"topic":"medicine"}`, "", "idem-publish-no-bundle"))
+	if published.Error != nil {
+		t.Fatalf("event.publish active ephemeral bundle scope error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	runID := stringValue(t, result["run_id"], "run_id")
+	assertEventPublishPersistence(t, db, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
+	if got := countEventsByName(t, db, "scan.requested"); got != 1 {
+		t.Fatalf("scan.requested event count = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID != eventID {
+			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event.publish delivery")
+	}
+}
+
 func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
@@ -981,6 +1015,21 @@ func eventPublishBody(runID, fingerprint, eventName, payload, emitter, idempoten
 func eventPublishBodyWithBundleHash(runID, bundleHash, eventName, payload, emitter, idempotencyKey string) string {
 	parts := []string{
 		fmt.Sprintf(`"bundle_hash":%q`, bundleHash),
+		fmt.Sprintf(`"event_name":%q`, eventName),
+		fmt.Sprintf(`"payload":%s`, payload),
+		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),
+	}
+	if strings.TrimSpace(runID) != "" {
+		parts = append(parts, fmt.Sprintf(`"run_id":%q`, runID))
+	}
+	if strings.TrimSpace(emitter) != "" {
+		parts = append(parts, fmt.Sprintf(`"emitter":%q`, emitter))
+	}
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":"publish","method":"event.publish","params":{%s}}`, strings.Join(parts, ","))
+}
+
+func eventPublishBodyWithoutBundle(runID, eventName, payload, emitter, idempotencyKey string) string {
+	parts := []string{
 		fmt.Sprintf(`"event_name":%q`, eventName),
 		fmt.Sprintf(`"payload":%s`, payload),
 		fmt.Sprintf(`"idempotency_key":%q`, idempotencyKey),

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -110,7 +110,7 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 	}
 }
 
-func TestOperatorRunStartHandlersRequireBundleHashForCreateNewWork(t *testing.T) {
+func TestOperatorRunStartHandlersUseActiveEphemeralBundleScopeForCreateNewWork(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
@@ -122,8 +122,26 @@ func TestOperatorRunStartHandlersRequireBundleHashForCreateNewWork(t *testing.T)
 	runID := uuid.NewString()
 
 	started := rpcCall(t, handler, runStartBodyWithoutBundle(runID, "scan.requested", `{"topic":"medicine"}`, "idem-start-no-bundle"))
+	if started.Error != nil {
+		t.Fatalf("run.start active ephemeral bundle scope error = %#v", started.Error)
+	}
+	result := asMap(t, started.Result)
+	if result["run_id"] != runID || result["status"] != "running" {
+		t.Fatalf("run.start result = %#v", result)
+	}
+	assertRunStartPersistence(t, db, runID, "scan.requested", runStartTestFingerprint)
+}
+
+func TestOperatorRunStartHandlersRequireBundleScopeForCreateNewWorkWithoutActiveRuntimeFact(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &store.PostgresStore{DB: db}
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	handler := runStartTestHandler(t, pg, missingRunStartBundleScopePublisher{}, source)
+	runID := uuid.NewString()
+
+	started := rpcCall(t, handler, runStartBodyWithoutBundle(runID, "scan.requested", `{"topic":"medicine"}`, "idem-start-no-bundle"))
 	if started.Error == nil {
-		t.Fatal("run.start missing bundle_hash error = nil")
+		t.Fatal("run.start missing bundle scope error = nil")
 	}
 	if data := asMap(t, started.Error.Data); data["code"] != BundleScopeRequiredCode {
 		t.Fatalf("missing bundle scope data = %#v", data)
@@ -554,6 +572,12 @@ func (p failingRunStartPublisher) Publish(context.Context, events.Event) error {
 
 func (p failingRunStartPublisher) WithBundleFingerprint(ctx context.Context) context.Context {
 	return runtimecorrelation.WithBundleSourceFact(ctx, runStartTestBundleSourceFact())
+}
+
+type missingRunStartBundleScopePublisher struct{}
+
+func (missingRunStartBundleScopePublisher) Publish(context.Context, events.Event) error {
+	return errors.New("unexpected publish without active runtime bundle scope")
 }
 
 func runStartBody(runID, fingerprint, eventName, payload, idempotencyKey string) string {

--- a/internal/runtime/ingress/controller.go
+++ b/internal/runtime/ingress/controller.go
@@ -20,8 +20,9 @@ const (
 )
 
 var (
-	ErrAlreadyPaused = errors.New("runtime ingress already paused")
-	ErrNotPaused     = errors.New("runtime ingress is not paused")
+	ErrAlreadyPaused       = errors.New("runtime ingress already paused")
+	ErrNotPaused           = errors.New("runtime ingress is not paused")
+	ErrStateNotInitialized = errors.New("runtime ingress state is not initialized")
 )
 
 type Status string
@@ -214,6 +215,13 @@ func (c *Controller) ensureState(ctx context.Context, now time.Time) (State, err
 		return State{Status: StatusRunning}, nil
 	}
 	if c.store != nil {
+		state, err := c.store.LoadRuntimeIngressState(ctx)
+		if err == nil {
+			return state, nil
+		}
+		if !errors.Is(err, ErrStateNotInitialized) {
+			return State{}, err
+		}
 		return c.store.EnsureRuntimeIngressState(ctx, now)
 	}
 	c.mu.Lock()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1218,6 +1218,9 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 	if store == nil || workflow == nil {
 		return nil
 	}
+	if strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)) == "" {
+		return nil
+	}
 	source := workflow.SemanticSource()
 	if source == nil {
 		return nil

--- a/internal/store/backendselection/selection.go
+++ b/internal/store/backendselection/selection.go
@@ -59,10 +59,6 @@ func (b Backend) String() string {
 }
 
 func ActiveDefaultBackend() Backend {
-	return BackendPostgres
-}
-
-func FutureDefaultBackend() Backend {
 	return BackendSQLite
 }
 
@@ -85,14 +81,6 @@ func Resolve(in Input) (Selection, error) {
 	selection.SQLitePath = path
 	selection.SQLitePathSource = pathSource
 	return selection, nil
-}
-
-func SQLiteUnsupportedRuntimeError(path string) error {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		path = filepath.Clean(DefaultSQLiteRelativePath)
-	}
-	return fmt.Errorf("store backend %q is recognized but SQLite runtime stores are not implemented yet; runtime support remains tracked by #1085-#1088 (sqlite_path=%s)", BackendSQLite, path)
 }
 
 func resolveBackend(in Input) (Backend, Source, error) {

--- a/internal/store/backendselection/selection_test.go
+++ b/internal/store/backendselection/selection_test.go
@@ -48,11 +48,11 @@ func TestResolveBackendSourcePrecedence(t *testing.T) {
 			src:  SourceRuntimeConfig,
 		},
 		{
-			name: "rollout default remains postgres until SQLite runtime support lands",
+			name: "rollout default is sqlite for local dev",
 			in: Input{
 				RepoRoot: repo,
 			},
-			want: BackendPostgres,
+			want: BackendSQLite,
 			src:  SourceRolloutDefault,
 		},
 	}
@@ -161,17 +161,5 @@ func TestResolveRejectsEmptyExplicitSQLitePath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "sqlite path from environment must be non-empty") {
 		t.Fatalf("error = %v, want empty path guidance", err)
-	}
-}
-
-func TestSQLiteUnsupportedRuntimeErrorNamesTrackedTail(t *testing.T) {
-	err := SQLiteUnsupportedRuntimeError(filepath.Join("tmp", "dev.db"))
-	if err == nil {
-		t.Fatal("SQLiteUnsupportedRuntimeError returned nil")
-	}
-	for _, want := range []string{"sqlite", "#1085-#1088", "tmp"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q missing %q", err.Error(), want)
-		}
 	}
 }

--- a/internal/store/run_completion.go
+++ b/internal/store/run_completion.go
@@ -164,6 +164,7 @@ func normalRunCompletionPipelinesSettledTx(ctx context.Context, tx *sql.Tx, runI
 				AND r.subscriber_type = 'platform'
 				AND r.subscriber_id = 'pipeline'
 			WHERE e.run_id = $1::uuid
+			  AND e.event_name <> '`+runtimeLogEventName+`'
 			  AND (r.event_id IS NULL OR COALESCE(r.outcome, '') <> 'success')
 		)
 	`, runID).Scan(&unsettled); err != nil {

--- a/internal/store/run_completion_test.go
+++ b/internal/store/run_completion_test.go
@@ -107,6 +107,17 @@ func TestPostgresStore_ConvergeNormalRunCompletion_MarksCompletedWhenTerminalAnd
 	if err := pg.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		) VALUES (
+			gen_random_uuid(), $1::uuid, $2, NULL, NULL, 'global', '{"message":"diagnostic"}'::jsonb,
+			0, 'runtime', 'platform', $3::uuid, now()
+		)
+	`, fixture.RunID, runtimeLogEventName, fixture.EventID); err != nil {
+		t.Fatalf("seed runtime log: %v", err)
+	}
 	if err := pg.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, map[string][]string{"review": []string{"done"}}); err != nil {
 		t.Fatalf("ConvergeNormalRunCompletion: %v", err)
 	}

--- a/internal/store/runtime_ingress_state.go
+++ b/internal/store/runtime_ingress_state.go
@@ -40,7 +40,7 @@ func (s *PostgresStore) LoadRuntimeIngressState(ctx context.Context) (runtimeing
 		return state, nil
 	}
 	if err == sql.ErrNoRows {
-		return runtimeingress.State{}, fmt.Errorf("runtime ingress state is not initialized")
+		return runtimeingress.State{}, runtimeingress.ErrStateNotInitialized
 	}
 	return runtimeingress.State{}, fmt.Errorf("load runtime ingress state: %w", err)
 }

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -303,7 +303,7 @@ func (s *SQLiteRuntimeStore) sqliteRunDebugEvents(ctx context.Context, runID str
 		       COALESCE(produced_by, ''), COALESCE(produced_by_type, ''), payload
 		FROM events
 		WHERE run_id = ? AND event_name <> 'platform.runtime_log'
-		ORDER BY created_at ASC, event_id ASC
+		ORDER BY created_at DESC, event_id DESC
 		LIMIT ?
 	`, runID, limit)
 	if err != nil {

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -1,0 +1,436 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func (s *SQLiteRuntimeStore) requireRunHeaderCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	if !caps.Events.LogRunID {
+		return fmt.Errorf("run api read surface requires canonical events.run_id")
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) LoadRunHeader(ctx context.Context, runID string) (RunHeader, error) {
+	if err := s.requireRunHeaderCapabilities(ctx); err != nil {
+		return RunHeader{}, err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return RunHeader{}, ErrRunNotFound
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return RunHeader{}, ErrRunNotFound
+	}
+	row := s.DB.QueryRowContext(ctx, sqliteRunHeaderSelectSQL()+`
+WHERE r.run_id = ?
+`, runID)
+	header, err := scanSQLiteRunHeader(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return RunHeader{}, ErrRunNotFound
+	}
+	if err != nil {
+		return RunHeader{}, err
+	}
+	if strings.TrimSpace(header.TriggerEventID) == "" || strings.TrimSpace(header.TriggerEventType) == "" {
+		return RunHeader{}, fmt.Errorf("run %s is missing trigger event identity", runID)
+	}
+	return header, nil
+}
+
+func (s *SQLiteRuntimeStore) ListRunHeaders(ctx context.Context, opts RunHeaderListOptions) ([]RunHeader, string, error) {
+	if err := s.requireRunHeaderCapabilities(ctx); err != nil {
+		return nil, "", err
+	}
+	opts = defaultRunHeaderListOptions(opts)
+	args := make([]any, 0, 6)
+	where := []string{"(NULLIF(r.trigger_event_id, '') IS NOT NULL OR EXISTS (SELECT 1 FROM events e WHERE e.run_id = r.run_id))"}
+	if opts.Status != "" {
+		args = append(args, opts.Status)
+		where = append(where, "lower(r.status) = ?")
+	}
+	if opts.BundleHash != "" {
+		args = append(args, opts.BundleHash)
+		where = append(where, "r.bundle_hash = ?")
+	}
+	if opts.Since != nil {
+		args = append(args, opts.Since.UTC())
+		where = append(where, "r.started_at >= ?")
+	}
+	if opts.Until != nil {
+		args = append(args, opts.Until.UTC())
+		where = append(where, "r.started_at <= ?")
+	}
+	if opts.Cursor != "" {
+		startedAt, runID, err := decodeRunHeaderCursor(opts.Cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		args = append(args, startedAt.UTC(), startedAt.UTC(), runID)
+		where = append(where, "(r.started_at < ? OR (r.started_at = ? AND r.run_id < ?))")
+	}
+	args = append(args, opts.Limit+1)
+	rows, err := s.DB.QueryContext(ctx, sqliteRunHeaderSelectSQL()+`
+WHERE `+strings.Join(where, " AND ")+`
+ORDER BY r.started_at DESC, r.run_id DESC
+LIMIT ?
+`, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+	headers := make([]RunHeader, 0, opts.Limit)
+	for rows.Next() {
+		header, err := scanSQLiteRunHeader(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		if strings.TrimSpace(header.TriggerEventID) == "" || strings.TrimSpace(header.TriggerEventType) == "" {
+			return nil, "", fmt.Errorf("run %s is missing trigger event identity", header.RunID)
+		}
+		headers = append(headers, header)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	nextCursor := ""
+	if len(headers) > opts.Limit {
+		headers = headers[:opts.Limit]
+		nextCursor = encodeRunHeaderCursor(headers[len(headers)-1])
+	}
+	return headers, nextCursor, nil
+}
+
+func (s *SQLiteRuntimeStore) LoadRunDebugReport(ctx context.Context, runID string, opts RunDebugQueryOptions) (RunDebugReport, error) {
+	opts = defaultRunDebugQueryOptions(opts)
+	header, err := s.LoadRunHeader(ctx, runID)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report := RunDebugReport{
+		RunID:          header.RunID,
+		RunTableStatus: header.Status,
+		RootEventID:    header.TriggerEventID,
+		RootEventType:  header.TriggerEventType,
+		ErrorSummary:   header.ErrorSummary,
+		StartedAt:      header.StartedAt,
+		EndedAt:        header.EndedAt,
+		EventCount:     header.EventCount,
+		EntityCount:    header.EntityCount,
+	}
+	if lastEventAt, ok, err := s.sqliteRunLastEventAt(ctx, header.RunID); err != nil {
+		return RunDebugReport{}, err
+	} else if ok {
+		report.LastEventAt = lastEventAt
+	}
+	eventCounts, err := s.sqliteRunDebugEventCounts(ctx, header.RunID)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.EventCounts = eventCounts
+	deliveries, err := s.sqliteRunDebugDeliveryCounts(ctx, header.RunID)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.Deliveries = deliveries
+	events, err := s.sqliteRunDebugEvents(ctx, header.RunID, opts.EventLimit)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.Events = events
+	logs, err := s.sqliteRunDebugRuntimeLogs(ctx, header.RunID, opts)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.RuntimeLogs = logs
+	logSummary, warnErrorCount, err := s.sqliteRunDebugRuntimeLogSummary(ctx, header.RunID, opts.Component)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.RuntimeLogSummary = logSummary
+	report.WarnErrorLogCount = warnErrorCount
+	return report, nil
+}
+
+func sqliteRunHeaderSelectSQL() string {
+	return `
+SELECT
+	r.run_id,
+	lower(COALESCE(r.status, '')),
+	COALESCE(NULLIF(r.trigger_event_type, ''), (
+		SELECT e.event_name
+		FROM events e
+		WHERE e.run_id = r.run_id
+		ORDER BY e.created_at ASC, e.event_id ASC
+		LIMIT 1
+	), ''),
+	COALESCE(NULLIF(r.trigger_event_id, ''), (
+		SELECT e.event_id
+		FROM events e
+		WHERE e.run_id = r.run_id
+		ORDER BY e.created_at ASC, e.event_id ASC
+		LIMIT 1
+	), ''),
+	COALESCE(r.entity_count, 0),
+	COALESCE(NULLIF(r.event_count, 0), (SELECT COUNT(*) FROM events e WHERE e.run_id = r.run_id), 0),
+	r.started_at,
+	r.ended_at,
+	COALESCE(r.forked_from_run_id, ''),
+	COALESCE(r.error_summary, '')
+FROM runs r
+`
+}
+
+func scanSQLiteRunHeader(row runHeaderScanner) (RunHeader, error) {
+	var header RunHeader
+	var startedRaw, endedRaw any
+	if err := row.Scan(
+		&header.RunID,
+		&header.Status,
+		&header.TriggerEventType,
+		&header.TriggerEventID,
+		&header.EntityCount,
+		&header.EventCount,
+		&startedRaw,
+		&endedRaw,
+		&header.ForkedFromRunID,
+		&header.ErrorSummary,
+	); err != nil {
+		return RunHeader{}, err
+	}
+	startedAt, ok, err := sqliteTimeValue(startedRaw)
+	if err != nil {
+		return RunHeader{}, err
+	}
+	if ok {
+		header.StartedAt = startedAt
+	}
+	if endedAt, ok, err := sqliteTimeValue(endedRaw); err != nil {
+		return RunHeader{}, err
+	} else if ok {
+		header.EndedAt = &endedAt
+	}
+	header.Status = strings.ToLower(strings.TrimSpace(header.Status))
+	header.TriggerEventType = strings.TrimSpace(header.TriggerEventType)
+	header.TriggerEventID = strings.TrimSpace(header.TriggerEventID)
+	header.ForkedFromRunID = strings.TrimSpace(header.ForkedFromRunID)
+	header.ErrorSummary = strings.TrimSpace(header.ErrorSummary)
+	return header, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunLastEventAt(ctx context.Context, runID string) (time.Time, bool, error) {
+	var raw any
+	if err := s.DB.QueryRowContext(ctx, `SELECT MAX(created_at) FROM events WHERE run_id = ?`, runID).Scan(&raw); err != nil {
+		return time.Time{}, false, fmt.Errorf("load sqlite run last event timestamp: %w", err)
+	}
+	return sqliteTimeValue(raw)
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugEventCounts(ctx context.Context, runID string) ([]RunDebugEventCount, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT event_name, COUNT(*)
+		FROM events
+		WHERE run_id = ?
+		GROUP BY event_name
+		ORDER BY COUNT(*) DESC, event_name ASC
+	`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite run debug event counts: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugEventCount{}
+	for rows.Next() {
+		var item RunDebugEventCount
+		if err := rows.Scan(&item.EventName, &item.Count); err != nil {
+			return nil, fmt.Errorf("scan sqlite run debug event count: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite run debug event counts: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugDeliveryCounts(ctx context.Context, runID string) ([]RunDebugDeliveryCount, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(subscriber_id, ''), COALESCE(status, ''), COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = ?
+		  AND NOT (COALESCE(subscriber_type, '') = ? AND COALESCE(subscriber_id, '') = ?)
+		GROUP BY COALESCE(subscriber_id, ''), COALESCE(status, '')
+		ORDER BY COALESCE(subscriber_id, '') ASC, COALESCE(status, '') ASC
+	`, runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite run debug delivery counts: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugDeliveryCount{}
+	for rows.Next() {
+		var item RunDebugDeliveryCount
+		if err := rows.Scan(&item.SubscriberID, &item.Status, &item.Count); err != nil {
+			return nil, fmt.Errorf("scan sqlite run debug delivery count: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite run debug delivery counts: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugEvents(ctx context.Context, runID string, limit int) ([]RunDebugEvent, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT event_id, event_name, COALESCE(entity_id, ''), created_at,
+		       COALESCE(produced_by, ''), COALESCE(produced_by_type, ''), payload
+		FROM events
+		WHERE run_id = ? AND event_name <> 'platform.runtime_log'
+		ORDER BY created_at ASC, event_id ASC
+		LIMIT ?
+	`, runID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite run debug events: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugEvent{}
+	for rows.Next() {
+		var item RunDebugEvent
+		var createdRaw, payloadRaw any
+		if err := rows.Scan(&item.EventID, &item.EventName, &item.EntityID, &createdRaw, &item.Source, &item.SourceType, &payloadRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite run debug event: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
+			return nil, err
+		} else if ok {
+			item.CreatedAt = at
+		}
+		item.Payload = sqliteJSONRawMessage(payloadRaw)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite run debug events: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugRuntimeLogs(ctx context.Context, runID string, opts RunDebugQueryOptions) ([]RunDebugRuntimeLog, error) {
+	where := []string{"run_id = ?", "event_name = 'platform.runtime_log'"}
+	args := []any{runID}
+	if !opts.LogsAllLevels {
+		where = append(where, "COALESCE(json_extract(payload, '$.log_level'), '') IN ('warn', 'error')")
+	}
+	if opts.Component != "" {
+		where = append(where, "json_extract(payload, '$.details.component') = ?")
+		args = append(args, opts.Component)
+	}
+	args = append(args, opts.RuntimeLogLimit)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT event_id, created_at, COALESCE(entity_id, ''), payload
+		FROM events
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite run debug runtime logs: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugRuntimeLog{}
+	for rows.Next() {
+		var log OperatorRuntimeLogEntry
+		var createdRaw, payloadRaw any
+		if err := rows.Scan(&log.LogID, &createdRaw, &log.EntityID, &payloadRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite run debug runtime log: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
+			return nil, err
+		} else if ok {
+			log.TS = at
+		}
+		applySQLiteRuntimeLogPayload(&log, sqliteJSONRawMessage(payloadRaw))
+		detail, _ := json.Marshal(log.Details)
+		item := RunDebugRuntimeLog{
+			EventID:   strings.TrimSpace(log.LogID),
+			Level:     strings.TrimSpace(log.Level),
+			Message:   strings.TrimSpace(log.Message),
+			Component: strings.TrimSpace(log.Component),
+			Action:    strings.TrimSpace(sqliteObservabilityString(log.Details["action"])),
+			EventType: strings.TrimSpace(sqliteObservabilityString(log.Details["event_type"])),
+			AgentID:   strings.TrimSpace(log.Source),
+			EntityID:  strings.TrimSpace(log.EntityID),
+			Error:     strings.TrimSpace(log.ErrorCode),
+			Detail:    json.RawMessage(detail),
+			CreatedAt: log.TS.UTC(),
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite run debug runtime logs: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugRuntimeLogSummary(ctx context.Context, runID, component string) ([]RunDebugRuntimeSummary, int, error) {
+	where := []string{"run_id = ?", "event_name = 'platform.runtime_log'"}
+	args := []any{runID}
+	component = strings.TrimSpace(component)
+	if component != "" {
+		where = append(where, "json_extract(payload, '$.details.component') = ?")
+		args = append(args, component)
+	}
+	logLevels := "COALESCE(json_extract(payload, '$.log_level'), '') IN ('warn', 'error')"
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(json_extract(payload, '$.log_level'), 'info'),
+		       COALESCE(json_extract(payload, '$.details.component'), ''),
+		       COALESCE(json_extract(payload, '$.details.action'), ''),
+		       COUNT(*)
+		FROM events
+		WHERE `+strings.Join(where, " AND ")+`
+		  AND `+logLevels+`
+		GROUP BY COALESCE(json_extract(payload, '$.log_level'), 'info'),
+		         COALESCE(json_extract(payload, '$.details.component'), ''),
+		         COALESCE(json_extract(payload, '$.details.action'), '')
+		ORDER BY COUNT(*) DESC,
+		         COALESCE(json_extract(payload, '$.log_level'), 'info') ASC,
+		         COALESCE(json_extract(payload, '$.details.component'), '') ASC
+	`, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query sqlite run debug runtime log summary: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugRuntimeSummary{}
+	warnErrorCount := 0
+	for rows.Next() {
+		var item RunDebugRuntimeSummary
+		if err := rows.Scan(&item.Level, &item.Component, &item.Action, &item.Count); err != nil {
+			return nil, 0, fmt.Errorf("scan sqlite run debug runtime log summary: %w", err)
+		}
+		switch strings.ToLower(strings.TrimSpace(item.Level)) {
+		case "warn", "warning", "error":
+			warnErrorCount += item.Count
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("read sqlite run debug runtime log summary: %w", err)
+	}
+	return out, warnErrorCount, nil
+}

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Unix(1700000000, 0).UTC()
+	newer := uuid.NewString()
+	older := uuid.NewString()
+	newerEvent := uuid.NewString()
+	olderEvent := uuid.NewString()
+	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, status, bundle_hash, bundle_source, trigger_event_id, trigger_event_type,
+			forked_from_run_id, entity_count, event_count, error_summary, started_at, ended_at
+		)
+		VALUES
+			(?, 'running', ?, 'ephemeral', ?, 'scan.requested', NULL, 3, 0, NULL, ?, NULL),
+			(?, 'completed', ?, 'ephemeral', ?, 'scan.completed', ?, 5, 0, NULL, ?, ?)
+	`, newer, bundleA, newerEvent, now, older, bundleB, olderEvent, newer, now.Add(-time.Hour), now.Add(-30*time.Minute)); err != nil {
+		t.Fatalf("seed sqlite runs: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			(?, ?, 'scan.requested', 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.completed', 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'platform.runtime_log', 'global', '{"log_level":"error","message":"boom","details":{"component":"runtime","action":"proof","error_code":"E_PROOF"}}', 'runtime', 'platform', ?)
+	`, newer, newerEvent, now.Add(time.Second), older, olderEvent, now.Add(-time.Hour+time.Second), newer, uuid.NewString(), now.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed sqlite events: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES (?, ?, ?, 'agent', 'agent-1', 'pending', ?)
+	`, uuid.NewString(), newer, newerEvent, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("seed sqlite delivery: %v", err)
+	}
+
+	header, err := sqliteStore.LoadRunHeader(ctx, older)
+	if err != nil {
+		t.Fatalf("LoadRunHeader: %v", err)
+	}
+	if header.RunID != older || header.Status != "completed" || header.TriggerEventID != olderEvent || header.ForkedFromRunID != newer {
+		t.Fatalf("header = %#v", header)
+	}
+	if header.EndedAt == nil {
+		t.Fatal("header.EndedAt = nil, want terminal timestamp")
+	}
+
+	firstPage, cursor, err := sqliteStore.ListRunHeaders(ctx, RunHeaderListOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("ListRunHeaders first page: %v", err)
+	}
+	if len(firstPage) != 1 || firstPage[0].RunID != newer {
+		t.Fatalf("first page = %#v, want newer run", firstPage)
+	}
+	if cursor == "" {
+		t.Fatal("cursor empty for truncated sqlite run list")
+	}
+	secondPage, next, err := sqliteStore.ListRunHeaders(ctx, RunHeaderListOptions{Limit: 1, Cursor: cursor})
+	if err != nil {
+		t.Fatalf("ListRunHeaders second page: %v", err)
+	}
+	if len(secondPage) != 1 || secondPage[0].RunID != older || next != "" {
+		t.Fatalf("second page = %#v cursor=%q, want older only and no next cursor", secondPage, next)
+	}
+	filtered, _, err := sqliteStore.ListRunHeaders(ctx, RunHeaderListOptions{Status: "running", BundleHash: bundleA, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRunHeaders filtered: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].RunID != newer {
+		t.Fatalf("filtered = %#v, want newer only", filtered)
+	}
+
+	report, err := sqliteStore.LoadRunDebugReport(ctx, newer, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport: %v", err)
+	}
+	if report.RunID != newer || report.RootEventID != newerEvent || report.WarnErrorLogCount != 1 {
+		t.Fatalf("report = %#v", report)
+	}
+	if len(report.Deliveries) != 1 || report.Deliveries[0].SubscriberID != "agent-1" {
+		t.Fatalf("report deliveries = %#v, want agent-1 delivery count", report.Deliveries)
+	}
+	if len(report.RuntimeLogs) != 1 || report.RuntimeLogs[0].Component != "runtime" || report.RuntimeLogs[0].Action != "proof" {
+		t.Fatalf("runtime logs = %#v, want runtime proof log", report.RuntimeLogs)
+	}
+}
+
+func TestSQLiteRunAPIReadSurface_LoadRunHeaderNotFound(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	_, err := sqliteStore.LoadRunHeader(context.Background(), uuid.NewString())
+	if !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("LoadRunHeader error = %v, want ErrRunNotFound", err)
+	}
+}

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -16,6 +16,8 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	newer := uuid.NewString()
 	older := uuid.NewString()
 	newerEvent := uuid.NewString()
+	newerMiddleEvent := uuid.NewString()
+	newerLatestEvent := uuid.NewString()
 	olderEvent := uuid.NewString()
 	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -35,9 +37,11 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES
 			(?, ?, 'scan.requested', 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.progressed', 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.finished', 'global', '{}', 'test', 'agent', ?),
 			(?, ?, 'scan.completed', 'global', '{}', 'test', 'agent', ?),
 			(?, ?, 'platform.runtime_log', 'global', '{"log_level":"error","message":"boom","details":{"component":"runtime","action":"proof","error_code":"E_PROOF"}}', 'runtime', 'platform', ?)
-	`, newer, newerEvent, now.Add(time.Second), older, olderEvent, now.Add(-time.Hour+time.Second), newer, uuid.NewString(), now.Add(2*time.Second)); err != nil {
+	`, newer, newerEvent, now.Add(time.Second), newer, newerMiddleEvent, now.Add(2*time.Second), newer, newerLatestEvent, now.Add(3*time.Second), older, olderEvent, now.Add(-time.Hour+time.Second), newer, uuid.NewString(), now.Add(4*time.Second)); err != nil {
 		t.Fatalf("seed sqlite events: %v", err)
 	}
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
@@ -83,7 +87,7 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 		t.Fatalf("filtered = %#v, want newer only", filtered)
 	}
 
-	report, err := sqliteStore.LoadRunDebugReport(ctx, newer, RunDebugQueryOptions{})
+	report, err := sqliteStore.LoadRunDebugReport(ctx, newer, RunDebugQueryOptions{EventLimit: 2})
 	if err != nil {
 		t.Fatalf("LoadRunDebugReport: %v", err)
 	}
@@ -92,6 +96,9 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	}
 	if len(report.Deliveries) != 1 || report.Deliveries[0].SubscriberID != "agent-1" {
 		t.Fatalf("report deliveries = %#v, want agent-1 delivery count", report.Deliveries)
+	}
+	if len(report.Events) != 2 || report.Events[0].EventID != newerLatestEvent || report.Events[1].EventID != newerMiddleEvent {
+		t.Fatalf("report events = %#v, want latest non-log events first", report.Events)
 	}
 	if len(report.RuntimeLogs) != 1 || report.RuntimeLogs[0].Component != "runtime" || report.RuntimeLogs[0].Action != "proof" {
 		t.Fatalf("runtime logs = %#v, want runtime proof log", report.RuntimeLogs)

--- a/internal/store/sqlite_run_completion.go
+++ b/internal/store/sqlite_run_completion.go
@@ -1,0 +1,550 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
+	storerunlifecycle "swarm/internal/store/runlifecycle"
+)
+
+type sqliteRunCompletionDBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func (s *SQLiteRuntimeStore) LoadRunLifecycleSnapshot(ctx context.Context, runID string) (runtimebus.RunLifecycleSnapshot, error) {
+	if s == nil || s.DB == nil {
+		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	snap, err := s.sqliteLoadRunLifecycleSnapshot(ctx, s.DB, runID)
+	if err != nil {
+		return runtimebus.RunLifecycleSnapshot{}, err
+	}
+	return runtimebus.RunLifecycleSnapshot{
+		RunID:        snap.RunID,
+		Status:       snap.Status,
+		EventCount:   snap.EventCount,
+		EntityCount:  snap.EntityCount,
+		ErrorSummary: snap.ErrorSummary,
+		StartedAt:    snap.StartedAt,
+		EndedAt:      snap.EndedAt,
+	}, nil
+}
+
+func (s *SQLiteRuntimeStore) MarkRunTerminal(ctx context.Context, runID, status, errorSummary string, endedAt time.Time) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite mark run terminal tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, runID, status, errorSummary, endedAt); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite mark run terminal tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	eventID := sanitizeOptionalUUID(strings.TrimSpace(evt.ID))
+	if eventID == "" {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite standalone platform run convergence tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	rec, found, err := sqliteLoadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID)
+	if err != nil || !found || !isStandaloneRuntimePlatformRunRecord(rec) {
+		return err
+	}
+	switch strings.TrimSpace(rec.RunStatus) {
+	case "completed":
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite standalone platform run convergence noop tx: %w", err)
+		}
+		return nil
+	case "failed", "cancelled", "forked":
+		return fmt.Errorf("standalone runtime platform run %s already terminal with status %s", rec.RunID, strings.TrimSpace(rec.RunStatus))
+	}
+	active, err := sqliteHasActiveRunDeliveries(ctx, tx, rec.RunID)
+	if err != nil || active {
+		if err != nil {
+			return err
+		}
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite standalone platform active-delivery noop tx: %w", err)
+		}
+		return nil
+	}
+	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, rec.RunID, "completed", "", s.now()); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite standalone platform run convergence tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ConvergeNormalRunCompletion(ctx context.Context, eventID string, workflowTerminalStates []string, flowTerminalStates map[string][]string) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	eventID = sanitizeOptionalUUID(eventID)
+	if eventID == "" {
+		return nil
+	}
+	workflowTerminals := normalRunCompletionStateSet(workflowTerminalStates)
+	flowTerminals := normalRunCompletionFlowStateSets(flowTerminalStates)
+	if len(workflowTerminals) == 0 && len(flowTerminals) == 0 {
+		return nil
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if !normalRunCompletionSupported(caps) {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite normal run completion tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	candidate, found, err := sqliteNormalRunCompletionCandidateTx(ctx, tx, eventID)
+	if err != nil || !found {
+		return err
+	}
+	switch candidate.Status {
+	case "completed":
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite normal run completion noop tx: %w", err)
+		}
+		return nil
+	case "running":
+	default:
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite normal run completion non-running noop tx: %w", err)
+		}
+		return nil
+	}
+	if platformRec, platformFound, err := sqliteLoadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID); err != nil {
+		return err
+	} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite normal run completion platform noop tx: %w", err)
+		}
+		return nil
+	}
+	ready, err := s.sqliteNormalRunCompletionRunReadyTx(ctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
+	if err != nil || !ready {
+		if err != nil {
+			return err
+		}
+		committed = true
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit sqlite normal run completion not-ready noop tx: %w", err)
+		}
+		return nil
+	}
+	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, candidate.RunID, "completed", "", s.now()); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite normal run completion tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteLoadRunLifecycleSnapshot(ctx context.Context, q execQueryer, runID string) (storerunlifecycle.Snapshot, error) {
+	runID = nullUUIDString(runID)
+	if s == nil || q == nil || runID == "" {
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("run_id is required")
+	}
+	var (
+		snap      storerunlifecycle.Snapshot
+		startedAt any
+		endedAt   any
+	)
+	err := q.QueryRowContext(ctx, `
+		SELECT
+			run_id,
+			LOWER(COALESCE(status, '')),
+			COALESCE(event_count, 0),
+			COALESCE(entity_count, 0),
+			COALESCE(error_summary, ''),
+			started_at,
+			ended_at
+		FROM runs
+		WHERE run_id = ?
+	`, runID).Scan(
+		&snap.RunID,
+		&snap.Status,
+		&snap.EventCount,
+		&snap.EntityCount,
+		&snap.ErrorSummary,
+		&startedAt,
+		&endedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return storerunlifecycle.Snapshot{}, fmt.Errorf("run %s not found", runID)
+		}
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("load sqlite run snapshot: %w", err)
+	}
+	if at, ok, err := sqliteTimeValue(startedAt); err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	} else if ok {
+		snap.StartedAt = at
+	}
+	if at, ok, err := sqliteTimeValue(endedAt); err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	} else if ok {
+		snap.EndedAt = &at
+	}
+	snap.RunID = strings.TrimSpace(snap.RunID)
+	snap.Status = strings.TrimSpace(strings.ToLower(snap.Status))
+	snap.ErrorSummary = strings.TrimSpace(snap.ErrorSummary)
+	return snap, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteMarkRunTerminalTx(ctx context.Context, tx *sql.Tx, runID, status, errorSummary string, endedAt time.Time) (storerunlifecycle.Snapshot, error) {
+	if tx == nil {
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("sqlite run terminal tx is required")
+	}
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("run_id is required")
+	}
+	var err error
+	status, err = canonicalRunTerminalStatus(status)
+	if err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	}
+	errorSummary = strings.TrimSpace(errorSummary)
+	if status != "failed" {
+		errorSummary = ""
+	}
+	if endedAt.IsZero() {
+		endedAt = s.now()
+	}
+	if err := sqliteSyncRunCounts(ctx, tx, runID); err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	}
+	if status == "completed" || status == "failed" {
+		active, err := sqliteHasActiveRunDeliveries(ctx, tx, runID)
+		if err != nil {
+			return storerunlifecycle.Snapshot{}, err
+		}
+		if active {
+			return storerunlifecycle.Snapshot{}, fmt.Errorf("run %s still has active deliveries", runID)
+		}
+	}
+	result, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = ?,
+		    error_summary = NULLIF(?, ''),
+		    ended_at = COALESCE(ended_at, ?)
+		WHERE run_id = ?
+		  AND (status IN ('running', 'paused') OR status = ?)
+	`, status, errorSummary, endedAt.UTC(), runID, status)
+	if err != nil {
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("mark sqlite run terminal: %w", err)
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		current, loadErr := s.sqliteLoadRunLifecycleSnapshot(ctx, tx, runID)
+		if loadErr != nil {
+			return storerunlifecycle.Snapshot{}, loadErr
+		}
+		if current.Status != status {
+			return storerunlifecycle.Snapshot{}, fmt.Errorf("run %s already terminal with status %s", runID, current.Status)
+		}
+		return current, nil
+	}
+	return s.sqliteLoadRunLifecycleSnapshot(ctx, tx, runID)
+}
+
+func sqliteSyncRunCounts(ctx context.Context, q execQueryer, runID string) error {
+	runID = nullUUIDString(runID)
+	if q == nil || runID == "" {
+		return nil
+	}
+	_, err := q.ExecContext(ctx, `
+		UPDATE runs
+		SET
+			event_count = (SELECT COUNT(*) FROM events WHERE run_id = ?),
+			entity_count = (SELECT COUNT(DISTINCT entity_id) FROM events WHERE run_id = ?)
+		WHERE run_id = ?
+	`, runID, runID, runID)
+	if err != nil {
+		return fmt.Errorf("sync sqlite run counters: %w", err)
+	}
+	return nil
+}
+
+func sqliteHasActiveRunDeliveries(ctx context.Context, q execQueryer, runID string) (bool, error) {
+	runID = nullUUIDString(runID)
+	if q == nil || runID == "" {
+		return false, nil
+	}
+	var active bool
+	if err := q.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE run_id = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+			  )
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("load sqlite active deliveries: %w", err)
+	}
+	return active, nil
+}
+
+func sqliteNormalRunCompletionCandidateTx(ctx context.Context, tx *sql.Tx, eventID string) (normalRunCompletionCandidate, bool, error) {
+	var candidate normalRunCompletionCandidate
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			r.run_id,
+			LOWER(COALESCE(r.status, ''))
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = ?
+	`, eventID).Scan(&candidate.RunID, &candidate.Status)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return normalRunCompletionCandidate{}, false, nil
+	case err != nil:
+		return normalRunCompletionCandidate{}, false, fmt.Errorf("load sqlite normal run completion candidate: %w", err)
+	default:
+		candidate.RunID = strings.TrimSpace(candidate.RunID)
+		candidate.Status = strings.TrimSpace(candidate.Status)
+		return candidate, candidate.RunID != "", nil
+	}
+}
+
+func (s *SQLiteRuntimeStore) sqliteNormalRunCompletionRunReadyTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	runID string,
+	workflowTerminals map[string]struct{},
+	flowTerminals map[string]map[string]struct{},
+) (bool, error) {
+	runID = nullUUIDString(runID)
+	if runID == "" {
+		return false, nil
+	}
+	checks := []func(context.Context, *sql.Tx, string) (bool, error){
+		sqliteNormalRunCompletionPipelinesSettledTx,
+		sqliteNormalRunCompletionDeliveriesSettledTx,
+		sqliteNormalRunCompletionTimersSettledTx,
+		s.sqliteNormalRunCompletionSessionLeasesSettledTx,
+	}
+	for _, check := range checks {
+		ready, err := check(ctx, tx, runID)
+		if err != nil || !ready {
+			return ready, err
+		}
+	}
+	return sqliteNormalRunCompletionEntitiesTerminalTx(ctx, tx, runID, workflowTerminals, flowTerminals)
+}
+
+func sqliteNormalRunCompletionPipelinesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var unsettled bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM events e
+			LEFT JOIN event_receipts r
+				ON r.event_id = e.event_id
+				AND r.subscriber_type = 'platform'
+				AND r.subscriber_id = 'pipeline'
+			WHERE e.run_id = ?
+			  AND e.event_name <> ?
+			  AND (r.event_id IS NULL OR COALESCE(r.outcome, '') <> 'success')
+		)
+	`, runID, runtimeLogEventName).Scan(&unsettled); err != nil {
+		return false, fmt.Errorf("check sqlite normal run pipeline settlement: %w", err)
+	}
+	return !unsettled, nil
+}
+
+func sqliteNormalRunCompletionDeliveriesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	active, err := sqliteHasActiveRunDeliveries(ctx, tx, runID)
+	if err != nil {
+		return false, err
+	}
+	return !active, nil
+}
+
+func sqliteNormalRunCompletionTimersSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	var active bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM timers
+			WHERE run_id = ?
+			  AND status = 'active'
+		)
+	`, runID).Scan(&active); err != nil {
+		return false, fmt.Errorf("check sqlite normal run active timers: %w", err)
+	}
+	return !active, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteNormalRunCompletionSessionLeasesSettledTx(ctx context.Context, tx *sql.Tx, runID string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT lease_expires_at
+		FROM agent_sessions
+		WHERE run_id = ?
+		  AND status = 'active'
+		  AND lease_holder IS NOT NULL
+		  AND lease_expires_at IS NOT NULL
+	`, runID)
+	if err != nil {
+		return false, fmt.Errorf("check sqlite normal run active session leases: %w", err)
+	}
+	defer rows.Close()
+	now := s.now()
+	for rows.Next() {
+		var raw any
+		if err := rows.Scan(&raw); err != nil {
+			return false, fmt.Errorf("scan sqlite session lease expiry: %w", err)
+		}
+		expiresAt, ok, err := sqliteTimeValue(raw)
+		if err != nil {
+			return false, err
+		}
+		if ok && expiresAt.After(now) {
+			return false, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("read sqlite session lease expiries: %w", err)
+	}
+	return true, nil
+}
+
+func sqliteNormalRunCompletionEntitiesTerminalTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	runID string,
+	workflowTerminals map[string]struct{},
+	flowTerminals map[string]map[string]struct{},
+) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			LOWER(COALESCE(es.current_state, '')),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(fi.flow_template, '')
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = ?
+	`, runID)
+	if err != nil {
+		return false, fmt.Errorf("load sqlite normal run entity terminality: %w", err)
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		seen = true
+		var state, flowInstance, flowTemplate string
+		if err := rows.Scan(&state, &flowInstance, &flowTemplate); err != nil {
+			return false, fmt.Errorf("scan sqlite normal run entity terminality: %w", err)
+		}
+		terminals, ok := normalRunCompletionTerminalSetForEntity(flowTemplate, flowInstance, workflowTerminals, flowTerminals)
+		if !ok {
+			return false, nil
+		}
+		if _, ok := terminals[strings.TrimSpace(strings.ToLower(state))]; !ok {
+			return false, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("read sqlite normal run entity terminality: %w", err)
+	}
+	return seen, nil
+}
+
+func sqliteLoadStandaloneRuntimePlatformRunRecord(ctx context.Context, q sqliteRunCompletionDBTX, eventID string) (standaloneRuntimePlatformRunRecord, bool, error) {
+	eventID = sanitizeOptionalUUID(eventID)
+	if q == nil || eventID == "" {
+		return standaloneRuntimePlatformRunRecord{}, false, nil
+	}
+	var rec standaloneRuntimePlatformRunRecord
+	err := q.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(r.run_id, ''),
+			COALESCE(r.status, ''),
+			COALESCE(e.event_id, ''),
+			COALESCE(e.event_name, ''),
+			COALESCE(e.produced_by, ''),
+			COALESCE(e.produced_by_type, ''),
+			COALESCE(e.source_event_id, ''),
+			COALESCE(r.trigger_event_id, ''),
+			COALESCE(r.trigger_event_type, '')
+		FROM events e
+		INNER JOIN runs r ON r.run_id = e.run_id
+		WHERE e.event_id = ?
+		LIMIT 1
+	`, eventID).Scan(
+		&rec.RunID,
+		&rec.RunStatus,
+		&rec.EventID,
+		&rec.EventType,
+		&rec.ProducedBy,
+		&rec.ProducedByType,
+		&rec.SourceEventID,
+		&rec.TriggerEventID,
+		&rec.TriggerEventType,
+	)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return standaloneRuntimePlatformRunRecord{}, false, nil
+	case err != nil:
+		return standaloneRuntimePlatformRunRecord{}, false, fmt.Errorf("load sqlite standalone runtime platform run candidate: %w", err)
+	default:
+		return rec, true, nil
+	}
+}

--- a/internal/store/sqlite_run_completion_test.go
+++ b/internal/store/sqlite_run_completion_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"swarm/internal/events"
+)
+
+type sqliteNormalRunCompletionFixture struct {
+	RunID    string
+	EventID  string
+	EntityID string
+}
+
+func seedSQLiteNormalRunCompletionFixture(t *testing.T, store *SQLiteRuntimeStore, state string) sqliteNormalRunCompletionFixture {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	if err := store.AppendEvent(ctx, events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("example.started"),
+		SourceAgent: "test",
+		Payload:     json.RawMessage(`{"example":true}`),
+		CreatedAt:   now,
+	}.WithEntityID(entityID)); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (?, ?, '', 'default', 'example', 'Example', ?,
+			'{}', '{}', '{}', 1, ?, ?, ?)
+	`, runID, entityID, state, now, now, now); err != nil {
+		t.Fatalf("seed sqlite entity state: %v", err)
+	}
+	return sqliteNormalRunCompletionFixture{RunID: runID, EventID: eventID, EntityID: entityID}
+}
+
+func assertSQLiteRunCompletionStatus(t *testing.T, db *sql.DB, runID, want string, wantEnded bool) {
+	t.Helper()
+	var (
+		status string
+		ended  any
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, ''), ended_at
+		FROM runs
+		WHERE run_id = ?
+	`, runID).Scan(&status, &ended); err != nil {
+		t.Fatalf("load sqlite run status: %v", err)
+	}
+	if status != want {
+		t.Fatalf("run status = %q, want %q", status, want)
+	}
+	if _, ok, err := sqliteTimeValue(ended); err != nil {
+		t.Fatalf("parse ended_at: %v", err)
+	} else if ok != wantEnded {
+		t.Fatalf("ended_at present = %v, want %v", ok, wantEnded)
+	}
+}
+
+func TestSQLiteRuntimeStoreConvergeNormalRunCompletionMarksCompletedAndIgnoresRuntimeLogs(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	fixture := seedSQLiteNormalRunCompletionFixture(t, store, "done")
+	if err := store.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
+			scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
+		)
+		VALUES (?, ?, ?, NULL, NULL, '{}', '{}', '[]', 'global', ?, 0, 'runtime', 'platform', ?, ?)
+	`, uuid.NewString(), fixture.RunID, runtimeLogEventName, `{"message":"diagnostic"}`, fixture.EventID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite runtime log: %v", err)
+	}
+
+	if err := store.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, nil); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion: %v", err)
+	}
+	assertSQLiteRunCompletionStatus(t, store.DB, fixture.RunID, "completed", true)
+
+	snap, err := store.LoadRunLifecycleSnapshot(ctx, fixture.RunID)
+	if err != nil {
+		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	}
+	if snap.Status != "completed" || snap.EndedAt == nil || snap.EventCount != 2 || snap.EntityCount != 1 {
+		t.Fatalf("snapshot = %#v, want completed with runtime-log-inclusive counters", snap)
+	}
+	header, err := store.LoadRunHeader(ctx, fixture.RunID)
+	if err != nil {
+		t.Fatalf("LoadRunHeader: %v", err)
+	}
+	if header.Status != "completed" || header.EndedAt == nil {
+		t.Fatalf("run header = status:%q ended:%v, want completed with ended_at", header.Status, header.EndedAt)
+	}
+}
+
+func TestSQLiteRuntimeStoreConvergeNormalRunCompletionFailsClosedWhileDeliveryActive(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	fixture := seedSQLiteNormalRunCompletionFixture(t, store, "done")
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES (?, ?, ?, 'node', 'terminal-node', 'pending', 'matched_node_subscription', ?)
+	`, uuid.NewString(), fixture.RunID, fixture.EventID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite active delivery: %v", err)
+	}
+	if err := store.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt: %v", err)
+	}
+	if err := store.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, nil); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion active: %v", err)
+	}
+	assertSQLiteRunCompletionStatus(t, store.DB, fixture.RunID, "running", false)
+
+	if _, err := store.DB.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'delivered',
+		    reason_code = 'node_processed',
+		    delivered_at = ?
+		WHERE event_id = ?
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, time.Now().UTC(), fixture.EventID); err != nil {
+		t.Fatalf("settle sqlite active delivery: %v", err)
+	}
+	if err := store.ConvergeNormalRunCompletion(ctx, fixture.EventID, []string{"done"}, nil); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletion settled: %v", err)
+	}
+	assertSQLiteRunCompletionStatus(t, store.DB, fixture.RunID, "completed", true)
+}

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -41,6 +41,10 @@ type SQLiteRuntimeStore struct {
 
 var _ SchemaBootstrapper = (*SQLiteRuntimeStore)(nil)
 var _ runtimebus.EventStore = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.RunLifecyclePersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.RunLifecycleReadPersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.StandaloneRuntimePlatformRunConvergencePersistence = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.NormalRunCompletionConvergencePersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimemanager.ManagerPersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimepipeline.SchedulePersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimetools.MailboxPersistence = (*SQLiteRuntimeStore)(nil)
@@ -428,7 +432,7 @@ func (s *SQLiteRuntimeStore) LoadRuntimeIngressState(ctx context.Context) (runti
 		WHERE id = 1
 	`))
 	if err == sql.ErrNoRows {
-		return runtimeingress.State{}, fmt.Errorf("runtime ingress state is not initialized")
+		return runtimeingress.State{}, runtimeingress.ErrStateNotInitialized
 	}
 	if err != nil {
 		return runtimeingress.State{}, fmt.Errorf("load sqlite runtime ingress state: %w", err)

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"swarm/internal/events"
+	runtimebus "swarm/internal/runtime/bus"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimeingress "swarm/internal/runtime/ingress"
@@ -234,6 +235,47 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	})
 	if !errors.Is(err, ErrAPIIdempotencyConflict) {
 		t.Fatalf("idempotency conflict err = %v, want ErrAPIIdempotencyConflict", err)
+	}
+}
+
+func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishTxDoesNotReenterWrite(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES (?, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	bus, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(store, bus, runtimeingress.Options{})
+	if err := controller.SyncState(ctx); err != nil {
+		t.Fatalf("SyncState: %v", err)
+	}
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	eventID := uuid.NewString()
+	err = bus.Publish(ctx, (events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("item.received"),
+		SourceAgent: "api.v1",
+		Payload:     []byte(`{"entity_id":"11111111-1111-1111-1111-111111111111"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID("11111111-1111-1111-1111-111111111111"))
+	if err != nil {
+		t.Fatalf("Publish with runtime ingress gate: %v", err)
+	}
+	var count int
+	if err := store.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id = ?`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count event: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("event rows = %d, want 1", count)
 	}
 }
 

--- a/internal/store/sqlite_schema.go
+++ b/internal/store/sqlite_schema.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,16 +38,28 @@ func NewSQLiteSchemaStore(path string) (*SQLiteSchemaStore, error) {
 			return nil, fmt.Errorf("create sqlite schema store parent directory: %w", err)
 		}
 	}
-	db, err := sql.Open("sqlite", cleanPath)
+	db, err := sql.Open("sqlite", sqliteFileDSN(cleanPath))
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite schema store: %w", err)
 	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
 	store := &SQLiteSchemaStore{DB: db, path: cleanPath}
 	if err := store.configure(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return store, nil
+}
+
+func sqliteFileDSN(path string) string {
+	u := url.URL{Scheme: "file", Path: path}
+	q := u.Query()
+	q.Add("_pragma", "foreign_keys(ON)")
+	q.Add("_pragma", "busy_timeout(5000)")
+	q.Add("_pragma", "journal_mode(WAL)")
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func sqlitePathIsInMemory(path string) bool {
@@ -530,7 +543,6 @@ func loadSQLiteSchemaColumnCatalog(ctx context.Context, db *sql.DB) (schemaColum
 	if err != nil {
 		return schemaColumnCatalog{}, fmt.Errorf("inspect sqlite schema tables: %w", err)
 	}
-	defer rows.Close()
 
 	tableNames := make([]string, 0)
 	for rows.Next() {
@@ -544,7 +556,11 @@ func loadSQLiteSchemaColumnCatalog(ctx context.Context, db *sql.DB) (schemaColum
 		}
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
 		return schemaColumnCatalog{}, fmt.Errorf("read sqlite schema tables: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return schemaColumnCatalog{}, fmt.Errorf("close sqlite schema table rows: %w", err)
 	}
 
 	for _, tableName := range tableNames {
@@ -594,8 +610,8 @@ func sqliteEventReceiptsTypedSubscriberIdentityKeyExists(ctx context.Context, db
 	if err != nil {
 		return false, fmt.Errorf("inspect sqlite event_receipts indexes: %w", err)
 	}
-	defer rows.Close()
 
+	indexNames := []string{}
 	for rows.Next() {
 		var seq int
 		var indexName string
@@ -608,6 +624,19 @@ func sqliteEventReceiptsTypedSubscriberIdentityKeyExists(ctx context.Context, db
 		if unique != 1 {
 			continue
 		}
+		indexName = strings.TrimSpace(indexName)
+		if indexName != "" {
+			indexNames = append(indexNames, indexName)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, fmt.Errorf("read sqlite event_receipts indexes: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return false, fmt.Errorf("close sqlite event_receipts index rows: %w", err)
+	}
+	for _, indexName := range indexNames {
 		columns, err := sqliteIndexColumns(ctx, db, indexName)
 		if err != nil {
 			return false, err
@@ -615,9 +644,6 @@ func sqliteEventReceiptsTypedSubscriberIdentityKeyExists(ctx context.Context, db
 		if sameStringSlice(columns, []string{"event_id", "subscriber_type", "subscriber_id"}) {
 			return true, nil
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return false, fmt.Errorf("read sqlite event_receipts indexes: %w", err)
 	}
 	return false, nil
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1991,15 +1991,15 @@ engine:
     backend_ids:
       postgres:
         status: active_supported_runtime_backend
-        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments.
+        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments through flag, environment, or runtime config.
       sqlite:
-        status: explicit_local_store_backend_until_runtime_construction_gate
+        status: active_local_dev_default_runtime_backend
         meaning: >
-          Local/dev SQLite runtime store selection. Explicit sqlite selection may construct the selected typed SQLite store
-          owners promoted by #1086 and staged by #1087, including backend-neutral runtime diagnostics/log persistence
-          promoted by #1150 and backend-neutral mailbox_write materialization promoted by #1186, without exposing a raw
-          runtime SQL handle to Postgres-only consumers. SQLite remains staged until the public default flip is separately
-          proven by #1088; it does not promote production multi-writer SQLite semantics.
+          Local/dev SQLite runtime store selection. No-selection local/dev runtime startup resolves to SQLite through the
+          rollout default owned by internal/store/backendselection. Explicit sqlite selection constructs the selected typed
+          SQLite store owners promoted by #1086/#1087/#1147/#1148/#1149/#1150/#1186/#1157 without exposing a raw runtime
+          SQL handle to Postgres-only runtime consumers. SQLite is the local/dev default; it does not promote production
+          multi-writer SQLite semantics.
     selector_precedence:
       source_order:
       - flag
@@ -2014,11 +2014,12 @@ engine:
       runtime_config:
         backend_key: store.backend
       rollout_default:
-        active_no_selection_default_until_sqlite_runtime_support: postgres
-        future_local_dev_default_after_supported_surface_proof: sqlite
+        active_no_selection_default: sqlite
+        postgres_opt_in_backend: postgres
         rule: >
-          No-selection must not expose a broken SQLite runtime default before #1088 proves the supported SQLite runtime
-          path and explicit Postgres opt-in path together.
+          No-selection local/dev runtime startup resolves to SQLite. Postgres remains explicitly selectable through
+          --store postgres, SWARM_STORE_BACKEND=postgres, or store.backend=postgres and remains the production/external
+          backend.
     sqlite_path:
       canonical_owner: internal/store/backendselection SQLite path resolver
       environment: SWARM_SQLITE_PATH
@@ -2052,15 +2053,19 @@ engine:
         Existing SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
         selector resolves to postgres. They are not generic backend selectors and must not imply backend selection by
         presence alone.
-    staged_runtime_rule:
+    runtime_backend_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
-      Explicit sqlite selection is recognized as a canonical backend id. It may construct the selected typed SQLite store
-      owners without passing a raw runtime SQL handle into Postgres-only runtime consumers. runtime.NewRuntime must
-      consume backend-neutral owners for runtime construction, including #1186 mailbox_write materialization, while public
-      default selection and CI/public support surfaces split to #1088/#1089 remain unavailable until their owning children land.
+      SQLite is recognized as the active local/dev default backend id. It constructs the selected typed SQLite store owners
+      without passing a raw runtime SQL handle into Postgres-only runtime consumers. runtime.NewRuntime must consume
+      backend-neutral owners for runtime construction, including #1186 mailbox_write materialization and #1157 agent.usage
+      reads.
     - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
       existing Postgres runtime store path.
+    - >
+      Local/dev SQLite `swarm run --contracts` may stamp an ephemeral bundle source fact when no Postgres bundle catalog
+      is present. DB-loaded `--bundle-hash` boot remains Postgres-only until a separate bundle-catalog portability owner
+      promotes SQLite support.
     required_consumers:
     - cmd/swarm defaultServeOptions
     - cmd/swarm swarm serve --store
@@ -2070,10 +2075,10 @@ engine:
     - cmd/swarm runForkRuntimeOwnerHarness
     - runtime config loading for store.backend and store.sqlite.path
     split_boundaries:
-    - "SQLite dialect/schema/bootstrap remains split to #1085."
-    - "Backend-neutral core runtime persistence stores remain split to #1086."
+    - "SQLite dialect/schema/bootstrap is promoted by #1085."
+    - "Backend-neutral core runtime persistence stores are promoted by #1086."
     - "SQLite runtime construction semantics remain under #1087 parent closeout; mailbox_write materialization is promoted by #1186 and must consume its backend-neutral owner rather than the raw pipeline SQL database."
-    - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
+    - "Public local/dev default flip plus zero-service swarm run proof is promoted by #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_store_schema_dialect_bootstrap:
     promoted_by: '#1085'
@@ -2116,9 +2121,9 @@ engine:
         SQLite must use SQLite catalog/PRAGMA inspection. Runtime readers may consume capability results, but runtime SQL
         portability remains split until #1086/#1087.
     split_boundaries:
-    - "Core runtime store method portability remains split to #1086."
-    - "Explicit SQLite local-runtime session locking, event delivery/replay, and trace/read model semantics remain staged under #1087 and do not unblock runtime construction until the raw-SQL consumer blocker is resolved or explicitly split."
-    - "Public local/dev default flip plus zero-service swarm run proof remains split to #1088."
+    - "Core runtime store method portability is promoted by #1086."
+    - "Explicit SQLite local-runtime session locking, event delivery/replay, and trace/read model semantics are promoted under #1087 child closeout."
+    - "Public local/dev default flip plus zero-service swarm run proof is promoted by #1088."
     - "Docs, CI, and repo-wide stale-default closeout remains split to #1089."
   runtime_core_persistence_store_contracts:
     promoted_by: '#1086'
@@ -2128,15 +2133,15 @@ engine:
       Core runtime persistence selected for #1086 is owned by typed store contracts selected during runtime store construction.
       CLI/runtime startup may keep raw database handles only for explicitly split surfaces, but selected core persistence
       operations must be reachable through the runtime store bundle instead of treating Postgres-only construction as the
-      semantic owner. SQLite support at this layer is file-backed selected-store support only; it is not the public local/dev
-      default and does not promote production SQLite semantics.
+      semantic owner. SQLite support at this layer is file-backed local/dev runtime support; it is the public local/dev
+      default promoted by #1088 and does not promote production SQLite semantics.
     backend_implementations:
       postgres:
         owner: internal/store.PostgresStore implementations consumed through selected runtime store interfaces
         status: active_supported_runtime_backend
       sqlite:
         owner: internal/store.SQLiteRuntimeStore
-        status: staged_selected_core_store_backend
+        status: active_local_dev_default_store_backend
         rules:
         - Must be file-backed and use the canonical SQLite path selected by internal/store/backendselection.
         - "Must consume the #1085 SQLite schema/bootstrap capability owner before selected runtime methods execute."
@@ -2148,9 +2153,8 @@ engine:
           to Postgres-only runtime consumers.
         - Must not pass a raw runtime SQL handle to Postgres-only runtime consumers.
         - >
-          Must keep public default selection fail-closed until #1088 proves zero-service SQLite `swarm run` and explicit
-          Postgres opt-in together. Explicit SQLite construction remains local/dev selected-store support only; it does
-          not promote production multi-writer SQLite semantics.
+          Must support the #1088 zero-service SQLite `swarm run` local/dev default and explicit Postgres opt-in proof.
+          SQLite construction remains local/dev support only; it does not promote production multi-writer SQLite semantics.
     selected_contracts:
     - name: runtime_store_bundle_construction
       owner: cmd/swarm buildStores plus storeBundle.runtimeStores consuming typed runtime store interfaces
@@ -2200,7 +2204,7 @@ engine:
       - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150
-      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - broader docs/CI/repo-wide closeout owned by #1089
       - production multi-writer SQLite budget concurrency semantics
     - name: operator_agent_usage_read_rows
       owner: internal/store.OperatorAgentUsageReadStore consumed by api_specification.method_catalog.agent.usage through apiv1.OperatorReadOptions.AgentUsage
@@ -2217,7 +2221,7 @@ engine:
       excludes:
       - spend writes, threshold evaluation, and runtime budget side effects owned by runtime_budget_spend_rows
       - agent.diagnose, agent.delivery_diagnostics, conversation, dashboard, trace, and runtime diagnostics surfaces
-      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - broader docs/CI/repo-wide closeout owned by #1089
       - public-source and CI closeout owned by #1089
       - production multi-writer SQLite concurrency semantics
     - name: runtime_tool_entity_and_human_task_rows
@@ -2235,7 +2239,7 @@ engine:
       - public operator mailbox API decisions owned by api_specification.method_catalog.mailbox.*
       - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
       - runtime diagnostics/logging owned by #1150
-      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - broader docs/CI/repo-wide closeout owned by #1089
       - production multi-writer SQLite concurrency semantics
     - name: runtime_diagnostics_log_rows
       owner: internal/runtime.RuntimeLogPersistence consumed by internal/runtime.RuntimeLogger through runtime.Stores.RuntimeLogStore
@@ -2250,7 +2254,7 @@ engine:
         persistence, bundle-source fail-closed run creation, and run counter synchronization.
       excludes:
       - public operator agent.usage reads over spend_ledger owned by operator_agent_usage_read_rows
-      - local/dev default flip and zero-service swarm run proof owned by #1088
+      - broader docs/CI/repo-wide closeout owned by #1089
       - repo-wide CI closeout owned by #1089
       - production multi-writer SQLite concurrency semantics
     - name: mailbox_write_materialization_rows
@@ -2267,7 +2271,7 @@ engine:
       excludes:
       - broad public mailbox decision API behavior owned by api_specification.method_catalog.mailbox.*
       - dashboard and digest mailbox read closure
-      - public local/dev default flip and zero-service swarm run proof owned by #1088
+      - broader docs/CI/repo-wide closeout owned by #1089
       - repo-wide CI closeout owned by #1089
       - production multi-writer SQLite concurrency semantics
     - name: mailbox_rows
@@ -2329,7 +2333,7 @@ engine:
         consumer must receive a separately gated backend-neutral owner before it can participate in explicit SQLite runtime
         construction.
     split_boundaries:
-    - "Public local/dev SQLite default flip and zero-service swarm run proof remain split to #1088."
+    - "Public local/dev SQLite default flip and zero-service swarm run proof are promoted by #1088."
     - "Docs, CI, repo-wide stale-default closeout, and #1066 parent proof remain split to #1089."
     - "Production multi-writer SQLite concurrency semantics are not promoted by #1087."
     - "Additional raw-SQL runtime feature parity for SQLite requires a separately gated backend-neutral owner before use."
@@ -5715,7 +5719,8 @@ multi_bundle_persistence:
         - DB-loaded same-bundle source/fork loaders consume the persisted bundle catalog runtime source owner.
         - New-work routing and bundle_hash admission remain #1022.
         - Bundle register/delete APIs remain #1017/#1018/#1019.
-        - SQLite runtime support remains blocked by #1087/#1088 unless separately gated.
+        - SQLite local/dev runtime support is promoted for `swarm run --contracts`, but DB-loaded `--bundle-hash`
+          bundle-catalog boot remains Postgres-only unless separately gated.
     serve_db_loaded_runtime_source:
       status: implemented_for_boot_pinned_postgres_serve_bundle_hash_contexts
       cli_flag: 'swarm serve --bundle-hash <bundle-v1:sha256:<64 lowercase hex>> [--bundle-hash <bundle-v1:sha256:<64 lowercase hex>> ...]'

--- a/tests/tier1-primitives/test-emits-single/events.yaml
+++ b/tests/tier1-primitives/test-emits-single/events.yaml
@@ -1,4 +1,6 @@
 item.received:
+  swarm:
+    source: external
   entity_id: string
 item.processed:
   entity_id: string


### PR DESCRIPTION
Closes #1088
Part of #1066

## Governing refs / context

- `platform-spec.yaml`: `engine.runtime_store_backend_selection`
- `platform-spec.yaml`: `engine.runtime_store_schema_dialect_bootstrap`
- `platform-spec.yaml`: `engine.runtime_core_persistence_store_contracts`
- `platform-spec.yaml`: `workspace_model.data_source_authority`
- `platform-spec.yaml`: `multi_bundle_persistence.serve_runtime_source`
- Binding issue/gate context: reopened #1088 approved gate for `runtime.sqlite_local_dev_default_switch_and_supported_surface_proof`; #1089 remains docs/CI/repo-wide closeout; production SQLite multi-writer semantics are not promoted.

## Semantic migration

- New canonical default owner: `internal/store/backendselection.ActiveDefaultBackend()` now returns `sqlite` for no-selection local/dev runtime startup.
- Old invalid paths removed/updated: Postgres active default prose/help/tests, `FutureDefaultBackend`, `SQLiteUnsupportedRuntimeError`, Postgres-only local `--contracts` bundle catalog assumptions, Postgres-only API health/run read path for selected SQLite runtime, and request-only bundle scope admission for a single active ephemeral local runtime.
- Production path checked: explicit Postgres opt-in remains available through `--store postgres`, `SWARM_STORE_BACKEND=postgres`, and `store.backend=postgres`; DB-loaded `--bundle-hash` startup remains Postgres-only.
- Migration completeness: complete for the approved #1088 chosen class. #1066 parent remains open until #1089 docs/CI/repo-wide closeout lands.