### PR TITLE
[agent-e][issue #1119] Key accumulators by matched handler

### DIFF
--- a/internal/runtime/engine/declarative_node.go
+++ b/internal/runtime/engine/declarative_node.go
@@ -3,9 +3,12 @@ package engine
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/runtime/core/eventidentity"
 	"swarm/internal/runtime/core/identity"
+	"swarm/internal/runtime/semanticview"
 )
 
 type DeclarativeNode struct {
@@ -34,11 +37,20 @@ func (n *DeclarativeNode) handle(ctx context.Context, req ExecutionRequest) (Exe
 	}
 	req.NodeID = nodeID
 	if isZeroHandler(req.Handler) {
-		handler, ok := n.executor.deps.Source.NodeEventHandler(nodeID.String(), string(req.Event.Type))
-		if !ok {
+		resolved := resolvedExecutionHandler(n.executor.deps.Source, nodeID.String(), string(req.Event.Type))
+		if !resolved.matched {
 			return ExecutionResult{}, ErrMissingNodeHandler
 		}
-		req.Handler = handler
+		req.Handler = resolved.handler
+		if strings.TrimSpace(req.HandlerEventKey) == "" {
+			req.HandlerEventKey = resolved.handlerEventKey
+		}
+	}
+	if strings.TrimSpace(req.HandlerEventKey) == "" {
+		resolved := resolvedExecutionHandler(n.executor.deps.Source, nodeID.String(), string(req.Event.Type))
+		if resolved.matched {
+			req.HandlerEventKey = resolved.handlerEventKey
+		}
 	}
 	return n.executor.Execute(ctx, req)
 }
@@ -52,4 +64,55 @@ func (n *DeclarativeNode) Handle(ctx context.Context, req ExecutionRequest) (Exe
 
 func isZeroHandler(handler runtimecontracts.SystemNodeEventHandler) bool {
 	return reflect.DeepEqual(handler, runtimecontracts.SystemNodeEventHandler{})
+}
+
+type executionHandlerResolution struct {
+	handler         runtimecontracts.SystemNodeEventHandler
+	handlerEventKey string
+	matched         bool
+}
+
+func resolvedExecutionHandler(source semanticview.Source, nodeID, eventType string) executionHandlerResolution {
+	if source == nil {
+		return executionHandlerResolution{}
+	}
+	if bundle, ok := semanticview.Bundle(source); ok {
+		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
+		if resolved.Matched {
+			handler, ok := source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				handler = resolved.Handler
+			}
+			return executionHandlerResolution{
+				handler:         handler,
+				handlerEventKey: strings.TrimSpace(resolved.AuthoredEventType),
+				matched:         true,
+			}
+		}
+	}
+	handler, ok := source.NodeEventHandler(nodeID, eventType)
+	if !ok {
+		return executionHandlerResolution{}
+	}
+	return executionHandlerResolution{
+		handler:         handler,
+		handlerEventKey: matchedHandlerEventKeyFromHandlers(source.NodeEventHandlers(nodeID), eventType),
+		matched:         true,
+	}
+}
+
+func matchedHandlerEventKeyFromHandlers(handlers map[string]runtimecontracts.SystemNodeEventHandler, eventType string) string {
+	eventType = strings.TrimSpace(eventType)
+	for key := range handlers {
+		if strings.TrimSpace(key) == eventType {
+			return strings.TrimSpace(key)
+		}
+	}
+	for key := range handlers {
+		key = strings.TrimSpace(key)
+		if key != "" && eventidentity.MatchPattern(key, eventType) {
+			return key
+		}
+	}
+	return eventType
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -18,7 +18,6 @@ import (
 	"swarm/internal/runtime/core/identity"
 	"swarm/internal/runtime/core/paths"
 	runtimepinrouting "swarm/internal/runtime/core/pinrouting"
-	"swarm/internal/runtime/core/timeridentity"
 	"swarm/internal/runtime/core/values"
 	"swarm/internal/runtime/entityruntime"
 	"swarm/internal/runtime/semanticview"
@@ -702,7 +701,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	frame.result.AccumulatorCompletionDiagnostics.CompletionMode = spec.Completion.String()
 	frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = len(frame.req.Handler.OnComplete) > 0 || len(spec.OnComplete) > 0
 	frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationNotAttempted
-	bucketRef := timeridentity.NewAccumulatorBucketRef(frame.req.NodeID.String(), string(frame.req.Event.Type))
+	bucketRef := handlerAccumulatorBucketRef(frame.req)
 	if isAccumulationTimeoutEvent(frame.req.Event.Type) {
 		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
 		if !ok || parsed.NodeID != frame.req.NodeID.String() {
@@ -863,7 +862,7 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 	if spec == nil {
 		return nil
 	}
-	acc, _ := loadAccumulator(frame.state.State, frame.req.NodeID, frame.req.Event.Type)
+	acc, _ := loadAccumulatorForBucket(frame.state.State, handlerAccumulatorBucketRef(frame.req))
 	value, err := computeValue(acc, frame.payload, spec)
 	if err != nil {
 		return err
@@ -1140,7 +1139,8 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 	if !frame.accumulatorProjectionEligible {
 		return nil
 	}
-	result := accprojection.ForHandlerWithAccumulator(e.deps.Source, frame.req.FlowID.String(), frame.req.NodeID.String(), string(frame.req.Event.Type), activeAccumulatorName(frame.req.Handler))
+	handlerEventType := handlerAccumulatorEventType(frame.req)
+	result := accprojection.ForHandlerWithAccumulator(e.deps.Source, frame.req.FlowID.String(), frame.req.NodeID.String(), string(handlerEventType), activeAccumulatorName(frame.req.Handler))
 	if len(result.Issues) > 0 {
 		return fmt.Errorf("accumulator projection declarations are invalid: %s", result.Issues[0].Message)
 	}
@@ -1150,9 +1150,9 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 		}
 		return nil
 	}
-	acc, ok := loadAccumulator(frame.state.State, frame.req.NodeID, frame.req.Event.Type)
+	acc, ok := loadAccumulatorForBucket(frame.state.State, handlerAccumulatorBucketRef(frame.req))
 	if !ok {
-		return fmt.Errorf("accumulator projection source missing for node %s event %s", frame.req.NodeID.String(), string(frame.req.Event.Type))
+		return fmt.Errorf("accumulator projection source missing for node %s event %s", frame.req.NodeID.String(), string(handlerEventType))
 	}
 	for _, binding := range result.Bindings {
 		projected, err := e.projectAccumulatorItems(frame, binding, acc.Items)

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -829,11 +829,18 @@ func TestExecutor_AccumulatorProjectionMaterializesForQualifiedRuntimeEvent(t *t
 			Type:    "scoring/score.dimension_complete",
 			Payload: json.RawMessage(`{"dimension":"market","score":87}`),
 		},
-		Handler: handler,
-		State:   testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+		HandlerEventKey: "score.dimension_complete",
+		Handler:         handler,
+		State:           testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
+	}
+	if _, ok := loadAccumulatorForBucket(StateSnapshot{StateCarrier: result.StateMutation.StateCarrier}, accumulatorBucketRef("scoring-node", "score.dimension_complete")); !ok {
+		t.Fatalf("logical accumulator bucket missing from state mutation: %#v", result.StateMutation.StateCarrier.StateBuckets)
+	}
+	if _, ok := loadAccumulatorForBucket(StateSnapshot{StateCarrier: result.StateMutation.StateCarrier}, accumulatorBucketRef("scoring-node", "scoring/score.dimension_complete")); ok {
+		t.Fatalf("concrete runtime event bucket survived in state mutation: %#v", result.StateMutation.StateCarrier.StateBuckets)
 	}
 	scores, ok := result.StateMutation.Metadata["scores"].([]any)
 	if !ok || len(scores) != 1 {
@@ -848,6 +855,135 @@ func TestExecutor_AccumulatorProjectionMaterializesForQualifiedRuntimeEvent(t *t
 	}
 	if _, exists := score["event_type"]; exists {
 		t.Fatalf("projected score leaked accumulator metadata: %#v", score)
+	}
+}
+
+func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEvents(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_count",
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+			DedupBy:      "payload.component_id",
+			DedupPath:    runtimecontracts.RefExpression("payload.component_id").RefPath,
+		},
+	}
+	firstState := testStateSnapshot("pending", map[string]any{"expected_count": 2}, nil, map[string]map[string]any{})
+	first, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "lifecycle-orchestrator",
+		FlowID:   "operating",
+		Event: events.Event{
+			ID:        "evt-a",
+			Type:      "component-scaffold/a/component.scaffolded",
+			Payload:   json.RawMessage(`{"component_id":"a"}`),
+			CreatedAt: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		}.WithEntityID("entity-1"),
+		HandlerEventKey: "component.scaffolded",
+		Handler:         handler,
+		State:           firstState,
+	})
+	if err != nil {
+		t.Fatalf("first Execute error: %v", err)
+	}
+	if !first.AccumulatorCompletionDiagnostics.Relevant || first.AccumulatorCompletionDiagnostics.CompletionReached {
+		t.Fatalf("first diagnostics = %#v, want relevant waiting accumulator", first.AccumulatorCompletionDiagnostics)
+	}
+	secondState := testStateSnapshot("pending", map[string]any{"expected_count": 2}, nil, first.StateMutation.StateCarrier.StateBuckets)
+	second, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "lifecycle-orchestrator",
+		FlowID:   "operating",
+		Event: events.Event{
+			ID:        "evt-b",
+			Type:      "component-scaffold/b/component.scaffolded",
+			Payload:   json.RawMessage(`{"component_id":"b"}`),
+			CreatedAt: time.Date(2026, time.January, 1, 0, 0, 1, 0, time.UTC),
+		}.WithEntityID("entity-1"),
+		HandlerEventKey: "component.scaffolded",
+		Handler:         handler,
+		State:           secondState,
+	})
+	if err != nil {
+		t.Fatalf("second Execute error: %v", err)
+	}
+	if !second.AccumulatorCompletionDiagnostics.CompletionReached {
+		t.Fatalf("second diagnostics = %#v, want completion reached", second.AccumulatorCompletionDiagnostics)
+	}
+	state := StateSnapshot{StateCarrier: second.StateMutation.StateCarrier}
+	acc, ok := loadAccumulatorForBucket(state, accumulatorBucketRef("lifecycle-orchestrator", "component.scaffolded"))
+	if !ok {
+		t.Fatalf("logical accumulator bucket missing: %#v", second.StateMutation.StateCarrier.StateBuckets)
+	}
+	if got := len(acc.Items); got != 2 {
+		t.Fatalf("accumulator items = %d, want 2", got)
+	}
+	if got := acc.Items[0]["event_type"]; got != "component-scaffold/a/component.scaffolded" {
+		t.Fatalf("first item event_type = %#v", got)
+	}
+	if got := acc.Items[1]["event_type"]; got != "component-scaffold/b/component.scaffolded" {
+		t.Fatalf("second item event_type = %#v", got)
+	}
+	if _, ok := loadAccumulatorForBucket(state, accumulatorBucketRef("lifecycle-orchestrator", "component-scaffold/a/component.scaffolded")); ok {
+		t.Fatalf("first concrete event bucket survived: %#v", second.StateMutation.StateCarrier.StateBuckets)
+	}
+	if _, ok := loadAccumulatorForBucket(state, accumulatorBucketRef("lifecycle-orchestrator", "component-scaffold/b/component.scaffolded")); ok {
+		t.Fatalf("second concrete event bucket survived: %#v", second.StateMutation.StateCarrier.StateBuckets)
+	}
+}
+
+func TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	state := testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{})
+	storeAccumulator(&state, "lifecycle-orchestrator", "component.scaffolded", &Accumulator{
+		Items: []map[string]any{
+			{"component_id": "a"},
+			{"component_id": "b"},
+		},
+	})
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "lifecycle-orchestrator",
+		FlowID:   "operating",
+		Event: events.Event{
+			ID:      "evt-b",
+			Type:    "component-scaffold/b/component.scaffolded",
+			Payload: json.RawMessage(`{"component_id":"b"}`),
+		}.WithEntityID("entity-1"),
+		HandlerEventKey: "component.scaffolded",
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpCount,
+				StoreAs:   "entity.component_count",
+			},
+		},
+		State: state,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.StateMutation.Metadata["component_count"]; got != 2 {
+		t.Fatalf("component_count = %#v, want 2", got)
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -280,6 +280,18 @@ func accumulatorBucketRef(nodeID identity.NodeID, eventType events.EventType) ti
 	return timeridentity.NewAccumulatorBucketRef(nodeID.String(), string(eventType))
 }
 
