### PR TITLE
[agent-b][issue #1256] Event publish typed diagnostics

### DIFF
--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -429,7 +430,11 @@ func (e *jsonRPCError) Error() string {
 		return ""
 	}
 	if code := applicationErrorCode(e.Data); code != "" {
-		return fmt.Sprintf("%s: %s", code, e.Message)
+		message := fmt.Sprintf("%s: %s", code, e.Message)
+		if details := applicationErrorDetails(e.Data); details != "" {
+			message = fmt.Sprintf("%s (details: %s)", message, details)
+		}
+		return message
 	}
 	return e.Message
 }
@@ -445,6 +450,49 @@ func applicationErrorCode(raw json.RawMessage) string {
 		return ""
 	}
 	return strings.TrimSpace(data.Code)
+}
+
+func applicationErrorDetails(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var data struct {
+		Details map[string]any `json:"details"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil || len(data.Details) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(data.Details))
+	for key := range data.Details {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if value := applicationErrorDetailValue(data.Details[key]); value != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func applicationErrorDetailValue(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case float64, bool:
+		return fmt.Sprint(typed)
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil || string(raw) == "null" {
+			return ""
+		}
+		return string(raw)
+	}
 }
 
 type cliAPIHTTPError struct {

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -287,6 +287,7 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 		handler    http.HandlerFunc
 		wantCode   int
 		wantStderr string
+		wantExtra  []string
 	}{
 		{
 			name: "run not found exits five",
@@ -297,6 +298,7 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 			},
 			wantCode:   5,
 			wantStderr: "RUN_NOT_FOUND",
+			wantExtra:  []string{"event_name=scan.requested"},
 		},
 		{
 			name: "source event not found exits five",
@@ -458,8 +460,10 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 			if code != tc.wantCode {
 				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
 			}
-			if !strings.Contains(stderr.String(), tc.wantStderr) {
-				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			for _, want := range append([]string{tc.wantStderr}, tc.wantExtra...) {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)
+				}
 			}
 		})
 	}

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -13,10 +13,12 @@ import (
 	"net/netip"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/division-sh/swarm/internal/apispec"
+	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
@@ -302,9 +304,89 @@ func (h *Handler) responseFromResult(req Request, result any, err error) rpcResp
 		if errors.As(err, &paramsErr) && paramsErr != nil {
 			return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: invalidParams(req.CorrelationID, paramsErr.Details)}
 		}
+		h.logInternalFallback(req, err)
 		return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: h.standardError(codeInternalError, "internal error", req.CorrelationID, map[string]any{"error": err.Error()})}
 	}
 	return rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: result}
+}
+
+func (h *Handler) logInternalFallback(req Request, err error) {
+	if err == nil {
+		return
+	}
+	fields := []any{
+		"method", strings.TrimSpace(req.Method),
+		"correlation_id", strings.TrimSpace(req.CorrelationID),
+		"transport", strings.TrimSpace(req.Transport),
+		"request_hash", strings.TrimSpace(req.RequestHash),
+		"error", err.Error(),
+	}
+	if req.ID != nil {
+		fields = append(fields, "request_id", fmt.Sprint(req.ID))
+	}
+	fields = append(fields, safeRequestIdentifierFields(req.Params)...)
+	diaglog.ProcessLog(diaglog.LevelError, "api", "json-rpc internal error", fields...)
+}
+
+func safeRequestIdentifierFields(params map[string]any) []any {
+	if len(params) == 0 {
+		return nil
+	}
+	fields := make([]any, 0, 16)
+	for _, key := range []string{
+		"run_id",
+		"event_name",
+		"event_id",
+		"source_event_id",
+		"bundle_hash",
+		"agent_id",
+		"session_id",
+		"fork_id",
+		"conversation_id",
+		"turn_index",
+	} {
+		if value := safeRequestIdentifierValue(params[key]); value != "" {
+			fields = append(fields, key, value)
+		}
+	}
+	if bundleRef := asStringMap(params["bundle_ref"]); bundleRef != nil {
+		if fingerprint := safeRequestIdentifierValue(bundleRef["fingerprint"]); fingerprint != "" {
+			fields = append(fields, "bundle_ref_fingerprint", fingerprint)
+		}
+	}
+	if payload := asStringMap(params["payload"]); payload != nil {
+		if entityID := safeRequestIdentifierValue(payload["entity_id"]); entityID != "" {
+			fields = append(fields, "entity_id", entityID)
+		}
+	}
+	return fields
+}
+
+func safeRequestIdentifierValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(typed), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case int32:
+		return strconv.FormatInt(int64(typed), 10)
+	case uint:
+		return strconv.FormatUint(uint64(typed), 10)
+	case uint64:
+		return strconv.FormatUint(typed, 10)
+	case uint32:
+		return strconv.FormatUint(uint64(typed), 10)
+	default:
+		return ""
+	}
 }
 
 type webSocketSession struct {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -1,11 +1,13 @@
 package apiv1
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -242,6 +244,54 @@ func TestHandlerHTTPJSONRPCEnvelopeAndErrorSemantics(t *testing.T) {
 				t.Fatalf("standard error data missing correlation_id: %#v", data)
 			}
 		})
+	}
+}
+
+func TestHandlerLogsInternalFallbackErrors(t *testing.T) {
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: map[string]MethodHandler{
+			"event.publish": func(context.Context, Request) (any, error) {
+				return nil, errors.New("boom-event-publish-internal")
+			},
+		},
+	})
+
+	var resp rpcResponse
+	logOutput := captureProcessLog(t, func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":null,"method":"event.publish","params":{"event_name":"scan.requested","run_id":"run-log","payload":{"entity_id":"entity-log","secret":"do-not-log"}}}`))
+		req.Header.Set("Authorization", "Bearer "+testToken)
+		req.Header.Set("X-Correlation-ID", "trace-log")
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode rpc response: %v body=%s", err, rec.Body.String())
+		}
+	})
+
+	if resp.Error == nil || resp.Error.Code != codeInternalError {
+		t.Fatalf("error = %#v, want internal fallback", resp.Error)
+	}
+	for _, want := range []string{
+		"runtime.error component=api",
+		"json-rpc internal error",
+		`"method":"event.publish"`,
+		`"correlation_id":"trace-log"`,
+		`"run_id":"run-log"`,
+		`"event_name":"scan.requested"`,
+		`"entity_id":"entity-log"`,
+		"boom-event-publish-internal",
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("log output = %q, want substring %q", logOutput, want)
+		}
+	}
+	if strings.Contains(logOutput, "do-not-log") || strings.Contains(logOutput, "secret") {
+		t.Fatalf("log output leaked payload data: %q", logOutput)
 	}
 }
 
