### PR TITLE
[agent-e][issue #1230] Move dashboard capability gates to SQLite

### DIFF
--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -515,7 +516,7 @@ func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *t
 }
 
 func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListEvents(context.Background(), EventFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -524,7 +525,7 @@ func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCapabilityOwner(t *
 }
 
 func TestSQLObservabilityReader_GetEvent_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, _, err := reader.GetEvent(context.Background(), "evt-1"); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -533,7 +534,7 @@ func TestSQLObservabilityReader_GetEvent_FailsClosedWithoutCapabilityOwner(t *te
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListRuntimeLogs(context.Background(), RuntimeLogFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -542,7 +543,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwne
 }
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListIncidents(context.Background(), IncidentFilter{SinceHours: 24}); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -551,7 +552,7 @@ func TestSQLObservabilityReader_ListIncidents_FailsClosedWithoutCapabilityOwner(
 }
 
 func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCanonicalEventSurface(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Deliveries = store.SchemaFlavorLegacy
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -562,7 +563,7 @@ func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCanonicalEventSurfa
 }
 
 func TestSQLObservabilityReader_GetEvent_FailsClosedWhenCapabilityOwnerReportsUnavailableEventSurface(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Deliveries = store.SchemaFlavorUnavailable
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -573,7 +574,7 @@ func TestSQLObservabilityReader_GetEvent_FailsClosedWhenCapabilityOwnerReportsUn
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRuntimeLogSurface(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Log = store.SchemaFlavorLegacy
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -584,7 +585,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRunti
 }
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedWhenCapabilityOwnerReportsUnavailableRuntimeLogSurface(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	db := storetest.StartSQLiteRuntimeStore(t).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Log = store.SchemaFlavorUnavailable
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})


### PR DESCRIPTION
Part of #1230
Part of #1218
Part of #1196

## Summary

- Move the 8 approved dashboard observability capability-gate tests from `testutil.StartPostgres` to the shared `storetest.StartSQLiteRuntimeStore` helper from #1227.
- Leave the 12 protected dashboard projection/read-owner rows on `StartPostgres` because they execute Postgres-backed dashboard/store readers.
- Do not change production dashboard, store, runtime, platform spec, CLI, catalog E2E, async, or CI behavior.

## Governing Context

No exact product/runtime spec section directly governs this test-health migration. Binding context is #1230, #1218, #1196, the #1230 independent gate outcome, merged #1227, and adjacent root `platform-spec.yaml` `platform_tables.test_bootstrap` canonical test bootstrap ownership.

## Semantic Migration

New canonical owner consumed: `internal/store/storetest.StartSQLiteRuntimeStore` for backend-neutral dashboard tests that only need a non-nil/default persistent DB-backed reader and fail before SQL/store reads.

Old producer / reader / writer path now invalid for this slice: the 8 capability-gate tests using `testutil.StartPostgres` solely to construct `NewSQLObservabilityReader` before capability-resolution failure.

Production paths checked for surviving old behavior: dashboard projection/read-owner rows remain on `testutil.StartPostgres`; no production paths changed.

Migration completeness: complete for the approved dashboard capability-gate child class only. #1230/#1218 remain open for protected/split dashboard projection rows and other package-family residuals.

## Proof

- Refreshed inventory: `rg "StartPostgres\\(" -g '*_test.go' | wc -l` -> 577.
- Refreshed dashboard inventory: `rg -n "StartPostgres\\(" internal/dashboard -g '*_test.go' | wc -l` -> 12.
- Focused moved-row proof: `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_(ListEvents_FailsClosedWithoutCapabilityOwner|GetEvent_FailsClosedWithoutCapabilityOwner|ListRuntimeLogs_FailsClosedWithoutCapabilityOwner|ListIncidents_FailsClosedWithoutCapabilityOwner|ListEvents_FailsClosedWithoutCanonicalEventSurface|GetEvent_FailsClosedWhenCapabilityOwnerReportsUnavailableEventSurface|ListRuntimeLogs_FailsClosedWithoutCanonicalRuntimeLogSurface|ListIncidents_FailsClosedWhenCapabilityOwnerReportsUnavailableRuntimeLogSurface)$' -count=1`
- Dashboard package proof: `go test ./internal/dashboard/server -count=1`
- Dashboard recursive proof: `go test ./internal/dashboard/... -count=1`
- Whole suite: `go test ./...`