### PR TITLE
[agent-b][issue #1215] Bootstrap serve Postgres schema before recovery

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -355,6 +355,17 @@ func serveBundleHashes(opts serveOptions) ([]string, error) {
 	return out, nil
 }
 
+func servePreCatalogPlatformSpecPath(resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) (string, error) {
+	hashes, err := serveBundleHashes(opts)
+	if err != nil {
+		return "", err
+	}
+	if len(hashes) > 0 {
+		return embeddedPlatformSpecPath()
+	}
+	return resolvedPaths.PlatformSpecPath, nil
+}
+
 func loadServeRuntimeBundles(ctx context.Context, repo string, stores storeBundle, resolvedPaths cliContractPlatformSpecPaths, opts serveOptions) ([]serveRuntimeBundle, error) {
 	hashes, err := serveBundleHashes(opts)
 	if err != nil {
@@ -641,7 +652,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
 	if stores.Postgres != nil {
-		if _, err := initializeServePlatformStateStores(ctx, stores, resolvedPaths.PlatformSpecPath); err != nil {
+		preCatalogPlatformSpecPath, err := servePreCatalogPlatformSpecPath(resolvedPaths, opts)
+		if err != nil {
+			reporter.emit(4, "bundle_load", "FAILED", err.Error())
+			log.Printf("resolve pre-catalog platform spec: %v", err)
+			return 1
+		}
+		if _, err := initializeServePlatformStateStores(ctx, stores, preCatalogPlatformSpecPath); err != nil {
 			reporter.emit(4, "bundle_load", "FAILED", err.Error())
 			log.Printf("initialize platform state stores: %v", err)
 			return 1

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -56,6 +56,8 @@ import (
 	storebackend "swarm/internal/store/backendselection"
 	"swarm/internal/store/runbundle"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -238,6 +240,7 @@ type serveRuntimeBundleContextRequest struct {
 	Stores                 storeBundle
 	Config                 *config.Config
 	Loaded                 serveRuntimeBundle
+	StateStoreSummary      string
 	Options                serveOptions
 	MountSources           workspaceMountSources
 	WorkspaceBackend       workspaceBackendSelection
@@ -484,9 +487,13 @@ func prepareLoadedServeBundleSource(ctx context.Context, stores storeBundle, loa
 
 func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serveRuntimeBundleContext, error) {
 	loaded := req.Loaded
-	stateStoreSummary, err := initializeStateStores(req.Ctx, req.Stores, loaded.bundle)
-	if err != nil {
-		return serveRuntimeBundleContext{}, err
+	stateStoreSummary := strings.TrimSpace(req.StateStoreSummary)
+	if stateStoreSummary == "" {
+		var err error
+		stateStoreSummary, err = initializeStateStores(req.Ctx, req.Stores, loaded.bundle)
+		if err != nil {
+			return serveRuntimeBundleContext{}, err
+		}
 	}
 	bundleSourceFact, err := prepareLoadedServeBundleSource(req.Ctx, req.Stores, loaded, req.Options.Dev)
 	if err != nil {
@@ -633,6 +640,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
+	if stores.Postgres != nil {
+		if _, err := initializeServePlatformStateStores(ctx, stores, resolvedPaths.PlatformSpecPath); err != nil {
+			reporter.emit(4, "bundle_load", "FAILED", err.Error())
+			log.Printf("initialize platform state stores: %v", err)
+			return 1
+		}
+	}
 	loadedBundles, err := loadServeRuntimeBundles(ctx, repo, stores, resolvedPaths, opts)
 	if err != nil {
 		reporter.emit(4, "bundle_load", "FAILED", err.Error())
@@ -656,6 +670,15 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	source := loadedBundle.source
 	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
 	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
+	stateStoreSummaries := make([]string, len(loadedBundles))
+	if stores.Postgres != nil {
+		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles)
+		if err != nil {
+			slog.Error("initialize state stores", "error", err)
+			return 1
+		}
+		stateStoreSummaries = summaries
+	}
 	if opts.AbandonActiveRuns {
 		if stores.Postgres == nil {
 			slog.Error("abandon active runs failed", "error", "postgres store is required")
@@ -719,6 +742,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			Stores:                 stores,
 			Config:                 cfg,
 			Loaded:                 loaded,
+			StateStoreSummary:      serveStateStoreSummaryAt(stateStoreSummaries, i),
 			Options:                opts,
 			MountSources:           mountSources,
 			WorkspaceBackend:       workspaceBackend,
@@ -2557,9 +2581,82 @@ func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runt
 	}
 	plans := append(platformPlans, entityPlans...)
 	plans = append(plans, statePlans...)
-	if err := stores.SchemaBootstrapper.EnsureSchemaTables(ctx, plans); err != nil {
+	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
 		return "", err
 	}
+	return summarizeServeSchemaPlans(plans), nil
+}
+
+func initializeServePlatformStateStores(ctx context.Context, stores storeBundle, platformSpecPath string) (string, error) {
+	if stores.SchemaBootstrapper == nil {
+		return "store wiring ready", nil
+	}
+	spec, err := loadServePlatformSpecDocument(platformSpecPath)
+	if err != nil {
+		return "", err
+	}
+	plans, err := store.GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		return "", fmt.Errorf("platform-owned tables: %w", err)
+	}
+	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
+		return "", err
+	}
+	return summarizeServeSchemaPlans(plans), nil
+}
+
+func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBundle, loaded []serveRuntimeBundle) ([]string, error) {
+	summaries := make([]string, len(loaded))
+	for i, bundle := range loaded {
+		summary, err := initializeStateStores(ctx, stores, bundle.bundle)
+		if err != nil {
+			return nil, fmt.Errorf("bundle %s state stores: %w", bundle.serveIdentityDetail(), err)
+		}
+		summaries[i] = summary
+	}
+	return summaries, nil
+}
+
+func ensureServeSchemaTables(ctx context.Context, stores storeBundle, plans []store.SchemaTableDDL) error {
+	if stores.SchemaBootstrapper == nil {
+		return nil
+	}
+	if err := stores.SchemaBootstrapper.EnsureSchemaTables(ctx, plans); err != nil {
+		return err
+	}
+	if err := rebindServePostgresSchemaCapabilities(ctx, stores); err != nil {
+		return err
+	}
+	return nil
+}
+
+func rebindServePostgresSchemaCapabilities(ctx context.Context, stores storeBundle) error {
+	if stores.Postgres == nil {
+		return nil
+	}
+	if _, err := stores.Postgres.BindSchemaCapabilities(ctx); err != nil {
+		return fmt.Errorf("bind post-bootstrap schema capabilities: %w", err)
+	}
+	return nil
+}
+
+func loadServePlatformSpecDocument(platformSpecPath string) (runtimecontracts.PlatformSpecDocument, error) {
+	platformSpecPath = strings.TrimSpace(platformSpecPath)
+	if platformSpecPath == "" {
+		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("platform spec path is required")
+	}
+	data, err := os.ReadFile(platformSpecPath)
+	if err != nil {
+		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("read platform spec: %w", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", err)
+	}
+	return spec, nil
+}
+
+func summarizeServeSchemaPlans(plans []store.SchemaTableDDL) string {
 	tableNames := make([]string, 0, len(plans))
 	totalColumns := 0
 	for _, plan := range plans {
@@ -2569,9 +2666,16 @@ func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runt
 	sort.Strings(tableNames)
 	slog.Info("swarm boot state stores", "tables", len(plans), "columns", totalColumns, "detail", strings.Join(tableNames, ", "))
 	if len(tableNames) == 0 {
-		return "verified 0 generated tables", nil
+		return "verified 0 generated tables"
 	}
-	return fmt.Sprintf("verified %d generated tables (%s)", len(plans), strings.Join(tableNames, ", ")), nil
+	return fmt.Sprintf("verified %d generated tables (%s)", len(plans), strings.Join(tableNames, ", "))
+}
+
+func serveStateStoreSummaryAt(summaries []string, index int) string {
+	if index < 0 || index >= len(summaries) {
+		return ""
+	}
+	return strings.TrimSpace(summaries[index])
 }
 
 type swarmWorkflowModule struct {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2681,6 +2681,54 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 	}
 }
 
+func TestRunServeRuntimeDBLoadedUsesEmbeddedSpecBeforeCatalogRead(t *testing.T) {
+	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
+	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	if _, err := pg.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+		ParsedJSON:  projection.ParsedJSON,
+		DataBlob:    projection.DataBlob,
+		Metadata:    projection.Metadata,
+	}); err != nil {
+		t.Fatalf("UpsertBundleCatalog: %v", err)
+	}
+
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(serveCtx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			BundleHash:         projection.BundleHash,
+			PlatformSpecPath:   filepath.Join(t.TempDir(), "missing-platform-spec.yaml"),
+			StoreMode:          "postgres",
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancelServe()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	if strings.Contains(out.String(), "missing-platform-spec.yaml") || strings.Contains(out.String(), "read platform spec") {
+		t.Fatalf("DB-loaded serve used missing local platform spec before catalog read:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersistedIdentity(t *testing.T) {
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2919,8 +2919,81 @@ func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(
 	}
 }
 
+func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe(t *testing.T) {
+	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	for _, table := range []string{"bundles", "runs", "events", "event_deliveries"} {
+		assertPostgresTableExists(t, db, table)
+	}
+	if !strings.Contains(out.String(), "state_stores=verified") {
+		t.Fatalf("serve output missing state store proof:\n%s", out.String())
+	}
+}
+
+func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon(t *testing.T) {
+	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:           writeServeRuntimeTestConfig(t),
+			ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:     defaultPlatformSpecPath,
+			StoreMode:            "postgres",
+			APIListenAddr:        "127.0.0.1:0",
+			MCPListenAddr:        "127.0.0.1:0",
+			SelfCheck:            true,
+			Dev:                  true,
+			RequireBundleMatch:   false,
+			NoRequireBundleMatch: true,
+			AbandonActiveRuns:    true,
+			Verbose:              true,
+			Output:               &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	for _, table := range []string{"bundles", "runs", "run_control_state", "event_receipts"} {
+		assertPostgresTableExists(t, db, table)
+	}
+	if strings.Contains(out.String(), "relation") && strings.Contains(out.String(), "does not exist") {
+		t.Fatalf("serve output contains missing-table failure:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
-	_, _, _ = installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+	_, _, _ = installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
 	})
 	missingHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -2951,6 +3024,9 @@ func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "ready                      ok") || strings.Contains(out.String(), "[22/22]") {
 		t.Fatalf("serve reached readiness after missing DB-loaded bundle:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "bundle catalog read surface requires bundles columns") || strings.Contains(out.String(), "relation \"bundles\" does not exist") {
+		t.Fatalf("serve reported schema/bootstrap failure instead of typed bundle unavailability:\n%s", out.String())
 	}
 }
 
@@ -3095,11 +3171,30 @@ func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func()
 	})
 }
 
+func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+	t.Helper()
+	return installServeRuntimePostgresTestStoresForDatabase(t, func(workspaceMountSources) serveWorkspaceLifecycle {
+		return workspaceFactory()
+	}, false)
+}
+
 func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+	t.Helper()
+	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true)
+}
+
+func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle, useTemplate bool) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
 	oldBuildStores := buildStoresForServe
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	var dsn string
+	var db *sql.DB
+	var cleanup func()
+	if useTemplate {
+		dsn, db, cleanup = testutil.StartPostgres(t)
+	} else {
+		dsn, db, cleanup = testutil.StartEmptyPostgres(t)
+	}
 	t.Cleanup(cleanup)
 	runtimePG, err := store.NewPostgresStore(dsn)
 	if err != nil {
@@ -3138,6 +3233,17 @@ func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, wor
 		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
 	})
 	return dsn, db, runtimePG
+}
+
+func assertPostgresTableExists(t *testing.T, db *sql.DB, tableName string) {
+	t.Helper()
+	var found sql.NullString
+	if err := db.QueryRowContext(context.Background(), `SELECT to_regclass($1)::text`, "public."+tableName).Scan(&found); err != nil {
+		t.Fatalf("check table %s exists: %v", tableName, err)
+	}
+	if !found.Valid || strings.TrimSpace(found.String) == "" {
+		t.Fatalf("table %s was not bootstrapped", tableName)
+	}
 }
 
 func seedServeRuntimeUnavailableBundleRunState(t *testing.T, ctx context.Context, db *sql.DB, runID, source, fingerprint string) {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -49,7 +49,19 @@ func init() {
 // database cloned from one canonical schema template, and drops that database on cleanup.
 func StartPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
 	t.Helper()
+	return startPostgresDatabase(t, true)
+}
 
+// StartEmptyPostgres provides an isolated database without the canonical schema
+// template. Use it for bootstrapping tests that must prove schema creation from
+// a fresh Postgres database.
+func StartEmptyPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
+	t.Helper()
+	return startPostgresDatabase(t, false)
+}
+
+func startPostgresDatabase(t *testing.T, useTemplate bool) (dsn string, db *sql.DB, cleanup func()) {
+	t.Helper()
 	sharedPostgres.mu.Lock()
 	var err error
 	if !sharedPostgres.started {
@@ -69,13 +81,18 @@ func StartPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
 	defer adminDB.Close()
 
 	sharedPostgres.lifecycle.Lock()
-	if err := sharedPostgres.ensureTemplateDatabase(adminDB); err != nil {
+	if useTemplate {
+		if err := sharedPostgres.ensureTemplateDatabase(adminDB); err != nil {
+			sharedPostgres.lifecycle.Unlock()
+			t.Fatalf("initialize postgres template: %v", err)
+		}
+		if err := createIsolatedDatabaseFromTemplate(adminDB, dbName, sharedPostgres.template); err != nil {
+			sharedPostgres.lifecycle.Unlock()
+			t.Fatalf("create isolated postgres database %q: %v", dbName, err)
+		}
+	} else if err := createIsolatedDatabase(adminDB, dbName); err != nil {
 		sharedPostgres.lifecycle.Unlock()
-		t.Fatalf("initialize postgres template: %v", err)
-	}
-	if err := createIsolatedDatabaseFromTemplate(adminDB, dbName, sharedPostgres.template); err != nil {
-		sharedPostgres.lifecycle.Unlock()
-		t.Fatalf("create isolated postgres database %q: %v", dbName, err)
+		t.Fatalf("create empty postgres database %q: %v", dbName, err)
 	}
 
 	dsn = withDBName(adminDSN, dbName)


### PR DESCRIPTION
Closes #1215

## Governing Refs / Context
- Pre-Implementation Coverage Audit: #1215 comment `4593937048`.
- Gate outcome: #1215 comment `4594029415`, approved as first slice for `postgres_serve_schema_bootstrap_before_serve_boot_db_consumers`.
- Exact spec refs: `platform-spec.yaml` root sections `runtime_store_schema_dialect_bootstrap`, `multi_bundle_persistence.persistence_model.serve_db_loaded_runtime_source`, `runtime_boot.active_run_abandon_quiescence.ordering`, `resume_and_recovery.active_restart_recovery.startup_owner.ordering`, and `platform_tables.tables.bundles`.
- No platform-spec change is included because this PR implements existing bootstrap-order authority rather than adding new runtime/schema semantics.

## What Changed
- Bootstraps Postgres platform tables immediately after serve DB connection, before DB-loaded bundle catalog reads.
- Uses the embedded/default platform spec for DB-loaded pre-catalog bootstrap so stale or missing local `--platform-spec` cannot block reading the persisted bundle row.
- Bootstraps full loaded-bundle state stores before active-run abandon, startup recovery, bundle availability checks, and admission.
- Rebinds Postgres schema capabilities after serve boot schema bootstrap so stale pre-bootstrap capability inference is not reused.
- Adds fresh-empty Postgres test coverage for disk-contract serve boot, dev/abandon boot, `--bundle-hash <missing>` typed `BUNDLE_UNAVAILABLE`, and DB-loaded boot with a missing local platform spec.

## Semantic Migration
- Canonical owners remain `PostgresStore.EnsureSchemaTables` and `PostgresStore.BindSchemaCapabilities` for schema/capability ownership, with `runServeRuntime` owning serve boot ordering.
- Old invalid path: serve boot DB consumers could run before schema bootstrap, with `buildServeRuntimeBundleContext` acting as the first bootstrap point.
- Old invalid path from review: DB-loaded pre-catalog bootstrap could consume the local/configured platform spec before the persisted runtime source was loaded.
- Production paths checked: DB-loaded bundle catalog read, disk-contract serve boot, active-run abandon, startup recovery, bundle-match admission, and runtime context construction.
- Migration is complete for the approved #1215 first slice.

## Validation
- `go test ./cmd/swarm -run 'TestRunServeRuntime(FreshEmptyPostgres|BundleHashMissing|UnavailableBundleStartupRecoveryFails|UnavailableBundleStartupRecoveryOrphans|AbandonActiveRunsQuiesces)' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntime(DBLoadedUsesEmbeddedSpecBeforeCatalogRead|DBLoadedRunForkSupportedSurfaceExecutesAndStampsPersistedIdentity|BundleHashMissingFailsBeforeReadiness|FreshEmptyPostgres)' -count=1`
- `go test ./cmd/swarm -run 'Test(LoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource|RunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersistedIdentity)' -count=1`
- `go test ./internal/store -run 'TestPostgresStore_EnsureSchemaTables_ReportsOutdatedSchemaForLegacyTimers' -count=1`
- `go test ./...`