### PR TITLE
[agent-c][issue #1233] Canonicalize bus channel waits

### DIFF
--- a/internal/runtime/bus/eventbus_internal_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_internal_test_helpers_test.go
@@ -1,0 +1,18 @@
+package bus
+
+import (
+	"testing"
+
+	"swarm/internal/events"
+)
+
+func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) events.Event {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		return evt
+	default:
+		t.Fatalf("%s: expected queued bus event", context)
+		return events.Event{}
+	}
+}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -344,15 +344,6 @@ func (*replayCapableAtomicStoreMissingScope) ClaimPipelineReplay(context.Context
 	return nil, false, nil
 }
 
-func waitForNoEvent(t *testing.T, ch <-chan events.Event) {
-	t.Helper()
-	select {
-	case evt := <-ch:
-		t.Fatalf("unexpected event delivered: %#v", evt)
-	case <-time.After(25 * time.Millisecond):
-	}
-}
-
 func assertSortedStringsEqual(t *testing.T, got, want []string) {
 	t.Helper()
 	got = append([]string(nil), got...)
@@ -489,13 +480,9 @@ func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *te
 	if !hasRuntimeLogAction(logger.entries, "pipeline_receipt_persist_failed") {
 		t.Fatalf("logger entries = %#v, want pipeline_receipt_persist_failed", logger.entries)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for delivered event")
+	got := requireBusEvent(t, ch, "post-commit receipt failure delivery")
+	if got.ID != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
 	}
 }
 
@@ -548,13 +535,9 @@ func TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable(t 
 	if !hasRuntimeLogAction(logger.entries, "publish_post_commit_convergence_failed") {
 		t.Fatalf("logger entries = %#v, want publish_post_commit_convergence_failed", logger.entries)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for delivered event")
+	got := requireBusEvent(t, ch, "post-commit completion failure delivery")
+	if got.ID != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
 	}
 }
 
@@ -653,11 +636,7 @@ func TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition(t *testing.T) {
 	if err := bus.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for delivered event")
-	}
+	_ = requireBusEvent(t, ch, "queued delivery lifecycle transition")
 
 	var found bool
 	for _, entry := range logger.entries {
@@ -749,11 +728,7 @@ func TestEventBusPublish_AttachesBundleSourceFactToRuntimeLogs(t *testing.T) {
 	}.WithEntityID("ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for delivered event")
-	}
+	_ = requireBusEvent(t, ch, "bundle source fact delivery")
 	for _, entry := range logger.entries {
 		if entry.HasSource && entry.SourceFact == sourceFact.Normalized() {
 			return
@@ -913,23 +888,15 @@ func TestEventBusPublishDirect_FiltersEntityScopedRecipientsByExplicitMetadata(t
 		t.Fatalf("PublishDirect: %v", err)
 	}
 
-	select {
-	case evt := <-controlCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("control event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("control-plane did not receive direct event")
+	evt := requireBusEvent(t, controlCh, "direct delivery to control-plane")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("control event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-matchCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("matched event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("matching entity-scoped reviewer did not receive direct event")
+	evt = requireBusEvent(t, matchCh, "direct delivery to matching entity-scoped reviewer")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("matched event entity_id = %q, want ent-1", got)
 	}
-	waitForNoEvent(t, otherCh)
+	requireNoBusEvent(t, otherCh, "direct delivery to filtered entity-scoped reviewer")
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane", "reviewer-ent-1"})
 }
@@ -958,23 +925,15 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *test
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case evt := <-controlCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("control event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("control-plane did not receive event")
+	evt := requireBusEvent(t, controlCh, "explicit metadata delivery to control-plane")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("control event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-matchCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("matched event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("entity-scoped reviewer did not receive matching event")
+	evt = requireBusEvent(t, matchCh, "explicit metadata delivery to entity-scoped reviewer")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("matched event entity_id = %q, want ent-1", got)
 	}
-	waitForNoEvent(t, otherCh)
+	requireNoBusEvent(t, otherCh, "explicit metadata delivery to filtered entity-scoped reviewer")
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane", "reviewer-ent-1"})
 }
@@ -1002,15 +961,11 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByTypedEnvelopeNotPayload(
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case evt := <-matchCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("matched event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("entity-scoped reviewer did not receive typed-envelope match")
+	evt := requireBusEvent(t, matchCh, "typed-envelope delivery to entity-scoped reviewer")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("matched event entity_id = %q, want ent-1", got)
 	}
-	waitForNoEvent(t, otherCh)
+	requireNoBusEvent(t, otherCh, "typed-envelope delivery to filtered entity-scoped reviewer")
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"reviewer-ent-1"})
 }
 
@@ -1035,12 +990,8 @@ func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) 
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case <-controlCh:
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("control-plane did not receive event")
-	}
-	waitForNoEvent(t, missingCh)
+	_ = requireBusEvent(t, controlCh, "descriptor delivery to control-plane")
+	requireNoBusEvent(t, missingCh, "descriptor delivery to missing reviewer")
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"control-plane"})
 }
