### PR TITLE
[agent-a][issue #1241] Route root system-node deliveries

### DIFF
--- a/internal/runtime/bus/committed_replay_scope.go
+++ b/internal/runtime/bus/committed_replay_scope.go
@@ -51,10 +51,24 @@ func (eb *EventBus) replayRecipientsForCommittedEvent(
 		}
 	}
 	if scope == runtimereplayclaim.CommittedReplayScopeSubscribed && hasDeliveryRouteSubscriberType(persistedRoutes, "node") {
-		live := deliveryRouteRecipientIDs(persistedRoutes)
-		internal := deliveryRouteRecipientIDsByType(persistedRoutes, "node")
+		internal, err := eb.currentInternalRecipientsForCommittedEvent(ctx, evt)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		live := uniqueStrings(append(deliveryRouteRecipientIDsByType(persistedRoutes, "agent"), internal...))
+		if len(live) == 0 {
+			live = deliveryRouteRecipientIDs(persistedRoutes)
+			internal = deliveryRouteRecipientIDsByType(persistedRoutes, "node")
+		}
 		if len(live) > 0 {
-			return live, internal, persistedRoutes, nil
+			routes := append([]events.DeliveryRoute(nil), persistedRoutes...)
+			for _, recipient := range internal {
+				if hasDeliveryRouteRecipient(routes, "node", recipient) {
+					continue
+				}
+				routes = append(routes, events.DeliveryRoute{SubscriberType: "node", SubscriberID: recipient})
+			}
+			return live, internal, events.NormalizeDeliveryRoutes(routes), nil
 		}
 	}
 	switch scope {
@@ -71,6 +85,9 @@ func (eb *EventBus) replayRecipientsForCommittedEvent(
 			routes = deliveryRoutesFromTargetMap(persisted, "agent", eb.deliveryTargetsForEvent(ctx, evt.ID))
 		}
 		for _, recipient := range internal {
+			if hasDeliveryRouteRecipient(routes, "node", recipient) {
+				continue
+			}
 			routes = append(routes, events.DeliveryRoute{SubscriberType: "node", SubscriberID: recipient})
 		}
 		return live, internal, events.NormalizeDeliveryRoutes(routes), nil
@@ -83,6 +100,20 @@ func hasDeliveryRouteSubscriberType(routes []events.DeliveryRoute, subscriberTyp
 	subscriberType = strings.TrimSpace(subscriberType)
 	for _, route := range events.NormalizeDeliveryRoutes(routes) {
 		if route.SubscriberType == subscriberType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDeliveryRouteRecipient(routes []events.DeliveryRoute, subscriberType, subscriberID string) bool {
+	subscriberType = strings.TrimSpace(subscriberType)
+	subscriberID = strings.TrimSpace(subscriberID)
+	if subscriberType == "" || subscriberID == "" {
+		return false
+	}
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberType == subscriberType && route.SubscriberID == subscriberID {
 			return true
 		}
 	}

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -109,6 +109,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.PersistedRecipients = manifest.PersistedRecipients
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
@@ -400,6 +401,63 @@ func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscri
 		})
 	}
 	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return nil
+	}
+	rootNodeIDs := routedRootNodeSubscriberIDsForNoTargetEvent(evt, routed)
+	if len(rootNodeIDs) == 0 {
+		return nil
+	}
+	internalRecipients := filterOutAgentIDs(recipients, persisted)
+	if len(internalRecipients) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(rootNodeIDs))
+	for _, recipient := range sortedStringKeys(rootNodeIDs) {
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   recipient,
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedRootNodeSubscriberIDsForNoTargetEvent(evt events.Event, routed []Subscriber) map[string]struct{} {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" || strings.Contains(eventType, "/") {
+		return nil
+	}
+	out := make(map[string]struct{}, len(routed))
+	for _, subscriber := range routed {
+		if !routedRootNodeMatchesNoTargetEvent(evt, subscriber) {
+			continue
+		}
+		out[strings.TrimSpace(subscriber.ID)] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func routedRootNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber) bool {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+		return false
+	}
+	if strings.Trim(strings.TrimSpace(subscriber.Path), "/") != "" {
+		return false
+	}
+	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return false
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	return eventType != "" && !strings.Contains(eventType, "/")
 }
 
 func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber) []string {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -369,6 +369,57 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRou
 	}
 }
 
