### PR TITLE
[agent-b][issue #1200] Add bundle delete CLI consumer

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -81,6 +81,28 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 	}
 }
 
+func TestBundleDeleteCLIConsumesCanonicalAPIOnly(t *testing.T) {
+	source := readProductionCommandSources(t)["bundle.go"]
+	for _, needle := range []string{
+		"internal/runtime/bundledelete",
+		"internal/runtime/destructivereset",
+		"internal/store",
+		"PlanBundleDelete(",
+		"ApplyBundleDeleteFinalMutation(",
+		"ApplyBundleForceDeletePreservationCleanup(",
+		"ManagedResetContainerInventory(",
+		"DELETE FROM",
+		"UPDATE runs",
+	} {
+		if strings.Contains(source, needle) {
+			t.Fatalf("bundle.go contains non-authoritative bundle delete bypass %q; swarm bundle delete must consume /v1/rpc bundle.delete only", needle)
+		}
+	}
+	if !strings.Contains(source, "bundleDeleteMethod") || !strings.Contains(source, `"bundle.delete"`) || !strings.Contains(source, "newCLIAPIClient(") {
+		t.Fatalf("bundle.go must expose bundle.delete only through the shared CLI API client")
+	}
+}
+
 func TestCLILocalRuntimeHelpersRemainNonOperatorQuarantined(t *testing.T) {
 	sources := readProductionCommandSources(t)
 	all := strings.Join(sortedSourceValues(sources), "\n")
@@ -168,6 +190,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "bundle agents", args: []string{"bundle", "agents", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
 		{name: "bundle register", args: []string{"bundle", "register", envelopePath}},
 		{name: "bundle register contracts", args: []string{"bundle", "register", "--contracts", contractsDir}},
+		{name: "bundle delete", args: []string{"bundle", "delete", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
 		{name: "conversations list", args: []string{"conversations", "list"}},
 		{name: "conversation view", args: []string{"conversation", "view", "session-1"}},
 		{name: "conversation turn", args: []string{"conversation", "turn", "session-1", "1"}},

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -379,11 +379,18 @@ func runBundleDeleteCommand(ctx context.Context, out, errOut io.Writer, opts bun
 	if err := validateBundleDeleteResult(result, bundleHash); err != nil {
 		return returnCLIAPIError(errOut, err, bundleDeleteAPIErrorClassifier())
 	}
-	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+	if err := renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
 		writeBundleDeleteHuman(w, result)
 	}, func() ([]string, error) {
 		return []string{result.BundleHash}, nil
-	})
+	}); err != nil {
+		return err
+	}
+	if !*result.OK || *result.PartialFailure {
+		writeBundleDeleteFailures(errOut, result)
+		return commandExitError{code: cliExitRuntime}
+	}
+	return nil
 }
 
 func (opts bundleListCommandOptions) params() (map[string]any, error) {
@@ -672,6 +679,23 @@ func validateBundleDeleteResult(result bundleDeleteResult, expectedBundleHash st
 			return fmt.Errorf("malformed bundle.delete result: errors[%d].message is required", i)
 		}
 	}
+	switch result.Status {
+	case "dry_run":
+		if !*result.OK || !*result.DryRun || *result.Deleted || *result.PartialFailure {
+			return fmt.Errorf("malformed bundle.delete result: dry_run status must be ok=true deleted=false dry_run=true partial_failure=false")
+		}
+	case "completed":
+		if !*result.OK || *result.DryRun || !*result.Deleted || *result.PartialFailure {
+			return fmt.Errorf("malformed bundle.delete result: completed status must be ok=true deleted=true dry_run=false partial_failure=false")
+		}
+	case "partial_failure":
+		if *result.OK || *result.DryRun || *result.Deleted || !*result.PartialFailure {
+			return fmt.Errorf("malformed bundle.delete result: partial_failure status must be ok=false deleted=false dry_run=false partial_failure=true")
+		}
+		if len(result.Errors) == 0 {
+			return fmt.Errorf("malformed bundle.delete result: partial_failure status requires errors")
+		}
+	}
 	return nil
 }
 
