### PR TITLE
[agent-e][issue #1254] Support SQLite entity read surfaces

### DIFF
--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	apiv1 "github.com/division-sh/swarm/internal/apiv1"
+	"github.com/division-sh/swarm/internal/store/storetest"
 )
 
 func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
@@ -93,6 +97,91 @@ func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No entities match the filter.") {
 		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
+	}
+}
+
+func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	runID := "11111111-1111-1111-1111-111111111111"
+	entityA := "22222222-2222-2222-2222-222222222222"
+	entityB := "33333333-3333-3333-3333-333333333333"
+	now := time.Unix(1700000000, 0).UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES
+			(?, ?, 'scoring/vertical-a', 'vertical', 'discovered',
+			 '{}', '{"vertical_name":"Healthcare"}', '{}', 1, ?, ?, ?),
+			(?, ?, 'scoring/vertical-b', 'vertical', 'pending',
+			 '{}', '{"vertical_name":"Manufacturing"}', '{}', 1, ?, ?, ?)
+	`, runID, entityA, now, now, now, runID, entityB, now, now, now); err != nil {
+		t.Fatalf("seed sqlite entity_state: %v", err)
+	}
+	registry, err := apiv1.LoadRegistry(resolvePath(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	apiHandler, err := apiv1.NewHandler(apiv1.Options{
+		Registry:   registry,
+		AuthTokens: []string{"test-token"},
+		Handlers: apiv1.OperatorReadHandlers(apiv1.OperatorReadOptions{
+			Entities: sqliteStore,
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	server := httptest.NewServer(apiHandler)
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"entities", "list", "--run-id", runID, "--type", "vertical", "--limit", "10"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("entities list code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"ENTITY_ID", "RUN_ID", entityA, entityB, "vertical", "discovered", "pending"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entities list stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("entities list stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(ctx, t.TempDir(), []string{"entity", "view", entityA, "--run-id", runID}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("entity view code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Entity " + entityA, "type=vertical state=discovered", `fields={"vertical_name":"Healthcare"}`} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity view stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("entity view stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(ctx, t.TempDir(), []string{"entity", "aggregate", "--run-id", runID, "--group-by", "entity_type"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("entity aggregate code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"GROUP\tCOUNT", "vertical\t2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity aggregate stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("entity aggregate stderr = %q, want empty", stderr.String())
 	}
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -853,6 +853,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		if runStore, ok := stores.ObservabilityStore.(apiv1.RunReadStore); ok {
 			apiRuns = runStore
 		}
+		if entityStore, ok := stores.ObservabilityStore.(apiv1.EntityReadStore); ok {
+			apiEntities = entityStore
+		}
 	}
 	resetPlanner := runtimedestructivereset.InventoryPlanner{
 		Reader: runtimedestructivereset.CompositeInventoryReader{

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -205,6 +205,9 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	if _, ok := stores.ObservabilityStore.(apiv1.RunReadStore); !ok {
 		t.Fatalf("sqlite ObservabilityStore = %T, want selected run read store for run.get/list", stores.ObservabilityStore)
 	}
+	if _, ok := stores.ObservabilityStore.(apiv1.EntityReadStore); !ok {
+		t.Fatalf("sqlite ObservabilityStore = %T, want selected entity read store for entity.*", stores.ObservabilityStore)
+	}
 	runtimeStores := stores.runtimeStores()
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)

--- a/internal/apiv1/operator_entity_test.go
+++ b/internal/apiv1/operator_entity_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
 )
 
@@ -193,6 +194,79 @@ func TestOperatorEntityHandlersServeContractEntityTypesFromPostgres(t *testing.T
 	stateCounts := asMap(t, asMap(t, typedState.Result)["counts"])
 	if stateCounts["discovered"] != float64(1) || stateCounts["pending"] != float64(1) {
 		t.Fatalf("typed current_state counts = %#v", stateCounts)
+	}
+}
+
+func TestOperatorEntityHandlersServeContractEntityTypesFromSQLite(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	runID := "11111111-1111-1111-1111-111111111111"
+	entityA := "22222222-2222-2222-2222-222222222222"
+	entityB := "33333333-3333-3333-3333-333333333333"
+	now := time.Unix(1700000000, 0).UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES
+			(?, ?, 'scoring/vertical-a', 'vertical', 'discovered',
+			 '{}', '{"vertical_name":"Healthcare"}', '{}', 1, ?, ?, ?),
+			(?, ?, 'scoring/vertical-b', 'vertical', 'pending',
+			 '{}', '{"vertical_name":"Manufacturing"}', '{}', 1, ?, ?, ?)
+	`, runID, entityA, now, now, now, runID, entityB, now, now, now); err != nil {
+		t.Fatalf("seed sqlite entity_state: %v", err)
+	}
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Entities: sqliteStore,
+		}),
+	})
+
+	list := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"list","method":"entity.list","params":{"run_id":"11111111-1111-1111-1111-111111111111","type":"vertical","limit":10}}`)
+	if list.Error != nil {
+		t.Fatalf("entity.list error = %#v", list.Error)
+	}
+	rows, _ := asMap(t, list.Result)["entities"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("entity.list rows = %#v", list.Result)
+	}
+	for _, row := range rows {
+		if got := asMap(t, row)["entity_type"]; got != "vertical" {
+			t.Fatalf("entity.list entity_type = %#v, want vertical", got)
+		}
+	}
+
+	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"entity.get","params":{"entity_id":"22222222-2222-2222-2222-222222222222","run_id":"11111111-1111-1111-1111-111111111111"}}`)
+	if get.Error != nil {
+		t.Fatalf("entity.get error = %#v", get.Error)
+	}
+	getResult := asMap(t, get.Result)
+	if got := asMap(t, getResult["entity"])["entity_type"]; got != "vertical" {
+		t.Fatalf("entity.get entity_type = %#v, want vertical", got)
+	}
+	if fields := asMap(t, getResult["fields"]); fields["vertical_name"] != "Healthcare" {
+		t.Fatalf("entity.get fields = %#v", fields)
+	}
+
+	byType := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"agg-type","method":"entity.aggregate","params":{"run_id":"11111111-1111-1111-1111-111111111111","group_by":"entity_type"}}`)
+	if byType.Error != nil {
+		t.Fatalf("entity.aggregate entity_type error = %#v", byType.Error)
+	}
+	typeCounts := asMap(t, asMap(t, byType.Result)["counts"])
+	if typeCounts["vertical"] != float64(2) || typeCounts["default"] != nil {
+		t.Fatalf("entity_type counts = %#v", typeCounts)
+	}
+
+	entityContext := mailboxEntityContext(ctx, store.MailboxV1Item{
+		SourceRunID:    runID,
+		SourceEntityID: entityA,
+	}, sqliteStore)
+	if !entityContext.Available || entityContext.Entity == nil || entityContext.Entity.Entity.EntityID != entityA {
+		t.Fatalf("mailbox entity context = %#v, want sqlite entity context", entityContext)
 	}
 }
 

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	"swarm/internal/config"
-	"swarm/internal/events"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	runtimecorrelation "swarm/internal/runtime/correlation"
-	llmselection "swarm/internal/runtime/llm/selection"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/events"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 type OpenAIResponsesRuntime struct {

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"swarm/internal/config"
-	runtimeactors "swarm/internal/runtime/core/actors"
-	"swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {

--- a/internal/store/operator_entity_read_surface.go
+++ b/internal/store/operator_entity_read_surface.go
@@ -101,6 +101,35 @@ func (s *PostgresStore) requireOperatorEntityCapabilities(ctx context.Context) e
 	return nil
 }
 
+func (s *SQLiteRuntimeStore) requireOperatorEntityCapabilities(ctx context.Context) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case caps.EntityState != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("entity_state", caps.EntityState)
+	case !caps.EntityRunID:
+		return fmt.Errorf("operator entity read surface requires canonical entity_state.run_id")
+	}
+	catalog, err := loadSQLiteSchemaColumnCatalog(ctx, s.DB)
+	if err != nil {
+		return err
+	}
+	required := []string{
+		"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name",
+		"current_state", "gates", "fields", "accumulator", "revision",
+		"created_at", "updated_at",
+	}
+	if !catalog.hasColumns("entity_state", required...) {
+		return fmt.Errorf("operator entity read surface requires entity_state columns %v", required)
+	}
+	return nil
+}
+
 func (s *PostgresStore) ListOperatorEntities(ctx context.Context, opts OperatorEntityListOptions) (OperatorEntityListResult, error) {
 	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
 		return OperatorEntityListResult{}, err
@@ -225,6 +254,121 @@ func (s *PostgresStore) ListOperatorEntities(ctx context.Context, opts OperatorE
 	return OperatorEntityListResult{Entities: entities, NextCursor: nextCursor}, nil
 }
 
+func (s *SQLiteRuntimeStore) ListOperatorEntities(ctx context.Context, opts OperatorEntityListOptions) (OperatorEntityListResult, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityListResult{}, err
+	}
+	opts, err := defaultOperatorEntityListOptions(opts)
+	if err != nil {
+		return OperatorEntityListResult{}, err
+	}
+	args := make([]any, 0, 12)
+	where := []string{"1=1"}
+	add := func(value any) {
+		args = append(args, value)
+	}
+	if opts.RunID != "" {
+		add(opts.RunID)
+		where = append(where, "es.run_id = ?")
+	}
+	if opts.EntityID != "" {
+		add(opts.EntityID)
+		where = append(where, "es.entity_id = ?")
+	}
+	if opts.Flow != "" {
+		add(opts.Flow)
+		add(opts.Flow + "/%")
+		where = append(where, "(es.flow_instance = ? OR es.flow_instance LIKE ?)")
+	}
+	if opts.Type != "" {
+		add(opts.Type)
+		where = append(where, "es.entity_type = ?")
+	}
+	if opts.CurrentState != "" {
+		add(opts.CurrentState)
+		where = append(where, "es.current_state = ?")
+	}
+	if opts.Cursor != "" {
+		cursor, err := decodeEntityPositionCursor(opts.Cursor, "entity.list")
+		if err != nil {
+			return OperatorEntityListResult{}, err
+		}
+		updatedAt, err := time.Parse(time.RFC3339Nano, cursor.UpdatedAt)
+		if err != nil || strings.TrimSpace(cursor.EntityID) == "" || strings.TrimSpace(cursor.RunID) == "" {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		if _, err := uuid.Parse(cursor.EntityID); err != nil {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		if _, err := uuid.Parse(cursor.RunID); err != nil {
+			return OperatorEntityListResult{}, ErrInvalidEntityCursor
+		}
+		add(updatedAt.UTC())
+		add(updatedAt.UTC())
+		add(cursor.EntityID)
+		add(cursor.EntityID)
+		add(cursor.RunID)
+		where = append(where, `(
+			es.updated_at < ?
+			OR (
+				es.updated_at = ?
+				AND (
+					es.entity_id > ?
+					OR (es.entity_id = ? AND es.run_id > ?)
+				)
+			)
+		)`)
+	}
+	add(opts.Limit + 1)
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(es.entity_id, ''),
+			COALESCE(es.run_id, ''),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			COALESCE(es.current_state, ''),
+			COALESCE(es.revision, 0),
+			es.created_at,
+			es.updated_at,
+			COALESCE(es.slug, ''),
+			COALESCE(es.name, '')
+		FROM entity_state es
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY es.updated_at DESC, es.entity_id ASC, es.run_id ASC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return OperatorEntityListResult{}, fmt.Errorf("list sqlite operator entities: %w", err)
+	}
+	defer rows.Close()
+	entities := []OperatorEntitySummary{}
+	for rows.Next() {
+		item, err := scanSQLiteOperatorEntitySummary(rows)
+		if err != nil {
+			return OperatorEntityListResult{}, fmt.Errorf("scan sqlite operator entity summary: %w", err)
+		}
+		entities = append(entities, item)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityListResult{}, fmt.Errorf("read sqlite operator entity summaries: %w", err)
+	}
+	nextCursor := ""
+	if len(entities) > opts.Limit {
+		entities = entities[:opts.Limit]
+		last := entities[len(entities)-1]
+		nextCursor = encodeEntityPositionCursor(entityPositionCursor{
+			Kind:      "entity.list",
+			UpdatedAt: last.UpdatedAt.UTC().Format(time.RFC3339Nano),
+			EntityID:  last.EntityID,
+			RunID:     last.RunID,
+		})
+	}
+	if entities == nil {
+		entities = []OperatorEntitySummary{}
+	}
+	return OperatorEntityListResult{Entities: entities, NextCursor: nextCursor}, nil
+}
+
 func (s *PostgresStore) LoadOperatorEntity(ctx context.Context, entityID, runID string) (OperatorEntityFull, error) {
 	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
 		return OperatorEntityFull{}, err
@@ -270,6 +414,56 @@ func (s *PostgresStore) LoadOperatorEntity(ctx context.Context, entityID, runID 
 		return OperatorEntityFull{}, ErrEntityNotFound
 	case 1:
 		return s.loadOperatorEntityRow(ctx, entityID, matches[0])
+	default:
+		return OperatorEntityFull{}, ErrAmbiguousEntityRunID
+	}
+}
+
+func (s *SQLiteRuntimeStore) LoadOperatorEntity(ctx context.Context, entityID, runID string) (OperatorEntityFull, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityFull{}, err
+	}
+	entityID = strings.TrimSpace(entityID)
+	runID = strings.TrimSpace(runID)
+	if entityID == "" {
+		return OperatorEntityFull{}, ErrEntityNotFound
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return OperatorEntityFull{}, &EntityReadParamError{Field: "entity_id", Reason: "must be a UUID"}
+	}
+	if runID != "" {
+		if _, err := uuid.Parse(runID); err != nil {
+			return OperatorEntityFull{}, &EntityReadParamError{Field: "run_id", Reason: "must be a UUID"}
+		}
+		return s.loadSQLiteOperatorEntityRow(ctx, entityID, runID)
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(es.run_id, '')
+		FROM entity_state es
+		WHERE es.entity_id = ?
+		ORDER BY es.updated_at DESC, es.run_id ASC
+		LIMIT 2
+	`, entityID)
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("resolve sqlite operator entity run scope: %w", err)
+	}
+	defer rows.Close()
+	matches := []string{}
+	for rows.Next() {
+		var match string
+		if err := rows.Scan(&match); err != nil {
+			return OperatorEntityFull{}, fmt.Errorf("scan sqlite operator entity run scope: %w", err)
+		}
+		matches = append(matches, match)
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("read sqlite operator entity run scopes: %w", err)
+	}
+	switch len(matches) {
+	case 0:
+		return OperatorEntityFull{}, ErrEntityNotFound
+	case 1:
+		return s.loadSQLiteOperatorEntityRow(ctx, entityID, matches[0])
 	default:
 		return OperatorEntityFull{}, ErrAmbiguousEntityRunID
 	}
