### PR TITLE
[agent-h][issue #1251] Support SQLite serve abandon quiescence

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -46,6 +46,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimerunforkadmission "github.com/division-sh/swarm/internal/runtime/runforkadmission"
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
+	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
@@ -147,6 +148,7 @@ type storeBundle struct {
 	IdempotencyStore    apiv1.APIIdempotencyStore
 	TurnStore           runtimellm.TurnPersistence
 	StartupOwnership    runtimestartupownership.Store
+	RunQuiescenceStore  runtimerunquiescence.ServeAbandonStore
 }
 
 type sqlDBPinger struct {
@@ -650,7 +652,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
 	defer closeDB(stores.SQLDB)
-	if stores.Postgres != nil {
+	if stores.SchemaBootstrapper != nil {
 		preCatalogPlatformSpecPath, err := servePreCatalogPlatformSpecPath(resolvedPaths, opts)
 		if err != nil {
 			reporter.emit(4, "bundle_load", "FAILED", err.Error())
@@ -687,7 +689,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
 	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
 	stateStoreSummaries := make([]string, len(loadedBundles))
-	if stores.Postgres != nil {
+	if stores.SchemaBootstrapper != nil {
 		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles)
 		if err != nil {
 			slog.Error("initialize state stores", "error", err)
@@ -696,11 +698,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		stateStoreSummaries = summaries
 	}
 	if opts.AbandonActiveRuns {
-		if stores.Postgres == nil {
-			slog.Error("abandon active runs failed", "error", "postgres store is required")
+		if stores.RunQuiescenceStore == nil {
+			slog.Error("abandon active runs failed", "error", "selected store active-run quiescence owner is required")
 			return 3
 		}
-		result, err := stores.Postgres.ApplyServeAbandonActiveRunQuiescence(ctx, time.Now().UTC())
+		result, err := stores.RunQuiescenceStore.ApplyServeAbandonActiveRunQuiescence(ctx, time.Now().UTC())
 		if err != nil {
 			slog.Error("abandon active runs failed", "error", err)
 			return 3
@@ -2422,6 +2424,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			IdempotencyStore:    pg,
 			TurnStore:           pg,
 			StartupOwnership:    pg,
+			RunQuiescenceStore:  pg,
 		}, nil
 	case storebackend.BackendSQLite:
 		sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)
@@ -2459,6 +2462,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			IdempotencyStore:    sqliteStore,
 			TurnStore:           sqliteStore,
 			StartupOwnership:    sqliteStore,
+			RunQuiescenceStore:  sqliteStore,
 		}, nil
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3635,6 +3635,123 @@ func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon(t *te
 	}
 }
 
+func TestRunServeRuntimeFreshEmptySQLiteBootsWithDevAbandon(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:           writeServeRuntimeTestConfig(t),
+			ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:     defaultPlatformSpecPath,
+			APIListenAddr:        "127.0.0.1:0",
+			MCPListenAddr:        "127.0.0.1:0",
+			SelfCheck:            true,
+			Dev:                  true,
+			RequireBundleMatch:   false,
+			NoRequireBundleMatch: true,
+			AbandonActiveRuns:    true,
+			Verbose:              true,
+			Output:               &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	if strings.Contains(out.String(), "postgres store is required") {
+		t.Fatalf("serve output contains stale postgres-only abandon failure:\n%s", out.String())
+	}
+	if _, err := os.Stat(sqlitePath); err != nil {
+		t.Fatalf("sqlite dev db not created at %s: %v", sqlitePath, err)
+	}
+}
+
+func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	runID, eventID := seedServeRuntimeSQLiteAbandonWork(t, sqlitePath)
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:         writeServeRuntimeTestConfig(t),
+			ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:   defaultPlatformSpecPath,
+			APIListenAddr:      "127.0.0.1:0",
+			MCPListenAddr:      "127.0.0.1:0",
+			SelfCheck:          true,
+			RequireBundleMatch: true,
+			AbandonActiveRuns:  true,
+			Verbose:            true,
+			Output:             &out,
+		})
+	}()
+
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	if err != nil {
+		t.Fatalf("reopen sqlite store: %v", err)
+	}
+	defer func() {
+		if err := sqliteStore.Close(); err != nil {
+			t.Fatalf("close sqlite store: %v", err)
+		}
+	}()
+	ctx = context.Background()
+	var runStatus, controlStatus, reason, controlledBy string
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT r.status, rc.control_status, COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, '')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = ?
+	`, runID).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("load sqlite serve-abandoned run/control: %v", err)
+	}
+	if runStatus != "cancelled" || controlStatus != "stopped" || reason != runtimerunquiescence.ServeAbandonReasonCode || controlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("sqlite serve run/control = %s/%s/%s/%s, want cancelled/stopped/%s/%s", runStatus, controlStatus, reason, controlledBy, runtimerunquiescence.ServeAbandonReasonCode, runtimerunquiescence.ServeAbandonControlledBy)
+	}
+	var deliveryStatus, deliveryReason string
+	var activeSession sql.NullString
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), active_session_id
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-a'
+	`, eventID).Scan(&deliveryStatus, &deliveryReason, &activeSession); err != nil {
+		t.Fatalf("load sqlite serve-abandoned delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != runtimerunquiescence.ServeAbandonReasonCode || activeSession.Valid {
+		t.Fatalf("sqlite serve delivery = %s/%s active=%v, want dead_letter/%s inactive", deliveryStatus, deliveryReason, activeSession.Valid, runtimerunquiescence.ServeAbandonReasonCode)
+	}
+	for _, subscriberID := range []string{"agent-a", "pipeline"} {
+		var outcome, receiptReason string
+		if err := sqliteStore.DB.QueryRowContext(ctx, `
+			SELECT outcome, COALESCE(reason_code, '')
+			FROM event_receipts
+			WHERE event_id = ?
+			  AND subscriber_id = ?
+		`, eventID, subscriberID).Scan(&outcome, &receiptReason); err != nil {
+			t.Fatalf("load sqlite serve receipt %s: %v", subscriberID, err)
+		}
+		if outcome != "dead_letter" || receiptReason != runtimerunquiescence.ServeAbandonReasonCode {
+			t.Fatalf("sqlite serve receipt %s = %s/%s, want dead_letter/%s", subscriberID, outcome, receiptReason, runtimerunquiescence.ServeAbandonReasonCode)
+		}
+	}
+}
+
 func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	_, _, _ = installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -3821,6 +3938,62 @@ func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory f
 	}, false)
 }
 
