### PR TITLE
[agent-a][issue #1122] Fail closed query_entities handler context

### DIFF
--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -42,7 +42,7 @@ func TestHandlerExecutionStateSnapshotRejectsMalformedPersistedGateShape(t *test
 		EntityID: "ent-1",
 		Stage:    WorkflowStateID("queued"),
 		Metadata: map[string]any{"gates": "invalid"},
-	})
+	}, "default", "v-test")
 	if err == nil {
 		t.Fatal("expected malformed persisted gates to fail closed")
 	}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -323,6 +323,13 @@ func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext,
 		return 0, err
 	}
 	flowID := strings.TrimSpace(asString(ctx.Entity["workflow_name"]))
+	if flowID == "" {
+		return 0, fmt.Errorf("query_entities requires entity.workflow_name in expression context")
+	}
+	runID := strings.TrimSpace(asString(ctx.Event["run_id"]))
+	if runID == "" {
+		return 0, fmt.Errorf("query_entities requires event.run_id in expression context")
+	}
 	contract, ok := entityruntime.ResolveForFlow(e.coordinator.SemanticSource(), flowID)
 	if !ok {
 		return 0, fmt.Errorf("flow-owned entity contract is not available for workflow %s", flowID)
@@ -332,7 +339,7 @@ func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext,
 			return 0, err
 		}
 	}
-	return e.coordinator.workflowStore.QueryEntityCount(context.Background(), asString(ctx.Event["run_id"]), e.coordinator.SemanticSource(), contract, parsed)
+	return e.coordinator.workflowStore.QueryEntityCount(context.Background(), runID, e.coordinator.SemanticSource(), contract, parsed)
 }
 
 func queryEntityStateCount(runID string, db *sql.DB, source semanticview.Source, contract entityruntime.Contract, predicate workflowEntityQueryPredicate) (int, error) {

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -217,7 +217,11 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, fmt.Errorf("build runtime engine: %w", err)
 	}
-	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, triggerCtx.State)
+	workflowVersion := ""
+	if source != nil {
+		workflowVersion = source.WorkflowVersion()
+	}
+	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, triggerCtx.State, flowID, workflowVersion)
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
 	}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -12,6 +12,7 @@ import (
 
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	runtimecorrelation "swarm/internal/runtime/correlation"
 	runtimeengine "swarm/internal/runtime/engine"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
@@ -1198,7 +1199,7 @@ func TestHandlerExecutionStateSnapshotCreateEntityIncludesInitialStateAndDefault
 			"revision_count": 0,
 			"is_duplicate":   false,
 		},
-	})
+	}, "validation", "v-test")
 	if err != nil {
 		t.Fatalf("handlerExecutionStateSnapshot: %v", err)
 	}
