### PR TITLE
[agent-a][issue #1224] Activate native OpenAI Responses backend

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -192,7 +192,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 		},
 	}
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", opts.ConfigPath, "Optional path to Swarm runtime config")
-	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, or openai_compatible")
+	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, openai_compatible, or openai_responses")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend for local serve: docker (default isolation backend) or host (explicit local-dev opt-in)")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -316,7 +316,7 @@ func TestCLI_ServeOwnsRuntimeStartupFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("serve help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "--contracts", "--data", "--workspace-backend", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
+	for _, want := range []string{"Start the Swarm runtime", "--config", "--backend", "openai_responses", "--contracts", "--data", "--workspace-backend", "--bundle-hash", "--api-listen-addr", "API, WebSocket, health, and readiness routes", "--mcp-listen-addr", "MCP and tools routes", "--platform-spec", "--store", "--self-check", "--dev", "--require-bundle-match", "--no-require-bundle-match", "--abandon-active-runs", "--shutdown-grace", "--verbose"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("serve help missing %q:\n%s", want, stdout.String())
 		}
@@ -2362,9 +2362,11 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 								Required bool   `yaml:"required"`
 							} `yaml:"credential_source"`
 							EndpointSource struct {
-								ConfigKey string `yaml:"config_key"`
-								EnvVar    string `yaml:"env_var"`
-								Rule      string `yaml:"rule"`
+								ConfigKey      string `yaml:"config_key"`
+								EnvVar         string `yaml:"env_var"`
+								Required       bool   `yaml:"required"`
+								BuiltInDefault string `yaml:"built_in_default"`
+								Rule           string `yaml:"rule"`
 							} `yaml:"endpoint_source"`
 						} `yaml:"active_backend_profiles"`
 						PendingBackendProfiles map[string]struct {
@@ -2508,33 +2510,33 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 	if got := profiles["openai_compatible"]; got.Provider != "openai_compatible" || got.ProviderContractRuntimeMode != "openai_compatible" || got.EndpointSource.EnvVar != "" || !strings.Contains(got.EndpointSource.Rule, "SWARM_OPENAI_COMPATIBLE_BASE_URL is retired") {
 		t.Fatalf("openai_compatible profile = %#v", got)
 	}
-	if _, ok := profiles["openai_responses"]; ok {
-		t.Fatalf("openai_responses must not be active until #1224: %#v", profiles["openai_responses"])
+	openAIResponses := profiles["openai_responses"]
+	if openAIResponses.Provider != "openai" || openAIResponses.ProviderContractRuntimeMode != "openai_responses" || openAIResponses.Transport != "api" {
+		t.Fatalf("openai_responses profile = %#v", openAIResponses)
 	}
-	pendingResponses := authority.BackendProfileIdentity.PendingBackendProfiles["openai_responses"]
-	if pendingResponses.Provider != "openai" || pendingResponses.ProviderContractRuntimeMode != "openai_responses" || pendingResponses.Status != "source_authority_only_not_selectable" {
-		t.Fatalf("pending openai_responses profile = %#v", pendingResponses)
+	if openAIResponses.CredentialSource.EnvVar != "OPENAI_API_KEY" || !openAIResponses.CredentialSource.Required {
+		t.Fatalf("openai_responses credential source = %#v", openAIResponses.CredentialSource)
 	}
-	if pendingResponses.CredentialSource.EnvVar != "OPENAI_API_KEY" || !pendingResponses.CredentialSource.Required {
-		t.Fatalf("pending openai_responses credential source = %#v", pendingResponses.CredentialSource)
+	if openAIResponses.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || openAIResponses.EndpointSource.EnvVar != "" || openAIResponses.EndpointSource.Required || openAIResponses.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
+		t.Fatalf("openai_responses endpoint source = %#v", openAIResponses.EndpointSource)
 	}
-	if pendingResponses.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || pendingResponses.EndpointSource.EnvVar != "" || pendingResponses.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
-		t.Fatalf("pending openai_responses endpoint source = %#v", pendingResponses.EndpointSource)
+	if _, ok := authority.BackendProfileIdentity.PendingBackendProfiles["openai_responses"]; ok {
+		t.Fatalf("openai_responses must not remain pending after #1224 activation: %#v", authority.BackendProfileIdentity.PendingBackendProfiles)
 	}
 	openAIRejectedTarget := authority.BackendProfileIdentity.RejectedTargetNames["openai"]
-	for _, want := range []string{"not active", "openai_responses", "#1224"} {
+	for _, want := range []string{"must not be accepted", "openai_responses", "#1224"} {
 		if !strings.Contains(strings.ToLower(openAIRejectedTarget), strings.ToLower(want)) {
 			t.Fatalf("openai rejected target missing %q: %#v", want, authority.BackendProfileIdentity.RejectedTargetNames)
 		}
 	}
-	if !strings.Contains(strings.ToLower(authority.BackendProfileIdentity.RejectedTargetNames["openai"]), "not active") {
+	if !strings.Contains(strings.ToLower(authority.BackendProfileIdentity.RejectedTargetNames["openai"]), "provider identity") {
 		t.Fatalf("openai rejected target missing design decision: %#v", authority.BackendProfileIdentity.RejectedTargetNames)
 	}
 	responses := authority.NativeOpenAIResponsesSourceAuthority
-	if responses.PromotedBy != "#1229" || responses.ImplementationStatus != "source_authority_only_runtime_split" {
+	if responses.PromotedBy != "#1229" || responses.ImplementationStatus != "runtime_adapter_activated_first_subset" {
 		t.Fatalf("native responses source authority status = %#v", responses)
 	}
-	if responses.TargetBackendProfileID != "openai_responses" || responses.ProviderIdentity != "openai" || responses.ActivationStatus != "pending_runtime_adapter_not_selectable" {
+	if responses.TargetBackendProfileID != "openai_responses" || responses.ProviderIdentity != "openai" || responses.ActivationStatus != "active_backend_profile_runtime_adapter_promoted_by_1224" {
 		t.Fatalf("native responses identity = %#v", responses)
 	}
 	for _, want := range []string{"api-reference/responses", "docs/models", "function-calling", "streaming-responses"} {
@@ -2542,7 +2544,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("native responses authoritative refs missing %q: %#v", want, responses.AuthoritativeRefs)
 		}
 	}
-	for _, want := range []string{"MUST NOT be accepted", "openai remains a rejected", "openai_compatible remains Chat Completions-compatible"} {
+	for _, want := range []string{"openai_responses is accepted", "openai remains a rejected", "openai_compatible remains Chat Completions-compatible"} {
 		if !joinedContains(responses.ActiveSelectorPolicy, want) {
 			t.Fatalf("native responses selector policy missing %q: %#v", want, responses.ActiveSelectorPolicy)
 		}
@@ -2567,8 +2569,8 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("native responses model alias %s = %q, want %q; aliases=%#v", alias, got, model, responses.ModelAliasDefaults)
 		}
 	}
-	if !strings.Contains(responses.ModelAliasRule, "not consumed by boot or verify until openai_responses is activated") {
-		t.Fatalf("native responses model alias rule does not preserve inactive boundary: %s", responses.ModelAliasRule)
+	if !strings.Contains(responses.ModelAliasRule, "consumed by") || !strings.Contains(responses.ModelAliasRule, "openai_responses") {
+		t.Fatalf("native responses model alias rule does not record active consumption: %s", responses.ModelAliasRule)
 	}
 	for _, want := range []string{"function tools", "function-call output", "raw Responses payloads", "previous_response_id", "backend profile id openai_responses", "exact provider-reported usage"} {
 		combined := strings.Join(responses.ProviderContractExpectations.ToolSchema, " ") +
@@ -2580,8 +2582,8 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("native responses provider contract expectations missing %q: %#v", want, responses.ProviderContractExpectations)
 		}
 	}
-	if !strings.Contains(responses.StoreProfileImplication, "No agents.llm_backend schema/check migration is required") || !strings.Contains(responses.StoreProfileImplication, "not active") {
-		t.Fatalf("native responses store implication must preserve inactive boundary: %s", responses.StoreProfileImplication)
+	if !strings.Contains(responses.StoreProfileImplication, "schema/check admission") || !strings.Contains(responses.StoreProfileImplication, "openai_responses") {
+		t.Fatalf("native responses store implication must record active persisted admission: %s", responses.StoreProfileImplication)
 	}
 	for _, want := range []string{"#1224", "previous_response_id", "Provider matrix"} {
 		if !joinedContains(responses.SplitBoundaries, want) {
@@ -2598,9 +2600,9 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 		}
 	}
 	for alias, backendModels := range map[string]map[string]string{
-		"cheap":    {"anthropic": "claude-3-5-haiku", "claude_cli": "haiku", "openai_compatible": "gpt-compatible-mini"},
-		"regular":  {"anthropic": "claude-3-5-sonnet", "claude_cli": "sonnet", "openai_compatible": "gpt-compatible"},
-		"frontier": {"anthropic": "claude-3-opus", "claude_cli": "opus", "openai_compatible": "gpt-compatible-frontier"},
+		"cheap":    {"anthropic": "claude-3-5-haiku", "claude_cli": "haiku", "openai_compatible": "gpt-compatible-mini", "openai_responses": "gpt-5.4-nano"},
+		"regular":  {"anthropic": "claude-3-5-sonnet", "claude_cli": "sonnet", "openai_compatible": "gpt-compatible", "openai_responses": "gpt-5.4"},
+		"frontier": {"anthropic": "claude-3-opus", "claude_cli": "opus", "openai_compatible": "gpt-compatible-frontier", "openai_responses": "gpt-5.5"},
 	} {
 		for backend, model := range backendModels {
 			if got := strings.TrimSpace(models.BuiltInModelDefaults[alias][backend]); got != model {
@@ -2613,7 +2615,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("model alias authority missing %q:\n%#v", want, models)
 		}
 	}
-	for _, want := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_COMPATIBLE_API_KEY"} {
+	for _, want := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_COMPATIBLE_API_KEY", "OPENAI_API_KEY"} {
 		if !stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, want) {
 			t.Fatalf("secret env sources missing %q: %#v", want, authority.CredentialAndConfigPolicy.SecretEnvSources)
 		}
@@ -2623,12 +2625,12 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("runtime config canonical list missing %q: %#v", want, authority.CredentialAndConfigPolicy.RuntimeConfigCanonicalFor)
 		}
 	}
-	for _, want := range []string{"anthropic", "claude_cli", "openai_compatible", "api and cli_test", "model", "write time"} {
+	for _, want := range []string{"anthropic", "claude_cli", "openai_compatible", "openai_responses", "api and cli_test", "model", "write time"} {
 		if !joinedContains(authority.PersistenceRules, want) {
 			t.Fatalf("persistence rules missing %q: %#v", want, authority.PersistenceRules)
 		}
 	}
-	for _, want := range []string{"#1127", "#1128", "#1129", "#1130", "#1229", "#1224", "MUST NOT change runtime"} {
+	for _, want := range []string{"#1127", "#1128", "#1129", "#1130", "#1229", "#1224", "active backend runtime implementation"} {
 		if !joinedContains(authority.SplitBoundaries, want) {
 			t.Fatalf("split boundaries missing %q: %#v", want, authority.SplitBoundaries)
 		}
@@ -5530,6 +5532,8 @@ func TestDefaultRuntimeConfig_RejectsRetiredLLMBackendEnv(t *testing.T) {
 
 func TestDefaultRuntimeConfig_DoesNotInferLLMBackendFromCredentials(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("OPENAI_API_KEY", "openai-test-key")
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "compatible-test-key")
 	cfg, err := defaultRuntimeConfig()
 	if err != nil {
 		t.Fatalf("defaultRuntimeConfig: %v", err)

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -101,7 +101,7 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.bundleHash, "bundle-hash", "", "Expected server canonical bundle hash")
 	cmd.Flags().StringVar(&opts.bundleFingerprint, "bundle-fingerprint", "", "Expected server bundle fingerprint")
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "Path to Swarm runtime config for local foreground startup")
-	cmd.Flags().StringVar(&opts.backend, "backend", "", "LLM backend profile for local foreground startup: anthropic, claude_cli, or openai_compatible")
+	cmd.Flags().StringVar(&opts.backend, "backend", "", "LLM backend profile for local foreground startup: anthropic, claude_cli, openai_compatible, or openai_responses")
 	cmd.Flags().StringVar(&opts.contractsPath, "contracts", "", "Path to Swarm contract bundle root for local foreground startup")
 	cmd.Flags().StringVar(&opts.dataSource, "data", "", "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", "", "Path to platform spec yaml for local foreground startup")

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -153,7 +153,7 @@ func TestRunCommandHelpShowsDataFlag(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("run --help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"--data", "Path to agent-visible read-only /data reference directory"} {
+	for _, want := range []string{"--data", "Path to agent-visible read-only /data reference directory", "--backend", "openai_responses"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("run help missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,7 @@ type LLMConfig struct {
 	ClaudeAPI        ClaudeAPIConfig           `yaml:"claude_api"`
 	ClaudeCLI        ClaudeCLIConfig           `yaml:"claude_cli"`
 	OpenAICompatible OpenAICompatibleConfig    `yaml:"openai_compatible"`
+	OpenAIResponses  OpenAIResponsesConfig     `yaml:"openai_responses"`
 }
 
 type LLMSessionConfig struct {
@@ -123,6 +124,10 @@ type OpenAICompatibleConfig struct {
 	BaseURL      string `yaml:"base_url"`
 	DefaultModel string `yaml:"default_model"`
 	LowCostModel string `yaml:"low_cost_model"`
+}
+
+type OpenAIResponsesConfig struct {
+	BaseURL string `yaml:"base_url"`
 }
 
 type LoadOptions struct {
@@ -201,6 +206,11 @@ func (c *Config) validate(backendOverride string) error {
 	}
 	if profile.ID == llmselection.BackendOpenAICompatible {
 		if _, err := llmselection.ResolveBaseURL(profile, c.LLM.OpenAICompatible.BaseURL); err != nil {
+			return err
+		}
+	}
+	if profile.ID == llmselection.BackendOpenAIResponses {
+		if _, err := llmselection.ResolveBaseURL(profile, c.LLM.OpenAIResponses.BaseURL); err != nil {
 			return err
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,6 +204,25 @@ func TestValidate_OpenAICompatibleRequiresProfileOwnedConfig(t *testing.T) {
 	}
 }
 
+func TestValidate_OpenAIResponsesUsesProfileOwnedDefaultAndOverride(t *testing.T) {
+	c := &Config{}
+	c.LLM.Backend = "openai_responses"
+	c.LLM.Session.LockTTL = 1 * time.Second
+	c.LLM.Session.RotateAfterTurns = 1
+	c.LLM.Session.RotateOnParseFailures = 1
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate with built-in OpenAI Responses base URL: %v", err)
+	}
+	c.LLM.OpenAIResponses.BaseURL = "localhost:8080"
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "llm.openai_responses.base_url") {
+		t.Fatalf("Validate invalid base_url error = %v, want openai_responses base URL guidance", err)
+	}
+	c.LLM.OpenAIResponses.BaseURL = "https://proxy.test/v1"
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate with OpenAI Responses override: %v", err)
+	}
+}
+
 func TestValidate_RejectsRetiredRuntimeMode(t *testing.T) {
 	c := &Config{}
 	c.LLM.RuntimeMode = "api"

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -51,6 +51,8 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 		})
 	case llmselection.BackendOpenAICompatible:
 		runtime = NewOpenAICompatibleRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+	case llmselection.BackendOpenAIResponses:
+		runtime = NewOpenAIResponsesRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
 	default:
 		return nil, fmt.Errorf("unsupported llm backend profile: %s", profile.ID)
 	}

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -329,6 +329,7 @@ type budgetCapture struct {
 	runtimeMode string
 	usage       UsageTokens
 	exact       bool
+	meta        map[string]any
 }
 
 func (b *budgetCapture) LockExecutionScope(string) func() { return func() {} }
@@ -336,10 +337,13 @@ func (b *budgetCapture) IsEntityEmergency(string) bool    { return false }
 func (b *budgetCapture) IsEntityThrottle(string) bool     { return false }
 func (b *budgetCapture) IsEmergency(string) bool          { return false }
 func (b *budgetCapture) IsThrottle(string) bool           { return false }
-func (b *budgetCapture) RecordEntityLLMUsage(_ context.Context, _ string, _ string, runtimeMode string, usage UsageTokens, exact bool, _ any) error {
+func (b *budgetCapture) RecordEntityLLMUsage(_ context.Context, _ string, _ string, runtimeMode string, usage UsageTokens, exact bool, meta any) error {
 	b.runtimeMode = runtimeMode
 	b.usage = usage
 	b.exact = exact
+	if m, ok := meta.(map[string]any); ok {
+		b.meta = m
+	}
 	return nil
 }
 func (b *budgetCapture) RecordLLMUsage(ctx context.Context, entityID string, agentID string, runtimeMode string, usage UsageTokens, exact bool, meta any) error {

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -1,0 +1,830 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"swarm/internal/config"
+	"swarm/internal/events"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	runtimecorrelation "swarm/internal/runtime/correlation"
+	llmselection "swarm/internal/runtime/llm/selection"
+	"swarm/internal/runtime/sessions"
+)
+
+type OpenAIResponsesRuntime struct {
+	cfg           *config.Config
+	sessions      sessions.Registry
+	turns         TurnPersistence
+	conversations ConversationPersistence
+	budget        BudgetGuard
+	lockOwner     string
+	httpClient    *http.Client
+	baseURL       string
+	apiKey        string
+	events        EventPublisher
+}
+
+func NewOpenAIResponsesRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAIResponsesRuntime {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAIResponses)
+	baseURL, _ := llmselection.ResolveBaseURL(profile, cfg.LLM.OpenAIResponses.BaseURL)
+	return &OpenAIResponsesRuntime{
+		cfg:           cfg,
+		sessions:      sessions,
+		turns:         turns,
+		conversations: conversations,
+		budget:        budget,
+		lockOwner:     lockOwner,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+		baseURL: baseURL,
+		apiKey:  llmselection.CredentialValue(profile, os.LookupEnv),
+		events:  publisher,
+	}
+}
+
+func (r *OpenAIResponsesRuntime) ProviderContract() ProviderContract {
+	return OpenAIResponsesProviderContract()
+}
+
+func OpenAIResponsesProviderContract() ProviderContract {
+	return ProviderContract{
+		RuntimeMode: llmselection.ProviderContractRuntimeModeOpenAIResponses,
+		Provider:    llmselection.ProviderOpenAI,
+		Transport:   ProviderTransportAPI,
+		ToolSchema: ProviderToolSchemaContract{
+			ValidatesInputSchemas: true,
+			TranslatesTools:       true,
+			ReturnsToolResults:    true,
+		},
+		SessionLifecycle: ProviderSessionLifecycleContract{
+			StartsSessions:            true,
+			ContinuesSessions:         true,
+			SupportsConversationModes: true,
+			ProviderSessionIDStrategy: "platform_managed_provider_response_metadata",
+			RotatesSessions:           true,
+			PreservesRetryLineage:     true,
+		},
+		Response: ProviderResponseContract{
+			NormalizesMessages:   true,
+			NormalizesToolCalls:  true,
+			PreservesRawResponse: true,
+			StreamingParser:      "openai_responses_sse",
+		},
+		NativeTools: ProviderNativeToolContract{
+			FallbackToolsAllowed: true,
+		},
+		Persistence: ProviderPersistenceContract{
+			PersistsTurns:                 true,
+			PersistsConversationSnapshots: true,
+			PersistsTaskModeAudit:         true,
+		},
+		Budget: ProviderBudgetContract{
+			UsageAccounting: BudgetUsageExact,
+		},
+	}
+}
+
+func (r *OpenAIResponsesRuntime) PersistConversationSnapshot(ctx context.Context, s *Session) error {
+	if r.conversations == nil || s == nil {
+		return nil
+	}
+	mode, err := sessions.ParseConversationRuntimeMode(s.ConversationMode)
+	if err != nil {
+		return err
+	}
+	if !shouldPersistConversationMode(mode) {
+		return nil
+	}
+	return r.conversations.UpsertConversation(ctx, ConversationRecord{
+		SessionID:    s.ID,
+		AgentID:      s.AgentID,
+		SessionScope: strings.TrimSpace(s.SessionScope),
+		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
+		RunID:        strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx)),
+		Mode:         mode.String(),
+		Messages:     s.Messages,
+		Summary:      BuildSessionSummary(s),
+		TurnCount:    s.TurnCount,
+		Status:       "active",
+	})
+}
+
+func (r *OpenAIResponsesRuntime) StartSession(ctx context.Context, agentID, systemPrompt string, tools []ToolDefinition) (*Session, error) {
+	scope := sessions.ScopeFromContext(ctx)
+	actor, _ := runtimeactors.ActorFromContext(ctx)
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(scope.ConversationMode), sessions.NormalizeSessionScope(scope.SessionScope), scope.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var lease *sessions.Lease
+	if !resolved.Stateless {
+		lease, err = r.sessions.Acquire(ctx, agentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, resolved.ScopeKey)
+		if err != nil {
+			return nil, err
+		}
+		if err := r.sessions.Release(ctx, lease); err != nil {
+			return nil, err
+		}
+	}
+
+	s := &Session{
+		ID: ensurePlatformSessionID(func() string {
+			if lease != nil {
+				return lease.SessionID
+			}
+			return ""
+		}()),
+		AgentID:          agentID,
+		RuntimeMode:      resolved.RuntimeMode.String(),
+		ConversationMode: resolved.RuntimeMode.String(),
+		SessionScope:     resolved.Scope.String(),
+		ScopeKey:         resolved.ScopeKey,
+		RetryReason: func() string {
+			if lease != nil {
+				return lease.RetryReason
+			}
+			return ""
+		}(),
+		RetriesFromSessionID: func() string {
+			if lease != nil {
+				return lease.RetriesFromSessionID
+			}
+			return ""
+		}(),
+		ProviderSessionID: func() string {
+			if lease != nil {
+				return lease.ProviderSessionID
+			}
+			return ""
+		}(),
+		SystemPrompt: augmentAgentSystemPrompt(systemPrompt, actor, tools),
+		Tools:        tools,
+		Messages:     nil,
+	}
+	if r.conversations != nil && !resolved.Stateless {
+		if rec, ok, err := r.conversations.LoadActiveConversation(ctx, agentID, resolved.RuntimeMode.String(), resolved.Scope.String(), resolved.ScopeKey); err == nil && ok {
+			s.Messages = rec.Messages
+			s.TurnCount = rec.TurnCount
+			s.RetryReason = strings.TrimSpace(rec.RetryReason)
+			s.RetriesFromSessionID = strings.TrimSpace(rec.RetriesFromSessionID)
+			s.Watchdog = rec.Watchdog
+		}
+	}
+	publishAgentStarted(ctx, r.events, s, events.EventType("platform.agent_started"))
+	return s, nil
+}
+
+func (r *OpenAIResponsesRuntime) ContinueSession(ctx context.Context, s *Session, message Message) (*Response, error) {
+	if s == nil {
+		return nil, errors.New("nil session")
+	}
+	actor, _ := runtimeactors.ActorFromContext(ctx)
+	entityID := actor.EffectiveEntityID()
+	scopeKey := budgetExecutionScopeKey(actor)
+	if r.budget != nil {
+		unlockScope := r.budget.LockExecutionScope(scopeKey)
+		defer unlockScope()
+		if r.budget.IsEntityEmergency(entityID) {
+			return nil, fmt.Errorf("budget emergency: refusing llm execution (entity=%s)", entityID)
+		}
+	}
+
+	resolved, err := resolvedSessionScope(ctx, sessions.NormalizeConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode)), sessions.NormalizeSessionScope(coalesce(s.SessionScope, "")), s.ScopeKey)
+	if err != nil {
+		return nil, err
+	}
+	var lease *sessions.Lease
+	if !resolved.Stateless {
+		lease, err = r.sessions.Acquire(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, r.lockOwner, resolved.ScopeKey)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = r.sessions.Release(ctx, lease) }()
+		stopLeaseHeartbeat := sessions.StartLeaseHeartbeatWithErrorHandler(ctx, r.sessions, lease, resolved.RuntimeMode, func(heartbeatErr error) {
+			logPublisherRuntime(ctx, r.events, "warn", "session_lease_heartbeat_failed", "Refreshing the OpenAI Responses session lease heartbeat failed", s.AgentID, s.ID, entityID, map[string]any{
+				"runtime_mode": resolved.RuntimeMode.String(),
+				"scope_key":    resolved.ScopeKey,
+			}, heartbeatErr)
+		})
+		defer stopLeaseHeartbeat()
+
+		if lease.SessionID != s.ID {
+			LogSessionAdoptedForRun(ctx, r.events, s.AgentID, resolved.RuntimeMode.String(), s.ID, lease.SessionID, resolved.ScopeKey)
+			s.ID = lease.SessionID
+		}
+	}
+	if err := requireInboundDeliveryActiveForSession(ctx, r.events, s, "error", "Marking the reused agent delivery in progress failed", map[string]any{
+		"runtime_mode": resolved.RuntimeMode.String(),
+		"scope_key":    resolved.ScopeKey,
+	}, entityID); err != nil {
+		return nil, fmt.Errorf("mark inbound delivery active for reused openai-responses session: %w", err)
+	}
+
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAIResponses)
+	if strings.TrimSpace(r.apiKey) == "" {
+		r.apiKey = llmselection.CredentialValue(profile, os.LookupEnv)
+		if strings.TrimSpace(r.apiKey) == "" {
+			return nil, llmselection.RequireCredential(profile, os.LookupEnv)
+		}
+	}
+	if strings.TrimSpace(r.baseURL) == "" {
+		baseURL, err := llmselection.ResolveBaseURL(profile, r.cfg.LLM.OpenAIResponses.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+		r.baseURL = baseURL
+	}
+
+	reqBody, err := r.buildRequest(ctx, s, message)
+	if err != nil {
+		return nil, err
+	}
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal openai-responses request: %w", err)
+	}
+
+	start := time.Now()
+	rawResp, parsed, err := r.sendRequest(ctx, reqJSON)
+	latency := time.Since(start)
+	if err != nil {
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		if !resolved.Stateless {
+			if rotated, rotateErr := MaybeRotateAfterParseFailures(ctx, s, resolved.RuntimeMode, r.sessions, r.lockOwner, r.cfg.LLM.Session.RotateOnParseFailures, r.events); rotateErr == nil && rotated != nil {
+				lease = rotated
+			}
+		}
+		return nil, err
+	}
+
+	usage, ok := openAIResponsesUsage(parsed)
+	if !ok {
+		err := errors.New("openai-responses response missing usage")
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		return nil, err
+	}
+
+	resp, err := convertOpenAIResponsesResponse(parsed)
+	if err != nil {
+		s.ParseFailures++
+		r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+			AgentID:        s.AgentID,
+			RuntimeMode:    resolved.RuntimeMode.String(),
+			SessionID:      s.ID,
+			RequestPayload: reqJSON,
+			ResponseRaw:    rawResp,
+			ParseOK:        false,
+			Latency:        latency,
+			Error:          err.Error(),
+		}, nil))
+		return nil, err
+	}
+	resp.Raw = rawResp
+
+	s.Messages = append(s.Messages, message, resp.Message)
+	s.TurnCount++
+	s.ParseFailures = 0
+	if !resolved.Stateless {
+		if err := r.sessions.IncrementTurn(ctx, s.AgentID, resolved.RuntimeMode, resolved.Scope, s.ID, resolved.ScopeKey); err != nil {
+			return nil, err
+		}
+	}
+
+	r.persistTurn(ctx, enrichTurnRecord(ctx, s, AgentTurnRecord{
+		AgentID:        s.AgentID,
+		RuntimeMode:    resolved.RuntimeMode.String(),
+		SessionID:      s.ID,
+		RequestPayload: reqJSON,
+		ResponseRaw:    rawResp,
+		ParseOK:        true,
+		Latency:        latency,
+	}, &resp))
+	r.persistConversation(ctx, s)
+
+	if r.budget != nil {
+		usage.Model = strings.TrimSpace(coalesce(usage.Model, reqBody.Model))
+		meta := usageMetadataForContext(ctx, profile, usage.Model)
+		meta["session_id"] = s.ID
+		meta["usage_accounting"] = string(BudgetUsageExact)
+		if err := r.budget.RecordEntityLLMUsage(ctx, entityID, s.AgentID, profile.ID, usage, true, meta); err != nil {
+			logPublisherRuntime(ctx, r.events, "warn", "record_openai_responses_llm_usage_failed", "Recording OpenAI Responses LLM usage failed", s.AgentID, s.ID, entityID, nil, err)
+		}
+	}
+
+	if !resolved.Stateless {
+		if rotated, rotateErr := MaybeRotateAfterTurn(ctx, s, resolved.RuntimeMode, r.sessions, r.lockOwner, r.cfg.LLM.Session.RotateAfterTurns, r.events); rotateErr == nil && rotated != nil {
+			lease = rotated
+		}
+	}
+
+	return &resp, nil
+}
+
+func (r *OpenAIResponsesRuntime) persistConversation(ctx context.Context, s *Session) {
+	if r.conversations == nil || s == nil {
+		return
+	}
+	mode, err := sessions.ParseConversationRuntimeMode(coalesce(s.ConversationMode, s.RuntimeMode))
+	if err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_responses_conversation_invalid_mode", "Persisting the OpenAI Responses conversation was skipped because the session mode was invalid", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": strings.TrimSpace(s.ConversationMode),
+			"runtime_mode":      strings.TrimSpace(s.RuntimeMode),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+		return
+	}
+	if !shouldPersistConversationMode(mode) {
+		return
+	}
+	if err := r.conversations.UpsertConversation(ctx, ConversationRecord{
+		SessionID:    s.ID,
+		AgentID:      s.AgentID,
+		SessionScope: strings.TrimSpace(s.SessionScope),
+		ScopeKey:     strings.TrimSpace(s.ScopeKey),
+		Watchdog:     s.Watchdog,
+		Mode:         mode.String(),
+		Messages:     s.Messages,
+		Summary:      BuildSessionSummary(s),
+		TurnCount:    s.TurnCount,
+		Status:       "active",
+	}); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_responses_conversation_failed", "Persisting the OpenAI Responses conversation failed", s.AgentID, s.ID, "", map[string]any{
+			"conversation_mode": mode.String(),
+			"scope_key":         strings.TrimSpace(s.ScopeKey),
+		}, err)
+	}
+}
+
+func (r *OpenAIResponsesRuntime) persistTurn(ctx context.Context, turn AgentTurnRecord) {
+	if r.turns == nil {
+		return
+	}
+	if err := r.turns.AppendAgentTurn(ctx, turn); err != nil {
+		logPublisherRuntime(ctx, r.events, "error", "persist_openai_responses_turn_failed", "Persisting the OpenAI Responses agent turn failed", turn.AgentID, turn.SessionID, turn.EntityID, nil, err)
+	}
+}
+
+func (r *OpenAIResponsesRuntime) buildRequest(ctx context.Context, s *Session, input Message) (openAIResponsesRequest, error) {
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAIResponses)
+	items := make([]any, 0, len(s.Messages)+2)
+	for _, m := range s.Messages {
+		items = append(items, toOpenAIResponsesInputItems(m)...)
+	}
+	items = append(items, toOpenAIResponsesInputItems(input)...)
+	if len(items) == 0 {
+		return openAIResponsesRequest{}, errors.New("at least one input item is required")
+	}
+
+	tools := make([]openAIResponsesTool, 0, len(s.Tools))
+	for _, t := range s.Tools {
+		schema := t.Schema
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		if err := ValidateProviderToolSchema(t.Name, schema); err != nil {
+			return openAIResponsesRequest{}, err
+		}
+		tools = append(tools, openAIResponsesTool{
+			Type:        "function",
+			Name:        strings.TrimSpace(t.Name),
+			Description: DeliveredToolDescription(t),
+			Parameters:  schema,
+		})
+	}
+
+	modelReq := llmselection.ModelResolution{
+		Models: r.cfg.LLM.Models,
+	}
+	if actor, ok := runtimeactors.ActorFromContext(ctx); ok {
+		modelReq.Model = actor.Model
+	}
+	resolvedModel, err := llmselection.ResolveModel(profile, modelReq)
+	if err != nil {
+		return openAIResponsesRequest{}, err
+	}
+	return openAIResponsesRequest{
+		Model:        resolvedModel.ConcreteModel,
+		Instructions: strings.TrimSpace(s.SystemPrompt),
+		Input:        items,
+		Tools:        tools,
+	}, nil
+}
+
+func (r *OpenAIResponsesRuntime) sendRequest(ctx context.Context, payload []byte) ([]byte, openAIResponsesResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIResponsesURL(r.baseURL), bytes.NewReader(payload))
+	if err != nil {
+		return nil, openAIResponsesResponse{}, fmt.Errorf("build openai-responses request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer "+r.apiKey)
+
+	httpResp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, openAIResponsesResponse{}, fmt.Errorf("openai-responses request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, openAIResponsesResponse{}, fmt.Errorf("read openai-responses response: %w", err)
+	}
+
+	var parsed openAIResponsesResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return body, openAIResponsesResponse{}, fmt.Errorf("decode openai-responses response: %w", err)
+	}
+	if httpResp.StatusCode >= 300 {
+		msg := strings.TrimSpace(parsed.Error.Message)
+		if msg == "" {
+			msg = strings.TrimSpace(string(body))
+		}
+		return body, parsed, openAIResponsesHTTPError{StatusCode: httpResp.StatusCode, Message: msg}
+	}
+	if parsed.Error.Message != "" {
+		return body, parsed, fmt.Errorf("openai-responses error: %s", parsed.Error.Message)
+	}
+	return body, parsed, nil
+}
+
+func openAIResponsesURL(baseURL string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return normalized + "/responses"
+}
+
+func toOpenAIResponsesInputItems(m Message) []any {
+	role := strings.ToLower(strings.TrimSpace(m.Role))
+	content := strings.TrimSpace(m.Content)
+	switch role {
+	case "assistant":
+		items := make([]any, 0, 1+len(m.ToolCalls))
+		if content != "" {
+			items = append(items, openAIResponsesMessageInput{Role: "assistant", Content: content})
+		}
+		for _, call := range openAIResponsesFunctionCallInputs(m.ToolCalls) {
+			items = append(items, call)
+		}
+		return items
+	case "tool":
+		if items := openAIResponsesToolResultItems(content); len(items) > 0 {
+			return items
+		}
+		if content == "" {
+			return nil
+		}
+		return []any{openAIResponsesMessageInput{Role: "user", Content: "Tool result:\n" + content}}
+	case "system":
+		if content == "" {
+			return nil
+		}
+		return []any{openAIResponsesMessageInput{Role: "system", Content: content}}
+	default:
+		if content == "" {
+			return nil
+		}
+		return []any{openAIResponsesMessageInput{Role: "user", Content: content}}
+	}
+}
+
+func openAIResponsesFunctionCallInputs(calls []ToolCall) []openAIResponsesFunctionCallInput {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]openAIResponsesFunctionCallInput, 0, len(calls))
+	for _, call := range calls {
+		name := strings.TrimSpace(call.Name)
+		if name == "" {
+			continue
+		}
+		args := "{}"
+		if call.Arguments != nil {
+			if b, err := json.Marshal(call.Arguments); err == nil {
+				args = string(b)
+			}
+		}
+		out = append(out, openAIResponsesFunctionCallInput{
+			Type:      "function_call",
+			CallID:    strings.TrimSpace(call.ID),
+			Name:      name,
+			Arguments: args,
+		})
+	}
+	return out
+}
+
+func openAIResponsesToolResultItems(content string) []any {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(content), &entries); err != nil {
+		return nil
+	}
+	items := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		id, _ := entry["tool_call_id"].(string)
+		id = strings.TrimSpace(id)
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			continue
+		}
+		if id == "" {
+			items = append(items, openAIResponsesMessageInput{
+				Role:    "user",
+				Content: "Tool result:\n" + string(raw),
+			})
+			continue
+		}
+		items = append(items, openAIResponsesFunctionCallOutputInput{
+			Type:   "function_call_output",
+			CallID: id,
+			Output: string(raw),
+		})
+	}
+	return items
+}
+
+func convertOpenAIResponsesResponse(parsed openAIResponsesResponse) (Response, error) {
+	if len(parsed.Output) == 0 {
+		return Response{}, errors.New("openai-responses response missing output")
+	}
+	var content []string
+	resp := Response{
+		Message: Message{
+			Role: "assistant",
+		},
+	}
+	for _, item := range parsed.Output {
+		switch strings.TrimSpace(item.Type) {
+		case "message":
+			for _, part := range item.Content {
+				if strings.TrimSpace(part.Text) != "" {
+					content = append(content, strings.TrimSpace(part.Text))
+				}
+			}
+		case "function_call":
+			name := strings.TrimSpace(item.Name)
+			if name == "" {
+				continue
+			}
+			id := strings.TrimSpace(item.CallID)
+			if id == "" {
+				id = strings.TrimSpace(item.ID)
+			}
+			resp.ToolCalls = append(resp.ToolCalls, ToolCall{
+				ID:        id,
+				Name:      name,
+				Arguments: parseOpenAIResponsesToolArguments(item.Arguments),
+			})
+		}
+	}
+	resp.Message.Content = strings.Join(content, "\n")
+	resp.Message.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+	if resp.Message.Content == "" && len(resp.ToolCalls) == 0 {
+		return Response{}, errors.New("openai-responses response missing message or function call output")
+	}
+	return resp, nil
+}
+
+func parseOpenAIResponsesToolArguments(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]any{}
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return raw
+	}
+	return decoded
+}
+
+func openAIResponsesUsage(parsed openAIResponsesResponse) (UsageTokens, bool) {
+	if parsed.Usage.InputTokens == nil || parsed.Usage.OutputTokens == nil {
+		return UsageTokens{}, false
+	}
+	return UsageTokens{
+		InputTokens:  *parsed.Usage.InputTokens,
+		OutputTokens: *parsed.Usage.OutputTokens,
+		Model:        strings.TrimSpace(parsed.Model),
+	}, true
+}
+
+func parseOpenAIResponsesSSE(raw []byte) (Response, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var dataLines []string
+	var text strings.Builder
+	var calls []ToolCall
+	var completed *openAIResponsesResponse
+	process := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		payload := strings.TrimSpace(strings.Join(dataLines, "\n"))
+		dataLines = nil
+		if payload == "" || payload == "[DONE]" {
+			return nil
+		}
+		var evt openAIResponsesStreamEvent
+		if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+			return fmt.Errorf("decode openai-responses stream event: %w", err)
+		}
+		switch evt.Type {
+		case "response.output_text.delta":
+			text.WriteString(evt.Delta)
+		case "response.output_text.done":
+			if text.Len() == 0 {
+				text.WriteString(evt.Text)
+			}
+		case "response.function_call_arguments.done":
+			name := strings.TrimSpace(evt.Name)
+			if name != "" {
+				id := strings.TrimSpace(evt.CallID)
+				if id == "" {
+					id = strings.TrimSpace(evt.ItemID)
+				}
+				calls = append(calls, ToolCall{
+					ID:        id,
+					Name:      name,
+					Arguments: parseOpenAIResponsesToolArguments(evt.Arguments),
+				})
+			}
+		case "response.output_item.done":
+			if strings.TrimSpace(evt.Item.Type) == "function_call" && strings.TrimSpace(evt.Item.Name) != "" {
+				id := strings.TrimSpace(evt.Item.CallID)
+				if id == "" {
+					id = strings.TrimSpace(evt.Item.ID)
+				}
+				calls = append(calls, ToolCall{
+					ID:        id,
+					Name:      strings.TrimSpace(evt.Item.Name),
+					Arguments: parseOpenAIResponsesToolArguments(evt.Item.Arguments),
+				})
+			}
+		case "response.completed":
+			resp := evt.Response
+			completed = &resp
+		case "response.failed":
+			msg := strings.TrimSpace(evt.Response.Error.Message)
+			if msg == "" {
+				msg = "openai-responses stream failed"
+			}
+			return errors.New(msg)
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			if err := process(); err != nil {
+				return Response{}, err
+			}
+			continue
+		}
+		if after, ok := strings.CutPrefix(line, "data:"); ok {
+			dataLines = append(dataLines, strings.TrimSpace(after))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Response{}, err
+	}
+	if err := process(); err != nil {
+		return Response{}, err
+	}
+	if completed != nil && len(completed.Output) > 0 {
+		return convertOpenAIResponsesResponse(*completed)
+	}
+	resp := Response{
+		Message: Message{
+			Role:    "assistant",
+			Content: strings.TrimSpace(text.String()),
+		},
+		ToolCalls: calls,
+	}
+	resp.Message.ToolCalls = append([]ToolCall(nil), resp.ToolCalls...)
+	if resp.Message.Content == "" && len(resp.ToolCalls) == 0 {
+		return Response{}, errors.New("openai-responses stream missing message or function call output")
+	}
+	return resp, nil
+}
+
+type openAIResponsesHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e openAIResponsesHTTPError) Error() string {
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = "request failed"
+	}
+	return fmt.Sprintf("openai-responses status %d: %s", e.StatusCode, msg)
+}
+
+type openAIResponsesRequest struct {
+	Model        string                `json:"model"`
+	Instructions string                `json:"instructions,omitempty"`
+	Input        []any                 `json:"input"`
+	Tools        []openAIResponsesTool `json:"tools,omitempty"`
+}
+
+type openAIResponsesTool struct {
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Parameters  any    `json:"parameters"`
+}
+
+type openAIResponsesMessageInput struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIResponsesFunctionCallInput struct {
+	Type      string `json:"type"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openAIResponsesFunctionCallOutputInput struct {
+	Type   string `json:"type"`
+	CallID string `json:"call_id"`
+	Output string `json:"output"`
+}
+
+type openAIResponsesResponse struct {
+	ID     string                      `json:"id"`
+	Model  string                      `json:"model"`
+	Output []openAIResponsesOutputItem `json:"output"`
+	Usage  struct {
+		InputTokens  *int `json:"input_tokens"`
+		OutputTokens *int `json:"output_tokens"`
+		TotalTokens  *int `json:"total_tokens"`
+	} `json:"usage"`
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    any    `json:"code"`
+	} `json:"error"`
+}
+
+type openAIResponsesOutputItem struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Role      string `json:"role"`
+	CallID    string `json:"call_id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+	Content   []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+type openAIResponsesStreamEvent struct {
+	Type      string                    `json:"type"`
+	Delta     string                    `json:"delta"`
+	Text      string                    `json:"text"`
+	ItemID    string                    `json:"item_id"`
+	CallID    string                    `json:"call_id"`
+	Name      string                    `json:"name"`
+	Arguments string                    `json:"arguments"`
+	Item      openAIResponsesOutputItem `json:"item"`
+	Response  openAIResponsesResponse   `json:"response"`
+}

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -650,7 +650,34 @@ func parseOpenAIResponsesSSE(raw []byte) (Response, error) {
 	var dataLines []string
 	var text strings.Builder
 	var calls []ToolCall
+	pendingCalls := map[string]*openAIResponsesPendingFunctionCall{}
+	var pendingCallOrder []string
 	var completed *openAIResponsesResponse
+	ensurePendingCall := func(key string) (*openAIResponsesPendingFunctionCall, error) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, errors.New("openai-responses stream function call event missing item_id or call_id")
+		}
+		pending, ok := pendingCalls[key]
+		if !ok {
+			pending = &openAIResponsesPendingFunctionCall{ItemID: key}
+			pendingCalls[key] = pending
+			pendingCallOrder = append(pendingCallOrder, key)
+		}
+		return pending, nil
+	}
+	recordFunctionItem := func(item openAIResponsesOutputItem) error {
+		if strings.TrimSpace(item.Type) != "function_call" {
+			return nil
+		}
+		key := openAIResponsesFunctionCallStreamKey(item.ID, item.CallID)
+		pending, err := ensurePendingCall(key)
+		if err != nil {
+			return err
+		}
+		pending.mergeItem(item)
+		return nil
+	}
 	process := func() error {
 		if len(dataLines) == 0 {
 			return nil
@@ -671,30 +698,29 @@ func parseOpenAIResponsesSSE(raw []byte) (Response, error) {
 			if text.Len() == 0 {
 				text.WriteString(evt.Text)
 			}
+		case "response.output_item.added":
+			if err := recordFunctionItem(evt.Item); err != nil {
+				return err
+			}
+		case "response.function_call_arguments.delta":
+			pending, err := ensurePendingCall(openAIResponsesFunctionCallStreamKey(evt.ItemID, evt.CallID))
+			if err != nil {
+				return err
+			}
+			pending.mergeEvent(evt)
+			pending.Arguments += evt.Delta
 		case "response.function_call_arguments.done":
-			name := strings.TrimSpace(evt.Name)
-			if name != "" {
-				id := strings.TrimSpace(evt.CallID)
-				if id == "" {
-					id = strings.TrimSpace(evt.ItemID)
-				}
-				calls = append(calls, ToolCall{
-					ID:        id,
-					Name:      name,
-					Arguments: parseOpenAIResponsesToolArguments(evt.Arguments),
-				})
+			pending, err := ensurePendingCall(openAIResponsesFunctionCallStreamKey(evt.ItemID, evt.CallID))
+			if err != nil {
+				return err
+			}
+			pending.mergeEvent(evt)
+			if strings.TrimSpace(evt.Arguments) != "" {
+				pending.Arguments = evt.Arguments
 			}
 		case "response.output_item.done":
-			if strings.TrimSpace(evt.Item.Type) == "function_call" && strings.TrimSpace(evt.Item.Name) != "" {
-				id := strings.TrimSpace(evt.Item.CallID)
-				if id == "" {
-					id = strings.TrimSpace(evt.Item.ID)
-				}
-				calls = append(calls, ToolCall{
-					ID:        id,
-					Name:      strings.TrimSpace(evt.Item.Name),
-					Arguments: parseOpenAIResponsesToolArguments(evt.Item.Arguments),
-				})
+			if err := recordFunctionItem(evt.Item); err != nil {
+				return err
 			}
 		case "response.completed":
 			resp := evt.Response
@@ -727,8 +753,10 @@ func parseOpenAIResponsesSSE(raw []byte) (Response, error) {
 		return Response{}, err
 	}
 	if completed != nil && len(completed.Output) > 0 {
+		mergeOpenAIResponsesStreamCalls(completed, pendingCallOrder, pendingCalls)
 		return convertOpenAIResponsesResponse(*completed)
 	}
+	calls = append(calls, openAIResponsesPendingToolCalls(pendingCallOrder, pendingCalls)...)
 	resp := Response{
 		Message: Message{
 			Role:    "assistant",
@@ -741,6 +769,122 @@ func parseOpenAIResponsesSSE(raw []byte) (Response, error) {
 		return Response{}, errors.New("openai-responses stream missing message or function call output")
 	}
 	return resp, nil
+}
+
+func openAIResponsesFunctionCallStreamKey(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+type openAIResponsesPendingFunctionCall struct {
+	ItemID    string
+	CallID    string
+	Name      string
+	Arguments string
+}
+
+func (p *openAIResponsesPendingFunctionCall) mergeEvent(evt openAIResponsesStreamEvent) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(evt.ItemID) != "" {
+		p.ItemID = strings.TrimSpace(evt.ItemID)
+	}
+	if strings.TrimSpace(evt.CallID) != "" {
+		p.CallID = strings.TrimSpace(evt.CallID)
+	}
+	if strings.TrimSpace(evt.Name) != "" {
+		p.Name = strings.TrimSpace(evt.Name)
+	}
+}
+
+func (p *openAIResponsesPendingFunctionCall) mergeItem(item openAIResponsesOutputItem) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(item.ID) != "" {
+		p.ItemID = strings.TrimSpace(item.ID)
+	}
+	if strings.TrimSpace(item.CallID) != "" {
+		p.CallID = strings.TrimSpace(item.CallID)
+	}
+	if strings.TrimSpace(item.Name) != "" {
+		p.Name = strings.TrimSpace(item.Name)
+	}
+	if strings.TrimSpace(item.Arguments) != "" {
+		p.Arguments = item.Arguments
+	}
+}
+
+func mergeOpenAIResponsesStreamCalls(completed *openAIResponsesResponse, order []string, pending map[string]*openAIResponsesPendingFunctionCall) {
+	if completed == nil || len(pending) == 0 {
+		return
+	}
+	seen := map[string]struct{}{}
+	for i, item := range completed.Output {
+		if strings.TrimSpace(item.Type) != "function_call" {
+			continue
+		}
+		key := openAIResponsesFunctionCallStreamKey(item.ID, item.CallID)
+		if key != "" {
+			seen[key] = struct{}{}
+		}
+		if call, ok := pending[key]; ok {
+			if strings.TrimSpace(item.CallID) == "" {
+				item.CallID = call.CallID
+			}
+			if strings.TrimSpace(item.Name) == "" {
+				item.Name = call.Name
+			}
+			if strings.TrimSpace(item.Arguments) == "" {
+				item.Arguments = call.Arguments
+			}
+			completed.Output[i] = item
+		}
+	}
+	for _, key := range order {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		call := pending[key]
+		if call == nil || strings.TrimSpace(call.Name) == "" {
+			continue
+		}
+		completed.Output = append(completed.Output, openAIResponsesOutputItem{
+			ID:        call.ItemID,
+			Type:      "function_call",
+			CallID:    call.CallID,
+			Name:      call.Name,
+			Arguments: call.Arguments,
+		})
+	}
+}
+
+func openAIResponsesPendingToolCalls(order []string, pending map[string]*openAIResponsesPendingFunctionCall) []ToolCall {
+	if len(pending) == 0 {
+		return nil
+	}
+	calls := make([]ToolCall, 0, len(pending))
+	for _, key := range order {
+		call := pending[key]
+		if call == nil || strings.TrimSpace(call.Name) == "" {
+			continue
+		}
+		id := strings.TrimSpace(call.CallID)
+		if id == "" {
+			id = strings.TrimSpace(call.ItemID)
+		}
+		calls = append(calls, ToolCall{
+			ID:        id,
+			Name:      strings.TrimSpace(call.Name),
+			Arguments: parseOpenAIResponsesToolArguments(call.Arguments),
+		})
+	}
+	return calls
 }
 
 type openAIResponsesHTTPError struct {

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -1,0 +1,299 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"swarm/internal/config"
+	runtimeactors "swarm/internal/runtime/core/actors"
+	"swarm/internal/runtime/sessions"
+)
+
+func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	var requests []openAIResponsesRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("path = %s, want /responses", r.URL.Path)
+		}
+		if got := r.Header.Get("authorization"); got != "Bearer test-key" {
+			t.Fatalf("authorization = %q, want bearer test-key", got)
+		}
+		var req openAIResponsesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		w.Header().Set("content-type", "application/json")
+		switch len(requests) {
+		case 1:
+			if req.Model != "gpt-5.4-nano" {
+				t.Fatalf("first request model = %q, want cheap model", req.Model)
+			}
+			if !strings.Contains(req.Instructions, "system prompt") {
+				t.Fatalf("instructions = %q, want system prompt", req.Instructions)
+			}
+			if len(req.Tools) != 1 || req.Tools[0].Type != "function" || req.Tools[0].Name != "lookup" {
+				t.Fatalf("tools = %#v, want lookup function tool", req.Tools)
+			}
+			if !openAIResponsesRequestHasMessage(req.Input, "user", "check status") {
+				t.Fatalf("first request input missing user message: %#v", req.Input)
+			}
+			_, _ = w.Write([]byte(`{
+				"id":"resp_1",
+				"model":"gpt-5.4-nano",
+				"output":[{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"query\":\"status\"}"}],
+				"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18}
+			}`))
+		case 2:
+			if !openAIResponsesRequestHasFunctionCall(req.Input, "call_1") {
+				t.Fatalf("second request input missing prior function_call call_1: %#v", req.Input)
+			}
+			if !openAIResponsesRequestHasFunctionOutput(req.Input, "call_1") {
+				t.Fatalf("second request input missing function_call_output call_1: %#v", req.Input)
+			}
+			_, _ = w.Write([]byte(`{
+				"id":"resp_2",
+				"model":"gpt-5.4-nano",
+				"output":[{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],
+				"usage":{"input_tokens":13,"output_tokens":5,"total_tokens":18}
+			}`))
+		default:
+			t.Fatalf("unexpected request %d", len(requests))
+		}
+	}))
+	defer server.Close()
+
+	turns := &turnCapture{}
+	conversations := &captureConversationStore{}
+	budget := &budgetCapture{}
+	cfg := openAIResponsesTestConfig(server.URL)
+	runtime, err := RuntimeFactory{
+		Cfg:           cfg,
+		Sessions:      sessions.NewInMemoryRegistry(time.Second),
+		Turns:         turns,
+		Conversations: conversations,
+		Budget:        budget,
+		LockOwner:     "worker-1",
+	}.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, err := RequireProviderContract("openai_responses", runtime); err != nil {
+		t.Fatalf("RequireProviderContract: %v", err)
+	}
+
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
+		ID:       "agent-1",
+		Model:    "cheap",
+		EntityID: "entity-1",
+		FlowPath: "support/inst-1",
+	})
+	ctx = sessions.WithScope(ctx, sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1")
+	conv := NewConversation("agent-1", "task-1", "system prompt", []ToolDefinition{{
+		Name:        "lookup",
+		Description: "Lookup status",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+			"required": []any{"query"},
+		},
+	}}, SessionScoped, 5, runtime)
+	conv.SetToolExecutor(openAIToolExecutor{})
+
+	resp, err := conv.Step(ctx, "check status")
+	if err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if resp.Message.Content != "done" {
+		t.Fatalf("response content = %q, want done", resp.Message.Content)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if len(turns.records) != 2 {
+		t.Fatalf("turn records = %d, want 2", len(turns.records))
+	}
+	if turns.records[0].RuntimeMode != sessions.RuntimeModeSession.String() || !turns.records[0].ParseOK {
+		t.Fatalf("first turn record = %#v", turns.records[0])
+	}
+	if len(turns.records[0].ToolCalls) != 1 || turns.records[0].ToolCalls[0].ID != "call_1" {
+		t.Fatalf("first turn tool calls = %#v, want call_1", turns.records[0].ToolCalls)
+	}
+	if !strings.Contains(string(turns.records[0].ResponseRaw), `"resp_1"`) {
+		t.Fatalf("first turn raw response = %s, want raw Responses payload", string(turns.records[0].ResponseRaw))
+	}
+	if conversations.record.SessionID == "" || conversations.record.Mode != sessions.RuntimeModeSession.String() {
+		t.Fatalf("conversation record = %#v, want session snapshot", conversations.record)
+	}
+	if budget.runtimeMode != "openai_responses" || !budget.exact {
+		t.Fatalf("budget runtime=%q exact=%v, want openai_responses exact", budget.runtimeMode, budget.exact)
+	}
+	if budget.usage.InputTokens != 13 || budget.usage.OutputTokens != 5 || budget.usage.Model != "gpt-5.4-nano" {
+		t.Fatalf("budget usage = %#v, want final response usage", budget.usage)
+	}
+	if budget.meta["backend_profile"] != "openai_responses" || budget.meta["provider"] != "openai" || budget.meta["transport"] != "api" || budget.meta["resolved_model"] != "gpt-5.4-nano" {
+		t.Fatalf("budget meta = %#v, want backend/provider/transport/model facts", budget.meta)
+	}
+}
+
+func TestOpenAIResponsesRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","model":"gpt-5.4","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`))
+	}))
+	defer server.Close()
+
+	turns := &turnCapture{}
+	runtime := NewOpenAIResponsesRuntime(openAIResponsesTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", turns, nil, nil, nil)
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: "regular"})
+	ctx = sessions.WithScope(ctx, sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	_, err = runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "missing usage") {
+		t.Fatalf("ContinueSession error = %v, want missing usage", err)
+	}
+	if len(turns.records) != 1 || turns.records[0].ParseOK {
+		t.Fatalf("turn records = %#v, want parse failure", turns.records)
+	}
+}
+
+func TestOpenAIResponsesRuntimeFailsClosedWhenCredentialMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	runtime := NewOpenAIResponsesRuntime(openAIResponsesTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil)
+	ctx := sessions.WithScope(context.Background(), sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	_, err = runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Fatalf("ContinueSession error = %v, want missing OPENAI_API_KEY", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want fail closed before HTTP request", requests)
+	}
+}
+
+func TestOpenAIResponsesURLUsesConfiguredBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "official version base", base: "https://api.openai.com/v1", want: "https://api.openai.com/v1/responses"},
+		{name: "local fixture root", base: "https://fixture.test", want: "https://fixture.test/responses"},
+		{name: "trim slash", base: "https://fixture.test/v1/", want: "https://fixture.test/v1/responses"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openAIResponsesURL(tt.base); got != tt.want {
+				t.Fatalf("openAIResponsesURL(%q) = %q, want %q", tt.base, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponsesSSEParserNormalizesTextAndFunctionCalls(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"hel"}`,
+		``,
+		`data: {"type":"response.output_text.delta","delta":"lo"}`,
+		``,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"query\":\"status\"}"}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	resp, err := parseOpenAIResponsesSSE([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseOpenAIResponsesSSE: %v", err)
+	}
+	if resp.Message.Content != "hello" {
+		t.Fatalf("content = %q, want hello", resp.Message.Content)
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "call_1" || resp.ToolCalls[0].Name != "lookup" {
+		t.Fatalf("tool calls = %#v, want lookup call_1", resp.ToolCalls)
+	}
+}
+
+func openAIResponsesTestConfig(baseURL string) *config.Config {
+	return &config.Config{
+		LLM: config.LLMConfig{
+			Backend: "openai_responses",
+			Session: config.LLMSessionConfig{
+				LockTTL:               time.Second,
+				RotateAfterTurns:      40,
+				RotateOnParseFailures: 3,
+			},
+			OpenAIResponses: config.OpenAIResponsesConfig{
+				BaseURL: baseURL,
+			},
+		},
+	}
+}
+
+func openAIResponsesRequestHasMessage(items []any, role, content string) bool {
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if obj["role"] == role && strings.Contains(fmtString(obj["content"]), content) {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIResponsesRequestHasFunctionCall(items []any, id string) bool {
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if obj["type"] == "function_call" && obj["call_id"] == id {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIResponsesRequestHasFunctionOutput(items []any, id string) bool {
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if obj["type"] == "function_call_output" && obj["call_id"] == id {
+			return true
+		}
+	}
+	return false
+}
+
+func fmtString(v any) string {
+	if v == nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(strings.Trim(fmt.Sprintf("%v", v), `"`)), `\n`, "\n"), `\t`, "\t"))
+}

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -236,6 +236,39 @@ func TestOpenAIResponsesSSEParserNormalizesTextAndFunctionCalls(t *testing.T) {
 	}
 }
 