@@ -800,6 +824,19 @@ func writeBundleDeleteHuman(w io.Writer, result bundleDeleteResult) {
 		result.BundleHash, result.Status, *result.Deleted, *result.Force, *result.DryRun, *result.ActiveRunsStopped, *result.DeliveriesCancelled, *result.ContainersStopped, *result.PartialFailure)
 	if len(result.Errors) > 0 {
 		fmt.Fprintf(w, "errors=%s\n", compactJSONValue(result.Errors))
+	}
+}
+
+func writeBundleDeleteFailures(errOut io.Writer, result bundleDeleteResult) {
+	if errOut == nil {
+		return
+	}
+	if len(result.Errors) == 0 {
+		fmt.Fprintln(errOut, "bundle.delete partial failure")
+		return
+	}
+	for _, failure := range result.Errors {
+		fmt.Fprintf(errOut, "bundle.delete failure: scope=%s message=%s\n", failure.Scope, failure.Message)
 	}
 }
 

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -19,6 +19,7 @@ const (
 	bundleGetMethod      = "bundle.get"
 	bundleAgentsMethod   = "bundle.agents"
 	bundleRegisterMethod = "bundle.register"
+	bundleDeleteMethod   = "bundle.delete"
 )
 
 type bundleListCommandOptions struct {
@@ -48,6 +49,19 @@ type bundleRegisterCommandOptions struct {
 	contractsSet      bool
 	idempotencyKeySet bool
 	repoRoot          string
+}
+
+type bundleDeleteCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+
+	force          bool
+	dryRun         bool
+	idempotencyKey string
+
+	forceSet          bool
+	dryRunSet         bool
+	idempotencyKeySet bool
 }
 
 type bundleListResult struct {
@@ -86,6 +100,30 @@ type bundleRegistrationResult struct {
 	DataSizeBytes *int64 `json:"data_size_bytes"`
 }
 
+type bundleDeleteResult struct {
+	OK                  *bool                      `json:"ok"`
+	Status              string                     `json:"status"`
+	OperationName       string                     `json:"operation_name"`
+	BundleHash          string                     `json:"bundle_hash"`
+	Force               *bool                      `json:"force"`
+	Deleted             *bool                      `json:"deleted"`
+	DryRun              *bool                      `json:"dry_run"`
+	ActiveRunsStopped   *int                       `json:"active_runs_stopped"`
+	DeliveriesCancelled *int                       `json:"deliveries_cancelled"`
+	ContainersStopped   *int                       `json:"containers_stopped"`
+	PartialFailure      *bool                      `json:"partial_failure"`
+	Plan                map[string]any             `json:"plan"`
+	Cleanup             map[string]any             `json:"cleanup"`
+	Containers          map[string]any             `json:"containers"`
+	FinalMutation       map[string]any             `json:"final_mutation"`
+	Errors              []bundleDeletePartialError `json:"errors,omitempty"`
+}
+
+type bundleDeletePartialError struct {
+	Scope   string `json:"scope"`
+	Message string `json:"message"`
+}
+
 type bundleAgentDefinition struct {
 	AgentID          string   `json:"agent_id"`
 	FlowInstance     string   `json:"flow_instance,omitempty"`
@@ -114,6 +152,7 @@ func newBundleCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
 		newBundleShowCommand(opts),
 		newBundleAgentsCommand(opts),
 		newBundleRegisterCommand(repoRoot, opts),
+		newBundleDeleteCommand(opts),
 	)
 	return cmd
 }
@@ -197,6 +236,30 @@ func newBundleRegisterCommand(repoRoot string, opts rootCommandOptions) *cobra.C
 	cmd.Flags().StringVar(&registerOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.register")
 	bindCLIOutputFlags(cmd, &registerOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &registerOpts.apiOptions)
+	return cmd
+}
+
+func newBundleDeleteCommand(opts rootCommandOptions) *cobra.Command {
+	deleteOpts := bundleDeleteCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "delete <bundle-hash>",
+		Short: "Delete a persisted bundle through /v1/rpc bundle.delete.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deleteOpts.forceSet = cmd.Flags().Changed("force")
+			deleteOpts.dryRunSet = cmd.Flags().Changed("dry-run")
+			deleteOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
+			if err := deleteOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			return runBundleDeleteCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), deleteOpts, args[0])
+		},
+	}
+	cmd.Flags().BoolVar(&deleteOpts.force, "force", false, "Force bundle deletion by quiescing affected active work before deleting")
+	cmd.Flags().BoolVar(&deleteOpts.dryRun, "dry-run", false, "Plan bundle deletion without applying destructive changes")
+	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.delete")
+	bindCLIOutputFlags(cmd, &deleteOpts.output)
+	bindCLIAPIConnectionFlags(cmd, &deleteOpts.apiOptions)
 	return cmd
 }
 
@@ -300,6 +363,29 @@ func runBundleRegisterCommand(ctx context.Context, out, errOut io.Writer, opts b
 	})
 }
 