+func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string, string) {
+	t.Helper()
+	spec, err := loadServePlatformSpecDocument(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("load platform spec: %v", err)
+	}
+	plans, err := store.GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
+		_ = sqliteStore.Close()
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	ctx := context.Background()
+	now := time.Date(2026, 5, 18, 4, 30, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	activeSessionID := uuid.NewString()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_fingerprint, started_at)
+		VALUES (?, 'running', ?, ?)
+	`, runID, "sha256:2222222222222222222222222222222222222222222222222222222222222222", now.Add(-time.Hour)); err != nil {
+		_ = sqliteStore.Close()
+		t.Fatalf("seed sqlite active run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			?, ?, 'serve.abandon.test', 'global', '{}', 'test', 'agent', ?
+		)
+	`, eventID, runID, now); err != nil {
+		_ = sqliteStore.Close()
+		t.Fatalf("seed sqlite active delivery event: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, reason_code, created_at
+		) VALUES (
+			?, ?, ?, 'agent', 'agent-a', 'in_progress', ?, 'agent_processing', ?
+		)
+	`, uuid.NewString(), runID, eventID, activeSessionID, now); err != nil {
+		_ = sqliteStore.Close()
+		t.Fatalf("seed sqlite active delivery: %v", err)
+	}
+	if err := sqliteStore.Close(); err != nil {
+		t.Fatalf("close seeded sqlite store: %v", err)
+	}
+	return runID, eventID
+}
+
 func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
 	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true)
@@ -3866,6 +4039,7 @@ func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFac
 			RuntimeIngressStore: runtimePG,
 			IdempotencyStore:    runtimePG,
 			TurnStore:           runtimePG,
+			RunQuiescenceStore:  runtimePG,
 		}, nil
 	}
 	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources, _ workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
@@ -6872,6 +7046,7 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 			ManagerStore:       runtimePG,
 			ScheduleStore:      runtimePG,
 			TurnStore:          runtimePG,
+			RunQuiescenceStore: runtimePG,
 		}, nil
 	}
 	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
@@ -6965,6 +7140,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 					ManagerStore:       runtimePG,
 					ScheduleStore:      runtimePG,
 					TurnStore:          runtimePG,
+					RunQuiescenceStore: runtimePG,
 				}, nil
 			}
 			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
@@ -7132,6 +7308,7 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 			ManagerStore:       runtimePG,
 			ScheduleStore:      runtimePG,
 			TurnStore:          runtimePG,
+			RunQuiescenceStore: runtimePG,
 		}, nil
 	}
 	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3645,6 +3645,7 @@ func TestRunServeRuntimeFreshEmptySQLiteBootsWithDirectAbandon(t *testing.T) {
 
 func runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t *testing.T, dev bool) {
 	t.Helper()
+	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
 	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
@@ -3684,6 +3685,7 @@ func runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t *testing.T, dev bool) {
 }
 
 func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testing.T) {
+	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
 	runID, eventID := seedServeRuntimeSQLiteAbandonWork(t, sqlitePath)
@@ -4003,6 +4005,17 @@ func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string,
 		t.Fatalf("close seeded sqlite store: %v", err)
 	}
 	return runID, eventID
+}
+
+func stubServeRuntimeWorkspaceLifecycle(t *testing.T) {
+	t.Helper()
+	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+		return serveRuntimeWorkspaceStub{}, nil
+	}
+	t.Cleanup(func() {
+		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
+	})
 }
 
 func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3636,9 +3636,20 @@ func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon(t *te
 }
 
 func TestRunServeRuntimeFreshEmptySQLiteBootsWithDevAbandon(t *testing.T) {
+	runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t, true)
+}
+
+func TestRunServeRuntimeFreshEmptySQLiteBootsWithDirectAbandon(t *testing.T) {
+	runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t, false)
+}
+
+func runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t *testing.T, dev bool) {
+	t.Helper()
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
 	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	requireBundleMatch := !dev
+	noRequireBundleMatch := dev
 	ctx, cancel := context.WithCancel(context.Background())
 	var out lockedBuffer
 	done := make(chan int, 1)
@@ -3650,9 +3661,9 @@ func TestRunServeRuntimeFreshEmptySQLiteBootsWithDevAbandon(t *testing.T) {
 			APIListenAddr:        "127.0.0.1:0",
 			MCPListenAddr:        "127.0.0.1:0",
 			SelfCheck:            true,
-			Dev:                  true,
-			RequireBundleMatch:   false,
-			NoRequireBundleMatch: true,
+			Dev:                  dev,
+			RequireBundleMatch:   requireBundleMatch,
+			NoRequireBundleMatch: noRequireBundleMatch,
 			AbandonActiveRuns:    true,
 			Verbose:              true,
 			Output:               &out,

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	"swarm/internal/config"
-	"swarm/internal/events"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	runtimecorrelation "swarm/internal/runtime/correlation"
-	llmselection "swarm/internal/runtime/llm/selection"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/events"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 type OpenAIResponsesRuntime struct {

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"swarm/internal/config"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {

--- a/internal/runtime/runquiescence/types.go
+++ b/internal/runtime/runquiescence/types.go
@@ -1,6 +1,9 @@
 package runquiescence
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	ServeAbandonOperationName = "swarm.serve.abandon_active_runs"
@@ -29,6 +32,10 @@ type Result struct {
 	Runs                 []QuiescedRun
 	Deliveries           []QuiescedDelivery
 	PipelineReceiptCount int
+}
+
+type ServeAbandonStore interface {
+	ApplyServeAbandonActiveRunQuiescence(context.Context, time.Time) (Result, error)
 }
 
 type QuiescedRun struct {

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -13,6 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
 
@@ -30,6 +31,17 @@ type activeRunQuiescenceDeliveryTarget struct {
 }
 
 func (s *PostgresStore) ApplyServeAbandonActiveRunQuiescence(ctx context.Context, at time.Time) (runtimerunquiescence.Result, error) {
+	return s.ApplyActiveRunQuiescence(ctx, runtimerunquiescence.Request{
+		OperationName: runtimerunquiescence.ServeAbandonOperationName,
+		RequestedAt:   at,
+		AllActiveRuns: true,
+		ReasonCode:    runtimerunquiescence.ServeAbandonReasonCode,
+		ControlledBy:  runtimerunquiescence.ServeAbandonControlledBy,
+		DeliveryNote:  runtimerunquiescence.ServeAbandonDeliveryNote,
+	})
+}
+
+func (s *SQLiteRuntimeStore) ApplyServeAbandonActiveRunQuiescence(ctx context.Context, at time.Time) (runtimerunquiescence.Result, error) {
 	return s.ApplyActiveRunQuiescence(ctx, runtimerunquiescence.Request{
 		OperationName: runtimerunquiescence.ServeAbandonOperationName,
 		RequestedAt:   at,
@@ -185,6 +197,151 @@ func (s *PostgresStore) ApplyActiveRunQuiescence(ctx context.Context, req runtim
 	return out, nil
 }
 
+func (s *SQLiteRuntimeStore) ApplyActiveRunQuiescence(ctx context.Context, req runtimerunquiescence.Request) (runtimerunquiescence.Result, error) {
+	if s == nil || s.DB == nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	if !caps.Events.HasRuns {
+		return runtimerunquiescence.Result{}, fmt.Errorf("runs table is required")
+	}
+	if caps.Events.Deliveries != SchemaFlavorCanonical || !caps.Events.DeliveryRunID {
+		if caps.Events.Deliveries != SchemaFlavorCanonical {
+			return runtimerunquiescence.Result{}, unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
+		}
+		return runtimerunquiescence.Result{}, fmt.Errorf("active run quiescence requires canonical event_deliveries.run_id")
+	}
+	if caps.Events.Receipts != SchemaFlavorCanonical {
+		return runtimerunquiescence.Result{}, unsupportedSchemaCapability("event_receipts", caps.Events.Receipts)
+	}
+	now := req.RequestedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	out := runtimerunquiescence.Result{
+		OperationName: strings.TrimSpace(req.OperationName),
+		DryRun:        req.DryRun,
+		AppliedAt:     now,
+		ReasonCode:    strings.TrimSpace(req.ReasonCode),
+		ControlledBy:  strings.TrimSpace(req.ControlledBy),
+	}
+	if out.OperationName == "" {
+		return out, fmt.Errorf("active run quiescence operation_name is required")
+	}
+	if out.ReasonCode == "" {
+		return out, fmt.Errorf("active run quiescence reason_code is required")
+	}
+	if out.ControlledBy == "" {
+		return out, fmt.Errorf("active run quiescence controlled_by is required")
+	}
+	deliveryNote := strings.TrimSpace(req.DeliveryNote)
+	if deliveryNote == "" {
+		deliveryNote = out.ReasonCode
+	}
+
+	runIDs := normalizeQuiescenceRunIDs(req.RunIDs)
+	if len(runIDs) == 0 && !req.AllActiveRuns {
+		return out, nil
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("begin sqlite active run quiescence tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var runs []runtimerunquiescence.QuiescedRun
+	if req.AllActiveRuns {
+		runs, err = sqliteLockAllActiveQuiescenceRunsTx(ctx, tx)
+	} else {
+		runs, err = sqliteLockActiveQuiescenceRunsTx(ctx, tx, runIDs)
+	}
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	runIDs = quiescenceRunIDs(runs)
+	if len(runIDs) == 0 {
+		return out, nil
+	}
+	deliveries, err := sqliteLockActiveRunQuiescenceDeliveriesTx(ctx, tx, runIDs)
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	for _, delivery := range deliveries {
+		out.Deliveries = append(out.Deliveries, runtimerunquiescence.QuiescedDelivery{
+			DeliveryID:      delivery.DeliveryID,
+			RunID:           delivery.RunID,
+			EventID:         delivery.EventID,
+			SubscriberType:  delivery.SubscriberType,
+			SubscriberID:    delivery.SubscriberID,
+			PreviousStatus:  delivery.Status,
+			Status:          "dead_letter",
+			ReasonCode:      out.ReasonCode,
+			PreviousReason:  delivery.ReasonCode,
+			ActiveSessionID: delivery.ActiveSessionID,
+			Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != out.ReasonCode,
+		})
+	}
+	for _, run := range runs {
+		nextStatus := run.Status
+		changed := false
+		if activeRunQuiescenceRunStatusActive(run.Status) {
+			nextStatus = "cancelled"
+			changed = true
+		}
+		out.Runs = append(out.Runs, runtimerunquiescence.QuiescedRun{
+			RunID:          run.RunID,
+			PreviousStatus: run.Status,
+			Status:         nextStatus,
+			ReasonCode:     out.ReasonCode,
+			Changed:        changed,
+		})
+	}
+	if req.DryRun {
+		return out, nil
+	}
+
+	eventIDs := map[string]struct{}{}
+	for _, delivery := range deliveries {
+		if err := sqliteTerminalizeActiveRunQuiescenceDeliveryTx(ctx, tx, delivery, out.ReasonCode, deliveryNote, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+		if delivery.EventID != "" {
+			eventIDs[delivery.EventID] = struct{}{}
+		}
+	}
+	for eventID := range eventIDs {
+		if err := sqliteUpsertActiveRunQuiescencePipelineReceiptTx(ctx, tx, eventID, out.ReasonCode, deliveryNote, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+		out.PipelineReceiptCount++
+	}
+	for _, run := range runs {
+		if !activeRunQuiescenceRunStatusActive(run.Status) {
+			continue
+		}
+		if err := sqliteMarkActiveRunQuiescenceRunTerminalTx(ctx, tx, run.RunID, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+		if err := sqliteUpsertActiveRunQuiescenceRunControlTx(ctx, tx, run.RunID, out.ReasonCode, out.ControlledBy, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return runtimerunquiescence.Result{}, fmt.Errorf("commit sqlite active run quiescence tx: %w", err)
+	}
+	committed = true
+	return out, nil
+}
+
 func normalizeQuiescenceRunIDs(runIDs []string) []string {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(runIDs))
@@ -313,6 +470,90 @@ func lockActiveRunQuiescenceDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs
 	return out, nil
 }
 
+func sqliteLockAllActiveQuiescenceRunsTx(ctx context.Context, tx *sql.Tx) ([]runtimerunquiescence.QuiescedRun, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id, COALESCE(status, '')
+		FROM runs
+		WHERE lower(COALESCE(status, '')) IN ('running', 'paused')
+		ORDER BY run_id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("lock sqlite all active quiescence runs: %w", err)
+	}
+	return scanActiveRunQuiescenceRuns(rows)
+}
+
+func sqliteLockActiveQuiescenceRunsTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]runtimerunquiescence.QuiescedRun, error) {
+	if len(runIDs) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(runIDs))
+	for _, runID := range runIDs {
+		args = append(args, runID)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT run_id, COALESCE(status, '')
+		FROM runs
+		WHERE run_id IN (`+sqlitePlaceholders(len(runIDs))+`)
+		  AND lower(COALESCE(status, '')) IN ('running', 'paused')
+		ORDER BY run_id
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lock sqlite active quiescence runs: %w", err)
+	}
+	return scanActiveRunQuiescenceRuns(rows)
+}
+
+func sqliteLockActiveRunQuiescenceDeliveriesTx(ctx context.Context, tx *sql.Tx, runIDs []string) ([]activeRunQuiescenceDeliveryTarget, error) {
+	if len(runIDs) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(runIDs))
+	for _, runID := range runIDs {
+		args = append(args, runID)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			d.delivery_id,
+			COALESCE(d.run_id, ''),
+			d.event_id,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.active_session_id, '')
+		FROM event_deliveries d
+		WHERE d.run_id IN (`+sqlitePlaceholders(len(runIDs))+`)
+		  AND d.subscriber_type IN ('agent', 'node')
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("d")+`
+		ORDER BY d.run_id, d.event_id, d.subscriber_type, d.subscriber_id
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lock sqlite active run quiescence deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []activeRunQuiescenceDeliveryTarget
+	for rows.Next() {
+		var item activeRunQuiescenceDeliveryTarget
+		if err := rows.Scan(&item.DeliveryID, &item.RunID, &item.EventID, &item.SubscriberType, &item.SubscriberID, &item.Status, &item.ReasonCode, &item.ActiveSessionID); err != nil {
+			return nil, fmt.Errorf("scan sqlite active run quiescence delivery: %w", err)
+		}
+		item.DeliveryID = strings.TrimSpace(item.DeliveryID)
+		item.RunID = strings.TrimSpace(item.RunID)
+		item.EventID = strings.TrimSpace(item.EventID)
+		item.SubscriberType = strings.TrimSpace(item.SubscriberType)
+		item.SubscriberID = strings.TrimSpace(item.SubscriberID)
+		item.Status = strings.TrimSpace(item.Status)
+		item.ReasonCode = strings.TrimSpace(item.ReasonCode)
+		item.ActiveSessionID = strings.TrimSpace(item.ActiveSessionID)
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite active run quiescence deliveries: %w", err)
+	}
+	return out, nil
+}
+
 func terminalizeActiveRunQuiescenceDeliveryTx(ctx context.Context, tx *sql.Tx, item activeRunQuiescenceDeliveryTarget, reasonCode, note string, at time.Time) error {
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE event_deliveries
@@ -361,6 +602,54 @@ func terminalizeActiveRunQuiescenceDeliveryTx(ctx context.Context, tx *sql.Tx, i
 	return nil
 }
 
+func sqliteTerminalizeActiveRunQuiescenceDeliveryTx(ctx context.Context, tx *sql.Tx, item activeRunQuiescenceDeliveryTarget, reasonCode, note string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'dead_letter',
+			reason_code = ?,
+			last_error = ?,
+			active_session_id = NULL,
+			delivered_at = COALESCE(delivered_at, ?)
+		WHERE delivery_id = ?
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("")+`
+	`, reasonCode, note, at.UTC(), item.DeliveryID); err != nil {
+		return fmt.Errorf("terminalize sqlite active run quiescence delivery %s: %w", item.DeliveryID, err)
+	}
+	sideEffects, err := json.Marshal(map[string]any{
+		"manager_status": "dead_letter",
+		"reason_code":    reasonCode,
+		"error":          note,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal sqlite active run quiescence receipt side effects: %w", err)
+	}
+	idempotencyKey := ""
+	if item.SubscriberType == "node" {
+		idempotencyKey = runtimepipeline.SystemNodeReceiptIdempotencyKey(item.SubscriberID, item.EventID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			?, e.event_id, ?, ?, e.entity_id, e.flow_instance,
+			'dead_letter', ?, ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			idempotency_key = COALESCE(excluded.idempotency_key, event_receipts.idempotency_key),
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), item.SubscriberType, item.SubscriberID, reasonCode, string(sideEffects), sqliteNullString(idempotencyKey), at.UTC(), item.EventID); err != nil {
+		return fmt.Errorf("upsert sqlite active run quiescence delivery receipt: %w", err)
+	}
+	return nil
+}
+
 func upsertActiveRunQuiescencePipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, reasonCode, note string, at time.Time) error {
 	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects("dead_letter", reasonCode, note))
 	if err != nil {
@@ -387,6 +676,32 @@ func upsertActiveRunQuiescencePipelineReceiptTx(ctx context.Context, tx *sql.Tx,
 	return nil
 }
 
+func sqliteUpsertActiveRunQuiescencePipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, reasonCode, note string, at time.Time) error {
+	sideEffects, err := marshalPipelineReceiptSideEffects(newPipelineReceiptSideEffects("dead_letter", reasonCode, note))
+	if err != nil {
+		return fmt.Errorf("marshal sqlite active run quiescence pipeline receipt: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			?, e.event_id, 'platform', ?, e.entity_id, e.flow_instance,
+			'dead_letter', ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			outcome = 'dead_letter',
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), activeRunQuiescencePipelineSubscriberID, reasonCode, string(sideEffects), at.UTC(), eventID); err != nil {
+		return fmt.Errorf("upsert sqlite active run quiescence pipeline receipt: %w", err)
+	}
+	return nil
+}
+
 func upsertActiveRunQuiescenceRunControlTx(ctx context.Context, tx *sql.Tx, runID, reasonCode, controlledBy string, at time.Time) error {
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
@@ -402,6 +717,119 @@ func upsertActiveRunQuiescenceRunControlTx(ctx context.Context, tx *sql.Tx, runI
 		return fmt.Errorf("persist active run quiescence run control state: %w", err)
 	}
 	return nil
+}
+
+func sqliteMarkActiveRunQuiescenceRunTerminalTx(ctx context.Context, tx *sql.Tx, runID string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE runs
+		SET status = 'cancelled',
+		    ended_at = COALESCE(ended_at, ?)
+		WHERE run_id = ?
+		  AND (status IN ('running', 'paused') OR status = 'cancelled')
+	`, at.UTC(), runID); err != nil {
+		return fmt.Errorf("mark sqlite active run quiescence run terminal: %w", err)
+	}
+	return nil
+}
+
+func sqliteUpsertActiveRunQuiescenceRunControlTx(ctx context.Context, tx *sql.Tx, runID, reasonCode, controlledBy string, at time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)
+		VALUES (?, 'stopped', ?, ?, ?, NULL, ?)
+		ON CONFLICT(run_id) DO UPDATE SET
+			control_status = 'stopped',
+			reason = excluded.reason,
+			controlled_by = excluded.controlled_by,
+			updated_at = excluded.updated_at,
+			paused_at = NULL,
+			stopped_at = COALESCE(run_control_state.stopped_at, excluded.stopped_at)
+	`, runID, reasonCode, controlledBy, at.UTC(), at.UTC()); err != nil {
+		return fmt.Errorf("persist sqlite active run quiescence run control state: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ActiveRunDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (string, bool, error) {
+	if s == nil || s.DB == nil {
+		return "", false, fmt.Errorf("sqlite runtime store is required")
+	}
+	eventID = strings.TrimSpace(eventID)
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	if eventID == "" || subscriberType == "" || subscriberID == "" {
+		return "", false, nil
+	}
+	reasons := activeRunQuiescenceTerminalReasonCodes()
+	args := []any{eventID, subscriberType, subscriberID}
+	for _, reason := range reasons {
+		args = append(args, reason)
+	}
+	var reason string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = ?
+		  AND subscriber_id = ?
+		  AND status = 'dead_letter'
+		  AND reason_code IN (`+sqlitePlaceholders(len(reasons))+`)
+		ORDER BY reason_code
+		LIMIT 1
+	`, args...).Scan(&reason)
+	switch {
+	case err == sql.ErrNoRows:
+		return "", false, nil
+	case err != nil:
+		return "", false, fmt.Errorf("check sqlite active run delivery quiescence: %w", err)
+	default:
+		return strings.TrimSpace(reason), true, nil
+	}
+}
+
+func (s *SQLiteRuntimeStore) DestructiveResetDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error) {
+	if s == nil || s.DB == nil {
+		return false, fmt.Errorf("sqlite runtime store is required")
+	}
+	return s.deliveryQuiescedForReason(ctx, eventID, subscriberType, subscriberID, runtimedestructivereset.QuiescenceReasonCode)
+}
+
+func (s *SQLiteRuntimeStore) ServeAbandonDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (bool, error) {
+	if s == nil || s.DB == nil {
+		return false, fmt.Errorf("sqlite runtime store is required")
+	}
+	return s.deliveryQuiescedForReason(ctx, eventID, subscriberType, subscriberID, runtimerunquiescence.ServeAbandonReasonCode)
+}
+
+func (s *SQLiteRuntimeStore) deliveryQuiescedForReason(ctx context.Context, eventID, subscriberType, subscriberID, reasonCode string) (bool, error) {
+	eventID = strings.TrimSpace(eventID)
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	reasonCode = strings.TrimSpace(reasonCode)
+	if eventID == "" || subscriberType == "" || subscriberID == "" || reasonCode == "" {
+		return false, nil
+	}
+	var ok bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = ?
+			  AND subscriber_id = ?
+			  AND status = 'dead_letter'
+			  AND reason_code = ?
+		)
+	`, eventID, subscriberType, subscriberID, reasonCode).Scan(&ok); err != nil {
+		return false, fmt.Errorf("check sqlite delivery quiescence: %w", err)
+	}
+	return ok, nil
+}
+
+func sqlitePlaceholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return strings.TrimRight(strings.Repeat("?,", count), ",")
 }
 
 func activeRunQuiescenceDeliveryPredicateSQL(alias string) string {

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -277,6 +277,111 @@ func TestPostgresStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableW
 	}
 }
 
+func TestSQLiteRuntimeStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableWork(t *testing.T) {
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 18, 2, 10, 0, 0, time.UTC)
+	runID := uuid.NewString()
+	pausedRunID := uuid.NewString()
+	terminalRunID := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at) VALUES
+			(?, 'running', ?),
+			(?, 'paused', ?),
+			(?, 'completed', ?)
+	`, runID, now.Add(-time.Hour), pausedRunID, now.Add(-time.Hour), terminalRunID, now.Add(-time.Hour)); err != nil {
+		t.Fatalf("seed sqlite runs: %v", err)
+	}
+	agentPending := seedSQLiteServeAbandonEvent(t, ctx, store, runID, "serve.agent.pending", now)
+	agentInProgress := seedSQLiteServeAbandonEvent(t, ctx, store, runID, "serve.agent.in_progress", now)
+	agentRetryableFailed := seedSQLiteServeAbandonEvent(t, ctx, store, runID, "serve.agent.failed_retryable", now)
+	agentExhaustedFailed := seedSQLiteServeAbandonEvent(t, ctx, store, runID, "serve.agent.failed_exhausted", now)
+	nodePending := seedSQLiteServeAbandonEvent(t, ctx, store, runID, "serve.node.pending", now)
+	terminalRunPending := seedSQLiteServeAbandonEvent(t, ctx, store, terminalRunID, "serve.terminal.pending", now)
+	activeSessionID := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, retry_count, reason_code, created_at, delivered_at
+		) VALUES
+			(?, ?, ?, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', ?, NULL),
+			(?, ?, ?, 'agent', 'agent-a', 'in_progress', ?, 0, 'agent_processing', ?, NULL),
+			(?, ?, ?, 'agent', 'agent-a', 'failed', NULL, 1, 'agent_retryable_error', ?, ?),
+			(?, ?, ?, 'agent', 'agent-a', 'failed', NULL, 2, 'retry_exhausted', ?, ?),
+			(?, ?, ?, 'node', 'node-a', 'pending', NULL, 0, 'matched_node_subscription', ?, NULL),
+			(?, ?, ?, 'agent', 'agent-a', 'pending', NULL, 0, 'matched_agent_subscription', ?, NULL)
+	`, uuid.NewString(), runID, agentPending, now,
+		uuid.NewString(), runID, agentInProgress, activeSessionID, now,
+		uuid.NewString(), runID, agentRetryableFailed, now.Add(-5*time.Minute), now.Add(-2*time.Minute),
+		uuid.NewString(), runID, agentExhaustedFailed, now.Add(-5*time.Minute), now.Add(-2*time.Minute),
+		uuid.NewString(), runID, nodePending, now,
+		uuid.NewString(), terminalRunID, terminalRunPending, now); err != nil {
+		t.Fatalf("seed sqlite deliveries: %v", err)
+	}
+
+	result, err := store.ApplyServeAbandonActiveRunQuiescence(ctx, now)
+	if err != nil {
+		t.Fatalf("ApplyServeAbandonActiveRunQuiescence: %v", err)
+	}
+	if result.OperationName != runtimerunquiescence.ServeAbandonOperationName || result.ReasonCode != runtimerunquiescence.ServeAbandonReasonCode || result.ControlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("serve abandon result metadata = %#v", result)
+	}
+	if len(result.Runs) != 2 {
+		t.Fatalf("runs = %#v, want running and paused rows cancelled", result.Runs)
+	}
+	if len(result.Deliveries) != 4 || result.PipelineReceiptCount != 4 {
+		t.Fatalf("deliveries=%d pipeline_receipts=%d, want 4/4", len(result.Deliveries), result.PipelineReceiptCount)
+	}
+	assertSQLiteServeAbandonRun(t, ctx, store, runID)
+	assertSQLiteServeAbandonRun(t, ctx, store, pausedRunID)
+	assertSQLiteServeAbandonDelivery(t, ctx, store, agentPending, "agent", "agent-a")
+	assertSQLiteServeAbandonDelivery(t, ctx, store, agentInProgress, "agent", "agent-a")
+	assertSQLiteServeAbandonDelivery(t, ctx, store, agentRetryableFailed, "agent", "agent-a")
+	assertSQLiteServeAbandonDelivery(t, ctx, store, nodePending, "node", "node-a")
+
+	if err := store.MarkEventDeliveryInProgress(ctx, agentRetryableFailed, "agent-a", uuid.NewString()); err != nil {
+		t.Fatalf("late retryable failed MarkEventDeliveryInProgress: %v", err)
+	}
+	if err := store.UpsertEventReceipt(ctx, agentInProgress, "agent-a", runtimemanager.ReceiptStatusProcessed, ""); err != nil {
+		t.Fatalf("late UpsertEventReceipt: %v", err)
+	}
+	if err := store.UpsertPipelineReceipt(ctx, agentInProgress, "processed", ""); err != nil {
+		t.Fatalf("late UpsertPipelineReceipt: %v", err)
+	}
+	assertSQLiteServeAbandonDelivery(t, ctx, store, agentRetryableFailed, "agent", "agent-a")
+	assertSQLiteServeAbandonReceipt(t, ctx, store, agentInProgress, "agent-a")
+	assertSQLiteServeAbandonReceipt(t, ctx, store, agentInProgress, activeRunQuiescencePipelineSubscriberID)
+
+	replay, err := store.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun: %v", err)
+	}
+	if len(replay) != 1 || replay[0].Event.ID != agentExhaustedFailed {
+		t.Fatalf("missing pipeline replay events = %#v, want only exhausted failed delivery", replay)
+	}
+	var exhaustedStatus, exhaustedReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+	`, agentExhaustedFailed).Scan(&exhaustedStatus, &exhaustedReason); err != nil {
+		t.Fatalf("load exhausted failed delivery: %v", err)
+	}
+	if exhaustedStatus != "failed" || exhaustedReason != "retry_exhausted" {
+		t.Fatalf("exhausted failed delivery = %s/%s, want untouched", exhaustedStatus, exhaustedReason)
+	}
+	var terminalDeliveryStatus, terminalDeliveryReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+	`, terminalRunPending).Scan(&terminalDeliveryStatus, &terminalDeliveryReason); err != nil {
+		t.Fatalf("load terminal run delivery: %v", err)
+	}
+	if terminalDeliveryStatus != "pending" || terminalDeliveryReason != "matched_agent_subscription" {
+		t.Fatalf("terminal run delivery = %s/%s, want untouched", terminalDeliveryStatus, terminalDeliveryReason)
+	}
+}
+
 func TestPostgresStore_ApplyDestructiveResetQuiescence_DryRunDoesNotMutate(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -359,6 +464,72 @@ func assertServeAbandonReceipt(t *testing.T, ctx context.Context, pg *PostgresSt
 	}
 	if outcome != "dead_letter" || reason != runtimerunquiescence.ServeAbandonReasonCode {
 		t.Fatalf("receipt %s/%s = %s/%s, want serve abandon dead_letter", eventID, subscriberID, outcome, reason)
+	}
+}
+
+func seedSQLiteServeAbandonEvent(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, runID, name string, at time.Time) string {
+	t.Helper()
+	eventID := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES (
+			?, ?, ?, 'global', '{}', 'test', 'agent', ?
+		)
+	`, eventID, runID, name, at.UTC()); err != nil {
+		t.Fatalf("seed sqlite event %s: %v", name, err)
+	}
+	return eventID
+}
+
+func assertSQLiteServeAbandonRun(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, runID string) {
+	t.Helper()
+	var runStatus, controlStatus, reason, controlledBy string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT r.status, rc.control_status, COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, '')
+		FROM runs r
+		JOIN run_control_state rc ON rc.run_id = r.run_id
+		WHERE r.run_id = ?
+	`, runID).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("load sqlite run/control state: %v", err)
+	}
+	if runStatus != "cancelled" || controlStatus != "stopped" || reason != runtimerunquiescence.ServeAbandonReasonCode || controlledBy != runtimerunquiescence.ServeAbandonControlledBy {
+		t.Fatalf("sqlite run/control = %s/%s/%s/%s, want cancelled/stopped/%s/%s", runStatus, controlStatus, reason, controlledBy, runtimerunquiescence.ServeAbandonReasonCode, runtimerunquiescence.ServeAbandonControlledBy)
+	}
+}
+
+func assertSQLiteServeAbandonDelivery(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, eventID, subscriberType, subscriberID string) {
+	t.Helper()
+	var status, reason string
+	var activeSession sql.NullString
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), active_session_id
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = ?
+		  AND subscriber_id = ?
+	`, eventID, subscriberType, subscriberID).Scan(&status, &reason, &activeSession); err != nil {
+		t.Fatalf("load sqlite delivery %s/%s/%s: %v", eventID, subscriberType, subscriberID, err)
+	}
+	if status != "dead_letter" || reason != runtimerunquiescence.ServeAbandonReasonCode || activeSession.Valid {
+		t.Fatalf("sqlite delivery %s/%s/%s = %s/%s active=%v, want serve abandon dead_letter", eventID, subscriberType, subscriberID, status, reason, activeSession.Valid)
+	}
+	assertSQLiteServeAbandonReceipt(t, ctx, store, eventID, subscriberID)
+}
+
+func assertSQLiteServeAbandonReceipt(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, eventID, subscriberID string) {
+	t.Helper()
+	var outcome, reason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_id = ?
+	`, eventID, subscriberID).Scan(&outcome, &reason); err != nil {
+		t.Fatalf("load sqlite receipt %s/%s: %v", eventID, subscriberID, err)
+	}
+	if outcome != "dead_letter" || reason != runtimerunquiescence.ServeAbandonReasonCode {
+		t.Fatalf("sqlite receipt %s/%s = %s/%s, want serve abandon dead_letter", eventID, subscriberID, outcome, reason)
 	}
 }
 

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -48,6 +48,14 @@ func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sq
 	if tx != nil {
 		exec = tx.ExecContext
 	}