+func handlerAccumulatorEventType(req ExecutionRequest) events.EventType {
+	eventType := strings.TrimSpace(req.HandlerEventKey)
+	if eventType == "" {
+		eventType = strings.TrimSpace(string(req.Event.Type))
+	}
+	return events.EventType(eventType)
+}
+
+func handlerAccumulatorBucketRef(req ExecutionRequest) timeridentity.AccumulatorBucketRef {
+	return accumulatorBucketRef(req.NodeID, handlerAccumulatorEventType(req))
+}
+
 func loadAccumulator(state StateSnapshot, nodeID identity.NodeID, eventType events.EventType) (*Accumulator, bool) {
 	return loadAccumulatorForBucket(state, accumulatorBucketRef(nodeID, eventType))
 }

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -213,11 +213,14 @@ type ExecutionRequest struct {
 	NodeID      identity.NodeID
 	FlowID      identity.FlowID
 	Event       events.Event
-	Handler     runtimecontracts.SystemNodeEventHandler
-	State       StateSnapshot
-	ChainDepth  int
-	MaxDepth    int
-	Preview     bool
+	// HandlerEventKey is the matched authored handler event key selected by
+	// runtime dispatch. Concrete Event.Type remains event provenance.
+	HandlerEventKey string
+	Handler         runtimecontracts.SystemNodeEventHandler
+	State           StateSnapshot
+	ChainDepth      int
+	MaxDepth        int
+	Preview         bool
 }
 
 type ExecutionContext struct {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -238,11 +238,15 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	if trigger == "" {
 		return false, nil
 	}
-	handler, ok := workflowNodeEventHandlerForDelivery(source, nodeID, evt)
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, nodeID, evt)
+	handler := resolved.Handler
+	handlerEventKey := resolved.HandlerEventKey
+	ok := resolved.Matched
 	if !ok && isAccumulationTimeoutEvent(events.EventType(trigger)) {
 		bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload))
 		if bucketOK && strings.TrimSpace(bucket.NodeID) == nodeID {
 			handler, ok = findAccumulationTimeoutHandlerForBucket(source, bucket)
+			handlerEventKey = bucket.EventType
 		}
 	}
 	if !ok {
@@ -250,8 +254,9 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	}
 	ctx = withPipelineFlowScope(ctx, workflowNodeFlowID(source, nodeID))
 	result, err := pc.executeNodeContractHandler(ctx, nodeID, handler, workflowTriggerContext{
-		Event: evt,
-		State: pc.currentWorkflowState(ctx, workflowEventEntityID(evt)),
+		Event:           evt,
+		HandlerEventKey: handlerEventKey,
+		State:           pc.currentWorkflowState(ctx, workflowEventEntityID(evt)),
 	}, false)
 	if err != nil {
 		if errors.Is(err, runtimeengine.ErrChainDepthExceeded) {

--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -22,7 +22,7 @@ func TestCoordinatorHandlerExecutionEngineUsesRuntimeEnginePath(t *testing.T) {
 	}
 	outcome, err := engine.ExecuteHandlerSteps(context.Background(), runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
-	}, events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"))
+	}, events.Event{Type: events.EventType("custom.trigger")}.WithEntityID("ent-1"), "custom.trigger")
 	if err != nil {
 		t.Fatalf("ExecuteHandlerSteps: %v", err)
 	}

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -68,20 +68,22 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 		return contractHandlerExecutionResult{}, nil
 	}
 	var (
-		nodeID  string
-		handler runtimecontracts.SystemNodeEventHandler
-		matched bool
+		nodeID          string
+		handler         runtimecontracts.SystemNodeEventHandler
+		handlerEventKey string
+		matched         bool
 	)
 	for _, owner := range owners {
-		candidate, ok := source.NodeEventHandler(owner, trigger)
-		if !ok {
+		resolved := workflowNodeEventHandlerResolutionForDelivery(source, owner, evt)
+		if !resolved.Matched {
 			continue
 		}
 		if matched {
 			return contractHandlerExecutionResult{}, nil
 		}
 		nodeID = strings.TrimSpace(owner)
-		handler = candidate
+		handler = resolved.Handler
+		handlerEventKey = resolved.HandlerEventKey
 		matched = true
 	}
 	if !matched && isAccumulationTimeoutEvent(events.EventType(trigger)) {
@@ -90,12 +92,16 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 			if ok {
 				nodeID = bucket.NodeID
 				handler = timeoutHandler
+				handlerEventKey = bucket.EventType
 				matched = true
 			}
 		}
 	}
 	if !matched {
 		return contractHandlerExecutionResult{}, nil
+	}
+	if strings.TrimSpace(triggerCtx.HandlerEventKey) == "" {
+		triggerCtx.HandlerEventKey = handlerEventKey
 	}
 	return pc.executeNodeContractHandler(ctx, nodeID, handler, triggerCtx, false)
 }
