### PR TITLE
[agent-a][issue #1229] Native OpenAI Responses source authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2445,7 +2445,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 		}
 	}
 	protocol := responses.ProtocolFamily
-	if protocol.Name != "native_openai_responses" || protocol.EndpointPath != "/v1/responses" || protocol.Transport != "api" {
+	if protocol.Name != "native_openai_responses" || protocol.EndpointPath != "/responses" || protocol.Transport != "api" {
 		t.Fatalf("native responses protocol = %#v", protocol)
 	}
 	for _, want := range []string{"Platform-managed text transcript", "function", "server-sent events", "previous_response_id"} {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2264,8 +2264,71 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 								Rule      string `yaml:"rule"`
 							} `yaml:"endpoint_source"`
 						} `yaml:"active_backend_profiles"`
+						PendingBackendProfiles map[string]struct {
+							Status                      string `yaml:"status"`
+							Provider                    string `yaml:"provider"`
+							Transport                   string `yaml:"transport"`
+							ProviderContractRuntimeMode string `yaml:"provider_contract_runtime_mode"`
+							Protocol                    string `yaml:"protocol"`
+							CredentialSource            struct {
+								EnvVar   string `yaml:"env_var"`
+								Required bool   `yaml:"required"`
+							} `yaml:"credential_source"`
+							EndpointSource struct {
+								ConfigKey      string `yaml:"config_key"`
+								EnvVar         string `yaml:"env_var"`
+								Required       bool   `yaml:"required"`
+								BuiltInDefault string `yaml:"built_in_default"`
+								Rule           string `yaml:"rule"`
+							} `yaml:"endpoint_source"`
+							ActivationRule string `yaml:"activation_rule"`
+							ProofBoundary  string `yaml:"proof_boundary"`
+						} `yaml:"pending_backend_profiles"`
 						RejectedTargetNames map[string]string `yaml:"rejected_target_names"`
 					} `yaml:"backend_profile_identity"`
