### PR TITLE
Add CODE_OF_CONDUCT and CHANGELOG for first OSS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to Division Swarm are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Division Swarm is pre-1.0; the public surface may change between minor versions
+until v1.0. Each entry below lists the platform-spec version it ships against.
+
+## [Unreleased]
+
+## [1.6.0] - 2026-06-01
+
+First public open-source release. Engine is Phase 11 (handler-first execution for
+the proven-safe subset; full handler-first execution in progress). Conformance
+suite covers 200+ contract bundles across 12 tiers (primitives, accumulation,
+atomic event-loop semantics, composition, boot verification, runtime fork,
+policy patterns).
+
+### Added
+
+- `swarm fork <source-run-id> --at-event <event-id>` CLI: re-execute a run from
+  any point in its history.
+- `swarm forkchat` CLI: fork one agent conversation into a sandbox, optionally at
+  a turn or event with an injected message.
+- `swarm agent diagnose <id>` CLI: inspect why an agent is stuck (its
+  pending-delivery queue in detail).
+- `swarm bundle` CLI family: list, view, register, and delete persisted contract
+  bundles by canonical hash.
+- GitHub Discussions enabled for questions, flow sharing, and feature requests.
+
+### Changed
+
+- Default runtime store for local/dev runs is now file-backed SQLite at
+  `.swarm/dev.db`; Postgres is opt-in via `--store postgres` or `store.backend`.
+- LLM runtime names: `anthropic` (was `api`), `claude_cli` (was `cli_test`).
+  Legacy aliases retained.
+- `swarm event publish` (was `swarm publish`); `swarm mailbox` (was
+  `swarm control mailbox`). Old forms removed.
+- README trimmed to front-door scope (identity, design positions, project
+  status). Tutorial content now lives at [docs.division.sh](https://docs.division.sh).
+
+### Fixed
+
+- SQLite store now accepts relative-path DSNs (e.g. `.swarm/dev.db`) without
+  failing to open; the file URL serializer was emitting an unparseable form
+  with leading-dot paths. (#1222)
+- `swarm run` now accepts the `--data` flag (previously only `swarm serve`
+  did); the workspace `/data` mount auto-creates at `.swarm/data/` when
+  unset, so the runtime no longer requires `SWARM_WORKSPACE_DATA_SOURCE`
+  for agent flows that do not read shared reference data. (#1223)
+
+### Retired
+
+- `SWARM_LLM_BACKEND` environment variable: rejected at boot. Backend is now
+  selected via `--backend` on `swarm serve` / `swarm run`, or `llm.backend`
+  in `config.yaml`.
+- `model_tier` agent field: rejected at boot. Authored agents declare `model`
+  with an alias (`cheap`, `regular`, or `frontier`); `llm.models` maps each
+  alias to a concrete model per backend.
+- Docker Compose: the bundled `docker-compose.yml` is no longer supported; the
+  zero-service SQLite default replaces the compose-based local-dev path.
+
+[Unreleased]: https://github.com/division-sh/swarm/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/division-sh/swarm/releases/tag/v1.6.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@division.sh. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+


### PR DESCRIPTION
Adds the two community-health files that GitHub's repo-health check flags as missing and that external contributors expect to find at launch.

## Files

**CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 verbatim from contributor-covenant.org, with the enforcement contact wired to `conduct@division.sh`. (If the email needs to be different, edit before merge.)

**CHANGELOG.md** — Keep-a-Changelog format. The 1.6.0 entry covers:

- Added: shipped CLI additions (`swarm fork`, `swarm forkchat`, `swarm agent diagnose`, `swarm bundle`), Discussions.
- Changed: SQLite-as-default for local/dev, `anthropic`/`claude_cli` runtime renames, CLI command renames (`swarm event publish`, `swarm mailbox`), README trim.
- Fixed: #1222 (relative-path SQLite DSN), #1223 (/data auto-default + `--data` parity).
- Retired: `SWARM_LLM_BACKEND` env var, `model_tier` agent field, Docker Compose.

Independent of #1238 (README Quickstart trim) — these can land in either order.

## TODO before tagging v1.6.0

- [ ] Confirm `conduct@division.sh` exists or change the address.
- [ ] Tag `v1.6.0` against master once both this and #1238 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)