### PR TITLE
[agent-a][issue #1101] Localize template instance system-node delivery

### DIFF
--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -39,6 +39,7 @@ type declarativeWorkflowNode struct {
 type DeclarativeNode struct {
 	nodeID   string
 	contract SystemNodeContract
+	source   semanticview.Source
 	policies map[string]WorkflowEventPolicy
 	engine   HandlerExecutionEngine
 	hooks    *ProductHookRegistry
@@ -64,6 +65,7 @@ func NewNode(contract SystemNodeContract, source semanticview.Source, engine Han
 	return &DeclarativeNode{
 		nodeID:   nodeID,
 		contract: contract,
+		source:   source,
 		policies: buildWorkflowNodePolicies(source, nodeID, subscriptions),
 		engine:   engine,
 		hooks:    hooks,
@@ -173,7 +175,13 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 	}
 	eventType := strings.TrimSpace(string(evt.Type))
 	handlerEventKey := eventType
-	handler, ok := n.contract.EventHandlers[eventType]
+	handler, ok := n.resolvedHandlerForDelivery(evt)
+	if !ok {
+		handler, ok = n.contract.EventHandlers[eventType]
+	}
+	if ok {
+		handlerEventKey = workflowNodeHandlerEventKeyForExecution(n.source, n.NodeID(), evt)
+	}
 	if !ok {
 		for pattern, candidate := range n.contract.EventHandlers {
 			if strings.TrimSpace(pattern) == eventType {
@@ -214,6 +222,14 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 		return nil, err
 	}
 	return outcome, nil
+}
+
+func (n *DeclarativeNode) resolvedHandlerForDelivery(evt Event) (SystemNodeEventHandler, bool) {
+	if n == nil || n.source == nil {
+		return SystemNodeEventHandler{}, false
+	}
+	resolved := workflowNodeEventHandlerResolutionForDelivery(n.source, n.NodeID(), evt)
+	return resolved.Handler, resolved.Matched
 }
 
 func (r *ProductHookRegistry) Register(actionID string, handler ActionHandler) {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -86,16 +86,48 @@ func workflowNodeEventPolicy(nodes []WorkflowNode, nodeID, eventType string) (Wo
 		if nodeID != "" && strings.TrimSpace(node.ID) != nodeID {
 			continue
 		}
-		if policy, ok := node.Policies[eventType]; ok {
+		if policy, ok := workflowNodePolicyForEventType(node.Policies, eventType); ok {
 			return policy, true
 		}
-		for pattern, policy := range node.Policies {
-			if strings.TrimSpace(pattern) == eventType {
-				continue
-			}
-			if runtimecontractsHandlerPatternMatches(pattern, eventType) {
-				return policy, true
-			}
+	}
+	return WorkflowEventPolicy{}, false
+}
+
+func workflowNodePolicyForDelivery(source semanticview.Source, node WorkflowNode, evt events.Event) (WorkflowEventPolicy, bool) {
+	eventType := strings.TrimSpace(string(evt.Type))
+	if policy, ok := workflowNodePolicyForEventType(node.Policies, eventType); ok {
+		return policy, true
+	}
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, strings.TrimSpace(node.ID), evt)
+	if !resolved.Matched {
+		return WorkflowEventPolicy{}, false
+	}
+	candidates := []string{resolved.HandlerEventKey}
+	if source != nil {
+		candidates = append(candidates, workflowNodeExternalEventType(source, strings.TrimSpace(node.ID), resolved.HandlerEventKey))
+	}
+	for _, candidate := range candidates {
+		if policy, ok := workflowNodePolicyForEventType(node.Policies, candidate); ok {
+			return policy, true
+		}
+	}
+	return WorkflowEventPolicy{}, false
+}
+
+func workflowNodePolicyForEventType(policies map[string]WorkflowEventPolicy, eventType string) (WorkflowEventPolicy, bool) {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" || policies == nil {
+		return WorkflowEventPolicy{}, false
+	}
+	if policy, ok := policies[eventType]; ok {
+		return policy, true
+	}
+	for pattern, policy := range policies {
+		if strings.TrimSpace(pattern) == eventType {
+			continue
+		}
+		if runtimecontractsHandlerPatternMatches(pattern, eventType) {
+			return policy, true
 		}
 	}
 	return WorkflowEventPolicy{}, false
@@ -737,6 +769,7 @@ func (pc *PipelineCoordinator) workflowNodeExecutors() []workflowNodeExecutor {
 
 func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(eventType string, evt events.Event) (bool, bool) {
 	eventType = strings.TrimSpace(eventType)
+	source := pc.SemanticSource()
 	for _, node := range pc.WorkflowNodes() {
 		if !pc.workflowNodeMatchesDeliveryTarget(strings.TrimSpace(node.ID), evt.TargetRoute()) {
 			continue
@@ -745,37 +778,11 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(eventType string, evt
 			policy WorkflowEventPolicy
 			ok     bool
 		)
-		if node.Policies != nil {
-			policy, ok = node.Policies[eventType]
-			if !ok {
-				for pattern, candidate := range node.Policies {
-					if strings.TrimSpace(pattern) == eventType {
-						continue
-					}
-					if runtimecontractsHandlerPatternMatches(pattern, eventType) {
-						policy = candidate
-						ok = true
-						break
-					}
-				}
-			}
-		}
+		policy, ok = workflowNodePolicyForDelivery(source, node, evt)
 		if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
 			if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload)); bucketOK && bucket.NodeID == strings.TrimSpace(node.ID) {
 				if node.Policies != nil {
-					policy, ok = node.Policies[bucket.EventType]
-					if !ok {
-						for pattern, candidate := range node.Policies {
-							if strings.TrimSpace(pattern) == bucket.EventType {
-								continue
-							}
-							if runtimecontractsHandlerPatternMatches(pattern, bucket.EventType) {
-								policy = candidate
-								ok = true
-								break
-							}
-						}
-					}
+					policy, ok = workflowNodePolicyForEventType(node.Policies, bucket.EventType)
 				}
 			}
 		}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeflowidentity "swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimemanager "swarm/internal/runtime/manager"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
@@ -84,6 +86,68 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM events
 		WHERE event_name = 'operating/opco.ceo_ready'
+	`, 1)
+}
+
+func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireStyleFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:            module,
+		InstanceActivator: manager.ActivateFlowInstance,
+		WorkflowStore:     workflowStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	bus.SetInterceptors(pc)
+
+	spinup := (events.Event{
+		ID:        "99999999-9999-4999-8999-999999999910",
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("opco.spinup_requested"),
+		Payload:   []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("22222222-2222-4222-8222-222222222222")
+	if err := bus.Publish(ctx, spinup); err != nil {
+		t.Fatalf("Publish spinup: %v", err)
+	}
+	autoEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
+	`, nil)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, autoEventID)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM events
+		WHERE event_name = 'operating/component_scaffold.spawn_requested'
 	`, 1)
 }
 
@@ -182,6 +246,64 @@ opco.ceo_ready:
 	}
 }
 
+func templateInstanceEmpireStyleFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"events.yaml": `opco.spinup_requested:
+  entity_id: string
+  instance_id: string
+  product_id: string
+`,
+		"nodes.yaml": `portfolio-node:
+  id: portfolio-node
+  execution_type: system_node
+  subscribes_to: [opco.spinup_requested]
+  event_handlers:
+    opco.spinup_requested:
+      action: create_flow_instance
+      template: operating
+      instance_id_from: payload.instance_id
+      config_from:
+        product_id: payload.product_id
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+auto_emit_on_create:
+  event: opco.product_initialization_requested
+`,
+		"flows/operating/events.yaml": `opco.product_initialization_requested:
+  instance_id: string
+  template_id: string
+  flow_path: string
+  parent_entity_id: string
+  product_id: string
+component_scaffold.spawn_requested:
+  instance_id: string
+  template_id: string
+  flow_path: string
+  parent_entity_id: string
+  product_id: string
+`,
+		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
+  id: lifecycle-orchestrator
+  execution_type: system_node
+  subscribes_to: [opco.product_initialization_requested]
+  produces: [component_scaffold.spawn_requested]
+  event_handlers:
+    opco.product_initialization_requested:
+      emit: component_scaffold.spawn_requested
+`,
+	}
+}
+
 func seedRuntimeTestRun(t *testing.T, db *sql.DB) context.Context {
 	t.Helper()
 	ctx := runtimecorrelation.WithRunID(context.Background(), templateInstanceDeliveryRunID)
@@ -208,6 +330,25 @@ func waitRuntimeDBCount(t *testing.T, ctx context.Context, db *sql.DB, query str
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("count = %d, want %d for query %s", got, want, strings.TrimSpace(query))
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func waitRuntimeEventID(t *testing.T, ctx context.Context, db *sql.DB, query string, args []any) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var got string
+		err := db.QueryRowContext(ctx, query, args...).Scan(&got)
+		if err == nil && got != "" {
+			return got
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("query event id: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for event id from query %s", strings.TrimSpace(query))
 		}
 		time.Sleep(25 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary

Closes #1101.

Implements the approved first-slice gate `runtime.template_instance_auto_emit_system_node_delivery_localization`:

- Uses the existing concrete receiver-path handler localization owner when pipeline interceptor policy decides whether a delivered event is executable local system-node work.
- Keeps replay-scope evidence separate from local handler delivery/receipt evidence.
- Adds an Empire-style auto-emit proof that creates a template instance, persists `operating/<instance>/opco.product_initialization_requested`, dispatches to `lifecycle-orchestrator`, records the local delivery/receipt, and emits `operating/component_scaffold.spawn_requested`.

## Governing refs/context

- `platform-spec.yaml` `event_identity_resolution.handler_lookup_localizes`: delivered external events must localize against the target node local interface before handler lookup.
- `platform-spec.yaml` `dynamic_instance_lifecycle`: template-instance paths are `{template_id}/{instance_id}/{local_name}` and `auto_emit_on_create` fires after successful instance startup.
- `platform-spec.yaml` event lifecycle `resolve_subscribers`: subscribers include system nodes from `nodes.yaml subscribes_to` and agents from `agents.yaml subscriptions`.
- #1101 pre-audit and independent gate: approved first slice only, not broader delivery/replay parent closure.

## Semantic migration

- Canonical owner after this PR: `workflowNodeEventHandlerResolutionForDelivery` remains the concrete receiver-path local handler resolution owner; `workflowNodePolicyForDelivery` now consumes it for interceptor policy admission.
- Old invalid path: interceptor policy lookup using only the raw concrete event name against static policy keys.
- Production paths checked: pipeline interceptor admission, workflow-runtime carrier delivery, no-target concrete routed node planning, direct declarative node handler resolution, static system-node delivery, route-table agent delivery, duplicate create fail-closed behavior.
- Migration complete for the chosen first-slice class; broader delivery/replay parent remains tracked outside this PR.

## Validation

- `go test ./internal/runtime -run 'TestTemplateInstance(NoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|AutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect)' -count=1 -v`
- `go test ./internal/runtime/pipeline -run 'TestTemplateInstanceSystemNodeDeliveryLocalizesConcreteEventToHandlerKey|Test.*workflowNodeInterceptPolicy|TestDeclarativeNodeHandleEvent_Matches|TestDeclarativeNodeHandleEvent_Selects' -count=1 -v`
- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute|TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute|TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryPlanning|TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution|TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately' -count=1 -v`
- `go test ./internal/runtime/manager -run TestActivateFlowInstanceRejectsDuplicateInstanceIDBeforeSideEffects -count=1 -v`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/manager -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./... -count=1`