### PR TITLE
[agent-g][issue #1138] Add host workspace backend

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -28,6 +28,7 @@ type runtimeProjectSupervisor struct {
 	ready            *atomic.Bool
 	dev              bool
 	mountSources     workspaceMountSources
+	workspaceBackend workspaceBackendSelection
 	startRuntime     func(context.Context, *runtime.Runtime) error
 	shutdownRuntime  func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
@@ -51,6 +52,7 @@ func newRuntimeProjectSupervisor(
 	stores storeBundle,
 	ready *atomic.Bool,
 	mountSources workspaceMountSources,
+	workspaceBackend workspaceBackendSelection,
 	initialRoot string,
 	initialBundle *runtimecontracts.WorkflowContractBundle,
 	initialSource semanticview.Source,
@@ -69,6 +71,7 @@ func newRuntimeProjectSupervisor(
 		ready:            ready,
 		dev:              dev,
 		mountSources:     mountSources,
+		workspaceBackend: workspaceBackend,
 		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
 			return rt.Start(ctx)
 		},
@@ -83,7 +86,7 @@ func newRuntimeProjectSupervisor(
 		},
 		initStateStores: initializeStateStores,
 		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
-			return configuredWorkspaceLifecycle(stores.SQLDB, contractsRoot, source, mountSources)
+			return configuredWorkspaceLifecycleForBackend(stores.SQLDB, contractsRoot, source, mountSources, workspaceBackend)
 		},
 		createRuntime: func(ctx context.Context, deps runtime.RuntimeDeps) (*runtime.Runtime, error) {
 			return runtime.NewRuntime(ctx, deps)

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -207,7 +207,7 @@ func newSupervisorForLoadProjectFailureTest(
 	bundle := testBuilderSupervisorBundle(t)
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
-	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, "", nil, nil, nil)
+	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, "", nil, nil, nil)
 	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -143,6 +143,13 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 					return fmt.Errorf("--data must be non-empty")
 				}
 			}
+			if cmd.Flags().Changed("workspace-backend") {
+				backend, err := normalizeWorkspaceBackend(opts.WorkspaceBackend, "--workspace-backend")
+				if err != nil {
+					return err
+				}
+				opts.WorkspaceBackend = backend
+			}
 			if opts.Dev {
 				opts.AbandonActiveRuns = true
 				opts.NoRequireBundleMatch = true
@@ -152,6 +159,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 				opts.RequireBundleMatch = false
 			}
 			opts.StoreModeSet = cmd.Flags().Changed("store")
+			opts.WorkspaceBackendSet = cmd.Flags().Changed("workspace-backend")
 			if opts.ShutdownGrace <= 0 {
 				return fmt.Errorf("--shutdown-grace must be a positive duration")
 			}
@@ -187,6 +195,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, or openai_compatible")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
+	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend for local serve: docker (default isolation backend) or host (explicit local-dev opt-in)")
 	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -73,8 +73,8 @@ const (
 var (
 	buildStoresForServe                  = buildStores
 	runtimeConfigExecutablePath          = os.Executable
-	configuredWorkspaceLifecycleForServe = func(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (serveWorkspaceLifecycle, error) {
-		return configuredWorkspaceLifecycle(db, contractsRoot, source, mountSources)
+	configuredWorkspaceLifecycleForServe = func(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+		return configuredWorkspaceLifecycleForBackend(db, contractsRoot, source, mountSources, backend)
 	}
 )
 
@@ -192,6 +192,8 @@ type serveOptions struct {
 	Backend              string
 	ContractsPath        string
 	DataSource           string
+	WorkspaceBackend     string
+	WorkspaceBackendSet  bool
 	BundleHash           string
 	BundleHashes         []string
 	PlatformSpecPath     string
@@ -238,6 +240,7 @@ type serveRuntimeBundleContextRequest struct {
 	Loaded                 serveRuntimeBundle
 	Options                serveOptions
 	MountSources           workspaceMountSources
+	WorkspaceBackend       workspaceBackendSelection
 	Credentials            runtimecredentials.Store
 	BootStartedAt          time.Time
 	BootProgress           func(runtime.BootProgressEvent)
@@ -250,6 +253,7 @@ type serveRuntimeBundleContextRequest struct {
 func defaultServeOptions() serveOptions {
 	return serveOptions{
 		StoreMode:          storebackend.ActiveDefaultBackend().String(),
+		WorkspaceBackend:   defaultWorkspaceBackend,
 		APIListenAddr:      defaultAPIListenAddr,
 		MCPListenAddr:      defaultMCPListenAddr,
 		ShutdownGrace:      runtime.DefaultShutdownGrace,
@@ -490,7 +494,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	}
 	bootIdentity := loaded.bootIdentity
 	bootIdentity.BundleHash = strings.TrimSpace(bundleSourceFact.BundleHash)
-	workspaces, err := configuredWorkspaceLifecycleForServe(req.Stores.SQLDB, loaded.contractsRoot, loaded.source, req.MountSources)
+	workspaces, err := configuredWorkspaceLifecycleForServe(req.Stores.SQLDB, loaded.contractsRoot, loaded.source, req.MountSources, req.WorkspaceBackend)
 	if err != nil {
 		return serveRuntimeBundleContext{}, fmt.Errorf("configure workspaces: %w", err)
 	}
@@ -609,6 +613,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("resolve workspace data source: %v", err)
 		return 1
 	}
+	workspaceBackend, err := resolveWorkspaceBackend(opts.WorkspaceBackend, opts.WorkspaceBackendSet, cfg)
+	if err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
+		log.Printf("resolve workspace backend: %v", err)
+		return 1
+	}
 	storeSelection, err := resolveRuntimeStoreSelection(repo, opts.StoreMode, opts.StoreModeSet, cfg)
 	if err != nil {
 		reporter.emit(3, "db_connection", "FAILED", err.Error())
@@ -659,7 +669,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
 	if stores.Postgres != nil {
-		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(stores.SQLDB, loadedBundle.contractsRoot, source, mountSources)
+		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(stores.SQLDB, loadedBundle.contractsRoot, source, mountSources, workspaceBackend)
 		if err != nil {
 			slog.Error("configure recovery workspaces", "error", err)
 			return 1
@@ -711,6 +721,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			Loaded:                 loaded,
 			Options:                opts,
 			MountSources:           mountSources,
+			WorkspaceBackend:       workspaceBackend,
 			Credentials:            credentialStore,
 			BootStartedAt:          bootStartedAt,
 			BootProgress:           reporter.runtimeSink(),
@@ -767,7 +778,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackend, contractsRoot, bundle, source, rt, opts.Dev)
 	if len(pinnedBundleHashes) > 0 {
 		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is split to RuntimeContextManager Load/Unload work")
 	}
@@ -1404,7 +1415,14 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
-		workspaces, err := configuredWorkspaceLifecycle(stores.SQLDB, contractsRoot, source, mountSources)
+		workspaceBackend, err := resolveWorkspaceBackend("", false, cfg)
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: resolve workspace backend: %v\n", err)
+			}
+			return 1
+		}
+		workspaces, err := configuredWorkspaceLifecycleForBackend(stores.SQLDB, contractsRoot, source, mountSources, workspaceBackend)
 		if err != nil {
 			if out != nil {
 				fmt.Fprintf(out, "fork failed: configure workspaces: %v\n", err)
@@ -3068,6 +3086,42 @@ func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source seman
 			}
 			return nil, fmt.Errorf("workspace data source from %s cannot be combined with SWARM_WORKSPACE_VOLUMES_FROM=%s", sourceLabel, volumesFrom)
 		}
+		cfg.SharedDataSource = dataSource
+	}
+	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {
+		cfg.ContractsSource = contractsDir
+	}
+	manager.SetConfig(cfg)
+	manager.SetSemanticSource(source)
+	return manager, nil
+}
+
+func configuredWorkspaceLifecycleForBackend(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	selected := strings.TrimSpace(backend.Backend)
+	if selected == "" {
+		selected = defaultWorkspaceBackend
+	}
+	switch selected {
+	case workspace.BackendDocker:
+		return configuredWorkspaceLifecycle(db, contractsRoot, source, mountSources)
+	case workspace.BackendHost:
+		return configuredHostWorkspaceLifecycle(db, contractsRoot, source, mountSources)
+	default:
+		sourceLabel := strings.TrimSpace(backend.Source)
+		if sourceLabel == "" {
+			sourceLabel = "workspace backend"
+		}
+		return nil, fmt.Errorf("workspace backend from %s must be docker or host, got %q", sourceLabel, selected)
+	}
+}
+
+func configuredHostWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.HostManager, error) {
+	if volumesFrom := strings.TrimSpace(os.Getenv("SWARM_WORKSPACE_VOLUMES_FROM")); volumesFrom != "" {
+		return nil, fmt.Errorf("host workspace backend cannot consume SWARM_WORKSPACE_VOLUMES_FROM=%s", volumesFrom)
+	}
+	manager := workspace.NewHostManager(db)
+	cfg := workspace.DefaultHostConfig()
+	if dataSource := strings.TrimSpace(mountSources.DataSource); dataSource != "" {
 		cfg.SharedDataSource = dataSource
 	}
 	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -40,6 +40,7 @@ import (
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/runtime/sessions"
 	runtimetools "swarm/internal/runtime/tools"
+	workspace "swarm/internal/runtime/workspace"
 	"swarm/internal/store"
 	storebackend "swarm/internal/store/backendselection"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
@@ -315,7 +316,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--data", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--data", "--workspace-backend", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -732,6 +733,35 @@ func TestCLI_ServeDataFlagRejectsEmptySource(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--data must be non-empty") {
 		t.Fatalf("serve stderr = %q, want --data validation error", stderr.String())
+	}
+}
+
+func TestCLI_ServeWorkspaceBackendFlagFeedsServeOptions(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--workspace-backend", "host"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.WorkspaceBackend != workspace.BackendHost || !captured.WorkspaceBackendSet {
+		t.Fatalf("workspace backend opts = backend %q set %v, want host set=true", captured.WorkspaceBackend, captured.WorkspaceBackendSet)
+	}
+}
+
+func TestCLI_ServeWorkspaceBackendFlagRejectsUnsupportedBackend(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--workspace-backend", "none"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code == 0 {
+		t.Fatalf("serve code = 0, want failure stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--workspace-backend") || !strings.Contains(stderr.String(), "docker or host") {
+		t.Fatalf("serve stderr = %q, want workspace backend validation error", stderr.String())
 	}
 }
 
@@ -1438,6 +1468,45 @@ func TestConfiguredWorkspaceLifecycleRejectsExplicitDataSourceWithVolumesFrom(t 
 	}
 }
 
+func TestConfiguredWorkspaceLifecycleForBackendSelectsHostWithoutDocker(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "")
+	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+		DataSource:       dataDir,
+		DataSourceSource: "--data",
+	}, workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend"})
+	if err != nil {
+		t.Fatalf("configuredWorkspaceLifecycleForBackend: %v", err)
+	}
+	manager, ok := lifecycle.(*workspace.HostManager)
+	if !ok {
+		t.Fatalf("lifecycle = %T, want *workspace.HostManager", lifecycle)
+	}
+	if err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	if err := manager.EnsureSystemWorkspaces(context.Background()); err != nil {
+		t.Fatalf("EnsureSystemWorkspaces: %v", err)
+	}
+}
+
+func TestConfiguredWorkspaceLifecycleForBackendRejectsHostVolumesFrom(t *testing.T) {
+	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "swarm-orchestrator")
+	_, err := configuredWorkspaceLifecycleForBackend(nil, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+		DataSource:       t.TempDir(),
+		DataSourceSource: "--data",
+	}, workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend"})
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend cannot consume SWARM_WORKSPACE_VOLUMES_FROM") {
+		t.Fatalf("configuredWorkspaceLifecycleForBackend error = %v, want host volumes-from rejection", err)
+	}
+}
+
 func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	repoRoot := t.TempDir()
 	flagDir := filepath.Join(repoRoot, "flag-data")
