### PR TITLE
Trim README to front-door scope; correct fork CLI and Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Swarm runs fleets of LLM agents as a durable, stateful system. You declare it in
 
 More than a simple orchestrator that decides which agent runs next, Swarm runs the system around it. Work is modeled as entities (an order, a ticket, a candidate business) moving through a state machine you declare: the runtime schedules hundreds at once, keeps them isolated, meters their spend, persists their state, and resumes them after a crash, days later if a timer or a human kept them waiting. Any run can be replayed or forked from the log. Deterministic routing is one piece; the rest is the operating system.
 
-Single Go binary, local/dev SQLite persistence by default. Postgres remains an explicit external/production opt-in backend. Three LLM backend profiles ship today: `anthropic` for Anthropic API, `claude_cli` for the Claude CLI subprocess transport, and `openai_compatible` for Chat Completions-compatible HTTP JSON. All three consume the shared LLM provider adapter contract; native OpenAI Responses and provider-specific OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, or vLLM support remain separate gated runtime/config work.
+Single Go binary, local/dev SQLite by default with Postgres as a production opt-in. Multiple LLM backends ship today: the Anthropic API, the Claude CLI, and any OpenAI Chat Completions endpoint.
 
 **Long-term direction:** entire divisions (engineering, support, operations) running as autonomous Swarm flows. Humans in the loop where judgment is required; agents and deterministic system nodes everywhere else.
 
@@ -18,12 +18,12 @@ Single Go binary, local/dev SQLite persistence by default. Postgres remains an e
 
 Swarm makes a small number of opinionated choices and sticks to them.
 
