### PR TITLE
[agent-f][issue #976] Support boot-pinned cross-bundle run fork

### DIFF
--- a/cmd/swarm/fork.go
+++ b/cmd/swarm/fork.go
@@ -55,7 +55,7 @@ func newForkCommand(opts rootCommandOptions) *cobra.Command {
 			return runForkCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), forkOpts, args[0])
 		},
 	}
-	cmd.Flags().StringVar(&forkOpts.bundleHash, "bundle-hash", "", "Target bundle hash for same-bundle run.fork validation")
+	cmd.Flags().StringVar(&forkOpts.bundleHash, "bundle-hash", "", "Target bundle hash for run.fork selection")
 	cmd.Flags().StringVar(&forkOpts.atEvent, "at-event", "", "Fork at this source event id")
 	cmd.Flags().StringVar(&forkOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for retry-safe fork creation")
 	bindCLIOutputFlags(cmd, &forkOpts.output)

--- a/cmd/swarm/fork_test.go
+++ b/cmd/swarm/fork_test.go
@@ -178,14 +178,14 @@ func TestForkCommandFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 			wantStderr: "IDEMPOTENCY_CONFLICT: Application error: IDEMPOTENCY_CONFLICT",
 		},
 		{
-			name: "cross bundle split failure",
+			name: "target bundle unavailable",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
-				writeRunForkJSONRPCError(t, w, req.ID, "UNSUPPORTED_BUNDLE_HASH_FORK")
+				writeRunForkJSONRPCError(t, w, req.ID, "BUNDLE_UNAVAILABLE")
 			},
 			wantCode:   cliExitRuntime,
-			wantStderr: "UNSUPPORTED_BUNDLE_HASH_FORK: Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
+			wantStderr: "BUNDLE_UNAVAILABLE: Application error: BUNDLE_UNAVAILABLE",
 		},
 		{
 			name: "malformed missing owner",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -450,9 +450,8 @@ func loadServeRuntimeBundleFromCatalog(ctx context.Context, repo string, stores 
 		return serveRuntimeBundle{}, fmt.Errorf("compute DB-loaded boot bundle identity: %w", err)
 	}
 	fact := runtimecorrelation.BundleSourceFact{
-		BundleHash:        runtimeSource.BundleHash,
-		BundleSource:      storerunlifecycle.BundleSourcePersisted,
-		BundleFingerprint: bootIdentity.Fingerprint,
+		BundleHash:   runtimeSource.BundleHash,
+		BundleSource: storerunlifecycle.BundleSourcePersisted,
 	}.Normalized()
 	cleanupOnError = false
 	return serveRuntimeBundle{

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2940,6 +2940,223 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 	stopped = true
 }
 
+func TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity(t *testing.T) {
+	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	ctx := context.Background()
+	sourceBundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
+	sourceProjection, err := runtimecontracts.BuildBundleCatalogProjection(sourceBundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection(source): %v", err)
+	}
+	targetRoot := filepath.Join(t.TempDir(), "target-contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "package.yaml"), `
+name: cross-bundle-target
+version: 1.0.0
+description: Cross-bundle target fixture for run.fork.
+platform_version: ">=1.1.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "schema.yaml"), `
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+pins:
+  inputs:
+    events: [task.requested]
+  outputs:
+    events: [task.completed]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "nodes.yaml"), `
+test-node:
+  id: test-node
+  execution_type: system_node
+  subscribes_to: [task.requested]
+  produces: [task.completed]
+  event_handlers:
+    task.requested:
+      advances_to: done
+      emit:
+        event: task.completed
+        broadcast: true
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "events.yaml"), `
+task.requested:
+  swarm:
+    source: external
+  entity_id: string
+task.completed:
+  swarm:
+    source: external
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(targetRoot, "entities.yaml"), `{}`)
+	targetBundle := loadWorkflowValidationBundleAt(t, targetRoot)
+	targetProjection, err := runtimecontracts.BuildBundleCatalogProjection(targetBundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection(target): %v", err)
+	}
+	for label, projection := range map[string]runtimecontracts.BundleCatalogProjection{
+		"source": sourceProjection,
+		"target": targetProjection,
+	} {
+		if _, err := pg.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+			BundleHash:  projection.BundleHash,
+			ContentYAML: projection.ContentYAML,
+			ParsedJSON:  projection.ParsedJSON,
+			DataBlob:    projection.DataBlob,
+			Metadata:    projection.Metadata,
+		}); err != nil {
+			t.Fatalf("UpsertBundleCatalog(%s): %v", label, err)
+		}
+	}
+	if sourceProjection.BundleHash == targetProjection.BundleHash {
+		t.Fatalf("source and target projections unexpectedly share hash %s", sourceProjection.BundleHash)
+	}
+
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(serveCtx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			BundleHash:         sourceProjection.BundleHash,
+			BundleHashes:       []string{targetProjection.BundleHash},
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			StoreMode:          "postgres",
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+	stopped := false
+	t.Cleanup(func() {
+		if stopped {
+			return
+		}
+		cancelServe()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out stopping runServeRuntime\noutput:\n%s", out.String())
+		}
+	})
+	waitForServeReadyLine(t, &out, done)
+	apiAddr := serveRuntimeAPIListenerFromOutput(t, out.String())
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	at := time.Unix(1700000345, 0).UTC()
+	seedRunForkSelectedExecutionSourceEvent(t, db, sourceRunID, entityID, sourceEventID, "task.requested", "complete-task", "pending", "Serve Cross Bundle Entity", "serve-cross-bundle-test", at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE runs
+		SET bundle_hash = $2,
+		    bundle_source = $3
+		WHERE run_id = $1::uuid
+	`, sourceRunID, sourceProjection.BundleHash, storerunlifecycle.BundleSourcePersisted); err != nil {
+		t.Fatalf("stamp source run bundle identity: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cliOpts := defaultRootCommandOptions()
+	cliOpts.apiRPCEndpointOverride = "http://" + apiAddr + "/v1/rpc"
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{
+		"fork", sourceRunID,
+		"--bundle-hash", targetProjection.BundleHash,
+		"--at-event", sourceEventID,
+		"--idempotency-key", "db-loaded-cross-bundle-serve-fork",
+		"--json",
+	}, &stdout, &stderr, cliOpts)
+	if code != 0 {
+		t.Fatalf("swarm fork code=%d stderr=%s stdout=%s\nserve output:\n%s", code, stderr.String(), stdout.String(), out.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("swarm fork stderr=%q, want empty", stderr.String())
+	}
+	var rpcResult apiv1.RunForkExecutionResult
+	if err := json.Unmarshal(stdout.Bytes(), &rpcResult); err != nil {
+		t.Fatalf("decode swarm fork json: %v\n%s", err, stdout.String())
+	}
+	if rpcResult.SourceRunID != sourceRunID || rpcResult.BundleHash != targetProjection.BundleHash || rpcResult.ExecutedEventCount != 1 {
+		t.Fatalf("run.fork result = %#v, want source=%s target=%s executed=1", rpcResult, sourceRunID, targetProjection.BundleHash)
+	}
+
+	var forkBundleHash, forkBundleSource, forkBundleFingerprint string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(bundle_hash, ''), COALESCE(bundle_source, ''), COALESCE(bundle_fingerprint, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, rpcResult.ForkRunID).Scan(&forkBundleHash, &forkBundleSource, &forkBundleFingerprint); err != nil {
+		t.Fatalf("load fork run bundle identity: %v", err)
+	}
+	if forkBundleHash != targetProjection.BundleHash || forkBundleSource != storerunlifecycle.BundleSourcePersisted || forkBundleFingerprint != "" {
+		t.Fatalf("fork bundle identity = hash:%q source:%q fingerprint:%q, want persisted target %s without legacy fingerprint", forkBundleHash, forkBundleSource, forkBundleFingerprint, targetProjection.BundleHash)
+	}
+	var mode, selectedHash, contractsRoot string
+	if err := db.QueryRowContext(ctx, `
+		SELECT mode, COALESCE(bundle_hash, ''), COALESCE(contracts_root, '')
+		FROM run_fork_selected_contract_bindings
+		WHERE fork_run_id = $1::uuid
+	`, rpcResult.ForkRunID).Scan(&mode, &selectedHash, &contractsRoot); err != nil {
+		t.Fatalf("load selected-contract binding: %v", err)
+	}
+	if mode != store.RunForkContractSelectionModeBundleHash || selectedHash != targetProjection.BundleHash || contractsRoot != "" {
+		t.Fatalf("selected-contract binding = mode:%q hash:%q root:%q, want target bundle_hash selection", mode, selectedHash, contractsRoot)
+	}
+	var routeMode, routeHash string
+	if err := db.QueryRowContext(ctx, `
+		SELECT mode, COALESCE(bundle_hash, '')
+		FROM run_fork_selected_contract_route_recoveries
+		WHERE fork_run_id = $1::uuid
+	`, rpcResult.ForkRunID).Scan(&routeMode, &routeHash); err != nil {
+		t.Fatalf("load selected-contract route recovery: %v", err)
+	}
+	if routeMode != store.RunForkContractSelectionModeBundleHash || routeHash != targetProjection.BundleHash {
+		t.Fatalf("route recovery = mode:%q hash:%q, want target bundle_hash selection", routeMode, routeHash)
+	}
+	var forkEventID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT fork_event_id::text
+		FROM run_fork_selected_contract_executions
+		WHERE fork_run_id = $1::uuid AND source_event_id = $2::uuid
+	`, rpcResult.ForkRunID, sourceEventID).Scan(&forkEventID); err != nil {
+		t.Fatalf("load selected-contract execution lineage: %v", err)
+	}
+	var targetSubscriberDeliveries, sourceSubscriberDeliveries int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid AND event_id = $2::uuid AND subscriber_id = 'test-node'
+	`, rpcResult.ForkRunID, forkEventID).Scan(&targetSubscriberDeliveries); err != nil {
+		t.Fatalf("count target subscriber deliveries: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid AND event_id = $2::uuid AND subscriber_id = 'complete-task'
+	`, rpcResult.ForkRunID, forkEventID).Scan(&sourceSubscriberDeliveries); err != nil {
+		t.Fatalf("count source subscriber deliveries: %v", err)
+	}
+	if targetSubscriberDeliveries == 0 || sourceSubscriberDeliveries != 0 {
+		t.Fatalf("fork delivery recipients target=%d source=%d, want target bundle route only", targetSubscriberDeliveries, sourceSubscriberDeliveries)
+	}
+
+	cancelServe()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime exit code = %d\noutput:\n%s", code, out.String())
+	}
+	stopped = true
+}
+
 func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 	dataDir := t.TempDir()
 	var capturedMountSources workspaceMountSources

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -269,7 +269,9 @@ func TestGeneratedOpenRPCBundleIdentityDescriptionsPreserveConstraints(t *testin
 	}
 	assertOpenRPCParamDescriptionContains(t, "run.fork", runForkParams, "bundle_hash",
 		"#976",
-		"UNSUPPORTED_BUNDLE_HASH_FORK",
+		"loaded/boot-pinned RuntimeContextManager BundleContext",
+		"BUNDLE_UNAVAILABLE",
+		"BUNDLE_DATA_INTEGRITY_ERROR",
 	)
 }
 

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -476,7 +476,7 @@ func mutatingHTTPRuntimeErrorProbes() []mutatingHTTPRuntimeErrorProbe {
 		{Method: "run.fork", Params: map[string]any{"source_run_id": runForkTestSourceRunID, "fork_event_id": runForkTestEventID, "idempotency_key": "idem-error"}, Code: EventNotFoundCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runFork.err = errors.New("fork point event " + runForkTestEventID + " not found in source run " + runForkTestSourceRunID)
 		}}},
