### PR TITLE
fix: sqlite DSN serialization for relative paths

### DIFF
--- a/internal/store/sqlite_schema.go
+++ b/internal/store/sqlite_schema.go
@@ -53,7 +53,14 @@ func NewSQLiteSchemaStore(path string) (*SQLiteSchemaStore, error) {
 }
 
 func sqliteFileDSN(path string) string {
-	u := url.URL{Scheme: "file", Path: path}
+	// Use Opaque (not Path) so the result serializes as `file:<path>?...`.
+	// With Path, url.URL.String() emits `file://<path>...`, which makes the
+	// driver treat the first path segment as the URI authority. For a relative
+	// path like `.swarm/dev.db` that yields `file://.swarm/dev.db`, binds the
+	// connection to a malformed URI, and the very first statement fails with
+	// "SQL logic error: out of memory (1)". Opaque form is unambiguous for
+	// both relative and absolute paths.
+	u := url.URL{Scheme: "file", Opaque: path}
 	q := u.Query()
 	q.Add("_pragma", "foreign_keys(ON)")
 	q.Add("_pragma", "busy_timeout(5000)")

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -520,3 +520,48 @@ func sqliteTableExists(t *testing.T, db *sql.DB, tableName string) bool {
 	}
 	return exists == 1
 }
+
+// TestSQLiteSchemaStoreAcceptsRelativePath is a regression guard for the
+// `sqliteFileDSN` path. Before this guard, the DSN was built with
+// `url.URL{Scheme: "file", Path: path}`, which for a relative path like
+// `.swarm/dev.db` serialized to `file://.swarm/dev.db` and bound the
+// connection to a malformed URI; the first statement then failed with
+// "SQL logic error: out of memory (1)". This test runs the open path with a
+// relative path from a temp working directory and confirms a trivial query
+// succeeds, which is only possible if the DSN is parsed correctly.
+func TestSQLiteSchemaStoreAcceptsRelativePath(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Fatalf("restore chdir: %v", err)
+		}
+	})
+
+	store, err := NewSQLiteSchemaStore(".swarm/dev.db")
+	if err != nil {
+		t.Fatalf("NewSQLiteSchemaStore(relative): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+
+	var got int
+	if err := store.DB.QueryRow(`SELECT 1`).Scan(&got); err != nil {
+		t.Fatalf("SELECT 1 on relative-path store: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("SELECT 1 returned %d, want 1", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".swarm", "dev.db")); err != nil {
+		t.Fatalf("relative-path store did not create file at expected location: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`internal/store/sqlite_schema.go`'s `sqliteFileDSN` built the DSN as `url.URL{Scheme: "file", Path: path}.String()`. With an **absolute** path that serializes to `file:///abs/path` (correct), but with a **relative** path like the default `.swarm/dev.db` it serializes to `file://.swarm/dev.db`, where the URL parser binds `.swarm` as the *authority* component and `/dev.db` as the path. The connection lives, but the very first statement (`PRAGMA foreign_keys = ON`) fails with the cryptic `"SQL logic error: out of memory (1)"`.

## Visible impact

Before: `swarm run` or `swarm serve` with default SQLite storage fails at boot:

```
ERROR init stores: enable sqlite foreign keys: SQL logic error: out of memory (1)
local serve exited before readiness: code=1
```

After the fix (verified end-to-end on a minimal `greeting-flow` bundle):

```
INFO swarm boot state stores tables=29 columns=389 ...
swarm runtime ready contracts=greeting-flow flows=0 nodes=1 agents=0 events=1 api_listener=127.0.0.1:8081
run started: run_id=1af1e29f-... status=running
trace event_id=... event_name=greeting.requested subscriber=node/greeter
run terminal: status=completed event_count=2 entity_count=1
```

## Why CI didn't catch it

Every existing SQLite test opens the store via `t.TempDir()`, which returns an absolute path. The broken code path was only reachable in the runtime default, which uses the relative `.swarm/dev.db`.

## Fix

One field swap in `sqliteFileDSN`: `Path: path` → `Opaque: path`. `url.URL{Scheme: "file", Opaque: path}` serializes as `file:<path>?...` for both relative and absolute paths, which modernc/sqlite parses correctly.

## Regression coverage

`TestSQLiteSchemaStoreAcceptsRelativePath` chdir's to a temp directory, opens `NewSQLiteSchemaStore(".swarm/dev.db")` with a relative path, and asserts that a trivial `SELECT 1` succeeds. With the pre-fix code, this test fails with the OOM error on the first statement.

## Repro (minimal)

```go
package main

import (
    "context"
    "database/sql"
    "net/url"
    _ "modernc.org/sqlite"
)

func main() {
    u := url.URL{Scheme: "file", Path: ".swarm/dev.db"}
    db, _ := sql.Open("sqlite", u.String())
    _, err := db.ExecContext(context.Background(), \`PRAGMA foreign_keys = ON\`)
    // err: SQL logic error: out of memory (1)
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)