### PR TITLE
[agent-h][issue #1260] Bind analyzer lint evidence authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6467,6 +6467,91 @@ reader:
 	}
 }
 
+func TestRunVerifyCommand_FirstFlowEquivalentSuppressesTutorialLintEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: ticket-flow
+version: "1.0.0"
+platform: ">=1.6.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: ticket-flow
+initial_state: open
+terminal_states: [resolved]
+states: [open, assigned, resolved]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+ticket:
+  category:
+    type: text
+    initial: ""
+  priority:
+    type: text
+    initial: ""
+  resolution:
+    type: text
+    initial: ""
+    _unused_reader_reason: External operator readout from the persisted ticket record
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+ticket.classified:
+  swarm:
+    source: external (first-flow verify proof)
+  category: text
+  priority: text
+ticket.assigned:
+  category: text
+  priority: text
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+classifier:
+  id: classifier
+  execution_type: system_node
+  subscribes_to: [ticket.classified]
+  produces: [ticket.assigned]
+  event_handlers:
+    ticket.classified:
+      guard:
+        check: "entity.category != '' && entity.priority != ''"
+      emit:
+        event: ticket.assigned
+        broadcast: true
+        fields:
+          category: entity.category
+          priority: entity.priority
+      advances_to: assigned
+assignee:
+  id: assignee
+  execution_type: system_node
+  subscribes_to: [ticket.assigned]
+  event_handlers:
+    ticket.assigned:
+      guard:
+        check: "entity.category != ''"
+      advances_to: resolved
+`)
+
+	var buf bytes.Buffer
+	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
+	}
+	out := buf.String()
+	if strings.Contains(out, "lint_evidence: cross_surface_named_type_use") {
+		t.Fatalf("verify output should not contain tutorial cross-surface lint evidence:\n%s", out)
+	}
+	if strings.Contains(out, "lint_evidence: entity_reader_coverage") {
+		t.Fatalf("verify output should not contain tutorial reader coverage lint evidence:\n%s", out)
+	}
+	if !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify output missing success marker:\n%s", out)
+	}
+}
+
 func TestRunVerifyCommand_FailsForUndefinedSelectedBackendModelAlias(t *testing.T) {
 	root := t.TempDir()
 	writeVerifyModelAliasFixture(t, root, "not_configured")

--- a/internal/runtime/bootverify/workflow_cross_surface_named_type_checks.go
+++ b/internal/runtime/bootverify/workflow_cross_surface_named_type_checks.go
@@ -10,7 +10,15 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
-const crossSurfaceNamedTypeUseCheckID = "cross_surface_named_type_use"
+const (
+	crossSurfaceNamedTypeUseCheckID = "cross_surface_named_type_use"
+
+	crossSurfaceExactDuplicateMinFields     = 3
+	crossSurfaceExactDuplicateMinCandidates = 3
+	crossSurfaceNearDuplicateMinPairs       = 4
+	crossSurfaceNearDuplicateMaxSizeDelta   = 2
+	crossSurfaceNearDuplicateMinPercent     = 75
+)
 
 type crossSurfaceShapeCandidate struct {
 	Label     string
@@ -42,7 +50,7 @@ func crossSurfaceNamedTypeUseFindings(source semanticview.Source) []Finding {
 
 	findings := make([]Finding, 0)
 	for _, group := range groups {
-		if len(group.Candidates) < 2 {
+		if !crossSurfaceExactDuplicateMeetsThreshold(group) {
 			continue
 		}
 		findings = append(findings, Finding{
@@ -68,6 +76,13 @@ func crossSurfaceNamedTypeUseFindings(source semanticview.Source) []Finding {
 		return findings[i].Location < findings[j].Location
 	})
 	return findings
+}
+
+func crossSurfaceExactDuplicateMeetsThreshold(group crossSurfaceShapeGroup) bool {
+	if len(group.Candidates) < 2 {
+		return false
+	}
+	return len(group.Pairs) >= crossSurfaceExactDuplicateMinFields || len(group.Candidates) >= crossSurfaceExactDuplicateMinCandidates
 }
 
 func collectCrossSurfaceShapeCandidates(source semanticview.Source) []crossSurfaceShapeCandidate {
@@ -341,7 +356,7 @@ func nearDuplicateCrossSurfaceShapeFindings(groups []crossSurfaceShapeGroup) []F
 }
 
 func conservativeNearDuplicateShape(left, right crossSurfaceShapeGroup) (int, int, []string, bool) {
-	if left.Signature == right.Signature || len(left.Pairs) < 4 || len(right.Pairs) < 4 {
+	if left.Signature == right.Signature || len(left.Pairs) < crossSurfaceNearDuplicateMinPairs || len(right.Pairs) < crossSurfaceNearDuplicateMinPairs {
 		return 0, 0, nil, false
 	}
 	leftPairs := map[string]struct{}{}
@@ -356,7 +371,9 @@ func conservativeNearDuplicateShape(left, right crossSurfaceShapeGroup) (int, in
 	}
 	common := len(commonPairs)
 	total := maxInt(len(left.Pairs), len(right.Pairs))
-	if common < 4 || total-common > 2 || common*100 < total*75 {
+	if common < crossSurfaceNearDuplicateMinPairs ||
+		total-common > crossSurfaceNearDuplicateMaxSizeDelta ||
+		common*100 < total*crossSurfaceNearDuplicateMinPercent {
 		return 0, 0, nil, false
 	}
 	sort.Strings(commonPairs)

--- a/internal/runtime/bootverify/workflow_cross_surface_named_type_checks_test.go
+++ b/internal/runtime/bootverify/workflow_cross_surface_named_type_checks_test.go
@@ -34,6 +34,66 @@ func TestRun_ReportsCrossSurfaceExactDuplicateShapesAsLintEvidence(t *testing.T)
 	}
 }
 
+func TestRun_DoesNotReportLowSignalTwoByTwoExactDuplicateShape(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"ticket.classified": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "text"},
+						"priority": {Type: "text"},
+					},
+				},
+			},
+			"ticket.assigned": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category": {Type: "text"},
+						"priority": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.LintEvidence(), crossSurfaceNamedTypeUseCheckID, "identical shape {category:text, priority:text}") {
+		t.Fatalf("expected low-signal 2x2 exact duplicate shape to be ignored, got %#v", report.LintEvidence())
+	}
+}
+
+func TestRun_ReportsTwoCandidateThreeFieldExactDuplicateShape(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"ticket.classified": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category":   {Type: "text"},
+						"priority":   {Type: "text"},
+						"confidence": {Type: "numeric"},
+					},
+				},
+			},
+			"ticket.assigned": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"category":   {Type: "text"},
+						"priority":   {Type: "text"},
+						"confidence": {Type: "numeric"},
+					},
+				},
+			},
+		},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.LintEvidence(), crossSurfaceNamedTypeUseCheckID, "identical shape {category:text, confidence:numeric, priority:text}") {
+		t.Fatalf("expected 2-candidate 3-field exact duplicate lint evidence, got %#v", report.LintEvidence())
+	}
+}
+
 func TestRun_ReportsConservativeNearDuplicateShapeAsLintEvidence(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -176,9 +176,12 @@ func (c *checkerContext) entityReaderCoverage() []Finding {
 
 	readers := wave1EntityReaderCoverageByFlow(c.source)
 	for _, contract := range wave1DeclaredEntityContracts(c.source) {
-		for fieldName := range contract.Contract.Fields {
+		for fieldName, fieldDecl := range contract.Contract.Fields {
 			fieldName = strings.TrimSpace(fieldName)
 			if fieldName == "" || wave1EntityEnvelopeField(fieldName) {
+				continue
+			}
+			if strings.TrimSpace(fieldDecl.UnusedReaderReason) != "" {
 				continue
 			}
 			if _, ok := readers[contract.FlowID][fieldName]; ok {

--- a/internal/runtime/bootverify/workflow_entity_reader_coverage_checks_test.go
+++ b/internal/runtime/bootverify/workflow_entity_reader_coverage_checks_test.go
@@ -1,0 +1,67 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_SuppressesEntityReaderCoverageWithUnusedReaderReason(t *testing.T) {
+	bundle := entityReaderCoverageBundle(runtimecontracts.EntityFieldDecl{
+		Type:               "text",
+		Initial:            "",
+		UnusedReaderReason: "external operator readout",
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.LintEvidence(), "entity_reader_coverage", "resolution") {
+		t.Fatalf("expected _unused_reader_reason to suppress reader coverage lint, got %#v", report.LintEvidence())
+	}
+	if reportContains(report.HardInvalidities(), "entity_writer_coverage", "resolution") {
+		t.Fatalf("_unused_reader_reason must not affect writer-covered fields, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_ReportsEntityReaderCoverageWithoutUnusedReaderReason(t *testing.T) {
+	bundle := entityReaderCoverageBundle(runtimecontracts.EntityFieldDecl{
+		Type:    "text",
+		Initial: "",
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.LintEvidence(), "entity_reader_coverage", "flow root entity_type ticket declares field resolution with no detected internal reader coverage") {
+		t.Fatalf("expected reader coverage lint without _unused_reader_reason, got %#v", report.LintEvidence())
+	}
+}
+
+func TestRun_UnusedReaderReasonDoesNotSatisfyEntityWriterCoverage(t *testing.T) {
+	bundle := entityReaderCoverageBundle(runtimecontracts.EntityFieldDecl{
+		Type:               "text",
+		UnusedReaderReason: "external operator readout",
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.HardInvalidities(), "entity_writer_coverage", "without authored writer coverage") {
+		t.Fatalf("_unused_reader_reason must not satisfy writer coverage, got %#v", report.HardInvalidities())
+	}
+	if reportContains(report.LintEvidence(), "entity_reader_coverage", "resolution") {
+		t.Fatalf("expected _unused_reader_reason to suppress reader coverage independently, got %#v", report.LintEvidence())
+	}
+}
+
+func entityReaderCoverageBundle(field runtimecontracts.EntityFieldDecl) *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"ticket": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"resolution": field,
+				},
+			},
+		},
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -618,13 +618,14 @@ type EntityContract struct {
 }
 
 type EntityFieldDecl struct {
-	Type            string         `yaml:"type"`
-	Initial         any            `yaml:"initial"`
-	Immutable       bool           `yaml:"immutable"`
-	Description     string         `yaml:"description"`
-	MaterializeFrom string         `yaml:"materialize_from"`
-	Project         map[string]any `yaml:"project"`
-	UnusedReason    string         `yaml:"_unused_reason"`
+	Type               string         `yaml:"type"`
+	Initial            any            `yaml:"initial"`
+	Immutable          bool           `yaml:"immutable"`
+	Description        string         `yaml:"description"`
+	MaterializeFrom    string         `yaml:"materialize_from"`
+	Project            map[string]any `yaml:"project"`
+	UnusedReason       string         `yaml:"_unused_reason"`
+	UnusedReaderReason string         `yaml:"_unused_reader_reason"`
 }
 type ProjectPackageRef struct {
 	ID      string `yaml:"id"`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1001,6 +1001,30 @@ project:
 	}
 }
 
+func TestEntityFieldDeclDecode_PreservesUnusedReaderReason(t *testing.T) {
+	var field EntityFieldDecl
+	if err := yaml.Unmarshal([]byte(`
+type: text
+_unused_reader_reason: External operator readout
+`), &field); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := field.UnusedReaderReason; got != "External operator readout" {
+		t.Fatalf("UnusedReaderReason = %q", got)
+	}
+}
+
+func TestEntityFieldDeclDecode_RejectsShortUnusedReaderReason(t *testing.T) {
+	var field EntityFieldDecl
+	err := yaml.Unmarshal([]byte(`
+type: text
+_unused_reader_reason: short
+`), &field)
+	if err == nil || !strings.Contains(err.Error(), "_unused_reader_reason must be at least 10 characters") {
+		t.Fatalf("yaml.Unmarshal error = %v, want _unused_reader_reason length error", err)
+	}
+}
+
 func TestAccumulateSpecDecode_PreservesDescriptionAndRejectsUnknownField(t *testing.T) {
 	var spec AccumulateSpec
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -273,12 +273,13 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	}
 	parsed, err := decodeWave1FieldNode(node, wave1FieldNodeOptions{
-		Context:              "entity field",
-		AllowInitial:         true,
-		AllowImmutable:       true,
-		AllowUnusedReason:    true,
-		AllowMaterializeFrom: true,
-		AllowProject:         true,
+		Context:                 "entity field",
+		AllowInitial:            true,
+		AllowImmutable:          true,
+		AllowUnusedReason:       true,
+		AllowUnusedReaderReason: true,
+		AllowMaterializeFrom:    true,
+		AllowProject:            true,
 	})
 	if err != nil {
 		return err
@@ -290,6 +291,7 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 	f.MaterializeFrom = parsed.MaterializeFrom
 	f.Project = parsed.Project
 	f.UnusedReason = parsed.UnusedReason
+	f.UnusedReaderReason = parsed.UnusedReaderReason
 	return nil
 }
 
@@ -338,6 +340,9 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 	if opts.AllowUnusedReason {
 		allowed["_unused_reason"] = struct{}{}
 	}
+	if opts.AllowUnusedReaderReason {
+		allowed["_unused_reader_reason"] = struct{}{}
+	}
 	if opts.AllowMaterializeFrom {
 		allowed["materialize_from"] = struct{}{}
 	}
@@ -364,7 +369,7 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				}
 				listOf = listValue
 				continue
-			case "initial", "immutable", "_unused_reason", "materialize_from", "project":
+			case "initial", "immutable", "_unused_reason", "_unused_reader_reason", "materialize_from", "project":
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
 			default:
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
@@ -401,6 +406,12 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				return wave1ParsedFieldNode{}, err
 			}
 			field.UnusedReason = text
+		case "_unused_reader_reason":
+			text, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.UnusedReaderReason = text
 		case "materialize_from":
 			text, err := decodeScalarStringNode(value)
 			if err != nil {
@@ -429,6 +440,9 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 	}
 	if opts.AllowUnusedReason && strings.TrimSpace(field.UnusedReason) != "" && len(strings.TrimSpace(field.UnusedReason)) < 10 {
 		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reason must be at least 10 characters", opts.Context)
+	}
+	if opts.AllowUnusedReaderReason && strings.TrimSpace(field.UnusedReaderReason) != "" && len(strings.TrimSpace(field.UnusedReaderReason)) < 10 {
+		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reader_reason must be at least 10 characters", opts.Context)
 	}
 	return field, nil
 }
@@ -525,20 +539,22 @@ func buildFlatEventPayloadSpec(node *yaml.Node) (EventPayloadSpec, error) {
 }
 
 type wave1FieldNodeOptions struct {
-	Context              string
-	AllowInitial         bool
-	AllowImmutable       bool
-	AllowUnusedReason    bool
-	AllowMaterializeFrom bool
-	AllowProject         bool
+	Context                 string
+	AllowInitial            bool
+	AllowImmutable          bool
+	AllowUnusedReason       bool
+	AllowUnusedReaderReason bool
+	AllowMaterializeFrom    bool
+	AllowProject            bool
 }
 
 type wave1ParsedFieldNode struct {
-	Type            string
-	Initial         any
-	Immutable       bool
-	Description     string
-	MaterializeFrom string
-	Project         map[string]any
-	UnusedReason    string
+	Type               string
+	Initial            any
+	Immutable          bool
+	Description        string
+	MaterializeFrom    string
+	Project            map[string]any
+	UnusedReason       string
+	UnusedReaderReason string
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -480,6 +480,7 @@ type_system:
         immutable: true           # entities only
         description: Human-readable annotation
         _unused_reason: Reason    # entities only; verify suppression for E1
+        _unused_reader_reason: Reason # entities only; reader lint suppression for external/operator readout
   restrictions:
     retired:
     - jsonb as an author-declared contract type
@@ -540,12 +541,16 @@ entity_contracts:
             <target_policy_field>: policy.<policy_path>
             <target_literal_field>: <literal>
           _unused_reason: <reason>
+          _unused_reader_reason: <reason>
     notes:
     - Entity-level metadata is underscore-prefixed.
     - State does not live in entity contracts.
     - Envelope names are reserved and must not be author-declared.
     - '`materialize_from` is valid only for a list of a declared named type.'
     - '`materialize_from` and `_unused_reason` are mutually exclusive.'
+    - '`_unused_reader_reason` documents that a field is intentionally read only outside platform-visible internal handlers.
+      It suppresses only the informational `entity_reader_coverage` slice; it does not count as writer coverage, authorize
+      runtime/API reads, or change persistence semantics.'
     - 'A `materialize_from` field is runtime-owned and not agent-writable.'
   accumulator_entity_projection:
     description: |
@@ -7559,7 +7564,45 @@ static_analyzer:
       excludes:
       - external/operator readers outside platform visibility
       - hard gating or warning-level surfacing
+    accepted_suppression:
+      unused_reader_reason:
+        field_metadata: _unused_reader_reason
+        rule: Explicit `_unused_reader_reason:` with a trimmed reason of at least 10 characters declares intentional
+          external/operator readout and suppresses this lint-evidence slice only.
     rule: Emit lint evidence when a declared entity field has no detected internal reader on the supported verify surface.
+  slice_9a_cross_surface_named_type_use:
+    id: cross_surface_named_type_use
+    domain: semantic_validity
+    authority: lint_evidence
+    severity: informational
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - type_system.field_forms
+    - spec_authority.review_artifact_boundary
+    - design_principles
+    scope:
+      description: Informational audit over repeated authored object shapes that may represent an unextracted named type.
+      applies_to:
+      - root and flow type catalog named-type field shapes
+      - root and flow entity contract field shapes, excluding platform envelope fields
+      - resolved event payload field shapes
+      - root, project, and flow policy object shapes
+      excludes:
+      - scalar-only values and object shapes with fewer than two normalized field/type pairs
+      - runtime-delivered payload instances or persisted runtime state
+      - hard gating or warning-level surfacing
+      - exact duplicate shapes with exactly two candidates and exactly two normalized field/type pairs
+    exact_duplicate_threshold:
+      rule: Emit exact duplicate lint evidence only when the normalized shape appears in at least two authored candidates
+        and either `field_count >= 3` or `candidate_count >= 3`.
+    near_duplicate_threshold:
+      rule: Emit near-duplicate lint evidence only when compared shapes are not exact duplicates, both shapes have at least
+        four field/type pairs, they share at least four field/type pairs, the larger shape has at most two additional pairs,
+        and common pair coverage is at least 75% of the larger shape.
+    rule: Emit lint evidence when authored object shapes satisfy the exact duplicate or near-duplicate thresholds; the finding
+      must remain advisory and must not require authors to extract a named type unless the shared shape is genuinely the same
+      concept.
   slice_10_agent_prompt_lint_structural:
     id: agent_prompt_lint_structural
     domain: semantic_validity


### PR DESCRIPTION
## Summary

Part of #1260.

This PR closes the code/spec/test portion of the approved #1260 implementation boundary:

- Promotes `cross_surface_named_type_use` into `platform-spec.yaml` with the approved exact duplicate threshold: `field_count >= 3 OR candidate_count >= 3`.
- Adds `_unused_reader_reason` as entity-field metadata for external/operator readout and documents it in `platform-spec.yaml`.
- Updates bootverify and contract parsing to consume the platform-owned behavior.
- Adds focused and supported `swarm verify` proof for the first-flow-equivalent tutorial-noise shape.

This PR does not claim full #1260 closure because the public docs source for `/build/first-flow`, `/reference/analyzer-checks`, and `/reference/contracts/entities` is not present in `division-sh/swarm`. The docs artifact remains a coordinated follow-up/split condition from the lead gate.

## Governing refs / context

- `platform-spec.yaml` `spec_authority.review_artifact_boundary`
- `platform-spec.yaml` `validation.severity_behavior.lint_evidence`
- `platform-spec.yaml` `static_analyzer.authority_levels`
- `platform-spec.yaml` `static_analyzer.slice_9_entity_reader_coverage`
- New `platform-spec.yaml` `static_analyzer.slice_9a_cross_surface_named_type_use`
- #1260 pre-audit and lead gate comments

## Semantic migration

- New canonical owner: `platform-spec.yaml` `static_analyzer` for both the cross-surface lint threshold and entity reader external-readout suppression.
- Old non-authoritative path now invalid: implementation-only `cross_surface_named_type_use` exact duplicate threshold based solely on `len(group.Candidates) >= 2`.
- Old reader path now invalid: `entity_reader_coverage` treating every no-internal-reader field as lint evidence despite the spec excluding external/operator readers.
- Checked production paths: `checks.go` lint registration, bootverify cross-surface analyzer, bootverify entity reader coverage, entity field parser/model, `cmd/swarm verify` text output path.
- Migration completeness: complete for Swarm code/spec/tests on the supported `swarm verify` surface; incomplete for live docs-source artifacts because they are outside this repo.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./cmd/swarm -run 'TestEntityFieldDeclDecode_(PreservesUnusedReaderReason|RejectsShortUnusedReaderReason)|TestRun_(ReportsCrossSurfaceExactDuplicateShapesAsLintEvidence|DoesNotReportLowSignalTwoByTwoExactDuplicateShape|ReportsTwoCandidateThreeFieldExactDuplicateShape|ReportsConservativeNearDuplicateShapeAsLintEvidence|DoesNotReportLowConfidenceSmallNearDuplicateShape|SuppressesEntityReaderCoverageWithUnusedReaderReason|ReportsEntityReaderCoverageWithoutUnusedReaderReason|UnusedReaderReasonDoesNotSatisfyEntityWriterCoverage)|TestRunVerifyCommand_(SurfacesLintEvidence|FirstFlowEquivalentSuppressesTutorialLintEvidence)' -count=1`
- `go test ./...`