+func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(string) []Subscriber {
+				return []Subscriber{{
+					ID:           "portfolio-node",
+					Type:         "node",
+					MatchPattern: "opco.spinup_requested",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "portfolio-node", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "opco.spinup_requested",
+	}).WithEntityID("ent-root"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "portfolio-node" {
+		t.Fatalf("recipients = %#v, want [portfolio-node]", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal node", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want semantic root node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "portfolio-node" {
+		t.Fatalf("delivery route = %#v, want node/portfolio-node", route)
+	}
+	if !route.Target.Empty() {
+		t.Fatalf("delivery target = %#v, want empty root target", route.Target)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+}
+
 func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -2,6 +2,8 @@ package bus
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -190,6 +192,64 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 	}
 }
 
+func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	source := semanticview.Wrap(loadTargetRouteTempBundle(t, routedRootNodeFixtureFiles()))
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("portfolio-node", events.EventType("opco.spinup_requested"))
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("opco.spinup_requested"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-root")
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "root routed node event delivery")
+	if got.FlowInstance() != "" {
+		t.Fatalf("delivered flow instance = %q, want root event", got.FlowInstance())
+	}
+
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want one semantic root node route", routes)
+	}
+	route := routes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "portfolio-node" {
+		t.Fatalf("delivery route = %#v, want node/portfolio-node", route)
+	}
+	if !route.Target.Empty() {
+		t.Fatalf("delivery target = %#v, want empty root target", route.Target)
+	}
+
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, replayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if len(live) != 1 || live[0] != "portfolio-node" {
+		t.Fatalf("replay live recipients = %#v, want portfolio-node", live)
+	}
+	if len(internal) != 1 || internal[0] != "portfolio-node" {
+		t.Fatalf("replay internal recipients = %#v, want portfolio-node", internal)
+	}
+	if len(replayRoutes) != 1 || replayRoutes[0].SubscriberID != "portfolio-node" || !replayRoutes[0].Target.Empty() {
+		t.Fatalf("replay routes = %#v, want empty node/portfolio-node route", replayRoutes)
+	}
+
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	got = requireBusEvent(t, ch, "root routed node replay delivery")
+	if got.FlowInstance() != "" {
+		t.Fatalf("replayed flow instance = %q, want root event", got.FlowInstance())
+	}
+}
+
 func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntityIDs ...string) {
 	t.Helper()
 	seen := map[string]struct{}{}
@@ -208,6 +268,45 @@ func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntit
 		if _, ok := seen[want]; !ok {
 			t.Fatalf("missing target delivery for %q; saw %#v", want, seen)
 		}
+	}
+}
+
+func loadTargetRouteTempBundle(t *testing.T, files map[string]string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
+	if err != nil {
+		t.Fatalf("load target route temp bundle: %v", err)
+	}
+	return bundle
+}
+
+func routedRootNodeFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+`,
+		"events.yaml": `opco.spinup_requested:
+  entity_id: string
+`,
+		"nodes.yaml": `portfolio-node:
+  id: portfolio-node
+  execution_type: system_node
+  subscribes_to: [opco.spinup_requested]
+  event_handlers:
+    opco.spinup_requested: {}
+`,
 	}
 }
 

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -214,9 +214,12 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 	if len(recipients) > 0 {
 		deliveryRoutes = events.NormalizeDeliveryRoutes(append(deliveryRoutes, deliveryRoutesFromTargetMap(recipients, "agent", d.bus.deliveryTargetsForEvent(ctx, intent.Event.ID))...))
 	}
-	internalRecipients := deliveryRouteRecipientIDsByType(deliveryRoutes, "node")
+	internalRecipients := deliveryRouteRecipientIDsByType(pendingInternalRoutes, "node")
+	if len(internalRecipients) == 0 {
+		internalRecipients = deliveryRouteRecipientIDsByType(deliveryRoutes, "node")
+	}
 	liveRecipients := uniqueStrings(append(append([]string(nil), recipients...), internalRecipients...))
-	if len(deliveryRoutes) > 0 {
+	if len(deliveryRoutes) > 0 && len(pendingInternalRoutes) == 0 {
 		liveRecipients = uniqueStrings(append(deliveryRouteRecipientIDs(deliveryRoutes), recipients...))
 	}
 	if len(liveRecipients) == 0 {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -431,8 +431,12 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 				frame.result.EmitIntents = append(frame.result.EmitIntents, actionIntents...)
 			}
 			result = frame.result
+			if err := e.persist(frame.tx.Context(), frame); err != nil {
+				return err
+			}
+			result = frame.result
 			intents = append([]EmitIntent(nil), frame.result.EmitIntents...)
-			return e.persist(frame.tx.Context(), frame)
+			return nil
 		})
 	})
 	if err != nil {

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	"swarm/internal/config"
-	"swarm/internal/events"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	runtimecorrelation "swarm/internal/runtime/correlation"
-	llmselection "swarm/internal/runtime/llm/selection"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/events"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 type OpenAIResponsesRuntime struct {

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"swarm/internal/config"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -151,6 +151,104 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 	`, 1)
 }
 