@@ -1574,6 +1643,70 @@ func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing
 	}
 }
 
+func TestResolveWorkspaceBackendPrecedence(t *testing.T) {
+	result, err := resolveWorkspaceBackendFromInput(workspaceBackendInput{
+		FlagBackend:   "host",
+		FlagSet:       true,
+		ConfigBackend: workspace.BackendDocker,
+		ConfigSet:     true,
+		EnvBackend:    workspace.BackendDocker,
+		EnvSet:        true,
+	})
+	if err != nil {
+		t.Fatalf("resolve workspace backend flag precedence: %v", err)
+	}
+	if result.Backend != workspace.BackendHost || result.Source != "--workspace-backend" {
+		t.Fatalf("flag precedence result = %#v, want host from --workspace-backend", result)
+	}
+
+	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{
+		ConfigBackend: workspace.BackendHost,
+		ConfigSet:     true,
+		EnvBackend:    workspace.BackendDocker,
+		EnvSet:        true,
+	})
+	if err != nil {
+		t.Fatalf("resolve workspace backend config precedence: %v", err)
+	}
+	if result.Backend != workspace.BackendHost || result.Source != "workspace.backend" {
+		t.Fatalf("config precedence result = %#v, want host from workspace.backend", result)
+	}
+
+	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{
+		EnvBackend: workspace.BackendHost,
+		EnvSet:     true,
+	})
+	if err != nil {
+		t.Fatalf("resolve workspace backend env precedence: %v", err)
+	}
+	if result.Backend != workspace.BackendHost || result.Source != envWorkspaceBackend {
+		t.Fatalf("env precedence result = %#v, want host from %s", result, envWorkspaceBackend)
+	}
+
+	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{})
+	if err != nil {
+		t.Fatalf("resolve workspace backend default: %v", err)
+	}
+	if result.Backend != workspace.BackendDocker || result.Source != "default" {
+		t.Fatalf("default result = %#v, want docker default", result)
+	}
+}
+
+func TestResolveWorkspaceBackendRejectsEmptyConfigBeforeEnvFallback(t *testing.T) {
+	result, err := resolveWorkspaceBackendFromInput(workspaceBackendInput{
+		ConfigBackend: " \t ",
+		ConfigSet:     true,
+		EnvBackend:    workspace.BackendHost,
+		EnvSet:        true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "workspace.backend") || !strings.Contains(err.Error(), "must be non-empty") {
+		t.Fatalf("resolve empty configured workspace backend error = %v, want fail-closed config rejection before env fallback", err)
+	}
+	if result.Backend != "" || result.Source != "workspace.backend" {
+		t.Fatalf("empty configured workspace backend result = %#v, want no env fallback", result)
+	}
+}
+
 func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 	var spec struct {
 		WorkspaceModel struct {
@@ -1647,6 +1780,113 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
 		if !joinedContains(command.Consumers, want) {
 			t.Fatalf("serve command data authority consumers missing %q: %#v", want, command.Consumers)
+		}
+	}
+}
+
+func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
+	var spec struct {
+		WorkspaceModel struct {
+			WorkspaceBackendSelection struct {
+				PromotedBy           string   `yaml:"promoted_by"`
+				ImplementationStatus string   `yaml:"implementation_status"`
+				CanonicalOwner       string   `yaml:"canonical_owner"`
+				Scope                string   `yaml:"scope"`
+				CLIFlag              string   `yaml:"cli_flag"`
+				ConfigKey            string   `yaml:"config_key"`
+				EnvVar               string   `yaml:"env_var"`
+				SourceOrder          []string `yaml:"source_order"`
+				DefaultBackend       string   `yaml:"default_backend"`
+				Backends             map[string]struct {
+					Behavior      string `yaml:"behavior"`
+					WorkspaceRoot struct {
+						EnvVar  string `yaml:"env_var"`
+						Default string `yaml:"default"`
+						Rule    string `yaml:"rule"`
+					} `yaml:"workspace_root"`
+				} `yaml:"backends"`
+				FailureBehavior []string `yaml:"failure_behavior"`
+				Consumers       []string `yaml:"consumers"`
+				SplitScope      []string `yaml:"split_scope"`
+			} `yaml:"workspace_backend_selection"`
+		} `yaml:"workspace_model"`
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					WorkspaceBackendSelection struct {
+						PromotedBy     string   `yaml:"promoted_by"`
+						Owner          string   `yaml:"owner"`
+						Flag           string   `yaml:"flag"`
+						ConfigKey      string   `yaml:"config_key"`
+						EnvVar         string   `yaml:"env_var"`
+						DefaultBackend string   `yaml:"default_backend"`
+						Consumers      []string `yaml:"consumers"`
+					} `yaml:"workspace_backend_selection"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	authority := spec.WorkspaceModel.WorkspaceBackendSelection
+	if strings.TrimSpace(authority.PromotedBy) != "#1138" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+		t.Fatalf("workspace backend authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
+	}
+	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_backend_selection") {
+		t.Fatalf("workspace backend canonical owner = %q", authority.CanonicalOwner)
+	}
+	if authority.CLIFlag != "--workspace-backend <docker|host>" || authority.ConfigKey != "workspace.backend" || authority.EnvVar != envWorkspaceBackend {
+		t.Fatalf("workspace backend selectors = %#v", authority)
+	}
+	for _, want := range []string{"--workspace-backend", "workspace.backend", envWorkspaceBackend, "docker default"} {
+		if !stringSliceContains(authority.SourceOrder, want) {
+			t.Fatalf("workspace backend order missing %q: %#v", want, authority.SourceOrder)
+		}
+	}
+	if authority.DefaultBackend != workspace.BackendDocker {
+		t.Fatalf("workspace backend default = %q, want docker", authority.DefaultBackend)
+	}
+	dockerBackend, ok := authority.Backends[workspace.BackendDocker]
+	if !ok || !strings.Contains(dockerBackend.Behavior, "Docker fail-closed") || !strings.Contains(dockerBackend.Behavior, "configured workspace image") {
+		t.Fatalf("docker backend spec missing default fail-closed behavior: %#v", authority.Backends)
+	}
+	hostBackend, ok := authority.Backends[workspace.BackendHost]
+	if !ok || !strings.Contains(hostBackend.Behavior, "Explicit local-dev opt-in") || !strings.Contains(hostBackend.Behavior, "MUST NOT require Docker") {
+		t.Fatalf("host backend spec missing local-dev no-Docker behavior: %#v", authority.Backends)
+	}
+	if hostBackend.WorkspaceRoot.EnvVar != workspace.EnvHostWorkspaceRoot || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
+		t.Fatalf("host workspace root spec = %#v", hostBackend.WorkspaceRoot)
+	}
+	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "SWARM_WORKSPACE_VOLUMES_FROM", "Claude CLI", "native tool execution"} {
+		if !joinedContains(authority.FailureBehavior, want) {
+			t.Fatalf("workspace backend failure behavior missing %q: %#v", want, authority.FailureBehavior)
+		}
+	}
+	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+		if !joinedContains(authority.Consumers, want) {
+			t.Fatalf("workspace backend consumers missing %q: %#v", want, authority.Consumers)
+		}
+	}
+	for _, want := range []string{"#1137", "#1136", "full host Claude CLI", "production SQLite"} {
+		if !joinedContains(authority.SplitScope, want) {
+			t.Fatalf("workspace backend split scope missing %q: %#v", want, authority.SplitScope)
+		}
+	}
+	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceBackendSelection
+	if command.PromotedBy != "#1138" || command.Owner != "workspace_model.workspace_backend_selection" || command.Flag != "--workspace-backend <docker|host>" {
+		t.Fatalf("serve command workspace backend authority = %#v", command)
+	}
+	if command.ConfigKey != "workspace.backend" || command.EnvVar != envWorkspaceBackend || command.DefaultBackend != workspace.BackendDocker {
+		t.Fatalf("serve command workspace backend selectors = %#v", command)
+	}
+	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+		if !joinedContains(command.Consumers, want) {
+			t.Fatalf("serve command workspace backend consumers missing %q: %#v", want, command.Consumers)
 		}
 	}
 }
@@ -2621,6 +2861,59 @@ func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 	}
 }
 
+func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
+	dataDir := t.TempDir()
+	configPath := writeServeRuntimeTestConfig(t)
+
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(serveCtx, repoRoot(), serveOptions{
+			ConfigPath:           configPath,
+			ContractsPath:        filepath.Join("tests", "tier1-primitives", "test-emits-single"),
+			DataSource:           dataDir,
+			WorkspaceBackend:     workspace.BackendHost,
+			WorkspaceBackendSet:  true,
+			PlatformSpecPath:     defaultPlatformSpecPath,
+			StoreMode:            storebackend.ActiveDefaultBackend().String(),
+			APIListenAddr:        "127.0.0.1:0",
+			MCPListenAddr:        "127.0.0.1:0",
+			SelfCheck:            true,
+			RequireBundleMatch:   false,
+			ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
+			Verbose:              true,
+			Output:               &out,
+			NoRequireBundleMatch: true,
+		})
+	}()
+	stopped := false
+	t.Cleanup(func() {
+		if stopped {
+			return
+		}
+		cancelServe()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out stopping runServeRuntime\noutput:\n%s", out.String())
+		}
+	})
+	waitForServeReadyLine(t, &out, done)
+	cancelServe()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	stopped = true
+	if strings.Contains(out.String(), "workspace image") || strings.Contains(out.String(), "docker is not available") {
+		t.Fatalf("host workspace serve output shows Docker dependency despite host backend:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	_, _, _ = installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -2832,7 +3125,7 @@ func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, wor
 			TurnStore:           runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources, _ workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return workspaceFactory(mountSources), nil
 	}
 	t.Cleanup(func() {
@@ -5825,7 +6118,7 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 			TurnStore:          runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
@@ -5918,7 +6211,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 					TurnStore:          runtimePG,
 				}, nil
 			}
-			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 				return serveRuntimeWorkspaceStub{}, nil
 			}
 			t.Cleanup(func() {
@@ -6085,7 +6378,7 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 			TurnStore:          runtimePG,
 		}, nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1862,7 +1862,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if hostBackend.WorkspaceRoot.EnvVar != workspace.EnvHostWorkspaceRoot || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
 		t.Fatalf("host workspace root spec = %#v", hostBackend.WorkspaceRoot)
 	}
-	for _, want := range []string{"canonical/evaluated paths", "symlink escapes"} {
+	for _, want := range []string{"canonical/evaluated paths", "Every host lifecycle consumer", "symlink escapes"} {
 		if !strings.Contains(hostBackend.WorkspaceRoot.Rule, want) {
 			t.Fatalf("host workspace root rule missing %q:\n%s", want, hostBackend.WorkspaceRoot.Rule)
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1862,6 +1862,11 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if hostBackend.WorkspaceRoot.EnvVar != workspace.EnvHostWorkspaceRoot || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
 		t.Fatalf("host workspace root spec = %#v", hostBackend.WorkspaceRoot)
 	}
+	for _, want := range []string{"canonical/evaluated paths", "symlink escapes"} {
+		if !strings.Contains(hostBackend.WorkspaceRoot.Rule, want) {
+			t.Fatalf("host workspace root rule missing %q:\n%s", want, hostBackend.WorkspaceRoot.Rule)
+		}
+	}
 	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "SWARM_WORKSPACE_VOLUMES_FROM", "Claude CLI", "native tool execution"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("workspace backend failure behavior missing %q: %#v", want, authority.FailureBehavior)

--- a/cmd/swarm/workspace_backend.go
+++ b/cmd/swarm/workspace_backend.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"swarm/internal/config"
+	workspace "swarm/internal/runtime/workspace"
+)
+
+const (
+	envWorkspaceBackend     = "SWARM_WORKSPACE_BACKEND"
+	defaultWorkspaceBackend = workspace.BackendDocker
+)
+
+type workspaceBackendSelection struct {
+	Backend string
+	Source  string
+}
+
+type workspaceBackendInput struct {
+	FlagBackend string
+	FlagSet     bool
+
+	ConfigBackend string
+	ConfigSet     bool
+
+	EnvBackend string
+	EnvSet     bool
+}
+
+func resolveWorkspaceBackend(flagBackend string, flagSet bool, cfg *config.Config) (workspaceBackendSelection, error) {
+	envBackend, envSet := os.LookupEnv(envWorkspaceBackend)
+	configBackend, configSet := runtimeConfigWorkspaceBackend(cfg)
+	return resolveWorkspaceBackendFromInput(workspaceBackendInput{
+		FlagBackend:   flagBackend,
+		FlagSet:       flagSet,
+		ConfigBackend: configBackend,
+		ConfigSet:     configSet,
+		EnvBackend:    envBackend,
+		EnvSet:        envSet,
+	})
+}
+
+func resolveWorkspaceBackendFromInput(in workspaceBackendInput) (workspaceBackendSelection, error) {
+	switch {
+	case in.FlagSet:
+		backend, err := normalizeWorkspaceBackend(in.FlagBackend, "--workspace-backend")
+		return workspaceBackendSelection{Backend: backend, Source: "--workspace-backend"}, err
+	case in.ConfigSet:
+		backend, err := normalizeWorkspaceBackend(in.ConfigBackend, "workspace.backend")
+		return workspaceBackendSelection{Backend: backend, Source: "workspace.backend"}, err
+	case in.EnvSet:
+		backend, err := normalizeWorkspaceBackend(in.EnvBackend, envWorkspaceBackend)
+		return workspaceBackendSelection{Backend: backend, Source: envWorkspaceBackend}, err
+	default:
+		return workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, nil
+	}
+}
+
+func runtimeConfigWorkspaceBackend(cfg *config.Config) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	return cfg.Workspace.Backend, cfg.Workspace.BackendConfigured()
+}
+
+func normalizeWorkspaceBackend(raw string, source string) (string, error) {
+	backend := strings.ToLower(strings.TrimSpace(raw))
+	if backend == "" {
+		return "", fmt.Errorf("workspace backend from %s must be non-empty", source)
+	}
+	switch backend {
+	case workspace.BackendDocker, workspace.BackendHost:
+		return backend, nil
+	default:
+		return "", fmt.Errorf("workspace backend from %s must be docker or host, got %q", source, strings.TrimSpace(raw))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,8 +53,10 @@ type StoreSQLiteConfig struct {
 
 type WorkspaceConfig struct {
 	DataSource string `yaml:"data_source"`
+	Backend    string `yaml:"backend"`
 
 	dataSourceSet bool
+	backendSet    bool
 }
 
 func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -66,9 +68,11 @@ func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
 	*w = WorkspaceConfig(decoded)
 	if value.Kind == yaml.MappingNode {
 		for i := 0; i+1 < len(value.Content); i += 2 {
-			if value.Content[i].Value == "data_source" {
+			switch value.Content[i].Value {
+			case "data_source":
 				w.dataSourceSet = true
-				break
+			case "backend":
+				w.backendSet = true
 			}
 		}
 	}
@@ -77,6 +81,10 @@ func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
 
 func (w WorkspaceConfig) DataSourceConfigured() bool {
 	return w.dataSourceSet || strings.TrimSpace(w.DataSource) != ""
+}
+
+func (w WorkspaceConfig) BackendConfigured() bool {
+	return w.backendSet || strings.TrimSpace(w.Backend) != ""
 }
 
 type LLMConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,6 +67,9 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	if !cfg.Workspace.DataSourceConfigured() {
 		t.Fatal("workspace.data_source presence was not preserved")
 	}
+	if cfg.Workspace.Backend != "" {
+		t.Fatalf("workspace.backend = %q, want empty", cfg.Workspace.Backend)
+	}
 
 	var ext ExtensionsConfig
 	if err := cfg.DecodeExtensions(&ext); err != nil {
@@ -113,6 +116,35 @@ func TestLoad_PreservesEmptyWorkspaceDataSourcePresence(t *testing.T) {
 	}
 	if cfg.Workspace.DataSource != "   " {
 		t.Fatalf("workspace.data_source = %q, want preserved whitespace", cfg.Workspace.DataSource)
+	}
+}
+
+func TestLoad_PreservesWorkspaceBackendPresence(t *testing.T) {
+	cfgText := strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  backend: \"   \"",
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	p := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(p, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Workspace.BackendConfigured() {
+		t.Fatal("empty workspace.backend presence was not preserved")
+	}
+	if cfg.Workspace.Backend != "   " {
+		t.Fatalf("workspace.backend = %q, want preserved whitespace", cfg.Workspace.Backend)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -23,8 +23,15 @@ func (r *ClaudeCLIRuntime) run(ctx context.Context, args []string, target *works
 	return r.runWithInput(ctx, args, target, "", MonitorTurnMeta{})
 }
 
+func errClaudeHostWorkspaceUnsupported() error {
+	return fmt.Errorf("%w: host workspace backend does not support Claude CLI execution yet", ErrClaudeWorkspaceRequired)
+}
+
 func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, target *workspace.Target, input string, meta MonitorTurnMeta) (*Response, error) {
 	timeout := r.effectiveCLITimeout(ctx)
+	if target != nil && target.HostBackend() {
+		return nil, errClaudeHostWorkspaceUnsupported()
+	}
 	if target == nil || !target.Enabled() {
 		return nil, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
 	}

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -65,6 +65,41 @@ func TestClaudeCLIRuntimeContinueSession_RejectsHostFallbackWhenTargetMissing(t 
 	_ = session
 }
 
+func TestClaudeCLIRuntimeRejectsHostWorkspaceBackend(t *testing.T) {
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+	target := &workspace.Target{
+		Workdir: t.TempDir(),
+		Backend: workspace.BackendHost,
+	}
+
+	_, err := runtime.runWithInput(context.Background(), nil, target, "hello", MonitorTurnMeta{})
+	if !errors.Is(err, ErrClaudeWorkspaceRequired) {
+		t.Fatalf("runWithInput error = %v, want ErrClaudeWorkspaceRequired", err)
+	}
+	if !strings.Contains(err.Error(), "host workspace backend does not support Claude CLI execution yet") {
+		t.Fatalf("runWithInput error = %v, want host backend fail-closed diagnostic", err)
+	}
+}
+
+func TestClaudeCLIRuntimeWorkspaceCommandRejectsHostWorkspaceBackend(t *testing.T) {
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+	target := &workspace.Target{
+		Workdir: t.TempDir(),
+		Backend: workspace.BackendHost,
+	}
+
+	_, _, exitCode, err := runtime.runWorkspaceCommand(context.Background(), target, "", "sh", "-lc", "true")
+	if !errors.Is(err, ErrClaudeWorkspaceRequired) {
+		t.Fatalf("runWorkspaceCommand error = %v, want ErrClaudeWorkspaceRequired", err)
+	}
+	if !strings.Contains(err.Error(), "host workspace backend does not support Claude CLI execution yet") {
+		t.Fatalf("runWorkspaceCommand error = %v, want host backend fail-closed diagnostic", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("runWorkspaceCommand exit code = %d, want zero for pre-exec fail-closed path", exitCode)
+	}
+}
+
 func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")

--- a/internal/runtime/llm/cli_runtime_startup_probe.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe.go
@@ -112,6 +112,9 @@ func PlannedProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools [
 
 func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []string, target *workspace.Target, input string) (*Response, error) {
 	timeout := r.effectiveCLITimeout(ctx)
+	if target != nil && target.HostBackend() {
+		return nil, errClaudeHostWorkspaceUnsupported()
+	}
 	if target == nil || !target.Enabled() {
 		return nil, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
 	}

--- a/internal/runtime/llm/cli_tool_result_relay.go
+++ b/internal/runtime/llm/cli_tool_result_relay.go
@@ -92,6 +92,9 @@ func (r *ClaudeCLIRuntime) runWorkspaceCommand(ctx context.Context, target *work
 	if r != nil && r.execWorkspaceFn != nil {
 		return r.execWorkspaceFn(ctx, target, stdin, args...)
 	}
+	if target != nil && target.HostBackend() {
+		return nil, nil, 0, errClaudeHostWorkspaceUnsupported()
+	}
 	if target == nil || !target.Enabled() {
 		return nil, nil, 0, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
 	}

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -299,6 +299,9 @@ func (e *Executor) resolveNativeWorkspace(ctx context.Context, actor models.Agen
 func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Target, timeout time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	if target != nil && target.HostBackend() {
+		return nil, nil, -1, fmt.Errorf("host workspace backend does not support native tool execution yet")
+	}
 	var cmd *exec.Cmd
 	if target != nil && target.Enabled() {
 		dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	workspace "swarm/internal/runtime/workspace"
+)
+
+func TestNativeWorkspaceCommandFailsClosedForHostBackend(t *testing.T) {
+	exec := &Executor{}
+	_, _, exitCode, err := exec.runWorkspaceCommand(context.Background(), &workspace.Target{
+		Workdir: t.TempDir(),
+		Backend: workspace.BackendHost,
+	}, time.Second, "", "sh", "-lc", "true")
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
+		t.Fatalf("runWorkspaceCommand error = %v, want host backend fail-closed error", err)
+	}
+	if exitCode != -1 {
+		t.Fatalf("exit code = %d, want -1 for fail-closed host backend", exitCode)
+	}
+}

--- a/internal/runtime/workspace/host_manager.go
+++ b/internal/runtime/workspace/host_manager.go
@@ -229,13 +229,17 @@ func (m *HostManager) ensureHostWorkspaceDir(rel string) (string, error) {
 		return "", fmt.Errorf("host workspace path is required")
 	}
 	path := filepath.Join(append([]string{root}, components...)...)
-	if err := ensurePathWithinRoot(path, root, "host workspace"); err != nil {
+	canonicalPath, err := canonicalPathForOverlap(path, "host workspace")
+	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(path, 0o700); err != nil {
-		return "", fmt.Errorf("create host workspace %s: %w", path, err)
+	if err := ensurePathWithinRoot(canonicalPath, root, "host workspace"); err != nil {
+		return "", err
 	}
-	return path, nil
+	if err := os.MkdirAll(canonicalPath, 0o700); err != nil {
+		return "", fmt.Errorf("create host workspace %s: %w", canonicalPath, err)
+	}
+	return canonicalPath, nil
 }
 
 func (m *HostManager) hostRoot() (string, error) {
@@ -249,18 +253,20 @@ func (m *HostManager) hostRoot() (string, error) {
 	if scope := strings.TrimSpace(m.cfg.BundleScope); scope != "" {
 		root = filepath.Join(root, SanitizeSlug(scope))
 	}
-	return root, nil
+	return canonicalPathForOverlap(root, "host workspace root")
 }
 
 func (m *HostManager) validateSharedMounts() error {
-	if err := validateReadableDir(strings.TrimSpace(m.cfg.SharedDataSource), "workspace validation failed: /data source"); err != nil {
+	dataSource, err := canonicalReadableDir(strings.TrimSpace(m.cfg.SharedDataSource), "workspace validation failed: /data source")
+	if err != nil {
 		return err
 	}
-	if err := validateReadableDir(strings.TrimSpace(m.cfg.ContractsSource), "workspace validation failed: /opt/swarm/contracts source"); err != nil {
+	contractsSource, err := canonicalReadableDir(strings.TrimSpace(m.cfg.ContractsSource), "workspace validation failed: /opt/swarm/contracts source")
+	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(filepath.Join(strings.TrimSpace(m.cfg.ContractsSource), "package.yaml")); err != nil {
-		return fmt.Errorf("workspace validation failed: contracts source %s missing package.yaml", strings.TrimSpace(m.cfg.ContractsSource))
+	if _, err := os.Stat(filepath.Join(contractsSource, "package.yaml")); err != nil {
+		return fmt.Errorf("workspace validation failed: contracts source %s missing package.yaml", contractsSource)
 	}
 	root, err := m.hostRoot()
 	if err != nil {
@@ -270,11 +276,11 @@ func (m *HostManager) validateSharedMounts() error {
 		name string
 		path string
 	}{
-		{name: "/data source", path: m.cfg.SharedDataSource},
-		{name: "/opt/swarm/contracts source", path: m.cfg.ContractsSource},
+		{name: "/data source", path: dataSource},
+		{name: "/opt/swarm/contracts source", path: contractsSource},
 	} {
 		if pathsOverlap(root, source.path) {
-			return fmt.Errorf("workspace validation failed: host workspace root %s must not overlap %s %s", root, source.name, filepath.Clean(source.path))
+			return fmt.Errorf("workspace validation failed: host workspace root %s must not overlap %s %s", root, source.name, source.path)
 		}
 	}
 	return nil
@@ -317,9 +323,59 @@ func cleanAbsPath(path string, label string) (string, error) {
 	return filepath.Clean(path), nil
 }
 
+func canonicalReadableDir(path, prefix string) (string, error) {
+	canonicalPath, err := canonicalPathForOverlap(path, prefix)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("%s %s: %w", prefix, canonicalPath, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s %s is not a directory", prefix, canonicalPath)
+	}
+	return canonicalPath, nil
+}
+
+func canonicalPathForOverlap(path, label string) (string, error) {
+	clean, err := cleanAbsPath(path, label)
+	if err != nil {
+		return "", err
+	}
+	current := clean
+	missing := []string{}
+	for {
+		info, statErr := os.Lstat(current)
+		if statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				resolved, err := filepath.EvalSymlinks(current)
+				if err != nil {
+					return "", fmt.Errorf("resolve %s symlink %s: %w", label, current, err)
+				}
+				return filepath.Clean(filepath.Join(append([]string{resolved}, missing...)...)), nil
+			}
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", fmt.Errorf("resolve %s %s: %w", label, current, err)
+			}
+			return filepath.Clean(filepath.Join(append([]string{resolved}, missing...)...)), nil
+		}
+		if !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("inspect %s %s: %w", label, current, statErr)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("resolve %s %s: no existing ancestor", label, clean)
+		}
+		missing = append([]string{filepath.Base(current)}, missing...)
+		current = parent
+	}
+}
+
 func pathsOverlap(a, b string) bool {
-	cleanA, errA := cleanAbsPath(a, "path")
-	cleanB, errB := cleanAbsPath(b, "path")
+	cleanA, errA := canonicalPathForOverlap(a, "path")
+	cleanB, errB := canonicalPathForOverlap(b, "path")
 	if errA != nil || errB != nil {
 		return false
 	}

--- a/internal/runtime/workspace/host_manager.go
+++ b/internal/runtime/workspace/host_manager.go
@@ -117,6 +117,9 @@ func (m *HostManager) EnsurePrereqs(context.Context) error {
 	if m == nil {
 		return fmt.Errorf("host workspace manager is required")
 	}
+	if err := m.validateSharedMounts(); err != nil {
+		return err
+	}
 	root, err := m.hostRoot()
 	if err != nil {
 		return err
@@ -220,6 +223,9 @@ func (m *HostManager) hostTarget(rel string) (*Target, error) {
 }
 
 func (m *HostManager) ensureHostWorkspaceDir(rel string) (string, error) {
+	if err := m.validateSharedMounts(); err != nil {
+		return "", err
+	}
 	root, err := m.hostRoot()
 	if err != nil {
 		return "", err

--- a/internal/runtime/workspace/host_manager.go
+++ b/internal/runtime/workspace/host_manager.go
@@ -1,0 +1,347 @@
+package workspace
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	runtimedestructivereset "swarm/internal/runtime/destructivereset"
+	"swarm/internal/runtime/semanticview"
+
+	models "swarm/internal/runtime/core/actors"
+)
+
+const EnvHostWorkspaceRoot = "SWARM_WORKSPACE_HOST_ROOT"
+
+type HostConfig struct {
+	WorkspaceRoot       string
+	SharedDataSource    string
+	DataMountPoint      string
+	ContractsSource     string
+	ContractsMountPoint string
+	BundleHash          string
+	BundleScope         string
+}
+
+type HostManager struct {
+	db     *sql.DB
+	cfg    HostConfig
+	source semanticview.Source
+}
+
+func DefaultHostConfig() HostConfig {
+	return HostConfig{
+		WorkspaceRoot:       EnvOrDefault(EnvHostWorkspaceRoot, defaultHostWorkspaceRoot()),
+		SharedDataSource:    "",
+		DataMountPoint:      EnvOrDefault("SWARM_WORKSPACE_DATA_MOUNT", "/data"),
+		ContractsSource:     EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", ""),
+		ContractsMountPoint: EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_MOUNT", "/opt/swarm/contracts"),
+	}
+}
+
+func NewHostManager(db *sql.DB) *HostManager {
+	return &HostManager{
+		db:  db,
+		cfg: DefaultHostConfig(),
+	}
+}
+
+func (m *HostManager) SetConfig(cfg HostConfig) {
+	if m == nil {
+		return
+	}
+	m.cfg = cfg
+}
+
+func (m *HostManager) SetConfigForTest(cfg HostConfig) {
+	if m == nil {
+		return
+	}
+	m.cfg = cfg
+}
+
+func (m *HostManager) SetSemanticSource(source semanticview.Source) {
+	if m == nil {
+		return
+	}
+	m.source = source
+}
+
+func (m *HostManager) SetBundleScope(bundleHash string) {
+	if m == nil {
+		return
+	}
+	cfg := m.cfg
+	cfg.BundleHash = strings.TrimSpace(bundleHash)
+	cfg.BundleScope = bundleScopeKey(bundleHash)
+	m.cfg = cfg
+}
+
+func (m *HostManager) ValidateSource(_ context.Context, source semanticview.Source) error {
+	if m == nil {
+		return fmt.Errorf("host workspace manager is required")
+	}
+	if source == nil {
+		return fmt.Errorf("workspace semantic source is required")
+	}
+	m.source = source
+	if err := m.validateSharedMounts(); err != nil {
+		return err
+	}
+	classes, err := workspaceClassesForSource(source)
+	if err != nil {
+		return err
+	}
+	for agentID, entry := range source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		class := strings.TrimSpace(entry.WorkspaceClass)
+		if class == "" {
+			continue
+		}
+		scope, ok := classes[class]
+		if !ok {
+			return fmt.Errorf("workspace validation failed: agent %s references undefined workspace_class %q", agentID, class)
+		}
+		if !isSupportedWorkspaceScope(scope) {
+			return fmt.Errorf("workspace validation failed: workspace_class %q declares unsupported workspace_scope %q", class, scope)
+		}
+	}
+	return nil
+}
+
+func (m *HostManager) EnsurePrereqs(context.Context) error {
+	if m == nil {
+		return fmt.Errorf("host workspace manager is required")
+	}
+	root, err := m.hostRoot()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return fmt.Errorf("host workspace prerequisite failed: create workspace root %s: %w", root, err)
+	}
+	return nil
+}
+
+func (m *HostManager) EnsureSystemWorkspaces(ctx context.Context) error {
+	if err := m.EnsurePrereqs(ctx); err != nil {
+		return err
+	}
+	for _, name := range []string{"scaffold", "system"} {
+		if _, err := m.ensureHostWorkspaceDir(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *HostManager) EnsureEntityWorkspace(_ context.Context, entityID string) error {
+	if strings.TrimSpace(entityID) == "" {
+		return fmt.Errorf("entity_id is required")
+	}
+	_, err := m.ensureHostWorkspaceDir(filepath.Join("entities", SanitizeSlug(entityID)))
+	return err
+}
+
+func (m *HostManager) StopEntityWorkspace(context.Context, string) error {
+	return nil
+}
+
+func (m *HostManager) ResolveWorkspace(_ context.Context, actor models.AgentConfig) (*Target, error) {
+	if m == nil {
+		return nil, fmt.Errorf("host workspace manager is required")
+	}
+	class, err := workspaceClassForSource(m.source, actor)
+	if err != nil {
+		return nil, err
+	}
+	switch workspaceRouteClass(class) {
+	case "scaffold":
+		return m.hostTarget("scaffold")
+	case "system":
+		return m.hostTarget("system")
+	}
+	scope, scopeKey, err := workspaceScopeForActor(m.source, actor)
+	if err != nil {
+		return nil, err
+	}
+	switch scope {
+	case "per-flow-instance":
+		return m.hostTarget(filepath.Join("flows", SanitizeSlug(scopeKey)))
+	default:
+		return m.hostTarget(filepath.Join("agents", SanitizeSlug(scopeKey)))
+	}
+}
+
+func (m *HostManager) CleanupDevEntityContainers(context.Context) (runtimedestructivereset.ContainerResetResult, error) {
+	return runtimedestructivereset.ContainerResetResult{
+		OperationName: DevEntityCleanupOperationName,
+		AppliedAt:     time.Now().UTC(),
+	}, nil
+}
+
+func (m *HostManager) ManagedResetContainerInventory(context.Context) ([]runtimedestructivereset.ContainerRef, error) {
+	return nil, nil
+}
+
+func (m *HostManager) InspectManagedContainer(context.Context, string) (runtimedestructivereset.ManagedContainerInspection, error) {
+	return runtimedestructivereset.ManagedContainerInspection{}, nil
+}
+
+func (m *HostManager) StopManagedContainer(context.Context, string) error {
+	return nil
+}
+
+func (m *HostManager) RuntimeWorkspaceContainers(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (m *HostManager) SystemWorkspaceContainers() []string {
+	return nil
+}
+
+func (m *HostManager) KillOrphanProcesses(context.Context) error {
+	return nil
+}
+
+func (m *HostManager) hostTarget(rel string) (*Target, error) {
+	workdir, err := m.ensureHostWorkspaceDir(rel)
+	if err != nil {
+		return nil, err
+	}
+	return &Target{
+		Workdir: workdir,
+		Backend: BackendHost,
+	}, nil
+}
+
+func (m *HostManager) ensureHostWorkspaceDir(rel string) (string, error) {
+	root, err := m.hostRoot()
+	if err != nil {
+		return "", err
+	}
+	components := sanitizedHostPathComponents(rel)
+	if len(components) == 0 {
+		return "", fmt.Errorf("host workspace path is required")
+	}
+	path := filepath.Join(append([]string{root}, components...)...)
+	if err := ensurePathWithinRoot(path, root, "host workspace"); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return "", fmt.Errorf("create host workspace %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func (m *HostManager) hostRoot() (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("host workspace manager is required")
+	}
+	root, err := cleanAbsPath(m.cfg.WorkspaceRoot, "host workspace root")
+	if err != nil {
+		return "", err
+	}
+	if scope := strings.TrimSpace(m.cfg.BundleScope); scope != "" {
+		root = filepath.Join(root, SanitizeSlug(scope))
+	}
+	return root, nil
+}
+
+func (m *HostManager) validateSharedMounts() error {
+	if err := validateReadableDir(strings.TrimSpace(m.cfg.SharedDataSource), "workspace validation failed: /data source"); err != nil {
+		return err
+	}
+	if err := validateReadableDir(strings.TrimSpace(m.cfg.ContractsSource), "workspace validation failed: /opt/swarm/contracts source"); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(strings.TrimSpace(m.cfg.ContractsSource), "package.yaml")); err != nil {
+		return fmt.Errorf("workspace validation failed: contracts source %s missing package.yaml", strings.TrimSpace(m.cfg.ContractsSource))
+	}
+	root, err := m.hostRoot()
+	if err != nil {
+		return err
+	}
+	for _, source := range []struct {
+		name string
+		path string
+	}{
+		{name: "/data source", path: m.cfg.SharedDataSource},
+		{name: "/opt/swarm/contracts source", path: m.cfg.ContractsSource},
+	} {
+		if pathsOverlap(root, source.path) {
+			return fmt.Errorf("workspace validation failed: host workspace root %s must not overlap %s %s", root, source.name, filepath.Clean(source.path))
+		}
+	}
+	return nil
+}
+
+func sanitizedHostPathComponents(raw string) []string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		slug := SanitizeSlug(part)
+		if slug != "" {
+			out = append(out, slug)
+		}
+	}
+	return out
+}
+
+func defaultHostWorkspaceRoot() string {
+	home, err := os.UserHomeDir()
+	if err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".swarm", "workspaces")
+	}
+	return filepath.Join(os.TempDir(), "swarm", "workspaces")
+}
+
+func cleanAbsPath(path string, label string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("resolve %s %s: %w", label, path, err)
+		}
+		path = abs
+	}
+	return filepath.Clean(path), nil
+}
+
+func pathsOverlap(a, b string) bool {
+	cleanA, errA := cleanAbsPath(a, "path")
+	cleanB, errB := cleanAbsPath(b, "path")
+	if errA != nil || errB != nil {
+		return false
+	}
+	return pathWithinRoot(cleanA, cleanB) || pathWithinRoot(cleanB, cleanA)
+}
+
+func pathWithinRoot(pathValue, root string) bool {
+	pathValue = filepath.Clean(strings.TrimSpace(pathValue))
+	root = filepath.Clean(strings.TrimSpace(root))
+	if pathValue == "" || root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, pathValue)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func ensurePathWithinRoot(pathValue, root, label string) error {
+	if !pathWithinRoot(pathValue, root) {
+		return fmt.Errorf("%s path %s escapes root %s", label, filepath.Clean(pathValue), filepath.Clean(root))
+	}
+	return nil
+}

--- a/internal/runtime/workspace/host_manager_test.go
+++ b/internal/runtime/workspace/host_manager_test.go
@@ -193,6 +193,35 @@ func TestHostManagerRejectsSymlinkedWorkspaceChildEscape(t *testing.T) {
 	}
 }
 
+func TestHostManagerResolveWorkspaceValidatesRootBeforeCreate(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	rootLink := filepath.Join(t.TempDir(), "host-workspaces")
+	if err := os.Symlink(dataDir, rootLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	manager := NewHostManager(nil)
+	manager.SetConfig(HostConfig{
+		WorkspaceRoot:       rootLink,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      "/data",
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: "/opt/swarm/contracts",
+	})
+	manager.SetSemanticSource(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+
+	_, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{ID: "agent-1"})
+	if err == nil || !strings.Contains(err.Error(), "must not overlap /data source") {
+		t.Fatalf("ResolveWorkspace error = %v, want validation-before-create overlap rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "agents")); !os.IsNotExist(err) {
+		t.Fatalf("ResolveWorkspace created workspace directory through symlinked host root: %v", err)
+	}
+}
+
 func TestHostManagerContainerSurfacesAreNoop(t *testing.T) {
 	manager := NewHostManager(nil)
 	inventory, err := manager.ManagedResetContainerInventory(context.Background())

--- a/internal/runtime/workspace/host_manager_test.go
+++ b/internal/runtime/workspace/host_manager_test.go
@@ -49,6 +49,7 @@ func TestHostManagerResolveWorkspaceCreatesScopedHostTargets(t *testing.T) {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 	root := filepath.Join(t.TempDir(), "host-workspaces")
+	canonicalRoot := canonicalTestPath(t, root)
 	manager := NewHostManager(nil)
 	manager.SetConfig(HostConfig{
 		WorkspaceRoot:       root,
@@ -78,8 +79,8 @@ func TestHostManagerResolveWorkspaceCreatesScopedHostTargets(t *testing.T) {
 	if dedicated == nil || dedicated.Enabled() || !dedicated.HostBackend() {
 		t.Fatalf("dedicated target = %#v, want host target without container", dedicated)
 	}
-	if !strings.HasPrefix(filepath.Clean(dedicated.Workdir), filepath.Join(root, "agents")) {
-		t.Fatalf("dedicated workdir = %q, want under agents root %q", dedicated.Workdir, filepath.Join(root, "agents"))
+	if !strings.HasPrefix(filepath.Clean(dedicated.Workdir), filepath.Join(canonicalRoot, "agents")) {
+		t.Fatalf("dedicated workdir = %q, want under agents root %q", dedicated.Workdir, filepath.Join(canonicalRoot, "agents"))
 	}
 
 	shared, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
@@ -93,8 +94,8 @@ func TestHostManagerResolveWorkspaceCreatesScopedHostTargets(t *testing.T) {
 	if shared == nil || shared.Enabled() || !shared.HostBackend() {
 		t.Fatalf("shared target = %#v, want host target without container", shared)
 	}
-	if !strings.HasPrefix(filepath.Clean(shared.Workdir), filepath.Join(root, "flows")) {
-		t.Fatalf("shared workdir = %q, want under flows root %q", shared.Workdir, filepath.Join(root, "flows"))
+	if !strings.HasPrefix(filepath.Clean(shared.Workdir), filepath.Join(canonicalRoot, "flows")) {
+		t.Fatalf("shared workdir = %q, want under flows root %q", shared.Workdir, filepath.Join(canonicalRoot, "flows"))
 	}
 }
 
@@ -122,6 +123,76 @@ func TestHostManagerRejectsWorkspaceRootOverlappingReadOnlySources(t *testing.T)
 	}
 }
 
+func TestHostManagerRejectsSymlinkedWorkspaceRootIntoReadOnlySources(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	for _, tt := range []struct {
+		name       string
+		target     string
+		wantSource string
+	}{
+		{name: "data", target: dataDir, wantSource: "/data source"},
+		{name: "contracts", target: contractsDir, wantSource: "/opt/swarm/contracts source"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rootLink := filepath.Join(t.TempDir(), "host-workspaces")
+			if err := os.Symlink(tt.target, rootLink); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+			manager := NewHostManager(nil)
+			manager.SetConfig(HostConfig{
+				WorkspaceRoot:       rootLink,
+				SharedDataSource:    dataDir,
+				DataMountPoint:      "/data",
+				ContractsSource:     contractsDir,
+				ContractsMountPoint: "/opt/swarm/contracts",
+			})
+			err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+			if err == nil || !strings.Contains(err.Error(), "must not overlap "+tt.wantSource) {
+				t.Fatalf("ValidateSource error = %v, want symlink overlap rejection for %s", err, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestHostManagerRejectsSymlinkedWorkspaceChildEscape(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	root := filepath.Join(t.TempDir(), "host-workspaces")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.Symlink(dataDir, filepath.Join(root, "agents")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	manager := NewHostManager(nil)
+	manager.SetConfig(HostConfig{
+		WorkspaceRoot:       root,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      "/data",
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: "/opt/swarm/contracts",
+	})
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	if err := manager.ValidateSource(context.Background(), source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	manager.SetSemanticSource(source)
+	_, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{ID: "agent-1"})
+	if err == nil || !strings.Contains(err.Error(), "escapes root") {
+		t.Fatalf("ResolveWorkspace error = %v, want symlink child escape rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "agent-1")); !os.IsNotExist(err) {
+		t.Fatalf("symlinked workspace child created under /data: %v", err)
+	}
+}
+
 func TestHostManagerContainerSurfacesAreNoop(t *testing.T) {
 	manager := NewHostManager(nil)
 	inventory, err := manager.ManagedResetContainerInventory(context.Background())
@@ -138,4 +209,13 @@ func TestHostManagerContainerSurfacesAreNoop(t *testing.T) {
 	if result.OperationName != DevEntityCleanupOperationName {
 		t.Fatalf("cleanup operation = %q, want %q", result.OperationName, DevEntityCleanupOperationName)
 	}
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	canonical, err := canonicalPathForOverlap(path, "test path")
+	if err != nil {
+		t.Fatalf("canonical test path %s: %v", path, err)
+	}
+	return canonical
 }

--- a/internal/runtime/workspace/host_manager_test.go
+++ b/internal/runtime/workspace/host_manager_test.go
@@ -1,0 +1,141 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/semanticview"
+)
+
+func TestHostManagerValidatesSourcesAndCreatesSystemWorkspacesWithoutDocker(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	root := filepath.Join(t.TempDir(), "host-workspaces")
+	manager := NewHostManager(nil)
+	manager.SetConfig(HostConfig{
+		WorkspaceRoot:       root,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      "/data",
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: "/opt/swarm/contracts",
+	})
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	if err := manager.ValidateSource(context.Background(), source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	if err := manager.EnsureSystemWorkspaces(context.Background()); err != nil {
+		t.Fatalf("EnsureSystemWorkspaces: %v", err)
+	}
+	for _, rel := range []string{"scaffold", "system"} {
+		if info, err := os.Stat(filepath.Join(root, rel)); err != nil || !info.IsDir() {
+			t.Fatalf("host workspace %s stat = info:%#v err:%v, want directory", rel, info, err)
+		}
+	}
+}
+
+func TestHostManagerResolveWorkspaceCreatesScopedHostTargets(t *testing.T) {
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	root := filepath.Join(t.TempDir(), "host-workspaces")
+	manager := NewHostManager(nil)
+	manager.SetConfig(HostConfig{
+		WorkspaceRoot:       root,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      "/data",
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: "/opt/swarm/contracts",
+	})
+	manager.SetSemanticSource(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"workspace_classes": {
+				Value: map[string]any{
+					"dedicated":   map[string]any{"workspace_scope": "per-agent"},
+					"shared_flow": map[string]any{"workspace_scope": "per-flow-instance"},
+				},
+			},
+		}},
+	}))
+
+	dedicated, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+		ID:             "Dedicated Agent",
+		WorkspaceClass: "dedicated",
+	})
+	if err != nil {
+		t.Fatalf("ResolveWorkspace dedicated: %v", err)
+	}
+	if dedicated == nil || dedicated.Enabled() || !dedicated.HostBackend() {
+		t.Fatalf("dedicated target = %#v, want host target without container", dedicated)
+	}
+	if !strings.HasPrefix(filepath.Clean(dedicated.Workdir), filepath.Join(root, "agents")) {
+		t.Fatalf("dedicated workdir = %q, want under agents root %q", dedicated.Workdir, filepath.Join(root, "agents"))
+	}
+
+	shared, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
+		ID:             "shared-agent",
+		FlowPath:       "flows/acme/review",
+		WorkspaceClass: "shared_flow",
+	})
+	if err != nil {
+		t.Fatalf("ResolveWorkspace shared: %v", err)
+	}
+	if shared == nil || shared.Enabled() || !shared.HostBackend() {
+		t.Fatalf("shared target = %#v, want host target without container", shared)
+	}
+	if !strings.HasPrefix(filepath.Clean(shared.Workdir), filepath.Join(root, "flows")) {
+		t.Fatalf("shared workdir = %q, want under flows root %q", shared.Workdir, filepath.Join(root, "flows"))
+	}
+}
+
+func TestHostManagerRejectsWorkspaceRootOverlappingReadOnlySources(t *testing.T) {
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	contractsDir := t.TempDir()
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	manager := NewHostManager(nil)
+	manager.SetConfig(HostConfig{
+		WorkspaceRoot:       root,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      "/data",
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: "/opt/swarm/contracts",
+	})
+	err := manager.ValidateSource(context.Background(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
+	if err == nil || !strings.Contains(err.Error(), "must not overlap /data source") {
+		t.Fatalf("ValidateSource error = %v, want overlap rejection", err)
+	}
+}
+
+func TestHostManagerContainerSurfacesAreNoop(t *testing.T) {
+	manager := NewHostManager(nil)
+	inventory, err := manager.ManagedResetContainerInventory(context.Background())
+	if err != nil {
+		t.Fatalf("ManagedResetContainerInventory: %v", err)
+	}
+	if len(inventory) != 0 {
+		t.Fatalf("inventory = %#v, want empty host container inventory", inventory)
+	}
+	result, err := manager.CleanupDevEntityContainers(context.Background())
+	if err != nil {
+		t.Fatalf("CleanupDevEntityContainers: %v", err)
+	}
+	if result.OperationName != DevEntityCleanupOperationName {
+		t.Fatalf("cleanup operation = %q, want %q", result.OperationName, DevEntityCleanupOperationName)
+	}
+}

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -24,11 +24,21 @@ import (
 type Target struct {
 	Container string
 	Workdir   string
+	Backend   string
 }
 
 func (t *Target) Enabled() bool {
 	return t != nil && strings.TrimSpace(t.Container) != ""
 }
+
+func (t *Target) HostBackend() bool {
+	return t != nil && strings.EqualFold(strings.TrimSpace(t.Backend), BackendHost)
+}
+
+const (
+	BackendDocker = "docker"
+	BackendHost   = "host"
+)
 
 type Resolver interface {
 	ResolveWorkspace(ctx context.Context, actor models.AgentConfig) (*Target, error)
@@ -480,6 +490,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 		return &Target{
 			Container: m.cfg.ScaffoldContainer,
 			Workdir:   m.cfg.ScaffoldWorkdir,
+			Backend:   BackendDocker,
 		}, nil
 	case "system":
 		if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.SystemContainer, m.systemContainerIdentity("workspace.ResolveWorkspace", runtimecontaineridentity.KindSystem), []string{
@@ -496,6 +507,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 		return &Target{
 			Container: m.cfg.SystemContainer,
 			Workdir:   m.cfg.SystemWorkdir,
+			Backend:   BackendDocker,
 		}, nil
 	}
 	scope, scopeKey, err := m.workspaceScopeForActor(actor)
@@ -519,21 +531,12 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 	return &Target{
 		Container: container,
 		Workdir:   m.cfg.EntityWorkdir,
+		Backend:   BackendDocker,
 	}, nil
 }
 
 func (m *DockerManager) workspaceClass(actor models.AgentConfig) (string, error) {
-	if cfgClass := strings.TrimSpace(actor.WorkspaceClass); cfgClass != "" {
-		return cfgClass, nil
-	}
-	source := m.semanticSource()
-	if source == nil {
-		return "", nil
-	}
-	if _, entry, ok := semanticview.ResolveAgentRegistryEntry(source, actor); ok {
-		return strings.TrimSpace(entry.WorkspaceClass), nil
-	}
-	return "", nil
+	return workspaceClassForSource(m.semanticSource(), actor)
 }
 
 func workspaceRouteClass(class string) string {
@@ -555,13 +558,29 @@ func (m *DockerManager) semanticSource() semanticview.Source {
 }
 
 func (m *DockerManager) workspaceScopeForActor(actor models.AgentConfig) (string, string, error) {
-	class, err := m.workspaceClass(actor)
+	return workspaceScopeForActor(m.semanticSource(), actor)
+}
+
+func workspaceClassForSource(source semanticview.Source, actor models.AgentConfig) (string, error) {
+	if cfgClass := strings.TrimSpace(actor.WorkspaceClass); cfgClass != "" {
+		return cfgClass, nil
+	}
+	if source == nil {
+		return "", nil
+	}
+	if _, entry, ok := semanticview.ResolveAgentRegistryEntry(source, actor); ok {
+		return strings.TrimSpace(entry.WorkspaceClass), nil
+	}
+	return "", nil
+}
+
+func workspaceScopeForActor(source semanticview.Source, actor models.AgentConfig) (string, string, error) {
+	class, err := workspaceClassForSource(source, actor)
 	if err != nil {
 		return "", "", err
 	}
 	scope := "per-agent"
 	if class != "" {
-		source := m.semanticSource()
 		if source == nil {
 			return "", "", fmt.Errorf("workspace resolution failed: semantic source is required for workspace_class %q", class)
 		}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6589,8 +6589,9 @@ workspace_model:
           rule: >
             The host workspace root is platform-managed and writable. Startup MUST create/validate required workspace roots and
             MUST reject roots that overlap the read-only `/data` source or loaded contracts source. Overlap checks MUST use
-            canonical/evaluated paths, and platform-managed workspace path creation MUST fail closed instead of following
-            symlink escapes out of the selected host workspace root.
+            canonical/evaluated paths. Every host lifecycle consumer MUST pass this validation before platform-managed
+            workspace path creation; path creation MUST fail closed instead of following symlink escapes out of the selected
+            host workspace root.
     failure_behavior:
     - Unsupported backend names fail closed before runtime construction.
     - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6554,6 +6554,57 @@ workspace_model:
     - '#1138 host workspace backend'
     - SQLite local default and broader local runtime onboarding
     - mount destination override semantics such as SWARM_WORKSPACE_DATA_MOUNT
+  workspace_backend_selection:
+    promoted_by: '#1138'
+    implementation_status: implemented_first_slice
+    canonical_owner: platform-spec.yaml#workspace_model.workspace_backend_selection
+    scope: >
+      Defines the workspace backend selector for `swarm serve` boot, dynamic Builder project reload, and selected-contract
+      run-fork lifecycle consumers. The selector chooses either the existing Docker workspace lifecycle or the explicit
+      host local-dev lifecycle; it does not make host execution behavior equivalent to Docker isolation.
+    cli_flag: --workspace-backend <docker|host>
+    config_key: workspace.backend
+    env_var: SWARM_WORKSPACE_BACKEND
+    source_order:
+    - --workspace-backend
+    - workspace.backend
+    - SWARM_WORKSPACE_BACKEND
+    - docker default
+    default_backend: docker
+    backends:
+      docker:
+        behavior: >
+          Default workspace backend. Startup preserves the existing Docker fail-closed checks for the configured workspace
+          image, Docker binary availability, Docker network, container creation, mounted `/data`, mounted contracts, and
+          managed container lifecycle.
+      host:
+        behavior: >
+          Explicit local-dev opt-in. Startup consumes the selected `/data` source from
+          `workspace_model.data_source_authority`, the loaded contracts source, and a platform-managed host workspace root.
+          It MUST NOT require Docker, build Docker images, or create containers. It MUST fail closed for unsupported execution
+          surfaces until those host execution semantics are explicitly promoted.
+        workspace_root:
+          env_var: SWARM_WORKSPACE_HOST_ROOT
+          default: ~/.swarm/workspaces
+          rule: >
+            The host workspace root is platform-managed and writable. Startup MUST create/validate required workspace roots and
+            MUST reject roots that overlap the read-only `/data` source or loaded contracts source.
+    failure_behavior:
+    - Unsupported backend names fail closed before runtime construction.
+    - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.
+    - Host backend MUST reject `SWARM_WORKSPACE_VOLUMES_FROM`; the host backend consumes explicit path authorities, not Docker
+      volume inheritance.
+    - Host backend MUST fail closed for Claude CLI, native tool execution, and tool relay surfaces unless a later gate promotes
+      safe host execution semantics.
+    consumers:
+    - swarm serve boot workspace lifecycle
+    - dynamic Builder project reload workspace lifecycle
+    - selected-contract run-fork workspace lifecycle
+    split_scope:
+    - '#1137 Compose/Postgres onboarding and Compose cleanup'
+    - '#1136 broader local onboarding/docs'
+    - full host Claude CLI, native tool execution, and tool relay parity
+    - production SQLite multi-writer semantics
   standard_mounts:
     description: Three mount points are available to every agent session. Products cannot add new mount points — they configure
       access and scope for these three via workspace class definitions.
@@ -8300,6 +8351,21 @@ cli_specification:
           `workspace_model.data_source_authority` before constructing any workspace lifecycle. The command MUST NOT
           derive `/data` from the Swarm source checkout or from a repo-local `data/` directory unless that path was
           explicitly selected by the operator through the promoted source order.
+        consumers:
+        - serve boot workspace lifecycle
+        - dynamic Builder project reload workspace lifecycle
+        - selected-contract run-fork workspace lifecycle
+      workspace_backend_selection:
+        promoted_by: '#1138'
+        owner: workspace_model.workspace_backend_selection
+        flag: --workspace-backend <docker|host>
+        config_key: workspace.backend
+        env_var: SWARM_WORKSPACE_BACKEND
+        default_backend: docker
+        rule: >
+          `swarm serve` MUST resolve workspace backend selection through
+          `workspace_model.workspace_backend_selection` before constructing any workspace lifecycle. The command MUST keep
+          Docker as the default isolation backend and MUST require an explicit selector for the host local-dev backend.
         consumers:
         - serve boot workspace lifecycle
         - dynamic Builder project reload workspace lifecycle

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6588,7 +6588,9 @@ workspace_model:
           default: ~/.swarm/workspaces
           rule: >
             The host workspace root is platform-managed and writable. Startup MUST create/validate required workspace roots and
-            MUST reject roots that overlap the read-only `/data` source or loaded contracts source.
+            MUST reject roots that overlap the read-only `/data` source or loaded contracts source. Overlap checks MUST use
+            canonical/evaluated paths, and platform-managed workspace path creation MUST fail closed instead of following
+            symlink escapes out of the selected host workspace root.
     failure_behavior:
     - Unsupported backend names fail closed before runtime construction.
     - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.


### PR DESCRIPTION
Part of #1138

## Summary
- Adds `swarm serve --workspace-backend <docker|host>` with precedence `--workspace-backend` > `workspace.backend` > `SWARM_WORKSPACE_BACKEND` > default `docker`.
- Adds the explicit host workspace lifecycle for local-dev serve boot: it consumes the selected `/data` source and loaded contracts source, creates platform-managed host workspace roots, and does not require Docker.
- Keeps Docker as the default backend and preserves Docker workspace lifecycle behavior. Host mode fails closed for unsupported Claude CLI/native/tool-relay execution surfaces.

## Governing Refs
- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_backend_selection`
- Adjacent input authority: `platform-spec.yaml#workspace_model.data_source_authority` / #1139
- Gate boundary: #1138 approved first slice `runtime.workspace_backend_selection_and_host_boot_lifecycle_for_local_serve`

## Semantic Migration
- New canonical owner: `platform-spec.yaml#workspace_model.workspace_backend_selection`, implemented by `cmd/swarm/workspace_backend.go` and consumed by `swarm serve`, Builder reload, and selected-contract run-fork workspace lifecycle construction.
- Old producer/reader path now invalid: workspace backend choice is no longer implicit inside the Docker manager or lower workspace lifecycle helpers; command boot must resolve it before lifecycle construction.
- Production paths checked for surviving old behavior: `swarm serve` boot, startup recovery workspace construction, Builder project supervisor reload, selected run-fork lifecycle, native tool execution, Claude CLI execution, and Claude tool relay.
- Migration completeness: complete for the approved first slice only. Full host execution parity, #1137/#1136 docs/onboarding, and production SQLite multi-writer semantics remain split.

## Proof
- `go test ./internal/config ./internal/runtime/workspace ./internal/runtime/tools`
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntime(RejectsHostWorkspaceBackend|WorkspaceCommandRejectsHostWorkspaceBackend|ContinueSession_RejectsHostFallbackWhenTargetMissing|RunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic)'`
- `go test ./cmd/swarm -run 'Test(CLI_ServeWorkspaceBackend|ResolveWorkspaceBackend|ConfiguredWorkspaceLifecycleForBackend|RunServeRuntimeHostWorkspaceBackend|PlatformSpecWorkspaceBackend)'`
- `go test ./...`
- Supported surface proof: built `cmd/swarm`, ran `swarm serve --workspace-backend host --contracts tests/tier1-primitives/test-emits-single --data <tmp>/data --api-listen-addr 127.0.0.1:0 --mcp-listen-addr 127.0.0.1:0 --no-require-bundle-match --verbose` with `SWARM_DOCKER_BIN=<tmp>/missing-docker`, `SWARM_WORKSPACE_HOST_ROOT=<tmp>/workspaces`, `SWARM_SQLITE_PATH=<tmp>/runtime.db`; reached `[22/22] ready` and output contained no Docker dependency diagnostics.