-- **Work is a durable state machine.** Every unit of work is an entity that moves through declared states by guarded transitions. The runtime persists state in the selected runtime store, so state survives a crash and hundreds of entities advance independently without interfering. Local/dev commands default to file-backed SQLite; Postgres is explicit opt-in for external and production deployments.
+- **Work is a durable state machine.** Every unit of work is an entity that moves through declared states by guarded transitions. The runtime persists state, so state survives a crash and hundreds of entities advance independently without interfering.
 - **The control loop is deterministic.** No LLM decides what fires next. Routing is derived from declared subscriptions, and every event runs through a fixed handler pipeline. Conditions use [CEL](https://github.com/google/cel-spec): strongly typed, non-Turing-complete, no hallucinating router.
 - **Every transition is one transaction.** Guard, accumulate, compute, commit, emit: all-or-nothing. A crash mid-handler leaves no partial state.
 - **Flows are composable units.** A flow package declares its identity, state machine, system nodes, events, agents, tools, and policy. Typed input and output pins make composition mechanical rather than a refactor. Create your specialized flows and import them in other Swarm projects.
 - **Agents are isolated.** Each agent runs in a scoped session and observes only the events it subscribes to. A coordinator addresses managers; managers address workers; workers do not share a context window. Per-entity Docker workspaces extend the isolation to the filesystem and process level: agents working on entity X have no access to entity Y's working tree.
-- **Execution is replayable.** Every event and every state mutation is persisted. Any run can be reconstructed turn by turn, audited end to end, or resumed from its last consistent checkpoint after a crash. Auditability is native. 
+- **Execution is replayable.** Every event and every state mutation is persisted. Any run can be reconstructed turn by turn, audited end to end, or resumed from its last consistent checkpoint after a crash. Auditability is native.
 - **Runs are forkable.** Re-execute any run from any point in its history with a counterfactual like a different policy value, a tweaked prompt, or an entirely new contract bundle, and compare outcomes against the original. Last week's failed run can be replayed against this week's fixed contracts. The cost of iterating on a flow drops to the cost of forking a run, which turns continuous improvement into a regular engineering loop instead of a deploy-and-watch cycle.
 - **Humans participate as a first-class actor.** Approvals, rejections, and deferrals flow through a durable mailbox using the same event model as the rest of the runtime. A pending decision is just another event waiting for its handler: a human's, in this case. Autonomy is a dial, not a switch.
 
@@ -34,7 +34,7 @@ The tradeoff: a Swarm flow cannot be re-wired by an LLM at runtime. That rigidit
 ## Try it
 
 ```bash
-# run the static analyzer: 54 contract checks against the platform spec
+# run the static analyzer against the platform spec
 swarm verify --contracts ./my-flow
 
 # start a run from a triggering event, stream its trace as it executes
@@ -44,7 +44,7 @@ swarm run --contracts ./my-flow --event order.created --payload ./payload.json
 swarm trace <run-id> -f
 
 # re-execute any run from any point in its history
-swarm fork --run <id> --at <event>
+swarm fork <source-run-id> --at-event <event-id>
 ```
 
 ---
@@ -76,51 +76,85 @@ guard ──▶ accumulate ──▶ compute ──▶ {advances_to, sets_gate, 
                                        atomic commit
 ```
 
-Guard failures have explicit semantics: `reject` (default), `discard`, `kill`, or `escalate:{event}`. Conditions use [CEL](https://github.com/google/cel-spec): strongly typed, non-Turing-complete.
+Conditions use [CEL](https://github.com/google/cel-spec): strongly typed, non-Turing-complete.
 
 ---
 
 ## Quickstart
 
-Requires Go 1.23, Docker for the current workspace-isolation backend, and a
-contract bundle. Plain local commands require no database service: when no
-runtime store is selected, Swarm uses file-backed SQLite at `.swarm/dev.db`.
-Credentials are required only for flows that actually invoke the configured LLM
-backend. The workspace backend also requires a compatible Docker image;
-`swarm-workspace:latest` is the default, or set `SWARM_WORKSPACE_IMAGE` to an
-image you already provide.
+Requires Go 1.23. Plain local commands need no database service: Swarm
+defaults to file-backed SQLite at `.swarm/dev.db`. LLM credentials are
+required only when a flow runs agents.
 
 ```bash
-# 1. clone
-git clone https://github.com/<org>/swarm && cd swarm
-
-# 2. build the CLI
+git clone https://github.com/division-sh/swarm && cd swarm
 go build ./cmd/swarm
-
-# 3. build the current workspace image
-docker build -f Dockerfile.workspace -t swarm-workspace:latest .
-
-# 4. choose the shared /data source explicitly for local workspaces
-export SWARM_WORKSPACE_DATA_SOURCE="$PWD/data"
-
-# 5. run a contract locally; this creates/uses .swarm/dev.db
-printf '{"entity_id":"11111111-1111-4111-8111-111111111111"}\n' > /tmp/swarm-payload.json
-./swarm run \
-  --contracts tests/tier1-primitives/test-emits-single \
-  --event item.received \
-  --payload /tmp/swarm-payload.json
 ```
 
-For a long-running local API runtime, use the same direct contract path:
+Define a self-contained flow next to the binary. The static analyzer expects
+six files; the four below carry the logic, and the other two are empty
+placeholders.
+
+```yaml greeting-flow/package.yaml
+name: greeting-flow
+version: 1.0.0
+description: Receives a greeting request and emits a greeting delivered event.
+platform_version: ">=1.6.0"
+flows: []
+```
+
+```yaml greeting-flow/schema.yaml
+initial_state: requested
+terminal_states: [greeted]
+states: [requested, greeted]
+pins:
+  inputs:
+    events: [greeting.requested]
+  outputs:
+    events: [greeting.delivered]
+```
+
+```yaml greeting-flow/events.yaml
+greeting.requested:
+  swarm:
+    source: external
+  entity_id: string
+greeting.delivered:
+  entity_id: string
+```
+
+```yaml greeting-flow/nodes.yaml
+greeter:
+  id: greeter
+  execution_type: system_node
+  subscribes_to: [greeting.requested]
+  produces: [greeting.delivered]
+  event_handlers:
+    greeting.requested:
+      advances_to: greeted
+      emit:
+        event: greeting.delivered
+        broadcast: true
+```
 
 ```bash
-./swarm serve --contracts tests/tier1-primitives/test-emits-single
+# Empty placeholders plus the entry-point payload
+echo '{}' > greeting-flow/agents.yaml
+echo '{}' > greeting-flow/policy.yaml
+echo '{"entity_id":"11111111-1111-4111-8111-111111111111"}' > greeting-flow/payload.json
+
+# Run the flow against the local SQLite runtime (creates .swarm/dev.db)
+./swarm run --contracts ./greeting-flow --event greeting.requested --payload greeting-flow/payload.json
 ```
 
-Plain local `swarm serve` and foreground `swarm run` use the built-in dev API
-token only on numeric loopback binds, with bearer auth still enabled. Set
-`SWARM_API_TOKEN` before exposing the API beyond loopback; the built-in token is
-not user isolation on a shared host.
+For a long-running local API runtime, point `swarm serve` at the same bundle:
+
+```bash
+./swarm serve --contracts ./greeting-flow
+```
+
+Local loopback uses a built-in dev API token (bearer auth still enabled); set
+`SWARM_API_TOKEN` to expose the API beyond loopback.
 
 See [`.env.example`](.env.example) for the public local environment template.
 
@@ -137,95 +171,40 @@ docker run -d --name swarm-postgres \
   postgres:16
 
 SWARM_DB_HOST=127.0.0.1 SWARM_DB_PASSWORD=postgres \
-  ./swarm serve --store postgres --contracts tests/tier1-primitives/test-emits-single
+  ./swarm serve --store postgres --contracts ./greeting-flow
 ```
 
-### Workspace Reference Data
+### For agent flows
 
-Agents see shared reference files at `/data`. For plain local `swarm serve`,
-choose that host source explicitly:
+A flow that runs agents on the `claude_cli` backend needs the workspace-isolation
+backend (Docker) and a compatible workspace image:
 
 ```bash
-swarm serve --contracts ./my-flow --data ./reference-data
+docker build -f Dockerfile.workspace -t swarm-workspace:latest .
 ```
 
-The source order is `--data > workspace.data_source >
-SWARM_WORKSPACE_DATA_SOURCE > no path source`. The runtime no longer treats a
-repo-local `data/` directory as the implicit source of truth. `/data` remains
-read-only and opaque to Swarm; contract-owned `flows/<flow>/data/` files are a
-separate bundled contract input.
+The `swarm-workspace:latest` tag is the default; set `SWARM_WORKSPACE_IMAGE` to
+use a different image. The shared `/data` mount auto-creates at `.swarm/data/`
+when the runtime starts; pass `--data <dir>` (on `swarm serve` or `swarm run`)
+if your agents need a specific host directory for `flow_data_access`.
 
-### LLM Backend Profiles
+See [LLM backends](#llm-backends) for selecting the agent backend and providing
+its credential.
 
-Select a shipped backend with `--backend` or the equivalent `llm.backend`
-config key. Selection precedence is
-`--backend > llm.backend > default anthropic`; environment variables never
-select the backend. Commands that need runtime/operator config discover an
-explicit `--config` first, `config.yaml` beside the running binary second, and
-built-in/default config last.
+### LLM backends
 
-```bash
-# Anthropic API transport.
-export ANTHROPIC_API_KEY=...
-swarm serve --backend anthropic
+Three backends ship today; select one with the `--backend` flag (or
+`llm.backend` in `config.yaml`). The default is `anthropic`.
 
-# Claude CLI transport.
-export CLAUDE_CODE_OAUTH_TOKEN=...
-swarm serve --backend claude_cli
+| Backend | Credential | Notes |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` | The Anthropic API transport. |
+| `claude_cli` | `CLAUDE_CODE_OAUTH_TOKEN` | Drives the Claude CLI as a subprocess; requires the workspace image (see "For agent flows"). |
+| `openai_compatible` | `OPENAI_COMPATIBLE_API_KEY` | Any Chat Completions endpoint; also needs `llm.openai_compatible.base_url` and a default model. |
 
-# Chat Completions-compatible HTTP JSON transport.
-export OPENAI_COMPATIBLE_API_KEY=...
-swarm serve --backend openai_compatible --config ./config.yaml
-```
-
-`openai_compatible` uses `llm.openai_compatible.base_url` as the deployment
-configuration for a Chat Completions-compatible HTTP JSON endpoint and
-normalizes it to `/v1/chat/completions`. This profile is not native OpenAI
-Responses API support, not an official-OpenAI-only provider identity, and not
-provider-matrix support for OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex,
-or vLLM.
-
-Runtime config owns non-secret LLM behavior, including backend selection,
-provider endpoint/base URLs, and model alias maps. Environment variables remain
-for credentials and explicitly-owned infra connection values only. The selected
-backend fails fast if its required credential is missing.
-
-| Backend | Required credential env var |
-|---|---|
-| `anthropic` | `ANTHROPIC_API_KEY` |
-| `claude_cli` | `CLAUDE_CODE_OAUTH_TOKEN` |
-| `openai_compatible` | `OPENAI_COMPATIBLE_API_KEY` |
-
-The following `config.yaml` is for the `openai_compatible` command above:
-
-```yaml
-# config.yaml
-llm:
-  backend: openai_compatible
-  session:
-    lock_ttl: 10s
-    rotate_after_turns: 40
-    rotate_on_parse_failures: 3
-  openai_compatible:
-    base_url: https://api.example.com
-  models:
-    regular:
-      anthropic: claude-3-5-sonnet
-      claude_cli: sonnet
-      openai_compatible: gpt-compatible
-```
-
-Authored agents choose provider-agnostic model aliases with `model`. Built-in
-aliases are `cheap`, `regular`, and `frontier`; `llm.models` can override any
-alias per backend profile.
-
-```yaml
-# agents.yaml
-support-agent:
-  model: regular
-  subscriptions: [ticket.created]
-  emit_events: [ticket.triaged]
-```
+Authored agents pick a model alias (`cheap`, `regular`, or `frontier`); `llm.models`
+maps each alias to a concrete model per backend. Full setup (env vars,
+`config.yaml`, alias resolution) is in [the docs](https://docs.division.sh/reference/configuration).
 
 ---
 
@@ -262,15 +241,15 @@ Generated subset of `swarm --help`. Each command targets the running orchestrato
 | `swarm health` | Operator health summary. |
 | `swarm events {list,follow,view}` | Inspect the event log. |
 | `swarm event {replay,view}` | Replay or view a single historical event. |
-| `swarm publish <event>` | Publish one event into the runtime. |
+| `swarm event publish <event-name>` | Publish one event into the runtime (`--payload-json` or `--payload-file`). |
 | `swarm entities {list,view,aggregate}` | Inspect entity state. |
 | `swarm agents` / `swarm agent {view,restart,directive,replay,replay-backlog}` | Inspect or control agents. |
 | `swarm conversations` / `swarm conversation {view,turn}` | Inspect agent sessions and turns. |
 | `swarm incidents` | List runtime incidents. |
 | `swarm logs` | List or follow runtime logs. |
-| `swarm control mailbox {list,view,approve,reject,defer}` | Human-in-the-loop mailbox decisions. |
+| `swarm mailbox {list,view,approve,reject,defer}` | Human-in-the-loop mailbox decisions. |
 | `swarm control nuke` | Destructively reset runtime state. |
-| `swarm fork` | Re-execute a run from any point in its history. *(Shipping shortly.)* |
+| `swarm fork <source-run-id> --at-event <event-id>` | Re-execute a run from any point in its history. |
 | `swarm version` | Print binary version. |
 | `swarm completion <shell>` | Generate shell completion. |
 
@@ -334,8 +313,7 @@ The static analyzer's refusal to boot on a half-finished contract is a feature i
 
 - Platform specification: **v1.6.0**, complete. See [`platform-spec.yaml`](platform-spec.yaml).
 - Engine: Go, Phase 11. Handler-first execution for the proven-safe subset; full handler-first execution in progress.
-- Conformance suite: **12 tiers, 201 distinct test contract bundles** spanning primitives, accumulation, atomic event-loop semantics, composition, boot verification, runtime fork, and policy patterns. The suite runs against a scripted LLM, so it doesn't pay an LLM bill.
-- The `swarm fork` CLI is shipping shortly. The engine plumbing is implemented and tested; only the user-facing command wrapper is pending.
+- Conformance suite: **12 tiers, 200+ distinct test contract bundles** spanning primitives, accumulation, atomic event-loop semantics, composition, boot verification, runtime fork, and policy patterns. The suite runs against a scripted LLM, so it doesn't pay an LLM bill.
 - Used internally to power autonomous multi-agent workflows. External use at your own risk.
 
 The trajectory points at running whole company divisions as autonomous flows. The shipped surface today covers a much smaller scope: deterministic multi-agent orchestration with human-in-the-loop, on a single deployment. Distributed execution, multi-tenant isolation, and a flow marketplace are not yet in scope.
@@ -354,6 +332,7 @@ source contract.
 | [`openrpc.json`](openrpc.json) | You need the generated public API artifact. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | You want to contribute issues, docs, code, or tests. |
 | [`SECURITY.md`](SECURITY.md) | You need to report a suspected vulnerability privately. |
+| [GitHub Discussions](https://github.com/division-sh/swarm/discussions) | You want to ask a question, share a flow, or propose a feature. |
 
 ---
 
@@ -378,7 +357,6 @@ go test ./...
 
 # zero-service local runtime command; uses SQLite by default
 printf '{"entity_id":"11111111-1111-4111-8111-111111111111"}\n' > /tmp/swarm-payload.json
-SWARM_WORKSPACE_DATA_SOURCE="$PWD/data" \
 go run ./cmd/swarm run --contracts tests/tier1-primitives/test-emits-single --event item.received --payload /tmp/swarm-payload.json
 
 # explicit Postgres opt-in runtime commands


### PR DESCRIPTION
Two correctness fixes and a substantial trim of reference material that had crept into the README. Updated after engine PR #1222 (SQLite relative-path DSN fix) and the closure of #1223 (auto-default `/data` + `--data` on `swarm run`).

**Net effect:** 398 → 365 lines (−8%), 74 insertions / 107 deletions, entirely in `README.md`.

## Correctness

- **"Try it"** showed `swarm fork --run <id> --at <event>`. The shipped CLI is `swarm fork <source-run-id> --at-event <event-id>` (positional source-run-id, no `--run`; `--at-event` not `--at`).
- **Quickstart** was 5 steps using `tests/tier1-primitives/test-emits-single` (an agent-free conformance fixture), forced a `docker build` of the workspace image, and exported `SWARM_WORKSPACE_DATA_SOURCE`. With #1222 + #1223 landed, none of that is required: the runtime auto-creates `.swarm/dev.db` (SQLite) and `.swarm/data/` (empty mount), so the demo simplifies to **clone → build → write four small yaml files → verify → run**, with **zero env vars and zero workspace setup** for an agent-free flow. Verified end-to-end on current master with `env | grep SWARM_` empty.
- **Dev section** dropped the now-stale `SWARM_WORKSPACE_DATA_SOURCE="$PWD/data"` prefix from the local runtime command (same reason; #1223 auto-creates).

## Trim (reference material moved to docs)

- Intro paragraph: drop the not-yet-shipped backend roll-call (OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM) and the "shared LLM provider adapter contract" detail.
- Design positions: drop the SQLite/Postgres restatement (already covered in the intro and the Quickstart).
- "Try it": drop the "54 contract checks" specific count.
- "A flow is a contract": drop the four-value guard-outcomes enumeration.
- Quickstart dev-token paragraph: compress to one line.
- Delete the **Workspace Reference Data** subsection. Its source precedence chain, the "no longer treats repo-local `data/` as implicit" changelog note, and the `/data` semantics are reference material — all live on `docs.division.sh/reference/workspaces`. Replace with a **For agent flows** subsection that explains the `claude_cli` Docker workspace image and notes `--data` for `flow_data_access` (with the auto-default fallback now that #1223 ships).
- Compress **LLM Backend Profiles** (75 lines) to **LLM backends** (~12 lines): a single backend/credential table plus a one-line model-alias note and a link to the docs.

## Quickstart end-to-end proof (current master)

```
$ env | grep SWARM_     # nothing set
$ ./swarm run --contracts ./greeting-flow --event greeting.requested --payload greeting-flow/payload.json
using built-in dev API token on loopback; set SWARM_API_TOKEN before exposing
INFO swarm boot state stores tables=29 columns=393 ...
INFO swarm runtime ready contracts=greeting-flow nodes=1 agents=0 events=1
run started: status=running
trace event_name=greeting.requested subscriber=node/greeter
run terminal: status=completed event_count=2 entity_count=1
$ ls .swarm
data/  dev.db
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