@@ -209,6 +215,10 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if handler.CreateEntity {
 		ctx = withWorkflowCreateEntityInitialValues(ctx, workflowEntitySchemaInitialValues(source, flowID))
 	}
+	handlerEventKey := strings.TrimSpace(triggerCtx.HandlerEventKey)
+	if handlerEventKey == "" {
+		handlerEventKey = workflowNodeHandlerEventKeyForExecution(source, nodeID, triggerCtx.Event)
+	}
 	deps := coordinatorEngineDependencies(pc)
 	if collectLocally {
 		deps.Outbox = noOpEngineOutbox{}
@@ -226,14 +236,15 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 		return contractHandlerExecutionResult{}, err
 	}
 	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
-		EntityID:   identity.NormalizeEntityID(entityID),
-		NodeID:     identity.NormalizeNodeID(nodeID),
-		FlowID:     identity.NormalizeFlowID(flowID),
-		Event:      triggerCtx.Event,
-		ChainDepth: triggerCtx.Event.ChainDepth,
-		Handler:    handler,
-		Preview:    preview,
-		State:      stateSnapshot,
+		EntityID:        identity.NormalizeEntityID(entityID),
+		NodeID:          identity.NormalizeNodeID(nodeID),
+		FlowID:          identity.NormalizeFlowID(flowID),
+		Event:           triggerCtx.Event,
+		HandlerEventKey: handlerEventKey,
+		ChainDepth:      triggerCtx.Event.ChainDepth,
+		Handler:         handler,
+		Preview:         preview,
+		State:           stateSnapshot,
 	})
 	if !preview {
 		logAccumulatorCompletionOutcome(ctx, pc.bus, nodeID, triggerCtx.Event, result.AccumulatorCompletionDiagnostics, err)
@@ -252,7 +263,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if !preview {
 		pc.recordInterceptedEmitDeadLetters(ctx, triggerCtx.Event, nodeID, handlerOutcomeFromExecutionResult(result))
 	}
-	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, entityID, nodeID, handler, triggerCtx.Event, result.StateMutation.StateCarrier.PersistedStateBuckets(), result.Status == runtimeengine.OutcomeWaiting); err != nil {
+	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, entityID, nodeID, handler, triggerCtx.Event, handlerEventKey, result.StateMutation.StateCarrier.PersistedStateBuckets(), result.Status == runtimeengine.OutcomeWaiting); err != nil {
 		return contractHandlerExecutionResult{}, err
 	}
 	if collectLocally {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -28,7 +28,7 @@ type HandlerOutcome struct {
 }
 
 type HandlerExecutionEngine interface {
-	ExecuteHandlerSteps(ctx context.Context, handler SystemNodeEventHandler, evt Event) (*HandlerOutcome, error)
+	ExecuteHandlerSteps(ctx context.Context, handler SystemNodeEventHandler, evt Event, handlerEventKey string) (*HandlerOutcome, error)
 }
 
 type declarativeWorkflowNode struct {
@@ -172,6 +172,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 		return nil, nil
 	}
 	eventType := strings.TrimSpace(string(evt.Type))
+	handlerEventKey := eventType
 	handler, ok := n.contract.EventHandlers[eventType]
 	if !ok {
 		for pattern, candidate := range n.contract.EventHandlers {
@@ -180,6 +181,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 			}
 			if runtimecontractsHandlerPatternMatches(pattern, eventType) {
 				handler = candidate
+				handlerEventKey = strings.TrimSpace(pattern)
 				ok = true
 				break
 			}
@@ -195,6 +197,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 					continue
 				}
 				handler = candidate
+				handlerEventKey = bucket.EventType
 				ok = true
 				break
 			}