+	terminalReasons := activeRunQuiescenceTerminalReasonCodes()
+	args := []any{uuid.NewString(), outcome, sqliteNullString(reasonCode), string(sideEffects), s.now(), eventID}
+	for _, reason := range terminalReasons {
+		args = append(args, reason)
+	}
+	for _, reason := range terminalReasons {
+		args = append(args, reason)
+	}
 	_, err = exec(ctx, `
 		INSERT INTO event_receipts (
 			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
@@ -58,12 +66,20 @@ func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sq
 			?, ?, ?, ?
 		FROM events e
 		WHERE e.event_id = ?
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM event_deliveries d
+			WHERE d.event_id = e.event_id
+			  AND d.status = 'dead_letter'
+			  AND d.reason_code IN (`+sqlitePlaceholders(len(terminalReasons))+`)
+		  )
 		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
 			outcome = excluded.outcome,
 			reason_code = excluded.reason_code,
 			side_effects = excluded.side_effects,
 			processed_at = excluded.processed_at
-	`, uuid.NewString(), outcome, sqliteNullString(reasonCode), string(sideEffects), s.now(), eventID)
+		WHERE COALESCE(event_receipts.reason_code, '') NOT IN (`+sqlitePlaceholders(len(terminalReasons))+`)
+	`, args...)
 	if err != nil {
 		return fmt.Errorf("upsert sqlite pipeline receipt: %w", err)
 	}
@@ -486,6 +502,11 @@ func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, ev
 	if eventID == "" || agentID == "" {
 		return fmt.Errorf("mark sqlite event delivery in progress: eventID and agentID required")
 	}
+	terminalReasons := activeRunQuiescenceTerminalReasonCodes()
+	args := []any{sqliteNullUUID(sessionID), s.now(), eventID, agentID}
+	for _, reason := range terminalReasons {
+		args = append(args, reason)
+	}
 	res, err := s.DB.ExecContext(ctx, `
 		UPDATE event_deliveries
 		SET status = 'in_progress',