-		{Method: "run.fork", Params: map[string]any{"source_run_id": runForkTestSourceRunID, "fork_event_id": runForkTestEventID, "bundle_hash": "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "idempotency_key": "idem-error"}, Code: UnsupportedBundleHashForkCode},
+		{Method: "run.fork", Params: map[string]any{"source_run_id": runForkTestSourceRunID, "fork_event_id": runForkTestEventID, "bundle_hash": "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "idempotency_key": "idem-error"}, Code: BundleUnavailableCode},
 		{Method: "run.fork", Params: map[string]any{"source_run_id": runForkTestSourceRunID, "fork_event_id": runForkTestEventID, "idempotency_key": "idem-error"}, Code: BundleUnavailableCode, Modifiers: []func(*mutatingRuntimeProbeState){func(s *mutatingRuntimeProbeState) {
 			s.runForkAvailability.rows[runForkTestSourceRunID] = runForkUnavailable(runForkTestSourceRunID, runForkTestBundleHash, "legacy")
 		}}},

--- a/internal/apiv1/operator_run_fork.go
+++ b/internal/apiv1/operator_run_fork.go
@@ -26,9 +26,10 @@ type RunForkExecutor interface {
 }
 
 type RunForkExecutionRequest struct {
-	SourceRunID string
-	ForkEventID string
-	BundleHash  string
+	SourceRunID       string
+	ForkEventID       string
+	BundleHash        string
+	ContractSelection store.RunForkContractSelection
 }
 
 type RunForkExecutionResult struct {
@@ -52,6 +53,10 @@ func (e SelectedContractRunForkExecutor) ExecuteRunFork(ctx context.Context, req
 	if e.Store == nil {
 		return RunForkExecutionResult{}, fmt.Errorf("run.fork requires selected-contract store")
 	}
+	selection := req.ContractSelection
+	if strings.TrimSpace(selection.Mode) == "" {
+		selection = e.ContractSelection
+	}
 	result, err := runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
 		SourceRunID:       strings.TrimSpace(req.SourceRunID),
 		At:                strings.TrimSpace(req.ForkEventID),
@@ -59,7 +64,7 @@ func (e SelectedContractRunForkExecutor) ExecuteRunFork(ctx context.Context, req
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
 		Store:             e.Store,
 		SourceLoader:      e.SourceLoader,
-		ContractSelection: e.ContractSelection,
+		ContractSelection: selection,
 		AgentRuntime:      e.AgentRuntime,
 	})
 	if err != nil {
@@ -96,13 +101,6 @@ func OperatorRunForkHandlers(opts OperatorReadOptions) map[string]MethodHandler 
 }
 
 func executeRunFork(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
-	if multiRuntimeContextMode(opts) {
-		return nil, NewApplicationError(UnsupportedBundleHashForkCode, false, map[string]any{
-			"tracked_follow_up":  "#976/#1025",
-			"unsupported_reason": "run.fork runtime dispatch in multi-context DB-loaded mode is split from the pinned RuntimeContextManager boot slice",
-			"supported_selector": "single DB-loaded runtime context or same source bundle_hash in serial mode",
-		})
-	}
 	params, err := runForkParamsFromRequest(req.Params)
 	if err != nil {
 		return nil, err
@@ -117,19 +115,44 @@ func executeRunFork(ctx context.Context, req Request, opts OperatorReadOptions, 
 	if !availability.Available() {
 		return nil, NewApplicationError(BundleUnavailableCode, false, runForkAvailabilityDetails(availability))
 	}
-	if params.BundleHash != "" && params.BundleHash != availability.BundleHash {
-		return nil, NewApplicationError(UnsupportedBundleHashForkCode, false, map[string]any{
-			"source_run_id":      availability.RunID,
-			"source_bundle_hash": availability.BundleHash,
-			"requested_hash":     params.BundleHash,
-			"tracked_follow_up":  "#976",
-			"unsupported_reason": "cross-bundle run.fork is split to #976",
-			"supported_selector": "same source bundle_hash only",
+	sourceBundleHash := strings.TrimSpace(availability.BundleHash)
+	targetBundleHash := strings.TrimSpace(params.BundleHash)
+	if targetBundleHash == "" {
+		targetBundleHash = sourceBundleHash
+	}
+	if targetBundleHash == "" {
+		return nil, NewApplicationError(BundleDataIntegrityErrorCode, false, map[string]any{
+			"source_run_id": availability.RunID,
+			"reason":        "source run has no canonical bundle_hash",
 		})
 	}
-	params.BundleHash = availability.BundleHash
+	selectedOpts := opts
+	selectedCtx := ctx
+	var contractSelection store.RunForkContractSelection
+	if runtimeContextManager(opts) != nil {
+		var contextErr error
+		selectedCtx, selectedOpts, _, contextErr = runtimeBundleContextByHash(ctx, opts, targetBundleHash, params.SourceRunID)
+		if contextErr != nil {
+			return nil, contextErr
+		}
+	} else if targetBundleHash != sourceBundleHash {
+		return nil, NewApplicationError(BundleUnavailableCode, false, map[string]any{
+			"source_run_id":      availability.RunID,
+			"source_bundle_hash": sourceBundleHash,
+			"bundle_hash":        targetBundleHash,
+			"cause":              "runtime_context_not_loaded",
+			"supported_selector": "same source bundle_hash in disk/serial mode, or loaded target BundleContext in DB-loaded RuntimeContextManager mode",
+		})
+	}
+	if targetBundleHash != sourceBundleHash {
+		contractSelection = store.RunForkContractSelection{
+			Mode:       store.RunForkContractSelectionModeBundleHash,
+			BundleHash: targetBundleHash,
+		}
+	}
+	params.BundleHash = targetBundleHash
 
-	completion, replay, err := opts.Idempotency.WithAPIIdempotency(ctx, store.APIIdempotencyRequest{
+	completion, replay, err := selectedOpts.Idempotency.WithAPIIdempotency(selectedCtx, store.APIIdempotencyRequest{
 		Method:         req.Method,
 		ActorTokenID:   req.ActorTokenID,
 		IdempotencyKey: params.IdempotencyKey,
@@ -138,10 +161,11 @@ func executeRunFork(ctx context.Context, req Request, opts OperatorReadOptions, 
 		TTL:            runForkIdempotencyTTL,
 		Now:            now,
 	}, func(ctx context.Context) (store.APIIdempotencyCompletion, error) {
-		result, err := opts.RunFork.ExecuteRunFork(ctx, RunForkExecutionRequest{
-			SourceRunID: params.SourceRunID,
-			ForkEventID: params.ForkEventID,
-			BundleHash:  params.BundleHash,
+		result, err := selectedOpts.RunFork.ExecuteRunFork(ctx, RunForkExecutionRequest{
+			SourceRunID:       params.SourceRunID,
+			ForkEventID:       params.ForkEventID,
+			BundleHash:        params.BundleHash,
+			ContractSelection: contractSelection,
 		})
 		if err != nil {
 			return store.APIIdempotencyCompletion{}, runForkError(params.SourceRunID, params.ForkEventID, err)
@@ -263,14 +287,12 @@ func runForkError(sourceRunID, forkEventID string, err error) error {
 	}
 	msg := err.Error()
 	switch {
-	case strings.Contains(msg, UnsupportedBundleHashForkCode) || strings.Contains(msg, "source hash mismatch"):
+	case strings.Contains(msg, UnsupportedBundleHashForkCode):
 		return NewApplicationError(UnsupportedBundleHashForkCode, false, map[string]any{
 			"run_id":             strings.TrimSpace(sourceRunID),
 			"event_id":           strings.TrimSpace(forkEventID),
 			"reason":             msg,
-			"tracked_follow_up":  "#976",
-			"unsupported_reason": "cross-bundle run.fork is split to #976",
-			"supported_selector": "same source bundle_hash only",
+			"unsupported_reason": "run.fork target bundle selection is unsupported for the requested mode",
 		})
 	case strings.Contains(msg, runbundle.CodeBundleDataIntegrityError):
 		return NewApplicationError(BundleDataIntegrityErrorCode, false, map[string]any{

--- a/internal/apiv1/operator_run_fork_test.go
+++ b/internal/apiv1/operator_run_fork_test.go
@@ -96,7 +96,7 @@ func TestOperatorRunForkHandlersFailClosedOnBundleAvailability(t *testing.T) {
 				runForkTestSourceRunID,
 				runForkTestEventID,
 			),
-			wantCode: UnsupportedBundleHashForkCode,
+			wantCode: BundleUnavailableCode,
 		},
 	}
 
@@ -174,15 +174,15 @@ func TestOperatorRunForkHandlersMapSourceAndEventErrors(t *testing.T) {
 	})
 
 	t.Run("executor source hash mismatch", func(t *testing.T) {
-		executor := &recordingRunForkExecutor{err: errors.New("DB-loaded selected-contract source hash mismatch: request bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc source " + runForkTestBundleHash)}
+		executor := &recordingRunForkExecutor{err: errors.New(runbundle.CodeBundleDataIntegrityError + ": selected_contracts source hash mismatch: request bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc source " + runForkTestBundleHash)}
 		handler := runForkTestHandler(t, &recordingRunForkAvailability{rows: map[string]runbundle.Availability{runForkTestSourceRunID: runForkAvailable(runForkTestSourceRunID, runForkTestBundleHash)}}, executor)
 		resp := rpcCall(t, handler, fmt.Sprintf(
 			`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"fork_event_id":%q,"idempotency_key":"hash-mismatch"}}`,
 			runForkTestSourceRunID,
 			runForkTestEventID,
 		))
-		if resp.Error == nil || asMap(t, resp.Error.Data)["code"] != UnsupportedBundleHashForkCode {
-			t.Fatalf("run.fork hash mismatch error = %#v, want %s", resp.Error, UnsupportedBundleHashForkCode)
+		if resp.Error == nil || asMap(t, resp.Error.Data)["code"] != BundleDataIntegrityErrorCode {
+			t.Fatalf("run.fork hash mismatch error = %#v, want %s", resp.Error, BundleDataIntegrityErrorCode)
 		}
 	})
 }

--- a/internal/apiv1/operator_runtime_context.go
+++ b/internal/apiv1/operator_runtime_context.go
@@ -7,6 +7,7 @@ import (
 
 	swruntime "swarm/internal/runtime"
 	runtimecorrelation "swarm/internal/runtime/correlation"
+	runtimerunforkadmission "swarm/internal/runtime/runforkadmission"
 	"swarm/internal/store"
 	"swarm/internal/store/runbundle"
 )
@@ -36,7 +37,42 @@ func operatorOptionsForBundleContext(opts OperatorReadOptions, contextDef *swrun
 	if contextDef.Runtime.Manager != nil {
 		selected.AgentControl = contextDef.Runtime.Manager
 	}
+	selected.RunFork = runForkExecutorForBundleContext(selected.RunFork, contextDef)
 	return selected
+}
+
+func runForkExecutorForBundleContext(executor RunForkExecutor, contextDef *swruntime.BundleContext) RunForkExecutor {
+	if contextDef == nil || contextDef.Runtime == nil || executor == nil {
+		return executor
+	}
+	apply := func(selected SelectedContractRunForkExecutor) SelectedContractRunForkExecutor {
+		selected.AgentRuntime.Config = contextDef.Runtime.Config
+		selected.AgentRuntime.EntityStore = contextDef.Runtime.Stores.ToolEntityStore
+		selected.AgentRuntime.HumanTaskStore = contextDef.Runtime.Stores.HumanTaskStore
+		selected.AgentRuntime.SessionRegistry = contextDef.Runtime.Stores.SessionRegistry
+		selected.AgentRuntime.ConversationStore = contextDef.Runtime.Stores.ConversationStore
+		selected.AgentRuntime.TurnStore = contextDef.Runtime.Stores.TurnStore
+		selected.AgentRuntime.ScheduleStore = contextDef.Runtime.Stores.ScheduleStore
+		selected.AgentRuntime.MailboxStore = contextDef.Runtime.Stores.MailboxStore
+		selected.AgentRuntime.Workspace = contextDef.Runtime.Workspace
+		selected.AgentRuntime.Credentials = contextDef.Runtime.Credentials
+		selected.AgentRuntime.LLMRuntime = contextDef.Runtime.LLM
+		selected.ContractSelection = runtimerunforkadmission.SelectedContractSelection(contextDef.Source, contextDef.ContractsRoot)
+		return selected
+	}
+	switch typed := executor.(type) {
+	case SelectedContractRunForkExecutor:
+		return apply(typed)
+	case *SelectedContractRunForkExecutor:
+		if typed == nil {
+			return executor
+		}
+		copied := *typed
+		selected := apply(copied)
+		return selected
+	default:
+		return executor
+	}
 }
 
 func runtimeBundleContextByHash(ctx context.Context, opts OperatorReadOptions, bundleHash, runID string) (context.Context, OperatorReadOptions, *swruntime.BundleContext, error) {

--- a/internal/apiv1/operator_runtime_context_test.go
+++ b/internal/apiv1/operator_runtime_context_test.go
@@ -325,6 +325,34 @@ func TestOperatorRuntimeContextManagerFailsClosedForUnloadedBundle(t *testing.T)
 	if got := countAllRunRows(t, fixture.db); got != 0 {
 		t.Fatalf("run rows after unloaded bundle = %d, want 0", got)
 	}
+
+	executor := &recordingRunForkExecutor{}
+	forkHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:                 func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			RunForkAvailability: &recordingRunForkAvailability{rows: map[string]runbundle.Availability{runForkTestSourceRunID: runForkAvailable(runForkTestSourceRunID, runStartTestBundleHash)}},
+			RunFork:             executor,
+			Idempotency:         newMutatingProbeIdempotencyStore(),
+			RuntimeContexts:     fixture.manager,
+		}),
+	})
+	forkResp := rpcCall(t, forkHandler, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"bundle_hash":%q,"idempotency_key":"fork-unloaded-context"}}`,
+		runForkTestSourceRunID,
+		runtimeContextTestBundleHashC,
+	))
+	if forkResp.Error == nil {
+		t.Fatal("run.fork unloaded target error = nil")
+	}
+	forkData := asMap(t, forkResp.Error.Data)
+	forkDetails := asMap(t, forkData["details"])
+	if forkData["code"] != BundleUnavailableCode || forkDetails["cause"] != "runtime_context_not_loaded" {
+		t.Fatalf("run.fork unloaded target error data = %#v", forkData)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("run.fork executor calls = %d, want 0 for unloaded target", executor.calls)
+	}
 }
 
 func TestOperatorRuntimeContextManagerFailsClosedForDeactivatedBundle(t *testing.T) {
@@ -362,6 +390,67 @@ func TestOperatorRuntimeContextManagerFailsClosedForDeactivatedBundle(t *testing
 	if got := countEventRowsByRunID(t, fixture.db, runID); got != 0 {
 		t.Fatalf("event rows for deactivated existing run = %d, want 0", got)
 	}
+
+	executor := &recordingRunForkExecutor{}
+	forkHandler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:                 func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			RunForkAvailability: &recordingRunForkAvailability{rows: map[string]runbundle.Availability{runForkTestSourceRunID: runForkAvailable(runForkTestSourceRunID, runStartTestBundleHash)}},
+			RunFork:             executor,
+			Idempotency:         newMutatingProbeIdempotencyStore(),
+			RuntimeContexts:     fixture.manager,
+		}),
+	})
+	forkResp := rpcCall(t, forkHandler, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"bundle_hash":%q,"idempotency_key":"fork-deactivated-context"}}`,
+		runForkTestSourceRunID,
+		runtimeContextTestBundleHashB,
+	))
+	if forkResp.Error == nil {
+		t.Fatal("run.fork deactivated target error = nil")
+	}
+	forkData := asMap(t, forkResp.Error.Data)
+	forkDetails := asMap(t, forkData["details"])
+	if forkData["code"] != BundleUnavailableCode || forkDetails["cause"] != swruntime.RuntimeContextCauseUnloaded {
+		t.Fatalf("run.fork deactivated target error data = %#v", forkData)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("run.fork executor calls = %d, want 0 for deactivated target", executor.calls)
+	}
+}
+
+func TestRunForkExecutorForBundleContextRebindsSelectedContractSelection(t *testing.T) {
+	primarySource := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	targetBundle := runStartTestBundle("triage.requested")
+	targetBundle.Semantics.Name = "target-review"
+	targetBundle.Semantics.Version = "2.0.0"
+	targetSource := semanticview.Wrap(targetBundle)
+	executor := SelectedContractRunForkExecutor{
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            store.RunForkContractSelectionModeSelectedContracts,
+			ContractsRoot:   "/tmp/primary-contracts",
+			WorkflowName:    primarySource.WorkflowName(),
+			WorkflowVersion: primarySource.WorkflowVersion(),
+		},
+	}
+
+	rebound := runForkExecutorForBundleContext(executor, &swruntime.BundleContext{
+		Source:        targetSource,
+		ContractsRoot: "/tmp/target-contracts",
+		Runtime:       &swruntime.Runtime{},
+	})
+
+	selected, ok := rebound.(SelectedContractRunForkExecutor)
+	if !ok {
+		t.Fatalf("rebound executor type = %T, want SelectedContractRunForkExecutor", rebound)
+	}
+	if selected.ContractSelection.Mode != store.RunForkContractSelectionModeSelectedContracts ||
+		selected.ContractSelection.ContractsRoot != "/tmp/target-contracts" ||
+		selected.ContractSelection.WorkflowName != "target-review" ||
+		selected.ContractSelection.WorkflowVersion != "2.0.0" {
+		t.Fatalf("rebound contract selection = %#v", selected.ContractSelection)
+	}
 }
 
 func TestOperatorRuntimeContextManagerFailsClosedForAmbiguousRuntimeConsumers(t *testing.T) {
@@ -389,29 +478,41 @@ func TestOperatorRuntimeContextManagerFailsClosedForAmbiguousRuntimeConsumers(t 
 		t.Fatal("runtime control called singleton ingress in multi-context mode")
 	}
 
-	executor := &recordingRunForkExecutor{}
+	executor := &recordingRunForkExecutor{
+		result: RunForkExecutionResult{
+			Owner:              "runtime.run_fork.selected_contract_execution",
+			SourceRunID:        runForkTestSourceRunID,
+			ForkRunID:          runForkTestForkRunID,
+			ForkEventID:        runForkTestEventID,
+			ForkRunStatus:      "running",
+			ExecutedEventCount: 1,
+		},
+	}
 	forkHandler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			Now:                 func() time.Time { return time.Unix(1700000000, 0).UTC() },
-			RunForkAvailability: &recordingRunForkAvailability{rows: map[string]runbundle.Availability{}},
+			RunForkAvailability: &recordingRunForkAvailability{rows: map[string]runbundle.Availability{runForkTestSourceRunID: runForkAvailable(runForkTestSourceRunID, runStartTestBundleHash)}},
 			RunFork:             executor,
 			Idempotency:         newMutatingProbeIdempotencyStore(),
 			RuntimeContexts:     fixture.manager,
 		}),
 	})
 	forkResp := rpcCall(t, forkHandler, fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"idempotency_key":"fork-context"}}`,
+		`{"jsonrpc":"2.0","id":"fork","method":"run.fork","params":{"source_run_id":%q,"bundle_hash":%q,"idempotency_key":"fork-context"}}`,
 		runForkTestSourceRunID,
+		runtimeContextTestBundleHashB,
 	))
-	if forkResp.Error == nil {
-		t.Fatal("run.fork error = nil")
+	if forkResp.Error != nil {
+		t.Fatalf("run.fork error = %#v", forkResp.Error)
 	}
-	if data := asMap(t, forkResp.Error.Data); data["code"] != UnsupportedBundleHashForkCode {
-		t.Fatalf("run.fork error data = %#v, want %s", data, UnsupportedBundleHashForkCode)
+	if executor.calls != 1 {
+		t.Fatalf("run.fork executor calls = %d, want 1", executor.calls)
 	}
-	if executor.calls != 0 {
-		t.Fatalf("run.fork executor calls = %d, want 0", executor.calls)
+	if executor.last.BundleHash != runtimeContextTestBundleHashB ||
+		executor.last.ContractSelection.Mode != store.RunForkContractSelectionModeBundleHash ||
+		executor.last.ContractSelection.BundleHash != runtimeContextTestBundleHashB {
+		t.Fatalf("run.fork executor request = %#v", executor.last)
 	}
 
 	agentControl := &fakeAgentControlController{}

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -681,7 +681,7 @@ methods:
   - method: run.fork
     transport: http
     required_params: [source_run_id]
-    declared_errors: [BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, UNSUPPORTED_BUNDLE_HASH_FORK, RUN_NOT_FOUND, EVENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
+    declared_errors: [BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, RUN_NOT_FOUND, EVENT_NOT_FOUND, IDEMPOTENCY_CONFLICT]
     happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_test, name: TestOperatorRunForkHandlersUseAvailabilityAndSelectedExecutor}]}
     required_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}, {kind: go_test, name: TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics}]}
     unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCMutatingHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -66,6 +66,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 
 	loadedSource, err := loadRunForkSelectedContractSource(ctx, req.SourceLoader, SelectedContractSourceLoadRequest{
 		SourceRunID: binding.SourceRunID,
+		BundleHash:  binding.ContractSelection.BundleHash,
 		Selection:   binding.ContractSelection,
 	})
 	if err != nil {
@@ -118,6 +119,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	admission, err := BuildSelectedContractExecutionAdmission(ctx, SelectedContractExecutionAdmissionRequest{
 		ForkRunID:         forkRunID,
 		SourceRunID:       binding.SourceRunID,
+		BundleHash:        binding.ContractSelection.BundleHash,
 		BindingReader:     req.Store,
 		SourceLoader:      req.SourceLoader,
 		FrontierAdmission: frontier,

--- a/internal/runtime/runforkexecution/admission.go
+++ b/internal/runtime/runforkexecution/admission.go
@@ -92,6 +92,9 @@ func (l ContractBundleSourceLoader) LoadRunForkSelectedContractSource(ctx contex
 	if err := validateSelectedSourceLoaderSelection(selection); err != nil {
 		return LoadedSelectedContractSource{}, err
 	}
+	if strings.TrimSpace(selection.Mode) == store.RunForkContractSelectionModeBundleHash {
+		return LoadedSelectedContractSource{}, fmt.Errorf("%s: disk selected-contract source loader cannot load bundle_hash mode %s", runbundle.CodeBundleUnavailable, strings.TrimSpace(selection.BundleHash))
+	}
 	repoRoot := strings.TrimSpace(l.RepoRoot)
 	if repoRoot == "" {
 		return LoadedSelectedContractSource{}, fmt.Errorf("selected-contract execution admission source loader requires repo root")
@@ -151,31 +154,42 @@ func (l BundleCatalogSelectedContractSourceLoader) LoadRunForkSelectedContractSo
 		return LoadedSelectedContractSource{}, fmt.Errorf("DB-loaded selected-contract source loader requires bundle catalog store")
 	}
 	sourceRunID := strings.TrimSpace(req.SourceRunID)
-	if sourceRunID == "" {
-		return LoadedSelectedContractSource{}, fmt.Errorf("DB-loaded selected-contract source loader requires source run_id")
-	}
-	availability, err := l.Store.LoadRunBundleAvailability(ctx, sourceRunID)
-	if err != nil {
-		return LoadedSelectedContractSource{}, err
-	}
-	if availability.DataIntegrityError() {
-		return LoadedSelectedContractSource{}, fmt.Errorf("%s: %s", runbundle.CodeBundleDataIntegrityError, availability.DetailString())
-	}
-	if !availability.Available() {
-		return LoadedSelectedContractSource{}, fmt.Errorf("%s: %s", runbundle.CodeBundleUnavailable, availability.DetailString())
-	}
-	bundleHash := strings.TrimSpace(req.BundleHash)
-	if bundleHash == "" {
-		bundleHash = strings.TrimSpace(availability.BundleHash)
-	}
-	if bundleHash == "" {
-		return LoadedSelectedContractSource{}, fmt.Errorf("%s: source run %s has no canonical bundle_hash", runbundle.CodeBundleDataIntegrityError, sourceRunID)
-	}
-	if bundleHash != strings.TrimSpace(availability.BundleHash) {
-		return LoadedSelectedContractSource{}, fmt.Errorf("DB-loaded selected-contract source hash mismatch: request %s source %s", bundleHash, availability.BundleHash)
+	requestedHash := strings.TrimSpace(req.BundleHash)
+	bundleHash := strings.TrimSpace(selection.BundleHash)
+	if selection.Mode == store.RunForkContractSelectionModeSelectedContracts {
+		if sourceRunID == "" {
+			return LoadedSelectedContractSource{}, fmt.Errorf("DB-loaded selected-contract source loader requires source run_id")
+		}
+		availability, err := l.Store.LoadRunBundleAvailability(ctx, sourceRunID)
+		if err != nil {
+			return LoadedSelectedContractSource{}, err
+		}
+		if availability.DataIntegrityError() {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: %s", runbundle.CodeBundleDataIntegrityError, availability.DetailString())
+		}
+		if !availability.Available() {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: %s", runbundle.CodeBundleUnavailable, availability.DetailString())
+		}
+		bundleHash = requestedHash
+		if bundleHash == "" {
+			bundleHash = strings.TrimSpace(availability.BundleHash)
+		}
+		if bundleHash == "" {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: source run %s has no canonical bundle_hash", runbundle.CodeBundleDataIntegrityError, sourceRunID)
+		}
+		if bundleHash != strings.TrimSpace(availability.BundleHash) {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: selected_contracts source hash mismatch: request %s source %s", runbundle.CodeBundleDataIntegrityError, bundleHash, availability.BundleHash)
+		}
+	} else {
+		if requestedHash != "" && requestedHash != bundleHash {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: target bundle_hash selection %s does not match request %s", runbundle.CodeBundleDataIntegrityError, bundleHash, requestedHash)
+		}
 	}
 	record, err := l.Store.LoadBundleCatalogRuntimeRecord(ctx, bundleHash)
 	if errors.Is(err, store.ErrBundleNotFound) {
+		if selection.Mode == store.RunForkContractSelectionModeBundleHash {
+			return LoadedSelectedContractSource{}, fmt.Errorf("%s: target bundle %s is not available", runbundle.CodeBundleUnavailable, bundleHash)
+		}
 		return LoadedSelectedContractSource{}, fmt.Errorf("%s: source run %s bundle row missing for %s", runbundle.CodeBundleDataIntegrityError, sourceRunID, bundleHash)
 	}
 	if err != nil {
@@ -464,6 +478,7 @@ func validateSelectionMatches(label string, want, got store.RunForkContractSelec
 	}
 	if strings.TrimSpace(want.Mode) != strings.TrimSpace(got.Mode) ||
 		strings.TrimSpace(want.ContractsRoot) != strings.TrimSpace(got.ContractsRoot) ||
+		strings.TrimSpace(want.BundleHash) != strings.TrimSpace(got.BundleHash) ||
 		strings.TrimSpace(want.WorkflowName) != strings.TrimSpace(got.WorkflowName) ||
 		strings.TrimSpace(want.WorkflowVersion) != strings.TrimSpace(got.WorkflowVersion) {
 		return fmt.Errorf("selected-contract execution admission %s selection does not match durable binding", label)
@@ -472,11 +487,26 @@ func validateSelectionMatches(label string, want, got store.RunForkContractSelec
 }
 
 func validateSelectedContractSelection(label string, selection store.RunForkContractSelection) error {
-	if strings.TrimSpace(selection.Mode) != "selected_contracts" {
-		return fmt.Errorf("selected-contract execution admission %s requires mode selected_contracts; got %q", label, selection.Mode)
-	}
-	if strings.TrimSpace(selection.ContractsRoot) == "" {
-		return fmt.Errorf("selected-contract execution admission %s requires contracts_root", label)
+	switch strings.TrimSpace(selection.Mode) {
+	case store.RunForkContractSelectionModeSelectedContracts:
+		if strings.TrimSpace(selection.ContractsRoot) == "" {
+			return fmt.Errorf("selected-contract execution admission %s requires contracts_root", label)
+		}
+		if strings.TrimSpace(selection.BundleHash) != "" {
+			return fmt.Errorf("selected-contract execution admission %s selected_contracts mode cannot carry bundle_hash", label)
+		}
+	case store.RunForkContractSelectionModeBundleHash:
+		if strings.TrimSpace(selection.BundleHash) == "" {
+			return fmt.Errorf("selected-contract execution admission %s requires bundle_hash", label)
+		}
+		if err := runtimecontracts.ValidateBundleHash(selection.BundleHash); err != nil {
+			return fmt.Errorf("selected-contract execution admission %s bundle_hash invalid: %w", label, err)
+		}
+		if strings.TrimSpace(selection.ContractsRoot) != "" {
+			return fmt.Errorf("selected-contract execution admission %s bundle_hash mode cannot carry contracts_root", label)
+		}
+	default:
+		return fmt.Errorf("selected-contract execution admission %s requires mode selected_contracts or bundle_hash; got %q", label, selection.Mode)
 	}
 	if strings.TrimSpace(selection.WorkflowName) == "" {
 		return fmt.Errorf("selected-contract execution admission %s requires workflow_name", label)
@@ -488,11 +518,20 @@ func validateSelectedContractSelection(label string, selection store.RunForkCont
 }
 
 func validateSelectedSourceLoaderSelection(selection store.RunForkContractSelection) error {
-	if strings.TrimSpace(selection.Mode) != "selected_contracts" {
-		return fmt.Errorf("selected-contract execution admission selected source loader requires mode selected_contracts; got %q", selection.Mode)
-	}
-	if strings.TrimSpace(selection.ContractsRoot) == "" {
-		return fmt.Errorf("selected-contract execution admission selected source loader requires contracts_root")
+	switch strings.TrimSpace(selection.Mode) {
+	case store.RunForkContractSelectionModeSelectedContracts:
+		if strings.TrimSpace(selection.ContractsRoot) == "" {
+			return fmt.Errorf("selected-contract execution admission selected source loader requires contracts_root")
+		}
+	case store.RunForkContractSelectionModeBundleHash:
+		if strings.TrimSpace(selection.BundleHash) == "" {
+			return fmt.Errorf("selected-contract execution admission selected source loader requires bundle_hash")
+		}
+		if err := runtimecontracts.ValidateBundleHash(selection.BundleHash); err != nil {
+			return fmt.Errorf("selected-contract execution admission selected source loader bundle_hash invalid: %w", err)
+		}
+	default:
+		return fmt.Errorf("selected-contract execution admission selected source loader requires mode selected_contracts or bundle_hash; got %q", selection.Mode)
 	}
 	return nil
 }

--- a/internal/runtime/runforkexecution/admission_test.go
+++ b/internal/runtime/runforkexecution/admission_test.go
@@ -430,6 +430,63 @@ func TestBundleCatalogSelectedContractSourceLoaderLoadsPersistedSourceForRequest
 	}
 }
 
+func TestBundleCatalogSelectedContractSourceLoaderLoadsCrossBundleTargetSelection(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := runForkExecutionRepoRoot(t)
+	bundle := loadRunForkExecutionFixtureBundle(t, filepath.Join("tests", "tier12-runtime-fork", "test-selected-contract-fork-execution"))
+	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	sourceRunID := uuid.NewString()
+	catalogStore := &fakeBundleCatalogSelectedContractSourceStore{
+		availability: runbundle.Availability{
+			RunID:            sourceRunID,
+			Status:           "running",
+			BundleHash:       "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			BundleSource:     storerunlifecycle.BundleSourcePersisted,
+			BundleRowPresent: true,
+		},
+		record: store.BundleCatalogRuntimeRecord{
+			BundleHash:  projection.BundleHash,
+			ContentYAML: projection.ContentYAML,
+			DataBlob:    projection.DataBlob,
+		},
+	}
+	loader := BundleCatalogSelectedContractSourceLoader{RepoRoot: repoRoot, Store: catalogStore}
+	selection := store.RunForkContractSelection{
+		Mode:       store.RunForkContractSelectionModeBundleHash,
+		BundleHash: projection.BundleHash,
+	}
+
+	loaded, err := loader.LoadRunForkSelectedContractSourceForRequest(ctx, SelectedContractSourceLoadRequest{
+		SourceRunID: sourceRunID,
+		BundleHash:  projection.BundleHash,
+		Selection:   selection,
+	})
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractSourceForRequest: %v", err)
+	}
+	defer cleanupLoadedSelectedContractSource(loaded)
+
+	if catalogStore.requestedRunID != "" {
+		t.Fatalf("requested source availability run = %q, want no source-run availability lookup for bundle_hash target", catalogStore.requestedRunID)
+	}
+	if catalogStore.requestedBundleHash != projection.BundleHash {
+		t.Fatalf("requested target hash = %q, want %q", catalogStore.requestedBundleHash, projection.BundleHash)
+	}
+	if loaded.BundleHash != projection.BundleHash ||
+		loaded.Selection.Mode != store.RunForkContractSelectionModeBundleHash ||
+		loaded.Selection.BundleHash != projection.BundleHash ||
+		loaded.Selection.WorkflowName != "test-selected-contract-fork-execution" ||
+		loaded.Selection.WorkflowVersion != "1.0.0" {
+		t.Fatalf("loaded target source = %#v", loaded)
+	}
+	if loaded.Selection.ContractsRoot != "" {
+		t.Fatalf("loaded selection contracts_root = %q, want no path owner for bundle_hash mode", loaded.Selection.ContractsRoot)
+	}
+}
+
 func TestBundleCatalogSelectedContractSourceLoaderFailsClosedOnUnavailableStates(t *testing.T) {
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -479,6 +536,57 @@ func TestBundleCatalogSelectedContractSourceLoaderFailsClosedOnMissingCatalogByt
 		SourceRunID: sourceRunID,
 		BundleHash:  hash,
 		Selection:   testDBLoadedContractSelection("/stale/db-loaded/source-root"),
+	})
+	if err == nil || !strings.Contains(err.Error(), runbundle.CodeBundleDataIntegrityError) {
+		t.Fatalf("error = %v, want %s", err, runbundle.CodeBundleDataIntegrityError)
+	}
+}
+
+func TestBundleCatalogSelectedContractSourceLoaderFailsClosedOnMissingCrossBundleTarget(t *testing.T) {
+	ctx := context.Background()
+	targetHash := "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	catalogStore := &fakeBundleCatalogSelectedContractSourceStore{recordErr: store.ErrBundleNotFound}
+	loader := BundleCatalogSelectedContractSourceLoader{
+		RepoRoot: runForkExecutionRepoRoot(t),
+		Store:    catalogStore,
+	}
+
+	_, err := loader.LoadRunForkSelectedContractSourceForRequest(ctx, SelectedContractSourceLoadRequest{
+		SourceRunID: uuid.NewString(),
+		BundleHash:  targetHash,
+		Selection: store.RunForkContractSelection{
+			Mode:       store.RunForkContractSelectionModeBundleHash,
+			BundleHash: targetHash,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), runbundle.CodeBundleUnavailable) {
+		t.Fatalf("error = %v, want %s", err, runbundle.CodeBundleUnavailable)
+	}
+	if catalogStore.requestedRunID != "" {
+		t.Fatalf("requested source availability run = %q, want no source-run availability lookup for bundle_hash target", catalogStore.requestedRunID)
+	}
+}
+
+func TestBundleCatalogSelectedContractSourceLoaderFailsClosedOnCorruptCrossBundleTarget(t *testing.T) {
+	ctx := context.Background()
+	targetHash := "bundle-v1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	loader := BundleCatalogSelectedContractSourceLoader{
+		RepoRoot: runForkExecutionRepoRoot(t),
+		Store: &fakeBundleCatalogSelectedContractSourceStore{
+			record: store.BundleCatalogRuntimeRecord{
+				BundleHash:  targetHash,
+				ContentYAML: "projection_version: swarm.bundle.catalog.v1\nfiles: []\ncanonical_inputs: []\n",
+			},
+		},
+	}
+
+	_, err := loader.LoadRunForkSelectedContractSourceForRequest(ctx, SelectedContractSourceLoadRequest{
+		SourceRunID: uuid.NewString(),
+		BundleHash:  targetHash,
+		Selection: store.RunForkContractSelection{
+			Mode:       store.RunForkContractSelectionModeBundleHash,
+			BundleHash: targetHash,
+		},
 	})
 	if err == nil || !strings.Contains(err.Error(), runbundle.CodeBundleDataIntegrityError) {
 		t.Fatalf("error = %v, want %s", err, runbundle.CodeBundleDataIntegrityError)

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -9,6 +9,7 @@ import (
 
 	"swarm/internal/events"
 	runtimebus "swarm/internal/runtime/bus"
+	runtimecontracts "swarm/internal/runtime/contracts"
 	runtimepipeline "swarm/internal/runtime/pipeline"
 	"swarm/internal/runtime/runforkadmission"
 	"swarm/internal/store"
@@ -326,16 +327,32 @@ func selectedContractExecutionFrontierEventIDs(events []store.RunForkContractFro
 func normalizeSelectedContractExecutionSelection(selection store.RunForkContractSelection) (store.RunForkContractSelection, error) {
 	selection.Mode = strings.TrimSpace(selection.Mode)
 	if selection.Mode == "" {
-		selection.Mode = "selected_contracts"
-	}
-	if selection.Mode != "selected_contracts" {
-		return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires mode selected_contracts; got %q", selection.Mode)
+		selection.Mode = store.RunForkContractSelectionModeSelectedContracts
 	}
 	selection.ContractsRoot = strings.TrimSpace(selection.ContractsRoot)
+	selection.BundleHash = strings.TrimSpace(selection.BundleHash)
 	selection.WorkflowName = strings.TrimSpace(selection.WorkflowName)
 	selection.WorkflowVersion = strings.TrimSpace(selection.WorkflowVersion)
-	if selection.ContractsRoot == "" {
-		return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires contracts_root")
+	switch selection.Mode {
+	case store.RunForkContractSelectionModeSelectedContracts:
+		if selection.ContractsRoot == "" {
+			return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires contracts_root")
+		}
+		if selection.BundleHash != "" {
+			return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution selected_contracts mode cannot carry bundle_hash")
+		}
+	case store.RunForkContractSelectionModeBundleHash:
+		if selection.BundleHash == "" {
+			return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires bundle_hash")
+		}
+		if err := runtimecontracts.ValidateBundleHash(selection.BundleHash); err != nil {
+			return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution bundle_hash invalid: %w", err)
+		}
+		if selection.ContractsRoot != "" {
+			return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution bundle_hash mode cannot carry contracts_root")
+		}
+	default:
+		return store.RunForkContractSelection{}, fmt.Errorf("selected-contract execution requires mode selected_contracts or bundle_hash; got %q", selection.Mode)
 	}
 	return selection, nil
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -176,6 +176,9 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return err
 		}
 	}
+	if err := s.ensureRunForkBundleHashSelectionSchema(ctx, catalog); err != nil {
+		return err
+	}
 	if catalog.hasTable("events") {
 		for _, stmt := range []struct {
 			column string
@@ -499,6 +502,64 @@ func (s *PostgresStore) ensureRunBundleSourceSchema(ctx context.Context, catalog
 	} {
 		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("ensure runs bundle source schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStore) ensureRunForkBundleHashSelectionSchema(ctx context.Context, catalog schemaColumnCatalog) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	for _, tableName := range []string{
+		runForkSelectedContractBindingTable,
+		runForkSelectedContractRouteRecoveryTable,
+	} {
+		if !catalog.hasTable(tableName) {
+			continue
+		}
+		for _, stmt := range []struct {
+			name string
+			sql  string
+		}{
+			{"add bundle_hash", fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS bundle_hash TEXT`, tableName)},
+			{"drop contracts_root not null", fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN contracts_root DROP NOT NULL`, tableName)},
+			{"drop legacy selection checks", fmt.Sprintf(`
+				DO $$
+				DECLARE rec RECORD;
+				BEGIN
+					FOR rec IN
+						SELECT c.conname
+						FROM pg_constraint c
+						JOIN pg_class tbl ON tbl.oid = c.conrelid
+						JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+						WHERE ns.nspname = 'public'
+						  AND tbl.relname = '%s'
+						  AND c.contype = 'c'
+						  AND pg_get_constraintdef(c.oid) LIKE '%%selected_contracts%%'
+					LOOP
+						EXECUTE format('ALTER TABLE %%I.%%I DROP CONSTRAINT %%I', 'public', '%s', rec.conname);
+					END LOOP;
+				END
+				$$;
+			`, tableName, tableName)},
+			{"add mode check", fmt.Sprintf(`ALTER TABLE %s ADD CONSTRAINT %s_mode_check CHECK (mode IN ('selected_contracts', 'bundle_hash'))`, tableName, tableName)},
+			{"add selection shape check", fmt.Sprintf(`ALTER TABLE %s ADD CONSTRAINT %s_selection_shape_check CHECK (
+				(
+					mode = 'selected_contracts'
+					AND NULLIF(BTRIM(COALESCE(contracts_root, '')), '') IS NOT NULL
+					AND NULLIF(BTRIM(COALESCE(bundle_hash, '')), '') IS NULL
+				)
+				OR (
+					mode = 'bundle_hash'
+					AND NULLIF(BTRIM(COALESCE(contracts_root, '')), '') IS NULL
+					AND bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'
+				)
+			)`, tableName, tableName)},
+		} {
+			if _, err := s.DB.ExecContext(ctx, stmt.sql); err != nil {
+				return fmt.Errorf("ensure %s %s: %w", tableName, stmt.name, err)
+			}
 		}
 	}
 	return nil

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -135,7 +135,7 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	if len(lineage.EntityIDs) == 0 {
 		return result, fmt.Errorf("fork activation requires materialized fork entity_state rows")
 	}
-	if catalog.hasColumns(runForkSelectedContractBindingTable, "fork_run_id", "source_run_id", "fork_event_id", "mode", "contracts_root", "workflow_name", "workflow_version", "created_at") {
+	if catalog.hasColumns(runForkSelectedContractBindingTable, "fork_run_id", "source_run_id", "fork_event_id", "mode", "contracts_root", "bundle_hash", "workflow_name", "workflow_version", "created_at") {
 		binding, err := loadRunForkSelectedContractBinding(ctx, tx, lineage.ForkRunID)
 		if err == nil {
 			result.SelectedContractBinding = &binding

--- a/internal/store/run_fork_contract_frontier_admission.go
+++ b/internal/store/run_fork_contract_frontier_admission.go
@@ -7,6 +7,9 @@ const (
 
 	RunForkSelectedContractDiagnosticPlatformOutcomePolicyOwner = "runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy"
 
+	RunForkContractSelectionModeSelectedContracts = "selected_contracts"
+	RunForkContractSelectionModeBundleHash        = "bundle_hash"
+
 	RunForkContractFrontierDispositionLineageNoAction = "lineage_no_action"
 
 	RunForkBlockerContractFrontierExecutionUnsupported = "contract_frontier_execution_unsupported"
@@ -16,6 +19,7 @@ const (
 type RunForkContractSelection struct {
 	Mode            string `json:"mode"`
 	ContractsRoot   string `json:"contracts_root,omitempty"`
+	BundleHash      string `json:"bundle_hash,omitempty"`
 	WorkflowName    string `json:"workflow_name,omitempty"`
 	WorkflowVersion string `json:"workflow_version,omitempty"`
 }

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -558,6 +558,58 @@ func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *tes
 	}
 }
 
+func TestRunForkSelectedContractBinding_MaterializesDurableBundleHashBinding(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	at := time.Unix(1700000515, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+
+	targetHash := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	selection := RunForkContractSelection{
+		Mode:            RunForkContractSelectionModeBundleHash,
+		BundleHash:      targetHash,
+		WorkflowName:    "selected-workflow",
+		WorkflowVersion: "v2",
+	}
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                eventID,
+		BundleHash:        targetHash,
+		BundleSource:      "persisted",
+		ContractSelection: &selection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	loaded, err := pg.RequireRunForkSelectedContractBinding(ctx, materialized.ForkRunID)
+	if err != nil {
+		t.Fatalf("RequireRunForkSelectedContractBinding: %v", err)
+	}
+	if loaded.ContractSelection.Mode != RunForkContractSelectionModeBundleHash ||
+		loaded.ContractSelection.BundleHash != targetHash ||
+		loaded.ContractSelection.ContractsRoot != "" ||
+		loaded.ContractSelection.WorkflowName != selection.WorkflowName ||
+		loaded.ContractSelection.WorkflowVersion != selection.WorkflowVersion {
+		t.Fatalf("loaded bundle_hash binding = %#v", loaded)
+	}
+	var forkBundleHash, forkBundleSource string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(bundle_hash, ''), COALESCE(bundle_source, '')
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, materialized.ForkRunID).Scan(&forkBundleHash, &forkBundleSource); err != nil {
+		t.Fatalf("load fork bundle identity: %v", err)
+	}
+	if forkBundleHash != targetHash || forkBundleSource != "persisted" {
+		t.Fatalf("fork bundle identity = %s/%s, want %s/persisted", forkBundleHash, forkBundleSource, targetHash)
+	}
+}
+
 func TestRunForkSelectedContractBinding_FailsClosedOnMissingDuplicateAndInvalidSelection(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_selected_contract_binding.go
+++ b/internal/store/run_fork_selected_contract_binding.go
@@ -42,6 +42,7 @@ func RequireRunForkSelectedContractBindingCapabilities(caps StoreSchemaCapabilit
 			"fork_event_id",
 			"mode",
 			"contracts_root",
+			"bundle_hash",
 			"workflow_name",
 			"workflow_version",
 			"created_at",
@@ -90,6 +91,7 @@ func (s *PostgresStore) LoadRunForkSelectedContractBinding(ctx context.Context, 
 		"fork_event_id",
 		"mode",
 		"contracts_root",
+		"bundle_hash",
 		"workflow_name",
 		"workflow_version",
 		"created_at",
@@ -131,15 +133,16 @@ func insertRunForkSelectedContractBinding(ctx context.Context, tx *sql.Tx, req R
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO run_fork_selected_contract_bindings (
 			fork_run_id, source_run_id, fork_event_id,
-			mode, contracts_root, workflow_name, workflow_version, created_at
+			mode, contracts_root, bundle_hash, workflow_name, workflow_version, created_at
 		)
 		VALUES (
 			$1::uuid, $2::uuid, $3::uuid,
-			$4, $5, $6, $7, $8
+			$4, NULLIF($5, ''), NULLIF($6, ''), $7, $8, $9
 		)
 	`, binding.ForkRunID, binding.SourceRunID, binding.ForkEventID,
 		binding.ContractSelection.Mode,
 		binding.ContractSelection.ContractsRoot,
+		binding.ContractSelection.BundleHash,
 		binding.ContractSelection.WorkflowName,
 		binding.ContractSelection.WorkflowVersion,
 		binding.CreatedAt); err != nil {
@@ -159,7 +162,8 @@ func loadRunForkSelectedContractBinding(ctx context.Context, querier interface {
 			source_run_id::text,
 			fork_event_id::text,
 			mode,
-			contracts_root,
+			COALESCE(contracts_root, ''),
+			COALESCE(bundle_hash, ''),
 			workflow_name,
 			workflow_version,
 			created_at
@@ -171,6 +175,7 @@ func loadRunForkSelectedContractBinding(ctx context.Context, querier interface {
 		&binding.ForkEventID,
 		&selection.Mode,
 		&selection.ContractsRoot,
+		&selection.BundleHash,
 		&selection.WorkflowName,
 		&selection.WorkflowVersion,
 		&binding.CreatedAt,
@@ -225,16 +230,32 @@ func normalizeRunForkSelectedContractBinding(req RunForkSelectedContractBindingR
 func normalizeRunForkSelectedContractSelection(selection RunForkContractSelection) (RunForkContractSelection, error) {
 	selection.Mode = strings.TrimSpace(selection.Mode)
 	if selection.Mode == "" {
-		selection.Mode = "selected_contracts"
-	}
-	if selection.Mode != "selected_contracts" {
-		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires mode selected_contracts; got %q", selection.Mode)
+		selection.Mode = RunForkContractSelectionModeSelectedContracts
 	}
 	selection.ContractsRoot = strings.TrimSpace(selection.ContractsRoot)
+	selection.BundleHash = strings.TrimSpace(selection.BundleHash)
 	selection.WorkflowName = strings.TrimSpace(selection.WorkflowName)
 	selection.WorkflowVersion = strings.TrimSpace(selection.WorkflowVersion)
-	if selection.ContractsRoot == "" {
-		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires contracts_root")
+	switch selection.Mode {
+	case RunForkContractSelectionModeSelectedContracts:
+		if selection.ContractsRoot == "" {
+			return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires contracts_root")
+		}
+		if selection.BundleHash != "" {
+			return RunForkContractSelection{}, fmt.Errorf("selected contract binding selected_contracts mode cannot carry bundle_hash")
+		}
+	case RunForkContractSelectionModeBundleHash:
+		if selection.BundleHash == "" {
+			return RunForkContractSelection{}, fmt.Errorf("selected contract binding bundle_hash mode requires bundle_hash")
+		}
+		if !canonicalBundleHashPattern.MatchString(selection.BundleHash) {
+			return RunForkContractSelection{}, fmt.Errorf("selected contract binding bundle_hash must be bundle-v1:sha256:<64 lowercase hex>")
+		}
+		if selection.ContractsRoot != "" {
+			return RunForkContractSelection{}, fmt.Errorf("selected contract binding bundle_hash mode cannot carry contracts_root")
+		}
+	default:
+		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires mode selected_contracts or bundle_hash; got %q", selection.Mode)
 	}
 	if selection.WorkflowName == "" {
 		return RunForkContractSelection{}, fmt.Errorf("selected contract binding requires workflow_name")

--- a/internal/store/run_fork_selected_contract_route_recovery.go
+++ b/internal/store/run_fork_selected_contract_route_recovery.go
@@ -64,6 +64,7 @@ func RequireRunForkSelectedContractRouteRecoveryCapabilities(caps StoreSchemaCap
 		"runtime_recovery_owner",
 		"mode",
 		"contracts_root",
+		"bundle_hash",
 		"workflow_name",
 		"workflow_version",
 		"route_topology_owner",
@@ -112,7 +113,7 @@ func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.C
 		INSERT INTO run_fork_selected_contract_route_recoveries (
 			fork_run_id, source_run_id, fork_event_id,
 			owner, runtime_recovery_owner,
-			mode, contracts_root, workflow_name, workflow_version,
+			mode, contracts_root, bundle_hash, workflow_name, workflow_version,
 			route_topology_owner, dynamic_topology_owner, recipient_planning_owner,
 			frontier_evidence_fingerprint, route_topology_fingerprint, recipient_planning_fingerprint,
 			static_route_event_count, dynamic_topology_proof_count, recipient_plan_event_count,
@@ -121,17 +122,18 @@ func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.C
 		VALUES (
 			$1::uuid, $2::uuid, $3::uuid,
 			$4, $5,
-			$6, $7, $8, $9,
-			$10, NULLIF($11, ''), $12,
-			$13, $14, $15,
-			$16, $17, $18,
-			$19::jsonb, $20::jsonb, $21
+			$6, NULLIF($7, ''), NULLIF($8, ''), $9, $10,
+			$11, NULLIF($12, ''), $13,
+			$14, $15, $16,
+			$17, $18, $19,
+			$20::jsonb, $21::jsonb, $22
 		)
 		ON CONFLICT (fork_run_id) DO UPDATE
 		SET owner = EXCLUDED.owner,
 		    runtime_recovery_owner = EXCLUDED.runtime_recovery_owner,
 		    mode = EXCLUDED.mode,
 		    contracts_root = EXCLUDED.contracts_root,
+		    bundle_hash = EXCLUDED.bundle_hash,
 		    workflow_name = EXCLUDED.workflow_name,
 		    workflow_version = EXCLUDED.workflow_version,
 		    route_topology_owner = EXCLUDED.route_topology_owner,
@@ -148,7 +150,7 @@ func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.C
 		    created_at = EXCLUDED.created_at
 	`, record.ForkRunID, record.SourceRunID, record.ForkEventID,
 		record.Owner, record.RuntimeRecoveryOwner,
-		record.ContractSelection.Mode, record.ContractSelection.ContractsRoot, record.ContractSelection.WorkflowName, record.ContractSelection.WorkflowVersion,
+		record.ContractSelection.Mode, record.ContractSelection.ContractsRoot, record.ContractSelection.BundleHash, record.ContractSelection.WorkflowName, record.ContractSelection.WorkflowVersion,
 		record.RouteTopologyOwner, record.DynamicTopologyOwner, record.RecipientPlanningOwner,
 		record.FrontierEvidenceFingerprint, record.RouteTopologyFingerprint, record.RecipientPlanningFingerprint,
 		record.StaticRouteEventCount, record.DynamicTopologyProofCount, record.RecipientPlanEventCount,
@@ -342,6 +344,7 @@ func validateRunForkSelectedContractRouteRecoverySelection(context string, left,
 	}
 	if left.Mode != right.Mode ||
 		left.ContractsRoot != right.ContractsRoot ||
+		left.BundleHash != right.BundleHash ||
 		left.WorkflowName != right.WorkflowName ||
 		left.WorkflowVersion != right.WorkflowVersion {
 		return fmt.Errorf("%s selected contract selection mismatch", strings.TrimSpace(context))
@@ -389,7 +392,8 @@ func runForkSelectedContractRouteRecoverySelect() string {
 			source_run_id::text,
 			fork_event_id::text,
 			mode,
-			contracts_root,
+			COALESCE(contracts_root, ''),
+			COALESCE(bundle_hash, ''),
 			workflow_name,
 			workflow_version,
 			route_topology_owner,
@@ -431,6 +435,7 @@ func scanRunForkSelectedContractRouteRecovery(row runForkSelectedContractRouteRe
 		&record.ForkEventID,
 		&selection.Mode,
 		&selection.ContractsRoot,
+		&selection.BundleHash,
 		&selection.WorkflowName,
 		&selection.WorkflowVersion,
 		&record.RouteTopologyOwner,

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -105,6 +105,68 @@ func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t
 	}
 }
 
+func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsBundleHashSelection(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, sourceRunID, forkRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, payload, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'item.received', '{}'::jsonb, 'platform')
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+
+	selection, topology, planning := testSelectedRouteRecoveryEvidence(eventID)
+	targetHash := "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	selection = RunForkContractSelection{
+		Mode:            RunForkContractSelectionModeBundleHash,
+		BundleHash:      targetHash,
+		WorkflowName:    selection.WorkflowName,
+		WorkflowVersion: selection.WorkflowVersion,
+	}
+	topology.ContractSelection = selection
+	planning.ContractSelection = selection
+
+	record, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	})
+	if err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if record.ContractSelection.Mode != RunForkContractSelectionModeBundleHash ||
+		record.ContractSelection.BundleHash != targetHash ||
+		record.ContractSelection.ContractsRoot != "" {
+		t.Fatalf("record selection = %#v", record.ContractSelection)
+	}
+	loaded, ok, err := pg.LoadRunForkSelectedContractRouteRecovery(ctx, forkRunID)
+	if err != nil {
+		t.Fatalf("LoadRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	if !ok {
+		t.Fatal("route recovery row not found")
+	}
+	if loaded.ContractSelection.Mode != RunForkContractSelectionModeBundleHash ||
+		loaded.ContractSelection.BundleHash != targetHash ||
+		loaded.ContractSelection.ContractsRoot != "" ||
+		!strings.Contains(string(loaded.RouteTopology), targetHash) ||
+		!strings.Contains(string(loaded.RecipientPlanning), targetHash) {
+		t.Fatalf("loaded bundle_hash route recovery = %#v", loaded)
+	}
+}
+
 func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJSONB(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -161,6 +223,74 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJS
 		}},
 	}); err != nil {
 		t.Fatalf("Authorize recovered JSONB recipient plan: %v", err)
+	}
+}
+
+func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughBundleHashJSONB(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running'), ($2::uuid, 'running')
+	`, sourceRunID, forkRunID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, payload, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'item.received', '{}'::jsonb, 'platform')
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed fork point event: %v", err)
+	}
+	selection, topology, planning := testSelectedRouteRecoveryEvidence(eventID)
+	targetHash := "bundle-v1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	selection = RunForkContractSelection{
+		Mode:            RunForkContractSelectionModeBundleHash,
+		BundleHash:      targetHash,
+		WorkflowName:    selection.WorkflowName,
+		WorkflowVersion: selection.WorkflowVersion,
+	}
+	topology.ContractSelection = selection
+	planning.ContractSelection = selection
+	if _, err := pg.RecordRunForkSelectedContractRouteRecovery(ctx, RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       sourceRunID,
+		ForkEventID:       eventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	}); err != nil {
+		t.Fatalf("RecordRunForkSelectedContractRouteRecovery: %v", err)
+	}
+	bus := &selectedRouteRecoveryPostgresBus{store: selectedRouteRecoveryStoreWrapper{pg: pg}}
+	am := runtimemanager.NewAgentManager(bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
+		return selectedRouteRecoveryAgent{id: cfg.ID}, nil
+	}, pg)
+
+	if err := am.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	guard, ok := am.SelectedContractRouteRecoveryRecipientGuard(forkRunID)
+	if !ok {
+		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
+	}
+	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000992", eventID)
+	evt := events.Event{
+		ID:          "00000000-0000-0000-0000-000000000992",
+		Type:        events.EventType("item.received"),
+		SourceAgent: RunForkSelectedContractExecutionOwner,
+	}
+	if err := guard.Authorize(ctx, evt, runtimebus.PublishRecipientPlan{
+		RoutedRecipients: []runtimebus.PublishDiagnosticRecipient{{
+			Type:        "node",
+			ID:          "node-a",
+			Path:        "flow-a/node-a",
+			RouteSource: "selected_contracts",
+		}},
+	}); err != nil {
+		t.Fatalf("Authorize recovered bundle_hash JSONB recipient plan: %v", err)
 	}
 }
 

--- a/openrpc.json
+++ b/openrpc.json
@@ -5315,7 +5315,7 @@
     },
     {
       "name": "run.fork",
-      "description": "Public selected-contract run fork mutation.\n\nCreates and executes a same-bundle selected-contract fork from a source run. The method consumes source bundle availability from runs.bundle_source / runs.bundle_hash and bundle-row presence before any fork mutation. Source runs whose canonical bundle bytes are unavailable fail closed with BUNDLE_UNAVAILABLE; persisted source rows with missing bundle data fail with BUNDLE_DATA_INTEGRITY_ERROR. The selected-contract execution path consumes the existing store/runtime run_fork selected_contracts owners and must not infer source identity from legacy bundle_fingerprint, bundle_ref, null-collapse, or local filesystem heuristics.\n\nIf bundle_hash is omitted, the source run's canonical bundle_hash is used. If bundle_hash is supplied and equals the source run bundle_hash, the same-bundle selected_contracts fork may proceed. Disk-loaded source execution uses the existing runtime selected-contract source loader. DB-loaded source execution must load source bytes from the persisted bundle catalog runtime source owner, verify the reconstructed bundle_hash, and stamp fork-created runs with bundle_source=persisted plus that canonical bundle_hash. If bundle_hash differs, the method fails closed with UNSUPPORTED_BUNDLE_HASH_FORK; cross-bundle fork routing remains split to #976. The swarm fork CLI consumes this method and must not call runtime/store helpers directly.\n",
+      "description": "Public selected-contract run fork mutation.\n\nCreates and executes a selected-contract fork from a source run. The method consumes source bundle availability from runs.bundle_source / runs.bundle_hash and bundle-row presence before any fork mutation. Source runs whose canonical bundle bytes are unavailable fail closed with BUNDLE_UNAVAILABLE; persisted source rows with missing bundle data fail with BUNDLE_DATA_INTEGRITY_ERROR. The selected-contract execution path consumes the existing store/runtime run_fork selected_contracts owners and must not infer source identity from legacy bundle_fingerprint, bundle_ref, null-collapse, or local filesystem heuristics.\n\nIf bundle_hash is omitted, the source run's canonical bundle_hash is used. If bundle_hash is supplied and equals the source run bundle_hash, the same-bundle selected_contracts fork may proceed. Disk-loaded source execution uses the existing runtime selected-contract source loader. DB-loaded same-bundle source execution must load source bytes from the persisted bundle catalog runtime source owner, verify the reconstructed bundle_hash, and stamp fork-created runs with bundle_source=persisted plus that canonical bundle_hash.\n\nIf bundle_hash differs from the source run bundle_hash, the target hash selects an already loaded/boot-pinned RuntimeContextManager BundleContext under current Option A. The method must persist selected-contract ownership as mode=bundle_hash with that target bundle_hash, recover routes against the same target identity, execute against the target BundleContext runtime/source, and stamp fork-created runs with bundle_source=persisted plus the target canonical bundle_hash. Valid target hashes that are not loaded by this process, have been unloaded or deactivated, are missing/deleted from the catalog, or otherwise lack supported persisted bytes fail closed with BUNDLE_UNAVAILABLE. Corrupt or hash-mismatched persisted target bytes fail with BUNDLE_DATA_INTEGRITY_ERROR. run.fork MUST NOT perform Dynamic Load, bundle.register runtime start, catalog-only runtime load, ambient CLI bundle selection, or Option B artifact capture. The swarm fork CLI consumes this method and must not call runtime/store helpers directly.\n",
       "params": [
         {
           "name": "source_run_id",
@@ -5336,7 +5336,7 @@
         {
           "name": "bundle_hash",
           "required": false,
-          "description": "Optional same-bundle selector. Must equal the source run's canonical bundle_hash; differing values fail with UNSUPPORTED_BUNDLE_HASH_FORK until #976.",
+          "description": "Optional target/source bundle selector. Equal or omitted values use same-bundle selected_contracts semantics. A differing value selects an already loaded/boot-pinned RuntimeContextManager BundleContext under #976; valid but unavailable targets fail with BUNDLE_UNAVAILABLE and corrupt target catalog bytes fail with BUNDLE_DATA_INTEGRITY_ERROR.",
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
@@ -5442,56 +5442,6 @@
                     "$ref": "#/components/schemas/OpaqueId"
                   },
                   "status": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              },
-              "retryable": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "code",
-              "details",
-              "retryable",
-              "correlation_id"
-            ],
-            "type": "object"
-          }
-        },
-        {
-          "code": -32037,
-          "message": "Application error: UNSUPPORTED_BUNDLE_HASH_FORK",
-          "data": {
-            "additionalProperties": false,
-            "properties": {
-              "code": {
-                "const": "UNSUPPORTED_BUNDLE_HASH_FORK",
-                "type": "string"
-              },
-              "correlation_id": {
-                "type": "string"
-              },
-              "details": {
-                "additionalProperties": false,
-                "properties": {
-                  "requested_hash": {
-                    "$ref": "#/components/schemas/BundleHash"
-                  },
-                  "source_bundle_hash": {
-                    "$ref": "#/components/schemas/BundleHash"
-                  },
-                  "source_run_id": {
-                    "$ref": "#/components/schemas/OpaqueId"
-                  },
-                  "supported_selector": {
-                    "type": "string"
-                  },
-                  "tracked_follow_up": {
-                    "type": "string"
-                  },
-                  "unsupported_reason": {
                     "type": "string"
                   }
                 },

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4128,7 +4128,7 @@ platform_tables:
         selected-contract execution; CLI/API arguments, dry-run JSON, and local model output are not semantic owners. It
         does not authorize handler execution, event/delivery replay, timer, route, session, turn, source-advanced, or
         contract-swap mutation.
-      ddl: "CREATE TABLE run_fork_selected_contract_bindings (\n    binding_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id      UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id    UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id    UUID NOT NULL REFERENCES events(event_id),\n    mode             TEXT NOT NULL CHECK (mode IN ('selected_contracts')),\n    contracts_root   TEXT NOT NULL,\n    workflow_name    TEXT NOT NULL,\n    workflow_version TEXT NOT NULL,\n    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_bindings_source (source_run_id, fork_event_id)\n);"
+      ddl: "CREATE TABLE run_fork_selected_contract_bindings (\n    binding_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id      UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id    UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id    UUID NOT NULL REFERENCES events(event_id),\n    mode             TEXT NOT NULL CHECK (mode IN ('selected_contracts', 'bundle_hash')),\n    contracts_root   TEXT,\n    bundle_hash      TEXT CHECK (bundle_hash IS NULL OR bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'),\n    workflow_name    TEXT NOT NULL,\n    workflow_version TEXT NOT NULL,\n    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((mode = 'selected_contracts' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NOT NULL AND NULLIF(TRIM(COALESCE(bundle_hash, '')), '') IS NULL) OR (mode = 'bundle_hash' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NULL AND bundle_hash IS NOT NULL)),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_bindings_source (source_run_id, fork_event_id)\n);"
     run_fork_selected_contract_executions:
       description: Source-to-fork lineage table for mutating selected-contract timestamp-fork execution. The runtime
         selected-contract execution owner publishes fresh fork-local events under the fork run_id and records which source
@@ -4152,7 +4152,7 @@ platform_tables:
         runtime.run_fork.selected_contract_recipient_planning before publish. This table does not authorize delivery
         replay, handler execution, receipts, dead letters, idempotency, timers, sessions, contract swap, or UI/API
         ownership.
-      ddl: "CREATE TABLE run_fork_selected_contract_route_recoveries (\n    recovery_id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                    UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                  UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                  UUID NOT NULL REFERENCES events(event_id),\n    owner                          TEXT NOT NULL,\n    runtime_recovery_owner         TEXT NOT NULL,\n    mode                           TEXT NOT NULL CHECK (mode IN ('selected_contracts')),\n    contracts_root                 TEXT NOT NULL,\n    workflow_name                  TEXT NOT NULL,\n    workflow_version               TEXT NOT NULL,\n    route_topology_owner           TEXT NOT NULL,\n    dynamic_topology_owner         TEXT,\n    recipient_planning_owner       TEXT NOT NULL,\n    frontier_evidence_fingerprint  TEXT NOT NULL,\n    route_topology_fingerprint     TEXT NOT NULL,\n    recipient_planning_fingerprint TEXT NOT NULL,\n    static_route_event_count       INTEGER NOT NULL DEFAULT 0,\n    dynamic_topology_proof_count   INTEGER NOT NULL DEFAULT 0,\n    recipient_plan_event_count     INTEGER NOT NULL DEFAULT 0,\n    route_topology                 JSONB NOT NULL,\n    recipient_planning             JSONB NOT NULL,\n    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_source (source_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_owner (owner, runtime_recovery_owner)\n);"
+      ddl: "CREATE TABLE run_fork_selected_contract_route_recoveries (\n    recovery_id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                    UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                  UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                  UUID NOT NULL REFERENCES events(event_id),\n    owner                          TEXT NOT NULL,\n    runtime_recovery_owner         TEXT NOT NULL,\n    mode                           TEXT NOT NULL CHECK (mode IN ('selected_contracts', 'bundle_hash')),\n    contracts_root                 TEXT,\n    bundle_hash                    TEXT CHECK (bundle_hash IS NULL OR bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'),\n    workflow_name                  TEXT NOT NULL,\n    workflow_version               TEXT NOT NULL,\n    route_topology_owner           TEXT NOT NULL,\n    dynamic_topology_owner         TEXT,\n    recipient_planning_owner       TEXT NOT NULL,\n    frontier_evidence_fingerprint  TEXT NOT NULL,\n    route_topology_fingerprint     TEXT NOT NULL,\n    recipient_planning_fingerprint TEXT NOT NULL,\n    static_route_event_count       INTEGER NOT NULL DEFAULT 0,\n    dynamic_topology_proof_count   INTEGER NOT NULL DEFAULT 0,\n    recipient_plan_event_count     INTEGER NOT NULL DEFAULT 0,\n    route_topology                 JSONB NOT NULL,\n    recipient_planning             JSONB NOT NULL,\n    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((mode = 'selected_contracts' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NOT NULL AND NULLIF(TRIM(COALESCE(bundle_hash, '')), '') IS NULL) OR (mode = 'bundle_hash' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NULL AND bundle_hash IS NOT NULL)),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_source (source_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_owner (owner, runtime_recovery_owner)\n);"
     event_deliveries:
       description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
         inherited from the parent event for run-scoped queries. delivery_target_route stores the concrete target_set
@@ -5770,7 +5770,7 @@ multi_bundle_persistence:
       split_boundaries:
         - Dynamic post-boot RuntimeContextManager Load remains split to #1176/#981 follow-up; this slice only implements unload/deactivation triggered by existing authoritative delete/nuke owners.
         - Same-bundle selected-contract fork execution from DB bytes consumes the persisted bundle catalog runtime source owner.
-        - Cross-bundle fork routing remains #976.
+        - Cross-bundle run.fork target selection is implemented for already loaded/boot-pinned target BundleContexts under #976.
         - Final lifecycle/scoped API conformance matrix remains #1025.
         - Ambient CLI bundle context remains #1028.
         - Bundle CLI inventory and swarm fork consumers remain #1023/#989.
@@ -6026,8 +6026,15 @@ multi_bundle_persistence:
         owner for the source run bundle_hash, verify the reconstructed hash, and stamp fork-created runs with
         bundle_source=persisted and that canonical bundle_hash.
       cross_bundle_rule: >
-        If bundle_hash differs from the source run bundle_hash, admission returns UNSUPPORTED_BUNDLE_HASH_FORK until #976
-        promotes and implements cross-bundle selected-contract routing.
+        If bundle_hash differs from the source run bundle_hash, the target hash selects an already loaded/boot-pinned
+        RuntimeContextManager BundleContext under current Option A. The fork loads target bundle bytes from the persisted
+        bundle catalog, persists selected-contract ownership as mode=bundle_hash with that target bundle_hash, records
+        route recovery against the same target identity, and stamps fork-created runs with bundle_source=persisted plus
+        the target canonical bundle_hash. Valid target hashes that are not loaded by this process, have been unloaded or
+        deactivated, are missing/deleted from the catalog, or otherwise lack supported persisted bytes fail closed with
+        BUNDLE_UNAVAILABLE. Corrupt or hash-mismatched persisted target bytes fail with BUNDLE_DATA_INTEGRITY_ERROR.
+        run.fork MUST NOT perform Dynamic Load, bundle.register runtime start, catalog-only runtime load, ambient CLI
+        bundle selection, or Option B artifact capture.
       unavailable_rule: >
         Source runs with bundle_source ephemeral, deleted, or legacy return BUNDLE_UNAVAILABLE for fork admission because
         the server lacks authoritative persisted bundle bytes.
@@ -6127,7 +6134,8 @@ multi_bundle_persistence:
       reason: event.publish/run.start create-new-work admission with required bundle_hash when run_id is absent is API/runtime routing implementation.
     cross_bundle_fork:
       tracker: '#976'
-      reason: Different target bundle_hash selected for run.fork requires selected-contract routing and admission work beyond source authority.
+      implementation_status: implemented_for_boot_pinned_option_a_targets
+      reason: Different target bundle_hash selected for run.fork consumes RuntimeContextManager loaded BundleContext ownership, persists selected-contract selection as mode=bundle_hash, recovers routes against that target hash, and fail-closes unloaded, unavailable, missing, deleted, or corrupt target bundle sources without Dynamic Load.
     db_loaded_same_bundle_source:
       tracker: '#1024'
       implementation_status: implemented_for_same_bundle_selected_contracts
@@ -6140,7 +6148,7 @@ multi_bundle_persistence:
     run_fork_cli_consumer:
       tracker: '#1023'
       implementation_status: implemented_by_1023_first_slice
-      reason: swarm fork consumes /v1/rpc run.fork only; same-bundle DB-loaded source loading is supported by #1024, and cross-bundle fork routing remains split to #976.
+      reason: swarm fork consumes /v1/rpc run.fork only; same-bundle DB-loaded source loading is supported by #1024, and cross-bundle target selection for already loaded/boot-pinned BundleContexts is supported by #976.
     multi_bundle_cli_inventory:
       tracker: '#1023'
       implementation_status: inventory_prepared_envelope_directory_register_and_bundle_delete_implemented
@@ -9879,7 +9887,7 @@ cli_specification:
       command: swarm fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
       tier: should_have
       implementation_status: implemented_public_cli_consumer
-      blocker_state: 'Implemented by #1023 over /v1/rpc run.fork after #989 promoted the API/runtime/spec owner; DB-loaded same-bundle source loading is supported by #1024 and cross-bundle fork remains split to #976.'
+      blocker_state: 'Implemented by #1023 over /v1/rpc run.fork after #989 promoted the API/runtime/spec owner; DB-loaded same-bundle source loading is supported by #1024 and boot-pinned Option A cross-bundle target selection is supported by #976.'
       owner: multi_bundle_persistence.cli_surface.run_fork
       api_owner: /v1/rpc run.fork
       behavior: >
@@ -9887,10 +9895,11 @@ cli_specification:
         `--bundle-hash`; draft `--bundle` is superseded by #1001. `--at-event` is an explicit fork-event selector only.
         The CLI validates source_run_id and fork_event_id as currently UUID-shaped runtime IDs before calling the
         handler, calls /v1/rpc run.fork exactly once, and renders only server-owned fork results.
-      split_blockers:
-        cross_bundle_fork: '#976'
+      implemented_dependencies:
         api_runtime_cli_owner: '#989'
         cli_inventory_gate: '#1023'
+        same_bundle_db_loaded_source: '#1024'
+        boot_pinned_cross_bundle_target_selection: '#976'
       rejected_legacy_flags:
       - --dry-run
       - --materialize-only
@@ -9901,10 +9910,10 @@ cli_specification:
       - no `swarm control run fork` command shape is promoted
       - no draft `--bundle` flag is promoted
       - no direct DB/store/runtime/fork harness access from CLI
-      - cross-bundle targets fail closed as #976 until that child lands
+      - cross-bundle targets select already loaded/boot-pinned RuntimeContextManager BundleContexts; valid but unloaded/unavailable targets fail with BUNDLE_UNAVAILABLE and corrupt target catalog bytes fail with BUNDLE_DATA_INTEGRITY_ERROR
       - DB-loaded same-bundle source loading is exercised through /v1/rpc run.fork, not a direct CLI runtime/store helper
       - missing SWARM_API_TOKEN, invalid args, and legacy harness flags make zero API calls
-      - RUN_NOT_FOUND, EVENT_NOT_FOUND, IDEMPOTENCY_CONFLICT, unsupported bundle fork, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
+      - RUN_NOT_FOUND, EVENT_NOT_FOUND, BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, IDEMPOTENCY_CONFLICT, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
     forkchat:
       command: swarm forkchat new|resume|list|view|delete
       tier: should_have
@@ -14290,7 +14299,7 @@ api_specification:
       - IDEMPOTENCY_CONFLICT
     run.fork:
       tier: should_have
-      description: "Public selected-contract run fork mutation.\n\nCreates and executes a same-bundle selected-contract fork from a source run. The method consumes source bundle availability from runs.bundle_source / runs.bundle_hash and bundle-row presence before any fork mutation. Source runs whose canonical bundle bytes are unavailable fail closed with BUNDLE_UNAVAILABLE; persisted source rows with missing bundle data fail with BUNDLE_DATA_INTEGRITY_ERROR. The selected-contract execution path consumes the existing store/runtime run_fork selected_contracts owners and must not infer source identity from legacy bundle_fingerprint, bundle_ref, null-collapse, or local filesystem heuristics.\n\nIf bundle_hash is omitted, the source run's canonical bundle_hash is used. If bundle_hash is supplied and equals the source run bundle_hash, the same-bundle selected_contracts fork may proceed. Disk-loaded source execution uses the existing runtime selected-contract source loader. DB-loaded source execution must load source bytes from the persisted bundle catalog runtime source owner, verify the reconstructed bundle_hash, and stamp fork-created runs with bundle_source=persisted plus that canonical bundle_hash. If bundle_hash differs, the method fails closed with UNSUPPORTED_BUNDLE_HASH_FORK; cross-bundle fork routing remains split to #976. The swarm fork CLI consumes this method and must not call runtime/store helpers directly.\n"
+      description: "Public selected-contract run fork mutation.\n\nCreates and executes a selected-contract fork from a source run. The method consumes source bundle availability from runs.bundle_source / runs.bundle_hash and bundle-row presence before any fork mutation. Source runs whose canonical bundle bytes are unavailable fail closed with BUNDLE_UNAVAILABLE; persisted source rows with missing bundle data fail with BUNDLE_DATA_INTEGRITY_ERROR. The selected-contract execution path consumes the existing store/runtime run_fork selected_contracts owners and must not infer source identity from legacy bundle_fingerprint, bundle_ref, null-collapse, or local filesystem heuristics.\n\nIf bundle_hash is omitted, the source run's canonical bundle_hash is used. If bundle_hash is supplied and equals the source run bundle_hash, the same-bundle selected_contracts fork may proceed. Disk-loaded source execution uses the existing runtime selected-contract source loader. DB-loaded same-bundle source execution must load source bytes from the persisted bundle catalog runtime source owner, verify the reconstructed bundle_hash, and stamp fork-created runs with bundle_source=persisted plus that canonical bundle_hash.\n\nIf bundle_hash differs from the source run bundle_hash, the target hash selects an already loaded/boot-pinned RuntimeContextManager BundleContext under current Option A. The method must persist selected-contract ownership as mode=bundle_hash with that target bundle_hash, recover routes against the same target identity, execute against the target BundleContext runtime/source, and stamp fork-created runs with bundle_source=persisted plus the target canonical bundle_hash. Valid target hashes that are not loaded by this process, have been unloaded or deactivated, are missing/deleted from the catalog, or otherwise lack supported persisted bytes fail closed with BUNDLE_UNAVAILABLE. Corrupt or hash-mismatched persisted target bytes fail with BUNDLE_DATA_INTEGRITY_ERROR. run.fork MUST NOT perform Dynamic Load, bundle.register runtime start, catalog-only runtime load, ambient CLI bundle selection, or Option B artifact capture. The swarm fork CLI consumes this method and must not call runtime/store helpers directly.\n"
       scope:
         required:
         - write:runs
@@ -14308,7 +14317,7 @@ api_specification:
           $ref: '#/components/schemas/OpaqueId'
       - name: bundle_hash
         required: false
-        description: "Optional same-bundle selector. Must equal the source run's canonical bundle_hash; differing values fail with UNSUPPORTED_BUNDLE_HASH_FORK until #976."
+        description: "Optional target/source bundle selector. Equal or omitted values use same-bundle selected_contracts semantics. A differing value selects an already loaded/boot-pinned RuntimeContextManager BundleContext under #976; valid but unavailable targets fail with BUNDLE_UNAVAILABLE and corrupt target catalog bytes fail with BUNDLE_DATA_INTEGRITY_ERROR."
         schema:
           $ref: '#/components/schemas/BundleHash'
       - name: idempotency_key
@@ -14323,7 +14332,6 @@ api_specification:
       errors:
       - BUNDLE_UNAVAILABLE
       - BUNDLE_DATA_INTEGRITY_ERROR
-      - UNSUPPORTED_BUNDLE_HASH_FORK
       - RUN_NOT_FOUND
       - EVENT_NOT_FOUND
       - IDEMPOTENCY_CONFLICT


### PR DESCRIPTION
## Summary

Implements the approved #976 cross-bundle `run.fork` / `swarm fork --bundle-hash` class for current Option A: a requested target bundle hash must already be boot-pinned/loaded in `RuntimeContextManager`, or the request fails closed.

Closes #976

## Governing Refs

- `platform-spec.yaml#api_specification` `run.fork`
- `platform-spec.yaml#multi_bundle_persistence.run_fork`
- `platform-spec.yaml#platform_tables.run_fork_selected_contract_bindings`
- `platform-spec.yaml#platform_tables.run_fork_selected_contract_route_recoveries`
- `platform-spec.yaml#cli_specification.command_catalog.run_fork`
- #1209 / PR #1211: Dynamic post-boot Load is parked for current Option A
- #1175 / #1176: RuntimeContextManager boot-pinned context and unload/deactivation boundaries
- #1024: same-bundle DB-loaded fork behavior remains a regression surface

## Semantic Migration

- New canonical owner: target `bundle_hash` selection is persisted in `run_fork_selected_contract_bindings` / `run_fork_selected_contract_route_recoveries` using `mode='bundle_hash'`, and execution resolves the target through the loaded `RuntimeContextManager` `BundleContext`.
- Old non-authoritative path now invalid: differing target hashes no longer hit the blanket `UNSUPPORTED_BUNDLE_HASH_FORK` gate, and target identity is no longer represented only by a temporary contracts root.
- Production paths checked: `/v1/rpc run.fork`, top-level `swarm fork --bundle-hash`, target source loading from `bundles`, selected-contract admission/execution, durable binding, route recovery, same-bundle DB-loaded fork, and disk selected-contract fork.
- Migration completeness: complete for #976 under current Option A. Dynamic Load, ambient CLI context, final matrix, and Option B artifact capture remain split and are not claimed here.

## Tests

- `go test ./internal/apiv1 -run 'TestRunForkExecutorForBundleContextRebindsSelectedContractSelection|TestOperatorRuntimeContextManagerFailsClosedForAmbiguousRuntimeConsumers' -count=1`
- `go test ./internal/store -run 'TestRecordRunForkSelectedContractRouteRecovery(FeedsManagerRecoveryThroughBundleHashJSONB|RoundTripsBundleHashSelection)' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeDBLoadedRunFork(CrossBundleTarget|SupportedSurface)' -count=1`
- `go test ./...`