### PR TITLE
[agent-g][issue #1235] Enable host native file operations

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2044,13 +2044,13 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	authority := spec.WorkspaceModel.WorkspaceExecutionTargetCapability
-	if strings.TrimSpace(authority.PromotedBy) != "#1213" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_slice" {
 		t.Fatalf("workspace execution target authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_execution_target_capability") || !strings.Contains(authority.ImplementationOwner, "internal/runtime/workspace.ExecutionTarget") {
 		t.Fatalf("workspace execution target owners = canonical:%q implementation:%q", authority.CanonicalOwner, authority.ImplementationOwner)
 	}
-	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "does not enable host native tools"} {
+	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "platform-managed native file read/write"} {
 		if !strings.Contains(authority.Scope, want) {
 			t.Fatalf("workspace execution target scope missing %q:\n%s", want, authority.Scope)
 		}
@@ -2068,8 +2068,18 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 		}
 	}
 	hostMode := authority.TargetModes[string(workspace.ExecutionModeHostLocal)]
-	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") || len(hostMode.Capabilities) != 0 {
-		t.Fatalf("host execution mode = %#v, want explicit unsupported first slice", hostMode)
+	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") {
+		t.Fatalf("host execution mode rule = %q", hostMode.Rule)
+	}
+	for _, want := range []string{string(workspace.ExecutionCapabilityFileRead), string(workspace.ExecutionCapabilityFileWrite)} {
+		if !stringSliceContains(hostMode.Capabilities, want) {
+			t.Fatalf("host execution capabilities missing %q: %#v", want, hostMode.Capabilities)
+		}
+	}
+	for _, forbidden := range []string{string(workspace.ExecutionCapabilityNativeCommand), string(workspace.ExecutionCapabilityToolResultRelay), string(workspace.ExecutionCapabilityClaudeCLI)} {
+		if stringSliceContains(hostMode.Capabilities, forbidden) {
+			t.Fatalf("host execution capabilities include forbidden %q: %#v", forbidden, hostMode.Capabilities)
+		}
 	}
 	unsupportedMode := authority.TargetModes[string(workspace.ExecutionModeUnsupported)]
 	if !strings.Contains(unsupportedMode.Rule, "process cwd") || len(unsupportedMode.Capabilities) != 0 {
@@ -2083,7 +2093,7 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 			t.Fatalf("logical read-only mounts missing %q: %#v", want, authority.LogicalMountAuthority.ReadOnly)
 		}
 	}
-	for _, want := range []string{"Relative execution paths", "Writes outside logical `/workspace`", "MUST NOT leak raw host backing paths", "data_source_authority"} {
+	for _, want := range []string{"Relative execution paths", "Writes outside logical `/workspace`", "MUST NOT leak raw host backing paths", "symlink escapes", "data_source_authority"} {
 		if !joinedContains(authority.LogicalMountAuthority.Rules, want) {
 			t.Fatalf("logical mount authority rules missing %q: %#v", want, authority.LogicalMountAuthority.Rules)
 		}
@@ -2098,21 +2108,21 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 			t.Fatalf("retired interpreters missing %q: %#v", want, authority.RetiredNonAuthoritativeInterpreters)
 		}
 	}
-	for _, want := range []string{"Host-local targets remain fail closed", "Empty-container targets", "Docker behavior"} {
+	for _, want := range []string{"native command execution", "Host-local file operations fail closed", "Empty-container targets", "Docker behavior"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("failure behavior missing %q: %#v", want, authority.FailureBehavior)
 		}
 	}