@@ -495,11 +516,17 @@ func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, ev
 		  AND subscriber_type = 'agent'
 		  AND subscriber_id = ?
 		  AND status IN ('pending', 'failed', 'in_progress')
-	`, sqliteNullUUID(sessionID), s.now(), eventID, agentID)
+		  AND COALESCE(reason_code, '') NOT IN (`+sqlitePlaceholders(len(terminalReasons))+`)
+	`, args...)
 	if err != nil {
 		return fmt.Errorf("mark sqlite event delivery in progress: %w", err)
 	}
 	if rows, _ := res.RowsAffected(); rows == 0 {
+		if _, ok, err := s.ActiveRunDeliveryQuiesced(ctx, eventID, "agent", agentID); err != nil {
+			return err
+		} else if ok {
+			return nil
+		}
 		return fmt.Errorf("mark sqlite event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
 	}
 	return nil
@@ -525,6 +552,9 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, ag
 	}
 	if !delivery.found {
 		return fmt.Errorf("upsert sqlite event receipt: delivery row required for event %s agent %s", eventID, agentID)
+	}
+	if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
+		return nil
 	}
 	state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
 	now := s.now()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2306,6 +2306,21 @@ engine:
       postgres_owner: internal/store.PostgresStore ingress/run-control methods
       excludes:
       - delivery release/abandon and replay behavior owned by #1087