@@ -1068,31 +1019,19 @@ func TestEventBusPublish_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case evt := <-workflowCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("workflow-runtime did not receive event")
+	evt := requireBusEvent(t, workflowCh, "internal workflow-runtime descriptor delivery")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-nodeCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("system node event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("system node did not receive event")
+	evt = requireBusEvent(t, nodeCh, "internal system-node descriptor delivery")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("system node event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-agentCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("agent event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("agent did not receive event")
+	evt = requireBusEvent(t, agentCh, "agent descriptor delivery")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("agent event entity_id = %q, want ent-1", got)
 	}
-	waitForNoEvent(t, missingCh)
+	requireNoBusEvent(t, missingCh, "descriptor delivery to missing agent")
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
 }
@@ -1122,23 +1061,15 @@ func TestEventBusPublishDeferred_UsesCanonicalSubscribedRecipientFiltering(t *te
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case evt := <-workflowCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("workflow-runtime did not receive deferred event")
+	evt := requireBusEvent(t, workflowCh, "deferred delivery to workflow-runtime")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("workflow-runtime event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-agentCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("agent event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("agent did not receive deferred event")
+	evt = requireBusEvent(t, agentCh, "deferred delivery to agent")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("agent event entity_id = %q, want ent-1", got)
 	}
-	waitForNoEvent(t, otherCh)
+	requireNoBusEvent(t, otherCh, "deferred delivery to filtered agent")
 
 	assertSortedStringsEqual(t, store.persistedDeliveries(), []string{"agent-a"})
 }
@@ -1161,7 +1092,7 @@ func TestEventBusPublish_FailsClosedWhenDescriptorLookupFails(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "descriptor lookup failed") {
 		t.Fatalf("Publish error = %v, want descriptor lookup failure", err)
 	}
-	waitForNoEvent(t, ch)
+	requireNoBusEvent(t, ch, "descriptor lookup failure delivery")
 	if got := store.persistedDeliveries(); len(got) != 0 {
 		t.Fatalf("persisted deliveries = %v, want none", got)
 	}
@@ -1182,11 +1113,7 @@ func TestEventBusWaitForQuiescenceWaitsForPublishCompletion(t *testing.T) {
 		publishDone <- eb.Publish(context.Background(), events.Event{Type: "task.completed", Payload: []byte(`{}`)})
 	}()
 
-	select {
-	case <-started:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("interceptor did not start")
-	}
+	requireSignalBefore(t, started, 500*time.Millisecond, "interceptor start")
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
@@ -1195,13 +1122,8 @@ func TestEventBusWaitForQuiescenceWaitsForPublishCompletion(t *testing.T) {
 	}
 
 	close(release)
-	select {
-	case err := <-publishDone:
-		if err != nil {
-			t.Fatalf("Publish: %v", err)
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("publish did not finish")
+	if err := requireErrorBefore(t, publishDone, 500*time.Millisecond, "publish completion"); err != nil {
+		t.Fatalf("Publish: %v", err)
 	}
 
 	waitCtx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
@@ -1280,18 +1202,10 @@ func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) 
 	}.WithEntityID("11111111-1111-1111-1111-111111111114")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	select {
-	case <-called:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for post-commit interceptor")
-	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event id = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for post-commit delivery")
+	requireSignalBefore(t, called, time.Second, "post-commit interceptor")
+	got := requireBusEvent(t, ch, "post-commit delivery")
+	if got.ID != eventID {
+		t.Fatalf("delivered event id = %s, want %s", got.ID, eventID)
 	}
 }
 
