### PR TITLE
[agent-c][issue #1196] Add test timing report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,25 @@ jobs:
         run: go test ./cmd/swarm -run TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction -count=1
 
       - name: Run tests
-        run: go test ./... -count=1
+        shell: bash
+        run: |
+          mkdir -p test-results
+          set +e
+          go test ./... -count=1 -json 2>&1 | tee test-results/go-test.json
+          test_status=${PIPESTATUS[0]}
+          set -e
+          go run ./cmd/swarm-test-timing \
+            -input test-results/go-test.json \
+            -markdown test-results/go-test-timing.md
+          cat test-results/go-test-timing.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$test_status"
+
+      - name: Upload test timing artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-test-timing
+          path: |
+            test-results/go-test.json
+            test-results/go-test-timing.md
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ data/*
 
 # Generated artifacts
 coverage
+test-results/
 internal/dashboard/ui/node_modules
 internal/dashboard/ui/dist
 /empire

--- a/cmd/swarm-test-timing/main.go
+++ b/cmd/swarm-test-timing/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"swarm/internal/testtiming"
+)
+
+func main() {
+	var inputPath string
+	var markdownPath string
+	var topN int
+	flag.StringVar(&inputPath, "input", "-", "path to go test -json output, or - for stdin")
+	flag.StringVar(&markdownPath, "markdown", "-", "path to write Markdown report, or - for stdout")
+	flag.IntVar(&topN, "top", 20, "number of slow packages and tests to include")
+	flag.Parse()
+
+	if err := run(inputPath, markdownPath, topN); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(inputPath string, markdownPath string, topN int) error {
+	input, closeInput, err := openInput(inputPath)
+	if err != nil {
+		return err
+	}
+	defer closeInput()
+
+	report, err := testtiming.ParseReport(input, testtiming.Options{TopN: topN})
+	if err != nil {
+		return err
+	}
+
+	output, closeOutput, err := openOutput(markdownPath)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	return testtiming.WriteMarkdown(output, report)
+}
+
+func openInput(path string) (io.Reader, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open input %s: %w", path, err)
+	}
+	return file, func() { _ = file.Close() }, nil
+}
+
+func openOutput(path string) (io.Writer, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdout, func() {}, nil
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("create markdown report %s: %w", path, err)
+	}
+	return file, func() { _ = file.Close() }, nil
+}

--- a/internal/testtiming/report.go
+++ b/internal/testtiming/report.go
@@ -1,0 +1,282 @@
+package testtiming
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+const defaultTopN = 20
+
+type Options struct {
+	TopN int
+}
+
+type Summary struct {
+	Events            int
+	MalformedLines    int
+	Packages          int
+	FailedPackages    int
+	SkippedPackages   int
+	Tests             int
+	FailedTests       int
+	SkippedTests      int
+	PackageElapsedSec float64
+}
+
+type PackageTiming struct {
+	Package string
+	Result  string
+	Elapsed float64
+}
+
+type TestTiming struct {
+	Package string
+	Test    string
+	Result  string
+	Elapsed float64
+}
+
+type Report struct {
+	Summary      Summary
+	SlowPackages []PackageTiming
+	SlowTests    []TestTiming
+}
+
+type event struct {
+	Action  string  `json:"Action"`
+	Package string  `json:"Package"`
+	Test    string  `json:"Test"`
+	Elapsed float64 `json:"Elapsed"`
+}
+
+func ParseReport(r io.Reader, opts Options) (Report, error) {
+	if r == nil {
+		return Report{}, fmt.Errorf("input reader is nil")
+	}
+	topN := opts.TopN
+	if topN <= 0 {
+		topN = defaultTopN
+	}
+	report := Report{}
+	packages := map[string]PackageTiming{}
+	tests := map[string]TestTiming{}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var evt event
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			report.Summary.MalformedLines++
+			continue
+		}
+		report.Summary.Events++
+		action := strings.TrimSpace(evt.Action)
+		pkg := strings.TrimSpace(evt.Package)
+		test := strings.TrimSpace(evt.Test)
+		if !isTerminalAction(action) || pkg == "" {
+			continue
+		}
+		if test == "" {
+			packages[pkg] = PackageTiming{Package: pkg, Result: action, Elapsed: evt.Elapsed}
+			continue
+		}
+		key := pkg + "\x00" + test
+		tests[key] = TestTiming{Package: pkg, Test: test, Result: action, Elapsed: evt.Elapsed}
+	}
+	if err := scanner.Err(); err != nil {
+		return Report{}, fmt.Errorf("read test JSON: %w", err)
+	}
+	report.SlowPackages = packageTimings(packages)
+	report.SlowTests = testTimings(tests)
+	report.Summary.Packages = len(report.SlowPackages)
+	report.Summary.Tests = len(report.SlowTests)
+	for _, pkg := range report.SlowPackages {
+		report.Summary.PackageElapsedSec += pkg.Elapsed
+		switch pkg.Result {
+		case "fail":
+			report.Summary.FailedPackages++
+		case "skip":
+			report.Summary.SkippedPackages++
+		}
+	}
+	for _, test := range report.SlowTests {
+		switch test.Result {
+		case "fail":
+			report.Summary.FailedTests++
+		case "skip":
+			report.Summary.SkippedTests++
+		}
+	}
+	report.SlowPackages = trimPackageTimings(report.SlowPackages, topN)
+	report.SlowTests = trimTestTimings(report.SlowTests, topN)
+	return report, nil
+}
+
+func WriteMarkdown(w io.Writer, report Report) error {
+	if w == nil {
+		return fmt.Errorf("output writer is nil")
+	}
+	if _, err := fmt.Fprintln(w, "# Go Test Timing Report"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "Generated from `go test -json`. Timing is observability-only; this report does not enforce budgets."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "## Summary"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| Metric | Value |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | ---: |"); err != nil {
+		return err
+	}
+	rows := []struct {
+		name  string
+		value string
+	}{
+		{"Parsed events", fmt.Sprintf("%d", report.Summary.Events)},
+		{"Malformed lines ignored", fmt.Sprintf("%d", report.Summary.MalformedLines)},
+		{"Packages", fmt.Sprintf("%d", report.Summary.Packages)},
+		{"Failed packages", fmt.Sprintf("%d", report.Summary.FailedPackages)},
+		{"Skipped packages", fmt.Sprintf("%d", report.Summary.SkippedPackages)},
+		{"Tests", fmt.Sprintf("%d", report.Summary.Tests)},
+		{"Failed tests", fmt.Sprintf("%d", report.Summary.FailedTests)},
+		{"Skipped tests", fmt.Sprintf("%d", report.Summary.SkippedTests)},
+		{"Package elapsed sum", formatSeconds(report.Summary.PackageElapsedSec)},
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(w, "| %s | %s |\n", row.name, row.value); err != nil {
+			return err
+		}
+	}
+	if err := writePackages(w, report.SlowPackages); err != nil {
+		return err
+	}
+	return writeTests(w, report.SlowTests)
+}
+
+func isTerminalAction(action string) bool {
+	return action == "pass" || action == "fail" || action == "skip"
+}
+
+func packageTimings(values map[string]PackageTiming) []PackageTiming {
+	out := make([]PackageTiming, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Elapsed != out[j].Elapsed {
+			return out[i].Elapsed > out[j].Elapsed
+		}
+		return out[i].Package < out[j].Package
+	})
+	return out
+}
+
+func testTimings(values map[string]TestTiming) []TestTiming {
+	out := make([]TestTiming, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Elapsed != out[j].Elapsed {
+			return out[i].Elapsed > out[j].Elapsed
+		}
+		if out[i].Package != out[j].Package {
+			return out[i].Package < out[j].Package
+		}
+		return out[i].Test < out[j].Test
+	})
+	return out
+}
+
+func trimPackageTimings(values []PackageTiming, limit int) []PackageTiming {
+	if limit <= 0 || len(values) <= limit {
+		return values
+	}
+	return values[:limit]
+}
+
+func trimTestTimings(values []TestTiming, limit int) []TestTiming {
+	if limit <= 0 || len(values) <= limit {
+		return values
+	}
+	return values[:limit]
+}
+
+func writePackages(w io.Writer, values []PackageTiming) error {
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "## Slowest Packages"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		_, err := fmt.Fprintln(w, "No package timing events found.")
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| Package | Result | Elapsed |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | --- | ---: |"); err != nil {
+		return err
+	}
+	for _, value := range values {
+		if _, err := fmt.Fprintf(w, "| `%s` | %s | %s |\n", value.Package, value.Result, formatSeconds(value.Elapsed)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTests(w io.Writer, values []TestTiming) error {
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "## Slowest Tests"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		_, err := fmt.Fprintln(w, "No test timing events found.")
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| Package | Test | Result | Elapsed |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | --- | --- | ---: |"); err != nil {
+		return err
+	}
+	for _, value := range values {
+		if _, err := fmt.Fprintf(w, "| `%s` | `%s` | %s | %s |\n", value.Package, value.Test, value.Result, formatSeconds(value.Elapsed)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatSeconds(seconds float64) string {
+	return fmt.Sprintf("%.3fs", seconds)
+}

--- a/internal/testtiming/report_test.go
+++ b/internal/testtiming/report_test.go
@@ -1,0 +1,98 @@
+package testtiming
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseReportSummarizesPackageAndTestTimings(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"Time":"2026-06-01T00:00:00Z","Action":"run","Package":"swarm/slow","Test":"TestSlow"}`,
+		`{"Time":"2026-06-01T00:00:10Z","Action":"pass","Package":"swarm/fast","Elapsed":1.25}`,
+		`{"Time":"2026-06-01T00:00:20Z","Action":"fail","Package":"swarm/slow","Test":"TestSlow","Elapsed":12.5}`,
+		`{"Time":"2026-06-01T00:00:21Z","Action":"pass","Package":"swarm/slow","Test":"TestMedium","Elapsed":3.125}`,
+		`{"Time":"2026-06-01T00:00:22Z","Action":"fail","Package":"swarm/slow","Elapsed":14}`,
+		`{"Time":"2026-06-01T00:00:23Z","Action":"skip","Package":"swarm/skipped","Test":"TestSkipped","Elapsed":0}`,
+		`{"Time":"2026-06-01T00:00:24Z","Action":"skip","Package":"swarm/skipped","Elapsed":0}`,
+		`not-json`,
+	}, "\n"))
+
+	report, err := ParseReport(input, Options{TopN: 10})
+	if err != nil {
+		t.Fatalf("ParseReport: %v", err)
+	}
+	if report.Summary.Events != 7 {
+		t.Fatalf("events = %d, want 7", report.Summary.Events)
+	}
+	if report.Summary.MalformedLines != 1 {
+		t.Fatalf("malformed lines = %d, want 1", report.Summary.MalformedLines)
+	}
+	if report.Summary.Packages != 3 || report.Summary.FailedPackages != 1 || report.Summary.SkippedPackages != 1 {
+		t.Fatalf("package summary = %+v, want 3 packages / 1 failed / 1 skipped", report.Summary)
+	}
+	if report.Summary.Tests != 3 || report.Summary.FailedTests != 1 || report.Summary.SkippedTests != 1 {
+		t.Fatalf("test summary = %+v, want 3 tests / 1 failed / 1 skipped", report.Summary)
+	}
+	if got, want := report.Summary.PackageElapsedSec, 15.25; got != want {
+		t.Fatalf("package elapsed sum = %v, want %v", got, want)
+	}
+	if got := report.SlowPackages[0]; got.Package != "swarm/slow" || got.Result != "fail" || got.Elapsed != 14 {
+		t.Fatalf("slowest package = %+v, want swarm/slow fail 14s", got)
+	}
+	if got := report.SlowTests[0]; got.Package != "swarm/slow" || got.Test != "TestSlow" || got.Result != "fail" || got.Elapsed != 12.5 {
+		t.Fatalf("slowest test = %+v, want swarm/slow TestSlow fail 12.5s", got)
+	}
+}
+
+func TestParseReportAppliesTopLimit(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"Action":"pass","Package":"swarm/a","Test":"TestA","Elapsed":1}`,
+		`{"Action":"pass","Package":"swarm/a","Elapsed":1}`,
+		`{"Action":"pass","Package":"swarm/b","Test":"TestB","Elapsed":2}`,
+		`{"Action":"pass","Package":"swarm/b","Elapsed":2}`,
+	}, "\n"))
+
+	report, err := ParseReport(input, Options{TopN: 1})
+	if err != nil {
+		t.Fatalf("ParseReport: %v", err)
+	}
+	if len(report.SlowPackages) != 1 || report.SlowPackages[0].Package != "swarm/b" {
+		t.Fatalf("slow packages = %+v, want only swarm/b", report.SlowPackages)
+	}
+	if len(report.SlowTests) != 1 || report.SlowTests[0].Test != "TestB" {
+		t.Fatalf("slow tests = %+v, want only TestB", report.SlowTests)
+	}
+	if report.Summary.Packages != 2 || report.Summary.Tests != 2 {
+		t.Fatalf("summary after trim = %+v, want untrimmed counts", report.Summary)
+	}
+}
+
+func TestWriteMarkdownIncludesSummaryAndTables(t *testing.T) {
+	report := Report{
+		Summary: Summary{
+			Events:            4,
+			Packages:          1,
+			Tests:             1,
+			PackageElapsedSec: 3.5,
+		},
+		SlowPackages: []PackageTiming{{Package: "swarm/pkg", Result: "pass", Elapsed: 3.5}},
+		SlowTests:    []TestTiming{{Package: "swarm/pkg", Test: "TestThing", Result: "pass", Elapsed: 2.25}},
+	}
+	var out strings.Builder
+	if err := WriteMarkdown(&out, report); err != nil {
+		t.Fatalf("WriteMarkdown: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"# Go Test Timing Report",
+		"| Parsed events | 4 |",
+		"| Package elapsed sum | 3.500s |",
+		"| `swarm/pkg` | pass | 3.500s |",
+		"| `swarm/pkg` | `TestThing` | pass | 2.250s |",
+		"observability-only",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+}


### PR DESCRIPTION
Part of #1196

## Summary

This PR closes the approved first-slice class `missing_ci_test_timing_observability_owner` for the required PR CI test path.

It adds a repo-local timing report owner for `go test -json` output and wires the existing CI `Run tests` step to:

- preserve the same `go test ./... -count=1` package selection and pass/fail semantics
- capture raw JSON output at `test-results/go-test.json`
- generate a Markdown timing report at `test-results/go-test-timing.md`
- append the report to the GitHub Actions step summary
- upload both files as the `go-test-timing` artifact, with `if: always()`

No Postgres harness behavior, catalog tiering, async test utilities, test selection, CI job splitting, or timing-budget enforcement is changed.

## Governing Context

No exact `platform-spec.yaml` section governs CI timing artifacts. Binding context:

- #1196 issue body and baseline timing/flake-risk evidence
- #1196 Pre-Implementation Coverage Audit and independent gate review approving `missing_ci_test_timing_observability_owner` as a first slice
- `.github/workflows/ci.yml` required PR test path
- `/Users/youmew/dev/swarm-docs/docs/IMPLEMENTER_GUIDELINES.md`
- `/Users/youmew/dev/swarm-docs/docs/SEMANTIC_DRIFT.md`
- `/Users/youmew/dev/swarm-docs/docs/watchlists/maintenance-and-cleanup.yaml#harness_reliability_and_local_smoke`

## Maintenance Owner

New canonical owner:

- `internal/testtiming` parses and renders Go test timing reports.
- `cmd/swarm-test-timing` exposes the repo-local CLI consumed by CI.

Old non-authoritative paths now invalid:

- Manual one-off `go test -json` timing summaries in issue prose.
- GitHub job wall-clock duration as the only proxy for package/test timing.
- Ad hoc YAML shell parsing for timing data.

Migration completeness:

- Complete for the approved first slice: the required PR CI test path now consumes the repo-local timing owner and uploads a durable artifact.
- #1196 remains open for Postgres harness optimization, catalog E2E tiering, deterministic async utilities, and CI job splitting.

## Validation

- `go test ./internal/testtiming ./cmd/swarm-test-timing`
- `set -o pipefail; go test ./internal/testtiming -json | go run ./cmd/swarm-test-timing -input - -top 5`
- `go test ./...`