+    - name: serve_active_run_abandon_quiescence_rows
+      owner: runtimerunquiescence.ServeAbandonStore consumed by cmd/swarm serve --abandon-active-runs and --dev
+      promoted_by: '#1251'
+      sqlite_owner: internal/store.SQLiteRuntimeStore.ApplyServeAbandonActiveRunQuiescence
+      postgres_owner: internal/store.PostgresStore.ApplyServeAbandonActiveRunQuiescence
+      scope: >
+        The selected runtime store owns serve-startup active-run abandon quiescence for its backend. Both SQLite local/dev
+        and Postgres production/external backends apply the same `server_restart_abandon` semantics over active runs,
+        same-run recoverable agent/node deliveries, agent/node event receipts, and platform pipeline receipts before
+        runtime startup can reclaim work. `cmd/swarm serve` consumes this typed selected-store owner and must not infer
+        support from raw Postgres handles or skip the operation on SQLite.
+      excludes:
+      - destructive reset/runtime.nuke container and row-deletion semantics
+      - broader startup recovery/replay policy outside the rows explicitly terminalized by serve abandon
+      - production multi-writer SQLite semantics
     - name: api_idempotency_rows
       owner: internal/store API idempotency persistence contract
       sqlite_owner: internal/store.SQLiteRuntimeStore.WithAPIIdempotency
