### PR TITLE
[agent-e][issue #1218] Move API idempotency tests to SQLite helper

### DIFF
--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -13,13 +13,13 @@ import (
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	"swarm/internal/store"
+	"swarm/internal/store/storetest"
 	"swarm/internal/testutil"
 )
 
 func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	pg := &store.PostgresStore{DB: db}
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	db := sqliteStore.DB
 	controller := &fakeAgentControlController{
 		directiveResponse: "accepted",
 		replayedCount:     7,
@@ -28,7 +28,7 @@ func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			Now:          func() time.Time { return time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC) },
-			Idempotency:  pg,
+			Idempotency:  sqliteStore,
 			AgentControl: controller,
 		}),
 	})
@@ -107,13 +107,11 @@ func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.
 }
 
 func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	pg := &store.PostgresStore{DB: db}
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Idempotency: pg,
+			Idempotency: sqliteStore,
 			AgentControl: &fakeAgentControlController{
 				errs: map[string]error{
 					"agent.send_directive": &runtimeagentcontrol.StateError{
@@ -156,15 +154,14 @@ func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
 }
 
 func TestOperatorAgentSendDirectiveRunTargetErrors(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	pg := &store.PostgresStore{DB: db}
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	db := sqliteStore.DB
 	missingRunID := "00000000-0000-0000-0000-000000000404"
 	terminalRunID := "00000000-0000-0000-0000-000000000405"
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Idempotency: pg,
+			Idempotency: sqliteStore,
 			AgentControl: &fakeAgentControlController{
 				errs: map[string]error{
 					"missing": &runtimeagentcontrol.StateError{
@@ -316,13 +313,11 @@ func TestOperatorAgentSendDirectiveUsesLegacyRunBundleSourceUntilSourceStampingO
 }
 
 func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	pg := &store.PostgresStore{DB: db}
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
-			Idempotency: pg,
+			Idempotency: sqliteStore,
 			AgentControl: &fakeAgentControlController{
 				errs: map[string]error{
 					"agent.restart": &runtimeagentcontrol.StateError{

--- a/internal/apiv1/operator_mailbox_materialization_test.go
+++ b/internal/apiv1/operator_mailbox_materialization_test.go
@@ -3,17 +3,14 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 	"swarm/internal/events"
-	"swarm/internal/platform"
-	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	storepkg "swarm/internal/store"
+	"swarm/internal/store/storetest"
 )
 
 func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T) {
@@ -81,21 +78,5 @@ func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T
 
 func newSQLiteMailboxMaterializationAPIStore(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
 	t.Helper()
-	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
-	if err != nil {
-		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
-	}
-	t.Cleanup(func() { _ = sqliteStore.Close() })
-	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
-	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
-	return sqliteStore
+	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
 }

--- a/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
+++ b/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
@@ -3,18 +3,15 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v3"
-	"swarm/internal/platform"
 	"swarm/internal/runtime/budgetspend"
-	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimeactors "swarm/internal/runtime/core/actors"
 	runtimemanager "swarm/internal/runtime/manager"
 	runtimesessions "swarm/internal/runtime/sessions"
 	storepkg "swarm/internal/store"
+	"swarm/internal/store/storetest"
 )
 
 func TestSQLiteAgentUsageOwnerBacksSupportedAPISurface(t *testing.T) {
@@ -73,23 +70,7 @@ func TestSQLiteAgentUsageOwnerBacksSupportedAPISurface(t *testing.T) {
 
 func newSQLiteAgentUsageStoreFixture(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
 	t.Helper()
-	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
-	if err != nil {
-		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
-	}
-	t.Cleanup(func() { _ = sqliteStore.Close() })
-	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
-	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
-	return sqliteStore
+	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
 }
 
 func seedSQLiteAgentUsageAgent(t *testing.T, ctx context.Context, sqliteStore *storepkg.SQLiteRuntimeStore, agentID string) {

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -5,18 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 	"swarm/internal/events"
-	"swarm/internal/platform"
 	runtimepkg "swarm/internal/runtime"
-	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimecorrelation "swarm/internal/runtime/correlation"
 	storepkg "swarm/internal/store"
+	"swarm/internal/store/storetest"
 )
 
 func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
@@ -80,23 +77,7 @@ type sqliteObservabilitySurfaceFixture struct {
 
 func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sqliteObservabilitySurfaceFixture {
 	t.Helper()
-	sqliteStore, err := storepkg.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
-	if err != nil {
-		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
-	}
-	t.Cleanup(func() { _ = sqliteStore.Close() })
-
-	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
-	plans, err := storepkg.GeneratePlatformTableDDLs(platformSpec)
-	if err != nil {
-		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
-	}
-	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
 
 	now := time.Unix(1700002000, 0).UTC()
 	runID := uuid.NewString()

--- a/internal/store/storetest/sqlite.go
+++ b/internal/store/storetest/sqlite.go
@@ -1,0 +1,50 @@
+package storetest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"swarm/internal/platform"
+	runtimecontracts "swarm/internal/runtime/contracts"
+	"swarm/internal/store"
+)
+
+// StartSQLiteRuntimeStore creates a file-backed SQLite runtime store with the
+// canonical platform schema for backend-neutral tests.
+func StartSQLiteRuntimeStore(t testing.TB) *store.SQLiteRuntimeStore {
+	t.Helper()
+	return StartSQLiteRuntimeStoreWithContext(t, context.Background())
+}
+
+func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context) *store.SQLiteRuntimeStore {
+	t.Helper()
+
+	var platformSpec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	plans, err := store.GeneratePlatformTableDDLs(platformSpec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	sqliteStore, err := store.NewSQLiteRuntimeStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqliteStore.Close(); err != nil {
+			t.Fatalf("close sqlite runtime store: %v", err)
+		}
+	})
+	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", dbPath, err)
+	}
+	return sqliteStore
+}


### PR DESCRIPTION
Part of #1218
Part of #1196

## Summary

- Add `internal/store/storetest.StartSQLiteRuntimeStore` as the shared file-backed SQLite/default-store helper for backend-neutral tests.
- Move the proven backend-neutral `internal/apiv1` agent-control idempotency/error-path tests from `testutil.StartPostgres` to the shared helper.
- Replace three existing local API SQLite fixture bootstraps with the shared helper so the first slice does not create another per-file owner.

## Governing Context

No exact product/runtime spec section directly governs this test-health migration. Binding context is #1218, parent #1196, the approved #1218 `Independent Pre-Implementation Gate`, prior #1207 / PR #1212, and adjacent root `platform-spec.yaml` `platform_tables.test_bootstrap` ownership for canonical schema bootstrap.

## Semantic Migration

New canonical owner: `internal/store/storetest.StartSQLiteRuntimeStore` / `StartSQLiteRuntimeStoreWithContext` for backend-neutral tests that need a persistent default SQLite runtime store with the canonical platform schema.

Old non-authoritative paths now invalid for this slice: per-file API SQLite fixture bootstrap code in `operator_mailbox_materialization_test.go`, `sqlite_agent_usage_supported_surface_test.go`, and `sqlite_observability_supported_surface_test.go`; backend-neutral agent-control idempotency/error tests using `testutil.StartPostgres` only to back API idempotency.

Production paths checked for surviving old behavior: none changed. Postgres-specific API rows remain on `testutil.StartPostgres`; repo-wide non-API package families remain tracked by #1218/#1196.

Migration completeness: complete for the approved `internal/apiv1` first-slice rows moved here; not complete for the repo-wide #1218 class.

## Proof

- Refreshed inventory: repo-wide `StartPostgres` test matches now 582; `internal/apiv1` matches now 67 after the four moved rows.
- Focused moved-row proof: `go test ./internal/store/storetest ./internal/apiv1 -run 'TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency|TestOperatorAgentControlHandlersTypedResourceErrors|TestOperatorAgentSendDirectiveRunTargetErrors|TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective|TestSQLite' -count=1`
- API package proof: `go test ./internal/apiv1 -count=1`
- Whole suite: `go test ./...`

