### PR TITLE
[agent-g][issue #1194] Fix Go 1.23 vet context mismatch

### DIFF
--- a/internal/runtime/tools/executor_entity_helpers_test.go
+++ b/internal/runtime/tools/executor_entity_helpers_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -23,7 +24,7 @@ func TestEntityStateQuery_OptionallyIncludesFlowInstance(t *testing.T) {
 	payload := map[string]any{
 		"flow_instance": " review/inst-1 ",
 	}
-	ctx := runtimecorrelation.WithRunID(t.Context(), "00000000-0000-0000-0000-000000000001")
+	ctx := runtimecorrelation.WithRunID(context.Background(), "00000000-0000-0000-0000-000000000001")
 
 	queryWithoutFlow, err := entityStateQueryForContractRun(ctx, nil, entityruntime.Contract{}, payload, false)
 	if err != nil {


### PR DESCRIPTION
Closes #1194

## Scope

Narrow Go 1.23 compatibility repair only. This PR replaces the test-only `testing.T.Context()` usage in `internal/runtime/tools/executor_entity_helpers_test.go` with `context.Background()` so the repository's declared `go 1.23.0` module policy remains coherent.

No #1089 docs/CI rollout changes are included.

## Proof

- `go test ./internal/runtime/tools -run TestEntityStateQuery_OptionallyIncludesFlowInstance -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go vet ./...`
- CI-equivalent local commands:
  - `gofmt -l .` check returned no files
  - `go build ./...`
  - `go build ./cmd/swarm`
  - `go run ./cmd/swarm-openrpc-gen --check`
  - `go test ./... -count=1`

## #1089 unblock note

The repo-wide `go vet ./...` blocker recorded in #1194 is removed locally by this PR, so #1089 can resume its docs/CI/repo-wide SQLite rollout proof after this merges, subject to CI confirmation.