@@ -9102,13 +9117,18 @@ cli_specification:
           mean unknown bundle and do not block startup. `--no-require-bundle-match` disables this admission gate for operator-approved
           recovery/dev workflows.
       active_run_abandon_quiescence:
-        implemented_by: '#808'
+        implemented_by: '#808/#1251'
         flag: --abandon-active-runs
-        owner: internal/runtime/runquiescence plus PostgresStore active-run quiescence owner, consumed by cmd/swarm serve
+        owner: internal/runtime/runquiescence plus selected runtime store active-run quiescence owner, consumed by cmd/swarm serve
         ordering: >
           `swarm serve --abandon-active-runs` applies after platform schema/state-store initialization and before bundle-match
           admission, startup recovery, runtime start, API readiness, or late delivery recovery can reclaim work. Failure to apply
           the quiescence owner is a serve startup failure; serve MUST NOT continue with partial abandon state.
+        backend_ownership: >
+          The selected runtime store implements this owner for its backend: `PostgresStore` for explicit Postgres and
+          `SQLiteRuntimeStore` for the local/dev SQLite default. Serve MUST call the selected owner for both direct
+          `--abandon-active-runs` and `--dev`; it MUST NOT special-case SQLite as a skip/no-op and MUST NOT use raw
+          Postgres handle presence as the capability decision.
         active_run_scope: >
           The owner selects all active source runs with `runs.status` in `running` or `paused`. Each selected run is terminalized
           as `runs.status=cancelled`, with `run_control_state.control_status=stopped`, `reason=server_restart_abandon`, and