+					NativeOpenAIResponsesSourceAuthority struct {
+						PromotedBy             string   `yaml:"promoted_by"`
+						ImplementationStatus   string   `yaml:"implementation_status"`
+						TargetBackendProfileID string   `yaml:"target_backend_profile_id"`
+						ProviderIdentity       string   `yaml:"provider_identity"`
+						ActivationStatus       string   `yaml:"activation_status"`
+						AuthoritativeRefs      []string `yaml:"authoritative_refs"`
+						ActiveSelectorPolicy   []string `yaml:"active_selector_policy"`
+						ProtocolFamily         struct {
+							Name              string `yaml:"name"`
+							EndpointPath      string `yaml:"endpoint_path"`
+							Transport         string `yaml:"transport"`
+							RequestBodyOwner  string `yaml:"request_body_owner"`
+							InputScope        string `yaml:"input_scope"`
+							ToolScope         string `yaml:"tool_scope"`
+							StreamingScope    string `yaml:"streaming_scope"`
+							SessionContinuity string `yaml:"session_continuity"`
+						} `yaml:"protocol_family"`
+						CredentialAndEndpointPolicy struct {
+							CredentialSource struct {
+								EnvVar   string `yaml:"env_var"`
+								Required bool   `yaml:"required"`
+							} `yaml:"credential_source"`
+							EndpointSource struct {
+								ConfigKey      string `yaml:"config_key"`
+								EnvVar         string `yaml:"env_var"`
+								Required       bool   `yaml:"required"`
+								BuiltInDefault string `yaml:"built_in_default"`
+							} `yaml:"endpoint_source"`
+							Rules []string `yaml:"rules"`
+						} `yaml:"credential_and_endpoint_policy"`
+						ModelAliasDefaults           map[string]string `yaml:"model_alias_defaults"`
+						ModelAliasRule               string            `yaml:"model_alias_rule"`
+						ProviderContractExpectations struct {
+							ToolSchema            []string `yaml:"tool_schema"`
+							ResponseNormalization []string `yaml:"response_normalization"`
+							SessionLifecycle      []string `yaml:"session_lifecycle"`
+							Persistence           []string `yaml:"persistence"`
+							Budget                []string `yaml:"budget"`
+						} `yaml:"provider_contract_expectations"`
+						StoreProfileImplication string   `yaml:"store_profile_implication"`
+						SplitBoundaries         []string `yaml:"split_boundaries"`
+					} `yaml:"native_openai_responses_source_authority"`
 					ModelAliasAuthority struct {
 						ContractField              string                       `yaml:"contract_field"`
 						Replaces                   string                       `yaml:"replaces"`
@@ -2342,8 +2405,85 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 	if got := profiles["openai_compatible"]; got.Provider != "openai_compatible" || got.ProviderContractRuntimeMode != "openai_compatible" || got.EndpointSource.EnvVar != "" || !strings.Contains(got.EndpointSource.Rule, "SWARM_OPENAI_COMPATIBLE_BASE_URL is retired") {
 		t.Fatalf("openai_compatible profile = %#v", got)
 	}
+	if _, ok := profiles["openai_responses"]; ok {
+		t.Fatalf("openai_responses must not be active until #1224: %#v", profiles["openai_responses"])
+	}
+	pendingResponses := authority.BackendProfileIdentity.PendingBackendProfiles["openai_responses"]
+	if pendingResponses.Provider != "openai" || pendingResponses.ProviderContractRuntimeMode != "openai_responses" || pendingResponses.Status != "source_authority_only_not_selectable" {
+		t.Fatalf("pending openai_responses profile = %#v", pendingResponses)
+	}
+	if pendingResponses.CredentialSource.EnvVar != "OPENAI_API_KEY" || !pendingResponses.CredentialSource.Required {
+		t.Fatalf("pending openai_responses credential source = %#v", pendingResponses.CredentialSource)
+	}
+	if pendingResponses.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || pendingResponses.EndpointSource.EnvVar != "" || pendingResponses.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
+		t.Fatalf("pending openai_responses endpoint source = %#v", pendingResponses.EndpointSource)
+	}
+	openAIRejectedTarget := authority.BackendProfileIdentity.RejectedTargetNames["openai"]
+	for _, want := range []string{"not active", "openai_responses", "#1224"} {
+		if !strings.Contains(strings.ToLower(openAIRejectedTarget), strings.ToLower(want)) {
+			t.Fatalf("openai rejected target missing %q: %#v", want, authority.BackendProfileIdentity.RejectedTargetNames)
+		}
+	}
 	if !strings.Contains(strings.ToLower(authority.BackendProfileIdentity.RejectedTargetNames["openai"]), "not active") {
 		t.Fatalf("openai rejected target missing design decision: %#v", authority.BackendProfileIdentity.RejectedTargetNames)
+	}
+	responses := authority.NativeOpenAIResponsesSourceAuthority
+	if responses.PromotedBy != "#1229" || responses.ImplementationStatus != "source_authority_only_runtime_split" {
+		t.Fatalf("native responses source authority status = %#v", responses)
+	}
+	if responses.TargetBackendProfileID != "openai_responses" || responses.ProviderIdentity != "openai" || responses.ActivationStatus != "pending_runtime_adapter_not_selectable" {
+		t.Fatalf("native responses identity = %#v", responses)
+	}
+	for _, want := range []string{"api-reference/responses", "docs/models", "function-calling", "streaming-responses"} {
+		if !joinedContains(responses.AuthoritativeRefs, want) {
+			t.Fatalf("native responses authoritative refs missing %q: %#v", want, responses.AuthoritativeRefs)
+		}
+	}
+	for _, want := range []string{"MUST NOT be accepted", "openai remains a rejected", "openai_compatible remains Chat Completions-compatible"} {
+		if !joinedContains(responses.ActiveSelectorPolicy, want) {
+			t.Fatalf("native responses selector policy missing %q: %#v", want, responses.ActiveSelectorPolicy)
+		}
+	}
+	protocol := responses.ProtocolFamily
+	if protocol.Name != "native_openai_responses" || protocol.EndpointPath != "/v1/responses" || protocol.Transport != "api" {
+		t.Fatalf("native responses protocol = %#v", protocol)
+	}
+	for _, want := range []string{"Platform-managed text transcript", "function", "server-sent events", "previous_response_id"} {
+		if !strings.Contains(protocol.InputScope+protocol.ToolScope+protocol.StreamingScope+protocol.SessionContinuity, want) {
+			t.Fatalf("native responses protocol scope missing %q: %#v", want, protocol)
+		}
+	}
+	if responses.CredentialAndEndpointPolicy.CredentialSource.EnvVar != "OPENAI_API_KEY" || !responses.CredentialAndEndpointPolicy.CredentialSource.Required {
+		t.Fatalf("native responses credential policy = %#v", responses.CredentialAndEndpointPolicy.CredentialSource)
+	}
+	if responses.CredentialAndEndpointPolicy.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || responses.CredentialAndEndpointPolicy.EndpointSource.EnvVar != "" || responses.CredentialAndEndpointPolicy.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
+		t.Fatalf("native responses endpoint policy = %#v", responses.CredentialAndEndpointPolicy.EndpointSource)
+	}
+	for alias, model := range map[string]string{"cheap": "gpt-5.4-nano", "regular": "gpt-5.4", "frontier": "gpt-5.5"} {
+		if got := strings.TrimSpace(responses.ModelAliasDefaults[alias]); got != model {
+			t.Fatalf("native responses model alias %s = %q, want %q; aliases=%#v", alias, got, model, responses.ModelAliasDefaults)
+		}
+	}
+	if !strings.Contains(responses.ModelAliasRule, "not consumed by boot or verify until openai_responses is activated") {
+		t.Fatalf("native responses model alias rule does not preserve inactive boundary: %s", responses.ModelAliasRule)
+	}
+	for _, want := range []string{"function tools", "function-call output", "raw Responses payloads", "previous_response_id", "backend profile id openai_responses", "exact provider-reported usage"} {
+		combined := strings.Join(responses.ProviderContractExpectations.ToolSchema, " ") +
+			strings.Join(responses.ProviderContractExpectations.ResponseNormalization, " ") +
+			strings.Join(responses.ProviderContractExpectations.SessionLifecycle, " ") +
+			strings.Join(responses.ProviderContractExpectations.Persistence, " ") +
+			strings.Join(responses.ProviderContractExpectations.Budget, " ")
+		if !strings.Contains(combined, want) {
+			t.Fatalf("native responses provider contract expectations missing %q: %#v", want, responses.ProviderContractExpectations)
+		}
+	}
+	if !strings.Contains(responses.StoreProfileImplication, "No agents.llm_backend schema/check migration is required") || !strings.Contains(responses.StoreProfileImplication, "not active") {
+		t.Fatalf("native responses store implication must preserve inactive boundary: %s", responses.StoreProfileImplication)
+	}
+	for _, want := range []string{"#1224", "previous_response_id", "Provider matrix"} {
+		if !joinedContains(responses.SplitBoundaries, want) {
+			t.Fatalf("native responses split boundaries missing %q: %#v", want, responses.SplitBoundaries)
+		}
 	}
 	models := authority.ModelAliasAuthority
 	if models.ContractField != "model" || models.Replaces != "model_tier" || models.AliasConfigKey != "llm.models" {
@@ -2385,7 +2525,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("persistence rules missing %q: %#v", want, authority.PersistenceRules)
 		}
 	}