+func runBundleDeleteCommand(ctx context.Context, out, errOut io.Writer, opts bundleDeleteCommandOptions, rawBundleHash string) error {
+	params, bundleHash, err := opts.params(rawBundleHash)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, bundleDeleteAPIErrorClassifier())
+	}
+	var result bundleDeleteResult
+	if err := client.call(ctx, bundleDeleteMethod, params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, bundleDeleteAPIErrorClassifier())
+	}
+	if err := validateBundleDeleteResult(result, bundleHash); err != nil {
+		return returnCLIAPIError(errOut, err, bundleDeleteAPIErrorClassifier())
+	}
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeBundleDeleteHuman(w, result)
+	}, func() ([]string, error) {
+		return []string{result.BundleHash}, nil
+	})
+}
+
 func (opts bundleListCommandOptions) params() (map[string]any, error) {
 	params := map[string]any{}
 	if opts.limitSet {
@@ -393,10 +479,37 @@ func (opts bundleRegisterCommandOptions) contractsDirectoryParams(args []string)
 	return params, nil
 }
 
+func (opts bundleDeleteCommandOptions) params(rawBundleHash string) (map[string]any, string, error) {
+	bundleHash, err := validateBundleHashArg("bundle hash", rawBundleHash)
+	if err != nil {
+		return nil, "", err
+	}
+	params := map[string]any{"bundle_hash": bundleHash}
+	if opts.forceSet {
+		params["force"] = opts.force
+	}
+	if opts.dryRunSet {
+		params["dry_run"] = opts.dryRun
+	}
+	if idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet); err != nil {
+		return nil, "", err
+	} else if idempotencyKey != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params, bundleHash, nil
+}
+
 func bundleAPIErrorClassifier() cliAPIErrorClassifier {
 	return cliAPIErrorClassifier{
 		notFoundCodes: []string{"BUNDLE_NOT_FOUND"},
 		conflictCodes: []string{"BUNDLE_REGISTER_CONFLICT", "IDEMPOTENCY_CONFLICT"},
+	}
+}
+
+func bundleDeleteAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{
+		notFoundCodes: []string{"BUNDLE_NOT_FOUND"},
+		conflictCodes: []string{"BUNDLE_HAS_ACTIVE_RUNS", "BUNDLE_DELETE_IN_PROGRESS", "IDEMPOTENCY_CONFLICT"},
 	}
 }
 
@@ -495,6 +608,69 @@ func validateBundleRegistrationResult(result bundleRegistrationResult) error {
 	}
 	if *result.DataSizeBytes < 0 {
 		return fmt.Errorf("malformed bundle.register result: data_size_bytes must be non-negative")
+	}
+	return nil
+}
+
+func validateBundleDeleteResult(result bundleDeleteResult, expectedBundleHash string) error {
+	if result.OK == nil {
+		return fmt.Errorf("malformed bundle.delete result: ok is required")
+	}
+	switch result.Status {
+	case "dry_run", "completed", "partial_failure":
+	default:
+		return fmt.Errorf("malformed bundle.delete result: status must be dry_run, completed, or partial_failure")
+	}
+	if result.OperationName != bundleDeleteMethod {
+		return fmt.Errorf("malformed bundle.delete result: operation_name must be %s", bundleDeleteMethod)
+	}
+	if _, err := validateBundleHashArg("bundle_hash", result.BundleHash); err != nil {
+		return fmt.Errorf("malformed bundle.delete result: %w", err)
+	}
+	if result.BundleHash != expectedBundleHash {
+		return fmt.Errorf("malformed bundle.delete result: bundle_hash=%q, want %q", result.BundleHash, expectedBundleHash)
+	}
+	if result.Force == nil {
+		return fmt.Errorf("malformed bundle.delete result: force is required")
+	}
+	if result.Deleted == nil {
+		return fmt.Errorf("malformed bundle.delete result: deleted is required")
+	}
+	if result.DryRun == nil {
+		return fmt.Errorf("malformed bundle.delete result: dry_run is required")
+	}
+	if result.PartialFailure == nil {
+		return fmt.Errorf("malformed bundle.delete result: partial_failure is required")
+	}
+	for name, value := range map[string]*int{
+		"active_runs_stopped":  result.ActiveRunsStopped,
+		"deliveries_cancelled": result.DeliveriesCancelled,
+		"containers_stopped":   result.ContainersStopped,
+	} {
+		if value == nil {
+			return fmt.Errorf("malformed bundle.delete result: %s is required", name)
+		}
+		if *value < 0 {
+			return fmt.Errorf("malformed bundle.delete result: %s must be non-negative", name)
+		}
+	}
+	for name, value := range map[string]map[string]any{
+		"plan":           result.Plan,
+		"cleanup":        result.Cleanup,
+		"containers":     result.Containers,
+		"final_mutation": result.FinalMutation,
+	} {
+		if value == nil {
+			return fmt.Errorf("malformed bundle.delete result: %s is required", name)
+		}
+	}
+	for i, item := range result.Errors {
+		if strings.TrimSpace(item.Scope) == "" {
+			return fmt.Errorf("malformed bundle.delete result: errors[%d].scope is required", i)
+		}
+		if strings.TrimSpace(item.Message) == "" {
+			return fmt.Errorf("malformed bundle.delete result: errors[%d].message is required", i)
+		}
 	}
 	return nil
 }