@@ -326,6 +520,61 @@ func (s *PostgresStore) AggregateOperatorEntities(ctx context.Context, opts Oper
 	}
 	if err := rows.Err(); err != nil {
 		return OperatorEntityAggregateResult{}, fmt.Errorf("read operator entity aggregate: %w", err)
+	}
+	return OperatorEntityAggregateResult{Counts: counts}, nil
+}
+
+func (s *SQLiteRuntimeStore) AggregateOperatorEntities(ctx context.Context, opts OperatorEntityAggregateOptions) (OperatorEntityAggregateResult, error) {
+	if err := s.requireOperatorEntityCapabilities(ctx); err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	opts, err := defaultOperatorEntityAggregateOptions(opts)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	args := make([]any, 0, 6)
+	add := func(value any) int {
+		args = append(args, value)
+		return len(args)
+	}
+	group, err := sqliteOperatorEntityAggregateGroup(opts.GroupBy, add)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, err
+	}
+	where := []string{"1=1"}
+	if opts.RunID != "" {
+		args = append(args, opts.RunID)
+		where = append(where, "es.run_id = ?")
+	}
+	if opts.Type != "" {
+		args = append(args, opts.Type)
+		where = append(where, "es.entity_type = ?")
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT COALESCE(`+group.Expr+`, 'unknown') AS bucket, COUNT(*)
+		FROM entity_state es
+		`+group.Join+`
+		WHERE `+strings.Join(where, " AND ")+`
+		GROUP BY bucket
+		ORDER BY COUNT(*) DESC, bucket ASC
+	`, args...)
+	if err != nil {
+		return OperatorEntityAggregateResult{}, fmt.Errorf("aggregate sqlite operator entities: %w", err)
+	}
+	defer rows.Close()
+	counts := map[string]int{}
+	for rows.Next() {
+		var (
+			key   string
+			count int
+		)
+		if err := rows.Scan(&key, &count); err != nil {
+			return OperatorEntityAggregateResult{}, fmt.Errorf("scan sqlite operator entity aggregate: %w", err)
+		}
+		counts[key] = count
+	}
+	if err := rows.Err(); err != nil {
+		return OperatorEntityAggregateResult{}, fmt.Errorf("read sqlite operator entity aggregate: %w", err)
 	}
 	return OperatorEntityAggregateResult{Counts: counts}, nil
 }
@@ -392,6 +641,108 @@ func (s *PostgresStore) loadOperatorEntityRow(ctx context.Context, entityID, run
 	out.Gates = decodedGates
 	out.Accumulated = decodedAccumulated
 	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) loadSQLiteOperatorEntityRow(ctx context.Context, entityID, runID string) (OperatorEntityFull, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(es.entity_id, ''),
+			COALESCE(es.run_id, ''),
+			COALESCE(es.flow_instance, ''),
+			COALESCE(es.entity_type, ''),
+			COALESCE(es.current_state, ''),
+			COALESCE(es.revision, 0),
+			es.created_at,
+			es.updated_at,
+			COALESCE(es.slug, ''),
+			COALESCE(es.name, ''),
+			COALESCE(es.fields, '{}'),
+			COALESCE(es.gates, '{}'),
+			COALESCE(es.accumulator, '{}')
+		FROM entity_state es
+		WHERE es.entity_id = ?
+		  AND es.run_id = ?
+	`, entityID, runID)
+	var (
+		out     OperatorEntityFull
+		fields  any
+		gates   any
+		accum   any
+		summary = &out.Entity
+	)
+	item, err := scanSQLiteOperatorEntitySummaryWithTail(row, &fields, &gates, &accum)
+	if err == sql.ErrNoRows {
+		return OperatorEntityFull{}, ErrEntityNotFound
+	}
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("load sqlite operator entity: %w", err)
+	}
+	*summary = item
+	decodedFields, err := decodeStoreJSONMap([]byte(sqliteJSONRawMessage(fields)))
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode sqlite operator entity fields: %w", err)
+	}
+	decodedGates, err := decodeStoreJSONBoolMap([]byte(sqliteJSONRawMessage(gates)))
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode sqlite operator entity gates: %w", err)
+	}
+	decodedAccumulated, err := decodeStoreJSONMap([]byte(sqliteJSONRawMessage(accum)))
+	if err != nil {
+		return OperatorEntityFull{}, fmt.Errorf("decode sqlite operator entity accumulated: %w", err)
+	}
+	out.Fields = decodedFields
+	out.Gates = decodedGates
+	out.Accumulated = decodedAccumulated
+	return out, nil
+}
+
+type sqliteOperatorEntityScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSQLiteOperatorEntitySummary(scanner sqliteOperatorEntityScanner) (OperatorEntitySummary, error) {
+	return scanSQLiteOperatorEntitySummaryWithTail(scanner)
+}
+
+func scanSQLiteOperatorEntitySummaryWithTail(scanner sqliteOperatorEntityScanner, tail ...any) (OperatorEntitySummary, error) {
+	var (
+		item       OperatorEntitySummary
+		createdRaw any
+		updatedRaw any
+	)
+	dest := []any{
+		&item.EntityID,
+		&item.RunID,
+		&item.FlowInstance,
+		&item.EntityType,
+		&item.CurrentState,
+		&item.Revision,
+		&createdRaw,
+		&updatedRaw,
+		&item.Slug,
+		&item.Name,
+	}
+	dest = append(dest, tail...)
+	if err := scanner.Scan(dest...); err != nil {
+		return OperatorEntitySummary{}, err
+	}
+	createdAt, ok, err := sqliteTimeValue(createdRaw)
+	if err != nil {
+		return OperatorEntitySummary{}, fmt.Errorf("decode created_at: %w", err)
+	}
+	if !ok {
+		return OperatorEntitySummary{}, fmt.Errorf("created_at is required")
+	}
+	updatedAt, ok, err := sqliteTimeValue(updatedRaw)
+	if err != nil {
+		return OperatorEntitySummary{}, fmt.Errorf("decode updated_at: %w", err)
+	}
+	if !ok {
+		return OperatorEntitySummary{}, fmt.Errorf("updated_at is required")
+	}
+	item.CreatedAt = createdAt
+	item.UpdatedAt = updatedAt
+	return item, nil
 }
 
 func defaultOperatorEntityListOptions(opts OperatorEntityListOptions) (OperatorEntityListOptions, error) {
@@ -461,6 +812,37 @@ func operatorEntityAggregateGroup(groupBy string, add func(any) int) (entityAggr
 		if path, ok := strings.CutPrefix(strings.TrimSpace(groupBy), "fields."); ok && entityAggregateFieldPattern.MatchString(path) {
 			n := add(path)
 			return entityAggregateGroup{Expr: fmt.Sprintf("NULLIF(es.fields #>> string_to_array($%d, '.'), '')", n)}, nil
+		}
+		return entityAggregateGroup{}, &EntityReadParamError{Field: "group_by", Reason: "unsupported entity aggregate group_by"}
+	}
+}
+
+func sqliteOperatorEntityAggregateGroup(groupBy string, add func(any) int) (entityAggregateGroup, error) {
+	switch strings.TrimSpace(groupBy) {
+	case "current_state":
+		return entityAggregateGroup{Expr: "NULLIF(es.current_state, '')"}, nil
+	case "flow", "flow_instance":
+		return entityAggregateGroup{Expr: "NULLIF(es.flow_instance, '')"}, nil
+	case "workflow_name":
+		return entityAggregateGroup{
+			Expr: "NULLIF(fi.flow_template, '')",
+			Join: "LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance",
+		}, nil
+	case "workflow_version":
+		return entityAggregateGroup{
+			Expr: "NULLIF(CAST(json_extract(COALESCE(fi.config, '{}'), '$.workflow_version') AS TEXT), '')",
+			Join: "LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance",
+		}, nil
+	case "type", "entity_type":
+		return entityAggregateGroup{Expr: "NULLIF(es.entity_type, '')"}, nil
+	case "slug":
+		return entityAggregateGroup{Expr: "NULLIF(es.slug, '')"}, nil
+	case "name":
+		return entityAggregateGroup{Expr: "NULLIF(es.name, '')"}, nil
+	default:
+		if path, ok := strings.CutPrefix(strings.TrimSpace(groupBy), "fields."); ok && entityAggregateFieldPattern.MatchString(path) {
+			add(sqliteToolJSONPath(path))
+			return entityAggregateGroup{Expr: "NULLIF(CAST(json_extract(COALESCE(es.fields, '{}'), ?) AS TEXT), '')"}, nil
 		}
 		return entityAggregateGroup{}, &EntityReadParamError{Field: "group_by", Reason: "unsupported entity aggregate group_by"}
 	}

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -159,3 +159,175 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 		t.Fatalf("AggregateOperatorEntities unsafe group = %v, want ErrInvalidEntityReadParam", err)
 	}
 }