-	for _, want := range []string{"#1127", "#1128", "#1129", "#1130", "MUST NOT change runtime"} {
+	for _, want := range []string{"#1127", "#1128", "#1129", "#1130", "#1229", "#1224", "MUST NOT change runtime"} {
 		if !joinedContains(authority.SplitBoundaries, want) {
 			t.Fatalf("split boundaries missing %q: %#v", want, authority.SplitBoundaries)
 		}

--- a/internal/runtime/llm/selection/profile_test.go
+++ b/internal/runtime/llm/selection/profile_test.go
@@ -31,7 +31,7 @@ func TestResolveActiveBackendProfiles(t *testing.T) {
 }
 
 func TestResolveActiveBackendRejectsReservedAndUnknown(t *testing.T) {
-	for _, raw := range []string{BackendMock, BackendLocal, LegacyBackendAPI, LegacyBackendCLITest, "openai"} {
+	for _, raw := range []string{BackendMock, BackendLocal, LegacyBackendAPI, LegacyBackendCLITest, "openai", "openai_responses"} {
 		t.Run(raw, func(t *testing.T) {
 			if _, err := ResolveActiveBackend(raw); err == nil {
 				t.Fatal("expected error")
@@ -51,6 +51,12 @@ func TestResolvePersistedBackendAllowsReservedProfiles(t *testing.T) {
 				t.Fatalf("profile id = %q, want %q", profile.ID, raw)
 			}
 		})
+	}
+}
+
+func TestResolvePersistedBackendRejectsSourceOnlyOpenAIResponsesProfile(t *testing.T) {
+	if _, err := ResolvePersistedBackend("openai_responses"); err == nil || !strings.Contains(err.Error(), "unsupported llm backend profile") {
+		t.Fatalf("ResolvePersistedBackend(openai_responses) error = %v, want unsupported profile", err)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2511,14 +2511,119 @@ engine:
             proof_boundary: This profile proves one non-Anthropic Chat Completions-compatible HTTP provider path. It remains
               named openai_compatible and is not a native OpenAI Responses API provider, not an official-OpenAI-only provider
               identity, not OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM closure, and not a provider matrix.
+        pending_backend_profiles:
+          openai_responses:
+            status: source_authority_only_not_selectable
+            provider: openai
+            transport: api
+            provider_contract_runtime_mode: openai_responses
+            protocol: Native OpenAI Responses API at /v1/responses relative to the configured base URL.
+            credential_source:
+              env_var: OPENAI_API_KEY
+              required: true
+            endpoint_source:
+              config_key: llm.openai_responses.base_url
+              env_var: null
+              required: false
+              built_in_default: https://api.openai.com/v1
+              rule: "This is deployment configuration, not a secret. Runtime config is canonical; no env-var endpoint selector is promoted."
+            activation_rule: "This profile is source-authority only after #1229. It is not active for --backend, config llm.backend, persisted agents.llm_backend, RuntimeFactory materialization, or CLI help until #1224 or a later gated implementation PR promotes the runtime adapter."
+            proof_boundary: >
+              This profile names native OpenAI Responses source authority only. It is not openai_compatible,
+              not Chat Completions-compatible HTTP JSON, not an OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM provider-matrix
+              proof, and not a provider runtime implementation.
         reserved_persisted_backend_profiles:
           mock: Reserved persisted profile id for fixture replay. It is not a supported active runtime backend until a
             dedicated provider/runtime owner lands.
           local: Reserved persisted profile id for local model execution. It is not a supported active runtime backend until
             a dedicated provider/runtime owner lands.
         rejected_target_names:
-          openai: Not active for this authority because the shipped non-Anthropic proof is Chat Completions-compatible and
-            may front OpenRouter or local-compatible endpoints. Native OpenAI Responses requires a separate provider/protocol gate.
+          openai: >
+            Not active for this authority because the shipped non-Anthropic proof is Chat Completions-compatible and
+            may front OpenRouter or local-compatible endpoints. Native OpenAI Responses source authority is named
+            openai_responses by #1229, but it remains source-authority only and not selectable until #1224 or a later gated
+            implementation PR promotes the runtime adapter.
+      native_openai_responses_source_authority:
+        promoted_by: '#1229'
+        implementation_status: source_authority_only_runtime_split
+        target_backend_profile_id: openai_responses
+        provider_identity: openai
+        activation_status: pending_runtime_adapter_not_selectable
+        authoritative_refs:
+          - "https://platform.openai.com/docs/api-reference/responses"
+          - "https://platform.openai.com/docs/models"
+          - "https://platform.openai.com/docs/guides/function-calling?api-mode=responses"
+          - "https://platform.openai.com/docs/guides/streaming-responses?api-mode=responses"
+        active_selector_policy:
+          - "openai_responses MUST NOT be accepted by --backend, config llm.backend, persisted agents.llm_backend, RuntimeFactory, or CLI help until a later gated implementation PR activates the runtime adapter."
+          - "openai remains a rejected backend selector name; provider identity and backend profile id are intentionally separate."
+          - "openai_compatible remains Chat Completions-compatible HTTP JSON and MUST NOT inherit native Responses semantics."
+        protocol_family:
+          name: native_openai_responses
+          endpoint_path: /v1/responses
+          transport: api
+          request_body_owner: "provider adapter behind internal/runtime/llm.ProviderContract after #1224"
+          input_scope: >
+            Platform-managed text transcript plus function-tool call outputs. Image, audio, file, provider prompt
+            templates, conversations, and provider-hosted item references are not part of the first source-authority subset.
+          tool_scope: >
+            Platform function tools only. OpenAI built-in tools such as web search, file search, code interpreter,
+            computer use, hosted shell, MCP, and tool search are explicitly outside the first subset until separately gated.
+          streaming_scope: >
+            Streaming must use Responses server-sent events when #1224 promotes runtime implementation. The
+            source authority names the parser family, but #1229 does not implement streaming or make it selectable.
+          session_continuity: >
+            Platform session IDs and platform-managed transcript history remain canonical. Provider response
+            IDs may be persisted as raw provider metadata, but previous_response_id/provider-hosted continuity is deferred
+            unless a later gate promotes it explicitly.
+        credential_and_endpoint_policy:
+          credential_source:
+            env_var: OPENAI_API_KEY
+            required: true
+          endpoint_source:
+            config_key: llm.openai_responses.base_url
+            env_var: null
+            required: false
+            built_in_default: https://api.openai.com/v1
+          rules:
+            - Environment variables provide the OpenAI API secret only; they do not select the backend or endpoint.
+            - Runtime config is canonical for endpoint/base URL overrides used by deterministic tests or deployments.
+            - "Credential validation happens only after a selected active backend exists; #1229 does not make openai_responses active."
+        model_alias_defaults:
+          cheap: gpt-5.4-nano
+          regular: gpt-5.4
+          frontier: gpt-5.5
+        model_alias_rule: >
+          The target profile uses the existing llm.models provider-scoped alias map. These defaults are source
+          authority for #1224 but are not consumed by boot or verify until openai_responses is activated by a later gated
+          implementation PR.
+        provider_contract_expectations:
+          tool_schema:
+            - Translate platform tools to OpenAI Responses function tools with validated JSON schema parameters.
+            - Return platform tool results as Responses function-call output items.
+          response_normalization:
+            - Normalize output messages and function calls into the platform response model.
+            - Preserve raw Responses payloads for turn and audit persistence.
+            - Treat provider built-in tool output as unsupported until a separate native-tool gate promotes it.
+          session_lifecycle:
+            - Preserve task, session, and session_per_entity conversation modes through platform-managed transcript state.
+            - Persist provider response IDs only as provider metadata until previous_response_id continuity is separately promoted.
+          persistence:
+            - Persist authored model alias, backend profile id openai_responses, provider identity openai, transport api, concrete
+              model, and raw provider response at write time once runtime implementation is promoted.
+          budget:
+            - Use exact provider-reported usage when available; fail closed or explicitly record unsupported usage if the provider
+              response lacks required accounting fields.
+        store_profile_implication: >
+          No agents.llm_backend schema/check migration is required for #1229 because openai_responses
+          is not active or persisted by this source-authority slice. The later runtime implementation PR must update store,
+          CLI, config, and RuntimeFactory activation together if it makes openai_responses selectable.
+        split_boundaries:
+          - '#1224 owns native OpenAI Responses runtime adapter implementation and deterministic protocol proof after this source authority lands.'
+          - Provider-hosted continuity through previous_response_id, OpenAI built-in tools, file/image/audio inputs, provider
+            prompt templates, conversations, and broader streaming parity remain separate gates unless explicitly promoted.
+          - Provider matrix work, OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM support, Compose/local defaults, .env release docs,
+            and provider-contributor docs remain split.
       model_alias_authority:
         contract_field: model
         replaces: model_tier
@@ -2580,6 +2685,8 @@ engine:
       - '#1128 owns backend selection/config discovery, --backend precedence, env selector retirement, and backend id migration.'
       - '#1129 owns model_tier to model alias migration, boot/verify alias validation, runtime model resolution, and audit writes.'
       - '#1130 owns public/local config and model-alias cleanup after behavior lands.'
+      - '#1229 defines native OpenAI Responses source authority only and MUST NOT make openai_responses selectable or add a runtime adapter.'
+      - '#1224 owns native OpenAI Responses runtime implementation/protocol proof after #1229.'
       - Implementing OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other additional
         provider remains a separate provider implementation/parity gate.
       - Native multi-backend-per-run remains deferred until a separate real user need is gated.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2517,7 +2517,7 @@ engine:
             provider: openai
             transport: api
             provider_contract_runtime_mode: openai_responses
-            protocol: Native OpenAI Responses API at /v1/responses relative to the configured base URL.
+            protocol: Native OpenAI Responses API resource path /responses relative to the configured base URL.
             credential_source:
               env_var: OPENAI_API_KEY
               required: true
@@ -2560,7 +2560,7 @@ engine:
           - "openai_compatible remains Chat Completions-compatible HTTP JSON and MUST NOT inherit native Responses semantics."
         protocol_family:
           name: native_openai_responses
-          endpoint_path: /v1/responses
+          endpoint_path: /responses
           transport: api
           request_body_owner: "provider adapter behind internal/runtime/llm.ProviderContract after #1224"
           input_scope: >


### PR DESCRIPTION
## Summary

Defines the native OpenAI Responses source authority without implementing or activating a runtime provider.

- Adds `openai_responses` as a pending/source-only backend profile in `platform-spec.yaml`.
- Names the native Responses protocol family, credential/env policy, endpoint config policy, model alias defaults, ProviderContract expectations, and split boundaries.
- Proves `openai_responses` is not active/selectable/persisted until a later gated implementation PR, and that `openai_compatible` remains Chat Completions-compatible only.

Closes #1229.
Part of #983.
#1224 remains the later native OpenAI Responses runtime/protocol proof child.

## Governing refs / context

- `platform-spec.yaml#engine.agent_session_management.llm_provider_adapter_contract`
- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`
- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority.native_openai_responses_source_authority`
- #1229 pre-audit: https://github.com/yazzaoui/Swarm/issues/1229#issuecomment-4594325071
- #1229 gate: https://github.com/yazzaoui/Swarm/issues/1229#issuecomment-4594356494
- Official OpenAI refs used for committed source facts:
  - https://platform.openai.com/docs/api-reference/responses
  - https://platform.openai.com/docs/models
  - https://platform.openai.com/docs/guides/function-calling?api-mode=responses
  - https://platform.openai.com/docs/guides/streaming-responses?api-mode=responses

## Semantic migration / authority

- New canonical source owner: `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority.native_openai_responses_source_authority`.
- Target backend profile id: `openai_responses`.
- Provider identity: `openai`.
- Old invalid paths: runtime-only native Responses constants, treating `openai_compatible` as native Responses, treating `openai` as a backend selector, or accepting `openai_responses` before runtime activation.
- Production paths checked for surviving old behavior: backend profile active set, selection resolver, persisted backend resolver, CLI/spec authority test, and store/schema implications. `openai_responses` remains inactive and unsupported at runtime.
- Migration completeness: source-authority slice complete; runtime adapter/store/CLI activation remains split to #1224 or a later gated implementation PR.

## Tests

- `python3 - <<'PY' ... yaml.safe_load(open('platform-spec.yaml')) ... PY`
- `go test ./internal/runtime/llm/selection ./cmd/swarm -run 'TestResolveActiveBackendRejectsReservedAndUnknown|TestResolvePersistedBackendRejectsSourceOnlyOpenAIResponsesProfile|TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted' -count=1`
- `go test ./internal/runtime/llm/selection ./internal/runtime/llm ./internal/config ./internal/store -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`