@@ -614,6 +790,17 @@ func writeBundleRegistrationHuman(w io.Writer, result bundleRegistrationResult) 
 	}
 	fmt.Fprintf(w, "bundle %s registered=%t has_data=%t data_size_bytes=%d\n",
 		result.BundleHash, *result.Registered, *result.HasData, *result.DataSizeBytes)
+}
+
+func writeBundleDeleteHuman(w io.Writer, result bundleDeleteResult) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "bundle %s status=%s deleted=%t force=%t dry_run=%t active_runs_stopped=%d deliveries_cancelled=%d containers_stopped=%d partial_failure=%t\n",
+		result.BundleHash, result.Status, *result.Deleted, *result.Force, *result.DryRun, *result.ActiveRunsStopped, *result.DeliveriesCancelled, *result.ContainersStopped, *result.PartialFailure)
+	if len(result.Errors) > 0 {
+		fmt.Fprintf(w, "errors=%s\n", compactJSONValue(result.Errors))
+	}
 }
 
 func compactJSONValue(value any) string {

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -248,6 +248,58 @@ func TestBundleDeleteJSONPreservesAPIShape(t *testing.T) {
 	}
 }
 
+func TestBundleDeletePartialFailureRendersAndExitsRuntime(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("9")
+	for _, tc := range []struct {
+		name string
+		args []string
+		json bool
+	}{
+		{name: "human", args: []string{"bundle", "delete", bundleHash, "--force"}},
+		{name: "json", args: []string{"bundle", "delete", bundleHash, "--force", "--json"}, json: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured jsonRPCRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writeJSONRPCResult(t, w, captured.ID, partialBundleDeleteResult(bundleHash))
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitRuntime {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+			}
+			assertBundleRequest(t, captured, bundleDeleteMethod, map[string]any{
+				"bundle_hash": bundleHash,
+				"force":       true,
+			})
+			if !strings.Contains(stderr.String(), "bundle.delete failure: scope=managed_containers message=container stop failed") {
+				t.Fatalf("stderr = %q, want partial failure details", stderr.String())
+			}
+			if tc.json {
+				var decoded map[string]any
+				if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+					t.Fatalf("decode stdout json: %v\n%s", err, stdout.String())
+				}
+				if decoded["ok"] != false || decoded["status"] != "partial_failure" || decoded["partial_failure"] != true {
+					t.Fatalf("json partial result = %#v", decoded)
+				}
+				return
+			}
+			for _, want := range []string{"status=partial_failure", "deleted=false", "partial_failure=true", "errors="} {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+		})
+	}
+}
+
 func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	bundleHash := validBundleHash("f")
@@ -931,6 +983,16 @@ func validBundleDeleteResult(bundleHash string, force, dryRun bool, status strin
 		"containers":           map[string]any{"selected": []any{}, "stopped": []any{}},
 		"final_mutation":       map[string]any{"bundle_hash": bundleHash, "deleted": deleted},
 	}
+}
+
+func partialBundleDeleteResult(bundleHash string) map[string]any {
+	result := validBundleDeleteResult(bundleHash, true, false, "partial_failure", false)
+	result["ok"] = false
+	result["partial_failure"] = true
+	result["errors"] = []map[string]any{
+		{"scope": "managed_containers", "message": "container stop failed"},
+	}
+	return result
 }
 
 func writeBundleJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -122,9 +122,135 @@ func TestBundleCommandsJSONPreserveAPIShape(t *testing.T) {
 	}
 }
 
