### PR TITLE
[agent-g][issue #1213] Add workspace execution target authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1896,6 +1896,129 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	}
 }
 
+func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
+	var spec struct {
+		WorkspaceModel struct {
+			WorkspaceExecutionTargetCapability struct {
+				PromotedBy           string `yaml:"promoted_by"`
+				ImplementationStatus string `yaml:"implementation_status"`
+				CanonicalOwner       string `yaml:"canonical_owner"`
+				Scope                string `yaml:"scope"`
+				ImplementationOwner  string `yaml:"implementation_owner"`
+				TargetModes          map[string]struct {
+					Rule         string   `yaml:"rule"`
+					Capabilities []string `yaml:"capabilities"`
+				} `yaml:"target_modes"`
+				LogicalMountAuthority struct {
+					Writable []string `yaml:"writable"`
+					ReadOnly []string `yaml:"read_only"`
+					Rules    []string `yaml:"rules"`
+				} `yaml:"logical_mount_authority"`
+				Consumers                           []string `yaml:"consumers"`
+				RetiredNonAuthoritativeInterpreters []string `yaml:"retired_non_authoritative_interpreters"`
+				FailureBehavior                     []string `yaml:"failure_behavior"`
+				SplitScope                          []string `yaml:"split_scope"`
+			} `yaml:"workspace_execution_target_capability"`
+		} `yaml:"workspace_model"`
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					WorkspaceExecutionTargetCapability struct {
+						PromotedBy string   `yaml:"promoted_by"`
+						Owner      string   `yaml:"owner"`
+						Rule       string   `yaml:"rule"`
+						Consumers  []string `yaml:"consumers"`
+					} `yaml:"workspace_execution_target_capability"`
+				} `yaml:"serve"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	authority := spec.WorkspaceModel.WorkspaceExecutionTargetCapability
+	if strings.TrimSpace(authority.PromotedBy) != "#1213" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+		t.Fatalf("workspace execution target authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
+	}
+	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_execution_target_capability") || !strings.Contains(authority.ImplementationOwner, "internal/runtime/workspace.ExecutionTarget") {
+		t.Fatalf("workspace execution target owners = canonical:%q implementation:%q", authority.CanonicalOwner, authority.ImplementationOwner)
+	}
+	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "does not enable host native tools"} {
+		if !strings.Contains(authority.Scope, want) {
+			t.Fatalf("workspace execution target scope missing %q:\n%s", want, authority.Scope)
+		}
+	}
+	dockerMode := authority.TargetModes[string(workspace.ExecutionModeDockerContainer)]
+	for _, want := range []string{
+		string(workspace.ExecutionCapabilityNativeCommand),
+		string(workspace.ExecutionCapabilityFileRead),
+		string(workspace.ExecutionCapabilityFileWrite),
+		string(workspace.ExecutionCapabilityToolResultRelay),
+		string(workspace.ExecutionCapabilityClaudeCLI),
+	} {
+		if !stringSliceContains(dockerMode.Capabilities, want) {
+			t.Fatalf("docker execution capabilities missing %q: %#v", want, dockerMode.Capabilities)
+		}
+	}
+	hostMode := authority.TargetModes[string(workspace.ExecutionModeHostLocal)]
+	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") || len(hostMode.Capabilities) != 0 {
+		t.Fatalf("host execution mode = %#v, want explicit unsupported first slice", hostMode)
+	}
+	unsupportedMode := authority.TargetModes[string(workspace.ExecutionModeUnsupported)]
+	if !strings.Contains(unsupportedMode.Rule, "process cwd") || len(unsupportedMode.Capabilities) != 0 {
+		t.Fatalf("unsupported execution mode = %#v, want fail-closed no fallback", unsupportedMode)
+	}
+	if !stringSliceContains(authority.LogicalMountAuthority.Writable, workspace.LogicalWorkspaceMount) {
+		t.Fatalf("logical writable mounts = %#v, want %s", authority.LogicalMountAuthority.Writable, workspace.LogicalWorkspaceMount)
+	}
+	for _, want := range []string{workspace.LogicalDataMount, workspace.LogicalContractsMount} {
+		if !stringSliceContains(authority.LogicalMountAuthority.ReadOnly, want) {
+			t.Fatalf("logical read-only mounts missing %q: %#v", want, authority.LogicalMountAuthority.ReadOnly)
+		}
+	}
+	for _, want := range []string{"Relative execution paths", "Writes outside logical `/workspace`", "MUST NOT leak raw host backing paths", "data_source_authority"} {
+		if !joinedContains(authority.LogicalMountAuthority.Rules, want) {
+			t.Fatalf("logical mount authority rules missing %q: %#v", want, authority.LogicalMountAuthority.Rules)
+		}
+	}
+	for _, want := range []string{"Host workspace target production", "native executor command", "native fallback tool definitions", "OpenAI-compatible/API fallback-tool routing", "tool-result relay", "Claude CLI process", "runtime Claude managed-agent startup"} {
+		if !joinedContains(authority.Consumers, want) {
+			t.Fatalf("workspace execution target consumers missing %q: %#v", want, authority.Consumers)
+		}
+	}
+	for _, want := range []string{"Target.Container", "Target.Enabled()", "raw Target.Workdir", "cwd fallback", "HostBackend()"} {
+		if !joinedContains(authority.RetiredNonAuthoritativeInterpreters, want) {
+			t.Fatalf("retired interpreters missing %q: %#v", want, authority.RetiredNonAuthoritativeInterpreters)
+		}
+	}
+	for _, want := range []string{"Host-local targets remain fail closed", "Empty-container targets", "Docker behavior"} {
+		if !joinedContains(authority.FailureBehavior, want) {
+			t.Fatalf("failure behavior missing %q: %#v", want, authority.FailureBehavior)
+		}
+	}
+	for _, want := range []string{"host native file", "host native bash", "host tool-result relay", "Claude CLI", "#1137"} {
+		if !joinedContains(authority.SplitScope, want) {
+			t.Fatalf("split scope missing %q: %#v", want, authority.SplitScope)
+		}
+	}
+	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceExecutionTargetCapability
+	if command.PromotedBy != "#1213" || command.Owner != "workspace_model.workspace_execution_target_capability" {
+		t.Fatalf("serve command workspace execution authority = %#v", command)
+	}
+	if !strings.Contains(command.Rule, "Host-local targets remain explicit and fail closed") {
+		t.Fatalf("serve command workspace execution rule = %q", command.Rule)
+	}
+	for _, want := range []string{"native executor", "fallback-tool routing", "tool-result relay", "Claude CLI"} {
+		if !joinedContains(command.Consumers, want) {
+			t.Fatalf("serve command workspace execution consumers missing %q: %#v", want, command.Consumers)
+		}
+	}
+}
+
 func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 	var spec struct {
 		CLISpecification struct {

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -27,13 +27,21 @@ func errClaudeHostWorkspaceUnsupported() error {
 	return fmt.Errorf("%w: host workspace backend does not support Claude CLI execution yet", ErrClaudeWorkspaceRequired)
 }
 
+func requireClaudeExecutionTarget(target *workspace.Target) (workspace.ExecutionTarget, error) {
+	execTarget := target.ExecutionTarget()
+	if execTarget.Supports(workspace.ExecutionCapabilityClaudeCLI) {
+		return execTarget, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(execTarget.Backend), workspace.BackendHost) {
+		return execTarget, errClaudeHostWorkspaceUnsupported()
+	}
+	return execTarget, fmt.Errorf("%w: %s", ErrClaudeWorkspaceRequired, execTarget.UnsupportedMessage(workspace.ExecutionCapabilityClaudeCLI))
+}
+
 func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, target *workspace.Target, input string, meta MonitorTurnMeta) (*Response, error) {
 	timeout := r.effectiveCLITimeout(ctx)
-	if target != nil && target.HostBackend() {
-		return nil, errClaudeHostWorkspaceUnsupported()
-	}
-	if target == nil || !target.Enabled() {
-		return nil, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
+	if _, err := requireClaudeExecutionTarget(target); err != nil {
+		return nil, err
 	}
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
 	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
@@ -43,7 +51,10 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := r.buildCommand(runCtx, args, target)
+	cmd, err := r.buildCommand(runCtx, args, target)
+	if err != nil {
+		return nil, err
+	}
 	if configuredCLIOutputFormat(r.cfg) == "stream-json" {
 		return r.runStreaming(runCtx, cmd, target, timeout, input, meta)
 	}
@@ -274,8 +285,12 @@ func summarizeCLIErrorOutput(raw string) string {
 	return msg
 }
 
-func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, target *workspace.Target) *exec.Cmd {
-	if target != nil && target.Enabled() {
+func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, target *workspace.Target) (*exec.Cmd, error) {
+	execTarget, err := requireClaudeExecutionTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	if execTarget.Mode == workspace.ExecutionModeDockerContainer {
 		dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
 		if dockerBin == "" {
 			dockerBin = "docker"
@@ -292,14 +307,14 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 		if oauthToken := llmselection.CredentialValue(profile, os.LookupEnv); oauthToken != "" {
 			dockerArgs = append(dockerArgs, "-e", profile.Credential.EnvVar+"="+oauthToken)
 		}
-		if strings.TrimSpace(target.Workdir) != "" {
-			dockerArgs = append(dockerArgs, "-w", target.Workdir)
+		if strings.TrimSpace(execTarget.Workdir) != "" {
+			dockerArgs = append(dockerArgs, "-w", execTarget.Workdir)
 		}
-		dockerArgs = append(dockerArgs, target.Container, r.cfg.LLM.ClaudeCLI.Command)
+		dockerArgs = append(dockerArgs, execTarget.Container, r.cfg.LLM.ClaudeCLI.Command)
 		dockerArgs = append(dockerArgs, args...)
-		return exec.CommandContext(ctx, dockerBin, dockerArgs...)
+		return exec.CommandContext(ctx, dockerBin, dockerArgs...), nil
 	}
-	return exec.CommandContext(ctx, r.cfg.LLM.ClaudeCLI.Command, args...)
+	return nil, fmt.Errorf("%w: %s", ErrClaudeWorkspaceRequired, execTarget.UnsupportedMessage(workspace.ExecutionCapabilityClaudeCLI))
 }
 
 func (r *ClaudeCLIRuntime) resolveWorkspace(ctx context.Context) (*workspace.Target, error) {
@@ -314,8 +329,8 @@ func (r *ClaudeCLIRuntime) resolveWorkspace(ctx context.Context) (*workspace.Tar
 	if err != nil {
 		return nil, err
 	}
-	if target == nil || !target.Enabled() {
-		return nil, fmt.Errorf("%w: no container workspace target resolved for agent %s", ErrClaudeWorkspaceRequired, strings.TrimSpace(actor.ID))
+	if _, err := requireClaudeExecutionTarget(target); err != nil {
+		return nil, fmt.Errorf("%w for agent %s", err, strings.TrimSpace(actor.ID))
 	}
 	return target, nil
 }

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -108,10 +108,14 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
 	runtime.cfg.LLM.ClaudeCLI.Command = "claude"
 
-	cmd := runtime.buildCommand(context.Background(), []string{"--print", "hello"}, &workspace.Target{
+	cmd, err := runtime.buildCommand(context.Background(), []string{"--print", "hello"}, &workspace.Target{
+		Backend:   workspace.BackendDocker,
 		Container: "swarm-agent-market-research",
 		Workdir:   "/workspace",
 	})
+	if err != nil {
+		t.Fatalf("buildCommand: %v", err)
+	}
 	got := strings.Join(cmd.Args, " ")
 	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8081/mcp") {
 		t.Fatalf("docker args = %q, want explicit container MCP gateway URL", got)

--- a/internal/runtime/llm/cli_runtime_startup_probe.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe.go
@@ -112,11 +112,8 @@ func PlannedProviderNativeVisibleToolsForActor(actor models.AgentConfig, tools [
 
 func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []string, target *workspace.Target, input string) (*Response, error) {
 	timeout := r.effectiveCLITimeout(ctx)
-	if target != nil && target.HostBackend() {
-		return nil, errClaudeHostWorkspaceUnsupported()
-	}
-	if target == nil || !target.Enabled() {
-		return nil, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
+	if _, err := requireClaudeExecutionTarget(target); err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(input) == "" {
 		return nil, errors.New("startup probe requires non-empty prompt")
@@ -125,7 +122,10 @@ func (r *ClaudeCLIRuntime) runUntilCLIStartupInit(ctx context.Context, args []st
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := r.buildCommand(runCtx, args, target)
+	cmd, err := r.buildCommand(runCtx, args, target)
+	if err != nil {
+		return nil, err
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("create claude stdout pipe: %w", err)

--- a/internal/runtime/llm/cli_tool_result_relay.go
+++ b/internal/runtime/llm/cli_tool_result_relay.go
@@ -34,10 +34,6 @@ func (r *ClaudeCLIRuntime) PersistOversizedToolResultRelay(ctx context.Context, 
 }
 
 func relayWorkspacePath(target *workspace.Target, session *Session, toolName string) string {
-	base := strings.TrimSpace(target.Workdir)
-	if base == "" {
-		base = "/workspace"
-	}
 	sessionID := "session"
 	if session != nil && strings.TrimSpace(session.ID) != "" {
 		sessionID = sanitizeRelayPathComponent(session.ID)
@@ -47,7 +43,11 @@ func relayWorkspacePath(target *workspace.Target, session *Session, toolName str
 		name = "tool"
 	}
 	filename := fmt.Sprintf("%s-%d.json", name, time.Now().UnixNano())
-	return path.Join(base, workspaceToolResultRelayDir, sessionID, filename)
+	relayPath, err := target.ExecutionTarget().WorkspacePath(path.Join(workspaceToolResultRelayDir, sessionID, filename))
+	if err != nil {
+		return path.Join(workspace.LogicalWorkspaceMount, workspaceToolResultRelayDir, sessionID, filename)
+	}
+	return relayPath
 }
 
 func sanitizeRelayPathComponent(raw string) string {
@@ -89,27 +89,28 @@ func (r *ClaudeCLIRuntime) writeWorkspaceRelayFile(ctx context.Context, target *
 }
 
 func (r *ClaudeCLIRuntime) runWorkspaceCommand(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error) {
-	if r != nil && r.execWorkspaceFn != nil {
-		return r.execWorkspaceFn(ctx, target, stdin, args...)
-	}
-	if target != nil && target.HostBackend() {
-		return nil, nil, 0, errClaudeHostWorkspaceUnsupported()
-	}
-	if target == nil || !target.Enabled() {
-		return nil, nil, 0, fmt.Errorf("%w: claude sessions must run in a container workspace", ErrClaudeWorkspaceRequired)
+	execTarget := target.ExecutionTarget()
+	if err := execTarget.Require(workspace.ExecutionCapabilityToolResultRelay); err != nil {
+		if strings.EqualFold(strings.TrimSpace(execTarget.Backend), workspace.BackendHost) {
+			return nil, nil, 0, errClaudeHostWorkspaceUnsupported()
+		}
+		return nil, nil, 0, fmt.Errorf("%w: %s", ErrClaudeWorkspaceRequired, err.Error())
 	}
 	if len(args) == 0 {
 		return nil, nil, 0, fmt.Errorf("workspace command args are required")
+	}
+	if r != nil && r.execWorkspaceFn != nil {
+		return r.execWorkspaceFn(ctx, target, stdin, args...)
 	}
 	dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
 	if dockerBin == "" {
 		dockerBin = "docker"
 	}
 	dockerArgs := []string{"exec", "-i"}
-	if strings.TrimSpace(target.Workdir) != "" {
-		dockerArgs = append(dockerArgs, "-w", target.Workdir)
+	if strings.TrimSpace(execTarget.Workdir) != "" {
+		dockerArgs = append(dockerArgs, "-w", execTarget.Workdir)
 	}
-	dockerArgs = append(dockerArgs, strings.TrimSpace(target.Container))
+	dockerArgs = append(dockerArgs, strings.TrimSpace(execTarget.Container))
 	dockerArgs = append(dockerArgs, args...)
 	cmd := exec.CommandContext(ctx, dockerBin, dockerArgs...)
 	var stdout bytes.Buffer

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -176,8 +176,9 @@ func validateClaudeManagedAgentWorkspaces(ctx context.Context, cfg *config.Confi
 		if err != nil {
 			return fmt.Errorf("resolve workspace for agent %s: %w", strings.TrimSpace(agentCfg.ID), err)
 		}
-		if target == nil || !target.Enabled() {
-			return fmt.Errorf("agent %s resolved no container workspace target", strings.TrimSpace(agentCfg.ID))
+		execTarget := target.ExecutionTarget()
+		if err := execTarget.Require(workspace.ExecutionCapabilityClaudeCLI); err != nil {
+			return fmt.Errorf("agent %s resolved workspace target that does not support Claude CLI execution: %w", strings.TrimSpace(agentCfg.ID), err)
 		}
 	}
 	return nil

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -129,7 +129,7 @@ func TestValidateClaudeManagedAgentWorkspaces_RequiresResolvedContainerTargets(t
 	}
 
 	err := validateClaudeManagedAgentWorkspaces(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), claudeStartupWorkspaceStub{}, manager)
-	if err == nil || !strings.Contains(err.Error(), "resolved no container workspace target") {
+	if err == nil || !strings.Contains(err.Error(), "does not support Claude CLI execution") {
 		t.Fatalf("expected workspace target error, got %v", err)
 	}
 }

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -48,6 +48,7 @@ type Executor struct {
 	validator                      *ToolInputValidator
 	dispatcher                     *ToolDispatcher
 	allowInternalLegacyEntityTools bool
+	execWorkspaceFn                func(ctx context.Context, target workspace.ExecutionTarget, timeout time.Duration, stdin string, args ...string) ([]byte, []byte, int, error)
 	oneShotMu                      sync.Mutex
 	oneShotEmits                   map[string]struct{}
 }
@@ -224,7 +225,7 @@ func (e *Executor) ToolDefinitionsForActorInContext(ctx context.Context, actor m
 	defs := e.ToolDefinitionsForActor(actor)
 	roleScopedNames := e.RoleScopedEntityToolNamesForActor(actor)
 	if len(roleScopedNames) == 0 || e.roleScopedEntityToolsEligibleForCurrentTurn(ctx, actor) {
-		return defs
+		return e.filterNativeDefinitionsForWorkspaceExecution(ctx, actor, defs)
 	}
 	filtered := make([]llm.ToolDefinition, 0, len(defs))
 	for _, def := range defs {
@@ -233,7 +234,7 @@ func (e *Executor) ToolDefinitionsForActorInContext(ctx context.Context, actor m
 		}
 		filtered = append(filtered, def)
 	}
-	return filtered
+	return e.filterNativeDefinitionsForWorkspaceExecution(ctx, actor, filtered)
 }
 
 func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
@@ -277,15 +278,17 @@ func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []st
 func (e *Executor) ToolCapabilitiesForActorInContext(ctx context.Context, actor models.AgentConfig, names []string, requestAllowed map[string]struct{}) toolcapabilities.Set {
 	set := e.ToolCapabilitiesForActor(actor, names, requestAllowed)
 	roleScopedNames := e.RoleScopedEntityToolNamesForActor(actor)
-	if len(roleScopedNames) == 0 || e.roleScopedEntityToolsEligibleForCurrentTurn(ctx, actor) {
-		return set
-	}
 	caps := make([]toolcapabilities.Capability, 0, len(set.ByName))
 	for name, cap := range set.ByName {
-		if _, ok := roleScopedNames[name]; ok {
-			cap.Visible = false
-			cap.Callable = false
-			cap.DenialReason = "current_entity_contract_unavailable"
+		if len(roleScopedNames) > 0 && !e.roleScopedEntityToolsEligibleForCurrentTurn(ctx, actor) {
+			if _, ok := roleScopedNames[name]; ok {
+				cap.Visible = false
+				cap.Callable = false
+				cap.DenialReason = "current_entity_contract_unavailable"
+			}
+		}
+		if cap.Visible || cap.Callable {
+			cap = e.applyWorkspaceExecutionDecision(ctx, actor, cap)
 		}
 		caps = append(caps, cap)
 	}

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -88,6 +87,9 @@ func (e *Executor) execNativeReadFile(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, err
 	}
+	if err := target.ExecutionTarget().Require(workspace.ExecutionCapabilityFileRead); err != nil {
+		return nil, err
+	}
 	path, err := resolveNativeReadPath(target, in.Path)
 	if err != nil {
 		return nil, err
@@ -109,6 +111,9 @@ func (e *Executor) execNativeWriteFile(ctx context.Context, actor models.AgentCo
 	}
 	target, err := e.resolveNativeWorkspace(ctx, actor)
 	if err != nil {
+		return nil, err
+	}
+	if err := target.ExecutionTarget().Require(workspace.ExecutionCapabilityFileWrite); err != nil {
 		return nil, err
 	}
 	path, err := resolveNativeWritePath(target, in.Path)
@@ -299,27 +304,32 @@ func (e *Executor) resolveNativeWorkspace(ctx context.Context, actor models.Agen
 func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Target, timeout time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if target != nil && target.HostBackend() {
-		return nil, nil, -1, fmt.Errorf("host workspace backend does not support native tool execution yet")
+	execTarget := target.ExecutionTarget()
+	if err := execTarget.Require(workspace.ExecutionCapabilityNativeCommand); err != nil {
+		return nil, nil, -1, err
+	}
+	if len(args) == 0 {
+		return nil, nil, -1, fmt.Errorf("workspace command args are required")
+	}
+	if e != nil && e.execWorkspaceFn != nil {
+		return e.execWorkspaceFn(runCtx, execTarget, timeout, stdin, args...)
 	}
 	var cmd *exec.Cmd
-	if target != nil && target.Enabled() {
+	switch execTarget.Mode {
+	case workspace.ExecutionModeDockerContainer:
 		dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
 		if dockerBin == "" {
 			dockerBin = "docker"
 		}
 		dockerArgs := []string{"exec", "-i"}
-		if workdir := strings.TrimSpace(target.Workdir); workdir != "" {
+		if workdir := strings.TrimSpace(execTarget.Workdir); workdir != "" {
 			dockerArgs = append(dockerArgs, "-w", workdir)
 		}
-		dockerArgs = append(dockerArgs, strings.TrimSpace(target.Container))
+		dockerArgs = append(dockerArgs, strings.TrimSpace(execTarget.Container))
 		dockerArgs = append(dockerArgs, args...)
 		cmd = exec.CommandContext(runCtx, dockerBin, dockerArgs...)
-	} else {
-		cmd = exec.CommandContext(runCtx, args[0], args[1:]...)
-		if target != nil && strings.TrimSpace(target.Workdir) != "" {
-			cmd.Dir = strings.TrimSpace(target.Workdir)
-		}
+	default:
+		return nil, nil, -1, fmt.Errorf("%s", execTarget.UnsupportedMessage(workspace.ExecutionCapabilityNativeCommand))
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -343,67 +353,11 @@ func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Ta
 }
 
 func resolveNativeReadPath(target *workspace.Target, raw string) (string, error) {
-	return resolveNativePath(target, raw, false)
+	return target.ExecutionTarget().ResolvePath(raw, workspace.PathAccessRead)
 }
 
 func resolveNativeWritePath(target *workspace.Target, raw string) (string, error) {
-	return resolveNativePath(target, raw, true)
-}
-
-func resolveNativePath(target *workspace.Target, raw string, write bool) (string, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", fmt.Errorf("path is required")
-	}
-	base := nativeWorkspaceBase(target)
-	if target != nil && target.Enabled() {
-		base = "/workspace"
-	}
-	clean := filepath.Clean(raw)
-	if !filepath.IsAbs(clean) {
-		clean = filepath.Join(base, clean)
-	}
-	clean = filepath.Clean(clean)
-	allowed := []string{base}
-	if target != nil && target.Enabled() {
-		if write {
-			allowed = []string{"/workspace"}
-		} else {
-			allowed = []string{"/workspace", "/data", "/opt/swarm/contracts"}
-		}
-	}
-	for _, root := range allowed {
-		if pathWithinRoot(clean, root) {
-			return clean, nil
-		}
-	}
-	if write {
-		return "", fmt.Errorf("write_file path %s is outside the writable workspace", raw)
-	}
-	return "", fmt.Errorf("read_file path %s is outside the allowed workspace mounts", raw)
-}
-
-func nativeWorkspaceBase(target *workspace.Target) string {
-	if target != nil && strings.TrimSpace(target.Workdir) != "" {
-		return strings.TrimSpace(target.Workdir)
-	}
-	if cwd, err := os.Getwd(); err == nil && strings.TrimSpace(cwd) != "" {
-		return cwd
-	}
-	return "/workspace"
-}
-
-func pathWithinRoot(pathValue, root string) bool {
-	pathValue = filepath.Clean(strings.TrimSpace(pathValue))
-	root = filepath.Clean(strings.TrimSpace(root))
-	if pathValue == "" || root == "" {
-		return false
-	}
-	rel, err := filepath.Rel(root, pathValue)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+	return target.ExecutionTarget().ResolvePath(raw, workspace.PathAccessWrite)
 }
 
 func (e *Executor) resolveWebSearchProviderConfig() (webSearchProviderConfig, error) {

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	models "swarm/internal/runtime/core/actors"
+	llm "swarm/internal/runtime/llm"
 	workspace "swarm/internal/runtime/workspace"
 )
 
@@ -21,4 +23,77 @@ func TestNativeWorkspaceCommandFailsClosedForHostBackend(t *testing.T) {
 	if exitCode != -1 {
 		t.Fatalf("exit code = %d, want -1 for fail-closed host backend", exitCode)
 	}
+}
+
+func TestNativeFileToolsFailClosedForHostBackendThroughExecutionTarget(t *testing.T) {
+	exec := &Executor{
+		workspaces: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
+		execWorkspaceFn: func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+			t.Fatalf("host native file tools must fail closed before workspace command execution")
+			return nil, nil, 0, nil
+		},
+	}
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "writer",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	})
+
+	_, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/input.txt"})
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
+		t.Fatalf("execNativeReadFile error = %v, want host fail-closed diagnostic", err)
+	}
+
+	_, err = exec.execNativeWriteFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/output.txt", "content": "hello"})
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
+		t.Fatalf("execNativeWriteFile error = %v, want host fail-closed diagnostic", err)
+	}
+}
+
+func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T) {
+	exec := &Executor{
+		workspaces: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
+	}
+	actor := models.AgentConfig{
+		ID: "host-agent",
+		NativeTools: models.NativeToolConfig{
+			Bash:      true,
+			FileIO:    true,
+			WebSearch: true,
+		},
+	}
+
+	defs := exec.ToolDefinitionsForActorInContext(context.Background(), actor)
+	for _, denied := range []string{"bash", "read_file", "write_file"} {
+		if containsToolDefinition(defs, denied) {
+			t.Fatalf("context definitions contain %q for host backend: %#v", denied, defs)
+		}
+	}
+	if !containsToolDefinition(defs, "web_search") {
+		t.Fatalf("context definitions missing web_search, which is not workspace-execution backed: %#v", defs)
+	}
+
+	caps := exec.ToolCapabilitiesForActorInContext(context.Background(), actor, []string{"bash", "read_file", "write_file", "web_search"}, nil)
+	for _, denied := range []string{"bash", "read_file", "write_file"} {
+		cap := caps.ByName[denied]
+		if cap.Visible || cap.Callable || !strings.Contains(cap.DenialReason, "host workspace backend does not support native tool execution yet") {
+			t.Fatalf("capability %s = %#v, want host workspace execution denial", denied, cap)
+		}
+	}
+	web := caps.ByName["web_search"]
+	if !web.Visible || !web.Callable {
+		t.Fatalf("web_search capability = %#v, want visible/callable", web)
+	}
+}
+
+func containsToolDefinition(defs []llm.ToolDefinition, name string) bool {
+	for _, def := range defs {
+		if strings.TrimSpace(def.Name) == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/tools/executor_workspace_execution.go
+++ b/internal/runtime/tools/executor_workspace_execution.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"strings"
+
+	models "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/core/toolcapabilities"
+	llm "swarm/internal/runtime/llm"
+	workspace "swarm/internal/runtime/workspace"
+)
+
+func nativeExecutionCapabilityForTool(name string) workspace.ExecutionCapability {
+	switch normalizeNativeToolName(name) {
+	case "bash":
+		return workspace.ExecutionCapabilityNativeCommand
+	case "read_file":
+		return workspace.ExecutionCapabilityFileRead
+	case "write_file":
+		return workspace.ExecutionCapabilityFileWrite
+	default:
+		return ""
+	}
+}
+
+func (e *Executor) nativeWorkspaceExecutionDecision(ctx context.Context, actor models.AgentConfig, name string) (bool, string) {
+	capability := nativeExecutionCapabilityForTool(name)
+	if capability == "" {
+		return true, ""
+	}
+	target, err := e.resolveNativeWorkspace(ctx, actor)
+	if err != nil {
+		return false, err.Error()
+	}
+	execTarget := target.ExecutionTarget()
+	if !execTarget.Supports(capability) {
+		return false, execTarget.UnsupportedMessage(capability)
+	}
+	return true, ""
+}
+
+func (e *Executor) applyWorkspaceExecutionDecision(ctx context.Context, actor models.AgentConfig, cap toolcapabilities.Capability) toolcapabilities.Capability {
+	if !cap.Visible && !cap.Callable {
+		return cap
+	}
+	if _, ok := nativeFallbackRegisteredTool(actor, cap.Name); !ok {
+		return cap
+	}
+	ok, reason := e.nativeWorkspaceExecutionDecision(ctx, actor, cap.Name)
+	if ok {
+		return cap
+	}
+	cap.Visible = false
+	cap.Callable = false
+	if strings.TrimSpace(reason) == "" {
+		reason = "workspace_execution_unsupported"
+	}
+	cap.DenialReason = reason
+	return cap
+}
+
+func (e *Executor) filterNativeDefinitionsForWorkspaceExecution(ctx context.Context, actor models.AgentConfig, defs []llm.ToolDefinition) []llm.ToolDefinition {
+	filtered := make([]llm.ToolDefinition, 0, len(defs))
+	for _, def := range defs {
+		if _, ok := nativeFallbackRegisteredTool(actor, def.Name); !ok {
+			filtered = append(filtered, def)
+			continue
+		}
+		ok, _ := e.nativeWorkspaceExecutionDecision(ctx, actor, def.Name)
+		if ok {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered
+}

--- a/internal/runtime/tools/tool_result_relay.go
+++ b/internal/runtime/tools/tool_result_relay.go
@@ -33,7 +33,14 @@ func (e *Executor) PersistOversizedToolResultRelay(ctx context.Context, toolName
 	if relay, ok, err := e.persistChunkedReadFileRelay(ctx, target, actor, toolName, rawJSON); ok {
 		return relay, err
 	}
-	relayPath := toolResultRelayPath(target, actor, toolName)
+	execTarget := target.ExecutionTarget()
+	if err := execTarget.Require(workspace.ExecutionCapabilityToolResultRelay); err != nil {
+		return runtimemcp.ToolResultRelayRef{}, err
+	}
+	relayPath, err := toolResultRelayPath(execTarget, actor, toolName)
+	if err != nil {
+		return runtimemcp.ToolResultRelayRef{}, err
+	}
 	_, stderr, exitCode, execErr := e.runWorkspaceCommand(ctx, target, 30*time.Second, string(rawJSON), "sh", "-lc", `mkdir -p -- "$(dirname -- "$1")" && cat > "$1"`, "swarm-tool-result-relay", relayPath)
 	if execErr != nil || exitCode != 0 {
 		msg := strings.TrimSpace(string(stderr))
@@ -57,6 +64,10 @@ func (e *Executor) persistChunkedReadFileRelay(ctx context.Context, target *work
 	if strings.TrimSpace(toolName) != "read_file" {
 		return runtimemcp.ToolResultRelayRef{}, false, nil
 	}
+	execTarget := target.ExecutionTarget()
+	if err := execTarget.Require(workspace.ExecutionCapabilityToolResultRelay); err != nil {
+		return runtimemcp.ToolResultRelayRef{}, true, err
+	}
 	var payload readFileRelayPayload
 	if err := json.Unmarshal(rawJSON, &payload); err != nil {
 		return runtimemcp.ToolResultRelayRef{}, false, nil
@@ -70,7 +81,10 @@ func (e *Executor) persistChunkedReadFileRelay(ctx context.Context, target *work
 	}
 	relayPaths := make([]string, 0, len(chunks))
 	for idx, chunk := range chunks {
-		relayPath := toolResultRelayChunkPath(target, actor, toolName, idx)
+		relayPath, err := toolResultRelayChunkPath(execTarget, actor, toolName, idx)
+		if err != nil {
+			return runtimemcp.ToolResultRelayRef{}, true, err
+		}
 		_, stderr, exitCode, execErr := e.runWorkspaceCommand(ctx, target, 30*time.Second, chunk, "sh", "-lc", `mkdir -p -- "$(dirname -- "$1")" && cat > "$1"`, "swarm-tool-result-relay", relayPath)
 		if execErr != nil || exitCode != 0 {
 			msg := strings.TrimSpace(string(stderr))
@@ -92,11 +106,7 @@ func (e *Executor) persistChunkedReadFileRelay(ctx context.Context, target *work
 	}, true, nil
 }
 
-func toolResultRelayPath(target *workspace.Target, actor models.AgentConfig, toolName string) string {
-	base := "/workspace"
-	if target != nil && strings.TrimSpace(target.Workdir) != "" {
-		base = strings.TrimSpace(target.Workdir)
-	}
+func toolResultRelayPath(target workspace.ExecutionTarget, actor models.AgentConfig, toolName string) (string, error) {
 	owner := sanitizeToolResultRelayPathComponent(actor.EffectiveEntityID())
 	if owner == "" {
 		owner = sanitizeToolResultRelayPathComponent(actor.ID)
@@ -109,14 +119,10 @@ func toolResultRelayPath(target *workspace.Target, actor models.AgentConfig, too
 		name = "tool"
 	}
 	filename := fmt.Sprintf("%s-%d.json", name, time.Now().UnixNano())
-	return path.Join(base, workspaceToolResultRelayDir, owner, filename)
+	return target.WorkspacePath(path.Join(workspaceToolResultRelayDir, owner, filename))
 }
 
-func toolResultRelayChunkPath(target *workspace.Target, actor models.AgentConfig, toolName string, idx int) string {
-	base := "/workspace"
-	if target != nil && strings.TrimSpace(target.Workdir) != "" {
-		base = strings.TrimSpace(target.Workdir)
-	}
+func toolResultRelayChunkPath(target workspace.ExecutionTarget, actor models.AgentConfig, toolName string, idx int) (string, error) {
 	owner := sanitizeToolResultRelayPathComponent(actor.EffectiveEntityID())
 	if owner == "" {
 		owner = sanitizeToolResultRelayPathComponent(actor.ID)
@@ -129,7 +135,7 @@ func toolResultRelayChunkPath(target *workspace.Target, actor models.AgentConfig
 		name = "tool"
 	}
 	filename := fmt.Sprintf("%s-chunk-%03d-%d.txt", name, idx+1, time.Now().UnixNano())
-	return path.Join(base, workspaceToolResultRelayDir, owner, filename)
+	return target.WorkspacePath(path.Join(workspaceToolResultRelayDir, owner, filename))
 }
 
 func sanitizeToolResultRelayPathComponent(raw string) string {

--- a/internal/runtime/tools/tool_result_relay_test.go
+++ b/internal/runtime/tools/tool_result_relay_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	models "swarm/internal/runtime/core/actors"
 	workspace "swarm/internal/runtime/workspace"
@@ -24,7 +25,21 @@ func TestExecutorPersistOversizedToolResultRelay_ChunksLargeReadFileResults(t *t
 	tmpDir := t.TempDir()
 	exec := &Executor{
 		workspaces: relayWorkspaceResolverStub{
-			target: &workspace.Target{Workdir: tmpDir},
+			target: &workspace.Target{Backend: workspace.BackendDocker, Container: "swarm-agent", Workdir: "/workspace"},
+		},
+		execWorkspaceFn: func(_ context.Context, _ workspace.ExecutionTarget, _ time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
+			if len(args) == 0 {
+				return nil, []byte("missing args"), 1, nil
+			}
+			relayPath := args[len(args)-1]
+			hostPath := filepath.Join(tmpDir, strings.TrimPrefix(relayPath, "/workspace/"))
+			if err := os.MkdirAll(filepath.Dir(hostPath), 0o755); err != nil {
+				return nil, []byte(err.Error()), 1, nil
+			}
+			if err := os.WriteFile(hostPath, []byte(stdin), 0o644); err != nil {
+				return nil, []byte(err.Error()), 1, nil
+			}
+			return nil, nil, 0, nil
 		},
 	}
 	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "market-research-agent"})
@@ -47,12 +62,13 @@ func TestExecutorPersistOversizedToolResultRelay_ChunksLargeReadFileResults(t *t
 		t.Fatalf("relay path = %q, want empty for chunked read_file relay", relay.Path)
 	}
 	for _, chunk := range relay.Chunks {
-		if !strings.HasPrefix(chunk, filepath.Join(tmpDir, workspaceToolResultRelayDir)+"/") {
-			t.Fatalf("chunk path = %q, want workspace relay path", chunk)
+		if !strings.HasPrefix(chunk, "/workspace/"+workspaceToolResultRelayDir+"/") {
+			t.Fatalf("chunk path = %q, want logical workspace relay path", chunk)
 		}
-		data, err := os.ReadFile(chunk)
+		hostChunk := filepath.Join(tmpDir, strings.TrimPrefix(chunk, "/workspace/"))
+		data, err := os.ReadFile(hostChunk)
 		if err != nil {
-			t.Fatalf("ReadFile(%q): %v", chunk, err)
+			t.Fatalf("ReadFile(%q): %v", hostChunk, err)
 		}
 		if len(data) == 0 {
 			t.Fatalf("chunk %q is empty", chunk)
@@ -60,5 +76,23 @@ func TestExecutorPersistOversizedToolResultRelay_ChunksLargeReadFileResults(t *t
 		if len(data) > toolResultRelayChunkBytes {
 			t.Fatalf("chunk %q length = %d, want <= %d", chunk, len(data), toolResultRelayChunkBytes)
 		}
+	}
+}
+
+func TestExecutorPersistOversizedToolResultRelay_FailsClosedForHostBackend(t *testing.T) {
+	exec := &Executor{
+		workspaces: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
+		execWorkspaceFn: func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+			t.Fatalf("host relay must fail closed before workspace command execution")
+			return nil, nil, 0, nil
+		},
+	}
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "market-research-agent"})
+
+	_, err := exec.PersistOversizedToolResultRelay(ctx, "sql_execute", []byte(`{"blob":"hello"}`))
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support tool result relay yet") {
+		t.Fatalf("PersistOversizedToolResultRelay error = %v, want host relay fail-closed diagnostic", err)
 	}
 }

--- a/internal/runtime/workspace/execution.go
+++ b/internal/runtime/workspace/execution.go
@@ -1,0 +1,263 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+const (
+	LogicalWorkspaceMount = "/workspace"
+	LogicalDataMount      = "/data"
+	LogicalContractsMount = "/opt/swarm/contracts"
+)
+
+type ExecutionMode string
+
+const (
+	ExecutionModeUnsupported     ExecutionMode = "unsupported"
+	ExecutionModeDockerContainer ExecutionMode = "docker_container"
+	ExecutionModeHostLocal       ExecutionMode = "host_local"
+)
+
+type ExecutionCapability string
+
+const (
+	ExecutionCapabilityNativeCommand   ExecutionCapability = "native_command"
+	ExecutionCapabilityFileRead        ExecutionCapability = "file_read"
+	ExecutionCapabilityFileWrite       ExecutionCapability = "file_write"
+	ExecutionCapabilityToolResultRelay ExecutionCapability = "tool_result_relay"
+	ExecutionCapabilityClaudeCLI       ExecutionCapability = "claude_cli"
+)
+
+type MountAccess string
+
+const (
+	MountAccessReadOnly  MountAccess = "read_only"
+	MountAccessReadWrite MountAccess = "read_write"
+)
+
+type ExecutionMount struct {
+	LogicalPath string
+	HostPath    string
+	Access      MountAccess
+}
+
+type ExecutionTarget struct {
+	Backend   string
+	Mode      ExecutionMode
+	Container string
+	Workdir   string
+	Mounts    []ExecutionMount
+
+	capabilities map[ExecutionCapability]struct{}
+}
+
+type PathAccess string
+
+const (
+	PathAccessRead  PathAccess = "read"
+	PathAccessWrite PathAccess = "write"
+)
+
+func (t *Target) ExecutionTarget() ExecutionTarget {
+	if t == nil {
+		return unsupportedExecutionTarget("")
+	}
+	backend := strings.ToLower(strings.TrimSpace(t.Backend))
+	container := strings.TrimSpace(t.Container)
+	switch backend {
+	case BackendDocker:
+		if container == "" {
+			return unsupportedExecutionTarget(BackendDocker)
+		}
+		return dockerExecutionTarget(container, strings.TrimSpace(t.Workdir), t.Mounts)
+	case BackendHost:
+		return hostExecutionTarget(strings.TrimSpace(t.Workdir), t.Mounts)
+	case "":
+		if container != "" {
+			return dockerExecutionTarget(container, strings.TrimSpace(t.Workdir), t.Mounts)
+		}
+		return unsupportedExecutionTarget("")
+	default:
+		return unsupportedExecutionTarget(backend)
+	}
+}
+
+func unsupportedExecutionTarget(backend string) ExecutionTarget {
+	return ExecutionTarget{
+		Backend: strings.TrimSpace(backend),
+		Mode:    ExecutionModeUnsupported,
+		Workdir: LogicalWorkspaceMount,
+		Mounts:  defaultLogicalExecutionMounts(),
+	}
+}
+
+func dockerExecutionTarget(container, workdir string, mounts []ExecutionMount) ExecutionTarget {
+	if workdir == "" {
+		workdir = LogicalWorkspaceMount
+	}
+	return ExecutionTarget{
+		Backend:   BackendDocker,
+		Mode:      ExecutionModeDockerContainer,
+		Container: container,
+		Workdir:   cleanLogicalPath(workdir),
+		Mounts:    executionMountsOrDefault(mounts),
+		capabilities: capabilitySet(
+			ExecutionCapabilityNativeCommand,
+			ExecutionCapabilityFileRead,
+			ExecutionCapabilityFileWrite,
+			ExecutionCapabilityToolResultRelay,
+			ExecutionCapabilityClaudeCLI,
+		),
+	}
+}
+
+func hostExecutionTarget(workdir string, mounts []ExecutionMount) ExecutionTarget {
+	return ExecutionTarget{
+		Backend:      BackendHost,
+		Mode:         ExecutionModeHostLocal,
+		Workdir:      LogicalWorkspaceMount,
+		Mounts:       executionMountsOrDefault(mounts),
+		capabilities: capabilitySet(),
+	}
+}
+
+func capabilitySet(caps ...ExecutionCapability) map[ExecutionCapability]struct{} {
+	out := make(map[ExecutionCapability]struct{}, len(caps))
+	for _, cap := range caps {
+		if cap == "" {
+			continue
+		}
+		out[cap] = struct{}{}
+	}
+	return out
+}
+
+func executionMountsOrDefault(mounts []ExecutionMount) []ExecutionMount {
+	if len(mounts) == 0 {
+		return defaultLogicalExecutionMounts()
+	}
+	out := make([]ExecutionMount, 0, len(mounts))
+	for _, mount := range mounts {
+		logical := cleanLogicalPath(mount.LogicalPath)
+		if logical == "." || logical == "" {
+			continue
+		}
+		access := mount.Access
+		if access == "" {
+			access = MountAccessReadOnly
+		}
+		out = append(out, ExecutionMount{
+			LogicalPath: logical,
+			HostPath:    strings.TrimSpace(mount.HostPath),
+			Access:      access,
+		})
+	}
+	if len(out) == 0 {
+		return defaultLogicalExecutionMounts()
+	}
+	return out
+}
+
+func defaultLogicalExecutionMounts() []ExecutionMount {
+	return []ExecutionMount{
+		{LogicalPath: LogicalWorkspaceMount, Access: MountAccessReadWrite},
+		{LogicalPath: LogicalDataMount, Access: MountAccessReadOnly},
+		{LogicalPath: LogicalContractsMount, Access: MountAccessReadOnly},
+	}
+}
+
+func (e ExecutionTarget) Supports(capability ExecutionCapability) bool {
+	if e.capabilities == nil {
+		return false
+	}
+	_, ok := e.capabilities[capability]
+	return ok
+}
+
+func (e ExecutionTarget) Require(capability ExecutionCapability) error {
+	if e.Supports(capability) {
+		return nil
+	}
+	return errors.New(e.UnsupportedMessage(capability))
+}
+
+func (e ExecutionTarget) UnsupportedMessage(capability ExecutionCapability) string {
+	if strings.EqualFold(strings.TrimSpace(e.Backend), BackendHost) {
+		switch capability {
+		case ExecutionCapabilityClaudeCLI:
+			return "host workspace backend does not support Claude CLI execution yet"
+		case ExecutionCapabilityToolResultRelay:
+			return "host workspace backend does not support tool result relay yet"
+		default:
+			return "host workspace backend does not support native tool execution yet"
+		}
+	}
+	switch capability {
+	case ExecutionCapabilityClaudeCLI:
+		return "claude sessions must run in a container workspace"
+	case ExecutionCapabilityToolResultRelay:
+		return "workspace target does not support tool result relay"
+	default:
+		return "workspace target does not support native tool execution"
+	}
+}
+
+func (e ExecutionTarget) ResolvePath(raw string, access PathAccess) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	clean := cleanLogicalPath(raw)
+	if !strings.HasPrefix(clean, "/") {
+		clean = path.Join(LogicalWorkspaceMount, clean)
+	}
+	clean = cleanLogicalPath(clean)
+	for _, mount := range e.Mounts {
+		if !logicalPathWithinRoot(clean, mount.LogicalPath) {
+			continue
+		}
+		if access == PathAccessWrite && mount.Access != MountAccessReadWrite {
+			return "", fmt.Errorf("write_file path %s is outside the writable workspace", raw)
+		}
+		return clean, nil
+	}
+	if access == PathAccessWrite {
+		return "", fmt.Errorf("write_file path %s is outside the writable workspace", raw)
+	}
+	return "", fmt.Errorf("read_file path %s is outside the allowed workspace mounts", raw)
+}
+
+func (e ExecutionTarget) WorkspacePath(rel string) (string, error) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" {
+		return "", fmt.Errorf("workspace relative path is required")
+	}
+	clean := cleanLogicalPath(rel)
+	if strings.HasPrefix(clean, "/") {
+		if !logicalPathWithinRoot(clean, LogicalWorkspaceMount) {
+			return "", fmt.Errorf("workspace path %s is outside %s", rel, LogicalWorkspaceMount)
+		}
+		return clean, nil
+	}
+	return path.Join(LogicalWorkspaceMount, clean), nil
+}
+
+func cleanLogicalPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	return path.Clean(strings.ReplaceAll(raw, "\\", "/"))
+}
+
+func logicalPathWithinRoot(value, root string) bool {
+	value = cleanLogicalPath(value)
+	root = cleanLogicalPath(root)
+	if value == "" || root == "" || !strings.HasPrefix(value, "/") || !strings.HasPrefix(root, "/") {
+		return false
+	}
+	return value == root || strings.HasPrefix(value, strings.TrimRight(root, "/")+"/")
+}

--- a/internal/runtime/workspace/execution_test.go
+++ b/internal/runtime/workspace/execution_test.go
@@ -1,0 +1,64 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExecutionTargetDistinguishesDockerHostAndEmptyContainer(t *testing.T) {
+	docker := (&Target{Backend: BackendDocker, Container: "swarm-agent", Workdir: "/workspace"}).ExecutionTarget()
+	if docker.Mode != ExecutionModeDockerContainer || !docker.Supports(ExecutionCapabilityNativeCommand) || !docker.Supports(ExecutionCapabilityClaudeCLI) {
+		t.Fatalf("docker execution target = %#v, want container execution capabilities", docker)
+	}
+
+	host := (&Target{Backend: BackendHost, Workdir: t.TempDir()}).ExecutionTarget()
+	if host.Mode != ExecutionModeHostLocal || host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityClaudeCLI) {
+		t.Fatalf("host execution target = %#v, want explicit unsupported host-local target", host)
+	}
+	if err := host.Require(ExecutionCapabilityNativeCommand); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
+		t.Fatalf("host native command error = %v, want fail-closed diagnostic", err)
+	}
+
+	empty := (&Target{Workdir: t.TempDir()}).ExecutionTarget()
+	if empty.Mode != ExecutionModeUnsupported || empty.Supports(ExecutionCapabilityNativeCommand) {
+		t.Fatalf("empty-container execution target = %#v, want unsupported", empty)
+	}
+}
+
+func TestExecutionTargetLogicalPathAuthority(t *testing.T) {
+	target := (&Target{
+		Backend: BackendHost,
+		Workdir: t.TempDir(),
+		Mounts:  []ExecutionMount{{LogicalPath: LogicalWorkspaceMount, Access: MountAccessReadWrite}, {LogicalPath: LogicalDataMount, Access: MountAccessReadOnly}, {LogicalPath: LogicalContractsMount, Access: MountAccessReadOnly}},
+	}).ExecutionTarget()
+
+	if got, err := target.ResolvePath("draft.txt", PathAccessWrite); err != nil || got != "/workspace/draft.txt" {
+		t.Fatalf("workspace write path = %q err=%v, want /workspace/draft.txt", got, err)
+	}
+	if got, err := target.ResolvePath("/data/corpus.jsonl", PathAccessRead); err != nil || got != "/data/corpus.jsonl" {
+		t.Fatalf("data read path = %q err=%v, want /data/corpus.jsonl", got, err)
+	}
+	if _, err := target.ResolvePath("/data/corpus.jsonl", PathAccessWrite); err == nil || !strings.Contains(err.Error(), "outside the writable workspace") {
+		t.Fatalf("data write error = %v, want read-only rejection", err)
+	}
+	if _, err := target.ResolvePath("/tmp/escape", PathAccessWrite); err == nil || !strings.Contains(err.Error(), "outside the writable workspace") {
+		t.Fatalf("outside write error = %v, want fail-closed rejection", err)
+	}
+	if _, err := target.ResolvePath(t.TempDir(), PathAccessRead); err == nil || !strings.Contains(err.Error(), "outside the allowed workspace mounts") {
+		t.Fatalf("raw host read error = %v, want raw host path rejection", err)
+	}
+}
+
+func TestExecutionTargetWorkspacePathStaysLogical(t *testing.T) {
+	target := (&Target{Backend: BackendHost, Workdir: t.TempDir()}).ExecutionTarget()
+	got, err := target.WorkspacePath(".swarm/tool-results/session/result.json")
+	if err != nil {
+		t.Fatalf("WorkspacePath: %v", err)
+	}
+	if got != "/workspace/.swarm/tool-results/session/result.json" {
+		t.Fatalf("workspace path = %q, want logical /workspace path", got)
+	}
+	if _, err := target.WorkspacePath("/data/result.json"); err == nil || !strings.Contains(err.Error(), "outside /workspace") {
+		t.Fatalf("WorkspacePath /data error = %v, want workspace-only rejection", err)
+	}
+}

--- a/internal/runtime/workspace/host_manager.go
+++ b/internal/runtime/workspace/host_manager.go
@@ -219,7 +219,24 @@ func (m *HostManager) hostTarget(rel string) (*Target, error) {
 	return &Target{
 		Workdir: workdir,
 		Backend: BackendHost,
+		Mounts:  m.hostExecutionMounts(workdir),
 	}, nil
+}
+
+func (m *HostManager) hostExecutionMounts(workdir string) []ExecutionMount {
+	dataMount := strings.TrimSpace(m.cfg.DataMountPoint)
+	if dataMount == "" {
+		dataMount = LogicalDataMount
+	}
+	contractsMount := strings.TrimSpace(m.cfg.ContractsMountPoint)
+	if contractsMount == "" {
+		contractsMount = LogicalContractsMount
+	}
+	return []ExecutionMount{
+		{LogicalPath: LogicalWorkspaceMount, HostPath: strings.TrimSpace(workdir), Access: MountAccessReadWrite},
+		{LogicalPath: dataMount, HostPath: strings.TrimSpace(m.cfg.SharedDataSource), Access: MountAccessReadOnly},
+		{LogicalPath: contractsMount, HostPath: strings.TrimSpace(m.cfg.ContractsSource), Access: MountAccessReadOnly},
+	}
 }
 
 func (m *HostManager) ensureHostWorkspaceDir(rel string) (string, error) {

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -25,6 +25,7 @@ type Target struct {
 	Container string
 	Workdir   string
 	Backend   string
+	Mounts    []ExecutionMount
 }
 
 func (t *Target) Enabled() bool {
@@ -491,6 +492,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 			Container: m.cfg.ScaffoldContainer,
 			Workdir:   m.cfg.ScaffoldWorkdir,
 			Backend:   BackendDocker,
+			Mounts:    dockerExecutionMounts(m.cfg),
 		}, nil
 	case "system":
 		if err := m.EnsureContainerRunningWithIdentity(ctx, m.cfg.SystemContainer, m.systemContainerIdentity("workspace.ResolveWorkspace", runtimecontaineridentity.KindSystem), []string{
@@ -508,6 +510,7 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 			Container: m.cfg.SystemContainer,
 			Workdir:   m.cfg.SystemWorkdir,
 			Backend:   BackendDocker,
+			Mounts:    dockerExecutionMounts(m.cfg),
 		}, nil
 	}
 	scope, scopeKey, err := m.workspaceScopeForActor(actor)
@@ -532,7 +535,24 @@ func (m *DockerManager) ResolveWorkspace(ctx context.Context, actor models.Agent
 		Container: container,
 		Workdir:   m.cfg.EntityWorkdir,
 		Backend:   BackendDocker,
+		Mounts:    dockerExecutionMounts(m.cfg),
 	}, nil
+}
+
+func dockerExecutionMounts(cfg DockerConfig) []ExecutionMount {
+	dataMount := strings.TrimSpace(cfg.DataMountPoint)
+	if dataMount == "" {
+		dataMount = LogicalDataMount
+	}
+	contractsMount := strings.TrimSpace(cfg.ContractsMountPoint)
+	if contractsMount == "" {
+		contractsMount = LogicalContractsMount
+	}
+	return []ExecutionMount{
+		{LogicalPath: LogicalWorkspaceMount, Access: MountAccessReadWrite},
+		{LogicalPath: dataMount, Access: MountAccessReadOnly},
+		{LogicalPath: contractsMount, Access: MountAccessReadOnly},
+	}
 }
 
 func (m *DockerManager) workspaceClass(actor models.AgentConfig) (string, error) {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6646,6 +6646,82 @@ workspace_model:
     - '#1136 broader local onboarding/docs'
     - full host Claude CLI, native tool execution, and tool relay parity
     - production SQLite multi-writer semantics
+  workspace_execution_target_capability:
+    promoted_by: '#1213'
+    implementation_status: implemented_first_slice
+    canonical_owner: platform-spec.yaml#workspace_model.workspace_execution_target_capability
+    scope: >
+      Defines the canonical runtime execution-target and capability authority for workspace-backed execution surfaces after
+      workspace backend selection. The owner distinguishes Docker container execution, explicit host-local targets, and
+      unsupported targets. It does not make host execution Docker-equivalent and does not enable host native tools, host
+      command execution, host tool-result relay, or host Claude/provider runtime support in this first slice.
+    implementation_owner: internal/runtime/workspace.ExecutionTarget
+    target_modes:
+      docker_container:
+        rule: >
+          A Docker target has an explicit backend, container identity, logical workdir, and standard logical mounts. Current
+          Docker-backed execution capabilities remain supported through this mode.
+        capabilities:
+        - native_command
+        - file_read
+        - file_write
+        - tool_result_relay
+        - claude_cli
+      host_local:
+        rule: >
+          A host target is an explicit local-dev backend target with platform-managed raw host backing paths and logical
+          mount identities. Host-local targets MUST NOT infer execution support from an empty container field and MUST fail
+          closed for all current execution capabilities until a later gate promotes a specific host execution surface.
+        capabilities: []
+      unsupported:
+        rule: >
+          Nil targets, unknown backend names, Docker targets without a container, and empty targets are unsupported. They MUST
+          fail closed instead of falling back to process cwd, raw workdir execution, or implicit host execution.
+        capabilities: []
+    logical_mount_authority:
+      writable:
+      - /workspace
+      read_only:
+      - /data
+      - /opt/swarm/contracts
+      rules:
+      - Relative execution paths resolve under logical `/workspace`.
+      - Writes outside logical `/workspace` fail closed.
+      - Reads outside logical `/workspace`, `/data`, and `/opt/swarm/contracts` fail closed.
+      - Runtime execution surfaces MUST expose logical paths as product semantics and MUST NOT leak raw host backing paths as
+        agent-visible authority.
+      - Host execution target production MUST consume `workspace_model.data_source_authority` for `/data` and the loaded
+        contracts source for `/opt/swarm/contracts`.
+    consumers:
+    - Docker workspace target production
+    - Host workspace target production
+    - native executor command execution
+    - native executor read_file and write_file path resolution
+    - native fallback tool definitions and callable capability truth
+    - OpenAI-compatible/API fallback-tool routing through tools.Executor
+    - native tool-result relay path construction and execution support
+    - Claude CLI process command construction
+    - Claude workspace-command relay
+    - Claude startup visible-tool probe workspace validation
+    - runtime Claude managed-agent startup validation
+    retired_non_authoritative_interpreters:
+    - Target.Container as execution support
+    - Target.Enabled() as execution support
+    - raw Target.Workdir as product path authority
+    - nil target or empty target cwd fallback
+    - ad hoc HostBackend() checks outside the execution-target owner
+    failure_behavior:
+    - Host-local targets remain fail closed for native tool execution, tool-result relay, and Claude/provider execution until
+      a later gate promotes and proves a specific host execution surface.
+    - Empty-container targets MUST NOT authorize local host execution.
+    - Docker behavior must remain regression-proven through the same typed owner.
+    split_scope:
+    - host native file operations
+    - host native bash/command execution
+    - host tool-result relay support
+    - Claude CLI/provider-native host runtime support
+    - Docker-equivalent host isolation claims
+    - '#1137 and #1136 docs/onboarding cleanup'
   standard_mounts:
     description: Three mount points are available to every agent session. Products cannot add new mount points — they configure
       access and scope for these three via workspace class definitions.
@@ -8411,6 +8487,19 @@ cli_specification:
         - serve boot workspace lifecycle
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
+      workspace_execution_target_capability:
+        promoted_by: '#1213'
+        owner: workspace_model.workspace_execution_target_capability
+        rule: >
+          `swarm serve` runtime execution surfaces MUST consume the typed workspace execution target/capability owner after
+          backend selection. Host-local targets remain explicit and fail closed for native command/file execution, tool-result
+          relay, and Claude/provider execution in this first slice; Docker targets continue through container execution.
+        consumers:
+        - native executor command/file path authority
+        - native fallback tool-surface truth
+        - OpenAI-compatible/API fallback-tool routing through tools.Executor
+        - tool-result relay path authority
+        - Claude CLI process/startup/relay validation
       unified_listener_bind_contract:
         implemented_by: '#853'
         superseded_by: '#992 listener_topology_v2_1 runtime bind implementation'


### PR DESCRIPTION
## Summary

Part of #1213.

This PR closes the approved first-slice failure class `runtime.host_workspace_execution_target_capability_authority` by adding a typed workspace execution target/capability owner and moving current runtime execution consumers to it. Host execution parity remains split and fail-closed.

## Governing Refs / Context

- #1213 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice.
- `platform-spec.yaml#workspace_model.workspace_execution_target_capability` promoted in this PR.
- Adjacent binding context: `platform-spec.yaml#workspace_model.workspace_backend_selection`, `platform-spec.yaml#workspace_model.data_source_authority`, `platform-spec.yaml#workspace_model.standard_mounts`, `platform-spec.yaml#workspace_model.mount_guarantees`, and `platform-spec.yaml#engine.native_tools.environment`.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#workspace_model.workspace_execution_target_capability` and `internal/runtime/workspace.ExecutionTarget`.
- Old producer/reader/writer paths now invalid as execution authority: `Target.Container`, `Target.Enabled()`, raw `Target.Workdir`, nil target/cwd fallback, and ad hoc host checks outside the typed owner.
- Production paths checked/moved: Docker and Host target production, native command/file path execution, native fallback definitions/capability truth, OpenAI/API fallback-tool routing through `tools.Executor`, native tool-result relay, Claude process command construction, Claude relay, Claude startup probe, and runtime Claude managed-agent startup validation.
- Migration completeness: complete for the typed execution target/capability owner. Host native file ops, host bash/command execution, host tool-result relay support, and Claude/provider host execution parity remain split.

## Proof

- `go test ./internal/runtime/workspace ./internal/runtime/tools ./internal/runtime/llm ./cmd/swarm -run 'Test(ExecutionTarget|NativeWorkspace|NativeFile|NativeFallback|ExecutorPersistOversizedToolResultRelay|ClaudeCLIRuntime|ValidateClaudeManagedAgentWorkspaces|PlatformSpecWorkspace(Backend|Execution)|RunServeRuntimeHostWorkspaceBackend)' -count=1`
- `go test ./...`