-	for _, want := range []string{"host native file", "host native bash", "host tool-result relay", "Claude CLI", "#1137"} {
+	for _, want := range []string{"host native bash", "host tool-result relay", "Claude CLI", "#1137"} {
 		if !joinedContains(authority.SplitScope, want) {
 			t.Fatalf("split scope missing %q: %#v", want, authority.SplitScope)
 		}
 	}
 	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceExecutionTargetCapability
-	if command.PromotedBy != "#1213" || command.Owner != "workspace_model.workspace_execution_target_capability" {
+	if command.PromotedBy != "#1213/#1235" || command.Owner != "workspace_model.workspace_execution_target_capability" {
 		t.Fatalf("serve command workspace execution authority = %#v", command)
 	}
-	if !strings.Contains(command.Rule, "Host-local targets remain explicit and fail closed") {
+	if !strings.Contains(command.Rule, "support only platform-managed native file read/write") {
 		t.Fatalf("serve command workspace execution rule = %q", command.Rule)
 	}
 	for _, want := range []string{"native executor", "fallback-tool routing", "tool-result relay", "Claude CLI"} {

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -70,6 +71,9 @@ func (e *Executor) execNativeBash(ctx context.Context, actor models.AgentConfig,
 	if execErr != nil && (ctx.Err() != nil || strings.Contains(strings.ToLower(execErr.Error()), "deadline exceeded")) {
 		return nil, execErr
 	}
+	if execErr != nil && exitCode == -1 {
+		return nil, execErr
+	}
 	return map[string]any{
 		"stdout":      string(stdout),
 		"stderr":      string(stderr),
@@ -89,6 +93,10 @@ func (e *Executor) execNativeReadFile(ctx context.Context, actor models.AgentCon
 	}
 	if err := target.ExecutionTarget().Require(workspace.ExecutionCapabilityFileRead); err != nil {
 		return nil, err
+	}
+	execTarget := target.ExecutionTarget()
+	if execTarget.Mode == workspace.ExecutionModeHostLocal {
+		return execNativeHostReadFile(execTarget, in.Path)
 	}
 	path, err := resolveNativeReadPath(target, in.Path)
 	if err != nil {
@@ -115,6 +123,10 @@ func (e *Executor) execNativeWriteFile(ctx context.Context, actor models.AgentCo
 	}
 	if err := target.ExecutionTarget().Require(workspace.ExecutionCapabilityFileWrite); err != nil {
 		return nil, err
+	}
+	execTarget := target.ExecutionTarget()
+	if execTarget.Mode == workspace.ExecutionModeHostLocal {
+		return execNativeHostWriteFile(execTarget, in.Path, in.Content)
 	}
 	path, err := resolveNativeWritePath(target, in.Path)
 	if err != nil {
@@ -358,6 +370,49 @@ func resolveNativeReadPath(target *workspace.Target, raw string) (string, error)
 
 func resolveNativeWritePath(target *workspace.Target, raw string) (string, error) {
 	return target.ExecutionTarget().ResolvePath(raw, workspace.PathAccessWrite)
+}
+
+func execNativeHostReadFile(target workspace.ExecutionTarget, rawPath string) (any, error) {
+	resolved, err := target.ResolveHostPath(rawPath, workspace.PathAccessRead)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(resolved.HostPath)
+	if err != nil {
+		return nil, fmt.Errorf("read_file failed for %s: %s", resolved.LogicalPath, hostFileErrorMessage(err))
+	}
+	return map[string]any{
+		"content":    string(data),
+		"size_bytes": len(data),
+	}, nil
+}
+
+func execNativeHostWriteFile(target workspace.ExecutionTarget, rawPath string, content string) (any, error) {
+	resolved, err := target.ResolveHostPath(rawPath, workspace.PathAccessWrite)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved.HostPath), 0o700); err != nil {
+		return nil, fmt.Errorf("write_file failed for %s: %s", resolved.LogicalPath, hostFileErrorMessage(err))
+	}
+	data := []byte(content)
+	if err := os.WriteFile(resolved.HostPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("write_file failed for %s: %s", resolved.LogicalPath, hostFileErrorMessage(err))
+	}
+	return map[string]any{
+		"bytes_written": len(data),
+	}, nil
+}
+
+func hostFileErrorMessage(err error) string {
+	switch {
+	case os.IsNotExist(err):
+		return "file does not exist"
+	case os.IsPermission(err):
+		return "permission denied"
+	default:
+		return "file is unavailable"
+	}
 }
 
 func (e *Executor) resolveWebSearchProviderConfig() (webSearchProviderConfig, error) {

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -2,12 +2,16 @@ package tools
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	runtimecontracts "swarm/internal/runtime/contracts"
 	models "swarm/internal/runtime/core/actors"
 	llm "swarm/internal/runtime/llm"
+	"swarm/internal/runtime/semanticview"
 	workspace "swarm/internal/runtime/workspace"
 )
 
@@ -25,13 +29,33 @@ func TestNativeWorkspaceCommandFailsClosedForHostBackend(t *testing.T) {
 	}
 }
 
-func TestNativeFileToolsFailClosedForHostBackendThroughExecutionTarget(t *testing.T) {
+func TestNativeFileToolsUseHostExecutionTargetWithoutShell(t *testing.T) {
+	workspaceDir := t.TempDir()
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceDir, "input.txt"), []byte("workspace content"), 0o644); err != nil {
+		t.Fatalf("write workspace input: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "ref.txt"), []byte("data content"), 0o644); err != nil {
+		t.Fatalf("write data ref: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("contracts content"), 0o644); err != nil {
+		t.Fatalf("write contracts package: %v", err)
+	}
 	exec := &Executor{
 		workspaces: relayWorkspaceResolverStub{
-			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+			target: &workspace.Target{
+				Backend: workspace.BackendHost,
+				Workdir: workspaceDir,
+				Mounts: []workspace.ExecutionMount{
+					{LogicalPath: workspace.LogicalWorkspaceMount, HostPath: workspaceDir, Access: workspace.MountAccessReadWrite},
+					{LogicalPath: workspace.LogicalDataMount, HostPath: dataDir, Access: workspace.MountAccessReadOnly},
+					{LogicalPath: workspace.LogicalContractsMount, HostPath: contractsDir, Access: workspace.MountAccessReadOnly},
+				},
+			},
 		},
 		execWorkspaceFn: func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
-			t.Fatalf("host native file tools must fail closed before workspace command execution")
+			t.Fatalf("host native file tools must not shell through workspace command execution")
 			return nil, nil, 0, nil
 		},
 	}
@@ -40,14 +64,232 @@ func TestNativeFileToolsFailClosedForHostBackendThroughExecutionTarget(t *testin
 		NativeTools: models.NativeToolConfig{FileIO: true},
 	})
 
-	_, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/input.txt"})
-	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("execNativeReadFile error = %v, want host fail-closed diagnostic", err)
+	readWorkspace, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/input.txt"})
+	if err != nil {
+		t.Fatalf("execNativeReadFile workspace: %v", err)
+	}
+	if got := readWorkspace.(map[string]any)["content"]; got != "workspace content" {
+		t.Fatalf("workspace read content = %#v", got)
+	}
+	readData, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/data/ref.txt"})
+	if err != nil {
+		t.Fatalf("execNativeReadFile data: %v", err)
+	}
+	if got := readData.(map[string]any)["content"]; got != "data content" {
+		t.Fatalf("data read content = %#v", got)
+	}
+	readContracts, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/opt/swarm/contracts/package.yaml"})
+	if err != nil {
+		t.Fatalf("execNativeReadFile contracts: %v", err)
+	}
+	if got := readContracts.(map[string]any)["content"]; got != "contracts content" {
+		t.Fatalf("contracts read content = %#v", got)
 	}
 
-	_, err = exec.execNativeWriteFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/output.txt", "content": "hello"})
+	written, err := exec.execNativeWriteFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/nested/output.txt", "content": "hello"})
+	if err != nil {
+		t.Fatalf("execNativeWriteFile workspace: %v", err)
+	}
+	if got := written.(map[string]any)["bytes_written"]; got != len([]byte("hello")) {
+		t.Fatalf("write bytes = %#v", got)
+	}
+	if data, err := os.ReadFile(filepath.Join(workspaceDir, "nested", "output.txt")); err != nil || string(data) != "hello" {
+		t.Fatalf("written workspace file = %q err=%v", data, err)
+	}
+
+	for _, forbidden := range []string{"/data/out.txt", "/opt/swarm/contracts/out.txt", "/tmp/out.txt", workspaceDir} {
+		_, err := exec.execNativeWriteFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": forbidden, "content": "nope"})
+		if err == nil {
+			t.Fatalf("execNativeWriteFile(%q) succeeded, want fail closed", forbidden)
+		}
+		if strings.Contains(err.Error(), workspaceDir) || strings.Contains(err.Error(), dataDir) || strings.Contains(err.Error(), contractsDir) {
+			t.Fatalf("execNativeWriteFile(%q) leaked host path in error: %v", forbidden, err)
+		}
+	}
+
+	if err := os.Symlink(dataDir, filepath.Join(workspaceDir, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, err = exec.execNativeReadFile(ctx, models.AgentConfig{ID: "writer"}, map[string]any{"path": "/workspace/link/ref.txt"})
+	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
+		t.Fatalf("execNativeReadFile symlink error = %v, want escape rejection", err)
+	}
+}
+
+func TestExecutorHostFileToolsUseHostManagerSupportedSurfaceWithoutDocker(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := filepath.Join(t.TempDir(), "host-workspaces")
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, "ref.txt"), []byte("data content"), 0o644); err != nil {
+		t.Fatalf("write data ref: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("contracts content"), 0o644); err != nil {
+		t.Fatalf("write contracts package: %v", err)
+	}
+
+	manager := workspace.NewHostManager(nil)
+	manager.SetConfig(workspace.HostConfig{
+		WorkspaceRoot:       workspaceRoot,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      workspace.LogicalDataMount,
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: workspace.LogicalContractsMount,
+	})
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	if err := manager.ValidateSource(ctx, source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	if err := manager.EnsurePrereqs(ctx); err != nil {
+		t.Fatalf("EnsurePrereqs: %v", err)
+	}
+
+	actor := models.AgentConfig{
+		ID:          "host-file-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true, Bash: true},
+	}
+	target, err := manager.ResolveWorkspace(ctx, actor)
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	if target == nil || !target.HostBackend() {
+		t.Fatalf("resolved workspace target = %#v, want host backend", target)
+	}
+	if err := os.WriteFile(filepath.Join(target.Workdir, "input.txt"), []byte("workspace content"), 0o644); err != nil {
+		t.Fatalf("write workspace input: %v", err)
+	}
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	exec.execWorkspaceFn = func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+		t.Fatalf("host file tools must use direct platform file operations, not workspace command execution")
+		return nil, nil, 0, nil
+	}
+	actorCtx := models.WithActor(ctx, actor)
+
+	readWorkspace, err := exec.Execute(actorCtx, "read_file", map[string]any{"path": "/workspace/input.txt"})
+	if err != nil {
+		t.Fatalf("Execute read_file workspace: %v", err)
+	}
+	if got := readWorkspace.(map[string]any)["content"]; got != "workspace content" {
+		t.Fatalf("workspace content = %#v", got)
+	}
+	readData, err := exec.Execute(actorCtx, "read_file", map[string]any{"path": "/data/ref.txt"})
+	if err != nil {
+		t.Fatalf("Execute read_file data: %v", err)
+	}
+	if got := readData.(map[string]any)["content"]; got != "data content" {
+		t.Fatalf("data content = %#v", got)
+	}
+	readContracts, err := exec.Execute(actorCtx, "read_file", map[string]any{"path": "/opt/swarm/contracts/package.yaml"})
+	if err != nil {
+		t.Fatalf("Execute read_file contracts: %v", err)
+	}
+	if got := readContracts.(map[string]any)["content"]; got != "contracts content" {
+		t.Fatalf("contracts content = %#v", got)
+	}
+	written, err := exec.Execute(actorCtx, "write_file", map[string]any{"path": "/workspace/out/result.txt", "content": "hello"})
+	if err != nil {
+		t.Fatalf("Execute write_file workspace: %v", err)
+	}
+	if got := written.(map[string]any)["bytes_written"]; got != len([]byte("hello")) {
+		t.Fatalf("bytes_written = %#v", got)
+	}
+	if data, err := os.ReadFile(filepath.Join(target.Workdir, "out", "result.txt")); err != nil || string(data) != "hello" {
+		t.Fatalf("written host workspace file = %q err=%v", data, err)
+	}
+
+	for _, forbidden := range []string{
+		"/data/out.txt",
+		"/opt/swarm/contracts/out.txt",
+		"/tmp/out.txt",
+		filepath.Join(target.Workdir, "out", "result.txt"),
+		"../escape.txt",
+	} {
+		_, err := exec.Execute(actorCtx, "write_file", map[string]any{"path": forbidden, "content": "nope"})
+		if err == nil {
+			t.Fatalf("Execute write_file(%q) succeeded, want fail closed", forbidden)
+		}
+		if strings.Contains(err.Error(), target.Workdir) || strings.Contains(err.Error(), dataDir) || strings.Contains(err.Error(), contractsDir) {
+			t.Fatalf("Execute write_file(%q) leaked host path in error: %v", forbidden, err)
+		}
+	}
+
+	if err := os.Symlink(dataDir, filepath.Join(target.Workdir, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, err = exec.Execute(actorCtx, "read_file", map[string]any{"path": "/workspace/link/ref.txt"})
+	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
+		t.Fatalf("Execute read_file symlink error = %v, want escape rejection", err)
+	}
+
+	_, err = exec.Execute(actorCtx, "bash", map[string]any{"command": "true"})
 	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("execNativeWriteFile error = %v, want host fail-closed diagnostic", err)
+		t.Fatalf("Execute bash error = %v, want host native command fail-closed", err)
+	}
+}
+
+func TestNativeFileToolsKeepDockerWorkspaceCommandExecution(t *testing.T) {
+	exec := &Executor{
+		workspaces: relayWorkspaceResolverStub{
+			target: &workspace.Target{
+				Backend:   workspace.BackendDocker,
+				Container: "swarm-agent",
+				Workdir:   workspace.LogicalWorkspaceMount,
+			},
+		},
+	}
+	var calls []string
+	exec.execWorkspaceFn = func(_ context.Context, execTarget workspace.ExecutionTarget, _ time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
+		if execTarget.Mode != workspace.ExecutionModeDockerContainer {
+			t.Fatalf("exec target mode = %s, want docker_container", execTarget.Mode)
+		}
+		if execTarget.Container != "swarm-agent" {
+			t.Fatalf("exec target container = %q, want swarm-agent", execTarget.Container)
+		}
+		if len(args) != 5 || args[0] != "sh" || args[1] != "-lc" {
+			t.Fatalf("workspace command args = %#v, want shell command with argv path", args)
+		}
+		calls = append(calls, strings.Join(args, "\x00"))
+		switch args[3] {
+		case "swarm-read-file":
+			if args[4] != "/workspace/input.txt" {
+				t.Fatalf("read path = %q, want /workspace/input.txt", args[4])
+			}
+			return []byte("docker content"), nil, 0, nil
+		case "swarm-write-file":
+			if args[4] != "/workspace/out/result.txt" {
+				t.Fatalf("write path = %q, want /workspace/out/result.txt", args[4])
+			}
+			if stdin != "hello" {
+				t.Fatalf("write stdin = %q, want hello", stdin)
+			}
+			return nil, nil, 0, nil
+		default:
+			t.Fatalf("unexpected workspace command label: %#v", args)
+			return nil, nil, 1, nil
+		}
+	}
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "docker-file-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	})
+
+	read, err := exec.execNativeReadFile(ctx, models.AgentConfig{ID: "docker-file-agent"}, map[string]any{"path": "/workspace/input.txt"})
+	if err != nil {
+		t.Fatalf("execNativeReadFile docker: %v", err)
+	}
+	if got := read.(map[string]any)["content"]; got != "docker content" {
+		t.Fatalf("docker read content = %#v", got)
+	}
+	written, err := exec.execNativeWriteFile(ctx, models.AgentConfig{ID: "docker-file-agent"}, map[string]any{"path": "out/result.txt", "content": "hello"})
+	if err != nil {
+		t.Fatalf("execNativeWriteFile docker: %v", err)
+	}
+	if got := written.(map[string]any)["bytes_written"]; got != len([]byte("hello")) {
+		t.Fatalf("docker write bytes = %#v", got)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("docker command calls = %#v, want two command executions", calls)
 	}
 }
 
@@ -67,20 +309,28 @@ func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T)
 	}
 
 	defs := exec.ToolDefinitionsForActorInContext(context.Background(), actor)
-	for _, denied := range []string{"bash", "read_file", "write_file"} {
+	for _, denied := range []string{"bash"} {
 		if containsToolDefinition(defs, denied) {
 			t.Fatalf("context definitions contain %q for host backend: %#v", denied, defs)
 		}
 	}
-	if !containsToolDefinition(defs, "web_search") {
-		t.Fatalf("context definitions missing web_search, which is not workspace-execution backed: %#v", defs)
+	for _, allowed := range []string{"read_file", "write_file", "web_search"} {
+		if !containsToolDefinition(defs, allowed) {
+			t.Fatalf("context definitions missing %q: %#v", allowed, defs)
+		}
 	}
 
 	caps := exec.ToolCapabilitiesForActorInContext(context.Background(), actor, []string{"bash", "read_file", "write_file", "web_search"}, nil)
-	for _, denied := range []string{"bash", "read_file", "write_file"} {
+	for _, denied := range []string{"bash"} {
 		cap := caps.ByName[denied]
 		if cap.Visible || cap.Callable || !strings.Contains(cap.DenialReason, "host workspace backend does not support native tool execution yet") {
 			t.Fatalf("capability %s = %#v, want host workspace execution denial", denied, cap)
+		}
+	}
+	for _, allowed := range []string{"read_file", "write_file"} {
+		cap := caps.ByName[allowed]
+		if !cap.Visible || !cap.Callable || cap.DenialReason != "" {
+			t.Fatalf("capability %s = %#v, want visible/callable host file operation", allowed, cap)
 		}
 	}
 	web := caps.ByName["web_search"]

--- a/internal/runtime/workspace/execution.go
+++ b/internal/runtime/workspace/execution.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -61,6 +62,12 @@ const (
 	PathAccessWrite PathAccess = "write"
 )
 
+type ResolvedPath struct {
+	LogicalPath string
+	HostPath    string
+	Access      PathAccess
+}
+
 func (t *Target) ExecutionTarget() ExecutionTarget {
 	if t == nil {
 		return unsupportedExecutionTarget("")
@@ -116,11 +123,14 @@ func dockerExecutionTarget(container, workdir string, mounts []ExecutionMount) E
 
 func hostExecutionTarget(workdir string, mounts []ExecutionMount) ExecutionTarget {
 	return ExecutionTarget{
-		Backend:      BackendHost,
-		Mode:         ExecutionModeHostLocal,
-		Workdir:      LogicalWorkspaceMount,
-		Mounts:       executionMountsOrDefault(mounts),
-		capabilities: capabilitySet(),
+		Backend: BackendHost,
+		Mode:    ExecutionModeHostLocal,
+		Workdir: LogicalWorkspaceMount,
+		Mounts:  executionMountsOrDefault(mounts),
+		capabilities: capabilitySet(
+			ExecutionCapabilityFileRead,
+			ExecutionCapabilityFileWrite,
+		),
 	}
 }
 
@@ -206,9 +216,33 @@ func (e ExecutionTarget) UnsupportedMessage(capability ExecutionCapability) stri
 }
 
 func (e ExecutionTarget) ResolvePath(raw string, access PathAccess) (string, error) {
+	resolved, _, err := e.resolveLogicalPath(raw, access)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func (e ExecutionTarget) ResolveExecutionPath(raw string, access PathAccess) (ResolvedPath, error) {
+	clean, mount, err := e.resolveLogicalPath(raw, access)
+	if err != nil {
+		return ResolvedPath{}, err
+	}
+	resolved := ResolvedPath{LogicalPath: clean, Access: access}
+	if e.Mode == ExecutionModeHostLocal {
+		hostPath, err := resolveHostBackingPath(clean, mount)
+		if err != nil {
+			return ResolvedPath{}, err
+		}
+		resolved.HostPath = hostPath
+	}
+	return resolved, nil
+}
+
+func (e ExecutionTarget) resolveLogicalPath(raw string, access PathAccess) (string, ExecutionMount, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return "", fmt.Errorf("path is required")
+		return "", ExecutionMount{}, fmt.Errorf("path is required")
 	}
 	clean := cleanLogicalPath(raw)
 	if !strings.HasPrefix(clean, "/") {
@@ -220,14 +254,28 @@ func (e ExecutionTarget) ResolvePath(raw string, access PathAccess) (string, err
 			continue
 		}
 		if access == PathAccessWrite && mount.Access != MountAccessReadWrite {
-			return "", fmt.Errorf("write_file path %s is outside the writable workspace", raw)
+			return "", ExecutionMount{}, fmt.Errorf("write_file path %s is outside the writable workspace", clean)
 		}
-		return clean, nil
+		return clean, mount, nil
 	}
 	if access == PathAccessWrite {
-		return "", fmt.Errorf("write_file path %s is outside the writable workspace", raw)
+		return "", ExecutionMount{}, fmt.Errorf("write_file path is outside the writable workspace")
 	}
-	return "", fmt.Errorf("read_file path %s is outside the allowed workspace mounts", raw)
+	return "", ExecutionMount{}, fmt.Errorf("read_file path is outside the allowed workspace mounts")
+}
+
+func (e ExecutionTarget) ResolveHostPath(raw string, access PathAccess) (ResolvedPath, error) {
+	resolved, err := e.ResolveExecutionPath(raw, access)
+	if err != nil {
+		return ResolvedPath{}, err
+	}
+	if e.Mode != ExecutionModeHostLocal {
+		return ResolvedPath{}, fmt.Errorf("workspace target is not a host-local execution target")
+	}
+	if strings.TrimSpace(resolved.HostPath) == "" {
+		return ResolvedPath{}, fmt.Errorf("host backing path for %s is unavailable", resolved.LogicalPath)
+	}
+	return resolved, nil
 }
 
 func (e ExecutionTarget) WorkspacePath(rel string) (string, error) {
@@ -260,4 +308,37 @@ func logicalPathWithinRoot(value, root string) bool {
 		return false
 	}
 	return value == root || strings.HasPrefix(value, strings.TrimRight(root, "/")+"/")
+}
+
+func resolveHostBackingPath(logicalPath string, mount ExecutionMount) (string, error) {
+	rootRaw := strings.TrimSpace(mount.HostPath)
+	if rootRaw == "" {
+		return "", fmt.Errorf("host backing path for %s is unavailable", cleanLogicalPath(mount.LogicalPath))
+	}
+	root, err := canonicalPathForOverlap(rootRaw, "host backing path")
+	if err != nil {
+		return "", fmt.Errorf("host backing path for %s is unavailable", cleanLogicalPath(mount.LogicalPath))
+	}
+	rel := logicalPathRelativeToRoot(logicalPath, mount.LogicalPath)
+	hostPath := root
+	if rel != "" {
+		hostPath = filepath.Join(root, filepath.FromSlash(rel))
+	}
+	resolved, err := canonicalPathForOverlap(hostPath, "host execution path")
+	if err != nil {
+		return "", fmt.Errorf("host execution path %s is unavailable", cleanLogicalPath(logicalPath))
+	}
+	if !pathWithinRoot(resolved, root) {
+		return "", fmt.Errorf("host execution path %s escapes %s", cleanLogicalPath(logicalPath), cleanLogicalPath(mount.LogicalPath))
+	}
+	return resolved, nil
+}
+
+func logicalPathRelativeToRoot(value, root string) string {
+	value = cleanLogicalPath(value)
+	root = cleanLogicalPath(root)
+	if value == root {
+		return ""
+	}
+	return strings.TrimPrefix(value, strings.TrimRight(root, "/")+"/")
 }

--- a/internal/runtime/workspace/execution_test.go
+++ b/internal/runtime/workspace/execution_test.go
@@ -1,6 +1,8 @@
 package workspace
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -12,8 +14,11 @@ func TestExecutionTargetDistinguishesDockerHostAndEmptyContainer(t *testing.T) {
 	}
 
 	host := (&Target{Backend: BackendHost, Workdir: t.TempDir()}).ExecutionTarget()
-	if host.Mode != ExecutionModeHostLocal || host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityClaudeCLI) {
-		t.Fatalf("host execution target = %#v, want explicit unsupported host-local target", host)
+	if host.Mode != ExecutionModeHostLocal || !host.Supports(ExecutionCapabilityFileRead) || !host.Supports(ExecutionCapabilityFileWrite) {
+		t.Fatalf("host execution target = %#v, want explicit host file capabilities", host)
+	}
+	if host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityToolResultRelay) || host.Supports(ExecutionCapabilityClaudeCLI) {
+		t.Fatalf("host execution target = %#v, want command/relay/claude unsupported", host)
 	}
 	if err := host.Require(ExecutionCapabilityNativeCommand); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
 		t.Fatalf("host native command error = %v, want fail-closed diagnostic", err)
@@ -46,6 +51,62 @@ func TestExecutionTargetLogicalPathAuthority(t *testing.T) {
 	}
 	if _, err := target.ResolvePath(t.TempDir(), PathAccessRead); err == nil || !strings.Contains(err.Error(), "outside the allowed workspace mounts") {
 		t.Fatalf("raw host read error = %v, want raw host path rejection", err)
+	}
+}
+
+func TestExecutionTargetHostBackingPathAuthority(t *testing.T) {
+	workspaceDir := t.TempDir()
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	target := (&Target{
+		Backend: BackendHost,
+		Workdir: workspaceDir,
+		Mounts: []ExecutionMount{
+			{LogicalPath: LogicalWorkspaceMount, HostPath: workspaceDir, Access: MountAccessReadWrite},
+			{LogicalPath: LogicalDataMount, HostPath: dataDir, Access: MountAccessReadOnly},
+			{LogicalPath: LogicalContractsMount, HostPath: contractsDir, Access: MountAccessReadOnly},
+		},
+	}).ExecutionTarget()
+
+	workspacePath, err := target.ResolveHostPath("drafts/out.txt", PathAccessWrite)
+	if err != nil {
+		t.Fatalf("ResolveHostPath workspace write: %v", err)
+	}
+	wantWorkspaceHostPath, err := canonicalPathForOverlap(filepath.Join(workspaceDir, "drafts", "out.txt"), "test workspace path")
+	if err != nil {
+		t.Fatalf("canonical workspace path: %v", err)
+	}
+	if workspacePath.LogicalPath != "/workspace/drafts/out.txt" || workspacePath.HostPath != wantWorkspaceHostPath {
+		t.Fatalf("workspace host path = %#v", workspacePath)
+	}
+
+	dataPath, err := target.ResolveHostPath("/data/ref.txt", PathAccessRead)
+	if err != nil {
+		t.Fatalf("ResolveHostPath data read: %v", err)
+	}
+	wantDataHostPath, err := canonicalPathForOverlap(filepath.Join(dataDir, "ref.txt"), "test data path")
+	if err != nil {
+		t.Fatalf("canonical data path: %v", err)
+	}
+	if dataPath.LogicalPath != "/data/ref.txt" || dataPath.HostPath != wantDataHostPath {
+		t.Fatalf("data host path = %#v", dataPath)
+	}
+
+	if _, err := target.ResolveHostPath("/data/ref.txt", PathAccessWrite); err == nil || !strings.Contains(err.Error(), "outside the writable workspace") {
+		t.Fatalf("data write error = %v, want read-only rejection", err)
+	}
+	if _, err := target.ResolveHostPath(workspaceDir, PathAccessRead); err == nil || !strings.Contains(err.Error(), "outside the allowed workspace mounts") {
+		t.Fatalf("raw host path error = %v, want logical path rejection", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dataDir, "ref.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatalf("write data ref: %v", err)
+	}
+	if err := os.Symlink(dataDir, filepath.Join(workspaceDir, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := target.ResolveHostPath("/workspace/link/ref.txt", PathAccessRead); err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
+		t.Fatalf("symlink escape error = %v, want escape rejection", err)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6783,14 +6783,15 @@ workspace_model:
     - full host Claude CLI, native tool execution, and tool relay parity
     - production SQLite multi-writer semantics
   workspace_execution_target_capability:
-    promoted_by: '#1213'
-    implementation_status: implemented_first_slice
+    promoted_by: '#1213/#1235'
+    implementation_status: implemented_host_file_slice
     canonical_owner: platform-spec.yaml#workspace_model.workspace_execution_target_capability
     scope: >
       Defines the canonical runtime execution-target and capability authority for workspace-backed execution surfaces after
       workspace backend selection. The owner distinguishes Docker container execution, explicit host-local targets, and
-      unsupported targets. It does not make host execution Docker-equivalent and does not enable host native tools, host
-      command execution, host tool-result relay, or host Claude/provider runtime support in this first slice.
+      unsupported targets. It does not make host execution Docker-equivalent. Host-local targets support only platform-managed
+      native file read/write over logical workspace mounts; host command execution, host tool-result relay, and host
+      Claude/provider runtime support remain unsupported unless a later gate promotes those surfaces.
     implementation_owner: internal/runtime/workspace.ExecutionTarget
     target_modes:
       docker_container:
@@ -6806,9 +6807,12 @@ workspace_model:
       host_local:
         rule: >
           A host target is an explicit local-dev backend target with platform-managed raw host backing paths and logical
-          mount identities. Host-local targets MUST NOT infer execution support from an empty container field and MUST fail
-          closed for all current execution capabilities until a later gate promotes a specific host execution surface.
-        capabilities: []
+          mount identities. Host-local targets MUST NOT infer execution support from an empty container field. Host-local
+          targets support file_read and file_write only through the platform-managed workspace execution owner; native_command,
+          tool_result_relay, and claude_cli remain unsupported.
+        capabilities:
+        - file_read
+        - file_write
       unsupported:
         rule: >
           Nil targets, unknown backend names, Docker targets without a container, and empty targets are unsupported. They MUST
@@ -6826,6 +6830,8 @@ workspace_model:
       - Reads outside logical `/workspace`, `/data`, and `/opt/swarm/contracts` fail closed.
       - Runtime execution surfaces MUST expose logical paths as product semantics and MUST NOT leak raw host backing paths as
         agent-visible authority.
+      - Host file operations MUST resolve private host backing paths through this owner from the selected logical mount and
+        MUST reject symlink escapes or raw host absolute paths as product input.
       - Host execution target production MUST consume `workspace_model.data_source_authority` for `/data` and the loaded
         contracts source for `/opt/swarm/contracts`.
     consumers:
@@ -6847,12 +6853,14 @@ workspace_model:
     - nil target or empty target cwd fallback
     - ad hoc HostBackend() checks outside the execution-target owner
     failure_behavior:
-    - Host-local targets remain fail closed for native tool execution, tool-result relay, and Claude/provider execution until
-      a later gate promotes and proves a specific host execution surface.
+    - Host-local targets remain fail closed for native command execution, tool-result relay, and Claude/provider execution until
+      a later gate promotes and proves those surfaces.
+    - Host-local file operations fail closed when the logical path is outside allowed mounts, when a write targets a read-only
+      mount, when a raw host path is provided as product input, or when private backing-path resolution would escape the selected
+      mount root.
     - Empty-container targets MUST NOT authorize local host execution.
     - Docker behavior must remain regression-proven through the same typed owner.
     split_scope:
-    - host native file operations
     - host native bash/command execution
     - host tool-result relay support
     - Claude CLI/provider-native host runtime support
@@ -8626,12 +8634,13 @@ cli_specification:
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
       workspace_execution_target_capability:
-        promoted_by: '#1213'
+        promoted_by: '#1213/#1235'
         owner: workspace_model.workspace_execution_target_capability
         rule: >
           `swarm serve` runtime execution surfaces MUST consume the typed workspace execution target/capability owner after
-          backend selection. Host-local targets remain explicit and fail closed for native command/file execution, tool-result
-          relay, and Claude/provider execution in this first slice; Docker targets continue through container execution.
+          backend selection. Host-local targets remain explicit and support only platform-managed native file read/write;
+          native command execution, tool-result relay, and Claude/provider execution remain fail closed. Docker targets continue
+          through container execution.
         consumers:
         - native executor command/file path authority
         - native fallback tool-surface truth


### PR DESCRIPTION
## Summary

- Promotes host-local `file_read` / `file_write` only through `internal/runtime/workspace.ExecutionTarget`.
- Adds owned logical-to-host path resolution that keeps agent-visible semantics logical and rejects raw host paths, read-only writes, outside mounts, `..` escapes, and symlink escapes.
- Routes host `read_file` / `write_file` through direct platform-managed file I/O while preserving Docker file operations through container command execution.
- Keeps host bash/native command, tool-result relay, and Claude/provider host execution fail closed.

Closes #1235
Part of #1213
Part of #1138

## Governing Context

Exact spec refs updated in this PR:

- `platform-spec.yaml#workspace_model.workspace_execution_target_capability`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_execution_target_capability`

Binding adjacent spec/context consumed:

- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#workspace_model.data_source_authority`
- `platform-spec.yaml#workspace_model.standard_mounts`
- `platform-spec.yaml#engine.native_tools`
- #1235 pre-audit and independent gate outcome.

## Semantic Migration

New canonical owner: `platform-spec.yaml#workspace_model.workspace_execution_target_capability` implemented by `internal/runtime/workspace.ExecutionTarget` and its owned path result.

Old non-authoritative path now invalid: host file operation policy cannot be inferred from raw `Target.Workdir`, empty `Container`, `HostBackend()` checks, or executor-local `filepath` interpretation. `tools.Executor` now consumes the execution target owner for host file path authorization and private backing-path resolution.

Production paths checked: host manager mount production, native fallback tool visibility/callability, host file read/write execution, Docker read/write regression, host bash/native-command denial, tool-result relay denial, and Claude/provider host execution denial.

Migration completeness: complete for #1235 child class only. Host bash/native command, host relay, Claude/provider host execution, Docker-equivalent isolation, and docs/operator polish remain split under #1213/#1138.

## Proof

- `go test ./internal/runtime/workspace ./internal/runtime/tools ./internal/runtime/llm ./cmd/swarm -run 'Test(ExecutionTarget|NativeWorkspace|NativeFile|ExecutorHostFile|NativeFallback|ExecutorPersistOversizedToolResultRelay|ClaudeCLIRuntimeRejectsHost|ClaudeCLIRuntimeWorkspaceCommandRejectsHost|PlatformSpecWorkspace(Backend|Execution)|RunServeRuntimeHostWorkspaceBackend|HostManager)' -count=1`
- `git diff --check`
- `go test ./...`