@@ -1208,6 +1209,12 @@ func TestHandlerExecutionStateSnapshotCreateEntityIncludesInitialStateAndDefault
 	}
 	if snapshot.CurrentState != "queued" {
 		t.Fatalf("snapshot current_state = %q, want queued", snapshot.CurrentState)
+	}
+	if snapshot.WorkflowName != "validation" {
+		t.Fatalf("snapshot workflow_name = %q, want validation", snapshot.WorkflowName)
+	}
+	if snapshot.WorkflowVersion != "v-test" {
+		t.Fatalf("snapshot workflow_version = %q, want v-test", snapshot.WorkflowVersion)
 	}
 	if snapshot.Metadata == nil {
 		t.Fatal("snapshot metadata = nil, want persisted metadata")
@@ -1389,6 +1396,125 @@ node-a:
 		t.Fatalf("expected initial-value mutation for revision_count, got %#v", initialMutations)
 	} else if got[2] != "create_entity" {
 		t.Fatalf("revision_count initial mutation metadata = %#v, want handler_step create_entity", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerQueryEntitiesGuardUsesWorkflowContext(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	bus := &recordingPipelineBus{}
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `
+name: runtime-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: validation
+    flow: validation
+    mode: static
+`,
+		"schema.yaml": "name: runtime-test\n",
+		"flows/validation/schema.yaml": `
+name: validation
+mode: static
+initial_state: queued
+states: [queued]
+`,
+		"flows/validation/entities.yaml": `
+validation_request:
+  request_id: text
+`,
+		"flows/validation/nodes.yaml": `
+node-a:
+  id: node-a
+  execution_type: system_node
+`,
+	})
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("expected temp workflow bundle")
+	}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		db:             db,
+		workflowStore:  NewWorkflowInstanceStore(db),
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+		module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("validation", []WorkflowStage{
+				{Name: "queued"},
+			}, nil),
+		},
+	}
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	const otherRunID = "88888888-8888-8888-8888-888888888888"
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, otherRunID); err != nil {
+		t.Fatalf("seed other run: %v", err)
+	}
+	otherCtx := runtimecorrelation.WithRunID(context.Background(), otherRunID)
+	seedQueryEntitiesGuardInstance(t, pc.workflowStore, ctx, "11111111-1111-1111-1111-111111111111", "validation/existing-same", "req-existing")
+	seedQueryEntitiesGuardInstance(t, pc.workflowStore, otherCtx, "22222222-2222-2222-2222-222222222222", "validation/existing-other", "req-cross-run")
+
+	handler := runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		Guard:        &runtimecontracts.GuardSpec{Check: `query_entities(request_id == payload.request_id).count == 0`},
+		Emit: runtimecontracts.EmitSpec{
+			Event: "request.accepted",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"request_id": runtimecontracts.RefExpression("payload.request_id"),
+			},
+		},
+	}
+	runHandler := func(entityID, requestID string) error {
+		_, err := pc.executeNodeContractHandler(ctx, "node-a", handler, workflowTriggerContext{
+			Event: events.Event{
+				ID:      "evt-" + requestID,
+				Type:    events.EventType("request.received"),
+				RunID:   testPipelineRunID,
+				Payload: mustJSON(map[string]any{"request_id": requestID}),
+			}.WithEntityID(entityID),
+			State: WorkflowState{EntityID: entityID, Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+		}, false)
+		return err
+	}
+
+	if err := runHandler("33333333-3333-3333-3333-333333333333", "req-new"); err != nil {
+		t.Fatalf("execute handler for new request: %v", err)
+	}
+	if err := runHandler("44444444-4444-4444-4444-444444444444", "req-cross-run"); err != nil {
+		t.Fatalf("execute handler for cross-run request: %v", err)
+	}
+	if got := bus.publishedCount(); got != 2 {
+		t.Fatalf("published count after accepted requests = %d, want 2", got)
+	}
+	if err := runHandler("55555555-5555-5555-5555-555555555555", "req-existing"); err != nil {
+		t.Fatalf("execute handler for duplicate request: %v", err)
+	}
+	if got := bus.publishedCount(); got != 2 {
+		t.Fatalf("published count after duplicate request = %d, want unchanged 2", got)
+	}
+}
+
+func seedQueryEntitiesGuardInstance(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, entityID, storageRef, requestID string) {
+	t.Helper()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      storageRef,
+		WorkflowName:    "validation",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"entity_id":  entityID,
+			"request_id": requestID,
+		},
+	}); err != nil {
+		t.Fatalf("seed query_entities guard instance %s: %v", entityID, err)
 	}
 }
 

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -282,8 +282,9 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 	if e.nodeID == "" || strings.TrimSpace(string(evt.Type)) == "" {
 		return &HandlerOutcome{Handled: false}, nil
 	}
+	source := e.coordinator.SemanticSource()
 	entityID := workflowEventEntityID(evt)
-	flowID := workflowNodeFlowID(e.coordinator.SemanticSource(), e.nodeID)
+	flowID := workflowNodeFlowID(source, e.nodeID)
 	selectedState := WorkflowState{}
 	hasSelectedState := false
 	if handler.SelectEntity != nil && !handler.SelectEntity.Empty() {
@@ -306,7 +307,7 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		selectedState = selected.State
 		hasSelectedState = true
 	}
-	entityID, evt = ensureHandlerEntityID(e.coordinator.SemanticSource(), flowID, handler, entityID, evt)
+	entityID, evt = ensureHandlerEntityID(source, flowID, handler, entityID, evt)
 	ctx = withPipelineFlowScope(ctx, flowID)
 	currentState := e.coordinator.currentWorkflowState(ctx, entityID)
 	if hasSelectedState && strings.TrimSpace(selectedState.EntityID) != "" && strings.TrimSpace(currentState.EntityID) == "" {
@@ -330,7 +331,11 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		exec = tmpExec
 		node = runtimeengine.NewDeclarativeNode(strings.TrimSpace(e.nodeID), exec)
 	}