+func TestOpenAIResponsesSSEParserNormalizesFunctionCallLifecycleThroughCompleted(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","call_id":"call_1","name":"lookup","arguments":""}}`,
+		``,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"query\""}`,
+		``,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":":\"status\"}"}`,
+		``,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\"query\":\"status\"}"}`,
+		``,
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"lookup","arguments":""}}`,
+		``,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.4","output":[{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"need lookup"}]},{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":""}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	resp, err := parseOpenAIResponsesSSE([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseOpenAIResponsesSSE: %v", err)
+	}
+	if resp.Message.Content != "need lookup" {
+		t.Fatalf("content = %q, want completed response text", resp.Message.Content)
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "call_1" || resp.ToolCalls[0].Name != "lookup" {
+		t.Fatalf("tool calls = %#v, want lookup call_1", resp.ToolCalls)
+	}
+	args, ok := resp.ToolCalls[0].Arguments.(map[string]any)
+	if !ok || args["query"] != "status" {
+		t.Fatalf("tool call arguments = %#v, want streamed query status", resp.ToolCalls[0].Arguments)
+	}
+}
+
 func openAIResponsesTestConfig(baseURL string) *config.Config {
 	return &config.Config{
 		LLM: config.LLMConfig{

--- a/internal/runtime/llm/provider_contract_test.go
+++ b/internal/runtime/llm/provider_contract_test.go
@@ -52,6 +52,14 @@ func TestProviderContractsValidateShippedRuntimes(t *testing.T) {
 			transport:       ProviderTransportAPI,
 			usageAccounting: BudgetUsageExact,
 		},
+		{
+			name:            "openai responses",
+			mode:            "openai_responses",
+			runtime:         NewOpenAIResponsesRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil),
+			provider:        "openai",
+			transport:       ProviderTransportAPI,
+			usageAccounting: BudgetUsageExact,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,6 +98,7 @@ func TestRuntimeFactoryValidatesProviderContract(t *testing.T) {
 		{backend: "anthropic", runtimeMode: "api", provider: "anthropic"},
 		{backend: "claude_cli", runtimeMode: "cli_test", provider: "claude"},
 		{backend: "openai_compatible", runtimeMode: "openai_compatible", provider: "openai_compatible"},
+		{backend: "openai_responses", runtimeMode: "openai_responses", provider: "openai"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.backend, func(t *testing.T) {

--- a/internal/runtime/llm/selection/profile.go
+++ b/internal/runtime/llm/selection/profile.go
@@ -9,6 +9,7 @@ const (
 	BackendAnthropic        = "anthropic"
 	BackendClaudeCLI        = "claude_cli"
 	BackendOpenAICompatible = "openai_compatible"
+	BackendOpenAIResponses  = "openai_responses"
 	BackendMock             = "mock"
 	BackendLocal            = "local"
 
@@ -18,6 +19,7 @@ const (
 	ProviderAnthropic        = "anthropic"
 	ProviderClaude           = "claude"
 	ProviderOpenAICompatible = "openai_compatible"
+	ProviderOpenAI           = "openai"
 	ProviderMock             = "mock"
 	ProviderLocal            = "local"
 
@@ -26,8 +28,9 @@ const (
 	TransportMock  = "mock"
 	TransportLocal = "local"
 
-	ProviderContractRuntimeModeAPI       = "api"
-	ProviderContractRuntimeModeClaudeCLI = "cli_test"
+	ProviderContractRuntimeModeAPI             = "api"
+	ProviderContractRuntimeModeClaudeCLI       = "cli_test"
+	ProviderContractRuntimeModeOpenAIResponses = BackendOpenAIResponses
 
 	DefaultBackend = BackendAnthropic
 
@@ -44,6 +47,10 @@ const (
 	OpenAICompatibleBaseURLConfigField = "llm.openai_compatible.base_url"
 	OpenAICompatibleDefaultModelConfig = "llm.openai_compatible.default_model"
 	OpenAICompatibleLowCostModelConfig = "llm.openai_compatible.low_cost_model"
+
+	OpenAIResponsesCredentialEnv      = "OPENAI_API_KEY"
+	OpenAIResponsesBaseURLConfigField = "llm.openai_responses.base_url"
+	OpenAIResponsesDefaultBaseURL     = "https://api.openai.com/v1"
 )
 
 type CredentialSource struct {
@@ -53,10 +60,11 @@ type CredentialSource struct {
 }
 
 type BaseURLSource struct {
-	ConfigKey string
-	EnvVar    string
-	Required  bool
-	Purpose   string
+	ConfigKey      string
+	EnvVar         string
+	Required       bool
+	BuiltInDefault string
+	Purpose        string
 }
 
 type Profile struct {
@@ -105,16 +113,19 @@ var builtInModelAliases = ModelAliases{
 		BackendAnthropic:        "claude-3-5-haiku",
 		BackendClaudeCLI:        "haiku",
 		BackendOpenAICompatible: "gpt-compatible-mini",
+		BackendOpenAIResponses:  "gpt-5.4-nano",
 	},
 	ModelAliasRegular: {
 		BackendAnthropic:        "claude-3-5-sonnet",
 		BackendClaudeCLI:        "sonnet",
 		BackendOpenAICompatible: "gpt-compatible",
+		BackendOpenAIResponses:  "gpt-5.4",
 	},
 	ModelAliasFrontier: {
 		BackendAnthropic:        "claude-3-opus",
 		BackendClaudeCLI:        "opus",
 		BackendOpenAICompatible: "gpt-compatible-frontier",
+		BackendOpenAIResponses:  "gpt-5.5",
 	},
 }
 
@@ -157,6 +168,24 @@ var profiles = map[string]Profile{
 			ConfigKey: OpenAICompatibleBaseURLConfigField,
 			Required:  true,
 			Purpose:   "openai-compatible chat completions endpoint base url",
+		},
+		Active: true,
+	},
+	BackendOpenAIResponses: {
+		ID:          BackendOpenAIResponses,
+		Provider:    ProviderOpenAI,
+		Transport:   TransportAPI,
+		RuntimeMode: ProviderContractRuntimeModeOpenAIResponses,
+		Credential: CredentialSource{
+			EnvVar:   OpenAIResponsesCredentialEnv,
+			Required: true,
+			Purpose:  "native OpenAI Responses runtime",
+		},
+		BaseURL: BaseURLSource{
+			ConfigKey:      OpenAIResponsesBaseURLConfigField,
+			Required:       false,
+			BuiltInDefault: OpenAIResponsesDefaultBaseURL,
+			Purpose:        "native OpenAI Responses endpoint base url",
 		},
 		Active: true,
 	},
@@ -290,6 +319,9 @@ func CredentialValue(profile Profile, lookup EnvLookup) string {
 func ResolveBaseURL(profile Profile, raw string) (string, error) {
 	baseURL := strings.TrimSpace(raw)
 	if baseURL == "" {
+		if strings.TrimSpace(profile.BaseURL.BuiltInDefault) != "" {
+			return strings.TrimRight(strings.TrimSpace(profile.BaseURL.BuiltInDefault), "/"), nil
+		}
 		if profile.BaseURL.Required {
 			field := strings.TrimSpace(profile.BaseURL.ConfigKey)
 			if field == "" {

--- a/internal/runtime/llm/selection/profile_test.go
+++ b/internal/runtime/llm/selection/profile_test.go
@@ -16,6 +16,7 @@ func TestResolveActiveBackendProfiles(t *testing.T) {
 		{raw: BackendAnthropic, wantID: BackendAnthropic, provider: ProviderAnthropic, transport: TransportAPI},
 		{raw: BackendClaudeCLI, wantID: BackendClaudeCLI, provider: ProviderClaude, transport: TransportCLI},
 		{raw: BackendOpenAICompatible, wantID: BackendOpenAICompatible, provider: ProviderOpenAICompatible, transport: TransportAPI},
+		{raw: BackendOpenAIResponses, wantID: BackendOpenAIResponses, provider: ProviderOpenAI, transport: TransportAPI},
 	}
 	for _, tt := range tests {
 		t.Run(tt.raw, func(t *testing.T) {
@@ -31,7 +32,7 @@ func TestResolveActiveBackendProfiles(t *testing.T) {
 }
 
 func TestResolveActiveBackendRejectsReservedAndUnknown(t *testing.T) {
-	for _, raw := range []string{BackendMock, BackendLocal, LegacyBackendAPI, LegacyBackendCLITest, "openai", "openai_responses"} {
+	for _, raw := range []string{BackendMock, BackendLocal, LegacyBackendAPI, LegacyBackendCLITest, "openai"} {
 		t.Run(raw, func(t *testing.T) {
 			if _, err := ResolveActiveBackend(raw); err == nil {
 				t.Fatal("expected error")
@@ -41,7 +42,7 @@ func TestResolveActiveBackendRejectsReservedAndUnknown(t *testing.T) {
 }
 
 func TestResolvePersistedBackendAllowsReservedProfiles(t *testing.T) {
-	for _, raw := range []string{BackendAnthropic, BackendClaudeCLI, BackendOpenAICompatible, BackendMock, BackendLocal} {
+	for _, raw := range []string{BackendAnthropic, BackendClaudeCLI, BackendOpenAICompatible, BackendOpenAIResponses, BackendMock, BackendLocal} {
 		t.Run(raw, func(t *testing.T) {
 			profile, err := ResolvePersistedBackend(raw)
 			if err != nil {
@@ -54,9 +55,13 @@ func TestResolvePersistedBackendAllowsReservedProfiles(t *testing.T) {
 	}
 }
 
-func TestResolvePersistedBackendRejectsSourceOnlyOpenAIResponsesProfile(t *testing.T) {
-	if _, err := ResolvePersistedBackend("openai_responses"); err == nil || !strings.Contains(err.Error(), "unsupported llm backend profile") {
-		t.Fatalf("ResolvePersistedBackend(openai_responses) error = %v, want unsupported profile", err)
+func TestResolvePersistedBackendAcceptsActivatedOpenAIResponsesProfile(t *testing.T) {
+	profile, err := ResolvePersistedBackend(BackendOpenAIResponses)
+	if err != nil {
+		t.Fatalf("ResolvePersistedBackend(openai_responses): %v", err)
+	}
+	if profile.Provider != ProviderOpenAI || profile.RuntimeMode != ProviderContractRuntimeModeOpenAIResponses {
+		t.Fatalf("openai_responses profile = %#v", profile)
 	}
 }
 
@@ -69,6 +74,7 @@ func TestMigratePersistedBackendBackfillsLegacyProfiles(t *testing.T) {
 		{raw: LegacyBackendAPI, want: BackendAnthropic, changed: true},
 		{raw: LegacyBackendCLITest, want: BackendClaudeCLI, changed: true},
 		{raw: BackendOpenAICompatible, want: BackendOpenAICompatible},
+		{raw: BackendOpenAIResponses, want: BackendOpenAIResponses},
 		{raw: BackendMock, want: BackendMock},
 	}
 	for _, tt := range tests {
@@ -184,6 +190,44 @@ func TestResolveOpenAICompatibleProfileAuthority(t *testing.T) {
 	}
 	if _, err := ResolveModelName(profile, ModelResolution{}); err == nil || !strings.Contains(err.Error(), "model is required") {
 		t.Fatalf("ResolveModelName missing error = %v, want model required", err)
+	}
+}
+
+func TestResolveOpenAIResponsesProfileAuthority(t *testing.T) {
+	profile, err := ResolveActiveBackend(BackendOpenAIResponses)
+	if err != nil {
+		t.Fatalf("ResolveActiveBackend: %v", err)
+	}
+	if profile.Provider != ProviderOpenAI || profile.RuntimeMode != ProviderContractRuntimeModeOpenAIResponses {
+		t.Fatalf("profile = %#v, want provider openai runtime openai_responses", profile)
+	}
+	if profile.Credential.EnvVar != OpenAIResponsesCredentialEnv {
+		t.Fatalf("credential env = %q, want %q", profile.Credential.EnvVar, OpenAIResponsesCredentialEnv)
+	}
+	if got, err := ResolveBaseURL(profile, ""); err != nil || got != OpenAIResponsesDefaultBaseURL {
+		t.Fatalf("ResolveBaseURL default = %q, %v; want %s", got, err, OpenAIResponsesDefaultBaseURL)
+	}
+	if got, err := ResolveBaseURL(profile, " https://proxy.test/v1/ "); err != nil || got != "https://proxy.test/v1" {
+		t.Fatalf("ResolveBaseURL override = %q, %v; want normalized base url", got, err)
+	}
+	for alias, want := range map[string]string{
+		ModelAliasCheap:    "gpt-5.4-nano",
+		ModelAliasRegular:  "gpt-5.4",
+		ModelAliasFrontier: "gpt-5.5",
+	} {
+		got, err := ResolveModelName(profile, ModelResolution{Model: alias})
+		if err != nil || got != want {
+			t.Fatalf("ResolveModelName(%s) = %q, %v; want %s", alias, got, err, want)
+		}
+	}
+	got, err := ResolveModelName(profile, ModelResolution{
+		Model: ModelAliasRegular,
+		Models: ModelAliases{
+			ModelAliasRegular: {BackendOpenAIResponses: "gpt-test"},
+		},
+	})
+	if err != nil || got != "gpt-test" {
+		t.Fatalf("ResolveModelName override = %q, %v; want gpt-test", got, err)
 	}
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -400,7 +400,7 @@ func (s *PostgresStore) ensureAgentLLMBackendProfiles(ctx context.Context) error
 		WHERE llm_backend IS NOT NULL;
 		ALTER TABLE agents
 			ADD CONSTRAINT agents_llm_backend_check
-			CHECK (llm_backend IN ('anthropic', 'claude_cli', 'openai_compatible', 'mock', 'local'));
+			CHECK (llm_backend IN ('anthropic', 'claude_cli', 'openai_compatible', 'openai_responses', 'mock', 'local'));
 	`); err != nil {
 		return fmt.Errorf("migrate agents.llm_backend profiles: %w", err)
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -797,6 +797,9 @@ func TestPostgresStore_EnsureSchemaCompatibilityColumnsMigratesAgentLLMBackendPr
 	if _, err := db.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode) VALUES ('agent-legacy', 'worker', 'sonnet', 'api', 'task')`); err == nil {
 		t.Fatal("insert legacy llm_backend api succeeded after migration")
 	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode) VALUES ('agent-openai-responses', 'worker', 'regular', 'openai_responses', 'task')`); err != nil {
+		t.Fatalf("insert openai_responses llm_backend after migration: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, conversation_mode) VALUES ('agent-default', 'worker', 'sonnet', 'task')`); err != nil {
 		t.Fatalf("insert default llm_backend after migration: %v", err)
 	}
@@ -5743,6 +5746,20 @@ func TestProjectPersistedAgentConfig_UsesCanonicalLLMBackendProfiles(t *testing.
 	}
 	if projection.LLMBackend != "openai_compatible" {
 		t.Fatalf("llm_backend = %q, want openai_compatible", projection.LLMBackend)
+	}
+
+	projection, err = projectPersistedAgentConfig(runtimeactors.AgentConfig{
+		ID:               "agent-openai-responses-backend",
+		Role:             "reviewer",
+		Model:            "regular",
+		LLMBackend:       "openai_responses",
+		ConversationMode: "task",
+	}, "")
+	if err != nil {
+		t.Fatalf("projectPersistedAgentConfig openai_responses: %v", err)
+	}
+	if projection.LLMBackend != "openai_responses" {
+		t.Fatalf("llm_backend = %q, want openai_responses", projection.LLMBackend)
 	}
 
 	_, err = projectPersistedAgentConfig(runtimeactors.AgentConfig{

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -220,6 +220,9 @@ func TestSQLiteSchemaStoreMigratesLegacyAgentLLMBackendProfiles(t *testing.T) {
 	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode) VALUES ('agent-legacy', 'worker', 'sonnet', 'api', 'task')`); err == nil {
 		t.Fatal("insert legacy sqlite llm_backend api succeeded after migration")
 	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode) VALUES ('agent-openai-responses', 'worker', 'regular', 'openai_responses', 'task')`); err != nil {
+		t.Fatalf("insert openai_responses sqlite llm_backend after migration: %v", err)
+	}
 	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, conversation_mode) VALUES ('agent-default', 'worker', 'sonnet', 'task')`); err != nil {
 		t.Fatalf("insert default sqlite llm_backend after migration: %v", err)
 	}

--- a/openrpc.json
+++ b/openrpc.json
@@ -8055,7 +8055,7 @@
             "type": "string"
           },
           "invocation_type": {
-            "description": "Backend profile id recorded by the spend ledger, such as anthropic, claude_cli, or openai_compatible.",
+            "description": "Backend profile id recorded by the spend ledger, such as anthropic, claude_cli, openai_compatible, or openai_responses.",
             "minLength": 1,
             "type": "string"
           },

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2444,8 +2444,14 @@ engine:
           budget_usage_accounting: exact
           native_tool_policy: fallback-aware non-strict runtime
           protocol: chat_completions_compatible_json
+        openai_responses:
+          provider: openai
+          transport: api
+          budget_usage_accounting: exact
+          native_tool_policy: fallback-aware non-strict runtime
+          protocol: native_openai_responses
       split_boundaries:
-      - Adding additional provider identities or protocol families such as OpenAI Responses, OpenRouter, Ollama, Bedrock,
+      - Adding additional provider identities or protocol families such as OpenRouter, Ollama, Bedrock,
         Azure OpenAI, Vertex, or vLLM requires a separate provider implementation/parity gate that consumes llm_provider_selection_config_authority.
       - Renaming cli_test is a separate compatibility/semantics decision.
       - Provider-selection UI is outside this adapter-contract slice.
@@ -2520,13 +2526,12 @@ engine:
             proof_boundary: This profile proves one non-Anthropic Chat Completions-compatible HTTP provider path. It remains
               named openai_compatible and is not a native OpenAI Responses API provider, not an official-OpenAI-only provider
               identity, not OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM closure, and not a provider matrix.
-        pending_backend_profiles:
           openai_responses:
-            status: source_authority_only_not_selectable
             provider: openai
             transport: api
             provider_contract_runtime_mode: openai_responses
             protocol: Native OpenAI Responses API resource path /responses relative to the configured base URL.
+            legacy_backend_ids: []
             credential_source:
               env_var: OPENAI_API_KEY
               required: true
@@ -2536,11 +2541,13 @@ engine:
               required: false
               built_in_default: https://api.openai.com/v1
               rule: "This is deployment configuration, not a secret. Runtime config is canonical; no env-var endpoint selector is promoted."
-            activation_rule: "This profile is source-authority only after #1229. It is not active for --backend, config llm.backend, persisted agents.llm_backend, RuntimeFactory materialization, or CLI help until #1224 or a later gated implementation PR promotes the runtime adapter."
             proof_boundary: >
-              This profile names native OpenAI Responses source authority only. It is not openai_compatible,
-              not Chat Completions-compatible HTTP JSON, not an OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM provider-matrix
-              proof, and not a provider runtime implementation.
+              This profile proves the first native OpenAI Responses runtime adapter subset: platform-managed text transcript,
+              platform function tools/function-call outputs, Responses output normalization, deterministic Responses SSE parsing,
+              turn/conversation persistence, and exact provider-reported usage. It is not openai_compatible, not
+              Chat Completions-compatible HTTP JSON, not provider-hosted previous_response_id continuity, not OpenAI built-in
+              tools/file/image/audio/prompt/conversation closure, not an OpenRouter/Ollama/Bedrock/Azure/Vertex/vLLM provider-matrix
+              proof, and not a provider runtime implementation for any backend id named openai.
         reserved_persisted_backend_profiles:
           mock: Reserved persisted profile id for fixture replay. It is not a supported active runtime backend until a
             dedicated provider/runtime owner lands.
@@ -2550,21 +2557,21 @@ engine:
           openai: >
             Not active for this authority because the shipped non-Anthropic proof is Chat Completions-compatible and
             may front OpenRouter or local-compatible endpoints. Native OpenAI Responses source authority is named
-            openai_responses by #1229, but it remains source-authority only and not selectable until #1224 or a later gated
-            implementation PR promotes the runtime adapter.
+            and activated as openai_responses by #1229/#1224; provider identity openai remains intentionally separate from
+            backend profile id and openai must not be accepted as a selector alias.
       native_openai_responses_source_authority:
         promoted_by: '#1229'
-        implementation_status: source_authority_only_runtime_split
+        implementation_status: runtime_adapter_activated_first_subset
         target_backend_profile_id: openai_responses
         provider_identity: openai
-        activation_status: pending_runtime_adapter_not_selectable
+        activation_status: active_backend_profile_runtime_adapter_promoted_by_1224
         authoritative_refs:
           - "https://platform.openai.com/docs/api-reference/responses"
           - "https://platform.openai.com/docs/models"
           - "https://platform.openai.com/docs/guides/function-calling?api-mode=responses"
           - "https://platform.openai.com/docs/guides/streaming-responses?api-mode=responses"
         active_selector_policy:
-          - "openai_responses MUST NOT be accepted by --backend, config llm.backend, persisted agents.llm_backend, RuntimeFactory, or CLI help until a later gated implementation PR activates the runtime adapter."
+          - "openai_responses is accepted by --backend, config llm.backend, persisted agents.llm_backend, RuntimeFactory, and CLI help after #1224."
           - "openai remains a rejected backend selector name; provider identity and backend profile id are intentionally separate."
           - "openai_compatible remains Chat Completions-compatible HTTP JSON and MUST NOT inherit native Responses semantics."
         protocol_family:
@@ -2579,8 +2586,8 @@ engine:
             Platform function tools only. OpenAI built-in tools such as web search, file search, code interpreter,
             computer use, hosted shell, MCP, and tool search are explicitly outside the first subset until separately gated.
           streaming_scope: >
-            Streaming must use Responses server-sent events when #1224 promotes runtime implementation. The
-            source authority names the parser family, but #1229 does not implement streaming or make it selectable.
+            Streaming uses Responses server-sent events for the first supported subset. The parser family is owned by
+            the native Responses adapter behind internal/runtime/llm.ProviderContract.
           session_continuity: >
             Platform session IDs and platform-managed transcript history remain canonical. Provider response
             IDs may be persisted as raw provider metadata, but previous_response_id/provider-hosted continuity is deferred
@@ -2597,15 +2604,14 @@ engine:
           rules:
             - Environment variables provide the OpenAI API secret only; they do not select the backend or endpoint.
             - Runtime config is canonical for endpoint/base URL overrides used by deterministic tests or deployments.
-            - "Credential validation happens only after a selected active backend exists; #1229 does not make openai_responses active."
+            - "Credential validation happens after openai_responses is selected and must fail closed before HTTP if OPENAI_API_KEY is missing."
         model_alias_defaults:
           cheap: gpt-5.4-nano
           regular: gpt-5.4
           frontier: gpt-5.5
         model_alias_rule: >
-          The target profile uses the existing llm.models provider-scoped alias map. These defaults are source
-          authority for #1224 but are not consumed by boot or verify until openai_responses is activated by a later gated
-          implementation PR.
+          The target profile uses the existing llm.models provider-scoped alias map. These defaults are consumed by
+          verify, boot, and runtime materialization for openai_responses after #1224.
         provider_contract_expectations:
           tool_schema:
             - Translate platform tools to OpenAI Responses function tools with validated JSON schema parameters.
@@ -2624,9 +2630,9 @@ engine:
             - Use exact provider-reported usage when available; fail closed or explicitly record unsupported usage if the provider
               response lacks required accounting fields.
         store_profile_implication: >
-          No agents.llm_backend schema/check migration is required for #1229 because openai_responses
-          is not active or persisted by this source-authority slice. The later runtime implementation PR must update store,
-          CLI, config, and RuntimeFactory activation together if it makes openai_responses selectable.
+          #1224 updates agents.llm_backend schema/check admission so openai_responses is a valid active persisted backend
+          profile id alongside anthropic, claude_cli, and openai_compatible. Legacy api and cli_test backfill behavior
+          remains unchanged.
         split_boundaries:
           - '#1224 owns native OpenAI Responses runtime adapter implementation and deterministic protocol proof after this source authority lands.'
           - Provider-hosted continuity through previous_response_id, OpenAI built-in tools, file/image/audio inputs, provider
@@ -2646,14 +2652,17 @@ engine:
             anthropic: claude-3-5-haiku
             claude_cli: haiku
             openai_compatible: gpt-compatible-mini
+            openai_responses: gpt-5.4-nano
           regular:
             anthropic: claude-3-5-sonnet
             claude_cli: sonnet
             openai_compatible: gpt-compatible
+            openai_responses: gpt-5.4
           frontier:
             anthropic: claude-3-opus
             claude_cli: opus
             openai_compatible: gpt-compatible-frontier
+            openai_responses: gpt-5.5
         alias_vocabulary_declaration: none; aliases are free-form strings in bundles, with well-formedness checked by verify
           and selected-backend resolution checked at boot.
         resolution_rule: Resolution is deterministic and provider-scoped. The canonical input is (backend profile id, authored
@@ -2669,6 +2678,7 @@ engine:
         - ANTHROPIC_API_KEY
         - CLAUDE_CODE_OAUTH_TOKEN
         - OPENAI_COMPATIBLE_API_KEY
+        - OPENAI_API_KEY
         - SWARM_TOOL_GATEWAY_TOKEN
         - SWARM_API_TOKEN
         - database password env/store sources
@@ -2681,7 +2691,7 @@ engine:
         infra_connection_override_policy: Config remains canonical; env overrides are allowed only for pragmatic infra/connection
           values explicitly named by their owning config sections. This does not allow env-based backend selection.
       persistence_rules:
-      - Target agents.llm_backend stores the provider-named backend profile ids anthropic, claude_cli, and openai_compatible.
+      - Target agents.llm_backend stores the provider-named backend profile ids anthropic, claude_cli, openai_compatible, and openai_responses.
       - "Legacy persisted backend ids api and cli_test are non-authoritative after #1128/#1129 migration and must be explicitly backfilled to anthropic and claude_cli."
       - "Authored model aliases replace model_tier as the bundle/source selector. Store/schema migration was closed by #1129."
       - Runtime manager/default materialization must persist the resolved backend profile id and model alias rather than
@@ -2694,8 +2704,8 @@ engine:
       - '#1128 owns backend selection/config discovery, --backend precedence, env selector retirement, and backend id migration.'
       - '#1129 owns model_tier to model alias migration, boot/verify alias validation, runtime model resolution, and audit writes.'
       - '#1130 owns public/local config and model-alias cleanup after behavior lands.'
-      - '#1229 defines native OpenAI Responses source authority only and MUST NOT make openai_responses selectable or add a runtime adapter.'
-      - '#1224 owns native OpenAI Responses runtime implementation/protocol proof after #1229.'
+      - '#1229 defines native OpenAI Responses source authority.'
+      - '#1224 owns native OpenAI Responses active backend runtime implementation/protocol proof after #1229.'
       - Implementing OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other additional
         provider remains a separate provider implementation/parity gate.
       - Native multi-backend-per-run remains deferred until a separate real user need is gated.
@@ -4331,14 +4341,14 @@ platform_tables:
         — set only for agents scoped to a specific entity (rare). The contract in agents.yaml is the source of truth and
         permissions_bundle is resolved at boot into the persisted permissions array rather than being stored directly.
         llm_backend stores the backend profile id owned by llm_provider_selection_config_authority. Active runtime profiles
-        are anthropic (Anthropic API transport), claude_cli (Claude CLI transport), and openai_compatible (Chat Completions-compatible
-        HTTP transport); legacy api and cli_test persisted rows are migration/backfill inputs only and are not valid new
+        are anthropic (Anthropic API transport), claude_cli (Claude CLI transport), openai_compatible (Chat Completions-compatible
+        HTTP transport), and openai_responses (native OpenAI Responses API transport); legacy api and cli_test persisted rows are migration/backfill inputs only and are not valid new
         config/operator inputs. mock and local are reserved persisted profile ids and are not active runtimes until a dedicated provider/runtime owner lands. This value is provider-selection
         deployment truth, not provider identity alone and not transport mode alone. This is a deployment/agent property, not
         a session property. agent_sessions.runtime_mode tracks conversation scope only.'
       ddl: "CREATE TABLE agents (\n    agent_id          TEXT PRIMARY KEY,\n    flow_instance     TEXT,\n    role        \
         \      TEXT NOT NULL,\n    model             TEXT NOT NULL,\n    llm_backend       TEXT NOT NULL DEFAULT 'anthropic' CHECK\
-        \ (llm_backend IN ('anthropic', 'claude_cli', 'openai_compatible', 'mock', 'local')),\n    conversation_mode TEXT NOT NULL CHECK (conversation_mode\
+        \ (llm_backend IN ('anthropic', 'claude_cli', 'openai_compatible', 'openai_responses', 'mock', 'local')),\n    conversation_mode TEXT NOT NULL CHECK (conversation_mode\
         \ IN ('task', 'session', 'session_per_entity')),\n    parent_agent_id   TEXT,\n    entity_id         UUID,\n    config\
         \            JSONB NOT NULL DEFAULT '{}',\n    subscriptions     JSONB NOT NULL DEFAULT '[]',\n    emit_events   \
         \    JSONB NOT NULL DEFAULT '[]',\n    tools             JSONB NOT NULL DEFAULT '[]',\n    permissions       JSONB\
@@ -8586,7 +8596,7 @@ cli_specification:
         enable-disable controls and env/config listener precedence remain pending follow-up children.
       runtime_config_backend_selection:
         config_flag: --config <path>
-        backend_flag: --backend <anthropic|claude_cli|openai_compatible>
+        backend_flag: --backend <anthropic|claude_cli|openai_compatible|openai_responses>
         owner: engine.agent_session_management.llm_provider_selection_config_authority
         rule: >
           `swarm serve` consumes the shared runtime config resolver: explicit --config first, config.yaml beside the
@@ -9075,7 +9085,7 @@ cli_specification:
       - --bundle-hash <bundle-v1:sha256:...>
       - --bundle-fingerprint <sha>
       - --config <path>
-      - --backend <anthropic|claude_cli|openai_compatible>
+      - --backend <anthropic|claude_cli|openai_compatible|openai_responses>
       - --contracts <path>
       - --data <path>
       - --platform-spec <path>
@@ -12404,7 +12414,7 @@ api_specification:
           invocation_type:
             type: string
             minLength: 1
-            description: Backend profile id recorded by the spend ledger, such as anthropic, claude_cli, or openai_compatible.
+            description: Backend profile id recorded by the spend ledger, such as anthropic, claude_cli, openai_compatible, or openai_responses.
           model:
             type: string
             minLength: 1


### PR DESCRIPTION
## Summary

- Activates the source-owned `openai_responses` backend profile across platform spec, selection/config validation, store admission, CLI help, RuntimeFactory, ProviderContract, OpenRPC, and tests.
- Adds a separate native OpenAI Responses runtime adapter for `POST /responses` with platform function tools, function-call output replay, response/tool-call normalization, deterministic SSE parser coverage, turn/conversation persistence, and exact provider usage accounting.
- Keeps `openai` rejected as a backend selector and keeps `openai_compatible` Chat Completions-compatible only.

Closes #1224
Part of #983

## Governing Refs

- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`
- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority.native_openai_responses_source_authority`
- #1229 / PR #1231 source-authority prerequisite for native OpenAI Responses.
- #1224 independent gate: approved first slice `runtime.llm_native_openai_responses_active_backend_protocol_proof`.

## Semantic Migration

- New canonical owner: `platform-spec.yaml` plus `internal/runtime/llm/selection` for backend/profile/config/model authority, and `internal/runtime/llm.ProviderContract` plus `OpenAIResponsesRuntime` for adapter protocol behavior.
- Old invalid paths: treating `openai_compatible` as native Responses, accepting backend selector `openai`, endpoint env-based selection, and source-only/pending `openai_responses` status.
- Production paths checked/moved: selection, config validation, SQLite/Postgres store admission, persisted projection, CLI help/spec command catalog, RuntimeFactory, ProviderContract, OpenRPC read description, persistence, and budget accounting.
- Migration completeness: complete for the #1229-supported first native Responses subset. #983 remains open for provider-hosted continuity, OpenAI built-ins, file/image/audio/prompt/conversation features, provider matrix, docs/defaults, and provider-contributor docs.

## Proof

- `python3 -c 'import yaml; yaml.safe_load(open("platform-spec.yaml")); print("platform-spec.yaml parsed")'`
- `go run ./cmd/swarm serve --help | grep -F "openai_responses"`
- `go run ./cmd/swarm run --help | grep -F "openai_responses"`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/runtime/llm ./cmd/swarm ./internal/store -run 'TestOpenAIResponses|TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted|TestCLI_ServeOwnsRuntimeStartupFlags|TestRunCommandHelpShowsDataFlag|TestSQLiteSchemaStoreMigratesLegacyAgentLLMBackendProfiles|TestPostgresStore_EnsureSchemaCompatibilityColumnsMigratesAgentLLMBackendProfiles|TestProjectPersistedAgentConfig_UsesCanonicalLLMBackendProfiles' -count=1`
- `go test ./...`

Live OpenAI smoke was not run; it is optional and non-closure-bearing under the gate.
