### PR TITLE
[agent-c][issue #1207] Canonicalize StartPostgres schema bootstrap

### DIFF
--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -1,0 +1,417 @@
+package platformschema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	runtimecontracts "swarm/internal/runtime/contracts"
+)
+
+type TableDDL struct {
+	TableName   string
+	SchemaKind  string
+	ColumnCount int
+	Statements  []string
+}
+
+var (
+	createTableName = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+"?([a-z_][a-z0-9_]*)"?`)
+	inlineIndexLine = regexp.MustCompile(`(?i)^(unique\s+)?index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
+)
+
+func GeneratePlatformTableDDLs(spec runtimecontracts.PlatformSpecDocument) ([]TableDDL, error) {
+	if len(spec.PlatformTables.Tables) == 0 {
+		return nil, fmt.Errorf("platform spec platform_tables.tables.*.ddl is required")
+	}
+	tableNames := make([]string, 0, len(spec.PlatformTables.Tables))
+	for tableName := range spec.PlatformTables.Tables {
+		tableNames = append(tableNames, strings.TrimSpace(tableName))
+	}
+	sort.Slice(tableNames, func(i, j int) bool {
+		left := platformTableOrder(tableNames[i])
+		right := platformTableOrder(tableNames[j])
+		if left != right {
+			return left < right
+		}
+		return tableNames[i] < tableNames[j]
+	})
+	plans := make([]TableDDL, 0, len(tableNames))
+	for _, declaredName := range tableNames {
+		tableSpec := spec.PlatformTables.Tables[declaredName]
+		rawDDL := strings.TrimSpace(tableSpec.DDL)
+		if rawDDL == "" {
+			return nil, fmt.Errorf("platform spec table %s ddl is required", declaredName)
+		}
+		statements, err := normalizePlatformDDLStatements(rawDDL)
+		if err != nil {
+			return nil, fmt.Errorf("platform spec table %s: %w", declaredName, err)
+		}
+		statements = stripDeprecatedEntitySubjectDDL(declaredName, statements)
+		tableName := declaredName
+		for _, statement := range statements {
+			if parsedTable := ExtractTableName(statement); parsedTable != "" {
+				tableName = parsedTable
+				break
+			}
+		}
+		plans = append(plans, TableDDL{
+			TableName:   tableName,
+			SchemaKind:  "platform_spec",
+			ColumnCount: columnCount(statements),
+			Statements:  statements,
+		})
+	}
+	return plans, nil
+}
+
+func Flatten(plans []TableDDL) []string {
+	if len(plans) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(plans)*2)
+	for _, plan := range plans {
+		for _, statement := range plan.Statements {
+			statement = strings.TrimSpace(statement)
+			if statement == "" {
+				continue
+			}
+			out = append(out, statement)
+		}
+	}
+	return out
+}
+
+func IncludesPlatformTables(plans []TableDDL) bool {
+	for _, plan := range plans {
+		if strings.TrimSpace(plan.SchemaKind) == "platform_spec" {
+			return true
+		}
+	}
+	return false
+}
+
+func EnsurePostgresTables(ctx context.Context, db *sql.DB, plans []TableDDL, mapStatementError func(TableDDL, error) error) error {
+	if db == nil {
+		return fmt.Errorf("postgres store is required for schema ddl")
+	}
+	if len(plans) == 0 {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
+		return fmt.Errorf("ensure pgcrypto extension: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin schema ddl tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, plan := range plans {
+		for _, statement := range plan.Statements {
+			statement = strings.TrimSpace(statement)
+			if statement == "" {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				if mapStatementError != nil {
+					if mapped := mapStatementError(plan, err); mapped != nil {
+						return mapped
+					}
+				}
+				return fmt.Errorf("ensure %s table %s: %w", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName), err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit schema ddl tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func ExtractTableName(statement string) string {
+	statement = strings.TrimSpace(statement)
+	matches := createTableName.FindStringSubmatch(statement)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(matches[1])
+}
+
+func PlanColumnNames(plan TableDDL) []string {
+	for _, statement := range plan.Statements {
+		if ExtractTableName(statement) == "" {
+			continue
+		}
+		return createTableColumnNames(statement)
+	}
+	return nil
+}
+
+func platformTableOrder(name string) int {
+	switch strings.TrimSpace(name) {
+	case "schema_version":
+		return 0
+	case "bundles":
+		return 3
+	case "runs":
+		return 5
+	case "events":
+		return 10
+	case "run_fork_selected_contract_bindings":
+		return 15
+	case "run_fork_selected_contract_executions":
+		return 18
+	case "run_fork_selected_contract_branch_divergences":
+		return 19
+	case "run_fork_selected_contract_route_recoveries":
+		return 20
+	case "dead_letters":
+		return 22
+	case "agents":
+		return 30
+	case "flow_instances":
+		return 40
+	case "entity_state":
+		return 50
+	case "agent_sessions":
+		return 60
+	case "agent_turns":
+		return 65
+	case "conversation_forks":
+		return 66
+	case "conversation_fork_snapshots":
+		return 67
+	case "conversation_fork_turns":
+		return 68
+	case "routing_rules":
+		return 70
+	case "event_deliveries":
+		return 80
+	case "run_fork_delivery_event_replays":
+		return 85
+	case "event_receipts":
+		return 90
+	case "entity_mutations":
+		return 95
+	case "mailbox":
+		return 100
+	case "api_idempotency":
+		return 105
+	case "runtime_ingress_state":
+		return 108
+	case "run_control_state":
+		return 109
+	case "spend_ledger":
+		return 110
+	case "timers":
+		return 120
+	default:
+		return 1000
+	}
+}
+
+func normalizePlatformDDLStatements(rawDDL string) ([]string, error) {
+	chunks := strings.Split(rawDDL, ";")
+	statements := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		statement := strings.TrimSpace(chunk)
+		if statement == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(strings.ToUpper(statement), "CREATE TABLE "):
+			tableStatement, indexStatements, err := normalizeCreateTable(statement)
+			if err != nil {
+				return nil, err
+			}
+			statements = append(statements, tableStatement)
+			statements = append(statements, indexStatements...)
+			continue
+		case strings.HasPrefix(strings.ToUpper(statement), "CREATE INDEX "):
+			statement = ensureIfNotExists(statement, "CREATE INDEX")
+		case strings.HasPrefix(strings.ToUpper(statement), "CREATE UNIQUE INDEX "):
+			statement = ensureIfNotExists(statement, "CREATE UNIQUE INDEX")
+		default:
+			return nil, fmt.Errorf("unsupported platform DDL statement %q", statement)
+		}
+		statements = append(statements, statement)
+	}
+	if len(statements) == 0 {
+		return nil, fmt.Errorf("no executable platform DDL statements found")
+	}
+	return statements, nil
+}
+
+func normalizeCreateTable(statement string) (string, []string, error) {
+	statement = ensureIfNotExists(statement, "CREATE TABLE")
+	tableName := ExtractTableName(statement)
+	if tableName == "" {
+		return "", nil, fmt.Errorf("unable to extract table name from %q", statement)
+	}
+	start := strings.Index(statement, "(")
+	end := strings.LastIndex(statement, ")")
+	if start < 0 || end <= start {
+		return statement, nil, nil
+	}
+	body := statement[start+1 : end]
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	indexStatements := make([]string, 0, 2)
+	for _, rawLine := range lines {
+		trimmed := strings.TrimSpace(strings.TrimSuffix(rawLine, ","))
+		if trimmed == "" {
+			continue
+		}
+		if matches := inlineIndexLine.FindStringSubmatch(trimmed); len(matches) >= 3 {
+			uniquePrefix := strings.TrimSpace(matches[1])
+			indexName := strings.TrimSpace(matches[2])
+			indexCols := strings.TrimSpace(matches[3])
+			whereClause := ""
+			if len(matches) >= 5 {
+				whereClause = strings.TrimSpace(matches[4])
+			}
+			statement := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			if uniquePrefix != "" {
+				statement = fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
+			}
+			if whereClause != "" {
+				statement += " " + whereClause
+			}
+			indexStatements = append(indexStatements, statement)
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	normalizedTable := fmt.Sprintf("%s (\n    %s\n)", statement[:start], strings.Join(kept, ",\n    "))
+	return normalizedTable, indexStatements, nil
+}
+
+func stripDeprecatedEntitySubjectDDL(declaredName string, statements []string) []string {
+	if strings.TrimSpace(declaredName) != "entity_state" {
+		return statements
+	}
+	filtered := make([]string, 0, len(statements))
+	for _, statement := range statements {
+		normalized := strings.ToLower(statement)
+		if strings.Contains(normalized, "idx_entity_subject") {
+			continue
+		}
+		if ExtractTableName(statement) == "entity_state" {
+			statement = stripCreateTableColumn(statement, "subject_id")
+		}
+		filtered = append(filtered, statement)
+	}
+	return filtered
+}
+
+func stripCreateTableColumn(statement, columnName string) string {
+	start := strings.Index(statement, "(")
+	end := strings.LastIndex(statement, ")")
+	if start < 0 || end <= start {
+		return statement
+	}
+	body := statement[start+1 : end]
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, rawLine := range lines {
+		trimmed := strings.TrimSpace(strings.TrimSuffix(rawLine, ","))
+		if trimmed == "" {
+			continue
+		}
+		identifier := strings.Trim(strings.Fields(trimmed)[0], `"`)
+		if identifier == columnName {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	return fmt.Sprintf("%s(\n    %s\n)%s", statement[:start], strings.Join(kept, ",\n    "), statement[end+1:])
+}
+
+func ensureIfNotExists(statement, prefix string) string {
+	statement = strings.TrimSpace(statement)
+	upper := strings.ToUpper(statement)
+	if strings.HasPrefix(upper, prefix+" IF NOT EXISTS ") {
+		return statement
+	}
+	return prefix + " IF NOT EXISTS " + strings.TrimSpace(statement[len(prefix):])
+}
+
+func columnCount(statements []string) int {
+	for _, statement := range statements {
+		tableName := ExtractTableName(statement)
+		if tableName == "" {
+			continue
+		}
+		start := strings.Index(statement, "(")
+		end := strings.LastIndex(statement, ")")
+		if start < 0 || end <= start {
+			return 0
+		}
+		count := 0
+		for _, line := range strings.Split(statement[start+1:end], "\n") {
+			line = strings.TrimSpace(strings.TrimSuffix(line, ","))
+			if line == "" || strings.HasPrefix(strings.ToUpper(line), "PRIMARY KEY") {
+				continue
+			}
+			count++
+		}
+		return count
+	}
+	return 0
+}
+
+func createTableColumnNames(statement string) []string {
+	start := strings.Index(statement, "(")
+	end := strings.LastIndex(statement, ")")
+	if start < 0 || end <= start {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, line := range strings.Split(statement[start+1:end], "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, ","))
+		if line == "" || createTableLineIsConstraint(line) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		columnName := strings.Trim(fields[0], `"`)
+		if columnName == "" {
+			continue
+		}
+		if _, exists := seen[columnName]; exists {
+			continue
+		}
+		seen[columnName] = struct{}{}
+		out = append(out, columnName)
+	}
+	return out
+}
+
+func createTableLineIsConstraint(line string) bool {
+	fields := strings.Fields(strings.ToUpper(strings.TrimSpace(line)))
+	if len(fields) == 0 {
+		return false
+	}
+	switch fields[0] {
+	case "PRIMARY", "FOREIGN", "UNIQUE", "CHECK", "CONSTRAINT", "EXCLUDE":
+		return true
+	default:
+		return false
+	}
+}
+
+func quoteIdent(v string) string {
+	return `"` + strings.ReplaceAll(v, `"`, `""`) + `"`
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"swarm/internal/config"
+	"swarm/internal/store/platformschema"
 )
 
 type PostgresStore struct {
@@ -77,42 +78,16 @@ func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTa
 	if len(plans) == 0 {
 		return nil
 	}
-	if _, err := s.DB.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
-		return fmt.Errorf("ensure pgcrypto extension: %w", err)
-	}
 	if schemaDDLIncludesPlatformTables(plans) {
 		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
 			return fmt.Errorf("ensure platform-table compatibility prerequisites: %w", err)
 		}
 	}
-	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("begin schema ddl tx: %w", err)
+	if err := platformschema.EnsurePostgresTables(ctx, s.DB, plans, func(plan SchemaTableDDL, cause error) error {
+		return s.outdatedSchemaErrorForPlan(ctx, plan, cause)
+	}); err != nil {
+		return err
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	for _, plan := range plans {
-		for _, statement := range plan.Statements {
-			statement = strings.TrimSpace(statement)
-			if statement == "" {
-				continue
-			}
-			if _, err := tx.ExecContext(ctx, statement); err != nil {
-				if schemaErr := s.outdatedSchemaErrorForPlan(ctx, plan, err); schemaErr != nil {
-					return schemaErr
-				}
-				return fmt.Errorf("ensure %s table %s: %w", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName), err)
-			}
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit schema ddl tx: %w", err)
-	}
-	committed = true
 	if schemaDDLIncludesPlatformTables(plans) {
 		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
 			return fmt.Errorf("ensure platform-table compatibility aftermath: %w", err)
@@ -155,12 +130,7 @@ func (s *PostgresStore) outdatedSchemaErrorForPlan(ctx context.Context, plan Sch
 }
 
 func schemaDDLIncludesPlatformTables(plans []SchemaTableDDL) bool {
-	for _, plan := range plans {
-		if strings.TrimSpace(plan.SchemaKind) == "platform_spec" {
-			return true
-		}
-	}
-	return false
+	return platformschema.IncludesPlatformTables(plans)
 }
 
 func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) error {

--- a/internal/store/schema_ddl.go
+++ b/internal/store/schema_ddl.go
@@ -7,20 +7,14 @@ import (
 	"strings"
 
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store/platformschema"
 )
 
-type SchemaTableDDL struct {
-	TableName   string
-	SchemaKind  string
-	ColumnCount int
-	Statements  []string
-}
+type SchemaTableDDL = platformschema.TableDDL
 
 var (
 	schemaDDLIdentifierPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 	schemaDDLNumericPattern    = regexp.MustCompile(`^numeric\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
-	schemaDDLCreateTableName   = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+"?([a-z_][a-z0-9_]*)"?`)
-	schemaDDLInlineIndexLine   = regexp.MustCompile(`(?i)^(unique\s+)?index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
 )
 
 func SchemaFieldTypeToDDL(schemaType string) (string, error) {
@@ -78,48 +72,7 @@ func NodeStateFieldTypeToDDL(schemaType string) (string, error) {
 }
 
 func GeneratePlatformTableDDLs(spec runtimecontracts.PlatformSpecDocument) ([]SchemaTableDDL, error) {
-	if len(spec.PlatformTables.Tables) == 0 {
-		return nil, fmt.Errorf("platform spec platform_tables.tables.*.ddl is required")
-	}
-	tableNames := make([]string, 0, len(spec.PlatformTables.Tables))
-	for tableName := range spec.PlatformTables.Tables {
-		tableNames = append(tableNames, strings.TrimSpace(tableName))
-	}
-	sort.Slice(tableNames, func(i, j int) bool {
-		left := platformTableOrder(tableNames[i])
-		right := platformTableOrder(tableNames[j])
-		if left != right {
-			return left < right
-		}
-		return tableNames[i] < tableNames[j]
-	})
-	plans := make([]SchemaTableDDL, 0, len(tableNames))
-	for _, declaredName := range tableNames {
-		tableSpec := spec.PlatformTables.Tables[declaredName]
-		rawDDL := strings.TrimSpace(tableSpec.DDL)
-		if rawDDL == "" {
-			return nil, fmt.Errorf("platform spec table %s ddl is required", declaredName)
-		}
-		statements, err := normalizePlatformDDLStatements(rawDDL)
-		if err != nil {
-			return nil, fmt.Errorf("platform spec table %s: %w", declaredName, err)
-		}
-		statements = stripDeprecatedEntitySubjectDDL(declaredName, statements)
-		tableName := declaredName
-		for _, statement := range statements {
-			if parsedTable := schemaDDLExtractTableName(statement); parsedTable != "" {
-				tableName = parsedTable
-				break
-			}
-		}
-		plans = append(plans, SchemaTableDDL{
-			TableName:   tableName,
-			SchemaKind:  "platform_spec",
-			ColumnCount: schemaDDLColumnCount(statements),
-			Statements:  statements,
-		})
-	}
-	return plans, nil
+	return platformschema.GeneratePlatformTableDDLs(spec)
 }
 
 func GenerateEntityTableDDLs(schema runtimecontracts.EntitySchema) ([]SchemaTableDDL, error) {
@@ -271,20 +224,7 @@ func GenerateNodeStateTableDDLs(nodes map[string]runtimecontracts.SystemNodeCont
 }
 
 func FlattenSchemaTableDDLs(plans []SchemaTableDDL) []string {
-	if len(plans) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(plans)*2)
-	for _, plan := range plans {
-		for _, statement := range plan.Statements {
-			statement = strings.TrimSpace(statement)
-			if statement == "" {
-				continue
-			}
-			out = append(out, statement)
-		}
-	}
-	return out
+	return platformschema.Flatten(plans)
 }
 
 func validateSchemaDDLIdentifier(name, context string) (string, error) {
@@ -307,281 +247,14 @@ func schemaDDLIndexName(parts ...string) string {
 	return name
 }
 
-func platformTableOrder(name string) int {
-	switch strings.TrimSpace(name) {
-	case "schema_version":
-		return 0
-	case "bundles":
-		return 3
-	case "runs":
-		return 5
-	case "events":
-		return 10
-	case "run_fork_selected_contract_bindings":
-		return 15
-	case "run_fork_selected_contract_executions":
-		return 18
-	case "run_fork_selected_contract_branch_divergences":
-		return 19
-	case "run_fork_selected_contract_route_recoveries":
-		return 20
-	case "dead_letters":
-		return 22
-	case "agents":
-		return 30
-	case "flow_instances":
-		return 40
-	case "entity_state":
-		return 50
-	case "agent_sessions":
-		return 60
-	case "agent_turns":
-		return 65
-	case "conversation_forks":
-		return 66
-	case "conversation_fork_snapshots":
-		return 67
-	case "conversation_fork_turns":
-		return 68
-	case "routing_rules":
-		return 70
-	case "event_deliveries":
-		return 80
-	case "run_fork_delivery_event_replays":
-		return 85
-	case "event_receipts":
-		return 90
-	case "entity_mutations":
-		return 95
-	case "mailbox":
-		return 100
-	case "api_idempotency":
-		return 105
-	case "runtime_ingress_state":
-		return 108
-	case "run_control_state":
-		return 109
-	case "spend_ledger":
-		return 110
-	case "timers":
-		return 120
-	default:
-		return 1000
-	}
-}
-
 func QuoteIdent(v string) string {
 	return quoteIdent(v)
 }
 
-func normalizePlatformDDLStatements(rawDDL string) ([]string, error) {
-	chunks := strings.Split(rawDDL, ";")
-	statements := make([]string, 0, len(chunks))
-	for _, chunk := range chunks {
-		statement := strings.TrimSpace(chunk)
-		if statement == "" {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE TABLE "):
-			tableStatement, indexStatements, err := schemaDDLNormalizeCreateTable(statement)
-			if err != nil {
-				return nil, err
-			}
-			statements = append(statements, tableStatement)
-			statements = append(statements, indexStatements...)
-			continue
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE INDEX "):
-			statement = schemaDDLEnsureIfNotExists(statement, "CREATE INDEX")
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE UNIQUE INDEX "):
-			statement = schemaDDLEnsureIfNotExists(statement, "CREATE UNIQUE INDEX")
-		default:
-			return nil, fmt.Errorf("unsupported platform DDL statement %q", statement)
-		}
-		statements = append(statements, statement)
-	}
-	if len(statements) == 0 {
-		return nil, fmt.Errorf("no executable platform DDL statements found")
-	}
-	return statements, nil
-}
-
-func schemaDDLNormalizeCreateTable(statement string) (string, []string, error) {
-	statement = schemaDDLEnsureIfNotExists(statement, "CREATE TABLE")
-	tableName := schemaDDLExtractTableName(statement)
-	if tableName == "" {
-		return "", nil, fmt.Errorf("unable to extract table name from %q", statement)
-	}
-	start := strings.Index(statement, "(")
-	end := strings.LastIndex(statement, ")")
-	if start < 0 || end <= start {
-		return statement, nil, nil
-	}
-	body := statement[start+1 : end]
-	lines := strings.Split(body, "\n")
-	kept := make([]string, 0, len(lines))
-	indexStatements := make([]string, 0, 2)
-	for _, rawLine := range lines {
-		trimmed := strings.TrimSpace(strings.TrimSuffix(rawLine, ","))
-		if trimmed == "" {
-			continue
-		}
-		if matches := schemaDDLInlineIndexLine.FindStringSubmatch(trimmed); len(matches) >= 3 {
-			uniquePrefix := strings.TrimSpace(matches[1])
-			indexName := strings.TrimSpace(matches[2])
-			indexCols := strings.TrimSpace(matches[3])
-			whereClause := ""
-			if len(matches) >= 5 {
-				whereClause = strings.TrimSpace(matches[4])
-			}
-			statement := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
-			if uniquePrefix != "" {
-				statement = fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
-			}
-			if whereClause != "" {
-				statement += " " + whereClause
-			}
-			indexStatements = append(indexStatements, statement)
-			continue
-		}
-		kept = append(kept, trimmed)
-	}
-	normalizedTable := fmt.Sprintf("%s (\n    %s\n)", statement[:start], strings.Join(kept, ",\n    "))
-	return normalizedTable, indexStatements, nil
-}
-
-func stripDeprecatedEntitySubjectDDL(declaredName string, statements []string) []string {
-	if strings.TrimSpace(declaredName) != "entity_state" {
-		return statements
-	}
-	filtered := make([]string, 0, len(statements))
-	for _, statement := range statements {
-		normalized := strings.ToLower(statement)
-		if strings.Contains(normalized, "idx_entity_subject") {
-			continue
-		}
-		if schemaDDLExtractTableName(statement) == "entity_state" {
-			statement = schemaDDLStripCreateTableColumn(statement, "subject_id")
-		}
-		filtered = append(filtered, statement)
-	}
-	return filtered
-}
-
-func schemaDDLStripCreateTableColumn(statement, columnName string) string {
-	start := strings.Index(statement, "(")
-	end := strings.LastIndex(statement, ")")
-	if start < 0 || end <= start {
-		return statement
-	}
-	body := statement[start+1 : end]
-	lines := strings.Split(body, "\n")
-	kept := make([]string, 0, len(lines))
-	for _, rawLine := range lines {
-		trimmed := strings.TrimSpace(strings.TrimSuffix(rawLine, ","))
-		if trimmed == "" {
-			continue
-		}
-		identifier := strings.Trim(strings.Fields(trimmed)[0], `"`)
-		if identifier == columnName {
-			continue
-		}
-		kept = append(kept, trimmed)
-	}
-	return fmt.Sprintf("%s(\n    %s\n)%s", statement[:start], strings.Join(kept, ",\n    "), statement[end+1:])
-}
-
-func schemaDDLEnsureIfNotExists(statement, prefix string) string {
-	statement = strings.TrimSpace(statement)
-	upper := strings.ToUpper(statement)
-	if strings.HasPrefix(upper, prefix+" IF NOT EXISTS ") {
-		return statement
-	}
-	return prefix + " IF NOT EXISTS " + strings.TrimSpace(statement[len(prefix):])
-}
-
 func schemaDDLExtractTableName(statement string) string {
-	statement = strings.TrimSpace(statement)
-	matches := schemaDDLCreateTableName.FindStringSubmatch(statement)
-	if len(matches) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(matches[1])
-}
-
-func schemaDDLColumnCount(statements []string) int {
-	for _, statement := range statements {
-		tableName := schemaDDLExtractTableName(statement)
-		if tableName == "" {
-			continue
-		}
-		start := strings.Index(statement, "(")
-		end := strings.LastIndex(statement, ")")
-		if start < 0 || end <= start {
-			return 0
-		}
-		count := 0
-		for _, line := range strings.Split(statement[start+1:end], "\n") {
-			line = strings.TrimSpace(strings.TrimSuffix(line, ","))
-			if line == "" || strings.HasPrefix(strings.ToUpper(line), "PRIMARY KEY") {
-				continue
-			}
-			count++
-		}
-		return count
-	}
-	return 0
+	return platformschema.ExtractTableName(statement)
 }
 
 func schemaDDLPlanColumnNames(plan SchemaTableDDL) []string {
-	for _, statement := range plan.Statements {
-		if schemaDDLExtractTableName(statement) == "" {
-			continue
-		}
-		return schemaDDLCreateTableColumnNames(statement)
-	}
-	return nil
-}
-
-func schemaDDLCreateTableColumnNames(statement string) []string {
-	start := strings.Index(statement, "(")
-	end := strings.LastIndex(statement, ")")
-	if start < 0 || end <= start {
-		return nil
-	}
-	seen := map[string]struct{}{}
-	out := make([]string, 0)
-	for _, line := range strings.Split(statement[start+1:end], "\n") {
-		line = strings.TrimSpace(strings.TrimSuffix(line, ","))
-		if line == "" || schemaDDLCreateTableLineIsConstraint(line) {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
-		}
-		columnName := strings.Trim(fields[0], `"`)
-		if columnName == "" {
-			continue
-		}
-		if _, exists := seen[columnName]; exists {
-			continue
-		}
-		seen[columnName] = struct{}{}
-		out = append(out, columnName)
-	}
-	return out
-}
-
-func schemaDDLCreateTableLineIsConstraint(line string) bool {
-	fields := strings.Fields(strings.ToUpper(strings.TrimSpace(line)))
-	if len(fields) == 0 {
-		return false
-	}
-	switch fields[0] {
-	case "PRIMARY", "FOREIGN", "UNIQUE", "CHECK", "CONSTRAINT", "EXCLUDE":
-		return true
-	default:
-		return false
-	}
+	return platformschema.PlanColumnNames(plan)
 }

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -22,18 +22,27 @@ import (
 )
 
 type sharedPostgresState struct {
-	mu        sync.Mutex
-	lifecycle sync.Mutex
-	started   bool
-	dockerBin string
-	name      string
-	adminDSN  string
-	template  string
-	templated bool
-	nextDBID  uint64
+	mu             sync.Mutex
+	lifecycle      sync.Mutex
+	started        bool
+	dockerBin      string
+	name           string
+	adminDSN       string
+	template       string
+	templated      bool
+	cleanupStarted bool
+	nextDBID       uint64
 }
 
 var sharedPostgres sharedPostgresState
+
+func init() {
+	if os.Getenv("SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP") != "1" {
+		return
+	}
+	runPostgresTemplateCleanupWatcherFromEnv()
+	os.Exit(0)
+}
 
 // StartPostgres provides an isolated database on a shared Postgres container.
 // The container is started once per test process; each call creates a fresh
@@ -289,8 +298,69 @@ func (s *sharedPostgresState) ensureTemplateDatabase(adminDB *sql.DB) error {
 		_ = dropIsolatedDatabase(adminDB, templateName)
 		return fmt.Errorf("close template database %q: %w", templateName, err)
 	}
+	if err := s.startTemplateCleanupWatcher(templateName); err != nil {
+		_ = dropIsolatedDatabase(adminDB, templateName)
+		return err
+	}
 	s.templated = true
 	return nil
+}
+
+func (s *sharedPostgresState) startTemplateCleanupWatcher(templateName string) error {
+	if s.cleanupStarted || s.dockerBin != "" {
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve postgres template cleanup binary: %w", err)
+	}
+	cmd := exec.Command(exe)
+	cmd.Env = append(os.Environ(),
+		"SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP=1",
+		"SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID="+strconv.Itoa(os.Getpid()),
+		"SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN="+s.adminDSN,
+		"SWARM_TEST_POSTGRES_TEMPLATE_NAME="+templateName,
+	)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start postgres template cleanup watcher: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("release postgres template cleanup watcher: %w", err)
+	}
+	s.cleanupStarted = true
+	return nil
+}
+
+func runPostgresTemplateCleanupWatcherFromEnv() {
+	parentPID, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID")))
+	if err != nil || parentPID <= 0 {
+		return
+	}
+	adminDSN := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN"))
+	templateName := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_TEMPLATE_NAME"))
+	if adminDSN == "" || templateName == "" {
+		return
+	}
+	waitForProcessExit(parentPID)
+	db, err := sql.Open("postgres", adminDSN)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	_ = dropIsolatedDatabase(db, templateName)
+}
+
+func waitForProcessExit(pid int) {
+	proc, err := os.FindProcess(pid)
+	if err != nil || proc == nil {
+		return
+	}
+	for {
+		if proc.Signal(syscall.Signal(0)) != nil {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 func initializeDatabase(db *sql.DB) error {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -9,12 +9,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store/platformschema"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -29,6 +28,8 @@ type sharedPostgresState struct {
 	dockerBin string
 	name      string
 	adminDSN  string
+	template  string
+	templated bool
 	nextDBID  uint64
 }
 
@@ -36,7 +37,7 @@ var sharedPostgres sharedPostgresState
 
 // StartPostgres provides an isolated database on a shared Postgres container.
 // The container is started once per test process; each call creates a fresh
-// database, applies the canonical schema, and drops that database on cleanup.
+// database cloned from one canonical schema template, and drops that database on cleanup.
 func StartPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
 	t.Helper()
 
@@ -59,29 +60,16 @@ func StartPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
 	defer adminDB.Close()
 
 	sharedPostgres.lifecycle.Lock()
-	if err := createIsolatedDatabase(adminDB, dbName); err != nil {
+	if err := sharedPostgres.ensureTemplateDatabase(adminDB); err != nil {
+		sharedPostgres.lifecycle.Unlock()
+		t.Fatalf("initialize postgres template: %v", err)
+	}
+	if err := createIsolatedDatabaseFromTemplate(adminDB, dbName, sharedPostgres.template); err != nil {
 		sharedPostgres.lifecycle.Unlock()
 		t.Fatalf("create isolated postgres database %q: %v", dbName, err)
 	}
 
 	dsn = withDBName(adminDSN, dbName)
-	db, err = sql.Open("postgres", dsn)
-	if err != nil {
-		_ = dropIsolatedDatabase(adminDB, dbName)
-		sharedPostgres.lifecycle.Unlock()
-		t.Fatalf("open postgres %q: %v", dbName, err)
-	}
-	if err := initializeDatabase(db); err != nil {
-		_ = db.Close()
-		_ = dropIsolatedDatabase(adminDB, dbName)
-		sharedPostgres.lifecycle.Unlock()
-		t.Fatalf("initialize postgres %q: %v", dbName, err)
-	}
-	if err := db.Close(); err != nil {
-		_ = dropIsolatedDatabase(adminDB, dbName)
-		sharedPostgres.lifecycle.Unlock()
-		t.Fatalf("close bootstrap postgres %q: %v", dbName, err)
-	}
 	db, err = sql.Open("postgres", dsn)
 	if err != nil {
 		_ = dropIsolatedDatabase(adminDB, dbName)
@@ -268,20 +256,49 @@ func (s *sharedPostgresState) nextDatabaseName() string {
 	return fmt.Sprintf("mas_test_%d_%d", os.Getpid(), id)
 }
 
+func (s *sharedPostgresState) templateDatabaseName() string {
+	if s.template == "" {
+		s.template = fmt.Sprintf("mas_template_%d", os.Getpid())
+	}
+	return s.template
+}
+
+func (s *sharedPostgresState) ensureTemplateDatabase(adminDB *sql.DB) error {
+	if s.templated {
+		return nil
+	}
+	templateName := s.templateDatabaseName()
+	if err := dropIsolatedDatabase(adminDB, templateName); err != nil {
+		return fmt.Errorf("reset template database %q: %w", templateName, err)
+	}
+	if err := createIsolatedDatabase(adminDB, templateName); err != nil {
+		return fmt.Errorf("create template database %q: %w", templateName, err)
+	}
+	templateDSN := withDBName(s.adminDSN, templateName)
+	templateDB, err := sql.Open("postgres", templateDSN)
+	if err != nil {
+		_ = dropIsolatedDatabase(adminDB, templateName)
+		return fmt.Errorf("open template database %q: %w", templateName, err)
+	}
+	if err := initializeDatabase(templateDB); err != nil {
+		_ = templateDB.Close()
+		_ = dropIsolatedDatabase(adminDB, templateName)
+		return fmt.Errorf("initialize template database %q: %w", templateName, err)
+	}
+	if err := templateDB.Close(); err != nil {
+		_ = dropIsolatedDatabase(adminDB, templateName)
+		return fmt.Errorf("close template database %q: %w", templateName, err)
+	}
+	s.templated = true
+	return nil
+}
+
 func initializeDatabase(db *sql.DB) error {
-	specPath, err := platformSpecPath()
+	spec, err := loadPlatformSpec()
 	if err != nil {
 		return err
 	}
-	b, err := os.ReadFile(specPath)
-	if err != nil {
-		return fmt.Errorf("read platform spec: %w", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(b, &spec); err != nil {
-		return fmt.Errorf("unmarshal platform spec: %w", err)
-	}
-	statements, err := bootstrapPlatformTableStatements(spec)
+	plans, err := platformschema.GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		return fmt.Errorf("generate platform tables ddl: %w", err)
 	}
@@ -289,18 +306,10 @@ func initializeDatabase(db *sql.DB) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	initSQL := []string{
-		`CREATE SCHEMA IF NOT EXISTS public`,
-		`GRANT ALL ON SCHEMA public TO postgres`,
-		`GRANT ALL ON SCHEMA public TO public`,
-		`CREATE EXTENSION IF NOT EXISTS pgcrypto`,
+	if err := ensurePublicSchema(ctx, db); err != nil {
+		return err
 	}
-	for _, stmt := range initSQL {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("init stmt %q: %w", stmt, err)
-		}
-	}
-	if err := execBootstrapStatements(ctx, db, statements); err != nil {
+	if err := platformschema.EnsurePostgresTables(ctx, db, plans, nil); err != nil {
 		return fmt.Errorf("bootstrap platform tables: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -315,10 +324,48 @@ func initializeDatabase(db *sql.DB) error {
 	return nil
 }
 
+func loadPlatformSpec() (runtimecontracts.PlatformSpecDocument, error) {
+	specPath, err := platformSpecPath()
+	if err != nil {
+		return runtimecontracts.PlatformSpecDocument{}, err
+	}
+	b, err := os.ReadFile(specPath)
+	if err != nil {
+		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("read platform spec: %w", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(b, &spec); err != nil {
+		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", err)
+	}
+	return spec, nil
+}
+
+func ensurePublicSchema(ctx context.Context, db *sql.DB) error {
+	for _, stmt := range []string{
+		`CREATE SCHEMA IF NOT EXISTS public`,
+		`GRANT ALL ON SCHEMA public TO postgres`,
+		`GRANT ALL ON SCHEMA public TO public`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("init stmt %q: %w", stmt, err)
+		}
+	}
+	return nil
+}
+
 func createIsolatedDatabase(adminDB *sql.DB, dbName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE "+quoteIdent(dbName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createIsolatedDatabaseFromTemplate(adminDB *sql.DB, dbName, templateName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE "+quoteIdent(dbName)+" WITH TEMPLATE "+quoteIdent(templateName)); err != nil {
 		return err
 	}
 	return nil
@@ -364,196 +411,6 @@ func platformSpecPath() (string, error) {
 		return "", fmt.Errorf("platform spec not found: %w", statErr)
 	}
 	return specPath, nil
-}
-
-var (
-	testutilCreateTableName = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+"?([a-z_][a-z0-9_]*)"?`)
-	testutilInlineIndexLine = regexp.MustCompile(`(?i)^(unique\s+)?index\s+([a-z_][a-z0-9_]*)\s*\((.+?)\)\s*(where\s+.+)?$`)
-)
-
-func bootstrapPlatformTableStatements(spec runtimecontracts.PlatformSpecDocument) ([]string, error) {
-	tableNames := make([]string, 0, len(spec.PlatformTables.Tables))
-	for tableName := range spec.PlatformTables.Tables {
-		tableNames = append(tableNames, strings.TrimSpace(tableName))
-	}
-	sort.Slice(tableNames, func(i, j int) bool {
-		left := bootstrapPlatformTableOrder(tableNames[i])
-		right := bootstrapPlatformTableOrder(tableNames[j])
-		if left != right {
-			return left < right
-		}
-		return tableNames[i] < tableNames[j]
-	})
-	statements := make([]string, 0, len(tableNames)*2)
-	for _, tableName := range tableNames {
-		normalized, err := bootstrapNormalizePlatformDDL(spec.PlatformTables.Tables[tableName].DDL)
-		if err != nil {
-			return nil, fmt.Errorf("platform table %s: %w", tableName, err)
-		}
-		statements = append(statements, normalized...)
-	}
-	return statements, nil
-}
-
-func execBootstrapStatements(ctx context.Context, db *sql.DB, statements []string) error {
-	for _, statement := range statements {
-		statement = strings.TrimSpace(statement)
-		if statement == "" {
-			continue
-		}
-		if _, err := db.ExecContext(ctx, statement); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func bootstrapNormalizePlatformDDL(rawDDL string) ([]string, error) {
-	chunks := strings.Split(rawDDL, ";")
-	statements := make([]string, 0, len(chunks))
-	for _, chunk := range chunks {
-		statement := strings.TrimSpace(chunk)
-		if statement == "" {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE TABLE "):
-			tableStmt, indexStatements, err := bootstrapNormalizeCreateTable(statement)
-			if err != nil {
-				return nil, err
-			}
-			statements = append(statements, tableStmt)
-			statements = append(statements, indexStatements...)
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE INDEX "):
-			statements = append(statements, bootstrapEnsureIfNotExists(statement, "CREATE INDEX"))
-		case strings.HasPrefix(strings.ToUpper(statement), "CREATE UNIQUE INDEX "):
-			statements = append(statements, bootstrapEnsureIfNotExists(statement, "CREATE UNIQUE INDEX"))
-		default:
-			return nil, fmt.Errorf("unsupported platform ddl statement %q", statement)
-		}
-	}
-	if len(statements) == 0 {
-		return nil, fmt.Errorf("no executable platform ddl statements found")
-	}
-	return statements, nil
-}
-
-func bootstrapNormalizeCreateTable(statement string) (string, []string, error) {
-	statement = bootstrapEnsureIfNotExists(statement, "CREATE TABLE")
-	tableName := bootstrapExtractTableName(statement)
-	if tableName == "" {
-		return "", nil, fmt.Errorf("unable to extract table name from %q", statement)
-	}
-	start := strings.Index(statement, "(")
-	end := strings.LastIndex(statement, ")")
-	if start < 0 || end <= start {
-		return statement, nil, nil
-	}
-	body := statement[start+1 : end]
-	lines := strings.Split(body, "\n")
-	kept := make([]string, 0, len(lines))
-	indexStatements := make([]string, 0, 2)
-	for _, rawLine := range lines {
-		trimmed := strings.TrimSpace(strings.TrimSuffix(rawLine, ","))
-		if trimmed == "" {
-			continue
-		}
-		if matches := testutilInlineIndexLine.FindStringSubmatch(trimmed); len(matches) >= 3 {
-			uniquePrefix := strings.TrimSpace(matches[1])
-			indexName := strings.TrimSpace(matches[2])
-			indexCols := strings.TrimSpace(matches[3])
-			whereClause := ""
-			if len(matches) >= 5 {
-				whereClause = strings.TrimSpace(matches[4])
-			}
-			indexStmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
-			if uniquePrefix != "" {
-				indexStmt = fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(%s)", quoteIdent(indexName), quoteIdent(tableName), indexCols)
-			}
-			if whereClause != "" {
-				indexStmt += " " + whereClause
-			}
-			indexStatements = append(indexStatements, indexStmt)
-			continue
-		}
-		kept = append(kept, trimmed)
-	}
-	return fmt.Sprintf("%s (\n    %s\n)", statement[:start], strings.Join(kept, ",\n    ")), indexStatements, nil
-}
-
-func bootstrapEnsureIfNotExists(statement, prefix string) string {
-	statement = strings.TrimSpace(statement)
-	upper := strings.ToUpper(statement)
-	if strings.HasPrefix(upper, prefix+" IF NOT EXISTS ") {
-		return statement
-	}
-	return prefix + " IF NOT EXISTS " + strings.TrimSpace(statement[len(prefix):])
-}
-
-func bootstrapExtractTableName(statement string) string {
-	statement = strings.TrimSpace(statement)
-	matches := testutilCreateTableName.FindStringSubmatch(statement)
-	if len(matches) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(matches[1])
-}
-
-func bootstrapPlatformTableOrder(name string) int {
-	switch strings.TrimSpace(name) {
-	case "schema_version":
-		return 0
-	case "runs":
-		return 5
-	case "events":
-		return 10
-	case "run_fork_selected_contract_bindings":
-		return 15
-	case "run_fork_selected_contract_executions":
-		return 18
-	case "run_fork_selected_contract_branch_divergences":
-		return 19
-	case "dead_letters":
-		return 20
-	case "agents":
-		return 30
-	case "flow_instances":
-		return 40
-	case "entity_state":
-		return 50
-	case "agent_sessions":
-		return 60
-	case "agent_turns":
-		return 65
-	case "conversation_forks":
-		return 66
-	case "conversation_fork_snapshots":
-		return 67
-	case "conversation_fork_turns":
-		return 68
-	case "routing_rules":
-		return 70
-	case "event_deliveries":
-		return 80
-	case "run_fork_delivery_event_replays":
-		return 85
-	case "event_receipts":
-		return 90
-	case "entity_mutations":
-		return 95
-	case "mailbox":
-		return 100
-	case "api_idempotency":
-		return 105
-	case "runtime_ingress_state":
-		return 108
-	case "spend_ledger":
-		return 110
-	case "timers":
-		return 120
-	default:
-		return 1000
-	}
 }
 
 func startContainerWatcher(dockerBin, containerName string) error {

--- a/internal/testutil/postgres_test.go
+++ b/internal/testutil/postgres_test.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 )
@@ -17,5 +18,61 @@ func TestStartPostgres_Smoke(t *testing.T) {
 	}
 	if one != 1 {
 		t.Fatalf("expected 1, got %d", one)
+	}
+}
+
+func TestStartPostgres_CanonicalSchemaTemplatePreservesIsolation(t *testing.T) {
+	spec, err := loadPlatformSpec()
+	if err != nil {
+		t.Fatalf("load platform spec: %v", err)
+	}
+	if spec.Platform.Version == "" {
+		t.Fatal("platform spec version is required")
+	}
+
+	_, firstDB, cleanupFirst := StartPostgres(t)
+	defer cleanupFirst()
+	assertStartPostgresSchema(t, firstDB, spec.Platform.Version)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := firstDB.ExecContext(ctx, `CREATE TABLE start_postgres_isolation_probe (id BIGINT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create isolation probe in first database: %v", err)
+	}
+
+	_, secondDB, cleanupSecond := StartPostgres(t)
+	defer cleanupSecond()
+	assertStartPostgresSchema(t, secondDB, spec.Platform.Version)
+
+	var leaked bool
+	if err := secondDB.QueryRowContext(ctx, `SELECT to_regclass('public.start_postgres_isolation_probe') IS NOT NULL`).Scan(&leaked); err != nil {
+		t.Fatalf("check isolation probe in second database: %v", err)
+	}
+	if leaked {
+		t.Fatal("table created in one StartPostgres database leaked into another")
+	}
+}
+
+func assertStartPostgresSchema(t *testing.T, db *sql.DB, wantVersion string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	for _, table := range []string{"schema_version", "bundles", "runs", "events", "event_receipts", "timers"} {
+		var exists bool
+		if err := db.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, "public."+table).Scan(&exists); err != nil {
+			t.Fatalf("check table %s: %v", table, err)
+		}
+		if !exists {
+			t.Fatalf("expected platform table %s to exist", table)
+		}
+	}
+
+	var gotVersion string
+	if err := db.QueryRowContext(ctx, `SELECT platform_version FROM schema_version WHERE id = 1`).Scan(&gotVersion); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if gotVersion != wantVersion {
+		t.Fatalf("schema_version platform_version = %q, want %q", gotVersion, wantVersion)
 	}
 }


### PR DESCRIPTION
Closes #1207
Part of #1196

## Summary

- Added `internal/store/platformschema` as the shared store-owned platform schema DDL generation/execution owner.
- Kept the public `store.GeneratePlatformTableDDLs` API by delegating to the shared owner, and moved `PostgresStore.EnsureSchemaTables` statement execution through that same owner.
- Reworked `internal/testutil.StartPostgres` to initialize one process-local canonical template database from root `platform-spec.yaml`, then clone fresh isolated per-call databases from that template.
- Removed the private `internal/testutil` platform-table DDL interpreter path and added schema/isolation coverage for the template-backed helper.

## Governing Context

Exact spec reference: root `platform-spec.yaml` `platform_tables.test_bootstrap`, especially `sources.platform_tables` and `bootstrap_function`, which require platform tables to come from `platform_tables.tables` and test setup to share the platform bootstrap path.

Binding gate context: #1207 approved class `startpostgres_noncanonical_per_call_platform_schema_bootstrap_cost`; #1196 remains the test-health umbrella.

Private process docs followed from `/Users/youmew/dev/swarm-docs/docs/IMPLEMENTER_GUIDELINES.md` and `/Users/youmew/dev/swarm-docs/docs/SEMANTIC_DRIFT.md`.

## Semantic Migration

New canonical owner: `internal/store/platformschema` for platform-table DDL generation, flattening, column extraction, platform-plan detection, and Postgres schema statement execution.

Public production-facing owner remains `internal/store.GeneratePlatformTableDDLs` and `PostgresStore.EnsureSchemaTables`, both now delegate to the shared owner.

Old invalid path: `internal/testutil/postgres.go` private bootstrap DDL interpreter and per-call full schema bootstrap for every isolated database.

Production paths checked for surviving old behavior: store schema DDL tests, full `internal/store`, representative `internal/runtime/pipeline`, and full `go test ./...`. Migration is complete for the #1207 chosen class.

## Validation

- `go test ./internal/store/platformschema ./internal/store -run TestGeneratePlatformTableDDLs -count=1`
- `go test ./internal/testutil -run TestStartPostgres -count=1`
- `go test ./internal/store -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./...`
- `go test ./internal/testutil -run TestStartPostgres -count=1 -json | go run ./cmd/swarm-test-timing -input - -top 10`

Timing proof for the final base: `swarm/internal/testutil` package elapsed `2.048s`; `TestStartPostgres_Smoke` `1.330s`; `TestStartPostgres_CanonicalSchemaTemplatePreservesIsolation` `0.100s`.

Static proof: no `internal/testutil` `bootstrapPlatformTableStatements`, `bootstrapNormalizePlatformDDL`, `bootstrapNormalizeCreateTable`, `bootstrapPlatformTableOrder`, or `execBootstrapStatements` path remains.