+
+func TestSQLiteOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	db := sqliteStore.DB
+
+	runA := uuid.NewString()
+	runB := uuid.NewString()
+	entityA := uuid.NewString()
+	entityB := uuid.NewString()
+	sharedEntity := uuid.NewString()
+	base := time.Unix(1700000000, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at) VALUES
+			(?, 'running', ?),
+			(?, 'running', ?)
+	`, runA, base, runB, base); err != nil {
+		t.Fatalf("seed sqlite runs: %v", err)
+	}
+	seedEntity := func(runID, entityID, flow, entityType, state, fields, gates, accumulated string, createdAt time.Time) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name,
+				current_state, gates, fields, accumulator, revision,
+				entered_state_at, created_at, updated_at
+			) VALUES (
+				?, ?, ?, ?, NULL, NULL,
+				?, ?, ?, ?, 1,
+				?, ?, ?
+			)
+		`, runID, entityID, flow, entityType, state, gates, fields, accumulated, createdAt, createdAt, createdAt); err != nil {
+			t.Fatalf("seed sqlite entity %s/%s: %v", runID, entityID, err)
+		}
+	}
+	seedEntity(runA, entityA, "review/primary", "mvp_spec", "collecting", `{"priority":"high","score":3}`, `{"approved":true}`, `{"score":3,"accumulator":{"count":2},"notes":["a",{"text":"probe"}]}`, base.Add(time.Minute))
+	seedEntity(runA, entityB, "review/secondary", "mvp_spec", "done", `{"priority":"low"}`, `{}`, `{}`, base)
+	seedEntity(runA, sharedEntity, "triage", "ticket", "collecting", `{"priority":"high"}`, `{}`, `{}`, base.Add(-time.Minute))
+	seedEntity(runB, sharedEntity, "triage", "ticket", "done", `{"priority":"low"}`, `{}`, `{}`, base.Add(-2*time.Minute))
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('review/primary', 'review', 'template', '{"workflow_version":"v1"}', 'active', ?),
+			('review/secondary', 'review', 'template', '{"workflow_version":"v2"}', 'active', ?),
+			('triage', 'triage', 'static', '{"workflow_version":"v1"}', 'active', ?)
+	`, base, base, base); err != nil {
+		t.Fatalf("seed sqlite flow instances: %v", err)
+	}
+
+	page1, err := sqliteStore.ListOperatorEntities(ctx, OperatorEntityListOptions{
+		RunID: runA,
+		Flow:  "review",
+		Type:  "mvp_spec",
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEntities page1: %v", err)
+	}
+	if len(page1.Entities) != 1 || page1.Entities[0].EntityID != entityA || page1.NextCursor == "" {
+		t.Fatalf("page1 = %#v", page1)
+	}
+	if got := page1.Entities[0].EntityType; got != "mvp_spec" {
+		t.Fatalf("page1 entity_type = %q, want mvp_spec", got)
+	}
+	page2, err := sqliteStore.ListOperatorEntities(ctx, OperatorEntityListOptions{
+		RunID:  runA,
+		Flow:   "review",
+		Type:   "mvp_spec",
+		Limit:  1,
+		Cursor: page1.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorEntities page2: %v", err)
+	}
+	if len(page2.Entities) != 1 || page2.Entities[0].EntityID != entityB {
+		t.Fatalf("page2 = %#v", page2)
+	}
+	stateFiltered, err := sqliteStore.ListOperatorEntities(ctx, OperatorEntityListOptions{RunID: runA, CurrentState: "collecting", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListOperatorEntities current_state: %v", err)
+	}
+	if len(stateFiltered.Entities) != 2 {
+		t.Fatalf("state filtered = %#v, want two collecting entities in runA", stateFiltered.Entities)
+	}
+
+	full, err := sqliteStore.LoadOperatorEntity(ctx, entityA, runA)
+	if err != nil {
+		t.Fatalf("LoadOperatorEntity: %v", err)
+	}
+	if full.Entity.FlowInstance != "review/primary" || full.Fields["priority"] != "high" || !full.Gates["approved"] {
+		t.Fatalf("full entity = %#v", full)
+	}
+	if full.Entity.EntityType != "mvp_spec" {
+		t.Fatalf("full entity_type = %q, want mvp_spec", full.Entity.EntityType)
+	}
+	if full.Accumulated["score"] != float64(3) {
+		t.Fatalf("full accumulated = %#v, want score", full.Accumulated)
+	}
+	if bucket, ok := full.Accumulated["accumulator"].(map[string]any); !ok || bucket["count"] != float64(2) {
+		t.Fatalf("full accumulated bucket = %#v, want count", full.Accumulated["accumulator"])
+	}
+	if notes, ok := full.Accumulated["notes"].([]any); !ok || len(notes) != 2 {
+		t.Fatalf("full accumulated notes = %#v, want two entries", full.Accumulated["notes"])
+	}
+	if _, err := sqliteStore.LoadOperatorEntity(ctx, sharedEntity, ""); !errors.Is(err, ErrAmbiguousEntityRunID) {
+		t.Fatalf("LoadOperatorEntity ambiguous = %v, want ErrAmbiguousEntityRunID", err)
+	}
+	if _, err := sqliteStore.LoadOperatorEntity(ctx, uuid.NewString(), ""); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("LoadOperatorEntity missing = %v, want ErrEntityNotFound", err)
+	}
+	if _, err := sqliteStore.LoadOperatorEntity(ctx, "not-a-uuid", ""); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("LoadOperatorEntity invalid entity id = %v, want ErrInvalidEntityReadParam", err)
+	}
+	if _, err := sqliteStore.LoadOperatorEntity(ctx, entityA, "not-a-uuid"); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("LoadOperatorEntity invalid run id = %v, want ErrInvalidEntityReadParam", err)
+	}
+	if _, err := sqliteStore.ListOperatorEntities(ctx, OperatorEntityListOptions{RunID: "not-a-uuid"}); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("ListOperatorEntities invalid run id = %v, want ErrInvalidEntityReadParam", err)
+	}
+	if _, err := sqliteStore.ListOperatorEntities(ctx, OperatorEntityListOptions{Cursor: "bad"}); !errors.Is(err, ErrInvalidEntityCursor) {
+		t.Fatalf("ListOperatorEntities invalid cursor = %v, want ErrInvalidEntityCursor", err)
+	}
+
+	stateAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "current_state"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities current_state: %v", err)
+	}
+	if stateAgg.Counts["collecting"] != 2 || stateAgg.Counts["done"] != 1 {
+		t.Fatalf("state aggregate = %#v", stateAgg.Counts)
+	}
+	typedStateAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "current_state", Type: "mvp_spec"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities typed current_state: %v", err)
+	}
+	if typedStateAgg.Counts["collecting"] != 1 || typedStateAgg.Counts["done"] != 1 || typedStateAgg.Counts["ticket"] != 0 {
+		t.Fatalf("typed state aggregate = %#v", typedStateAgg.Counts)
+	}
+	typeAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "entity_type"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities entity_type: %v", err)
+	}
+	if typeAgg.Counts["mvp_spec"] != 2 || typeAgg.Counts["ticket"] != 1 || typeAgg.Counts["default"] != 0 {
+		t.Fatalf("entity_type aggregate = %#v", typeAgg.Counts)
+	}
+	fieldAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities fields.priority: %v", err)
+	}
+	if fieldAgg.Counts["high"] != 2 || fieldAgg.Counts["low"] != 1 {
+		t.Fatalf("field aggregate = %#v", fieldAgg.Counts)
+	}
+	versionAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "workflow_version"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities workflow_version: %v", err)
+	}
+	if versionAgg.Counts["v1"] != 2 || versionAgg.Counts["v2"] != 1 {
+		t.Fatalf("workflow version aggregate = %#v", versionAgg.Counts)
+	}
+	nameAgg, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "workflow_name"})
+	if err != nil {
+		t.Fatalf("AggregateOperatorEntities workflow_name: %v", err)
+	}
+	if nameAgg.Counts["review"] != 2 || nameAgg.Counts["triage"] != 1 {
+		t.Fatalf("workflow name aggregate = %#v", nameAgg.Counts)
+	}
+	if _, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: runA, GroupBy: "fields.priority->unsafe"}); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("AggregateOperatorEntities unsafe group = %v, want ErrInvalidEntityReadParam", err)
+	}
+	if _, err := sqliteStore.AggregateOperatorEntities(ctx, OperatorEntityAggregateOptions{RunID: "not-a-uuid"}); !errors.Is(err, ErrInvalidEntityReadParam) {
+		t.Fatalf("AggregateOperatorEntities invalid run id = %v, want ErrInvalidEntityReadParam", err)
+	}
+}


### PR DESCRIPTION
Part of #1254

## Summary

- Implements the existing `apiv1.EntityReadStore` contract on `SQLiteRuntimeStore` for `entity.list`, `entity.get`, and `entity.aggregate` over canonical run-scoped `entity_state`.
- Wires the selected non-Postgres observability store into `apiEntities`, so SQLite-backed `swarm serve` registers the v1 `entity.*` handlers instead of returning `METHOD_UNAVAILABLE`.
- Adds SQLite store/API/CLI supported-surface proof, including mailbox entity context through the same corrected `EntityReadStore` path.
- Fixes two stale `swarm/internal/...` imports in the OpenAI responses runtime files that were already present on `origin/master` and blocked `go test ./...` before this PR could be proved.

## Gate Boundary

Approved gate: #1254 independent gate outcome `approved as first slice`.

Chosen working failure class closed by this PR: `sqlite_operator_entity_read_surface_missing_from_supported_api_and_cli`.

This PR does not claim full #1254 closure. `swarm status` / `RunHeader.entity_count`, `runs.entity_count`, lifecycle count synchronization, #1253 coupling, and dashboard/builder status summaries remain outside this gate boundary.

## Governing Refs / Context

Exact governing refs:

- `platform-spec.yaml#runtime_store_backend_selection`: local/dev default resolves to SQLite; Postgres is explicit opt-in.
- `platform-spec.yaml#schema_storage.entity_state`: `entity_state` is the current run-scoped state/registry and generic reads use it for run-scoped listing/filtering/lookup.
- `platform-spec.yaml#entity_registry_policy`: there is no separate entity registry; generic reads query `entity_state` through explicit run context.
- `README.md` documented surfaces: `swarm entities {list,view,aggregate}`, SQLite local/dev default, and the CLI as a JSON-RPC API client.
- `openrpc.json`: `entity.list`, `entity.get`, and `entity.aggregate` are supported v1 RPC methods.