@@ -938,6 +988,19 @@ func rpcCall(t *testing.T, handler *Handler, body string) rpcResponse {
 		t.Fatalf("decode rpc response: %v body=%s", err, rec.Body.String())
 	}
 	return resp
+}
+
+func captureProcessLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer log.SetOutput(previousWriter)
+	defer log.SetFlags(previousFlags)
+	fn()
+	return buf.String()
 }
 
 type fakePinger struct {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -406,9 +406,27 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 	handler := eventPublishTestHandlerWithObservability(t, pg, bus, source, observability)
 	body := eventPublishBody("", runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "", "idem-readback")
 
-	first := rpcCall(t, handler, body)
+	var first rpcResponse
+	logOutput := captureProcessLog(t, func() {
+		first = rpcCall(t, handler, body)
+	})
 	if first.Error == nil || !strings.Contains(fmt.Sprintf("%#v", first.Error.Data), "transient event readback failure") {
 		t.Fatalf("first event.publish error = %#v, want transient readback failure", first.Error)
+	}
+	if first.Error.Code != codeInternalError {
+		t.Fatalf("first event.publish code = %d, want %d", first.Error.Code, codeInternalError)
+	}
+	for _, want := range []string{
+		"runtime.error component=api",
+		"json-rpc internal error",
+		`"method":"event.publish"`,
+		`"correlation_id":"publish"`,
+		`"event_name":"scan.requested"`,
+		"transient event readback failure",
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("readback failure log = %q, want substring %q", logOutput, want)
+		}
 	}
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count after readback failure = %d, want 1", count)

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	"swarm/internal/config"
-	"swarm/internal/events"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	runtimecorrelation "swarm/internal/runtime/correlation"
-	llmselection "swarm/internal/runtime/llm/selection"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/events"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 type OpenAIResponsesRuntime struct {

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"swarm/internal/config"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {


### PR DESCRIPTION
Closes #1256

## Scope
- Adds central JSON-RPC `-32603` fallback logging for raw non-application errors, including method, correlation id, request hash, transport, raw error, and safe request identifiers.
- Keeps `event.publish` post-publish readback/decode/store failures as true internals unless already governed by existing typed application errors; it does not relabel them as `EVENT_PUBLISH_FAILED`.
- Extends shared CLI JSON-RPC application-error rendering to include sorted `details` values so `swarm event publish` surfaces typed diagnostic context instead of only a code/message.
- Mechanically fixes stale `swarm/internal/...` imports in the OpenAI Responses runtime files so the required suite can compile after the module migration.

## Governing Refs
- `platform-spec.yaml#api_specification.conventions.error_format`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`
- `platform-spec.yaml#cli_specification.command_catalog.event_publish`
- `openrpc.json` generated `event.publish` method and declared application error set
- #1256 pre-audit: https://github.com/division-sh/swarm/issues/1256#issuecomment-4596990358
- #1256 gate: https://github.com/division-sh/swarm/issues/1256#issuecomment-4597017132

## Boundary
#1255 remains split for runtime routing/entity_id semantics. This PR only closes the approved #1256 diagnostics slice: typed/public `event.publish` application-error rendering plus central logging for remaining true internals.

## Proof
- `go test ./internal/apiv1 -run 'TestHandlerLogsInternalFallbackErrors|TestOperatorEventPublish'`
- `go test ./cmd/swarm -run 'TestEventPublishMapsFailureExitCodes|TestCLIAPIErrorExitCodeClassifiesSharedCategories'`
- `go test ./internal/runtime/llm -run TestOpenAIResponsesRuntime`
- `go test ./...`
- No-bypass proof: `cmd/swarm/event_publish.go` calls `client.call(ctx, eventPublishMethod, ...)`; grep found no direct `store`, `runtime`, or `EventBus` references in that CLI file.