@@ -206,7 +209,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 	if n.engine == nil {
 		return nil, fmt.Errorf("declarative node %s has no handler execution engine", n.NodeID())
 	}
-	outcome, err := n.engine.ExecuteHandlerSteps(ctx, handler, evt)
+	outcome, err := n.engine.ExecuteHandlerSteps(ctx, handler, evt, handlerEventKey)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +272,7 @@ func newCoordinatorHandlerExecutionEngine(pc *PipelineCoordinator, nodeID string
 	return engine
 }
 
-func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Context, handler SystemNodeEventHandler, evt Event) (*HandlerOutcome, error) {
+func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Context, handler SystemNodeEventHandler, evt Event, handlerEventKey string) (*HandlerOutcome, error) {
 	if e == nil || e.coordinator == nil {
 		return nil, fmt.Errorf("handler execution engine is not configured")
 	}
@@ -331,6 +334,10 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		exec = tmpExec
 		node = runtimeengine.NewDeclarativeNode(strings.TrimSpace(e.nodeID), exec)
 	}
+	handlerEventKey = strings.TrimSpace(handlerEventKey)
+	if handlerEventKey == "" {
+		handlerEventKey = workflowNodeHandlerEventKeyForExecution(source, e.nodeID, evt)
+	}
 	workflowVersion := ""
 	if source != nil {
 		workflowVersion = source.WorkflowVersion()
@@ -340,13 +347,14 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		return nil, err
 	}
 	result, err := node.Handle(ctx, runtimeengine.ExecutionRequest{
-		EntityID:   identity.NormalizeEntityID(entityID),
-		NodeID:     identity.NormalizeNodeID(e.nodeID),
-		FlowID:     identity.NormalizeFlowID(flowID),
-		Event:      evt,
-		ChainDepth: evt.ChainDepth,
-		Handler:    handler,
-		State:      stateSnapshot,
+		EntityID:        identity.NormalizeEntityID(entityID),
+		NodeID:          identity.NormalizeNodeID(e.nodeID),
+		FlowID:          identity.NormalizeFlowID(flowID),
+		Event:           evt,
+		HandlerEventKey: handlerEventKey,
+		ChainDepth:      evt.ChainDepth,
+		Handler:         handler,
+		State:           stateSnapshot,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -13,13 +13,15 @@ import (
 )
 
 type recordingExecutionEngine struct {
-	called  bool
-	handler runtimecontracts.SystemNodeEventHandler
+	called          bool
+	handler         runtimecontracts.SystemNodeEventHandler
+	handlerEventKey string
 }
 
-func (r *recordingExecutionEngine) ExecuteHandlerSteps(_ context.Context, handler SystemNodeEventHandler, _ Event) (*HandlerOutcome, error) {
+func (r *recordingExecutionEngine) ExecuteHandlerSteps(_ context.Context, handler SystemNodeEventHandler, _ Event, handlerEventKey string) (*HandlerOutcome, error) {
 	r.called = true
 	r.handler = handler
+	r.handlerEventKey = handlerEventKey
 	return &HandlerOutcome{Handled: true}, nil
 }
 
@@ -75,6 +77,9 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 	if !engine.called {
 		t.Fatal("expected execution engine to be called")
 	}
+	if got := engine.handlerEventKey; got != "item.arrived" {
+		t.Fatalf("handler event key = %q, want item.arrived", got)
+	}
 }
 
 func TestDeclarativeNodeHandleEvent_MatchesWildcardHandler(t *testing.T) {
@@ -94,6 +99,9 @@ func TestDeclarativeNodeHandleEvent_MatchesWildcardHandler(t *testing.T) {
 	}
 	if !engine.called {
 		t.Fatal("expected execution engine to be called")
+	}
+	if got := engine.handlerEventKey; got != "*.completed" {
+		t.Fatalf("handler event key = %q, want *.completed", got)
 	}
 }
 
@@ -135,6 +143,9 @@ func TestDeclarativeNodeHandleEvent_MatchesDeepWildcardChildFlowHandler(t *testi
 	}
 	if !engine.called {
 		t.Fatal("expected execution engine to be called")
+	}
+	if got := engine.handlerEventKey; got != "**/task.done" {
+		t.Fatalf("handler event key = %q, want **/task.done", got)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -9,8 +9,9 @@ import (
 )
 
 type workflowTriggerContext struct {
-	Event events.Event
-	State WorkflowState
+	Event           events.Event
+	HandlerEventKey string
+	State           WorkflowState
 }
 
 type handlerExecutionPlan struct {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -517,8 +517,12 @@ opco.ceo_ready:
 	if _, ok := source.NodeEventHandler("lifecycle-orchestrator", string(evt.Type)); ok {
 		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
 	}
-	if _, ok := workflowNodeEventHandlerForDelivery(source, "lifecycle-orchestrator", evt); !ok {
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "lifecycle-orchestrator", evt)
+	if !resolved.Matched {
 		t.Fatal("expected concrete instance event to resolve to local lifecycle-orchestrator handler")
+	}
+	if got := resolved.HandlerEventKey; got != "opco.product_initialization_requested" {
+		t.Fatalf("handler event key = %q, want opco.product_initialization_requested", got)
 	}
 
 	bus := &recordingPipelineBus{}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -102,21 +102,101 @@ func workflowNodeEventPolicy(nodes []WorkflowNode, nodeID, eventType string) (Wo
 }
 
 func workflowNodeEventHandlerForDelivery(source semanticview.Source, nodeID string, evt events.Event) (runtimecontracts.SystemNodeEventHandler, bool) {
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, nodeID, evt)
+	return resolved.Handler, resolved.Matched
+}
+
+type workflowNodeEventHandlerResolution struct {
+	Handler         runtimecontracts.SystemNodeEventHandler
+	HandlerEventKey string
+	Matched         bool
+}
+
+func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, nodeID string, evt events.Event) workflowNodeEventHandlerResolution {
 	if source == nil {
-		return runtimecontracts.SystemNodeEventHandler{}, false
+		return workflowNodeEventHandlerResolution{}
 	}
 	rawEventType := eventidentity.Normalize(string(evt.Type))
 	if rawEventType == "" {
-		return runtimecontracts.SystemNodeEventHandler{}, false
+		return workflowNodeEventHandlerResolution{}
 	}
-	if handler, ok := source.NodeEventHandler(nodeID, rawEventType); ok {
-		return handler, true
+	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
+		return resolved
 	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
 	if localizedEventType == "" || localizedEventType == rawEventType {
-		return runtimecontracts.SystemNodeEventHandler{}, false
+		return workflowNodeEventHandlerResolution{}
 	}
-	return source.NodeEventHandler(nodeID, localizedEventType)
+	return workflowNodeEventHandlerResolutionForEventType(source, nodeID, localizedEventType)
+}
+
+func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, nodeID, eventType string) workflowNodeEventHandlerResolution {
+	if source == nil {
+		return workflowNodeEventHandlerResolution{}
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return workflowNodeEventHandlerResolution{}
+	}
+	if bundle, ok := semanticview.Bundle(source); ok {
+		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
+		if resolved.Matched {
+			handler, ok := source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				handler = resolved.Handler
+			}
+			return workflowNodeEventHandlerResolution{
+				Handler:         handler,
+				HandlerEventKey: strings.TrimSpace(resolved.AuthoredEventType),
+				Matched:         true,
+			}
+		}
+	}
+	handler, ok := source.NodeEventHandler(nodeID, eventType)
+	if !ok {
+		return workflowNodeEventHandlerResolution{}
+	}
+	return workflowNodeEventHandlerResolution{
+		Handler:         handler,
+		HandlerEventKey: workflowNodeMatchedHandlerEventKey(source, nodeID, eventType),
+		Matched:         true,
+	}
+}
+
+func workflowNodeMatchedHandlerEventKey(source semanticview.Source, nodeID, eventType string) string {
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil {
+		return eventType
+	}
+	handlers := source.NodeEventHandlers(nodeID)
+	if len(handlers) == 0 {
+		return eventType
+	}
+	for key := range handlers {
+		if eventidentity.Normalize(key) == eventType {
+			return strings.TrimSpace(key)
+		}
+	}
+	for key := range handlers {
+		key = strings.TrimSpace(key)
+		if key != "" && runtimecontractsHandlerPatternMatches(key, eventType) {
+			return key
+		}
+	}
+	return eventType
+}
+
+func workflowNodeHandlerEventKeyForExecution(source semanticview.Source, nodeID string, evt events.Event) string {
+	if isAccumulationTimeoutEvent(evt.Type) {
+		if bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); ok && strings.TrimSpace(bucket.NodeID) == strings.TrimSpace(nodeID) {
+			return bucket.EventType
+		}
+	}
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, nodeID, evt)
+	if resolved.Matched {
+		return resolved.HandlerEventKey
+	}
+	return eventidentity.Normalize(string(evt.Type))
 }
 
 func workflowNodeConcreteInstanceLocalEventType(source semanticview.Source, nodeID string, evt events.Event) string {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -173,6 +173,7 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	entityID, nodeID string,
 	handler runtimecontracts.SystemNodeEventHandler,
 	evt Event,
+	handlerEventKey string,
 	stateBuckets map[string]any,
 	waiting bool,
 ) error {
@@ -188,7 +189,7 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	if entityID == "" || nodeID == "" {
 		return nil
 	}
-	bucketRef, ok := accumulationTimeoutBucketRef(evt, nodeID)
+	bucketRef, ok := accumulationTimeoutBucketRef(evt, nodeID, handlerEventKey)
 	if !ok {
 		return nil
 	}
@@ -213,13 +214,17 @@ func workflowTimerLifecycleMatches(trigger timeridentity.Trigger, stage, sourceE
 	return trigger.MatchesStage(stage) || trigger.MatchesEvent(sourceEvent)
 }
 
-func accumulationTimeoutBucketRef(evt Event, nodeID string) (timeridentity.AccumulatorBucketRef, bool) {
+func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string) (timeridentity.AccumulatorBucketRef, bool) {
 	nodeID = strings.TrimSpace(nodeID)
 	if nodeID == "" {
 		return timeridentity.AccumulatorBucketRef{}, false
 	}
 	if !isAccumulationTimeoutEvent(evt.Type) {
-		bucket := timeridentity.NewAccumulatorBucketRef(nodeID, string(evt.Type))
+		eventType := strings.TrimSpace(handlerEventKey)
+		if eventType == "" {
+			eventType = strings.TrimSpace(string(evt.Type))
+		}
+		bucket := timeridentity.NewAccumulatorBucketRef(nodeID, eventType)
 		return bucket, bucket.Valid()
 	}
 	bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload))

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	"swarm/internal/events"
 	runtimecontracts "swarm/internal/runtime/contracts"
 	"swarm/internal/runtime/core/timeridentity"
