### PR TITLE
[agent-b][issue #1223] Default workspace data for run

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1559,6 +1559,20 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
 		t.Fatalf("env precedence result = %#v, want source %q from %s", result, envDir, envWorkspaceDataSource)
 	}
+
+	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot: repoRoot,
+	})
+	if err != nil {
+		t.Fatalf("resolve default workspace mount source: %v", err)
+	}
+	defaultDir := filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath)
+	if result.DataSource != defaultDir || result.DataSourceSource != defaultWorkspaceDataSourceSource {
+		t.Fatalf("default result = %#v, want source %q from %s", result, defaultDir, defaultWorkspaceDataSourceSource)
+	}
+	if info, err := os.Stat(defaultDir); err != nil || !info.IsDir() {
+		t.Fatalf("default data source stat = (%v, %v), want created directory", info, err)
+	}
 }
 
 func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeEnvFallback(t *testing.T) {
@@ -1579,17 +1593,72 @@ func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeEnvFallback(t *test
 	}
 }
 
-func TestResolveWorkspaceMountSourcesDoesNotInventRepoDataDefault(t *testing.T) {
+func TestResolveWorkspaceMountSourcesDefaultsToSwarmDataNotRepoData(t *testing.T) {
 	repoRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(repoRoot, "data"), 0o755); err != nil {
+	repoDataDir := filepath.Join(repoRoot, "data")
+	if err := os.MkdirAll(repoDataDir, 0o755); err != nil {
 		t.Fatalf("mkdir repo data: %v", err)
 	}
 	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{RepoRoot: repoRoot})
 	if err != nil {
 		t.Fatalf("resolve workspace mount sources: %v", err)
 	}
+	defaultDir := filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath)
+	if result.DataSource != defaultDir || result.DataSourceSource != defaultWorkspaceDataSourceSource {
+		t.Fatalf("workspace mount sources = %#v, want default %q", result, defaultDir)
+	}
+	if result.DataSource == repoDataDir {
+		t.Fatalf("workspace mount source = repo data dir %q, want managed .swarm/data default", repoDataDir)
+	}
+	if info, err := os.Stat(defaultDir); err != nil || !info.IsDir() {
+		t.Fatalf("default data source stat = (%v, %v), want created directory", info, err)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesDefaultWithoutRepoRoot(t *testing.T) {
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{})
+	if err != nil {
+		t.Fatalf("resolve workspace mount sources: %v", err)
+	}
+	if result.DataSource != defaultWorkspaceDataSourceRelativePath || result.DataSourceSource != defaultWorkspaceDataSourceSource {
+		t.Fatalf("workspace mount sources = %#v, want relative default source", result)
+	}
+	if info, err := os.Stat(filepath.Join(tmp, defaultWorkspaceDataSourceRelativePath)); err != nil || !info.IsDir() {
+		t.Fatalf("default data source stat = (%v, %v), want created directory", info, err)
+	}
+}
+
+func TestResolveWorkspaceMountSourcesUsesVolumesFromAlternateWithoutDefault(t *testing.T) {
+	repoRoot := t.TempDir()
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		VolumesFrom:      "swarm-orchestrator",
+		VolumesFromSet:   true,
+		EnvDataSource:    " ",
+		EnvDataSourceSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve workspace mount sources: %v", err)
+	}
 	if result.DataSource != "" || result.DataSourceSource != "" {
-		t.Fatalf("workspace mount sources = %#v, want no source without explicit owner", result)
+		t.Fatalf("workspace mount sources = %#v, want volumes-from alternate without path source", result)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath)); !os.IsNotExist(err) {
+		t.Fatalf("default data source stat error = %v, want not created", err)
 	}
 }
 
@@ -1738,6 +1807,15 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 						Consumers  []string `yaml:"consumers"`
 					} `yaml:"workspace_data_source_authority"`
 				} `yaml:"serve"`