@@ -1396,11 +1310,7 @@ func TestEventBusPublishTxRunsInterceptorsAfterCallerCommit(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
-	select {
-	case <-called:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for post-commit interceptor")
-	}
+	requireSignalBefore(t, called, time.Second, "post-commit interceptor")
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts = %d, want 1", got)
 	}
@@ -1678,13 +1588,9 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 				t.Fatalf("Publish(%s): %v", tc.eventType, err)
 			}
 
-			select {
-			case got := <-internal:
-				if got.ID != tc.eventID {
-					t.Fatalf("internal delivery event_id = %q, want %q", got.ID, tc.eventID)
-				}
-			case <-time.After(250 * time.Millisecond):
-				t.Fatalf("timed out waiting for internal %s delivery", tc.eventType)
+			got := requireBusEvent(t, internal, "standalone platform event internal delivery")
+			if got.ID != tc.eventID {
+				t.Fatalf("internal delivery event_id = %q, want %q", got.ID, tc.eventID)
 			}
 
 			runID, runStatus, triggerEventType := loadRunStateForEvent(t, ctx, db, tc.eventID)
@@ -1755,13 +1661,9 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 				t.Fatalf("Publish(%s): %v", tc.eventType, err)
 			}
 
-			select {
-			case got := <-subscription:
-				if got.ID != tc.eventID {
-					t.Fatalf("delivered event_id = %q, want %q", got.ID, tc.eventID)
-				}
-			case <-time.After(250 * time.Millisecond):
-				t.Fatalf("timed out waiting for agent delivery of %s", tc.eventType)
+			got := requireBusEvent(t, subscription, "standalone agent event delivery")
+			if got.ID != tc.eventID {
+				t.Fatalf("delivered event_id = %q, want %q", got.ID, tc.eventID)
 			}
 
 			if got := countEventDeliveriesForEvent(t, ctx, db, tc.eventID); got != 1 {
@@ -1825,11 +1727,7 @@ func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
 		t.Fatalf("Publish while paused: %v", err)
 	}
 
-	select {
-	case got := <-ch:
-		t.Fatalf("paused runtime delivered event %s before resume", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "paused runtime before resume")
 	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("event deliveries while paused = %d, want 1", got)
 	}
@@ -1847,13 +1745,9 @@ func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
 	if resumed.ReleasedCount != 1 {
 		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for queued event release")
+	got := requireBusEvent(t, ch, "queued event release after resume")
+	if got.ID != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
 	}
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
@@ -1875,11 +1769,7 @@ func TestEventBusPublish_HumanTaskEventsRouteBySubscriptionOnly(t *testing.T) {
 		t.Fatalf("Publish: %v", err)
 	}
 
-	select {
-	case evt := <-ch:
-		t.Fatalf("unexpected delivery without subscription: %#v", evt)
-	case <-time.After(50 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "human task event without subscription")
 }
 
 func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.T) {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -158,13 +158,9 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	select {
-	case got := <-ch:
-		if got.FlowInstance() != "operating/inst-1" {
-			t.Fatalf("delivered flow instance = %q, want operating/inst-1", got.FlowInstance())
-		}
-	case <-time.After(time.Second):
-		t.Fatal("workflow-runtime did not receive concrete routed node event")
+	got := requireBusEvent(t, ch, "concrete routed node event delivery")
+	if got.FlowInstance() != "operating/inst-1" {
+		t.Fatalf("delivered flow instance = %q, want operating/inst-1", got.FlowInstance())
 	}
 
 	routes := store.routes[evt.ID]
@@ -198,19 +194,15 @@ func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntit
 	t.Helper()
 	seen := map[string]struct{}{}
 	for range wantEntityIDs {
-		select {
-		case got := <-ch:
-			if len(got.TargetRoutes()) != 0 {
-				t.Fatalf("delivered event target_set = %#v, want singular delivery target", got.TargetRoutes())
-			}
-			target := got.TargetRoute()
-			if target.Empty() {
-				t.Fatalf("delivered target route is empty: %#v", got)
-			}
-			seen[target.EntityID] = struct{}{}
-		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for target route delivery; saw %#v", seen)
+		got := requireBusEvent(t, ch, "target route delivery")
+		if len(got.TargetRoutes()) != 0 {
+			t.Fatalf("delivered event target_set = %#v, want singular delivery target", got.TargetRoutes())
 		}
+		target := got.TargetRoute()
+		if target.Empty() {
+			t.Fatalf("delivered target route is empty: %#v", got)
+		}
+		seen[target.EntityID] = struct{}{}
 	}
 	for _, want := range wantEntityIDs {
 		if _, ok := seen[want]; !ok {

--- a/internal/runtime/bus/eventbus_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_test_helpers_test.go
@@ -1,0 +1,66 @@
+package bus_test
+
+import (
+	"testing"
+	"time"
+
+	"swarm/internal/events"
+)
+
+func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) events.Event {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		return evt
+	default:
+		t.Fatalf("%s: expected queued bus event", context)
+		return events.Event{}
+	}
+}
+
+func requireNoBusEvent(t testing.TB, ch <-chan events.Event, context string) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Fatalf("%s: unexpected bus event: %#v", context, evt)
+	default:
+	}
+}
+
+func requireBusEventTypes(t testing.TB, ch <-chan events.Event, context string, want ...events.EventType) {
+	t.Helper()
+	got := make(map[events.EventType]struct{}, len(want))
+	for len(got) < len(want) {
+		evt := requireBusEvent(t, ch, context)
+		got[evt.Type] = struct{}{}
+	}
+	for _, eventType := range want {
+		if _, ok := got[eventType]; !ok {
+			t.Fatalf("%s: received event types = %#v, missing %s", context, got, eventType)
+		}
+	}
+}
+
+func requireSignalBefore(t testing.TB, ch <-chan struct{}, timeout time.Duration, context string) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatalf("%s: timed out after %s", context, timeout)
+	}
+}
+
+func requireErrorBefore(t testing.TB, ch <-chan error, timeout time.Duration, context string) error {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-ch:
+		return err
+	case <-timer.C:
+		t.Fatalf("%s: timed out after %s", context, timeout)
+		return nil
+	}
+}

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -186,24 +186,15 @@ func TestEngineDispatcherQueuesWhenPipelineSQLTxActive(t *testing.T) {
 		_ = tx.Rollback()
 		t.Fatalf("post-commit actions = %d, want 1", len(postCommitActions))
 	}
