### PR TITLE
[agent-h][issue #1217] Tighten public material boundary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,23 @@
 .git
 .gitignore
 .DS_Store
+.idea
 
 # Local agent auth / editor state should never enter build context.
 .claude
 .codex
+AGENT_STATUS.md
+CONTROL.yaml
+RESPONSE.yaml
 
 # Large or generated artifacts.
 coverage
+test-results/
 **/*.log
 **/*.tmp
 empire
+empire.exe
+*.test
 
 # Dashboard frontend build artifacts.
 internal/dashboard/ui/node_modules
@@ -19,3 +26,11 @@ internal/dashboard/ui/dist
 # Local env files.
 .env
 .env.*
+!.env.example
+
+# Local data, Docker placeholder state, private docs, and parallel worktrees.
+data/
+.docker/
+worktrees/
+misc/
+docs/

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Only the system node writes state, and it does so in one transaction; agents rea
 - **Role-based routing authority.** Agent isolation is enforced by an authority layer that decides, per entity status, which agent role may address which other role. "Any agent can talk to any agent" is not a default the runtime offers.
 - **Reliability primitives.** Undeliverable events retry with exponential backoff and land in a dead-letter store after exhaustion. Dead-letters are indexed and replayable.
 - **Live budget tracking.** Token usage is tracked per entity and per actor in real time. Declared thresholds escalate into throttle and emergency states; humans get a mailbox item when the runtime hits an emergency.
-- **A comprehensive JSON-RPC API.** 43 methods across runs, events, agents, conversations, entities, mailbox, and runtime control, plus WebSocket subscriptions for live traces, event streams, log tails, and health. The surface is published as a machine-readable OpenRPC document, so clients can be generated rather than hand-coded. The `swarm` CLI is one such client; anyone can build their own.
+- **A comprehensive JSON-RPC API.** The generated method catalog spans runs, events, agents, conversations, entities, mailbox, and runtime control, plus WebSocket subscriptions for live traces, event streams, log tails, and health. The surface is published as a machine-readable OpenRPC document, so clients can be generated rather than hand-coded. The `swarm` CLI is one such client; anyone can build their own.
 - **MCP gateway.** Swarm both exposes and consumes the Model Context Protocol. External tools can drive a runtime over MCP; agents pull tool definitions from upstream MCP servers without code changes.
 
 ---


### PR DESCRIPTION
Closes #1217

## Summary

This PR closes the approved #1217 first slice for `maintenance.release_readiness.public_material_leak_and_artifact_reproducibility_floor`.

Changes:
- Mirrors the approved local/private material boundary into `.dockerignore` so Docker build context excludes private docs, local data, local `.docker/` state, worktrees, misc scratch space, local control files, and test/build artifacts.
- Keeps `.env.example` available as the public environment template while continuing to exclude real `.env*` files.
- Removes the hardcoded README API method count so public copy no longer drifts from generated `openrpc.json`.

## Governing Context

- #1217 issue body and approved pre-audit gate.
- `platform-spec.yaml#spec_authority`: root `platform-spec.yaml` is the merge-bearing platform specification.
- `platform-spec.yaml#api_specification`: root `openrpc.json` is generated from the spec/API catalog.
- #823 LICENSE/SPDX, #1138/#1213 host workspace runtime-security, broad README/product polish, and runtime/API/CLI semantics remain split.

## Source Authority / Migration

Canonical owners are unchanged:
- Public tracked material boundary: Git tracked tree plus `.gitignore` / `.dockerignore`.
- Platform source authority: root `platform-spec.yaml`.
- Public OpenRPC artifact: root `openrpc.json`, generated by `cmd/swarm-openrpc-gen`.

Old non-authoritative path repaired:
- `.dockerignore` previously did not exclude all private/local paths already excluded by `.gitignore`; Docker build context could still include those local/private directories if present. This PR closes that boundary mismatch.

No runtime, API, CLI, platform semantics, or generated artifact content changed.

## Proof

- `git ls-files 'docs/**' 'scripts/**' '.docker/**' Makefile docker-compose.yml Dockerfile.orchestrator` -> no tracked old private/docs/scripts/Compose surfaces.
- `git check-ignore platform-spec.yaml openrpc.json README.md LICENSE CONTRIBUTING.md SECURITY.md .env.example` -> no root public authority file is hidden by `.gitignore`.
- `git check-ignore docs/IMPLEMENTER_GUIDELINES.md docs/local/foo.md docs/example.local.md docs/example.draft.md docs/specs/foo.pdf docs/specs/foo.tar data/example.db .env .env.local .docker/foo` -> private/local material is ignored by `.gitignore`.
- High-entropy secret scan -> no direct private key, AWS, GitHub, OpenAI-style, Slack, or Google API-key hits.
- Credential keyword scan -> 1356 expected auth/config/test/env-template hits; no real secret identified.
- Private path scan -> only `/tmp/swarm-payload.json` README examples and `agent-haiku` test fixtures.
- Private draft/docs authority scan -> only ignore-boundary references, public docs/private-docs explanation, OpenAI public docs URLs, and split notes.
- Docker/Postgres scan -> SQLite local/dev default plus explicit Postgres opt-in / CI test service / spec split references only.
- `git grep -n -I '43 methods' -- .` -> remaining hits are historical internal compliance-matrix policy text only; README public hardcoded count removed.
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/apispec ./cmd/swarm-openrpc-gen -count=1`
- `docker build -t swarm-workspace:1217-proof -f Dockerfile.workspace .`
- `git diff --check`
- `go test ./...`