### PR DESCRIPTION
Closes #1251

## Summary
- Promote serve active-run abandon quiescence from a raw Postgres handle check to a selected-store `runtimerunquiescence.ServeAbandonStore` owner.
- Add SQLite `ApplyServeAbandonActiveRunQuiescence` with matching active run cancellation, recoverable delivery dead-lettering, agent/node receipts, and platform pipeline receipts.
- Bootstrap selected store schema before serve abandon so fresh SQLite `--dev` and direct `--abandon-active-runs` do not fail before readiness.
- Guard SQLite late delivery/receipt/pipeline receipt writers from resurrecting `server_restart_abandon` terminalized work.
- Update migrated `github.com/division-sh/swarm` import paths in the OpenAI Responses runtime package so the full suite builds on the current repository path.

## Governing Refs / Context
- `platform-spec.yaml#cli_specification.command_catalog.serve.active_run_abandon_quiescence`
- `platform-spec.yaml#cli_specification.command_catalog.serve.dev_mode_lifecycle_composition`
- `platform-spec.yaml#runtime_store_backend_selection`
- `platform-spec.yaml#runtime_core_persistence_store_contracts.runtime_ingress_and_run_control_rows`
- `platform-spec.yaml#runtime_core_persistence_store_contracts.event_delivery_receipt_and_replay_rows`
- New selected contract: `platform-spec.yaml#runtime_core_persistence_store_contracts.selected_contracts.serve_active_run_abandon_quiescence_rows`
- Binding issue gate: #1251 lead gate approved `sqlite_selected_store_serve_abandon_active_runs_quiescence_parity` as a first slice.

## Semantic Migration
- New canonical owner: `runtimerunquiescence.ServeAbandonStore`, implemented by `PostgresStore.ApplyServeAbandonActiveRunQuiescence` and `SQLiteRuntimeStore.ApplyServeAbandonActiveRunQuiescence`.
- Old invalid path: `cmd/swarm serve` deciding support from `stores.Postgres != nil` and directly calling the Postgres implementation.
- Production paths checked: direct `--abandon-active-runs`, `--dev` composition, Postgres regression path, SQLite fresh-store path, SQLite active run/delivery/receipt quiescence path, and SQLite late writer guards.
- Migration completeness: complete for the approved #1251 chosen class; broader SQLite parity siblings remain open and are not claimed here.

## Validation
- `go test ./internal/store -run 'Test(PostgresStore|SQLiteRuntimeStore)_ApplyServeAbandonActiveRunQuiescence' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntime(FreshEmptySQLiteBootsWithDevAbandon|FreshEmptySQLiteBootsWithDirectAbandon|SQLiteAbandonActiveRunsQuiescesBeforeReadiness|AbandonActiveRunsQuiescesBeforeBundleMatchAdmission|FreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon)' -count=1`
- `go test ./...`
