### PR TITLE
[agent-f][issue #977] Agent identity source authority

### DIFF
--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -915,6 +915,53 @@ func TestRuntimeIngressConventionsRatifyQueueAndRejectSemantics(t *testing.T) {
 	assertMethodDescriptionContains(t, api, "runtime.resume", "exactly once")
 }
 
+func TestAgentIdentityModelRecordsCurrentSlugConstraint(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	identity := mustMappingValue(t, root, "agent_identity_model")
+	assertScalarValue(t, mappingValue(identity, "status"), "current_global_slug_constraint_promoted_source_authority")
+	assertScalarValue(t, mappingValue(identity, "promoted_by"), "#977")
+	assertScalarValue(t, mappingValue(identity, "current_supported_posture"), "global_live_slug_identity")
+	assertScalarContains(t, mappingValue(identity, "authority_rule"), "agent_id as the authored contract slug")
+	assertScalarContains(t, mappingValue(identity, "authority_rule"), "globally unique live runtime identity")
+
+	constraint := mustMappingValue(t, identity, "current_multi_bundle_constraint")
+	assertScalarContains(t, mappingValue(constraint, "rule"), "globally unique authored agent_id values")
+	assertScalarContains(t, mappingValue(constraint, "rule"), "Duplicate authored agent slugs across live loaded BundleContexts are unsupported")
+	assertScalarContains(t, mappingValue(constraint, "enforcement_status"), "does not add runtime/store enforcement")
+
+	migration := mustMappingValue(t, identity, "uuid_internal_migration_target")
+	assertScalarValue(t, mappingValue(migration, "tracker"), "#977")
+	assertScalarValue(t, mappingValue(migration, "status"), "staged_parent_only_not_current_runtime_behavior")
+	assertSurfaceListedValue(t, mustMappingValue(t, migration, "not_promoted_in_this_slice"), "agents.id UUID schema migration")
+	assertSurfaceListedValue(t, mustMappingValue(t, migration, "not_promoted_in_this_slice"), "duplicate slug support across loaded bundles")
+
+	disposition := mustMappingValue(t, identity, "consumer_disposition")
+	for _, key := range []string{
+		"uuid_internal_candidates",
+		"slug_display_aliases",
+		"bundle_scoped_lookup_candidates",
+		"historical_immutable_records",
+		"split_or_escalate",
+	} {
+		if mappingValue(disposition, key) == nil {
+			t.Fatalf("agent_identity_model.consumer_disposition missing %s", key)
+		}
+	}
+
+	multiBundle := mustMappingValue(t, root, "multi_bundle_persistence")
+	assertScalarValue(t, mappingValue(mustMappingValue(t, multiBundle, "agent_identity_boundary"), "owner"), "platform-spec.yaml#agent_identity_model")
+	sourceEvidence := mustMappingValue(t, multiBundle, "source_evidence")
+	assertScalarValue(t, mappingValue(sourceEvidence, "agent_identity_source_authority"), "#977")
+
+	api := mustMappingValue(t, root, "api_specification")
+	assertScalarValue(t, mappingValue(mustMappingValue(t, api, "agent_identity_boundary"), "owner"), "platform-spec.yaml#agent_identity_model")
+	blocked := mustMappingValue(t, mustMappingValue(t, api, "multi_bundle_publication_boundary"), "blocked_children")
+	assertScalarValue(t, mappingValue(blocked, "agent_identity_duplicate_slug_migration"), "#977")
+
+	cli := mustMappingValue(t, root, "cli_specification")
+	assertScalarValue(t, mappingValue(mustMappingValue(t, cli, "agent_identity_boundary"), "owner"), "platform-spec.yaml#agent_identity_model")
+}
+
 func TestContentDescriptorsDeclareRequiredFlag(t *testing.T) {
 	root := loadPlatformSpecYAMLNode(t)
 	api := mustMappingValue(t, root, "api_specification")
@@ -1077,4 +1124,24 @@ func assertSurfaceListed(t *testing.T, ingress *yaml.Node, listName, surface str
 		}
 	}
 	t.Fatalf("runtime_ingress.%s missing surface %s", listName, surface)
+}
+
+func assertSurfaceListedValue(t *testing.T, list *yaml.Node, want string) {
+	t.Helper()
+	if list == nil || list.Kind != yaml.SequenceNode {
+		t.Fatalf("list kind = %v, want sequence", listKind(list))
+	}
+	for _, entry := range list.Content {
+		if scalarValue(entry) == want {
+			return
+		}
+	}
+	t.Fatalf("list missing value %s", want)
+}
+
+func listKind(node *yaml.Node) yaml.Kind {
+	if node == nil {
+		return 0
+	}
+	return node.Kind
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -157,7 +157,9 @@ contract_formats:
       "intake". Root flow gets empty namespace.
     agent_id: 'Optional. If omitted, the YAML map key IS the agent ID. agents.yaml uses map keys as canonical identifiers:
       {"classifier-agent": {model: regular, ...}} means agent_id = "classifier-agent". Explicit id field overrides the
-      map key if present, but this is discouraged.'
+      map key if present, but this is discouraged. Under agent_identity_model.current_supported_posture this authored
+      slug is also the current public/runtime agent_id and must be unique across live loaded/boot-pinned bundles until
+      the #977 UUID-internal migration is separately promoted and implemented.'
     agent_emit_events: Optional. If omitted, defaults to empty list []. An agent that only observes (subscribes but never
       emits) may omit emit_events entirely.
   file_layout:
@@ -4320,7 +4322,10 @@ platform_tables:
         \    INDEX idx_entity_state (run_id, current_state),\n    INDEX idx_entity_type (run_id, entity_type),\n    INDEX\
         \ idx_entity_slug (run_id, slug) WHERE slug IS NOT NULL,\n    INDEX idx_entity_cross_run (entity_id)\n);"
     agents:
-      description: 'Runtime agent registry. One row per agent instance. Carries the full persisted runtime descriptor:
+      description: 'Runtime agent registry. One row per agent instance under the current global agent_id identity model.
+        agent_id remains the authored contract slug and current global live/runtime identity described by
+        agent_identity_model.current_supported_posture; duplicate authored agent slugs across live loaded/boot-pinned
+        bundles are unsupported until the #977 UUID-internal migration is separately promoted and implemented. Carries the full persisted runtime descriptor:
         role/model/llm_backend/conversation_mode/parent_agent_id as typed columns, subscriptions/emit_events/tools/permissions
         as JSONB arrays, and runtime_descriptor JSONB for the remaining control-plane fields that do not already have a
         first-class persisted column (for example type, mode, session_scope, session_scope_authority, workspace_class,
@@ -4348,7 +4353,7 @@ platform_tables:
         \ NULL,\n    INDEX idx_agents_role (role),\n    INDEX idx_agents_status (status),\n    INDEX idx_agents_parent (parent_agent_id)\
         \ WHERE parent_agent_id IS NOT NULL\n);"
     agent_sessions:
-      description: 'Live reusable agent conversation sessions. Used ONLY by session and session_per_entity
+      description: 'Live reusable agent conversation sessions keyed by the current global agent_id identity. Used ONLY by session and session_per_entity
         conversation modes. Task mode does NOT create rows here — task-mode audit goes to
         agent_conversation_audits instead. Supports three scopes: entity (one session per agent × entity),
         flow (one session per agent × flow instance), global (one session per agent, shared across all
@@ -5631,6 +5636,94 @@ run_model:
     run_pause: 'POST /runs/:run_id/pause — pause a running run.'
     run_resume: 'POST /runs/:run_id/resume — resume a paused run.'
     run_cancel: 'POST /runs/:run_id/cancel — cancel a running run. Drains in-flight events.'
+agent_identity_model:
+  status: current_global_slug_constraint_promoted_source_authority
+  promoted_by: '#977'
+  merge_bearing_owner: platform-spec.yaml#agent_identity_model
+  current_supported_posture: global_live_slug_identity
+  authority_rule: >
+    This section is the merge-bearing source authority for agent identity semantics under multi-bundle until a later
+    #977 child promotes and proves a UUID-internal migration. Current runtime/store/API/CLI/dashboard behavior treats
+    agent_id as the authored contract slug and as the globally unique live runtime identity. Issue prose that sketches
+    agents.id UUID or bundle-scoped slug aliases is design evidence only until promoted here with matching schema,
+    runtime, API/OpenRPC, CLI/dashboard, and historical-record proof.
+  concepts:
+    authored_slug:
+      source: agents.yaml map key or explicit id field after contract loading
+      current_public_name: agent_id
+      role: Human-authored and operator-facing display/lookup alias.
+    current_live_identity:
+      source: agents.agent_id and runtime Agent.ID()
+      role: Current durable primary key, runtime map key, EventBus subscriber key, session owner, delivery subscriber id,
+        and public agent lookup token.
+      limitation: This identity is global in the current platform and is not bundle-scoped.
+    bundle_scoped_lookup:
+      status: not_supported_for_duplicate_agent_slugs
+      rule: >
+        bundle_hash and RuntimeContextManager BundleContext selection identify runtime bundle context, not an immutable
+        agent identity. Current agent.* reads/control, conversation.current_for_agent, CLI agent commands, dashboard
+        read models, delivery/session/timer owners, and replay subscriber selection do not promise disambiguation of the
+        same authored agent_id across multiple live bundles.
+    historical_agent_reference:
+      role: Existing agent_id, subscriber_id, owner_agent, from_agent, source_agent_id, log, audit, delivery, receipt,
+        spend, timer, mailbox, and provenance rows record the identity value used when the fact was written.
+      migration_rule: >
+        Historical rows must not be blindly rewritten as part of a future UUID migration. A later child must classify
+        each table as immutable history, new-row UUID owner, display alias, or explicitly split surface.
+  current_multi_bundle_constraint:
+    rule: >
+      Every currently supported live loaded/boot-pinned runtime bundle sharing the same platform store/read model must
+      use globally unique authored agent_id values. Duplicate authored agent slugs across live loaded BundleContexts are
+      unsupported and must not be advertised as bundle-scoped or UUID-disambiguated behavior.
+    enforcement_status: >
+      This source-authority slice documents the supported contract only. It does not add runtime/store enforcement.
+      A future loader/admission/serve child that can detect duplicate live agent slugs before API readiness must fail
+      closed or receive its own gate; absent such proof, operators must avoid duplicate live slugs.
+    final_matrix_dependency: >
+      #1025 must treat duplicate agent slugs across live bundles as unsupported unless a later #977 implementation child
+      promotes UUID-internal identity and proves bundle-scoped lookup across all affected surfaces.
+  uuid_internal_migration_target:
+    tracker: '#977'
+    status: staged_parent_only_not_current_runtime_behavior
+    target_model: >
+      A future migration may introduce an immutable internal agent UUID, keep agent_id as authored slug/display alias,
+      and make slug lookup bundle- or run-scoped where public callers provide enough context. That target requires
+      separate gates for schema/backfill, runtime manager/EventBus/delivery/session ownership, API/OpenRPC resolution,
+      CLI/dashboard display behavior, and historical/provenance policy.
+    not_promoted_in_this_slice:
+      - agents.id UUID schema migration
+      - bundle-scoped UNIQUE(bundle_hash, agent_id) live alias enforcement
+      - UUID-backed EventBus, delivery, receipt, timer, session, spend, mailbox, or conversation ownership
+      - UUID-or-slug API parameter resolution
+      - CLI/dashboard UUID display or disambiguation behavior
+      - duplicate slug support across loaded bundles
+  consumer_disposition:
+    uuid_internal_candidates:
+      - agents table durable primary key after future migration
+      - runtime AgentManager maps and loop cancellation keys
+      - EventBus agent subscriptions and live delivery subscriber keys
+      - agent_sessions live ownership and session lookup
+      - executable timers owned by agents
+    slug_display_aliases:
+      - agents.yaml authored map keys and explicit id fields
+      - CLI positional agent-id inputs and normal text/table display
+      - dashboard/read-model display labels
+      - bundle.agents definition-only catalog output
+    bundle_scoped_lookup_candidates:
+      - agent-facing API methods when run_id or bundle context is explicit
+      - RuntimeContextManager-selected control paths that dispatch through a chosen BundleContext
+      - future duplicate-slug-safe dashboard/API reads
+    historical_immutable_records:
+      - agent_turns.agent_id
+      - agent_conversation_audits.agent_id
+      - event_deliveries and event_receipts subscriber_id rows already written
+      - spend_ledger.agent_id
+      - mailbox from_agent and provenance fields
+      - runtime logs, dead letters, source_agent_id, and audit payload identity fields
+    split_or_escalate:
+      - tool/MCP target_agent_id, to_agent_id, and gateway agent_id fields
+      - container/workspace identity labels
+      - broad UUID schema/runtime/API migration children
 multi_bundle_persistence:
   status: promoted_source_authority_with_partial_runtime_behavior
   promoted_by: '#1012'
@@ -5642,6 +5735,7 @@ multi_bundle_persistence:
     serve_db_loaded_runtime_source: '#1020'
     boot_pinned_runtime_context_manager: '#1175'
     dynamic_load_disposition: '#1209'
+    agent_identity_source_authority: '#977'
   authority_rule: >
     This section is the merge-bearing source authority for multi-bundle persistence, bundle identity, bundle-aware
     resume/delete/fork semantics, planned bundle API methods, and planned CLI command shape. The draft is now evidence
@@ -5664,6 +5758,15 @@ multi_bundle_persistence:
       Source-authority promotion proof must verify that generated OpenRPC methods are not silently published without
       implementation, and that future implementation PRs promote matching method_catalog entries and generated artifacts
       together.
+  agent_identity_boundary:
+    owner: platform-spec.yaml#agent_identity_model
+    tracker: '#977'
+    status: current_global_slug_constraint
+    rule: >
+      Multi-bundle BundleContext selection is governed by bundle_hash. It does not by itself provide duplicate agent slug
+      disambiguation. Current agent-facing runtime/store/API/CLI/dashboard surfaces consume agent_id under
+      agent_identity_model.current_supported_posture, so live loaded or boot-pinned bundles with duplicate authored
+      agent slugs are unsupported until a separately gated #977 UUID-internal identity migration lands.
   bundle_identity:
     canonical_name: bundle_hash
     format: 'bundle-v1:sha256:<64 lowercase hex>'
@@ -6113,7 +6216,11 @@ multi_bundle_persistence:
       runtime.incidents:
         rule: Accepts optional bundle_hash filter over source runtime-log rows before incident aggregation.
       agent.list:
-        rule: Future bundle-aware listing must disambiguate run-scoped loaded agents from persisted bundle agent catalog.
+        rule: >
+          Current live agent listing consumes agent_identity_model.current_supported_posture: agent_id is the globally
+          unique authored slug for live loaded agents, and duplicate slugs across live BundleContexts are unsupported.
+          Future duplicate-slug-safe listing must explicitly disambiguate run-scoped loaded agents from persisted bundle
+          agent catalog definitions and must not infer UUID or bundle-scoped lookup before a #977 child promotes it.
       event.list:
         rule: Multi-bundle-safe event listing requires explicit filter.run_id; unscoped event firehose reads are not public v1.
       event.subscribe:
@@ -7468,6 +7575,13 @@ cli_specification:
     - stale v1 `swarm investigate` command draft
     - non-promoted CLI UX v1 review draft
     - stale v1 `swarm investigate *` command catalog entries
+  agent_identity_boundary:
+    owner: platform-spec.yaml#agent_identity_model
+    status: current_global_slug_constraint
+    rule: >
+      Agent-facing CLI commands accept and display agent-id values as the current public authored slug. The CLI must not
+      resolve agent ids locally, infer bundle-scoped aliases from bundle_hash, display UUIDs as authoritative internal
+      identity, or claim duplicate-slug support until a #977 API/OpenRPC/CLI identity child promotes that behavior.
   catalog_accounting_model:
     owner: platform-spec.yaml#cli_specification.command_catalog
     accounting_unit: explicit_command_catalog_row
@@ -10516,6 +10630,15 @@ api_specification:
     blocked_children:
       cross_bundle_fork: '#976'
       bundle_hash_dual_accept_migration: '#1001'
+      agent_identity_duplicate_slug_migration: '#977'
+  agent_identity_boundary:
+    owner: platform-spec.yaml#agent_identity_model
+    status: current_global_slug_constraint
+    rule: >
+      Agent-facing method params named agent_id currently accept the public authored slug that is also the current global
+      live agent identity. The generated OpenRPC shape does not publish agents.id UUID, UUID-or-slug resolution, or
+      duplicate-slug bundle-scoped lookup. Methods that need duplicate-slug safety must either receive a separately
+      promoted #977 identity child or fail closed under their existing multi-context ambiguity rules.
   foundations:
     transport:
       json_rpc_over_http:


### PR DESCRIPTION
Part of #977

## Summary

Promotes the #977 first-slice agent identity source authority into `platform-spec.yaml`.

This PR chooses the current supported posture approved by the gate: `agent_id` remains the authored contract slug and current global live/runtime identity. Duplicate authored agent slugs across live loaded or boot-pinned bundles are unsupported until a separately gated #977 UUID-internal migration lands.

## Governing refs / context

- `platform-spec.yaml#agent_identity_model`
- `platform-spec.yaml#contract_formats.loader_defaults.agent_id`
- `platform-spec.yaml#platform_tables.tables.agents`
- `platform-spec.yaml#platform_tables.tables.agent_sessions`
- `platform-spec.yaml#multi_bundle_persistence.agent_identity_boundary`
- `platform-spec.yaml#api_specification.agent_identity_boundary`
- `platform-spec.yaml#cli_specification.agent_identity_boundary`
- #977 pre-audit and gate comment

## Source-authority migration notes

- New canonical owner: `platform-spec.yaml#agent_identity_model`.
- Current old assumption now explicitly constrained: `agent_id` as slug is global live identity, not bundle-scoped or UUID-disambiguated.
- Old producer/reader/writer paths now invalid as future authority: issue prose that treats UUID migration as already implemented, local API/CLI/dashboard code paths that infer duplicate-slug support, or bundle_hash context selection treated as agent identity disambiguation.
- Production paths checked for surviving old behavior: schema/read surfaces, runtime manager/EventBus/delivery/session ownership, API/OpenRPC, CLI, dashboard/read-model, historical/provenance fields as listed in the #977 audit.
- Migration complete: no. This PR completes only the source-authority first slice. Runtime/store/API/CLI UUID migration remains split under #977.

## Proof

- `go test ./internal/apispec`
- `go test ./...`
