### PR TITLE
[agent-c][issue #1220] Classify catalog E2E proof tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,15 +106,21 @@ jobs:
         shell: bash
         run: |
           mkdir -p test-results
+          mapfile -t test_packages < <(go list ./... | grep -v '^swarm/internal/runtime/cataloge2e$')
           set +e
-          go test ./... -count=1 -json 2>&1 | tee test-results/go-test.json
-          test_status=${PIPESTATUS[0]}
+          go test "${test_packages[@]}" -count=1 -json 2>&1 | tee test-results/go-test.json
+          package_status=${PIPESTATUS[0]}
+          go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1 -json 2>&1 | tee -a test-results/go-test.json
+          catalog_smoke_status=${PIPESTATUS[0]}
           set -e
           go run ./cmd/swarm-test-timing \
             -input test-results/go-test.json \
             -markdown test-results/go-test-timing.md
           cat test-results/go-test-timing.md >> "$GITHUB_STEP_SUMMARY"
-          exit "$test_status"
+          if [ "$package_status" -ne 0 ]; then
+            exit "$package_status"
+          fi
+          exit "$catalog_smoke_status"
 
       - name: Upload test timing artifact
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,15 @@ jobs:
         shell: bash
         run: |
           mkdir -p test-results
-          mapfile -t test_packages < <(go list ./... | grep -v '^swarm/internal/runtime/cataloge2e$')
+          go list ./... > test-results/go-packages.txt
+          awk '$0 != "swarm/internal/runtime/cataloge2e" { print }' test-results/go-packages.txt > test-results/go-packages-required.txt
+          if [ ! -s test-results/go-packages-required.txt ]; then
+            echo "no non-catalog Go packages discovered"
+            exit 1
+          fi
+          test_packages=$(cat test-results/go-packages-required.txt)
           set +e
-          go test "${test_packages[@]}" -count=1 -json 2>&1 | tee test-results/go-test.json
+          go test $test_packages -count=1 -json 2>&1 | tee test-results/go-test.json
           package_status=${PIPESTATUS[0]}
           go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1 -json 2>&1 | tee -a test-results/go-test.json
           catalog_smoke_status=${PIPESTATUS[0]}

--- a/internal/runtime/cataloge2e/README.md
+++ b/internal/runtime/cataloge2e/README.md
@@ -1,0 +1,44 @@
+# Catalog E2E Proof Tiers
+
+This package owns the catalog E2E proof boundary for runtime fixture behavior.
+
+Required PR smoke:
+
+```sh
+go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1
+```
+
+Full catalog conformance:
+
+```sh
+go test ./internal/runtime/cataloge2e -count=1
+```
+
+Manual diagnostic probe:
+
+```sh
+SWARM_CATALOG_E2E_DEBUG=1 go test ./internal/runtime/cataloge2e -run '^TestTier11Probe$' -count=1 -v
+```
+
+| Family / tier | Proof owner | Semantic proof | Tier |
+|---|---|---|---|
+| Required catalog smoke | `TestCatalogRequiredSmoke` | startup policy, boot warning truth, assertion harness behavior, and one Tier 1 runtime fixture | required PR smoke |
+| SQLite local smoke | `.github/workflows/ci.yml` `sqlite-local-dev` | no-selector CLI run on default SQLite using `tests/tier1-primitives/test-emits-single` | required PR smoke |
+| Catalog assertion harness | `assertions_test.go`, `assertions_harness_test.go` | causal entity lookup, handler outcome recognition, emitted-event assertion rules | required PR smoke through `TestCatalogRequiredSmoke`; full conformance also runs the focused tests |
+| Startup policy | `startup_policy_test.go` | strict/runtime catalog startup policy and warning-fixture authoritative startup truth | required PR smoke through `TestCatalogRequiredSmoke`; full conformance also runs the focused tests |
+| Tier 1 primitives | `tier1_primitives_e2e_test.go`, `tests/tier1-primitives` | primitive emits, advances, guards, gates, rules, evidence, payload transforms, data accumulation, and on-complete behavior | full conformance/manual/nightly; `test-emits-single` is the smoke representative |
+| Tier 2 accumulation | `tier2_accumulation_e2e_test.go`, `tests/tier2-accumulation` | accumulator all/partial/threshold/timeout/idempotency/crash-recovery/on-complete rollback behavior | full conformance/manual/nightly |
+| Tier 3 list processing | `tier3_list_processing_e2e_test.go`, `tests/tier3-list-processing` | fan-out, filter, group, and reduce behavior | full conformance/manual/nightly |
+| Tier 4 cross entity | `tier4_cross_entity_e2e_test.go`, `tests/tier4-cross-entity` | query/filter/group and cross-entity state clearing | full conformance/manual/nightly |
+| Tier 5 lifecycle | `tier5_lifecycle_e2e_test.go`, `tests/tier5-flow-lifecycle` | auto emit, terminal state behavior, timers, templates, and wildcard subscription behavior | full conformance/manual/nightly; touched-surface proof for lifecycle/timer changes |
+| Tier 6 event loop | `tier6_event_loop_e2e_test.go`, `tests/tier6-event-loop` | event atomicity, rollback, chain depth, concurrency, dead letters, validation, and persisted-before-delivery behavior | full conformance/manual/nightly; touched-surface proof for event-loop/pipeline changes |
+| Tier 7 composition | `tier7_composition_e2e_test.go`, `tests/tier7-composition` | cross-flow subscription, dual delivery, lifecycle, chain, and wildcard composition behavior | full conformance/manual/nightly |
+| Tier 8 boot verification | `tier8_boot_e2e_test.go`, `tests/tier8-boot-verification` | bootverify/runtime startup agreement for success, warning, and error fixtures | full conformance/manual/nightly; targeted warning truth is included in required smoke |
+| Tier 9 composition patterns | `tier9_composition_patterns_e2e_test.go`, `tests/tier9-composition-patterns` | accumulate/compute/branch, gate chains, guard/query/capacity, rules fanout/data, counter escalation, lifecycle patterns | full conformance/manual/nightly |
+| Tier 10 policy patterns | `tier10_policy_patterns_e2e_test.go`, `tests/tier10-policy-patterns` | policy capacity, counters, hard gates, multi-guard partials, threshold, and timeout behavior | full conformance/manual/nightly; touched-surface proof for policy changes |
+| Tier 11 flow composition | `tier11_flow_composition_e2e_test.go`, `tests/tier11-flow-composition` | child flow loading/events, nesting, pin wiring, policy/tool inheritance, child gates, required agents, sibling isolation, and subject ID flow behavior | full conformance/manual/nightly |
+| Tier 11 probe | `tier11_probe_test.go` | diagnostic output around Tier 11 fixtures | obsolete/duplicate as required proof; replacement is `TestTier11FlowCompositionCatalogFixtures_RealRuntime` plus `TestTier11FlowCompositionCatalogFixtures_AreExplicitlyClassified`; manual debug only |
+| Tier 12 runtime fork | `tier12_runtime_fork_e2e_test.go`, `tests/tier12-runtime-fork` | selected-contract fork execution, source isolation, fork-local runtime materialization, and non-agent replay fail-closed behavior | touched-surface proof for run-fork changes; included in full conformance |
+| Tier 12 runtime tools | `tier12_runtime_tools_e2e_test.go`, `tests/tier12-runtime-tools` | flow data access tool exposure, allowlist enforcement, traversal rejection, and undeclared actor fail-closed behavior | touched-surface proof for runtime tool/flow-data-access changes; included in full conformance |
+
+Excluded legacy fixtures remain owned by their per-tier exclusion maps. Do not delete or migrate them as part of catalog tiering unless the replacement issue is explicitly in scope.

--- a/internal/runtime/cataloge2e/required_smoke_test.go
+++ b/internal/runtime/cataloge2e/required_smoke_test.go
@@ -1,0 +1,46 @@
+package cataloge2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestCatalogRequiredSmoke(t *testing.T) {
+	t.Run("startup_policies", TestCatalogFixtureStartupPolicies_AreExplicit)
+	t.Run("tier8_warning_truth", TestTier8RuntimeBootMatchesAuthoritativeStartupTruthForWarningFixtures)
+	t.Run("assertions_causal_entity_ids", TestCatalogCausalEntityIDs_FollowsSourceEventIDChain)
+	t.Run("assertions_handler_outcome_names", func(t *testing.T) {
+		if !catalogAssertsAuthoritativeHandlerOutcome("success") {
+			t.Fatal("success handler outcome was not authoritative")
+		}
+		if catalogAssertsAuthoritativeHandlerOutcome("reject") {
+			t.Fatal("reject handler outcome was treated as authoritative success")
+		}
+		if !catalogRecognizesHandlerOutcome("terminal_reject") {
+			t.Fatal("terminal_reject handler outcome was not recognized")
+		}
+		if catalogRecognizesHandlerOutcome("succes") {
+			t.Fatal("misspelled handler outcome was recognized")
+		}
+	})
+	t.Run("assertions_ignore_top_level_non_success_preview", TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof)
+	t.Run("assertions_cross_flow_emitted_events", TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission)
+	t.Run("tier1_emits_single_runtime", func(t *testing.T) {
+		runCatalogRequiredSmokeFixture(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier1-primitives", "test-emits-single"), false)
+	})
+}
+
+func runCatalogRequiredSmokeFixture(t *testing.T, fixtureRoot string, startRuntime bool) {
+	t.Helper()
+
+	var expected catalogExpectedDocument
+	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
+
+	h := newRuntimeHarness(t, fixtureRoot, startRuntime)
+	h.seedEntityFields(expected)
+	for _, step := range expected.triggerSequence() {
+		h.publishAndWait(step, catalogRuntimePublishTimeout)
+	}
+	h.waitForExpectedEmittedEvents(expected, catalogRuntimePublishTimeout)
+	assertCatalogRuntimeOutcome(t, h, expected)
+}

--- a/internal/runtime/cataloge2e/tier11_probe_test.go
+++ b/internal/runtime/cataloge2e/tier11_probe_test.go
@@ -2,6 +2,7 @@ package cataloge2e
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,10 @@ import (
 )
 
 func TestTier11Probe(t *testing.T) {
+	if os.Getenv("SWARM_CATALOG_E2E_DEBUG") != "1" {
+		t.Skip("diagnostic duplicate of Tier 11 runtime/classification proof; run with SWARM_CATALOG_E2E_DEBUG=1 for manual probe output")
+	}
+
 	repoRoot := repoRootFromCatalogE2E(t)
 	for _, fixtureName := range []string{
 		"test-child-flow-absolute-path",


### PR DESCRIPTION
## Summary

- add `TestCatalogRequiredSmoke` as the stable required catalog smoke selector
- document catalog E2E required/full/touched/manual proof tiers in `internal/runtime/cataloge2e/README.md`
- update required CI to run all non-catalog packages plus the named catalog smoke, while preserving the full catalog conformance command
- make `TestTier11Probe` manual/debug-only because Tier 11 runtime and classification tests are the closure-bearing replacement proof

Closes #1220

## Governing refs / context

No exact `platform-spec.yaml` section governs test-tier placement. Binding context is #1220, parent #1196, the approved pre-audit/gate on #1220, current `.github/workflows/ci.yml`, and current `internal/runtime/cataloge2e` tier/fixture ownership.

## Proof owner migration

New canonical owner for required catalog PR smoke: `TestCatalogRequiredSmoke` plus `internal/runtime/cataloge2e/README.md`.

Old non-authoritative path now invalid for required PR proof: implicit package membership via CI `go test ./...` making every `internal/runtime/cataloge2e` fixture required on every PR.

Full conformance remains supported as:

```sh
go test ./internal/runtime/cataloge2e -count=1
```

Manual diagnostic probe remains available as:

```sh
SWARM_CATALOG_E2E_DEBUG=1 go test ./internal/runtime/cataloge2e -run '^TestTier11Probe$' -count=1 -v
```

Production/runtime paths checked for surviving behavior changes: none changed; this PR only touches test selection/proof ownership and package documentation.

Migration complete for #1220's catalog required-suite boundary. #1196 remains open for #1218 backend-neutral Postgres consumers, deterministic async hooks, and broader CI topology.

## Verification

- `go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1`
- `go test ./internal/runtime/cataloge2e -list .`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./... -count=1`
- combined JSON timing-parser smoke using `go test -json` output from `internal/testtiming` plus catalog smoke and `go run ./cmd/swarm-test-timing`
- `git diff --check`
- `go vet ./...`