-func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
+func TestBundleDeleteUsesCanonicalRPCAndRenders(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	bundleHash := validBundleHash("d")
+	var requests []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		force, _ := req.Params["force"].(bool)
+		dryRun, _ := req.Params["dry_run"].(bool)
+		status := "completed"
+		deleted := true
+		if dryRun {
+			status = "dry_run"
+			deleted = false
+		}
+		writeJSONRPCResult(t, w, req.ID, validBundleDeleteResult(bundleHash, force, dryRun, status, deleted))
+	}))
+	defer server.Close()
+
+	commands := []struct {
+		name       string
+		args       []string
+		wantParams map[string]any
+		wantStdout []string
+	}{
+		{
+			name:       "default",
+			args:       []string{"bundle", "delete", bundleHash},
+			wantParams: map[string]any{"bundle_hash": bundleHash},
+			wantStdout: []string{"bundle " + bundleHash, "status=completed", "deleted=true", "force=false", "dry_run=false"},
+		},
+		{
+			name:       "force",
+			args:       []string{"bundle", "delete", bundleHash, "--force"},
+			wantParams: map[string]any{"bundle_hash": bundleHash, "force": true},
+			wantStdout: []string{"bundle " + bundleHash, "status=completed", "deleted=true", "force=true"},
+		},
+		{
+			name:       "dry run idempotent",
+			args:       []string{"bundle", "delete", bundleHash, "--dry-run", "--idempotency-key", "idem-delete"},
+			wantParams: map[string]any{"bundle_hash": bundleHash, "dry_run": true, "idempotency_key": "idem-delete"},
+			wantStdout: []string{"bundle " + bundleHash, "status=dry_run", "deleted=false", "dry_run=true"},
+		},
+		{
+			name:       "explicit false flags",
+			args:       []string{"bundle", "delete", bundleHash, "--force=false", "--dry-run=false"},
+			wantParams: map[string]any{"bundle_hash": bundleHash, "force": false, "dry_run": false},
+			wantStdout: []string{"bundle " + bundleHash, "status=completed", "deleted=true", "force=false", "dry_run=false"},
+		},
+	}
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), command.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			for _, want := range command.wantStdout {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+			if strings.TrimSpace(stderr.String()) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+	if len(requests) != len(commands) {
+		t.Fatalf("requests = %d, want %d", len(requests), len(commands))
+	}
+	for i, command := range commands {
+		assertBundleRequest(t, requests[i], bundleDeleteMethod, command.wantParams)
+	}
+}
+
+func TestBundleDeleteJSONPreservesAPIShape(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("e")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validBundleDeleteResult(bundleHash, true, true, "dry_run", false))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "delete", bundleHash, "--force", "--dry-run", "--idempotency-key", "idem-delete", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertBundleRequest(t, captured, bundleDeleteMethod, map[string]any{
+		"bundle_hash":     bundleHash,
+		"force":           true,
+		"dry_run":         true,
+		"idempotency_key": "idem-delete",
+	})
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode stdout json: %v\n%s", err, stdout.String())
+	}
+	for _, want := range []string{"ok", "status", "operation_name", "bundle_hash", "force", "deleted", "dry_run", "plan", "cleanup", "containers", "final_mutation"} {
+		if _, ok := decoded[want]; !ok {
+			t.Fatalf("json output missing %q: %#v", want, decoded)
+		}
+	}
+	if decoded["operation_name"] != bundleDeleteMethod || decoded["bundle_hash"] != bundleHash || decoded["force"] != true || decoded["dry_run"] != true || decoded["deleted"] != false {
+		t.Fatalf("json delete result = %#v", decoded)
+	}
+	for _, wrapper := range []string{"bundle_delete", "delete_result", "result"} {
+		if _, ok := decoded[wrapper]; ok {
+			t.Fatalf("json output contains CLI wrapper %q: %#v", wrapper, decoded)
+		}
+	}
+}
+
+func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("f")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -159,6 +285,34 @@ func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
 	}
 	if _, ok := agent["model_tier"]; ok {
 		t.Fatalf("json agent contains retired model_tier field: %#v", agent)
+	}
+}
+
+func TestBundleDeleteHelpDocumentsCanonicalFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "delete", "--help"}, &stdout, &stderr, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		"delete <bundle-hash>",
+		"--force",
+		"--dry-run",
+		"--idempotency-key",
+		"--api-server",
+		"--json",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"archive", "contracts"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("help contains out-of-scope term %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -382,6 +536,10 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "show invalid hash", args: []string{"bundle", "show", "sha256:abc"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "agents invalid hash", args: []string{"bundle", "agents", "bad"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
 		{name: "get alias not promoted", args: []string{"bundle", "get", validBundleHash("a")}, wantStderr: "unknown command"},
+		{name: "delete missing hash", args: []string{"bundle", "delete"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "delete extra arg", args: []string{"bundle", "delete", validBundleHash("a"), "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "delete invalid hash", args: []string{"bundle", "delete", "bad"}, wantStderr: "bundle hash must match bundle-v1:sha256:<64 lowercase hex>"},
+		{name: "delete blank idempotency", args: []string{"bundle", "delete", validBundleHash("a"), "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "register missing envelope", args: []string{"bundle", "register"}, wantStderr: "register requires <registration-envelope-yaml> or --contracts <contracts-directory>"},
 		{name: "register missing file", args: []string{"bundle", "register", filepath.Join(t.TempDir(), "missing.yaml")}, wantStderr: "read registration envelope"},
 		{name: "register directory", args: []string{"bundle", "register", dirPath}, wantStderr: "registration envelope must be a file"},
@@ -393,7 +551,6 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
 		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
 		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "package contracts directory"},
-		{name: "delete not promoted", args: []string{"bundle", "delete", validBundleHash("a")}, wantStderr: "unknown command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			calls.Store(0)
@@ -553,6 +710,76 @@ func TestBundleCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantCode:   cliExitRuntime,
 			wantStderr: "malformed bundle.register result: data_size_bytes must be non-negative",
 		},
+		{
+			name: "bundle delete active runs conflict",
+			args: []string{"bundle", "delete", bundleHash},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "BUNDLE_HAS_ACTIVE_RUNS")
+			},
+			wantCode:   cliExitConflict,
+			wantStderr: "BUNDLE_HAS_ACTIVE_RUNS: Application error: BUNDLE_HAS_ACTIVE_RUNS",
+		},
+		{
+			name: "bundle delete in progress conflict",
+			args: []string{"bundle", "delete", bundleHash, "--force"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "BUNDLE_DELETE_IN_PROGRESS")
+			},
+			wantCode:   cliExitConflict,
+			wantStderr: "BUNDLE_DELETE_IN_PROGRESS: Application error: BUNDLE_DELETE_IN_PROGRESS",
+		},
+		{
+			name: "bundle delete idempotency conflict",
+			args: []string{"bundle", "delete", bundleHash, "--idempotency-key", "idem-delete"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "IDEMPOTENCY_CONFLICT")
+			},
+			wantCode:   cliExitConflict,
+			wantStderr: "IDEMPOTENCY_CONFLICT: Application error: IDEMPOTENCY_CONFLICT",
+		},
+		{
+			name: "bundle delete undeclared runtime nuke error fails closed",
+			args: []string{"bundle", "delete", bundleHash, "--force"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeBundleJSONRPCError(t, w, req.ID, "RUNTIME_NUKE_IN_PROGRESS")
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "RUNTIME_NUKE_IN_PROGRESS: Application error: RUNTIME_NUKE_IN_PROGRESS",
+		},
+		{
+			name: "malformed delete missing ok",
+			args: []string{"bundle", "delete", bundleHash},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validBundleDeleteResult(bundleHash, false, false, "completed", true)
+				delete(result, "ok")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed bundle.delete result: ok is required",
+		},
+		{
+			name: "malformed delete negative stopped count",
+			args: []string{"bundle", "delete", bundleHash, "--force"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validBundleDeleteResult(bundleHash, true, false, "completed", true)
+				result["active_runs_stopped"] = -1
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed bundle.delete result: active_runs_stopped must be non-negative",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -683,6 +910,26 @@ func validBundleRegistrationResult(bundleHash string) map[string]any {
 		"registered":      true,
 		"has_data":        true,
 		"data_size_bytes": 7,
+	}
+}
+
+func validBundleDeleteResult(bundleHash string, force, dryRun bool, status string, deleted bool) map[string]any {
+	return map[string]any{
+		"ok":                   true,
+		"status":               status,
+		"operation_name":       bundleDeleteMethod,
+		"bundle_hash":          bundleHash,
+		"force":                force,
+		"deleted":              deleted,
+		"dry_run":              dryRun,
+		"active_runs_stopped":  1,
+		"deliveries_cancelled": 2,
+		"containers_stopped":   3,
+		"partial_failure":      false,
+		"plan":                 map[string]any{"bundle_hash": bundleHash, "active_runs": []any{}, "non_active_runs": []any{}},
+		"cleanup":              map[string]any{"runs": []any{}, "deliveries": []any{}},
+		"containers":           map[string]any{"selected": []any{}, "stopped": []any{}},
+		"final_mutation":       map[string]any{"bundle_hash": bundleHash, "deleted": deleted},
 	}
 }
 

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -436,10 +436,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	cli := mustMappingValue(t, root, "cli_specification")
 	commandCatalog := mustMappingValue(t, cli, "command_catalog")
 	bundleCommand := mustMappingValue(t, commandCatalog, "bundle")
-	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents|register")
-	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_inventory_prepared_envelope_and_directory_register")
+	assertScalarValue(t, mustMappingValue(t, bundleCommand, "command"), "swarm bundle list|show|agents|register|delete")
+	assertScalarValue(t, mustMappingValue(t, bundleCommand, "implementation_status"), "implemented_inventory_prepared_envelope_directory_register_and_delete")
 	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "local directory swarm bundle register --contracts")
-	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Archive packaging and bundle.delete CLI remain split")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Destructive swarm bundle delete is implemented")
+	assertScalarContains(t, mustMappingValue(t, bundleCommand, "blocker_state"), "Archive packaging remains split")
 	runForkCatalog := mustMappingValue(t, commandCatalog, "run_fork")
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "command"), runForkCommand)
 	assertScalarValue(t, mustMappingValue(t, runForkCatalog, "implementation_status"), "implemented_public_cli_consumer")