+				Run struct {
+					Flags []string `yaml:"flags"`
+					Modes struct {
+						ForegroundLocalStart struct {
+							Invocation string `yaml:"invocation"`
+							Behavior   string `yaml:"behavior"`
+						} `yaml:"foreground_local_start"`
+					} `yaml:"modes"`
+				} `yaml:"run"`
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
@@ -1749,7 +1827,7 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	authority := spec.WorkspaceModel.DataSourceAuthority
-	if strings.TrimSpace(authority.PromotedBy) != "#1139" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+	if !strings.Contains(authority.PromotedBy, "#1139") || !strings.Contains(authority.PromotedBy, "#1223") || strings.TrimSpace(authority.ImplementationStatus) != "implemented" {
 		t.Fatalf("workspace data source authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.data_source_authority") {
@@ -1758,29 +1836,36 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 	if authority.CLIFlag != "--data" || authority.ConfigKey != "workspace.data_source" || authority.EnvVar != envWorkspaceDataSource {
 		t.Fatalf("workspace data source selectors = %#v", authority)
 	}
-	for _, want := range []string{"--data", "workspace.data_source", envWorkspaceDataSource, "no path source"} {
+	for _, want := range []string{"--data", "workspace.data_source", envWorkspaceDataSource, defaultWorkspaceDataSourceSource} {
 		if !stringSliceContains(authority.SourceOrder, want) {
 			t.Fatalf("workspace data source order missing %q: %#v", want, authority.SourceOrder)
 		}
 	}
-	for _, want := range []string{"repo-local `data/`", "fail closed", "SWARM_WORKSPACE_VOLUMES_FROM", "read-only", "opaque"} {
+	for _, want := range []string{defaultWorkspaceDataSourceRelativePath, "0755", "repo-local `data/`", "fail closed", "SWARM_WORKSPACE_VOLUMES_FROM", "read-only", "opaque"} {
 		if !strings.Contains(authority.DefaultBehavior+authority.FailureBehavior+authority.VolumesFromConflictRule+authority.ReadPolicy+strings.Join(authority.RetiredNonAuthoritativeSources, "\n"), want) {
 			t.Fatalf("workspace data source spec missing %q:\n%#v", want, authority)
 		}
 	}
-	for _, want := range []string{"#1137", "#1138", "SWARM_WORKSPACE_DATA_MOUNT"} {
+	for _, want := range []string{"#1137", "#1138", "#1214", "workspace-init", "SWARM_WORKSPACE_DATA_MOUNT"} {
 		if !joinedContains(authority.SplitScope, want) {
 			t.Fatalf("workspace data source split scope missing %q: %#v", want, authority.SplitScope)
 		}
 	}
 	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceDataSourceAuthority
-	if command.PromotedBy != "#1139" || command.Owner != "workspace_model.data_source_authority" || command.Flag != "--data <path>" {
+	if !strings.Contains(command.PromotedBy, "#1139") || !strings.Contains(command.PromotedBy, "#1223") || command.Owner != "workspace_model.data_source_authority" || command.Flag != "--data <path>" {
 		t.Fatalf("serve command data authority = %#v", command)
 	}
-	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+	for _, want := range []string{"serve boot", "local foreground swarm run", "Builder project reload", "selected-contract run-fork"} {
 		if !joinedContains(command.Consumers, want) {
 			t.Fatalf("serve command data authority consumers missing %q: %#v", want, command.Consumers)
 		}
+	}
+	run := spec.CLISpecification.CommandCatalog.Run
+	if !stringSliceContains(run.Flags, "--data <path>") {
+		t.Fatalf("run command flags missing --data <path>: %#v", run.Flags)
+	}
+	if !strings.Contains(run.Modes.ForegroundLocalStart.Invocation, "--data <path>") || !strings.Contains(run.Modes.ForegroundLocalStart.Behavior, "workspace_model.data_source_authority") || !strings.Contains(run.Modes.ForegroundLocalStart.Behavior, "--connect") || !strings.Contains(run.Modes.ForegroundLocalStart.Behavior, "--reattach") {
+		t.Fatalf("run local foreground data authority missing from spec: %#v", run.Modes.ForegroundLocalStart)
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1593,6 +1593,26 @@ func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeEnvFallback(t *test
 	}
 }
 
+func TestResolveWorkspaceMountSourcesRejectsEmptyEnvBeforeDefault(t *testing.T) {
+	repoRoot := t.TempDir()
+	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
+		RepoRoot:         repoRoot,
+		EnvDataSource:    " \t ",
+		EnvDataSourceSet: true,
+		VolumesFrom:      "swarm-orchestrator",
+		VolumesFromSet:   true,
+	})
+	if err == nil || !strings.Contains(err.Error(), envWorkspaceDataSource) || !strings.Contains(err.Error(), "must be non-empty") {
+		t.Fatalf("resolve workspace mount sources error = %v, want empty env rejection", err)
+	}
+	if result.DataSource != "" || result.DataSourceSource != envWorkspaceDataSource {
+		t.Fatalf("workspace mount sources = %#v, want no default or volumes-from fallback and env source label", result)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath)); !os.IsNotExist(err) {
+		t.Fatalf("default data source stat error = %v, want not created", err)
+	}
+}
+
 func TestResolveWorkspaceMountSourcesDefaultsToSwarmDataNotRepoData(t *testing.T) {
 	repoRoot := t.TempDir()
 	repoDataDir := filepath.Join(repoRoot, "data")
@@ -1645,11 +1665,9 @@ func TestResolveWorkspaceMountSourcesDefaultWithoutRepoRoot(t *testing.T) {
 func TestResolveWorkspaceMountSourcesUsesVolumesFromAlternateWithoutDefault(t *testing.T) {
 	repoRoot := t.TempDir()
 	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:         repoRoot,
-		VolumesFrom:      "swarm-orchestrator",
-		VolumesFromSet:   true,
-		EnvDataSource:    " ",
-		EnvDataSourceSet: true,
+		RepoRoot:       repoRoot,
+		VolumesFrom:    "swarm-orchestrator",
+		VolumesFromSet: true,
 	})
 	if err != nil {
 		t.Fatalf("resolve workspace mount sources: %v", err)

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -42,6 +42,7 @@ type runCommandOptions struct {
 	configPath        string
 	backend           string
 	contractsPath     string
+	dataSource        string
 	platformSpecPath  string
 	idempotencyKey    string
 	runID             string
@@ -102,6 +103,7 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "Path to Swarm runtime config for local foreground startup")
 	cmd.Flags().StringVar(&opts.backend, "backend", "", "LLM backend profile for local foreground startup: anthropic, claude_cli, or openai_compatible")
 	cmd.Flags().StringVar(&opts.contractsPath, "contracts", "", "Path to Swarm contract bundle root for local foreground startup")
+	cmd.Flags().StringVar(&opts.dataSource, "data", "", "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", "", "Path to platform spec yaml for local foreground startup")
 	cmd.Flags().StringVar(&opts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for run.start")
 	cmd.Flags().StringVar(&opts.runID, "run-id", "", "Optional caller-provided run id for run.start")
@@ -222,6 +224,9 @@ func (o runCommandOptions) validate() error {
 	if o.changedFlags["mcp-port"] {
 		return fmt.Errorf("--mcp-port is not supported until the serve owner can bind MCP explicitly")
 	}
+	if o.changedFlags["data"] && strings.TrimSpace(o.dataSource) == "" {
+		return fmt.Errorf("--data must be non-empty")
+	}
 	if o.changedFlags["api-port"] {
 		_, defaultMCPPort, err := net.SplitHostPort(defaultMCPListenAddr)
 		if err != nil {
@@ -241,7 +246,7 @@ func (o runCommandOptions) validate() error {
 		if strings.TrimSpace(o.eventName) != "" || strings.TrimSpace(o.payloadPath) != "" || strings.TrimSpace(o.idempotencyKey) != "" || strings.TrimSpace(o.runID) != "" {
 			return fmt.Errorf("--reattach is mutually exclusive with --event, --payload, --idempotency-key, and --run-id")
 		}
-		for _, flag := range []string{"bundle-hash", "bundle-fingerprint", "config", "backend", "contracts", "platform-spec", "api-port", "mcp-port"} {
+		for _, flag := range []string{"bundle-hash", "bundle-fingerprint", "config", "backend", "contracts", "data", "platform-spec", "api-port", "mcp-port"} {
 			if o.changedFlags[flag] {
 				return fmt.Errorf("--reattach is mutually exclusive with --%s", flag)
 			}
@@ -249,7 +254,7 @@ func (o runCommandOptions) validate() error {
 		return nil
 	}
 	if strings.TrimSpace(o.connectURL) != "" {
-		for _, flag := range []string{"config", "backend", "contracts", "platform-spec", "api-port"} {
+		for _, flag := range []string{"config", "backend", "contracts", "data", "platform-spec", "api-port"} {
 			if o.changedFlags[flag] {
 				return fmt.Errorf("--%s requires local foreground mode and cannot be used with --connect", flag)
 			}
@@ -361,6 +366,7 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	serveOpts.ConfigPath = opts.configPath
 	serveOpts.Backend = opts.backend
 	serveOpts.ContractsPath = resolvedPaths.ContractsPath
+	serveOpts.DataSource = opts.dataSource
 	serveOpts.PlatformSpecPath = resolvedPaths.PlatformSpecPath
 	if opts.apiPort > 0 {
 		serveOpts.APIListenAddr = net.JoinHostPort("127.0.0.1", strconv.Itoa(opts.apiPort))

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -60,7 +60,7 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	configPath := filepath.Join(repo, "runtime.yaml")
 	opts.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
 		serveCalled.Add(1)
-		if serveOpts.ConfigPath != configPath || serveOpts.Backend != "claude_cli" || serveOpts.ContractsPath != filepath.Join(repo, "contracts") || serveOpts.PlatformSpecPath != filepath.Join(repo, "platform.yaml") {
+		if serveOpts.ConfigPath != configPath || serveOpts.Backend != "claude_cli" || serveOpts.ContractsPath != filepath.Join(repo, "contracts") || serveOpts.DataSource != "reference-data" || serveOpts.PlatformSpecPath != filepath.Join(repo, "platform.yaml") {
 			t.Errorf("serve opts = %#v", serveOpts)
 		}
 		<-ctx.Done()
@@ -69,7 +69,7 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--config", configPath, "--backend", "claude_cli", "--contracts", "contracts", "--platform-spec", "platform.yaml"}, &stdout, &stderr, opts)
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--config", configPath, "--backend", "claude_cli", "--contracts", "contracts", "--data", "reference-data", "--platform-spec", "platform.yaml"}, &stdout, &stderr, opts)
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -141,6 +141,22 @@ func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	}
 	if serveOpts.StoreMode != "sqlite" || serveOpts.StoreModeSet {
 		t.Fatalf("store opts = mode %q set %v, want sqlite default with no flag source", serveOpts.StoreMode, serveOpts.StoreModeSet)
+	}
+	if serveOpts.DataSource != "" {
+		t.Fatalf("data source = %q, want unset so serve resolver owns default selection", serveOpts.DataSource)
+	}
+}
+
+func TestRunCommandHelpShowsDataFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--help"}, &stdout, &stderr, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("run --help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"--data", "Path to agent-visible read-only /data reference directory"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("run help missing %q:\n%s", want, stdout.String())
+		}
 	}
 }
 
@@ -652,14 +668,17 @@ func TestRunCommandValidationAndAuthNoCallPaths(t *testing.T) {
 		{name: "reattach rejects config flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--config", "swarm.yaml"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --config"},
 		{name: "reattach rejects backend flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--backend", "claude_cli"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --backend"},
 		{name: "reattach rejects local startup flags", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--contracts", "contracts"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --contracts"},
+		{name: "reattach rejects data flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--data", "reference-data"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --data"},
 		{name: "reattach rejects platform spec flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--platform-spec", "platform.yaml"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --platform-spec"},
 		{name: "reattach rejects api port flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--reattach", "run-1", "--api-port", "8081"}, wantCode: 2, wantStderr: "--reattach is mutually exclusive with --api-port"},
+		{name: "blank data rejected", token: "test-token", args: []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--data", " "}, wantCode: 2, wantStderr: "--data must be non-empty"},
 		{name: "api port zero rejected when explicit", token: "test-token", args: []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--api-port", "0"}, wantCode: 2, wantStderr: "--api-port must be between 1 and 65535"},
 		{name: "api port rejects default mcp listener conflict", token: "test-token", args: []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--api-port", "8082"}, wantCode: 2, wantStderr: "--api-port 8082 conflicts with default MCP listener 127.0.0.1:8082"},
 		{name: "mcp port unsupported", token: "test-token", args: []string{"run", "--event", "scan.requested", "--payload", payloadPath, "--mcp-port", "9000"}, wantCode: 2, wantStderr: "--mcp-port is not supported"},
 		{name: "connect rejects config local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--config", "swarm.yaml"}, wantCode: 2, wantStderr: "--config requires local foreground mode"},
 		{name: "connect rejects backend local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--backend", "claude_cli"}, wantCode: 2, wantStderr: "--backend requires local foreground mode"},
 		{name: "connect rejects contracts local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--contracts", "contracts"}, wantCode: 2, wantStderr: "--contracts requires local foreground mode"},
+		{name: "connect rejects data local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--data", "reference-data"}, wantCode: 2, wantStderr: "--data requires local foreground mode"},
 		{name: "connect rejects platform spec local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--platform-spec", "platform.yaml"}, wantCode: 2, wantStderr: "--platform-spec requires local foreground mode"},
 		{name: "connect rejects api port local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--api-port", "8081"}, wantCode: 2, wantStderr: "--api-port requires local foreground mode"},
 		{name: "connect rejects legacy path", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1/api/rpc", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "--connect path must be empty or /v1/rpc"},

--- a/cmd/swarm/workspace_data_source.go
+++ b/cmd/swarm/workspace_data_source.go
@@ -61,7 +61,7 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 	case in.ConfigDataSourceSet:
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.ConfigDataSource, "workspace.data_source")
 		return workspaceMountSources{DataSource: path, DataSourceSource: "workspace.data_source"}, err
-	case in.EnvDataSourceSet && strings.TrimSpace(in.EnvDataSource) != "":
+	case in.EnvDataSourceSet:
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.EnvDataSource, envWorkspaceDataSource)
 		return workspaceMountSources{DataSource: path, DataSourceSource: envWorkspaceDataSource}, err
 	case in.VolumesFromSet && strings.TrimSpace(in.VolumesFrom) != "":

--- a/cmd/swarm/workspace_data_source.go
+++ b/cmd/swarm/workspace_data_source.go
@@ -9,7 +9,13 @@ import (
 	"swarm/internal/config"
 )
 
-const envWorkspaceDataSource = "SWARM_WORKSPACE_DATA_SOURCE"
+const (
+	envWorkspaceDataSource  = "SWARM_WORKSPACE_DATA_SOURCE"
+	envWorkspaceVolumesFrom = "SWARM_WORKSPACE_VOLUMES_FROM"
+
+	defaultWorkspaceDataSourceRelativePath = ".swarm/data"
+	defaultWorkspaceDataSourceSource       = "default"
+)
 
 type workspaceMountSources struct {
 	DataSource       string
@@ -26,11 +32,15 @@ type workspaceDataSourceInput struct {
 
 	EnvDataSource    string
 	EnvDataSourceSet bool
+
+	VolumesFrom    string
+	VolumesFromSet bool
 }
 
 func resolveWorkspaceMountSources(repoRoot string, flagDataSource string, cfg *config.Config) (workspaceMountSources, error) {
 	envDataSource, envDataSourceSet := os.LookupEnv(envWorkspaceDataSource)
 	configDataSource, configDataSourceSet := runtimeConfigWorkspaceDataSource(cfg)
+	volumesFrom, volumesFromSet := os.LookupEnv(envWorkspaceVolumesFrom)
 	return resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
 		RepoRoot:            repoRoot,
 		FlagDataSource:      flagDataSource,
@@ -38,6 +48,8 @@ func resolveWorkspaceMountSources(repoRoot string, flagDataSource string, cfg *c
 		ConfigDataSourceSet: configDataSourceSet,
 		EnvDataSource:       envDataSource,
 		EnvDataSourceSet:    envDataSourceSet,
+		VolumesFrom:         volumesFrom,
+		VolumesFromSet:      volumesFromSet,
 	})
 }
 
@@ -52,8 +64,14 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 	case in.EnvDataSourceSet && strings.TrimSpace(in.EnvDataSource) != "":
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.EnvDataSource, envWorkspaceDataSource)
 		return workspaceMountSources{DataSource: path, DataSourceSource: envWorkspaceDataSource}, err
-	default:
+	case in.VolumesFromSet && strings.TrimSpace(in.VolumesFrom) != "":
 		return workspaceMountSources{}, nil
+	default:
+		path := filepath.Clean(resolvePath(in.RepoRoot, defaultWorkspaceDataSourceRelativePath))
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return workspaceMountSources{DataSource: path, DataSourceSource: defaultWorkspaceDataSourceSource}, fmt.Errorf("create default workspace data source %s: %w", path, err)
+		}
+		return workspaceMountSources{DataSource: path, DataSourceSource: defaultWorkspaceDataSourceSource}, nil
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6539,20 +6539,23 @@ workspace_model:
       absent. Production runtime code MUST NOT build a missing workspace image from source-checkout `Dockerfile.workspace`, use
       `runtime.Caller` / Go source paths as a runtime asset root, or walk for `go.mod` to recover build material.
     mount_source_rule: >
-      Host sources for `/data` and `/opt/swarm/contracts` MUST come from explicit deployment configuration, environment,
-      config/CLI path resolution, or an already selected workflow/project root passed by the command owner. Default workspace
-      runtime configuration MUST NOT derive those mount sources from the Swarm source checkout.
+      Host sources for `/data` and `/opt/swarm/contracts` MUST come from `workspace_model.data_source_authority`,
+      explicit deployment configuration, environment, config/CLI path resolution, or an already selected workflow/project
+      root passed by the command owner. Default workspace runtime configuration MUST NOT derive those mount sources from
+      the Swarm source checkout except for the promoted `.swarm/data` managed local default owned by
+      `workspace_model.data_source_authority`.
     split_scope: >
       Docker Compose setup and workspace image contents/default agent CLI availability remain tracked separately by #996 and
       #997 unless a future gate explicitly widens them.
   data_source_authority:
-    promoted_by: '#1139'
-    implementation_status: implemented_first_slice
+    promoted_by: '#1139/#1223'
+    implementation_status: implemented
     canonical_owner: platform-spec.yaml#workspace_model.data_source_authority
     scope: >
-      Defines the host/source authority for the agent-visible `/data` mount for `swarm serve` and current Docker workspace
-      lifecycle consumers. Compose/Postgres onboarding (#1137), host workspace backend implementation (#1138), SQLite default,
-      and mount destination override cleanup remain split.
+      Defines the host/source authority for the agent-visible `/data` mount for `swarm serve`, local foreground `swarm run`,
+      and current workspace lifecycle consumers. Compose/Postgres onboarding (#1137), host workspace backend execution
+      parity (#1138/#1213), SQLite store concurrency, agent-free workspace-init skipping, and mount destination override
+      cleanup remain split.
     cli_flag: --data
     config_key: workspace.data_source
     env_var: SWARM_WORKSPACE_DATA_SOURCE
@@ -6560,37 +6563,46 @@ workspace_model:
     - --data
     - workspace.data_source
     - SWARM_WORKSPACE_DATA_SOURCE
-    - no path source
+    - default
     default_behavior: >
-      The runtime MUST NOT synthesize a source path from the Swarm source checkout. In particular, a non-empty repo root or a
-      repo-local `data/` directory is not a valid `/data` source unless the operator selected it explicitly through the
-      authoritative source order.
+      If no explicit path source is selected and no deployment alternate such as `SWARM_WORKSPACE_VOLUMES_FROM` is active,
+      the command resolver MUST select the managed local default `.swarm/data` under the active repo root, or relative
+      `.swarm/data` when no repo root is available, create it with mode 0755 before workspace validation, and report source
+      label `default`. The runtime MUST NOT synthesize `/data` from the Swarm source checkout or from a repo-local `data/`
+      directory unless that path was explicitly selected through the authoritative source order.
     path_resolution_rule: >
       Non-empty relative path sources are resolved through the command path resolver with the active repo root when present;
       absolute path sources are used as-is after cleaning. Empty explicit values are invalid.
     failure_behavior: >
-      Missing or unreadable path sources fail closed during workspace boot validation. If no path source is selected,
-      workspace boot must still fail closed unless an explicit deployment alternate such as `SWARM_WORKSPACE_VOLUMES_FROM`
-      satisfies the invariant `/data` mount.
+      Missing or unreadable explicit path sources fail closed during workspace boot validation. Empty explicit values are
+      invalid and MUST NOT fall through to environment or default sources. Default directory creation failures fail closed
+      before workspace lifecycle construction.
     volumes_from_conflict_rule: >
-      `SWARM_WORKSPACE_VOLUMES_FROM` is an explicit deployment alternate, not a fallback path source. It MUST NOT be combined
-      with an explicit `/data` path source from `--data`, `workspace.data_source`, or `SWARM_WORKSPACE_DATA_SOURCE`; startup
-      must fail closed on that conflict.
+      `SWARM_WORKSPACE_VOLUMES_FROM` is an explicit Docker deployment alternate, not a fallback path source. If no explicit
+      `/data` path source is selected and `SWARM_WORKSPACE_VOLUMES_FROM` is active, the command resolver MUST NOT
+      materialize or override with `.swarm/data`; Docker workspace validation consumes the alternate shared mounts instead.
+      `SWARM_WORKSPACE_VOLUMES_FROM` MUST NOT be combined with an explicit `/data` path source from `--data`,
+      `workspace.data_source`, or `SWARM_WORKSPACE_DATA_SOURCE`; startup must fail closed on that conflict. Host backend
+      startup continues to reject `SWARM_WORKSPACE_VOLUMES_FROM`.
     read_policy: >
       `/data` remains read-only, global, and opaque to the platform. Source authority does not permit indexing, mutating,
       validating contents beyond mount readability, or folding runtime `/data` into workflow bundle identity.
     consumers:
     - swarm serve boot workspace lifecycle
+    - local foreground swarm run startup through the serve startup owner
     - builder project supervisor reload workspace lifecycle
     - selected-contract run-fork workspace lifecycle
     - Docker workspace manager SharedDataSource mount consumer
+    - Host workspace manager SharedDataSource mount consumer
     retired_non_authoritative_sources:
     - repoRoot/data derivation in cmd/swarm configuredWorkspaceLifecycle
     - lower-level Docker default ownership of SWARM_WORKSPACE_DATA_SOURCE
     split_scope:
     - '#1137 Compose/Postgres onboarding and Compose ./data:/data:ro deployment shape'
-    - '#1138 host workspace backend'
-    - SQLite local default and broader local runtime onboarding
+    - '#1138/#1213 host workspace backend execution parity'
+    - '#1214 SQLite first run/event locking'
+    - agent-free workspace-init skipping
+    - broader local runtime onboarding/docs polish
     - mount destination override semantics such as SWARM_WORKSPACE_DATA_MOUNT
   workspace_backend_selection:
     promoted_by: '#1138'
@@ -8458,7 +8470,7 @@ cli_specification:
           SWARM_LLM_BACKEND, SWARM_LLM_RUNTIME_MODE, llm.runtime_mode, and SWARM_OPENAI_COMPATIBLE_BASE_URL are retired
           selector/connection-owner seams and must fail closed.
       workspace_data_source_authority:
-        promoted_by: '#1139'
+        promoted_by: '#1139/#1223'
         owner: workspace_model.data_source_authority
         flag: --data <path>
         config_key: workspace.data_source
@@ -8467,9 +8479,11 @@ cli_specification:
           `swarm serve` MUST resolve the agent-visible `/data` source through
           `workspace_model.data_source_authority` before constructing any workspace lifecycle. The command MUST NOT
           derive `/data` from the Swarm source checkout or from a repo-local `data/` directory unless that path was
-          explicitly selected by the operator through the promoted source order.
+          explicitly selected by the operator through the promoted source order. When no explicit path source and no
+          deployment alternate are selected, the shared resolver MUST create and use the managed `.swarm/data` default.
         consumers:
         - serve boot workspace lifecycle
+        - local foreground swarm run startup through the serve startup owner
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
       workspace_backend_selection:
@@ -8939,6 +8953,7 @@ cli_specification:
       - --config <path>
       - --backend <anthropic|claude_cli|openai_compatible>
       - --contracts <path>
+      - --data <path>
       - --platform-spec <path>
       - --idempotency-key <key>
       - --run-id <id>
@@ -8948,13 +8963,15 @@ cli_specification:
         --mcp-port: 'Unsupported in #743; `swarm run` may consume the existing serve startup owner, but explicit MCP bind ownership remains split to the #750 serve-owner tail and MUST fail before API/WS calls.'
       modes:
         foreground_local_start:
-          invocation: swarm run --event <name> --payload <file> [--config <path>] [--backend <profile>] --contracts <path> --platform-spec <path>
+          invocation: swarm run --event <name> --payload <file> [--config <path>] [--backend <profile>] --contracts <path> [--data <path>] --platform-spec <path>
           behavior: >
             Start runtime/API/MCP through the existing serve startup owner, call health.check, call run.start, subscribe
             with run.subscribe_trace, render composed trace rows and final summary until terminal. Local runtime config and
-            backend selection consume the same shared resolver as `swarm serve`. When the caller does not pass
+            backend selection consume the same shared resolver as `swarm serve`; local `/data` source selection consumes
+            `workspace_model.data_source_authority` through the serve startup owner. When the caller does not pass
             `--bundle-hash` or the deprecated `--bundle-fingerprint`, run.start uses the active canonical bundle_hash
-            returned by health.check for create-new-work scope.
+            returned by health.check for create-new-work scope. `--data` is local foreground startup configuration only and
+            MUST fail closed with `--connect` or `--reattach`.
           ctrl_c: 'First Ctrl-C calls run.stop after a run_id exists, shuts down the locally started runtime, and exits 130. A second interrupt may hard-exit.'
         foreground_connected_start:
           invocation: swarm run --connect <url> --event <name> --payload <file>


### PR DESCRIPTION
## Summary

Closes #1223.

This PR promotes and implements the approved first slice for `workspace_data_source_default_and_run_local_startup_data_flag_parity`:

- Adds the managed `.swarm/data` default to the shared workspace data-source resolver.
- Adds `swarm run --data <path>` as a local foreground startup flag and passes it through the existing `swarm serve` startup owner.
- Preserves explicit-source precedence and fail-closed behavior for blank/missing explicit sources.
- Preserves `SWARM_WORKSPACE_VOLUMES_FROM` as the no-path Docker deployment alternate instead of materializing `.swarm/data` when it is active.

## Governing Refs

- Issue/gate: #1223, including the approved `Pre-Implementation Coverage Audit` and lead gate outcome.
- Spec: `platform-spec.yaml#workspace_model.data_source_authority`
- Spec: `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_data_source_authority`
- Spec: `platform-spec.yaml#cli_specification.command_catalog.run`

## Semantic Migration

- New canonical owner: `platform-spec.yaml#workspace_model.data_source_authority`, implemented by `cmd/swarm/workspace_data_source.go::resolveWorkspaceMountSources` / `resolveWorkspaceMountSourcesFromInput`.
- Old invalid path: the resolver default branch returning empty `workspaceMountSources{}` for ordinary no-path local startup.
- Old invalid path: `swarm run` lacking the `--data` local-start flag while `swarm serve` owned it.
- Production paths checked for surviving old behavior: `swarm serve`, local foreground `swarm run`, connected/reattach `swarm run`, Builder reload workspace lifecycle, selected-contract run-fork lifecycle, Docker workspace manager, Host workspace manager, and `SWARM_WORKSPACE_VOLUMES_FROM` handling.
- Migration completeness: complete for the approved chosen class; broader host execution parity, SQLite locking, docs polish, and agent-free workspace-init skipping remain split.

## Validation

- `go test ./cmd/swarm -run 'Test(ResolveWorkspaceMountSources|PlatformSpecWorkspaceDataSourceAuthorityPromoted|RunCommand|StartLocalRunServe|CLI_ServeOwnsRuntimeStartupFlags)' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime/workspace -count=1`
- `go test ./cmd/swarm -run 'TestConfiguredWorkspaceLifecycle' -count=1`
- `go test ./...`
- Static no-bypass scan: `rg -n "resolveWorkspaceMountSources\(|resolveWorkspaceMountSourcesFromInput\(|SWARM_WORKSPACE_DATA_SOURCE|SWARM_WORKSPACE_VOLUMES_FROM|SharedDataSource|DataSource" cmd internal --glob '!**/*_test.go'`
- `git diff --check`