### PR TITLE
[agent-g][issue #1214] Fix SQLite idempotent publish locking

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -21,6 +21,7 @@ import (
 	"swarm/internal/runtime/semanticview"
 	"swarm/internal/store"
 	storerunlifecycle "swarm/internal/store/runlifecycle"
+	"swarm/internal/store/storetest"
 	"swarm/internal/testutil"
 )
 
@@ -99,6 +100,104 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	}
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count after conflict = %d, want 1", count)
+	}
+}
+
+func TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runStartTestEventBusOptions(source))
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandlerWithStores(t, sqliteStore, sqliteStore, sqliteStore, bus, source)
+	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-sqlite-publish")
+
+	published := rpcCall(t, handler, body)
+	if published.Error != nil {
+		t.Fatalf("sqlite event.publish error = %#v", published.Error)
+	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	runID := stringValue(t, result["run_id"], "run_id")
+	if result["new_run_created"] != true {
+		t.Fatalf("sqlite new_run_created = %#v, want true", result["new_run_created"])
+	}
+	assertSQLiteEventPublishRows(t, sqliteStore.DB, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
+	if count := countSQLiteAPIIdempotencyRows(t, sqliteStore.DB); count != 1 {
+		t.Fatalf("sqlite api_idempotency rows = %d, want 1", count)
+	}
+
+	replay := rpcCall(t, handler, body)
+	if replay.Error != nil {
+		t.Fatalf("sqlite event.publish replay error = %#v", replay.Error)
+	}
+	replayResult := asMap(t, replay.Result)
+	if replayResult["event_id"] != eventID || replayResult["run_id"] != runID {
+		t.Fatalf("sqlite replay result = %#v, want original event/run", replayResult)
+	}
+	if count := countSQLiteEventsByName(t, sqliteStore.DB, "scan.requested"); count != 1 {
+		t.Fatalf("sqlite event rows after replay = %d, want 1", count)
+	}
+
+	conflict := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"changed"}`, "", "idem-sqlite-publish"))
+	if conflict.Error == nil {
+		t.Fatal("sqlite event.publish idempotency conflict error = nil")
+	}
+	if data := asMap(t, conflict.Error.Data); data["code"] != IdempotencyConflictCode {
+		t.Fatalf("sqlite idempotency conflict data = %#v", data)
+	}
+	if count := countSQLiteEventsByName(t, sqliteStore.DB, "scan.requested"); count != 1 {
+		t.Fatalf("sqlite event rows after conflict = %d, want 1", count)
+	}
+
+	nonIDEM := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"second"}`, "", ""))
+	if nonIDEM.Error != nil {
+		t.Fatalf("sqlite non-idempotent event.publish error = %#v", nonIDEM.Error)
+	}
+	if count := countSQLiteEventsByName(t, sqliteStore.DB, "scan.requested"); count != 2 {
+		t.Fatalf("sqlite event rows after non-idempotent publish = %d, want 2", count)
+	}
+	if count := countSQLiteAPIIdempotencyRows(t, sqliteStore.DB); count != 1 {
+		t.Fatalf("sqlite api_idempotency rows after non-idempotent publish = %d, want 1", count)
+	}
+}
+
+func TestOperatorEventPublishSQLitePayloadFailureLeavesNoIdempotencyCompletionOrRows(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runtimebus.EventBusOptions{
+		ContractBundle:   source,
+		BundleSourceFact: runStartTestBundleSourceFact(),
+		PayloadValidator: func(eventType string, _ []byte) error {
+			if eventType == "scan.requested" {
+				return errors.New("schema violation")
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	handler := eventPublishTestHandlerWithStores(t, sqliteStore, sqliteStore, sqliteStore, bus, source)
+
+	resp := rpcCall(t, handler, eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-sqlite-payload-fails"))
+	if resp.Error == nil {
+		t.Fatal("sqlite event.publish payload validation error = nil")
+	}
+	if data := asMap(t, resp.Error.Data); data["code"] != PayloadValidationFailedCode {
+		t.Fatalf("sqlite payload validation data = %#v", data)
+	}
+	if count := countSQLiteEventsByName(t, sqliteStore.DB, "scan.requested"); count != 0 {
+		t.Fatalf("sqlite event rows after failed publish = %d, want 0", count)
+	}
+	if count := countSQLiteAllRunRows(t, sqliteStore.DB); count != 0 {
+		t.Fatalf("sqlite run rows after failed publish = %d, want 0", count)
+	}
+	if count := countSQLiteAPIIdempotencyRows(t, sqliteStore.DB); count != 0 {
+		t.Fatalf("sqlite api_idempotency rows after failed publish = %d, want 0", count)
 	}
 }
 
@@ -1197,6 +1296,42 @@ func assertEventPublishPersistence(t *testing.T, db *sql.DB, runID, eventID, eve
 	}
 }
 
+func assertSQLiteEventPublishRows(t *testing.T, db *sql.DB, runID, eventID, eventName, producedBy string) {
+	t.Helper()
+	var runStatus, triggerType, triggerID string
+	if err := db.QueryRow(`
+		SELECT status, COALESCE(trigger_event_type, ''), COALESCE(trigger_event_id, '')
+		FROM runs
+		WHERE run_id = ?
+	`, runID).Scan(&runStatus, &triggerType, &triggerID); err != nil {
+		t.Fatalf("load sqlite event.publish run row: %v", err)
+	}
+	if runStatus != "running" || triggerType != eventName || triggerID != eventID {
+		t.Fatalf("sqlite run row status=%q trigger=%q/%q, want running/%s/%s", runStatus, triggerType, triggerID, eventName, eventID)
+	}
+	var entityID, gotProducedBy, payloadText string
+	if err := db.QueryRow(`
+		SELECT COALESCE(entity_id, ''), COALESCE(produced_by, ''), payload
+		FROM events
+		WHERE event_id = ?
+	`, eventID).Scan(&entityID, &gotProducedBy, &payloadText); err != nil {
+		t.Fatalf("load sqlite event.publish event row: %v", err)
+	}
+	if entityID != runID {
+		t.Fatalf("sqlite event entity_id = %q, want run_id %q", entityID, runID)
+	}
+	if gotProducedBy != producedBy {
+		t.Fatalf("sqlite event produced_by = %q, want %q", gotProducedBy, producedBy)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payloadText), &decoded); err != nil {
+		t.Fatalf("decode sqlite event.publish payload: %v", err)
+	}
+	if decoded["entity_id"] != runID || decoded["topic"] != "medicine" {
+		t.Fatalf("sqlite event.publish payload = %#v", decoded)
+	}
+}
+
 func assertEventSourceEventID(t *testing.T, db *sql.DB, eventID, wantSourceEventID string) {
 	t.Helper()
 	var got string
@@ -1248,6 +1383,33 @@ func countAllEventRows(t *testing.T, db *sql.DB) int {
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
 		t.Fatalf("count all event rows: %v", err)
+	}
+	return count
+}
+
+func countSQLiteEventsByName(t *testing.T, db *sql.DB, eventName string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = ?`, eventName).Scan(&count); err != nil {
+		t.Fatalf("count sqlite events: %v", err)
+	}
+	return count
+}
+
+func countSQLiteAllRunRows(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM runs`).Scan(&count); err != nil {
+		t.Fatalf("count sqlite runs: %v", err)
+	}
+	return count
+}
+
+func countSQLiteAPIIdempotencyRows(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM api_idempotency`).Scan(&count); err != nil {
+		t.Fatalf("count sqlite api_idempotency rows: %v", err)
 	}
 	return count
 }

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -33,6 +33,7 @@ type SQLiteRuntimeStore struct {
 	startupMu             sync.Mutex
 	sessionMu             sync.Mutex
 	replayMu              sync.Mutex
+	apiIdempotencyMu      sync.Mutex
 	startupOwner          string
 	replayClaims          map[string]struct{}
 	sessionLockTTL        time.Duration
@@ -614,6 +615,9 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 		completion, err := execute(ctx)
 		return completion, false, err
 	}
+	if s == nil || s.DB == nil {
+		return APIIdempotencyCompletion{}, false, fmt.Errorf("sqlite runtime store is required")
+	}
 	if execute == nil {
 		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency executor is required")
 	}
@@ -621,6 +625,7 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 	req.ActorTokenID = strings.TrimSpace(req.ActorTokenID)
 	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
 	req.RequestHash = strings.TrimSpace(req.RequestHash)
+	req.ResourceID = strings.TrimSpace(req.ResourceID)
 	if req.Method == "" || req.ActorTokenID == "" || req.RequestHash == "" {
 		return APIIdempotencyCompletion{}, false, fmt.Errorf("method, actor token id, and request hash are required")
 	}
@@ -630,20 +635,17 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 	if req.TTL <= 0 {
 		req.TTL = 24 * time.Hour
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return APIIdempotencyCompletion{}, false, fmt.Errorf("begin sqlite api idempotency tx: %w", err)
+
+	// SQLite is local-dev only here: serialize idempotent callbacks in-process,
+	// but never keep a SQLite write transaction open while the callback writes
+	// through the selected runtime store.
+	s.apiIdempotencyMu.Lock()
+	defer s.apiIdempotencyMu.Unlock()
+
+	if err := purgeExpiredSQLiteAPIIdempotency(ctx, s.DB, req.Now); err != nil {
+		return APIIdempotencyCompletion{}, false, err
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if _, err := tx.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, req.Now.UTC()); err != nil {
-		return APIIdempotencyCompletion{}, false, fmt.Errorf("purge expired sqlite api idempotency: %w", err)
-	}
-	existing, ok, err := sqliteLoadAPIIdempotency(ctx, tx, req)
+	existing, ok, err := sqliteLoadAPIIdempotency(ctx, s.DB, req)
 	if err != nil {
 		return APIIdempotencyCompletion{}, false, err
 	}
@@ -656,11 +658,10 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 				ResourceID:             existing.ResourceID,
 			}
 		}
-		if err := tx.Commit(); err != nil {
-			return APIIdempotencyCompletion{}, false, fmt.Errorf("commit sqlite api idempotency replay: %w", err)
-		}
-		committed = true
-		return APIIdempotencyCompletion{ResourceID: existing.ResourceID, Response: existing.Response}, true, nil
+		return APIIdempotencyCompletion{
+			ResourceID: existing.ResourceID,
+			Response:   append(json.RawMessage(nil), existing.Response...),
+		}, true, nil
 	}
 	completion, err := execute(ctx)
 	if err != nil {
@@ -669,17 +670,20 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 	if len(completion.Response) == 0 {
 		return APIIdempotencyCompletion{}, false, fmt.Errorf("api idempotency response is required")
 	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO api_idempotency (method, actor_token_id, idempotency_key, request_hash, resource_id, response, created_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, req.Method, req.ActorTokenID, req.IdempotencyKey, req.RequestHash, strings.TrimSpace(completion.ResourceID), string(completion.Response), req.Now.UTC(), req.Now.Add(req.TTL).UTC()); err != nil {
-		return APIIdempotencyCompletion{}, false, fmt.Errorf("store sqlite api idempotency response: %w", err)
+	if strings.TrimSpace(completion.ResourceID) == "" {
+		completion.ResourceID = req.ResourceID
 	}
-	if err := tx.Commit(); err != nil {
-		return APIIdempotencyCompletion{}, false, fmt.Errorf("commit sqlite api idempotency tx: %w", err)
+	if err := sqliteStoreAPIIdempotency(ctx, s.DB, req, completion); err != nil {
+		return APIIdempotencyCompletion{}, false, err
 	}
-	committed = true
 	return completion, false, nil
+}
+
+func purgeExpiredSQLiteAPIIdempotency(ctx context.Context, q execQueryer, now time.Time) error {
+	if _, err := q.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, now.UTC()); err != nil {
+		return fmt.Errorf("purge expired sqlite api idempotency: %w", err)
+	}
+	return nil
 }
 
 func sqliteLoadAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -33,7 +34,6 @@ type SQLiteRuntimeStore struct {
 	startupMu             sync.Mutex
 	sessionMu             sync.Mutex
 	replayMu              sync.Mutex
-	apiIdempotencyMu      sync.Mutex
 	startupOwner          string
 	replayClaims          map[string]struct{}
 	sessionLockTTL        time.Duration
@@ -52,6 +52,11 @@ var _ runtimetools.MailboxPersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimeingress.Store = (*SQLiteRuntimeStore)(nil)
 var _ runtimeruncontrol.Store = (*SQLiteRuntimeStore)(nil)
 var _ runtimereplayclaim.Participation = (*SQLiteRuntimeStore)(nil)
+
+var sqliteAPIIdempotencyLocks = struct {
+	sync.Mutex
+	byPath map[string]*sync.Mutex
+}{byPath: map[string]*sync.Mutex{}}
 
 func NewSQLiteRuntimeStore(path string) (*SQLiteRuntimeStore, error) {
 	schemaStore, err := NewSQLiteSchemaStore(path)
@@ -636,11 +641,12 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 		req.TTL = 24 * time.Hour
 	}
 
-	// SQLite is local-dev only here: serialize idempotent callbacks in-process,
-	// but never keep a SQLite write transaction open while the callback writes
-	// through the selected runtime store.
-	s.apiIdempotencyMu.Lock()
-	defer s.apiIdempotencyMu.Unlock()
+	// SQLite is local-dev only here: serialize idempotent callbacks in-process
+	// per database file, but never keep a SQLite write transaction open while
+	// the callback writes through the selected runtime store.
+	lock := sqliteAPIIdempotencyLockForPath(s.Path())
+	lock.Lock()
+	defer lock.Unlock()
 
 	if err := purgeExpiredSQLiteAPIIdempotency(ctx, s.DB, req.Now); err != nil {
 		return APIIdempotencyCompletion{}, false, err
@@ -684,6 +690,30 @@ func purgeExpiredSQLiteAPIIdempotency(ctx context.Context, q execQueryer, now ti
 		return fmt.Errorf("purge expired sqlite api idempotency: %w", err)
 	}
 	return nil
+}
+
+func sqliteAPIIdempotencyLockForPath(path string) *sync.Mutex {
+	key := sqliteAPIIdempotencyLockKey(path)
+	sqliteAPIIdempotencyLocks.Lock()
+	defer sqliteAPIIdempotencyLocks.Unlock()
+	lock := sqliteAPIIdempotencyLocks.byPath[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		sqliteAPIIdempotencyLocks.byPath[key] = lock
+	}
+	return lock
+}
+
+func sqliteAPIIdempotencyLockKey(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "<unknown>"
+	}
+	cleanPath := filepath.Clean(path)
+	if abs, err := filepath.Abs(cleanPath); err == nil {
+		return abs
+	}
+	return cleanPath
 }
 
 func sqliteLoadAPIIdempotency(ctx context.Context, q execQueryer, req APIIdempotencyRequest) (apiIdempotencyRecord, bool, error) {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -353,6 +354,92 @@ func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOr
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM api_idempotency WHERE method = ? AND idempotency_key = ?`, 0, req.Method, req.IdempotencyKey)
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM runs WHERE run_id = ?`, 0, runID)
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 0, eventID)
+}
+
+func TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	storeA := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath)
+	storeB := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath)
+	req := APIIdempotencyRequest{
+		Method:         "event.publish",
+		ActorTokenID:   "token-1",
+		IdempotencyKey: "idem-shared-path",
+		RequestHash:    "hash-shared-path",
+		Now:            time.Now().UTC(),
+	}
+
+	type callResult struct {
+		completion APIIdempotencyCompletion
+		replayed   bool
+		err        error
+	}
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondExecuted := make(chan struct{}, 1)
+	firstDone := make(chan callResult, 1)
+	secondDone := make(chan callResult, 1)
+	var callbackCalls atomic.Int32
+
+	go func() {
+		completion, replayed, err := storeA.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+			if calls := callbackCalls.Add(1); calls != 1 {
+				secondExecuted <- struct{}{}
+			}
+			close(firstStarted)
+			<-releaseFirst
+			return APIIdempotencyCompletion{ResourceID: "resource-1", Response: json.RawMessage(`{"ok":true}`)}, nil
+		})
+		firstDone <- callResult{completion: completion, replayed: replayed, err: err}
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first idempotency callback did not start")
+	}
+
+	go func() {
+		completion, replayed, err := storeB.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+			callbackCalls.Add(1)
+			secondExecuted <- struct{}{}
+			return APIIdempotencyCompletion{ResourceID: "resource-2", Response: json.RawMessage(`{"ok":false}`)}, nil
+		})
+		secondDone <- callResult{completion: completion, replayed: replayed, err: err}
+	}()
+
+	select {
+	case <-secondExecuted:
+		close(releaseFirst)
+		first := <-firstDone
+		second := <-secondDone
+		t.Fatalf("second handle executed callback before first completion; first=%+v second=%+v calls=%d", first, second, callbackCalls.Load())
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(releaseFirst)
+
+	var first callResult
+	select {
+	case first = <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first idempotency call did not finish")
+	}
+	if first.err != nil || first.replayed || first.completion.ResourceID != "resource-1" {
+		t.Fatalf("first idempotency result=%+v, want new resource-1", first)
+	}
+	var second callResult
+	select {
+	case second = <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second idempotency call did not finish")
+	}
+	if second.err != nil || !second.replayed || second.completion.ResourceID != "resource-1" || string(second.completion.Response) != `{"ok":true}` {
+		t.Fatalf("second idempotency result=%+v, want replayed resource-1", second)
+	}
+	if calls := callbackCalls.Load(); calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+	assertSQLiteRuntimeCount(t, storeA, `SELECT COUNT(*) FROM api_idempotency WHERE method = ? AND idempotency_key = ?`, 1, req.Method, req.IdempotencyKey)
 }
 
 func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
@@ -1108,12 +1195,16 @@ func TestSQLiteRuntimeStoreClaimScheduleRequiresActiveRow(t *testing.T) {
 
 func newBootstrappedSQLiteRuntimeStoreForTest(t *testing.T) *SQLiteRuntimeStore {
 	t.Helper()
+	return newBootstrappedSQLiteRuntimeStoreForPath(t, filepath.Join(t.TempDir(), ".swarm", "dev.db"))
+}
+
+func newBootstrappedSQLiteRuntimeStoreForPath(t *testing.T, dbPath string) *SQLiteRuntimeStore {
+	t.Helper()
 	spec := loadPlatformSpecForSQLiteSchemaTest(t)
 	plans, err := GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
 	store, err := NewSQLiteRuntimeStore(dbPath)
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -238,6 +238,158 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	}
 }
 
+func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	bus, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := "11111111-1111-1111-1111-111111111111"
+	req := APIIdempotencyRequest{
+		Method:         "event.publish",
+		ActorTokenID:   "token-1",
+		IdempotencyKey: "idem-nested-publish",
+		RequestHash:    "hash-nested-publish",
+		Now:            time.Now().UTC(),
+	}
+	publishCalls := 0
+	publish := func(ctx context.Context) (APIIdempotencyCompletion, error) {
+		publishCalls++
+		if err := bus.Publish(ctx, (events.Event{
+			ID:          eventID,
+			RunID:       runID,
+			Type:        events.EventType("item.received"),
+			SourceAgent: "api.v1",
+			Payload:     json.RawMessage(`{"entity_id":"11111111-1111-1111-1111-111111111111","topic":"medicine"}`),
+			CreatedAt:   time.Now().UTC(),
+		}).WithEntityID(entityID)); err != nil {
+			return APIIdempotencyCompletion{}, err
+		}
+		response, err := json.Marshal(map[string]string{"event_id": eventID, "run_id": runID})
+		if err != nil {
+			return APIIdempotencyCompletion{}, err
+		}
+		return APIIdempotencyCompletion{ResourceID: eventID, Response: response}, nil
+	}
+
+	first, replayed, err := store.WithAPIIdempotency(ctx, req, publish)
+	if err != nil {
+		t.Fatalf("WithAPIIdempotency nested publish: %v", err)
+	}
+	if replayed || first.ResourceID != eventID || publishCalls != 1 {
+		t.Fatalf("first completion=%+v replayed=%v calls=%d, want new event", first, replayed, publishCalls)
+	}
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM runs WHERE run_id = ?`, 1, runID)
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 1, eventID)
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM api_idempotency WHERE method = ? AND idempotency_key = ?`, 1, req.Method, req.IdempotencyKey)
+
+	second, replayed, err := store.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		return APIIdempotencyCompletion{}, errors.New("replay executed callback")
+	})
+	if err != nil {
+		t.Fatalf("WithAPIIdempotency replay: %v", err)
+	}
+	if !replayed || second.ResourceID != eventID || string(second.Response) != string(first.Response) || publishCalls != 1 {
+		t.Fatalf("replay completion=%+v replayed=%v calls=%d, want stored event", second, replayed, publishCalls)
+	}
+
+	req.RequestHash = "hash-nested-publish-conflict"
+	_, _, err = store.WithAPIIdempotency(ctx, req, func(context.Context) (APIIdempotencyCompletion, error) {
+		return APIIdempotencyCompletion{}, errors.New("conflict executed callback")
+	})
+	if !errors.Is(err, ErrAPIIdempotencyConflict) {
+		t.Fatalf("conflict err = %v, want ErrAPIIdempotencyConflict", err)
+	}
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 1, eventID)
+}
+
+func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOrRows(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store.SetEventPayloadValidator(func(eventType string, _ []byte) error {
+		if eventType == "item.failed" {
+			return errors.New("schema violation")
+		}
+		return nil
+	})
+	bus, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	req := APIIdempotencyRequest{
+		Method:         "event.publish",
+		ActorTokenID:   "token-1",
+		IdempotencyKey: "idem-failed-publish",
+		RequestHash:    "hash-failed-publish",
+		Now:            time.Now().UTC(),
+	}
+	completion, replayed, err := store.WithAPIIdempotency(ctx, req, func(ctx context.Context) (APIIdempotencyCompletion, error) {
+		err := bus.Publish(ctx, (events.Event{
+			ID:          eventID,
+			RunID:       runID,
+			Type:        events.EventType("item.failed"),
+			SourceAgent: "api.v1",
+			Payload:     json.RawMessage(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`),
+			CreatedAt:   time.Now().UTC(),
+		}).WithEntityID("22222222-2222-2222-2222-222222222222"))
+		if err != nil {
+			return APIIdempotencyCompletion{}, err
+		}
+		return APIIdempotencyCompletion{ResourceID: eventID, Response: json.RawMessage(`{"ok":true}`)}, nil
+	})
+	if err == nil {
+		t.Fatal("WithAPIIdempotency failed publish err = nil")
+	}
+	if replayed || completion.ResourceID != "" || len(completion.Response) != 0 {
+		t.Fatalf("failed completion=%+v replayed=%v, want no completion", completion, replayed)
+	}
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM api_idempotency WHERE method = ? AND idempotency_key = ?`, 0, req.Method, req.IdempotencyKey)
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM runs WHERE run_id = ?`, 0, runID)
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 0, eventID)
+}
+
+func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	tx, err := store.BeginEventTx(ctx)
+	if err != nil {
+		t.Fatalf("BeginEventTx: %v", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	if err := store.AppendEventTx(ctx, tx, (events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("item.received"),
+		SourceAgent: "api.v1",
+		Payload:     json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID("33333333-3333-3333-3333-333333333333")); err != nil {
+		t.Fatalf("AppendEventTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit event tx: %v", err)
+	}
+	committed = true
+
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM runs WHERE run_id = ?`, 1, runID)
+	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 1, eventID)
+}
+
 func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishTxDoesNotReenterWrite(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
@@ -276,6 +428,17 @@ func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishTxDoesNotReenterWrite(
 	}
 	if count != 1 {
 		t.Fatalf("event rows = %d, want 1", count)
+	}
+}
+
+func assertSQLiteRuntimeCount(t *testing.T, store *SQLiteRuntimeStore, query string, want int, args ...any) {
+	t.Helper()
+	var count int
+	if err := store.DB.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("count sqlite runtime rows: %v", err)
+	}
+	if count != want {
+		t.Fatalf("sqlite count for %q = %d, want %d", query, count, want)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2308,6 +2308,14 @@ engine:
       owner: internal/store API idempotency persistence contract
       sqlite_owner: internal/store.SQLiteRuntimeStore.WithAPIIdempotency
       postgres_owner: internal/store.PostgresStore.WithAPIIdempotency
+      promoted_by: '#1214'
+      scope: >
+        API idempotency owns replay, conflict detection, and completion persistence for mutating v1 API calls. SQLite
+        local-dev idempotency must serialize idempotent callback execution without holding a SQLite write transaction
+        across the callback, because callbacks may write through selected runtime owners such as EventBus.Publish and
+        SQLiteRuntimeStore.AppendEventTx. SQLite uses process-local serialization plus short database operations for
+        purge/load/completion rows; Postgres remains authoritative for production concurrency through its advisory-lock
+        owner. Callback or publish failure must leave no idempotency completion for the failed request.
       excludes:
       - broad API delivery/replay/concurrency semantics owned by #1087
     - name: runtime_session_registry_rows

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2313,9 +2313,10 @@ engine:
         API idempotency owns replay, conflict detection, and completion persistence for mutating v1 API calls. SQLite
         local-dev idempotency must serialize idempotent callback execution without holding a SQLite write transaction
         across the callback, because callbacks may write through selected runtime owners such as EventBus.Publish and
-        SQLiteRuntimeStore.AppendEventTx. SQLite uses process-local serialization plus short database operations for
-        purge/load/completion rows; Postgres remains authoritative for production concurrency through its advisory-lock
-        owner. Callback or publish failure must leave no idempotency completion for the failed request.
+        SQLiteRuntimeStore.AppendEventTx. SQLite uses process-local serialization keyed by the selected SQLite database
+        path plus short database operations for purge/load/completion rows; Postgres remains authoritative for production
+        concurrency through its advisory-lock owner. Callback or publish failure must leave no idempotency completion for
+        the failed request.
       excludes:
       - broad API delivery/replay/concurrency semantics owned by #1087
     - name: runtime_session_registry_rows


### PR DESCRIPTION
## Summary

Fixes the approved #1214 widened first slice: `sqlite_api_idempotency_publish_transaction_serialization`.

`SQLiteRuntimeStore.WithAPIIdempotency` now preserves replay/conflict semantics with process-local serialization keyed by the selected SQLite database path plus short SQLite purge/load/completion writes, instead of holding a SQLite write transaction while the callback executes. This prevents idempotent `event.publish` / `run.start` callbacks from re-entering EventBus/`AppendEventTx` under an already-open SQLite write transaction and surfacing `SQLITE_BUSY` from `sqliteEnsureRunRow`; it also covers two store handles opened to the same file in one process.

Closes #1214

## Governing refs / context

- `platform-spec.yaml` `api_specification.method_catalog.event.publish`: canonical event publication and workflow-creation primitive; `run.start` is a deprecated wrapper over the same owner.
- `platform-spec.yaml` `runtime_store_backend_selection`: SQLite is local/dev default; Postgres remains explicit opt-in; no production SQLite multi-writer claim.
- `platform-spec.yaml` `runtime_core_persistence_store_contracts.selected_contracts.event_append_and_run_lifecycle_rows`: selected event append/run lifecycle rows are owned by `runtimebus.EventStore`; SQLite owner is `SQLiteRuntimeStore.AppendEvent`.
- `platform-spec.yaml` `runtime_core_persistence_store_contracts.selected_contracts.api_idempotency_rows`: updated in this PR to bind SQLite idempotency to path-keyed process-local serialization with no write transaction across mutating callback execution.
- #1214 issue body, repaired Pre-Implementation Coverage Audit, and lead gate outcome `approved as first slice` for `sqlite_api_idempotency_publish_transaction_serialization`.

## Semantic migration

- New canonical owner after the change: `internal/store.SQLiteRuntimeStore.WithAPIIdempotency` remains the SQLite API idempotency owner, now explicitly serialized in-process per selected SQLite DB path without an open SQLite write transaction spanning callback execution.
- Old invalid path: SQLite `WithAPIIdempotency` opening a write transaction, purging/loading idempotency rows, executing arbitrary mutating callbacks, then writing completion inside the same transaction.
- Production paths checked for surviving old behavior: store-level SQLite `WithAPIIdempotency` + EventBus publish, two SQLite handles opened to the same DB path, supported SQLite `/v1/rpc event.publish`, non-idempotent SQLite `event.publish`, Postgres API idempotency/event publish/run.start regressions, and whole `go test ./...`.
- Migration completeness: complete for the approved #1214 child class. Parent SQLite portability and production multi-writer semantics remain outside this PR.

## Proof

- Red-before proof: the new focused tests failed before the owner change with `persist event: ensure sqlite run row: database is locked (5) (SQLITE_BUSY)` in both store-level nested publish and supported SQLite `event.publish`.
- Review-fix proof: `TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles` proves two `SQLiteRuntimeStore` handles for the same DB path share serialization and the second same-key request replays without executing its callback.
- `go test ./internal/store ./internal/apiv1 -run 'TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish|TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOrRows|TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles|TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock|TestOperatorEventPublishSQLitePayloadFailureLeavesNoIdempotencyCompletionOrRows' -count=1`
- `go test ./internal/store ./internal/apiv1 -run 'TestSQLiteRuntimeStoreSelectedCoreContracts|TestPostgresStore_APIIdempotencyReplaysAndConflicts|TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency' -count=1`
- `go test ./...`