@@ -464,13 +465,11 @@ func TestMultiBundleSourceAuthorityPublishesOnlyImplementedBundleReadAndRunForkM
 	if sequenceContainsScalar(remaining, "swarm bundle list|show|agents|register|delete") {
 		t.Fatal("remaining_should_have_not_implemented still includes implemented swarm bundle inventory commands")
 	}
-	for _, want := range []string{
-		"swarm bundle register --archive <archive-file>",
-		"swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]",
-	} {
-		if !sequenceContainsScalar(remaining, want) {
-			t.Fatalf("remaining_should_have_not_implemented missing %q", want)
-		}
+	if !sequenceContainsScalar(remaining, "swarm bundle register --archive <archive-file>") {
+		t.Fatal("remaining_should_have_not_implemented missing archive register split")
+	}
+	if sequenceContainsScalar(remaining, "swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]") {
+		t.Fatal("remaining_should_have_not_implemented still includes implemented swarm bundle delete")
 	}
 
 	apiBoundary := mustMappingValue(t, mustMappingValue(t, root, "api_specification"), "multi_bundle_publication_boundary")

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5987,16 +5987,16 @@ multi_bundle_persistence:
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
   cli_surface:
-    publication_status: bundle_inventory_register_envelope_directory_run_fork_and_boot_pinned_serve_bundle_hash_implemented_other_cli_children_pending
+    publication_status: bundle_inventory_register_envelope_directory_delete_run_fork_and_boot_pinned_serve_bundle_hash_implemented_other_cli_children_pending
     bundle_commands_supported:
       - swarm bundle list
       - swarm bundle show <bundle-hash>
       - swarm bundle agents <bundle-hash>
       - swarm bundle register <registration-envelope-yaml> [--data-blob <data-blob-json>] [--idempotency-key <key>]
       - swarm bundle register --contracts <contracts-directory> [--idempotency-key <key>]
+      - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     bundle_commands_split:
       - swarm bundle register --archive <archive-file>
-      - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     bundle_register_directory_packager:
       owner: internal/runtime/contracts.BuildBundleRegistrationDirectoryUpload
       status: implemented_local_directory_packager
@@ -6098,8 +6098,8 @@ multi_bundle_persistence:
       reason: swarm fork consumes /v1/rpc run.fork only; same-bundle DB-loaded source loading is supported by #1024, and cross-bundle fork routing remains split to #976.
     multi_bundle_cli_inventory:
       tracker: '#1023'
-      implementation_status: inventory_prepared_envelope_and_directory_register_implemented
-      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only, prepared-envelope swarm bundle register consumes /v1/rpc bundle.register only, and swarm bundle register --contracts packages a local contracts directory through the non-hashing registration upload owner before calling /v1/rpc bundle.register. Archive register packaging and bundle.delete CLI remain split until their exact CLI/runtime/packaging owners land.
+      implementation_status: inventory_prepared_envelope_directory_register_and_bundle_delete_implemented
+      reason: swarm bundle list/show/agents consume /v1/rpc bundle.list/get/agents only, prepared-envelope swarm bundle register consumes /v1/rpc bundle.register only, swarm bundle register --contracts packages a local contracts directory through the non-hashing registration upload owner before calling /v1/rpc bundle.register, and swarm bundle delete consumes /v1/rpc bundle.delete only. Archive register packaging remains split until archive input and extraction safety authority lands.
     bundle_hash_dual_accept_migration:
       tracker: '#1001'
       reason: Old bundle_fingerprint/bundle_ref names must be reconciled in code and generated artifacts under the locked bundle_hash naming decision.
@@ -9637,33 +9637,36 @@ cli_specification:
       - SESSION_NOT_FOUND, TURN_NOT_FOUND, malformed results, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation.current_for_agent, runtime.logs, run.trace, or forkchat usage
     bundle:
-      command: swarm bundle list|show|agents|register
+      command: swarm bundle list|show|agents|register|delete
       tier: should_have
-      implementation_status: implemented_inventory_prepared_envelope_and_directory_register
-      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Prepared-envelope swarm bundle register and local directory swarm bundle register --contracts are implemented over /v1/rpc bundle.register. Archive packaging and bundle.delete CLI remain split until their exact owners are promoted.'
+      implementation_status: implemented_inventory_prepared_envelope_directory_register_and_delete
+      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Prepared-envelope swarm bundle register and local directory swarm bundle register --contracts are implemented over /v1/rpc bundle.register. Destructive swarm bundle delete is implemented over /v1/rpc bundle.delete. Archive packaging remains split until archive input/extraction safety authority is promoted.'
       owners:
       - multi_bundle_persistence.cli_surface.bundle_commands_supported
       - multi_bundle_persistence.api_surface.bundle_methods_planned
       behavior: >
         Public CLI family for persisted bundle inventory, agent catalog inspection, prepared-envelope registration, and
-        local contracts-directory registration.
+        local contracts-directory registration, plus destructive bundle deletion through the canonical API owner.
         The implemented list/show/agents commands consume /v1/rpc bundle.list, bundle.get, and bundle.agents. The
         implemented register command consumes /v1/rpc bundle.register with an already-prepared
         BundleRegistrationEnvelopeV1 YAML file as content_yaml, optional BundleRegisterDataBlobV1 JSON from
         --data-blob, and optional --idempotency-key, or with --contracts <contracts-directory> through the non-hashing
         registration upload owner. The --contracts path may package local upload bytes but must not call internal
         store/runtime helpers, compute bundle_hash, build catalog projection bytes, infer persisted bundle state from
-        local files, or send server-local path semantics. Archive packaging remains split. Destructive bundle.delete has
-        a live API owner but remains split as a CLI consumer until a later gate promotes that command.
+        local files, or send server-local path semantics. The implemented delete command consumes /v1/rpc bundle.delete
+        with bundle_hash plus optional force, dry_run, and idempotency_key only; it must not plan active runs, inspect
+        bundle existence, call store/runtime/destructive reset owners, or infer deletion eligibility locally. Archive
+        packaging remains split.
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
       - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
+      - exact /v1/rpc bundle.delete call with only bundle_hash, optional force, optional dry_run, and optional idempotency_key
       - local directory packaging proves traversal/root escape, symlink fail-closed behavior, ignored file/dir policy, slash-relative NFC paths, duplicate and ASCII case-collision failure, text-vs-every-discovered-flow-data split including empty raw data, deterministic ordering, and no bundle_hash param
       - invalid args, invalid local envelope/data blob files, invalid local contracts directories, and missing SWARM_API_TOKEN make zero API calls
       - human and --json output render only server-owned result fields
-      - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, BUNDLE_HAS_ACTIVE_RUNS, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/hash-owner bundle reads or writes from CLI
-      - swarm bundle delete, unpromoted bundle.get alias, and archive register packaging remain absent/unknown until later CLI gates
+      - unpromoted bundle.get alias and archive register packaging remain absent/unknown until later CLI gates
     run_fork:
       command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
       tier: should_have
@@ -10109,7 +10112,6 @@ cli_specification:
     remaining_must_have_not_implemented: []
     remaining_should_have_not_implemented:
     - swarm bundle register --archive <archive-file>
-    - swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]
     rule: 'Remaining commands require separate gates and must consume canonical API owners; they MUST NOT resurrect direct DB/store/runtime-state readers.'
 
 api_specification:
@@ -10153,7 +10155,7 @@ api_specification:
       bundle register CLI consumer is implemented by #1167, and local contracts-directory packaging is implemented by
       #1187 through the non-hashing upload packager owner, while archive packaging remains split.
       run.fork is also promoted into method_catalog/OpenRPC with matching selected-contract API/runtime handler proof by
-      #989. The swarm bundle list/show/agents/register and swarm fork CLI consumers are implemented by #1023/#1167/#1187 and
+      #989. The swarm bundle list/show/agents/register/delete and swarm fork CLI consumers are implemented by #1023/#1167/#1187/#1200 and
       consume only those canonical /v1/rpc methods. bundle.delete is promoted into method_catalog/OpenRPC with matching
       API/runtime handler proof by #1018 and #1019: omitted or false force performs non-force deletion and force=true
       performs force cleanup. Remaining multi-bundle methods and shapes are


### PR DESCRIPTION
Closes #1200

## Governing refs / context
- `platform-spec.yaml#multi_bundle_persistence.bundle_delete`
- `platform-spec.yaml#cli_specification.command_catalog.bundle`
- Generated OpenRPC method `bundle.delete` in `openrpc.json`
- Binding issue/gate context: #1200 Pre-Implementation Coverage Audit and independent gate approval as the focused first slice