-	select {
-	case got := <-ch:
-		_ = tx.Rollback()
-		t.Fatalf("event delivered before post-commit flush: %#v", got)
-	case <-time.After(25 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "post-commit delivery before flush")
 
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("Commit: %v", err)
 	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
-	select {
-	case got := <-ch:
-		if got.ID != intent.Event.ID {
-			t.Fatalf("delivered event id = %s, want %s", got.ID, intent.Event.ID)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("timed out waiting for post-commit outbox dispatch")
+	got := requireBusEvent(t, ch, "post-commit outbox dispatch")
+	if got.ID != intent.Event.ID {
+		t.Fatalf("delivered event id = %s, want %s", got.ID, intent.Event.ID)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
@@ -269,23 +260,15 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 		t.Fatalf("Commit: %v", err)
 	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
-	select {
-	case got := <-originalCh:
-		if string(got.Payload) != `{"value":"original"}` {
-			t.Fatalf("delivered payload = %s, want original snapshot", string(got.Payload))
-		}
-		routes := got.TargetRoutes()
-		if len(routes) != 1 || routes[0].FlowInstance != "flow-original" || routes[0].EntityID != "entity-original" {
-			t.Fatalf("delivered target routes = %#v, want original snapshot", routes)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("timed out waiting for original recipient delivery")
+	got := requireBusEvent(t, originalCh, "immutable intent snapshot delivery")
+	if string(got.Payload) != `{"value":"original"}` {
+		t.Fatalf("delivered payload = %s, want original snapshot", string(got.Payload))
 	}
-	select {
-	case got := <-mutatedCh:
-		t.Fatalf("unexpected delivery to mutated recipient: %#v", got)
-	case <-time.After(25 * time.Millisecond):
+	routes := got.TargetRoutes()
+	if len(routes) != 1 || routes[0].FlowInstance != "flow-original" || routes[0].EntityID != "entity-original" {
+		t.Fatalf("delivered target routes = %#v, want original snapshot", routes)
 	}
+	requireNoBusEvent(t, mutatedCh, "mutated recipient delivery")
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
 	}
@@ -446,24 +429,12 @@ func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testin
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit: %v", err)
 	}
-	select {
-	case <-controlCh:
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("control-plane did not receive direct intent")
+	_ = requireBusEvent(t, controlCh, "direct intent delivery to control-plane")
+	evt := requireBusEvent(t, matchCh, "direct intent delivery to matching entity-scoped agent")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("matched event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-matchCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("matched event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("matching entity-scoped agent did not receive direct intent")
-	}
-	select {
-	case evt := <-otherCh:
-		t.Fatalf("unexpected event delivered to filtered recipient: %#v", evt)
-	case <-time.After(25 * time.Millisecond):
-	}
+	requireNoBusEvent(t, otherCh, "direct intent delivery to filtered recipient")
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
@@ -523,21 +494,13 @@ func TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedMan
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit: %v", err)
 	}
-	select {
-	case evt := <-internalCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("internal event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("expected internal subscriber to receive outbox event")
+	evt := requireBusEvent(t, internalCh, "outbox event delivery to internal subscriber")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("internal event entity_id = %q, want ent-1", got)
 	}
-	select {
-	case evt := <-agentCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("agent event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("expected agent subscriber to receive outbox event")
+	evt = requireBusEvent(t, agentCh, "outbox event delivery to agent subscriber")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("agent event entity_id = %q, want ent-1", got)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -615,13 +578,9 @@ func TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPe
 		t.Fatalf("DispatchPostCommit: %v", err)
 	}
 
-	select {
-	case evt := <-recipientCh:
-		if got := evt.EntityID(); got != "ent-1" {
-			t.Fatalf("delivered event entity_id = %q, want ent-1", got)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("expected explicit direct recipient to receive event")
+	evt := requireBusEvent(t, recipientCh, "direct no-tx delivery to explicit recipient")
+	if got := evt.EntityID(); got != "ent-1" {
+		t.Fatalf("delivered event entity_id = %q, want ent-1", got)
 	}
 }
 
@@ -678,11 +637,7 @@ func TestEngineDispatcher_TransactionalDirectIntentHonorsEmptyPersistedManifest(
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit: %v", err)
 	}
-	select {
-	case evt := <-filteredCh:
-		t.Fatalf("unexpected event delivered from empty authoritative manifest: %#v", evt)
-	case <-time.After(25 * time.Millisecond):
-	}
+	requireNoBusEvent(t, filteredCh, "empty authoritative direct manifest delivery")
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)

--- a/internal/runtime/bus/routing_derivation_internal_test.go
+++ b/internal/runtime/bus/routing_derivation_internal_test.go
@@ -3,7 +3,6 @@ package bus
 import (
 	"context"
 	"testing"
-	"time"
 
 	"swarm/internal/events"
 )
@@ -149,13 +148,9 @@ func TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution(t *testing.T
 	}); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	select {
-	case evt := <-ch:
-		if evt.Type != events.EventType(eventType) {
-			t.Fatalf("delivered event type = %q, want concrete child event", evt.Type)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for routed wildcard delivery")
+	evt := requireBusEvent(t, ch, "routed wildcard delivery")
+	if evt.Type != events.EventType(eventType) {
+		t.Fatalf("delivered event type = %q, want concrete child event", evt.Type)
 	}
 
 	diags := recorder.SnapshotPublishes()

--- a/internal/runtime/bus/run_control_dispatch_test.go
+++ b/internal/runtime/bus/run_control_dispatch_test.go
@@ -57,11 +57,7 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}.WithEntityID("21000000-0000-0000-0000-000000000002")); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("paused run delivered event %s before continue", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "paused run before continue")
 	if got := countPipelineReceiptsForEvent(t, ctx, db, pausedEventID); got != 0 {
 		t.Fatalf("paused run pipeline receipts = %d, want 0", got)
 	}
@@ -77,13 +73,9 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}.WithEntityID("21000000-0000-0000-0000-000000000003")); err != nil {
 		t.Fatalf("Publish other run event: %v", err)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != otherEventID {
-			t.Fatalf("delivered event = %s, want other run %s", got.ID, otherEventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for other run dispatch")
+	got := requireBusEvent(t, ch, "other run dispatch")
+	if got.ID != otherEventID {
+		t.Fatalf("delivered event = %s, want other run %s", got.ID, otherEventID)
 	}
 
 	result, err := controller.Continue(ctx, runtimeruncontrol.TransitionRequest{RunID: pausedRunID, Reason: "test", ControlledBy: "test"})
@@ -93,13 +85,9 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	if result.ReleasedDeliveries != 1 {
 		t.Fatalf("released deliveries = %d, want 1", result.ReleasedDeliveries)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != pausedEventID {
-			t.Fatalf("released event = %s, want paused run %s", got.ID, pausedEventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for paused run release")
+	got = requireBusEvent(t, ch, "paused run release")
+	if got.ID != pausedEventID {
+		t.Fatalf("released event = %s, want paused run %s", got.ID, pausedEventID)
 	}
 	if got := countPipelineReceiptsForEvent(t, ctx, db, pausedEventID); got != 1 {
 		t.Fatalf("paused run pipeline receipts after continue = %d, want 1", got)
@@ -151,11 +139,7 @@ func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t
 	}.WithEntityID("22000000-0000-0000-0000-000000000001")); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("paused run delivered event %s before continue", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "paused intercepted run before continue")
 	if got := recorder.count(); got != 0 {
 		t.Fatalf("interceptor executions before continue = %d, want 0", got)
 	}
@@ -174,22 +158,7 @@ func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t
 		t.Fatalf("interceptor executions after continue = %d, want 1", got)
 	}
 
-	received := map[events.EventType]struct{}{}
-	deadline := time.After(time.Second)
-	for len(received) < 2 {
-		select {
-		case got := <-ch:
-			received[got.Type] = struct{}{}
-		case <-deadline:
-			t.Fatalf("timed out waiting for released original and deferred events, got %#v", received)
-		}
-	}
-	if _, ok := received[eventType]; !ok {
-		t.Fatalf("released original event missing: %#v", received)
-	}
-	if _, ok := received[deferredType]; !ok {
-		t.Fatalf("released deferred event missing: %#v", received)
-	}
+	requireBusEventTypes(t, ch, "released original and deferred events", eventType, deferredType)
 	if got := countPipelineReceiptsForEvent(t, ctx, db, queuedEventID); got != 1 {
 		t.Fatalf("queued event receipts after continue = %d, want 1", got)
 	}
@@ -255,11 +224,7 @@ func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testin
 	if err := eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit while paused: %v", err)
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("paused post-commit dispatch delivered event %s before continue", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoBusEvent(t, ch, "paused post-commit dispatch before continue")
 	if got := recorder.count(); got != 0 {
 		t.Fatalf("post-commit interceptor executions while paused = %d, want 0", got)
 	}
@@ -277,22 +242,7 @@ func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testin
 	if got := recorder.count(); got != 1 {
 		t.Fatalf("post-commit interceptor executions after continue = %d, want 1", got)
 	}
-	received := map[events.EventType]struct{}{}
-	deadline := time.After(time.Second)
-	for len(received) < 2 {
-		select {
-		case got := <-ch:
-			received[got.Type] = struct{}{}
-		case <-deadline:
-			t.Fatalf("timed out waiting for released post-commit original and deferred events, got %#v", received)
-		}
-	}
-	if _, ok := received[eventType]; !ok {
-		t.Fatalf("released post-commit original event missing: %#v", received)
-	}
-	if _, ok := received[deferredType]; !ok {
-		t.Fatalf("released post-commit deferred event missing: %#v", received)
-	}
+	requireBusEventTypes(t, ch, "released post-commit original and deferred events", eventType, deferredType)
 	if got := countPipelineReceiptsForEvent(t, ctx, db, intent.Event.ID); got != 1 {
 		t.Fatalf("post-commit event receipts after continue = %d, want 1", got)
 	}

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -134,13 +134,9 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	if got := store.receipts["evt-1"]; got != "processed" {
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
-	select {
-	case evt := <-ch:
-		if evt.ID != "evt-1" {
-			t.Fatalf("delivered event id = %q, want evt-1", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected swept delivery")
+	evt := requireBusEvent(t, ch, "swept subscribed delivery")
+	if evt.ID != "evt-1" {
+		t.Fatalf("delivered event id = %q, want evt-1", evt.ID)
 	}
 }
 
@@ -173,7 +169,7 @@ func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback
 	if got := store.receipts["evt-2"]; got != "processed" {
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
-	waitForNoEvent(t, ch)
+	requireNoBusEvent(t, ch, "empty direct fan-out replay")
 }
 
 func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *testing.T) {
@@ -205,13 +201,9 @@ func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *test
 	if got := store.receipts["evt-internal-only"]; got != "processed" {
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
-	select {
-	case evt := <-internalCh:
-		if evt.ID != "evt-internal-only" {
-			t.Fatalf("delivered event id = %q, want evt-internal-only", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected internal subscriber to receive replayed event")
+	evt := requireBusEvent(t, internalCh, "internal-only replay delivery")
+	if evt.ID != "evt-internal-only" {
+		t.Fatalf("delivered event id = %q, want evt-internal-only", evt.ID)
 	}
 }
 
@@ -242,21 +234,13 @@ func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *t
 	if count != 1 {
 		t.Fatalf("swept count = %d, want 1", count)
 	}
-	select {
-	case evt := <-internalCh:
-		if evt.ID != "evt-mixed" {
-			t.Fatalf("internal delivered event id = %q, want evt-mixed", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected internal subscriber to receive replayed event")
+	evt := requireBusEvent(t, internalCh, "mixed replay delivery to internal subscriber")
+	if evt.ID != "evt-mixed" {
+		t.Fatalf("internal delivered event id = %q, want evt-mixed", evt.ID)
 	}
-	select {
-	case evt := <-agentCh:
-		if evt.ID != "evt-mixed" {
-			t.Fatalf("agent delivered event id = %q, want evt-mixed", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected persisted agent to receive replayed event")
+	evt = requireBusEvent(t, agentCh, "mixed replay delivery to persisted agent")
+	if evt.ID != "evt-mixed" {
+		t.Fatalf("agent delivered event id = %q, want evt-mixed", evt.ID)
 	}
 }
 
@@ -289,15 +273,11 @@ func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers
 	if count != 1 {
 		t.Fatalf("swept count = %d, want 1", count)
 	}
-	select {
-	case evt := <-agentCh:
-		if evt.ID != "evt-direct-mixed" {
-			t.Fatalf("agent delivered event id = %q, want evt-direct-mixed", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected direct persisted agent recipient to receive replayed event")
+	evt := requireBusEvent(t, agentCh, "direct replay delivery to persisted agent")
+	if evt.ID != "evt-direct-mixed" {
+		t.Fatalf("agent delivered event id = %q, want evt-direct-mixed", evt.ID)
 	}
-	waitForNoEvent(t, internalCh)
+	requireNoBusEvent(t, internalCh, "direct replay delivery to current internal subscriber")
 }
 
 func TestSweepUndispatched_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
@@ -331,7 +311,7 @@ func TestSweepUndispatched_DirectEmptyManifestDoesNotBroadenToCurrentInternalSub
 	if got := store.receipts["evt-direct-empty"]; got != "processed" {
 		t.Fatalf("receipt status = %q, want processed", got)
 	}
-	waitForNoEvent(t, internalCh)
+	requireNoBusEvent(t, internalCh, "direct empty manifest delivery to current internal subscriber")
 }
 
 func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
@@ -379,13 +359,9 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 	if got := store.receipts["evt-good"]; got != "processed" {
 		t.Fatalf("good receipt status = %q, want processed", got)
 	}
-	select {
-	case evt := <-ch:
-		if evt.ID != "evt-good" {
-			t.Fatalf("delivered event id = %q, want evt-good", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected good swept delivery")
+	evt := requireBusEvent(t, ch, "good replay delivery after malformed row")
+	if evt.ID != "evt-good" {
+		t.Fatalf("delivered event id = %q, want evt-good", evt.ID)
 	}
 }
 
@@ -447,14 +423,10 @@ func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinue
 	if !foundTerminalLog {
 		t.Fatal("expected explicit terminal committed replay-scope warning")
 	}
-	waitForNoEvent(t, missingCh)
-	select {
-	case evt := <-goodCh:
-		if evt.ID != "evt-good-after-markerless" {
-			t.Fatalf("delivered event id = %q, want evt-good-after-markerless", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected good event after markerless row to be replayed")
+	requireNoBusEvent(t, missingCh, "markerless replay delivery to missing subscriber")
+	evt := requireBusEvent(t, goodCh, "good replay delivery after markerless row")
+	if evt.ID != "evt-good-after-markerless" {
+		t.Fatalf("delivered event id = %q, want evt-good-after-markerless", evt.ID)
 	}
 }
 
@@ -487,11 +459,7 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 		}
 	}()
 
-	select {
-	case <-store.releasing:
-	case <-time.After(time.Second):
-		t.Fatal("expected first sweep to reach claim release")
-	}
+	requireSignalBefore(t, store.releasing, time.Second, "first sweep replay claim release")
 
 	secondCount, err := eb.SweepUndispatched(context.Background(), time.Hour, 10)
 	if err != nil {
@@ -502,21 +470,13 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 	}
 
 	close(store.releaseGate)
-	select {
-	case <-firstDone:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for first sweep to finish")
-	}
+	requireSignalBefore(t, firstDone, time.Second, "first sweep completion")
 
-	select {
-	case evt := <-ch:
-		if evt.ID != "evt-claim" {
-			t.Fatalf("delivered event id = %q, want evt-claim", evt.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected claimed replay delivery")
+	evt := requireBusEvent(t, ch, "claimed replay delivery")
+	if evt.ID != "evt-claim" {
+		t.Fatalf("delivered event id = %q, want evt-claim", evt.ID)
 	}
-	waitForNoEvent(t, ch)
+	requireNoBusEvent(t, ch, "duplicate claimed replay delivery")
 }
 
 func TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner(t *testing.T) {


### PR DESCRIPTION
Part of #1233

## Summary

- Add package-local bus test assertion helpers for queued event delivery, no-delivery, expected event sets, and bounded goroutine handshakes.
- Replace eligible ad hoc `time.After`/fixed no-event waits in the six approved `internal/runtime/bus` test files.
- Keep production runtime timeout behavior untouched, including `deliverySendTimeout` and `EventBus.WaitForQuiescence` semantics.

## Governing Context

No exact `platform-spec.yaml` product/runtime section governs this test-only wait-helper cleanup. Binding context is #1233, parent #1196, the posted Pre-Implementation Coverage Audit, and the independent gate decision approving `test_health.runtime_bus_channel_delivery_test_waits` as a first slice.

## Canonical Owner / Migration

New canonical owner: package-local bus test helpers in `internal/runtime/bus/eventbus_test_helpers_test.go` and `internal/runtime/bus/eventbus_internal_test_helpers_test.go`.

Old non-authoritative paths now invalid for this chosen class: inline bus-test `select` blocks using `time.After` for synchronous channel delivery/no-delivery and the old fixed-sleep `waitForNoEvent` helper.

Production paths checked for surviving old behavior: this PR does not touch production bus code. Static scan still shows protected `EventBus.WaitForQuiescence` test context deadlines and helper-owned `time.NewTimer` only.

Migration completeness: complete for the approved `internal/runtime/bus` channel-delivery test-wait class. #1233 remains open for non-bus deterministic async wait families.

## Proof

- `rg -n "time\\.After|time\\.Sleep|waitForNoEvent" internal/runtime/bus -g '*_test.go'` -> no matches.
- `rg -n "context\\.WithTimeout|time\\.NewTimer|time\\.NewTicker" internal/runtime/bus -g '*_test.go'` -> only helper `time.NewTimer` lines and protected `WaitForQuiescence` context deadlines.
- `go test ./internal/runtime/bus -run '^TestEventBusWaitForQuiescenceWaitsForPublishCompletion$' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./...`