## Semantic Migration

New canonical owner consumed by this PR:

- `apiv1.EntityReadStore` over run-scoped `entity_state`, implemented by both `PostgresStore` and `SQLiteRuntimeStore`.

Old path now invalid / non-authoritative:

- `cmd/swarm` Postgres-only `apiEntities` wiring, which left SQLite with nil `OperatorEntityHandlers` and generic `METHOD_UNAVAILABLE` for cataloged `entity.*` methods.
- Runtime/tool `QueryEntityStates` remains a different runtime/tool concept and is not used as a second public operator read owner.

Production paths checked for surviving old behavior:

- `cmd/swarm/main.go` non-Postgres API store wiring now assigns `apiEntities` when the selected observability store implements `EntityReadStore`.
- `/v1/rpc entity.list`, `entity.get`, and `entity.aggregate` are proved against a real SQLite runtime store.
- `swarm entities list`, `swarm entity view`, and `swarm entity aggregate` are proved through a real v1 API handler backed by SQLite, not direct DB access.
- Mailbox entity context is proved through the same SQLite `EntityReadStore` path.

Migration completeness:

- Complete for the approved `entity.*` API/CLI chosen class.
- Not complete for the broader #1254 parent because status entity-count semantics remain split by gate.

## Required Explanation

Why `057b6192 fix: marshal sqlite structured entity filters` did not close this:

- That commit covered SQLite runtime/tool `QueryEntityStates` structured field-filter marshalling. It did not implement `apiv1.EntityReadStore` on `SQLiteRuntimeStore`, did not wire SQLite into `apiEntities`, and did not prove `/v1/rpc entity.*` or CLI handler registration.

Why `58293728 fix: preserve sqlite create entity provenance` did not close this:

- That commit covered SQLite create/write provenance. It proved entity rows can be persisted with the right lineage, but it did not change the public operator read owner or the Postgres-only API handler wiring.

Why the previous suite missed “list one entity on SQLite”:

- Coverage was split across Postgres store tests, fake-store API tests, fake-server CLI tests, and SQLite runtime/tool query tests. None selected a SQLite runtime store, seeded one `entity_state` row, and read it through `/v1/rpc entity.list` plus the documented CLI surface.

## Tests

- `go test ./internal/store -run 'Test(SQLite)?OperatorEntityReadOwnerListGetAggregateAndCursor' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEntityHandlers(ServeContractEntityTypesFrom(SQLite|Postgres)|ExposeEntityNativeReads|TypedErrors)' -count=1`
- `go test ./cmd/swarm -run 'Test(EntityCommandsUseSQLiteEntityReadStoreThroughV1API|EntitiesListUsesEntityListV1RPCWithFilters|EntityViewUsesEntityGetAndRendersEntityNativeDetail|EntityAggregateUsesEntityAggregateDefaultsAndFilters|BuildStoresAcceptsSQLiteSelectedCoreRuntimeStore)' -count=1`
- `go test ./...`