## Summary
- Adds `swarm bundle delete <bundle-hash> [--force] [--dry-run] [--idempotency-key <key>]` as the public CLI consumer for `/v1/rpc bundle.delete`.
- Renders canonical `BundleDeleteResult` for human output and `--json`, with fail-closed validation for malformed responses and API errors.
- Promotes the supported CLI command rows in `platform-spec.yaml` and updates spec conformance tests.

## Semantic migration
- New canonical owner consumed by this CLI: `/v1/rpc bundle.delete`, with API shape from generated `openrpc.json` and server behavior owned by `internal/apiv1/operator_bundle_delete.go`, `internal/runtime/bundledelete`, and store final mutation owners.
- Old path now invalid: the CLI `delete not promoted` unknown-command placeholder and spec split state for `swarm bundle delete`.
- Old paths still non-authoritative: direct CLI reads/writes through `internal/store`, `internal/runtime/bundledelete`, `internal/runtime/destructivereset`, raw SQL, active-run planners, cleanup helpers, or bundle-existence probes.
- Production paths checked for surviving old behavior: `cmd/swarm/bundle.go`, `cmd/swarm/bundle_test.go`, `cmd/swarm/api_consumption_boundary_test.go`, `platform-spec.yaml`, and `internal/apispec/spec_test.go`.
- Migration completeness: complete for #1200 chosen class; parent #1023 remains open for unrelated residual command tails.

## Proof
- `go test ./cmd/swarm ./internal/apispec`
- `go test ./...`