-	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, currentState)
+	workflowVersion := ""
+	if source != nil {
+		workflowVersion = source.WorkflowVersion()
+	}
+	stateSnapshot, err := handlerExecutionStateSnapshot(handler, entityID, currentState, flowID, workflowVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -420,9 +425,11 @@ func handlerMaterializesEntity(source semanticview.Source, flowID string, handle
 	return false
 }
 
-func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID string, state WorkflowState) (runtimeengine.StateSnapshot, error) {
+func handlerExecutionStateSnapshot(handler SystemNodeEventHandler, entityID string, state WorkflowState, workflowName string, workflowVersion string) (runtimeengine.StateSnapshot, error) {
 	snapshot := runtimeengine.StateSnapshot{
-		EntityID: identity.NormalizeEntityID(entityID),
+		EntityID:        identity.NormalizeEntityID(entityID),
+		WorkflowName:    strings.TrimSpace(workflowName),
+		WorkflowVersion: strings.TrimSpace(workflowVersion),
 		StateCarrier: runtimeengine.NewStateCarrier(
 			nil,
 			nil,

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -22,7 +22,7 @@ func ValidateConditionCEL(expression string, context WorkflowConditionContext) e
 	if expression == "" || strings.EqualFold(expression, "else") {
 		return nil
 	}
-	normalized, _, err := normalizeWorkflowExpression(expression, workflowExpressionContext{})
+	normalized, _, err := normalizeWorkflowExpression(expression, workflowExpressionContext{AllowUnresolvedQueryOperands: true})
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -22,13 +22,14 @@ var workflowExpressionQueryEntitiesCountPattern = regexp.MustCompile(`query_enti
 var workflowExpressionQueryPredicatePattern = regexp.MustCompile(`^\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=|>=|<=|>|<)\s*(.+?)\s*$`)
 
 type workflowExpressionContext struct {
-	Entity           map[string]any
-	Event            map[string]any
-	Payload          map[string]any
-	Policy           map[string]any
-	Accumulated      any
-	FanOut           map[string]any
-	QueryEntityCount func(string) (int, error)
+	Entity                       map[string]any
+	Event                        map[string]any
+	Payload                      map[string]any
+	Policy                       map[string]any
+	Accumulated                  any
+	FanOut                       map[string]any
+	QueryEntityCount             func(string) (int, error)
+	AllowUnresolvedQueryOperands bool
 }
 
 type workflowExpressionEvaluator struct {
@@ -68,6 +69,9 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 		return false, fmt.Errorf("workflow expression evaluator is not initialized")
 	}
 	normalized, normalizedCtx, err := normalizeWorkflowExpression(expression, ctx)
+	if err != nil {
+		return false, err
+	}
 	if normalized == "" {
 		return false, fmt.Errorf("workflow expression is empty")
 	}
@@ -146,13 +150,14 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	expression = strings.TrimSpace(expression)
 	if expression == "" {
 		return "", workflowExpressionContext{
-			Entity:           cloneStringAnyMap(ctx.Entity),
-			Event:            cloneStringAnyMap(ctx.Event),
-			Payload:          cloneStringAnyMap(ctx.Payload),
-			Policy:           cloneStringAnyMap(ctx.Policy),
-			Accumulated:      cloneAccumulatedItems(ctx.Accumulated),
-			FanOut:           cloneStringAnyMap(ctx.FanOut),
-			QueryEntityCount: ctx.QueryEntityCount,
+			Entity:                       cloneStringAnyMap(ctx.Entity),
+			Event:                        cloneStringAnyMap(ctx.Event),
+			Payload:                      cloneStringAnyMap(ctx.Payload),
+			Policy:                       cloneStringAnyMap(ctx.Policy),
+			Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
+			FanOut:                       cloneStringAnyMap(ctx.FanOut),
+			QueryEntityCount:             ctx.QueryEntityCount,
+			AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 		}, nil
 	}
 	if strings.EqualFold(expression, "else") {
@@ -177,13 +182,14 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	normalized = normalizeWorkflowExpressionStringLiterals(normalized)
 	normalized = rewriteWorkflowExpressionEntityNullPresenceChecks(normalized)
 	normalizedCtx := workflowExpressionContext{
-		Entity:           cloneStringAnyMap(ctx.Entity),
-		Event:            cloneStringAnyMap(ctx.Event),
-		Payload:          cloneStringAnyMap(ctx.Payload),
-		Policy:           cloneStringAnyMap(ctx.Policy),
-		Accumulated:      cloneAccumulatedItems(ctx.Accumulated),
-		FanOut:           cloneStringAnyMap(ctx.FanOut),
-		QueryEntityCount: ctx.QueryEntityCount,
+		Entity:                       cloneStringAnyMap(ctx.Entity),
+		Event:                        cloneStringAnyMap(ctx.Event),
+		Payload:                      cloneStringAnyMap(ctx.Payload),
+		Policy:                       cloneStringAnyMap(ctx.Policy),
+		Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
+		FanOut:                       cloneStringAnyMap(ctx.FanOut),
+		QueryEntityCount:             ctx.QueryEntityCount,
+		AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 	}
 	normalized = workflowExpressionPolicyPlaceholder.ReplaceAllStringFunc(normalized, func(token string) string {
 		match := workflowExpressionPolicyPlaceholder.FindStringSubmatch(token)
@@ -288,7 +294,36 @@ func workflowExpressionResolveQueryOperand(raw string, ctx workflowExpressionCon
 	if parsed, err := strconv.ParseFloat(raw, 64); err == nil {
 		return parsed, nil
 	}
+	if root, scoped := workflowExpressionQueryOperandScope(raw); scoped {
+		switch root {
+		case "entity", "event", "payload", "policy", "fan_out":
+			if ctx.AllowUnresolvedQueryOperands {
+				return raw, nil
+			}
+			return nil, fmt.Errorf("query_entities operand %q is unavailable in expression context", raw)
+		default:
+			return nil, fmt.Errorf("unsupported query_entities operand scope %q in %q", root, raw)
+		}
+	}
 	return raw, nil
+}
+
+func workflowExpressionQueryOperandScope(raw string) (string, bool) {
+	root, _, ok := strings.Cut(strings.TrimSpace(raw), ".")
+	if !ok {
+		return "", false
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", false
+	}
+	for i, ch := range root {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || (i > 0 && ch >= '0' && ch <= '9') {
+			continue
+		}
+		return "", false
+	}
+	return root, true
 }
 
 func workflowExpressionLookupContextValue(ref string, ctx workflowExpressionContext) (any, bool) {

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -1,6 +1,9 @@
 package pipeline
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNormalizeWorkflowExpressionStringLiterals(t *testing.T) {
 	got, _, err := normalizeWorkflowExpression(
@@ -28,6 +31,12 @@ func TestValidateConditionCEL_RejectsFanOutOutsideDataAccumulationExpressions(t 
 	}
 }
 
+func TestValidateConditionCEL_AllowsQueryEntitiesPayloadOperandWithoutRuntimeValue(t *testing.T) {
+	if err := ValidateConditionCEL(`query_entities(name == payload.name).count == 0`, WorkflowConditionContextGuard); err != nil {
+		t.Fatalf("expected static query_entities payload operand to validate, got %v", err)
+	}
+}
+
 func TestValidateConditionCEL_AllowsItemOnlyInFilterLikeContexts(t *testing.T) {
 	if err := ValidateConditionCEL(`item.score > 50`, WorkflowConditionContextFilter); err != nil {
 		t.Fatalf("expected filter item scope to validate, got %v", err)
@@ -50,6 +59,54 @@ func TestNormalizeWorkflowExpression_RewritesQueryEntitiesCount(t *testing.T) {
 	want := `0 == 0`
 	if got != want {
 		t.Fatalf("normalizeWorkflowExpression(...) = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowExpressionEvaluator_EvalBoolSurfacesQueryRewriteError(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	_, err := eval.EvalBool(`query_entities(name ~= payload.name).count == 0`, workflowExpressionContext{
+		Payload: map[string]any{"name": "candidate-a"},
+	})
+	if err == nil {
+		t.Fatal("expected query_entities predicate error")
+	}
+	if got := err.Error(); !strings.Contains(got, "unsupported query_entities predicate") {
+		t.Fatalf("error = %q, want query_entities predicate diagnostic", got)
+	}
+}
+
+func TestWorkflowExpressionEvaluator_QueryEntitiesMissingScopedOperandFailsClosed(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	_, err := eval.EvalBool(`query_entities(name == payload.missing).count == 0`, workflowExpressionContext{
+		Payload: map[string]any{"name": "candidate-a"},
+	})
+	if err == nil {
+		t.Fatal("expected missing scoped operand to fail closed")
+	}
+	if got := err.Error(); !strings.Contains(got, "payload.missing") || !strings.Contains(got, "unavailable") {
+		t.Fatalf("error = %q, want missing scoped operand diagnostic", got)
+	}
+}
+
+func TestWorkflowExpressionEvaluator_QueryEntitiesUnsupportedScopedOperandFailsClosed(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	_, err := eval.EvalBool(`query_entities(name == request.id).count == 0`, workflowExpressionContext{})
+	if err == nil {
+		t.Fatal("expected unsupported scoped operand to fail closed")
+	}
+	if got := err.Error(); !strings.Contains(got, "unsupported query_entities operand scope") || !strings.Contains(got, "request.id") {
+		t.Fatalf("error = %q, want unsupported scoped operand diagnostic", got)
+	}
+}
+
+func TestWorkflowExpressionEvaluator_QueryEntitiesKeepsQuotedScopedLiteral(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`query_entities(name == "payload.missing").count == 0`, workflowExpressionContext{})
+	if err != nil {
+		t.Fatalf("EvalBool error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected quoted scoped-looking literal to remain a literal")
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -653,6 +653,15 @@ runtime_enforcement:
       entity selectors must resolve either to an envelope field or to a
       declared scalar or enum leaf. Composite whole-value comparison is
       not part of Wave 1.
+    handler_expression_rule: |
+      `query_entities(...).count` used inside handler boolean expressions
+      (guards, rules/on_complete conditions, and accumulator completion
+      expressions) resolves through the active handler workflow identity and
+      current run context. Missing workflow/run context, unsupported scoped
+      operands, or missing scoped operand values fail closed with a diagnostic.
+      Static validation may accept syntactically valid scoped operands whose
+      values are only available at runtime, but runtime evaluation must not
+      reinterpret unresolved scoped operands as string literals.
   error_shape:
     invalid_field: cause=invalid_tool_input with nearest declared matches
     immutable_write: cause=invalid_tool_input for post-create immutable writes
@@ -1027,6 +1036,9 @@ handler_specification:
         declared_field_resolution: Every entity.X reference must resolve against the inferred entity contract.
         nested_type_resolution: Nested paths must resolve through named types to a declared field.
         filter_leaf_rule: query_entities filter paths must resolve to scalar or enum leaves.
+        query_operand_rule: query_entities operands with supported scopes (entity, event, payload, policy, fan_out)
+          are validated as scoped operands; unsupported scoped roots are invalid. Runtime evaluation fails closed
+          when a supported scoped operand is unavailable in the handler context.
       rule: 'For every entity.X used as a value, X must be declared on the inferred entity contract. Universal
         presence semantics provide the runtime value via explicit initial or type default. Dynamic writes remain
         relevant for business meaning, but not for raw field readability.'


### PR DESCRIPTION
Closes #1122

## Summary
- Carry workflow name/version through handler `StateSnapshot` construction so handler expression contexts have the active workflow identity.
- Make `query_entities(...).count` in runtime handler boolean expressions require workflow/run context and fail closed on missing or unsupported scoped operands.
- Preserve static validation for runtime-only scoped operands while updating `platform-spec.yaml` to make the runtime fail-closed rule authoritative.

## Governing Refs / Context
- Issue audit: https://github.com/yazzaoui/Swarm/issues/1122#issuecomment-4589097808
- Gate approval: https://github.com/yazzaoui/Swarm/issues/1122#issuecomment-4589122395
- `platform-spec.yaml`: `runtime_enforcement.query_entities.handler_expression_rule`
- `platform-spec.yaml`: `handler_specification.expression_context.boot_validation.checks.query_operand_rule`

## Semantic Migration Record
- New canonical owner: `StateSnapshot`/`BuildBaseContext` for handler workflow identity, plus `workflowExpressionEvaluator` and `pipelineEngineEvaluator.queryEntityCount` for runtime `query_entities(...).count` evaluation.
- Old non-authoritative path now invalid: runtime handler expressions may no longer evaluate `query_entities(...).count` without workflow identity, active run id, or resolved supported scoped operands.
- Production paths checked for surviving old behavior: handler guards, rule/on_complete selection, accumulator completion, static condition validation, handler snapshot construction, and store-backed query count execution.
- Migration completeness: complete for the approved #1122 child; runtime tool query surfaces, handler query prefetch, #1119, and final #1025/Empire proof remain split.

## Verification
- `go test ./internal/runtime/pipeline -run 'TestValidateConditionCEL_AllowsQueryEntitiesPayloadOperandWithoutRuntimeValue|TestWorkflowExpressionEvaluator_(EvalBoolSurfacesQueryRewriteError|QueryEntitiesMissingScopedOperandFailsClosed|QueryEntitiesUnsupportedScopedOperandFailsClosed|QueryEntitiesKeepsQuotedScopedLiteral)|TestExecuteNodeContractHandlerQueryEntitiesGuardUsesWorkflowContext' -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/engine -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/cataloge2e ./internal/runtime/pipeline -count=1`
- `go test ./cmd/swarm -run TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