+	"swarm/internal/runtime/semanticview"
 	"swarm/internal/testutil"
 )
 
@@ -393,6 +394,78 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	}
 	if handle.Bucket.NodeID != "test-node" || handle.Bucket.EventType != "item.arrived" {
 		t.Fatalf("scheduled payload = %#v", payload)
+	}
+}
+
+func TestReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier2-accumulation", "test-accumulate-timeout")
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	module, err := newPipelineFixtureWorkflowModule(bundle)
+	if err != nil {
+		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
+	}
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
+	if pc == nil {
+		t.Fatal("expected coordinator")
+	}
+	start := time.Now().UTC()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_count",
+			Completion:   runtimecontracts.ParseAccumulateCompletion("timeout"),
+			TimeoutMS:    5000,
+		},
+	}
+	stateBuckets := map[string]any{
+		"test-node": map[string]any{
+			"handler_accumulators": map[string]any{
+				timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived").Key(): map[string]any{
+					"started_at": start.Format(time.RFC3339Nano),
+				},
+			},
+		},
+	}
+	evt := events.Event{
+		ID:          "evt-item-a",
+		Type:        events.EventType("component-scaffold/a/item.arrived"),
+		SourceAgent: "cataloge2e",
+		Payload:     []byte(`{"entity_id":"ent-001","item_id":"a"}`),
+		CreatedAt:   start,
+	}.WithEntityID("ent-001").WithFlowInstance("component-scaffold/a")
+
+	if err := pc.reconcileAccumulationTimeoutSchedule(context.Background(), "ent-001", "test-node", handler, evt, "item.arrived", stateBuckets, true); err != nil {
+		t.Fatalf("reconcileAccumulationTimeoutSchedule: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("registered schedules = %d, want 1", len(store.schedules))
+	}
+	got := store.schedules[0]
+	wantHandle := timeridentity.AccumulationTimeoutHandle(timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived"))
+	if got.TaskID != wantHandle.TaskID() {
+		t.Fatalf("scheduled task_id = %q, want %q", got.TaskID, wantHandle.TaskID())
+	}
+	if got.At.Before(start.Add(4900*time.Millisecond)) || got.At.After(start.Add(5100*time.Millisecond)) {
+		t.Fatalf("scheduled at = %s, want about %s", got.At.Format(time.RFC3339Nano), start.Add(5*time.Second).Format(time.RFC3339Nano))
+	}
+	payload := parsePayloadMap(got.Payload)
+	handle, ok := timeridentity.ParseTimerHandle(payload)
+	if !ok || handle.Kind != timeridentity.TimerHandleAccumulationTimeout {
+		t.Fatalf("scheduled payload = %#v", payload)
+	}
+	if handle.Bucket.NodeID != "test-node" || handle.Bucket.EventType != "item.arrived" {
+		t.Fatalf("scheduled payload bucket = %#v", handle.Bucket)
+	}
+	if _, ok := findAccumulationTimeoutHandlerForBucket(semanticview.Wrap(bundle), handle.Bucket); !ok {
+		t.Fatalf("timeout handler did not resolve for scheduled bucket %#v", handle.Bucket)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1975,6 +1975,14 @@ engine:
     tracking:
       setup: 'When an entity first encounters a handler with accumulate.track, the platform creates an accumulator record:
         expected items list, received items list (empty).'
+      bucket_identity: |
+        Handler accumulator buckets are keyed by the selected authored handler
+        event key after runtime handler resolution/localization, not by the
+        concrete event-bus event type that delivered the event. The concrete
+        event type remains event provenance and must be retained on accumulated
+        item metadata and diagnostics. Timeout bucket handles, compute reads,
+        and `materialize_from` projection reads must consume the same selected
+        handler event key.
       arrival: 'Each event arrival is identified by its dedup_by key. Default: sender session ID. Can be overridden to a payload
         field (e.g., payload.dimension). If the key was already received, the arrival is ignored (idempotent). If not, it
         is added to the received set and persisted.'


### PR DESCRIPTION
## Summary

- Carry the selected authored handler event key through pipeline/direct execution into `runtimeengine.ExecutionRequest`.
- Key handler accumulator write/read, compute reads, projection reads, and timeout schedule/payload lookup from that matched handler key while preserving concrete runtime event type as item provenance.
- Update `platform-spec.yaml#engine.accumulation_engine.tracking.bucket_identity` to make the runtime bucket identity rule authoritative.

## Governing refs / context

- `platform-spec.yaml#engine.event_identity`
- `platform-spec.yaml#entity_contracts.accumulator_entity_projection.runtime_binding_identity`
- `platform-spec.yaml#handler_specification.accumulate`
- `platform-spec.yaml#engine.accumulation_engine.tracking.bucket_identity`
- #1119 pre-audit and approved first-slice gate

## Semantic migration

- New canonical consumer path: `WorkflowContractBundle.ResolveNodeEventHandler` selects the authored handler key, and pipeline/direct execution carries it as `ExecutionRequest.HandlerEventKey`.
- Old invalid path: treating concrete `ExecutionRequest.Event.Type` as authoritative accumulator bucket identity.
- Production paths checked: pipeline delivery, authoritative runtime ingress, direct/declarative node execution, timeout scheduling/cancellation payloads, accumulator write/read, compute reads, and projection reads.
- Migration status: complete for the approved #1119 child class. Concrete scoped event type still survives as accumulator item/event provenance.

## Verification

- `go test ./internal/runtime/engine -run 'TestExecutor_(AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEvents|ComputeReadsAccumulatorByMatchedHandlerEventKey|AccumulatorProjectionMaterializesForQualifiedRuntimeEvent)$'`
- `go test ./internal/runtime/pipeline -run 'Test(TemplateInstanceSystemNodeDeliveryLocalizesConcreteEventToHandlerKey|DeclarativeNodeHandleEvent_(SelectsOnTimeoutAccumulatorHandler|MatchesWildcardHandler|MatchesDeepWildcardChildFlowHandler)|ReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey)$'`
- `go test ./internal/runtime/engine ./internal/runtime/pipeline`
- `go test ./...`

Closes #1119