### PR TITLE
[agent-b][issue #1258] Reject root pin emits without target

### DIFF
--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -82,21 +82,27 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 }
 
 func TestPinDeclaredOutputRecognizesRootSchemaOutputWithoutLeafFallback(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-		RootSchema: &runtimecontracts.FlowSchemaDocument{
-			Pins: runtimecontracts.FlowPins{
-				Outputs: runtimecontracts.FlowOutputPins{
-					Events: []string{"root.ready"},
-				},
-			},
-		},
-	})
+	source := testRootPinRoutingSource()
 
 	if !PinDeclaredOutput(source, "", "root.ready") {
 		t.Fatal("root output pin was not recognized")
 	}
 	if PinDeclaredOutput(source, "", "worker/root.ready") {
 		t.Fatal("namespaced event matched root output pin by leaf name")
+	}
+}
+
+func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testRootPinRoutingSource(),
+		EventType: "root.ready",
+	}, events.Event{Type: "root.ready"})
+
+	if result.Failure != FailureTargetRequiredMissing {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetRequiredMissing)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on failed root target resolution", got)
 	}
 }
 
@@ -123,6 +129,21 @@ func testPinRoutingSource() semanticview.Source {
 			ByID: map[string]*runtimecontracts.FlowContractView{
 				"child": &child,
 			},
+		},
+	})
+}
+
+func testRootPinRoutingSource() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"root.ready"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"root.ready": {},
 		},
 	})
 }


### PR DESCRIPTION
Closes #1258

## Summary

This PR is refreshed after #1282 / PR #1289 merged the canonical authored emit-site owner and migrated bootverify to consume it.

The obsolete #1270 local reconstruction commits were dropped. Current #1270 now adds the remaining direct #1258 proof that core pin-routing `Resolve` fails closed for a root schema output pin with no target mechanism.

## Governing Refs

- `platform-spec.yaml#engine.events.envelope_identity.target`
- `platform-spec.yaml#engine.workflow_contract.emit.pin_routing_activation.target_requirement`
- `platform-spec.yaml#engine.event_identity_resolution.resolution_rules.root_events_are_global`
- `platform-spec.yaml#engine.cross_flow_routing.target_resolution.fail_closed`
- Pre-audit: https://github.com/division-sh/swarm/issues/1258#issuecomment-4597799174
- Gate: https://github.com/division-sh/swarm/issues/1258#issuecomment-4597831190
- Canonical owner PR: #1289

## Semantic Migration

- New canonical owner: `internal/runtime/semanticview.AuthoredEmitSites`, introduced by #1289, owns authored workflow emit-site source identity.
- Consuming owner: `internal/runtime/bootverify/workflow_pin_routing_checks.go` consumes that owner for `pin_target_resolution`.
- Shared predicate owner: `internal/runtime/core/pinrouting.PinDeclaredOutput` recognizes root `schema.yaml` output pins.
- Old invalid path removed from this PR branch: bootverify-local reconstruction/de-dupe of root/project/flow emit sites.
- Migration status: complete for the #1258 verifier class on current master plus this final core `Resolve` proof.

## Validation

- `go test ./internal/runtime/core/pinrouting -run 'TestPinDeclaredOutput|TestValidateTargetSpec|TestResolve' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestPinTargetResolution' -count=1`
- `go test ./internal/runtime/tools -run 'TestHandleEmitTool_RootSchemaPinOutputStillRequiresTarget|TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget' -count=1`
- `go test ./...`
