### PR TITLE
[agent-h][issue #1257] Fail closed on explicit contracts paths

### DIFF
--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -570,6 +570,7 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 	badDataBlobPath := writeBundleRegisterFixture(t, "bad-data.json", `{bad json`)
 	multipleDataBlobPath := writeBundleRegisterFixture(t, "multi-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[]}{}`)
 	contractsDir := writeBundleRegisterContractsFixture(t)
+	invalidChildContractsDir := filepath.Join(contractsDir, "zzz-not-a-real-dir")
 	invalidContractsDir := t.TempDir()
 	dirPath := filepath.Join(t.TempDir(), "bundle-dir")
 	if err := os.Mkdir(dirPath, 0o700); err != nil {
@@ -602,6 +603,7 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register blank idempotency", args: []string{"bundle", "register", envelopePath, "--data-blob", dataBlobPath, "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
 		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
+		{name: "register contracts typo child under bundle", args: []string{"bundle", "register", "--contracts", invalidChildContractsDir}, wantStderr: "package contracts directory"},
 		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "package contracts directory"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/cli_paths_test.go
+++ b/cmd/swarm/cli_paths_test.go
@@ -172,7 +172,7 @@ func TestRunVerifyCommandConsumesContractPathResolver(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := repoRoot()
 	configContracts := filepath.Join(t.TempDir(), "config-contracts")
-	envContracts := filepath.Join(t.TempDir(), "env-contracts")
+	envContracts := filepath.Join(repo, "tests", "tier8-boot-verification", "test-boot-success", "zzz-not-a-real-dir")
 	legacyContracts := filepath.Join(t.TempDir(), "legacy-contracts")
 	writeWorkflowValidationFixtureFile(t, filepath.Join(legacyContracts, "package.yaml"), `name: legacy`)
 	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
@@ -196,8 +196,8 @@ func TestRunVerifyCommandConsumesContractPathResolver(t *testing.T) {
 
 func TestRunServeRuntimeConsumesContractPathResolverBeforeBundleLoad(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
-	repo := t.TempDir()
-	configContracts := filepath.Join(t.TempDir(), "config-contracts")
+	repo := repoRoot()
+	configContracts := filepath.Join(repo, "tests", "tier8-boot-verification", "test-boot-success", "zzz-not-a-real-dir")
 	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 		"contracts_path": configContracts,
 	}))

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2355,14 +2355,11 @@ func normalizeContractsRoot(path string) (string, error) {
 		return "", errors.New("contracts path is required")
 	}
 	root = filepath.Clean(root)
-	if _, err := os.Stat(filepath.Join(root, "package.yaml")); err == nil {
+	if regularFileExists(filepath.Join(root, "package.yaml")) {
 		return root, nil
 	}
-	parent := filepath.Dir(root)
-	if parent != root {
-		if _, err := os.Stat(filepath.Join(parent, "package.yaml")); err == nil {
-			return parent, nil
-		}
+	if filepath.Base(root) == "package.yaml" && regularFileExists(root) {
+		return filepath.Dir(root), nil
 	}
 	return "", fmt.Errorf("no package.yaml found under %s", path)
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6384,13 +6384,56 @@ func runVerifyCommandWithContractsForTest(ctx context.Context, repo, contractsPa
 }
 
 func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
-	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), filepath.Join(t.TempDir(), "missing"), &buf)
-	if code == 0 {
-		t.Fatal("expected non-zero exit code")
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "missing absolute path", path: filepath.Join(t.TempDir(), "missing")},
+		{name: "explicit child path under bundle", path: filepath.Join(repoRoot(), "tests", "tier8-boot-verification", "test-boot-success", "zzz-not-a-real-dir")},
 	}
-	if out := buf.String(); !strings.Contains(out, "verify failed: resolve contracts") {
-		t.Fatalf("output = %q", out)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), tc.path, &buf)
+			if code == 0 {
+				t.Fatal("expected non-zero exit code")
+			}
+			out := buf.String()
+			if !strings.Contains(out, "verify failed: resolve contracts") {
+				t.Fatalf("output = %q", out)
+			}
+			if !strings.Contains(out, tc.path) {
+				t.Fatalf("output does not name explicit path %q:\n%s", tc.path, out)
+			}
+		})
+	}
+}
+
+func TestNormalizeContractsRootExplicitPathValidation(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `name: explicit-root`)
+
+	got, err := normalizeContractsRoot(root)
+	if err != nil {
+		t.Fatalf("normalize directory root: %v", err)
+	}
+	if got != root {
+		t.Fatalf("root = %q, want %q", got, root)
+	}
+
+	got, err = normalizeContractsRoot(filepath.Join(root, "package.yaml"))
+	if err != nil {
+		t.Fatalf("normalize package file shorthand: %v", err)
+	}
+	if got != root {
+		t.Fatalf("root from package file = %q, want %q", got, root)
+	}
+
+	explicitChild := filepath.Join(root, "zzz-not-a-real-dir")
+	if got, err := normalizeContractsRoot(explicitChild); err == nil {
+		t.Fatalf("normalize explicit child returned %q, want fail-closed error", got)
+	} else if !strings.Contains(err.Error(), explicitChild) {
+		t.Fatalf("error = %q, want explicit child path %q", err.Error(), explicitChild)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6309,8 +6309,10 @@ multi_bundle_persistence:
         emits slash-relative NFC bundle paths in deterministic order, writes text inputs to content_yaml, and writes raw
         inputs under every discovered flow data directory to data_blob, including root flows/<flow>/data/...,
         package flows such as packages/<package>/flows/<flow>/data/..., and nested flow packages such as
-        flows/<parent>/flows/<child>/data/.... Empty raw-data files are represented as empty base64 strings. Archive
-        packaging remains split until archive format and extraction safety rules are promoted.
+        flows/<parent>/flows/<child>/data/.... Empty raw-data files are represented as empty base64 strings. The
+        `--contracts` value is an explicit operator input: it MUST name the selected contracts directory itself and
+        MUST NOT fall back to a parent bundle when the supplied path is a typo/non-root child. Archive packaging
+        remains split until archive format and extraction safety rules are promoted.
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev
@@ -8598,6 +8600,12 @@ cli_specification:
           If no source yields a contracts root and repo discovery does not find `contracts/package.yaml`, the
           command fails closed during local contract resolution with the promoted missing-contracts-source error.
           There is no implicit contracts root default without a discovered package file.
+        explicit_source_validation_rule: >
+          Values from `--contracts`, `SWARM_CONTRACTS_PATH`, and config `contracts_path` are explicit operator
+          inputs. After normal relative-path resolution, the resolver MUST validate the named value itself as either
+          a directory containing `package.yaml` or that directory's `package.yaml` file shorthand. It MUST NOT walk
+          upward or fall back to a parent directory to satisfy a typo/non-root child path. Repo-local
+          `contracts/package.yaml` discovery remains the only discovered default.
       platform_spec_path:
         accepted_sources:
           flag: --platform-spec <path>


### PR DESCRIPTION
## Summary

Part of #1257.

This PR closes only the F-002 first slice: `operator_cli.explicit_contracts_path_resolution_fail_closed`. It does not close the full #1257 five-row operator UX tracker and does not implement F-008, F-015, F-024, or F-025.

## Governing refs / context

- Approved gate: #1257 `Gate F failure-class verification for #1257`.
- Pre-audit: #1257 `Pre-Implementation Coverage Audit`.
- Exact spec owner: `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`.
- Adjacent bundle-register owner updated: `platform-spec.yaml#multi_bundle_persistence.cli_surface.bundle_register_directory_packager`.

## Semantic migration

- New canonical owner: explicit local contract path validation under `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`, implemented by `normalizeContractsRoot` and the shared CLI path resolver consumers.
- Old producer / reader / writer path now invalid: explicit `--contracts`, `SWARM_CONTRACTS_PATH`, or config `contracts_path` values that name a typo/non-root child under a valid bundle can no longer fall back to the parent bundle.
- Supported compatibility retained: an explicit path to the bundle directory itself remains valid, and an explicit path to that directory's `package.yaml` file remains valid shorthand.
- Production paths checked for surviving old behavior: `swarm verify`, `swarm serve`, local `swarm run` through serve startup, `swarm bundle register --contracts`, builder project loading, and selected-contract fork helper call sites. No hidden promoted CLI explicit-contract interpreter was found outside the shared owner. `SWARM_CONTRACTS_DIR` remains excluded from CLI resolution by existing spec/tests.
- Migration completeness: complete for the F-002 approved class. Parent #1257 remains open for sibling rows.

## Verification

- `go test ./cmd/swarm -run 'TestNormalizeContractsRootExplicitPathValidation|TestRunVerifyCommand_BadContractsPath|TestRunVerifyCommandConsumesContractPathResolver|TestRunServeRuntimeConsumesContractPathResolverBeforeBundleLoad|TestBundleCommandsRejectInvalidInputBeforeRequest' -count=1`
- Manual supported-surface proof:
  - `go run ./cmd/swarm verify --contracts tests/tier8-boot-verification/test-boot-success/zzz-not-a-real-dir` fails closed.
  - `SWARM_CONTRACTS_PATH=tests/tier8-boot-verification/test-boot-success/zzz-not-a-real-dir go run ./cmd/swarm verify` fails closed.
  - `SWARM_CONFIG=<config with contracts_path typo child> go run ./cmd/swarm verify` fails closed.
  - `go run ./cmd/swarm verify --contracts tests/tier8-boot-verification/test-boot-success/package.yaml` still succeeds as package-file shorthand.
- `go test ./cmd/swarm -run 'TestRunServeRuntimeDBLoadedUsesEmbeddedSpecBeforeCatalogRead|TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity|TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle|TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`

Note: an initial `go test ./...` run hit unrelated `cmd/swarm` serve readiness/listener timing failures; the exact failed serve tests passed in isolation, `go test ./cmd/swarm -count=1` passed, and a second `go test ./...` passed.