+func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireOutboxFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:            module,
+		InstanceActivator: manager.ActivateFlowInstance,
+		WorkflowStore:     workflowStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	subscribed := make(chan struct{}, 1)
+	pc.SetTestSubscribeHook(func() { subscribed <- struct{}{} })
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	go pc.Run(runCtx)
+	select {
+	case <-subscribed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow runtime did not subscribe")
+	}
+
+	mailbox := (events.Event{
+		ID:        "99999999-9999-4999-8999-999999999912",
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("mailbox.item_decided"),
+		Payload:   []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("22222222-2222-4222-8222-222222222222")
+	if err := bus.Publish(ctx, mailbox); err != nil {
+		t.Fatalf("Publish mailbox: %v", err)
+	}
+
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'approval-router' AND outcome = 'no_op'
+	`, 1, mailbox.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'approval-router'
+	`, 1, mailbox.ID)
+
+	spinupEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'opco.spinup_requested'
+	`, nil)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node' AND outcome = 'no_op'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, spinupEventID)
+
+	autoEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
+	`, nil)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, autoEventID)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM events
+		WHERE event_name = 'operating/component_scaffold.spawn_requested'
+	`, 1)
+}
+
 type runtimeTestWorkflowModule struct {
 	source       semanticview.Source
 	workflow     *runtimepipeline.WorkflowDefinition
@@ -261,6 +359,80 @@ flows:
   product_id: string
 `,
 		"nodes.yaml": `portfolio-node:
+  id: portfolio-node
+  execution_type: system_node
+  subscribes_to: [opco.spinup_requested]
+  event_handlers:
+    opco.spinup_requested:
+      action: create_flow_instance
+      template: operating
+      instance_id_from: payload.instance_id
+      config_from:
+        product_id: payload.product_id
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+auto_emit_on_create:
+  event: opco.product_initialization_requested
+`,
+		"flows/operating/events.yaml": `opco.product_initialization_requested:
+  instance_id: string
+  template_id: string
+  flow_path: string
+  parent_entity_id: string
+  product_id: string
+component_scaffold.spawn_requested:
+  instance_id: string
+  template_id: string
+  flow_path: string
+  parent_entity_id: string
+  product_id: string
+`,
+		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
+  id: lifecycle-orchestrator
+  execution_type: system_node
+  subscribes_to: [opco.product_initialization_requested]
+  produces: [component_scaffold.spawn_requested]
+  event_handlers:
+    opco.product_initialization_requested:
+      emit: component_scaffold.spawn_requested
+`,
+	}
+}
+
+func templateInstanceEmpireOutboxFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"events.yaml": `mailbox.item_decided:
+  entity_id: string
+  instance_id: string
+  product_id: string
+opco.spinup_requested:
+  instance_id: string
+  product_id: string
+`,
+		"nodes.yaml": `approval-router:
+  id: approval-router
+  execution_type: system_node
+  subscribes_to: [mailbox.item_decided]
+  produces: [opco.spinup_requested]
+  event_handlers:
+    mailbox.item_decided:
+      emit:
+        event: opco.spinup_requested
+        broadcast: true
+        fields:
+          instance_id: payload.instance_id
+          product_id: payload.product_id
+portfolio-node:
   id: portfolio-node
   execution_type: system_node
   subscribes_to: [opco.spinup_requested]


### PR DESCRIPTION
Closes #1241

## Summary

This PR closes the approved first-slice class `runtime.root_no_target_routed_system_node_delivery_planning`.

It fixes root no-target runtime events that resolve to root system-node subscribers so they now produce semantic node delivery evidence, dispatch through the runtime carrier, record node receipts, and preserve the separate replay-scope marker.

## Governing Refs

- `platform-spec.yaml#engine.events.routing_derivation`
- `platform-spec.yaml#engine.events.routing_derivation.delivery_rules`
- `platform-spec.yaml#engine.event_identity_resolution.resolution_rules.root_events_are_global`
- `platform-spec.yaml#engine.event_identity_resolution.resolution_rules.handler_lookup_localizes`
- Pre-audit: https://github.com/division-sh/swarm/issues/1241#issuecomment-4596928594
- Gate: https://github.com/division-sh/swarm/issues/1241#issuecomment-4596976877

## Semantic Migration

- New canonical behavior: route-table root system-node subscribers for no-target root events are consumed by the delivery planner and persisted as semantic `events.DeliveryRoute` rows.
- Old invalid path: root routed system-node subscribers were route-table truth only; concrete-instance-only routed-node helpers excluded `subscriber.Path == ""` and `evt.FlowInstance() == ""`, leaving only replay-scope evidence.
- Runtime carrier separation: persisted semantic node rows remain handler evidence; executable internal carrier routes stay in-memory/pending and are used for dispatch/replay fan-out.
- Engine outbox identity handoff: post-commit dispatch now uses emit intents after outbox persistence assigns canonical event IDs, so emitted root events dispatch against their persisted delivery manifest.
- Migration completeness: complete for the approved root no-target routed system-node delivery class. #1258 remains split for static root emit target-required verification.

## Validation

- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute|TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute|TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute|TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedManifest' -count=1`
- `go test ./internal/runtime -run 'TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect|TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect' -count=1`
- `go test ./internal/runtime/llm -run TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./internal/runtime/engine -count=1`
- `go test ./...`

## Notes

This PR also includes a non-semantic import-path repair in two OpenAI Responses files from `swarm/internal/...` to `github.com/division-sh/swarm/internal/...`, required for the migrated module path to compile during full-suite proof. It is not closure-bearing for #1241.
