### PR TITLE
[agent-g][issue #1250] Promote rule-level actions

### DIFF
--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -88,6 +88,60 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 	}
 }
 
+func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB)
+	}{
+		{
+			name: "sqlite_default_no_selector",
+			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+				t.Helper()
+				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+				handler := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
+				return handler, sqliteStore.DB
+			},
+		},
+		{
+			name: "postgres_explicit_opt_in",
+			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+				t.Helper()
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				pg := &store.PostgresStore{DB: db}
+				handler := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
+				return handler, db
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := conditionalRuleMailboxWriteSupportedSurfaceBundle(t)
+			source := semanticview.Wrap(bundle)
+			fact := bundleSourceFactForTestBundle(t, bundle)
+			handler, db := tc.setup(t, ctx, source, fact)
+
+			auto := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":50,"who":"alice"}`, "", "idem-rule-mailbox-write-auto-"+tc.name))
+			if auto.Error != nil {
+				t.Fatalf("auto event.publish error = %#v", auto.Error)
+			}
+			autoRunID := stringValue(t, asMap(t, auto.Result)["run_id"], "run_id")
+			waitForConditionalRuleEntityState(t, db, autoRunID, tc.name, "approved", 50)
+			assertMailboxListCount(t, handler, autoRunID, 0)
+
+			human := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"bob"}`, "", "idem-rule-mailbox-write-human-"+tc.name))
+			if human.Error != nil {
+				t.Fatalf("human event.publish error = %#v", human.Error)
+			}
+			humanResult := asMap(t, human.Result)
+			humanEventID := stringValue(t, humanResult["event_id"], "event_id")
+			humanRunID := stringValue(t, humanResult["run_id"], "run_id")
+			waitForConditionalRuleEntityState(t, db, humanRunID, tc.name, "awaiting_human", 250)
+			waitForConditionalRuleMailboxWrite(t, handler, humanRunID, humanEventID)
+		})
+	}
+}
+
 func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testing.T) {
 	ctx := context.Background()
 	bundle := mailboxWriteSupportedSurfaceBundle(t)
@@ -221,6 +275,64 @@ func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql
 	t.Fatalf("mailbox_write supported surface did not converge for %s: %v", backend, lastErr)
 }
 
+func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, runID, eventID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"rule-mailbox-list","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
+		if listed.Error != nil {
+			t.Fatalf("mailbox.list error = %#v", listed.Error)
+		}
+		items := asSlice(t, asMap(t, listed.Result)["items"])
+		if len(items) == 1 {
+			item := asMap(t, items[0])
+			if err := assertConditionalRuleMailboxItem(t, handler, item, runID, eventID); err != nil {
+				lastErr = err
+				time.Sleep(25 * time.Millisecond)
+				continue
+			}
+			return
+		}
+		lastErr = fmt.Errorf("mailbox.list returned %d items", len(items))
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("rule mailbox_write supported surface did not converge: %v", lastErr)
+}
+
+func assertConditionalRuleMailboxItem(t *testing.T, handler *Handler, item map[string]any, runID, eventID string) error {
+	t.Helper()
+	mailboxID := stringValue(t, item["mailbox_id"], "mailbox_id")
+	if item["type"] != "approval" || item["status"] != "pending" || item["priority"] != "normal" || item["source_event_id"] != eventID || item["source_entity_id"] != runID {
+		return fmt.Errorf("mailbox.list item = %#v, want approval pending normal for source event/entity", item)
+	}
+	payload := asMap(t, item["payload"])
+	if payload["who"] != "bob" || payload["amount"] != float64(250) || payload["review_kind"] != "conditional" {
+		return fmt.Errorf("mailbox.list payload = %#v, want selected rule payload", payload)
+	}
+	detail := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"rule-mailbox-get","method":"mailbox.get","params":{"mailbox_id":%q}}`, mailboxID))
+	if detail.Error != nil {
+		return fmt.Errorf("mailbox.get error = %#v", detail.Error)
+	}
+	detailPayload := asMap(t, asMap(t, detail.Result)["payload"])
+	if detailPayload["who"] != "bob" || detailPayload["amount"] != float64(250) || detailPayload["review_kind"] != "conditional" {
+		return fmt.Errorf("mailbox.get payload = %#v, want selected rule payload", detailPayload)
+	}
+	return nil
+}
+
+func assertMailboxListCount(t *testing.T, handler *Handler, runID string, want int) {
+	t.Helper()
+	listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"mailbox-list-count","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
+	if listed.Error != nil {
+		t.Fatalf("mailbox.list error = %#v", listed.Error)
+	}
+	items := asSlice(t, asMap(t, listed.Result)["items"])
+	if len(items) != want {
+		t.Fatalf("mailbox.list returned %d items for run %s, want %d: %#v", len(items), runID, want, items)
+	}
+}
+
 func assertMailboxWriteSupportedSurfaceItem(t *testing.T, handler *Handler, item map[string]any, runID, eventID string) error {
 	t.Helper()
 	mailboxID := stringValue(t, item["mailbox_id"], "mailbox_id")
@@ -244,33 +356,60 @@ func assertMailboxWriteSupportedSurfaceItem(t *testing.T, handler *Handler, item
 
 func assertMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string) {
 	t.Helper()
+	state, fields, err := loadMailboxWriteEntityState(t, db, runID, backend)
+	if err != nil {
+		t.Fatalf("load %s entity_state: %v", backend, err)
+	}
+	if state != "done" {
+		t.Fatalf("%s entity state = %q, want done", backend, state)
+	}
+	if fields["who"] != "alice" || fields["amount"] != float64(250) {
+		t.Fatalf("%s entity fields = %#v, want accumulated payload", backend, fields)
+	}
+}
+
+func waitForConditionalRuleEntityState(t *testing.T, db *sql.DB, runID, backend, wantState string, wantAmount int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		state, fields, err := loadMailboxWriteEntityState(t, db, runID, backend)
+		if err == nil {
+			if state == wantState && fields["amount"] == float64(wantAmount) {
+				return
+			}
+			lastErr = fmt.Errorf("state=%q fields=%#v", state, fields)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s entity state did not converge to %s: %v", backend, wantState, lastErr)
+}
+
+func loadMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string) (string, map[string]any, error) {
+	t.Helper()
 	var state string
 	var fieldsRaw []byte
 	switch backend {
 	case "sqlite_default_no_selector":
 		if err := db.QueryRow(`
-			SELECT current_state, fields
-			FROM entity_state
-			WHERE run_id = ?
-		`, runID).Scan(&state, &fieldsRaw); err != nil {
-			t.Fatalf("load sqlite entity_state: %v", err)
+				SELECT current_state, fields
+				FROM entity_state
+				WHERE run_id = ?
+			`, runID).Scan(&state, &fieldsRaw); err != nil {
+			return "", nil, err
 		}
 	default:
 		if err := db.QueryRow(`
-			SELECT current_state, fields
-			FROM entity_state
-			WHERE run_id = $1::uuid
-		`, runID).Scan(&state, &fieldsRaw); err != nil {
-			t.Fatalf("load postgres entity_state: %v", err)
+				SELECT current_state, fields
+				FROM entity_state
+				WHERE run_id = $1::uuid
+			`, runID).Scan(&state, &fieldsRaw); err != nil {
+			return "", nil, err
 		}
 	}
-	if state != "done" {
-		t.Fatalf("%s entity state = %q, want done", backend, state)
-	}
-	fields := decodeJSONMap(t, json.RawMessage(fieldsRaw))
-	if fields["who"] != "alice" || fields["amount"] != float64(250) {
-		t.Fatalf("%s entity fields = %#v, want accumulated payload", backend, fields)
-	}
+	return state, decodeJSONMap(t, json.RawMessage(fieldsRaw)), nil
 }
 
 func waitForSQLitePipelineReceipt(t *testing.T, db *sql.DB) (string, string, string) {
@@ -373,6 +512,99 @@ func mailboxWriteSupportedSurfaceBundle(t *testing.T) *runtimecontracts.Workflow
 			InitialState:   "new",
 			TerminalStates: []string{"done"},
 			States:         []string{"new", "done"},
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"thing.created"}},
+			},
+		},
+	}
+}
+
+func conditionalRuleMailboxWriteSupportedSurfaceBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		CreateEntity: true,
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "amount", Value: runtimecontracts.RefExpression("payload.amount")},
+				{TargetField: "who", Value: runtimecontracts.RefExpression("payload.who")},
+			},
+		},
+		Rules: []runtimecontracts.HandlerRuleEntry{
+			{
+				ID:         "auto_approve",
+				Condition:  "payload.amount < 100",
+				AdvancesTo: "approved",
+			},
+			{
+				ID:         "needs_human",
+				Condition:  "payload.amount >= 100",
+				AdvancesTo: "awaiting_human",
+				Action: runtimecontracts.ActionSpec{
+					ID: "mailbox_write",
+					Mailbox: &runtimecontracts.MailboxWriteSpec{
+						ItemType: runtimecontracts.LiteralExpression("approval"),
+						Summary:  runtimecontracts.LiteralExpression("Review refund"),
+						EntityID: runtimecontracts.RefExpression("event.entity_id"),
+						Payload: map[string]runtimecontracts.ExpressionValue{
+							"review_kind": runtimecontracts.LiteralExpression("conditional"),
+							"who":         runtimecontracts.RefExpression("payload.who"),
+							"amount":      runtimecontracts.RefExpression("payload.amount"),
+						},
+					},
+				},
+			},
+		},
+	}
+	return &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "rule-mailbox-write-supported-surface",
+			Version:      "1.0.0",
+			InitialStage: "new",
+			Stages: []runtimecontracts.WorkflowStageContract{
+				{ID: "new"},
+				{ID: "approved"},
+				{ID: "awaiting_human"},
+			},
+			TerminalStages: []string{"approved", "awaiting_human"},
+			Transitions: []runtimecontracts.WorkflowTransitionContract{
+				{
+					ID:      "auto-approve",
+					From:    []string{"new"},
+					To:      "approved",
+					Trigger: "thing.created",
+					Node:    "reviewer",
+				},
+				{
+					ID:      "needs-human",
+					From:    []string{"new"},
+					To:      "awaiting_human",
+					Trigger: "thing.created",
+					Node:    "reviewer",
+					Actions: []string{"mailbox_write"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"reviewer": {"thing.created": handler},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"thing.created": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"reviewer": {
+				ID:            "reviewer",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"thing.created"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"thing.created": handler,
+				},
+			},
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Name:           "rule-mailbox-write-supported-surface",
+			InitialState:   "new",
+			TerminalStates: []string{"approved", "awaiting_human"},
+			States:         []string{"new", "approved", "awaiting_human"},
 			Pins: runtimecontracts.FlowPins{
 				Inputs: runtimecontracts.FlowInputPins{Events: []string{"thing.created"}},
 			},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -858,6 +858,29 @@ func TestRun_ReportsMailboxWriteMissingMailboxSpec(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsRuleMailboxWriteMissingMailboxSpec(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID:     "needs-human",
+							Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "handler mailbox.review_requested rule needs-human mailbox_write is missing mailbox") {
+		t.Fatalf("expected rule handler_field_compliance missing mailbox error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsMailboxWriteMissingRequiredFields(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
@@ -881,6 +904,59 @@ func TestRun_ReportsMailboxWriteMissingRequiredFields(t *testing.T) {
 	}
 	if !reportContains(report.Errors(), "handler_field_compliance", "mailbox_write is missing mailbox.summary") {
 		t.Fatalf("expected handler_field_compliance missing mailbox.summary error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsRuleMailboxWriteMissingRequiredFields(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID: "needs-human",
+							Action: runtimecontracts.ActionSpec{
+								ID:      "mailbox_write",
+								Mailbox: &runtimecontracts.MailboxWriteSpec{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "handler mailbox.review_requested rule needs-human mailbox_write is missing mailbox.item_type") {
+		t.Fatalf("expected rule handler_field_compliance missing mailbox.item_type error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "handler_field_compliance", "handler mailbox.review_requested rule needs-human mailbox_write is missing mailbox.summary") {
+		t.Fatalf("expected rule handler_field_compliance missing mailbox.summary error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsHandlerLevelActionWithRules(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"mailbox-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.review_requested": {
+						Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID:        "needs-human",
+							Condition: "else",
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "handler-level action is invalid when rules are present") {
+		t.Fatalf("expected ambiguous handler-level action error, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -960,6 +960,68 @@ func TestRun_ReportsHandlerLevelActionWithRules(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsUnsupportedRuleActionContexts(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler runtimecontracts.SystemNodeEventHandler
+		want    string
+	}{
+		{
+			name: "on_complete",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				OnComplete: []runtimecontracts.HandlerRuleEntry{{
+					ID:     "complete",
+					Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+				}},
+			},
+			want: "handler.on_complete[complete] action is unsupported",
+		},
+		{
+			name: "accumulate on_complete",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					OnComplete: []runtimecontracts.HandlerRuleEntry{{
+						ID:     "complete",
+						Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+					}},
+				},
+			},
+			want: "handler.accumulate.on_complete[complete] action is unsupported",
+		},
+		{
+			name: "accumulate on_timeout",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					OnTimeout: &runtimecontracts.HandlerRuleEntry{
+						ID:     "timeout",
+						Action: runtimecontracts.ActionSpec{ID: "mailbox_write"},
+					},
+				},
+			},
+			want: "handler.accumulate.on_timeout[timeout] action is unsupported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+				Nodes: map[string]runtimecontracts.SystemNodeContract{
+					"mailbox-node": {
+						EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+							"mailbox.review_requested": tc.handler,
+						},
+					},
+				},
+			})
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.Errors(), "handler_field_compliance", tc.want) {
+				t.Fatalf("expected unsupported rule action context error %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_ReportsMailboxDeclarationOnNonMailboxAction(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{

--- a/internal/runtime/bootverify/workflow_handler_contract_checks.go
+++ b/internal/runtime/bootverify/workflow_handler_contract_checks.go
@@ -61,106 +61,80 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 		nodeID = strings.TrimSpace(nodeID)
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
-			if actionID := strings.TrimSpace(handler.Action.ID); actionID != "" {
-				if normalizeWorkflowBuiltinActionID(actionID) == "create_flow_instance" {
-					templateID := strings.TrimSpace(handler.Action.Template)
-					if templateID == "" {
-						c.handlerFindings = append(c.handlerFindings, Finding{
-							CheckID:  "handler_field_compliance",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s handler %s create_flow_instance is missing template", nodeID, eventType),
-							Location: nodeID,
-						})
-					} else if !flowSchemaIsTemplate(c.source, templateID) {
-						c.handlerFindings = append(c.handlerFindings, Finding{
-							CheckID:  "handler_field_compliance",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s handler %s create_flow_instance template %s is not mode: template", nodeID, eventType, templateID),
-							Location: nodeID,
-						})
-					}
-					if strings.TrimSpace(handler.Action.InstanceIDFrom) == "" {
-						c.handlerFindings = append(c.handlerFindings, Finding{
-							CheckID:  "handler_field_compliance",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s handler %s create_flow_instance is missing instance_id_from", nodeID, eventType),
-							Location: nodeID,
-						})
-					}
-					if handler.Action.ConfigFrom == nil || len(handler.Action.ConfigFrom.ConfigEntries()) == 0 {
-						c.handlerFindings = append(c.handlerFindings, Finding{
-							CheckID:  "handler_field_compliance",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s handler %s create_flow_instance is missing config_from", nodeID, eventType),
-							Location: nodeID,
-						})
-					}
+			if runtimecontracts.HandlerHasAmbiguousTopLevelAction(handler) {
+				c.handlerFindings = append(c.handlerFindings, handlerActionFinding(nodeID, eventType, "handler-level action is invalid when rules are present; move action ownership to the active rule"))
+			}
+			c.handlerFindings = append(c.handlerFindings, c.validateWorkflowActionSpec(nodeID, eventType, handler.EvidenceTarget, handler.Action)...)
+			for idx, rule := range handler.Rules {
+				ruleLabel := strings.TrimSpace(rule.ID)
+				if ruleLabel == "" {
+					ruleLabel = fmt.Sprintf("%d", idx)
 				}
-				if normalizeWorkflowBuiltinActionID(actionID) == "record_evidence" && strings.TrimSpace(handler.EvidenceTarget) == "" {
-					c.handlerFindings = append(c.handlerFindings, Finding{
-						CheckID:  "handler_field_compliance",
-						Severity: "error",
-						Message:  fmt.Sprintf("node %s handler %s record_evidence is missing evidence_target", nodeID, eventType),
-						Location: nodeID,
-					})
-				}
-				if normalizeWorkflowBuiltinActionID(actionID) == "mailbox_write" {
-					if handler.Action.Mailbox == nil {
-						c.handlerFindings = append(c.handlerFindings, Finding{
-							CheckID:  "handler_field_compliance",
-							Severity: "error",
-							Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox", nodeID, eventType),
-							Location: nodeID,
-						})
-					} else {
-						if handler.Action.Mailbox.ItemType.IsZero() {
-							c.handlerFindings = append(c.handlerFindings, Finding{
-								CheckID:  "handler_field_compliance",
-								Severity: "error",
-								Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox.item_type", nodeID, eventType),
-								Location: nodeID,
-							})
-						}
-						if handler.Action.Mailbox.Summary.IsZero() {
-							c.handlerFindings = append(c.handlerFindings, Finding{
-								CheckID:  "handler_field_compliance",
-								Severity: "error",
-								Message:  fmt.Sprintf("node %s handler %s mailbox_write is missing mailbox.summary", nodeID, eventType),
-								Location: nodeID,
-							})
-						}
-					}
-				} else if handler.Action.Mailbox != nil {
-					c.handlerFindings = append(c.handlerFindings, Finding{
-						CheckID:  "handler_field_compliance",
-						Severity: "error",
-						Message:  fmt.Sprintf("node %s handler %s mailbox declaration requires action mailbox_write", nodeID, eventType),
-						Location: nodeID,
-					})
-				}
-				if normalizeWorkflowBuiltinActionID(actionID) == "artifact_repo_commit" {
-					c.handlerFindings = append(c.handlerFindings, validateArtifactRepoActionSpec(c.source, nodeFlowID(c.source, nodeID), nodeID, eventType, handler.Action)...)
-				} else if handler.Action.ArtifactRepo != nil {
-					c.handlerFindings = append(c.handlerFindings, Finding{
-						CheckID:  "handler_field_compliance",
-						Severity: "error",
-						Message:  fmt.Sprintf("node %s handler %s artifact_repo declaration requires action artifact_repo_commit", nodeID, eventType),
-						Location: nodeID,
-					})
-				}
-				if !handlerActionExecutable(c.source, actionID) {
-					c.handlerFindings = append(c.handlerFindings, Finding{
-						CheckID:  "handler_field_compliance",
-						Severity: "error",
-						Message:  fmt.Sprintf("node %s handler %s action %s is not executable", nodeID, eventType, actionID),
-						Location: nodeID,
-					})
-				}
+				c.handlerFindings = append(c.handlerFindings, c.validateWorkflowActionSpec(nodeID, fmt.Sprintf("%s rule %s", eventType, ruleLabel), handler.EvidenceTarget, rule.Action)...)
 			}
 		}
 	}
 	c.handlerFindings = append(c.handlerFindings, runtimeHandledEventsMissingExecutors(c.source)...)
 	return c.handlerFindings
+}
+
+func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {
+	actionID := strings.TrimSpace(action.ID)
+	if actionID == "" {
+		return nil
+	}
+	findings := []Finding{}
+	switch normalizeWorkflowBuiltinActionID(actionID) {
+	case "create_flow_instance":
+		templateID := strings.TrimSpace(action.Template)
+		if templateID == "" {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, "create_flow_instance is missing template"))
+		} else if !flowSchemaIsTemplate(c.source, templateID) {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, fmt.Sprintf("create_flow_instance template %s is not mode: template", templateID)))
+		}
+		if strings.TrimSpace(action.InstanceIDFrom) == "" {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, "create_flow_instance is missing instance_id_from"))
+		}
+		if action.ConfigFrom == nil || len(action.ConfigFrom.ConfigEntries()) == 0 {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, "create_flow_instance is missing config_from"))
+		}
+	case "record_evidence":
+		if strings.TrimSpace(evidenceTarget) == "" {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, "record_evidence is missing evidence_target"))
+		}
+	case "mailbox_write":
+		if action.Mailbox == nil {
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, "mailbox_write is missing mailbox"))
+		} else {
+			if action.Mailbox.ItemType.IsZero() {
+				findings = append(findings, handlerActionFinding(nodeID, eventContext, "mailbox_write is missing mailbox.item_type"))
+			}
+			if action.Mailbox.Summary.IsZero() {
+				findings = append(findings, handlerActionFinding(nodeID, eventContext, "mailbox_write is missing mailbox.summary"))
+			}
+		}
+	}
+	if normalizeWorkflowBuiltinActionID(actionID) != "mailbox_write" && action.Mailbox != nil {
+		findings = append(findings, handlerActionFinding(nodeID, eventContext, "mailbox declaration requires action mailbox_write"))
+	}
+	if normalizeWorkflowBuiltinActionID(actionID) == "artifact_repo_commit" {
+		findings = append(findings, validateArtifactRepoActionSpec(c.source, nodeFlowID(c.source, nodeID), nodeID, eventContext, action)...)
+	} else if action.ArtifactRepo != nil {
+		findings = append(findings, handlerActionFinding(nodeID, eventContext, "artifact_repo declaration requires action artifact_repo_commit"))
+	}
+	if !handlerActionExecutable(c.source, actionID) {
+		findings = append(findings, handlerActionFinding(nodeID, eventContext, fmt.Sprintf("action %s is not executable", actionID)))
+	}
+	return findings
+}
+
+func handlerActionFinding(nodeID, eventContext, message string) Finding {
+	return Finding{
+		CheckID:  "handler_field_compliance",
+		Severity: "error",
+		Message:  fmt.Sprintf("node %s handler %s %s", nodeID, eventContext, message),
+		Location: nodeID,
+	}
 }
 
 func supportedWorkflowRuntimeExecutorIDs(source semanticview.Source) map[string]struct{} {

--- a/internal/runtime/bootverify/workflow_handler_contract_checks.go
+++ b/internal/runtime/bootverify/workflow_handler_contract_checks.go
@@ -72,10 +72,41 @@ func (c *checkerContext) handlerFieldCompliance() []Finding {
 				}
 				c.handlerFindings = append(c.handlerFindings, c.validateWorkflowActionSpec(nodeID, fmt.Sprintf("%s rule %s", eventType, ruleLabel), handler.EvidenceTarget, rule.Action)...)
 			}
+			c.handlerFindings = append(c.handlerFindings, rejectUnsupportedRuleActions(nodeID, eventType, handler)...)
 		}
 	}
 	c.handlerFindings = append(c.handlerFindings, runtimeHandledEventsMissingExecutors(c.source)...)
 	return c.handlerFindings
+}
+
+func rejectUnsupportedRuleActions(nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []Finding {
+	rejectRule := func(context string, rule runtimecontracts.HandlerRuleEntry) []Finding {
+		if strings.TrimSpace(rule.Action.ID) == "" {
+			return nil
+		}
+		return []Finding{handlerActionFinding(nodeID, eventType, fmt.Sprintf("%s action is unsupported; action is only allowed in handler.rules[*]", context))}
+	}
+	findings := []Finding{}
+	for idx, rule := range handler.OnComplete {
+		findings = append(findings, rejectRule(handlerRuleContext("handler.on_complete", idx, rule.ID), rule)...)
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			findings = append(findings, rejectRule(handlerRuleContext("handler.accumulate.on_complete", idx, rule.ID), rule)...)
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			findings = append(findings, rejectRule(handlerRuleContext("handler.accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID), *handler.Accumulate.OnTimeout)...)
+		}
+	}
+	return findings
+}
+
+func handlerRuleContext(prefix string, idx int, id string) string {
+	id = strings.TrimSpace(id)
+	if id != "" {
+		return fmt.Sprintf("%s[%s]", prefix, id)
+	}
+	return fmt.Sprintf("%s[%d]", prefix, idx)
 }
 
 func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -68,6 +68,20 @@ func HandlerHasAmbiguousTopLevelEmit(handler SystemNodeEventHandler) bool {
 	return !handler.Emit.Empty() && HandlerHasNestedEmitSites(handler)
 }
 
+func HandlerHasAmbiguousTopLevelAction(handler SystemNodeEventHandler) bool {
+	return strings.TrimSpace(handler.Action.ID) != "" && len(handler.Rules) > 0
+}
+
+func HandlerRuleActionIDs(handler SystemNodeEventHandler) []string {
+	out := make([]string, 0, len(handler.Rules))
+	for _, rule := range handler.Rules {
+		if id := strings.TrimSpace(rule.Action.ID); id != "" {
+			out = append(out, id)
+		}
+	}
+	return uniqueOrderedStrings(out)
+}
+
 func uniqueOrderedStrings(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -227,11 +227,14 @@ func deriveWorkflowActionEntries(bundle *WorkflowContractBundle) []GuardActionEn
 		node := bundle.Nodes[nodeID]
 		for _, eventType := range sortedContractKeys(node.EventHandlers) {
 			handler := node.EventHandlers[eventType]
-			id := strings.TrimSpace(handler.Action.ID)
-			if id == "" {
-				continue
+			if id := strings.TrimSpace(handler.Action.ID); id != "" {
+				seen[id] = GuardActionEntry{ID: id}
 			}
-			seen[id] = GuardActionEntry{ID: id}
+			for _, rule := range handler.Rules {
+				if id := strings.TrimSpace(rule.Action.ID); id != "" {
+					seen[id] = GuardActionEntry{ID: id}
+				}
+			}
 		}
 	}
 	return sortedGuardActionEntries(seen)
@@ -315,9 +318,17 @@ func deriveRuleTransitions(transition HandlerTransitionSemantic) []WorkflowTrans
 			To:      to,
 			Trigger: strings.TrimSpace(transition.EventType),
 			Node:    strings.TrimSpace(transition.NodeID),
+			Actions: actionIDsForRule(rule),
 		})
 	}
 	return out
+}
+
+func actionIDsForRule(rule HandlerRuleEntry) []string {
+	if id := strings.TrimSpace(rule.Action.ID); id != "" {
+		return []string{id}
+	}
+	return nil
 }
 
 func firstTransitionGuardID(guard *GuardSpec) string {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -294,17 +294,18 @@ func deriveAccumulateTimeoutTransition(transition HandlerTransitionSemantic) (Wo
 }
 
 func deriveRuleTransitions(transition HandlerTransitionSemantic) []WorkflowTransitionContract {
-	rules := transition.OnComplete
+	rules := append([]HandlerRuleEntry{}, transition.OnComplete...)
 	if len(rules) == 0 && transition.Accumulate != nil {
-		rules = transition.Accumulate.OnComplete
+		rules = append(rules, transition.Accumulate.OnComplete...)
 	}
-	rules = append(append([]HandlerRuleEntry{}, rules...), transition.Rules...)
-	if len(rules) == 0 {
-		return nil
-	}
+	nonHandlerRuleCount := len(rules)
+	rules = append(rules, transition.Rules...)
 	out := make([]WorkflowTransitionContract, 0, len(rules))
 	for idx, rule := range rules {
 		to := strings.TrimSpace(rule.AdvancesTo)
+		if to == "" && idx >= nonHandlerRuleCount && strings.TrimSpace(rule.Action.ID) != "" {
+			to = strings.TrimSpace(transition.AdvancesTo)
+		}
 		if to == "" {
 			continue
 		}

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -1,0 +1,53 @@
+package contracts
+
+import "testing"
+
+func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Nodes: map[string]SystemNodeContract{
+			"review_node": {
+				EventHandlers: map[string]SystemNodeEventHandler{
+					"expense.submitted": {
+						AdvancesTo: "awaiting_review",
+						Rules: []HandlerRuleEntry{
+							{
+								ID:        "needs-human",
+								Condition: "payload.amount > 100",
+								Action:    ActionSpec{ID: "request_review"},
+							},
+							{
+								ID:        "auto-approve",
+								Condition: "else",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	var found bool
+	for _, transition := range bundle.WorkflowTransitions() {
+		if transition.ID != "needs-human" {
+			continue
+		}
+		found = true
+		if transition.To != "awaiting_review" {
+			t.Fatalf("rule transition To = %q, want handler advances_to fallback", transition.To)
+		}
+		if got, want := transition.Actions, []string{"request_review"}; len(got) != len(want) || got[0] != want[0] {
+			t.Fatalf("rule transition Actions = %#v, want %#v", got, want)
+		}
+	}
+	if !found {
+		t.Fatalf("missing rule transition for rule-level action using handler advances_to fallback")
+	}
+
+	for _, transition := range bundle.WorkflowTransitions() {
+		if transition.ID == "auto-approve" {
+			t.Fatalf("derived fallback transition for rule without action: %#v", transition)
+		}
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -138,6 +138,7 @@ type HandlerRuleEntry struct {
 	Condition        string                   `yaml:"condition"`
 	AdvancesTo       string                   `yaml:"advances_to"`
 	Emit             EmitSpec                 `yaml:"emit"`
+	Action           ActionSpec               `yaml:"action"`
 	DataAccumulation WorkflowDataAccumulation `yaml:"data_accumulation"`
 	Compute          *ComputeSpec             `yaml:"compute"`
 	FanOut           *FanOutSpec              `yaml:"fan_out"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -34,6 +34,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		"condition":         {},
 		"advances_to":       {},
 		"emit":              {},
+		"action":            {},
 		"data_accumulation": {},
 		"compute":           {},
 		"fan_out":           {},

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -642,10 +642,10 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 	if h.ClearGates, err = decodeClearGatesNode(&aux.ClearGates); err != nil {
 		return err
 	}
-	if h.OnComplete, err = decodeHandlerRuleEntriesNode(&aux.OnComplete); err != nil {
+	if h.OnComplete, err = decodeHandlerRuleEntriesNode(&aux.OnComplete, handlerRuleDecodeContextOnComplete); err != nil {
 		return err
 	}
-	if h.Rules, err = decodeHandlerRuleEntriesNode(&aux.Rules); err != nil {
+	if h.Rules, err = decodeHandlerRuleEntriesNode(&aux.Rules, handlerRuleDecodeContextRules); err != nil {
 		return err
 	}
 	if h.Query, err = decodeQuerySpecNode(&aux.Query); err != nil {
@@ -659,6 +659,9 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 	}
 	if HandlerHasAmbiguousTopLevelEmit(*h) {
 		return fmt.Errorf("AMBIGUOUS-EMIT: handler-top-level emit is only allowed on single-emit handlers; move emit ownership to the active branch, rule, timeout, or fan_out site")
+	}
+	if HandlerHasAmbiguousTopLevelAction(*h) {
+		return fmt.Errorf("AMBIGUOUS-ACTION: handler-top-level action is only allowed on handlers without rules; move action ownership to the active rule")
 	}
 	return nil
 }
@@ -991,7 +994,16 @@ func decodeClearGatesNode(node *yaml.Node) ([]string, error) {
 	}
 }
 
-func decodeHandlerRuleEntryNode(node *yaml.Node) (*HandlerRuleEntry, error) {
+type handlerRuleDecodeContext string
+
+const (
+	handlerRuleDecodeContextRules                handlerRuleDecodeContext = "rules"
+	handlerRuleDecodeContextOnComplete           handlerRuleDecodeContext = "on_complete"
+	handlerRuleDecodeContextAccumulateOnComplete handlerRuleDecodeContext = "accumulate.on_complete"
+	handlerRuleDecodeContextAccumulateOnTimeout  handlerRuleDecodeContext = "accumulate.on_timeout"
+)
+
+func decodeHandlerRuleEntryNode(node *yaml.Node, context handlerRuleDecodeContext) (*HandlerRuleEntry, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, nil
 	}
@@ -999,13 +1011,16 @@ func decodeHandlerRuleEntryNode(node *yaml.Node) (*HandlerRuleEntry, error) {
 	if err := node.Decode(&rule); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && !rule.DataAccumulation.HasWrites() && rule.Compute == nil && rule.FanOut == nil {
+	if err := rejectRuleActionOutsideRules(rule, context); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && strings.TrimSpace(rule.Action.ID) == "" && !rule.DataAccumulation.HasWrites() && rule.Compute == nil && rule.FanOut == nil {
 		return nil, nil
 	}
 	return &rule, nil
 }
 
-func decodeHandlerRuleEntriesNode(node *yaml.Node) ([]HandlerRuleEntry, error) {
+func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeContext) ([]HandlerRuleEntry, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, nil
 	}
@@ -1015,10 +1030,15 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node) ([]HandlerRuleEntry, error) {
 		if err := node.Decode(&rules); err != nil {
 			return nil, err
 		}
+		for _, rule := range rules {
+			if err := rejectRuleActionOutsideRules(rule, context); err != nil {
+				return nil, err
+			}
+		}
 		return rules, nil
 	case yaml.MappingNode:
-		if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "data_accumulation", "compute", "fan_out") {
-			rule, err := decodeHandlerRuleEntryNode(node)
+		if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
+			rule, err := decodeHandlerRuleEntryNode(node, context)
 			if err != nil || rule == nil {
 				return nil, err
 			}
@@ -1034,6 +1054,9 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node) ([]HandlerRuleEntry, error) {
 			if err := node.Content[i+1].Decode(&rule); err != nil {
 				return nil, err
 			}
+			if err := rejectRuleActionOutsideRules(rule, context); err != nil {
+				return nil, err
+			}
 			if strings.TrimSpace(rule.ID) == "" {
 				rule.ID = id
 			}
@@ -1043,6 +1066,13 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node) ([]HandlerRuleEntry, error) {
 	default:
 		return nil, fmt.Errorf("unsupported rules yaml node kind %d", node.Kind)
 	}
+}
+
+func rejectRuleActionOutsideRules(rule HandlerRuleEntry, context handlerRuleDecodeContext) error {
+	if context == handlerRuleDecodeContextRules || strings.TrimSpace(rule.Action.ID) == "" {
+		return nil
+	}
+	return fmt.Errorf("UNSUPPORTED-ACTION: %s entries do not support action; rule-level action is only supported under handler.rules", context)
 }
 
 func decodeQuerySpecNode(node *yaml.Node) (*QuerySpec, error) {
@@ -1142,6 +1172,18 @@ func decodeEntitySelectionSpecNode(node *yaml.Node, label string) (*SelectEntity
 		})
 	}
 	return spec, nil
+}
+
+func (a *ActionSpec) UnmarshalYAML(node *yaml.Node) error {
+	if a == nil {
+		return nil
+	}
+	spec, err := decodeActionSpecNode(node)
+	if err != nil {
+		return err
+	}
+	*a = spec
+	return nil
 }
 
 func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -68,10 +68,10 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		Completion:   ParseAccumulateCompletion(aux.Completion),
 	}
 	var err error
-	if a.OnComplete, err = decodeHandlerRuleEntriesNode(&aux.OnComplete); err != nil {
+	if a.OnComplete, err = decodeHandlerRuleEntriesNode(&aux.OnComplete, handlerRuleDecodeContextAccumulateOnComplete); err != nil {
 		return err
 	}
-	if a.OnTimeout, err = decodeHandlerRuleEntryNode(&aux.OnTimeout); err != nil {
+	if a.OnTimeout, err = decodeHandlerRuleEntryNode(&aux.OnTimeout, handlerRuleDecodeContextAccumulateOnTimeout); err != nil {
 		return err
 	}
 	return nil

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -706,6 +706,107 @@ data_accumulation:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_PreservesRuleLevelAction(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  needs_human:
+    condition: "payload.amount >= 100"
+    advances_to: awaiting_human
+    action:
+      id: mailbox_write
+      mailbox:
+        item_type:
+          literal: approval
+        summary:
+          literal: Review refund
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := len(handler.Rules); got != 1 {
+		t.Fatalf("Rules len = %d, want 1", got)
+	}
+	rule := handler.Rules[0]
+	if got := rule.ID; got != "needs_human" {
+		t.Fatalf("rule ID = %q, want needs_human", got)
+	}
+	if got := rule.Action.ID; got != "mailbox_write" {
+		t.Fatalf("rule Action.ID = %q, want mailbox_write", got)
+	}
+	if rule.Action.Mailbox == nil {
+		t.Fatal("expected rule Action.Mailbox")
+	}
+	if got := rule.Action.Mailbox.ItemType.Literal; got != "approval" {
+		t.Fatalf("rule Action.Mailbox.ItemType = %#v, want approval", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsHandlerActionWithRules(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+action: mailbox_write
+rules:
+  needs_human:
+    condition: "else"
+    advances_to: awaiting_human
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-ACTION") {
+		t.Fatalf("yaml.Unmarshal error = %v, want AMBIGUOUS-ACTION", err)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsActionOutsideRulesContext(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "on_complete",
+			raw: `
+on_complete:
+  - id: done
+    condition: "else"
+    action:
+      id: mailbox_write
+`,
+		},
+		{
+			name: "accumulate_on_complete",
+			raw: `
+accumulate:
+  into: approvals
+  expected_from: entity.expected_approvals
+  on_complete:
+    - id: done
+      condition: "else"
+      action:
+        id: mailbox_write
+`,
+		},
+		{
+			name: "accumulate_on_timeout",
+			raw: `
+accumulate:
+  into: approvals
+  expected_from: entity.expected_approvals
+  on_timeout:
+    advances_to: timed_out
+    action:
+      id: mailbox_write
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var handler SystemNodeEventHandler
+			err := yaml.Unmarshal([]byte(tc.raw), &handler)
+			if err == nil || !strings.Contains(err.Error(), "UNSUPPORTED-ACTION") {
+				t.Fatalf("yaml.Unmarshal error = %v, want UNSUPPORTED-ACTION", err)
+			}
+		})
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_MergesScalarActionWithCreateFlowFields(t *testing.T) {
 	var handler SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -84,11 +84,22 @@ type executionFrame struct {
 	state                         ExecutionState
 	result                        ExecutionResult
 	rule                          *runtimecontracts.HandlerRuleEntry
+	ruleSource                    handlerRuleSource
 	payload                       map[string]any
 	topLevelDataAccumulation      runtimecontracts.WorkflowDataAccumulation
 	topLevelDataWritesApplied     bool
 	accumulatorProjectionEligible bool
 }
+
+type handlerRuleSource string
+
+const (
+	handlerRuleSourceNone                 handlerRuleSource = ""
+	handlerRuleSourceRules                handlerRuleSource = "handler.rules"
+	handlerRuleSourceOnComplete           handlerRuleSource = "handler.on_complete"
+	handlerRuleSourceAccumulateOnComplete handlerRuleSource = "handler.accumulate.on_complete"
+	handlerRuleSourceAccumulateOnTimeout  handlerRuleSource = "handler.accumulate.on_timeout"
+)
 
 type contextTx struct {
 	Tx
@@ -148,6 +159,9 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	if runtimecontracts.HandlerHasAmbiguousTopLevelAction(req.Handler) {
 		return fmt.Errorf("%w: handler-top-level action is only allowed on handlers without rules", ErrInvalidConfig)
 	}
+	if err := validateUnsupportedRuleActions(req.Handler); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
 	if req.Handler.CreateEntity && req.Handler.Accumulate != nil {
 		return fmt.Errorf("%w: handler declares both create_entity and accumulate", ErrInvalidConfig)
 	}
@@ -167,6 +181,41 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 	return nil
+}
+
+func validateUnsupportedRuleActions(handler runtimecontracts.SystemNodeEventHandler) error {
+	validateRule := func(context string, rule runtimecontracts.HandlerRuleEntry) error {
+		if strings.TrimSpace(rule.Action.ID) == "" {
+			return nil
+		}
+		return fmt.Errorf("%s action is unsupported; action is only allowed in handler.rules[*]", context)
+	}
+	for idx, rule := range handler.OnComplete {
+		if err := validateRule(handlerRuleContext("handler.on_complete", idx, rule.ID), rule); err != nil {
+			return err
+		}
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			if err := validateRule(handlerRuleContext("handler.accumulate.on_complete", idx, rule.ID), rule); err != nil {
+				return err
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			if err := validateRule(handlerRuleContext("handler.accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID), *handler.Accumulate.OnTimeout); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func handlerRuleContext(prefix string, idx int, id string) string {
+	id = strings.TrimSpace(id)
+	if id != "" {
+		return fmt.Sprintf("%s[%s]", prefix, id)
+	}
+	return fmt.Sprintf("%s[%d]", prefix, idx)
 }
 
 func validateHandlerEntityWriteTargets(source semanticview.Source, flowID string, handler runtimecontracts.SystemNodeEventHandler) error {
@@ -763,6 +812,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	frame.state.Accumulated = accumulatorExpressionValue(acc)
 	if isAccumulationTimeoutEvent(frame.req.Event.Type) && spec.OnTimeout != nil {
 		frame.rule = spec.OnTimeout
+		frame.ruleSource = handlerRuleSourceAccumulateOnTimeout
 		e.applyRule(frame, spec.OnTimeout)
 		return false, nil
 	}
@@ -1014,8 +1064,10 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 		return nil
 	}
 	rules := frame.req.Handler.OnComplete
+	ruleSource := handlerRuleSourceOnComplete
 	if len(rules) == 0 && frame.req.Handler.Accumulate != nil {
 		rules = frame.req.Handler.Accumulate.OnComplete
+		ruleSource = handlerRuleSourceAccumulateOnComplete
 	}
 	if frame.result.AccumulatorCompletionDiagnostics.Relevant && len(rules) > 0 {
 		frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = true
@@ -1032,6 +1084,7 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 	}
 	if rule != nil {
 		frame.rule = rule
+		frame.ruleSource = ruleSource
 		if frame.result.AccumulatorCompletionDiagnostics.Relevant &&
 			frame.result.AccumulatorCompletionDiagnostics.CompletionReached &&
 			frame.req.Handler.Accumulate != nil {
@@ -1060,6 +1113,7 @@ func (e *Executor) stepRules(frame *executionFrame) error {
 	}
 	if rule != nil {
 		frame.rule = rule
+		frame.ruleSource = handlerRuleSourceRules
 		e.applyRule(frame, rule)
 		if rule.FanOut != nil {
 			if _, err := e.stepFanOut(frame); err != nil {
@@ -1337,7 +1391,7 @@ func (e *Executor) stepEmits(frame *executionFrame) error {
 }
 
 func (e *Executor) stepAction(frame *executionFrame) error {
-	actionSpec := selectedActionSpec(frame.req.Handler, frame.rule)
+	actionSpec := selectedActionSpec(frame.req.Handler, frame.rule, frame.ruleSource)
 	actionKey := identity.NormalizeActionKey(actionSpec.ID)
 	if actionKey.IsZero() {
 		return nil
@@ -1930,8 +1984,8 @@ func selectedEmitSpec(handler runtimecontracts.SystemNodeEventHandler, rule *run
 	return handler.Emit
 }
 
-func selectedActionSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) runtimecontracts.ActionSpec {
-	if rule != nil && strings.TrimSpace(rule.Action.ID) != "" {
+func selectedActionSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry, source handlerRuleSource) runtimecontracts.ActionSpec {
+	if source == handlerRuleSourceRules && rule != nil && strings.TrimSpace(rule.Action.ID) != "" {
 		return rule.Action
 	}
 	return handler.Action

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -145,6 +145,9 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	if runtimecontracts.HandlerHasAmbiguousTopLevelEmit(req.Handler) {
 		return fmt.Errorf("%w: handler-top-level emit is only allowed on single-emit handlers", ErrInvalidConfig)
 	}
+	if runtimecontracts.HandlerHasAmbiguousTopLevelAction(req.Handler) {
+		return fmt.Errorf("%w: handler-top-level action is only allowed on handlers without rules", ErrInvalidConfig)
+	}
 	if req.Handler.CreateEntity && req.Handler.Accumulate != nil {
 		return fmt.Errorf("%w: handler declares both create_entity and accumulate", ErrInvalidConfig)
 	}
@@ -1334,7 +1337,8 @@ func (e *Executor) stepEmits(frame *executionFrame) error {
 }
 
 func (e *Executor) stepAction(frame *executionFrame) error {
-	actionKey := identity.NormalizeActionKey(frame.req.Handler.Action.ID)
+	actionSpec := selectedActionSpec(frame.req.Handler, frame.rule)
+	actionKey := identity.NormalizeActionKey(actionSpec.ID)
 	if actionKey.IsZero() {
 		return nil
 	}
@@ -1355,7 +1359,7 @@ func (e *Executor) stepAction(frame *executionFrame) error {
 		}
 		if e.deps.ActionRunner != nil {
 			execCtx := e.executionContext(frame, StepAction)
-			handled, err := e.deps.ActionRunner.ExecuteAction(frame.tx.Context(), frame.req.Handler.Action, entry, execCtx)
+			handled, err := e.deps.ActionRunner.ExecuteAction(frame.tx.Context(), actionSpec, entry, execCtx)
 			if err != nil {
 				return err
 			}
@@ -1924,6 +1928,13 @@ func selectedEmitSpec(handler runtimecontracts.SystemNodeEventHandler, rule *run
 		return rule.Emit
 	}
 	return handler.Emit
+}
+
+func selectedActionSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) runtimecontracts.ActionSpec {
+	if rule != nil && strings.TrimSpace(rule.Action.ID) != "" {
+		return rule.Action
+	}
+	return handler.Action
 }
 
 func (e *Executor) shapeEmitPayload(frame *executionFrame, eventType string, payload map[string]any) (map[string]any, error) {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2837,6 +2837,106 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 	}
 }
 
+func TestExecutor_RuleActionRunsOnlyForSelectedRule(t *testing.T) {
+	runner := &stubActionRunner{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+		ActionRegistry: stubActionRegistry{entries: map[identity.ActionKey]runtimeregistry.ActionInstruction{
+			identity.NormalizeActionKey("auto_action"): {
+				Key: identity.NormalizeActionKey("auto_action"),
+			},
+			identity.NormalizeActionKey("human_action"): {
+				Key: identity.NormalizeActionKey("human_action"),
+			},
+		}},
+		ActionRunner: runner,
+	}, stubEvaluator{bools: map[string]bool{
+		"payload.amount < 100":  false,
+		"payload.amount >= 100": true,
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "refund.requested", Payload: json.RawMessage(`{"amount":250}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Rules: []runtimecontracts.HandlerRuleEntry{
+				{
+					ID:        "auto",
+					Condition: "payload.amount < 100",
+					Action:    runtimecontracts.ActionSpec{ID: "auto_action"},
+				},
+				{
+					ID:        "needs-human",
+					Condition: "payload.amount >= 100",
+					Action:    runtimecontracts.ActionSpec{ID: "human_action"},
+				},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.RuleID; got != "needs-human" {
+		t.Fatalf("RuleID = %q, want needs-human", got)
+	}
+	if got := runner.called; !reflect.DeepEqual(got, []string{"human_action"}) {
+		t.Fatalf("action runner calls = %#v, want only selected rule action", got)
+	}
+	if got := result.ActionsExecuted; !reflect.DeepEqual(got, []string{"human_action"}) {
+		t.Fatalf("ActionsExecuted = %#v, want only selected rule action", got)
+	}
+}
+
+func TestExecutor_RejectsAmbiguousHandlerTopLevelActionWithRules(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+		ActionRegistry: stubActionRegistry{entries: map[identity.ActionKey]runtimeregistry.ActionInstruction{
+			identity.NormalizeActionKey("handler_action"): {
+				Key: identity.NormalizeActionKey("handler_action"),
+			},
+		}},
+		ActionRunner: &stubActionRunner{},
+	}, stubEvaluator{bools: map[string]bool{"payload.amount >= 100": true}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    events.Event{ID: "evt-1", Type: "refund.requested", Payload: json.RawMessage(`{"amount":250}`)},
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Action: runtimecontracts.ActionSpec{ID: "handler_action"},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "needs-human",
+				Condition: "payload.amount >= 100",
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil {
+		t.Fatalf("expected ambiguous handler-level action config to be rejected, got %+v", result)
+	}
+	if !strings.Contains(err.Error(), "handler-top-level action is only allowed on handlers without rules") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestExecutor_MergePersistedActionStatePreservesInMemoryWrites(t *testing.T) {
 	entityID := identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111")
 	baseline := testStateSnapshot("ready", map[string]any{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2937,6 +2937,117 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelActionWithRules(t *testing.T) {
 	}
 }
 
+func TestExecutor_RejectsUnsupportedRuleActionContextsBeforeExecution(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler runtimecontracts.SystemNodeEventHandler
+		want    string
+	}{
+		{
+			name: "on_complete",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				OnComplete: []runtimecontracts.HandlerRuleEntry{{
+					ID:        "complete",
+					Condition: "else",
+					Action:    runtimecontracts.ActionSpec{ID: "notify"},
+				}},
+			},
+			want: "handler.on_complete[complete] action is unsupported",
+		},
+		{
+			name: "accumulate on_complete",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnComplete: []runtimecontracts.HandlerRuleEntry{{
+						ID:        "complete",
+						Condition: "else",
+						Action:    runtimecontracts.ActionSpec{ID: "notify"},
+					}},
+				},
+			},
+			want: "handler.accumulate.on_complete[complete] action is unsupported",
+		},
+		{
+			name: "accumulate on_timeout",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnTimeout: &runtimecontracts.HandlerRuleEntry{
+						ID:     "timeout",
+						Action: runtimecontracts.ActionSpec{ID: "notify"},
+					},
+				},
+			},
+			want: "handler.accumulate.on_timeout[timeout] action is unsupported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &stubActionRunner{}
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source:     stubSource(),
+				StateRepo:  stubStateRepo{},
+				TxRunner:   stubRunner{},
+				Locker:     stubLocker{},
+				Outbox:     stubOutbox{},
+				Dispatcher: stubDispatcher{},
+				ActionRegistry: stubActionRegistry{entries: map[identity.ActionKey]runtimeregistry.ActionInstruction{
+					identity.NormalizeActionKey("notify"): {
+						Key: identity.NormalizeActionKey("notify"),
+					},
+				}},
+				ActionRunner: runner,
+			}, stubEvaluator{bools: map[string]bool{"payload.ok": true}})
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: "entity-1",
+				NodeID:   "node-1",
+				FlowID:   "flow-1",
+				Event:    events.Event{ID: "evt-1", Type: "task.completed", Payload: json.RawMessage(`{"ok":true}`)},
+				Handler:  tc.handler,
+				State:    testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+			})
+			if err == nil {
+				t.Fatalf("expected unsupported action context rejection, got result %+v", result)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			if len(runner.called) != 0 {
+				t.Fatalf("action runner calls = %#v, want none", runner.called)
+			}
+			if len(result.ActionsExecuted) != 0 {
+				t.Fatalf("ActionsExecuted = %#v, want none", result.ActionsExecuted)
+			}
+		})
+	}
+}
+
+func TestSelectedActionSpecConsumesRuleActionOnlyFromHandlerRules(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{Action: runtimecontracts.ActionSpec{ID: "handler_action"}}
+	rule := &runtimecontracts.HandlerRuleEntry{Action: runtimecontracts.ActionSpec{ID: "rule_action"}}
+	cases := []struct {
+		name   string
+		source handlerRuleSource
+		want   string
+	}{
+		{name: "handler rules", source: handlerRuleSourceRules, want: "rule_action"},
+		{name: "on complete", source: handlerRuleSourceOnComplete, want: "handler_action"},
+		{name: "accumulate on complete", source: handlerRuleSourceAccumulateOnComplete, want: "handler_action"},
+		{name: "accumulate on timeout", source: handlerRuleSourceAccumulateOnTimeout, want: "handler_action"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectedActionSpec(handler, rule, tc.source).ID; got != tc.want {
+				t.Fatalf("selectedActionSpec = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExecutor_MergePersistedActionStatePreservesInMemoryWrites(t *testing.T) {
 	entityID := identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111")
 	baseline := testStateSnapshot("ready", map[string]any{

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -129,10 +129,19 @@ func handlerExecutionOrderForPlan(plan handlerExecutionPlan) []string {
 	if len(plan.EmitEvents) > 0 {
 		steps = append(steps, "emits")
 	}
-	if plan.Action != "" {
+	if plan.Action != "" || handlerPlanHasRuleActions(plan) {
 		steps = append(steps, "action")
 	}
 	return steps
+}
+
+func handlerPlanHasRuleActions(plan handlerExecutionPlan) bool {
+	for _, rule := range plan.Rules {
+		if strings.TrimSpace(rule.Action.ID) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func handlerPlanHasEmitFields(plan handlerExecutionPlan) bool {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1214,8 +1214,9 @@ handler_specification:
     action:
       field: action
       type: string or object
-      purpose: 'Names a platform-provided action. Valid values: create_flow_instance, record_evidence, mailbox_write, artifact_repo_commit. The
-        platform executes the named action. NOT for platform actions — all behavior must be declarative.'
+      purpose: 'Names a platform-provided action on a handler without rules or on a handler.rules[*] branch. Valid values:
+        create_flow_instance, record_evidence, mailbox_write, artifact_repo_commit. The platform executes the named action.
+        NOT for product actions — all behavior must be declarative.'
       emit_interaction: If the resolved runtime action instruction emits a follow-up event, that event uses the action-originated
         emitted-event payload rules under observation_model.emitted_events.payload_rules. The action field itself does not
         declare authored payload fields; runtime-owned action instructions construct and validate any follow-up payload.
@@ -1411,17 +1412,19 @@ handler_specification:
     per source order. A handler may list on_complete before accumulate in YAML — the engine still runs accumulate first. Authors
     SHOULD order fields to match the dependency graph for readability, but the engine does not require it.
   rules_handler_interaction:
-    description: When a handler has rules, the active rule owns conditional emit selection for that execution.
+    description: When a handler has rules, the active rule owns conditional emit and action selection for that execution.
     execution_order: 1. rules execute first — the matching rule determines the active condition-specific side effects (rule-level
-      emit, data_accumulation, advances_to). 2. Handler-level data_accumulation executes AFTER rules when present and supplements
-      rule-level writes in the same atomic transaction. 3. Handler-level emit does NOT supplement rules. If rules are present,
-      handler-level emit is invalid and boot fails as ambiguous.
+      emit, action, data_accumulation, advances_to). 2. Handler-level data_accumulation executes AFTER rules when present and
+      supplements rule-level writes in the same atomic transaction. 3. Handler-level emit and handler-level action do NOT supplement
+      rules. If rules are present, handler-level emit or handler-level action is invalid and boot fails as ambiguous. 4. The
+      selected rule action executes at the normal action step after active state/gate/data updates and selected emit queuing, and
+      remains in the same system-node handler transaction as those side effects.
     example: 'order.received may have handler-level data_accumulation (3 fields) + rules with per-rule data_accumulation (category_data).
       Result: all 3 handler-level fields are written, PLUS the matching rule writes category_data. Event emission, however,
-      must be owned by the matching rule.'
+      and action must be owned by the matching rule.'
     precedence: Handler-level advances_to, sets_gate, and data_accumulation are defaults. If the matched rule specifies any
-      of these, the rule value OVERRIDES the handler-level value for that field only. emit never falls through from a handler
-      into a rules-based multi-emit handler.
+      of these, the rule value OVERRIDES the handler-level value for that field only. emit and action never fall through from
+      a handler into a rules-based multi-emit/action handler.
 engine:
   description: Specification for the platform engine — how it loads, validates, and executes flows.
   flow_tree_walker:
@@ -3503,10 +3506,10 @@ compliance:
     - 'If handler has guard: evaluate condition. If false, reject or kill.'
     - 'If handler has accumulate: track arrival, check completion, proceed only on complete.'
     - 'If handler has on_complete: evaluate conditions, execute matching branch.'
-    - 'If handler has rules: match payload field, select the matching rule-local emit if present.'
+    - 'If handler has rules: match payload field, select the matching rule-local emit and action if present.'
     - 'Apply advances_to, sets_gate, and data_accumulation from the active handler/branch/rule outcome.'
     - 'If the active emit site has emit: publish the selected follow-up event.'
-    - 'If handler has action that is a platform action: call registered platform action.'
+    - 'If the active handler or selected rule has action that is a platform action: call registered platform action.'
     - 'If the resolved action runtime instruction emits an event: publish it using the action-originated payload rules and fail-closed schema validation before commit.'
   product_boundary:
     description: Rules for product-specific code isolation.
@@ -3657,15 +3660,17 @@ tool_model:
       search_entities: Query entities by stage, field values, or metadata. Legacy trusted runtime-internal compatibility
         surface; not provider-visible or callable for normal agents.
     handler_actions:
-      description: These are handler ACTION field values, not agent-callable tools. They are invoked via the action field in
-        node handlers. The platform ships the handler code. They are listed separately from the tool catalog because agents
-        cannot call them directly.
+      description: These are handler/action-branch ACTION field values, not agent-callable tools. They are invoked via the
+        action field in node handlers without rules or in selected handler.rules branches. The platform ships the handler code.
+        They are listed separately from the tool catalog because agents cannot call them directly.
       actions:
         create_flow_instance: Create a new dynamic flow instance from a template.
         record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler.
-        mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler action only.
+        mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler-without-rules
+          or selected handler.rules branch action only.
         artifact_repo_commit: Deterministically commit allowlisted service-owned artifact files to a local git repository,
-          persist opaque artifact URL/ref metadata, and publish declared result events. Handler action only.
+          persist opaque artifact URL/ref metadata, and publish declared result events. Handler-without-rules or selected
+          handler.rules branch action only.
     planned_tools:
       description: Tools planned for future platform versions. Not yet implemented. The permission may exist (as an authorization
         gate) before the tool does.


### PR DESCRIPTION
Closes #1250

## Governing refs and gate boundary

Approved as the #1250 first slice for `runtime.rule_branch_action_authoring_and_execution_ownership`:

- Pre-audit: https://github.com/division-sh/swarm/issues/1250#issuecomment-4597811263
- Lead review: https://github.com/division-sh/swarm/issues/1250#issuecomment-4597859597
- Independent gate: https://github.com/division-sh/swarm/issues/1250#issuecomment-4597894258
- Authoritative spec refs updated in this PR: `platform-spec.yaml` action field, `rules_handler_interaction`, `compliance.handler_execution`, and handler action catalog.

## Semantic migration

New canonical owner:

- `platform-spec.yaml` owns that `handler.rules[*].action` is the conditional branch action authority, while handler-level `action` remains valid only when no rules exist.
- `internal/runtime/contracts.HandlerRuleEntry.Action` owns the parsed rule-local action.
- The selected action is consumed by loader validation, bootverify, semantic action inventories, derived rule transitions, execution planning, executor dispatch, and API-supported mailbox proof paths.

Old paths now invalid:

- Parser rejection of `handler.rules[*].action` as an undefined field.
- Handler-level `action` combined with `rules` as fallback or dual ownership.
- Executor action dispatch that only consulted handler-level action for a rule-selected handler.

Production paths checked for surviving old behavior:

- YAML loader and flow validation.
- Bootverify action shape validation.
- Semantic derivation and transition inventories.
- Runtime execution plan ordering.
- Executor selected action dispatch.
- SQLite default/no-selector and explicit Postgres API mailbox supported surface.
- Empire consumer grep for handler-level `action` combined with `rules`.

Migration status:

- Complete for the chosen `handler.rules[*].action` class.
- Handler-level `action` with no rules is preserved.
- `on_complete`, `accumulate.on_complete`, and `accumulate.on_timeout` actions remain unsupported and now fail closed.
- Broader follow-ups remain split for #1253 exact-once, rule-level `sets_gate`, and non-handler branch-action surfaces.

Private docs note:

- The private docs mirror under `/Users/youmew/dev/swarm-docs` was updated in-place for the spec mirror and verifier. It is outside this repository and therefore not included as repo files in this PR.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/pipeline ./internal/apiv1 -run 'Rule.*Action|Action.*Rules|ActionOutsideRules|RuleLevelAction|RuleMailboxWrite|HandlerLevelActionWithRules|MailboxWriteMissing|MailboxDeclaration|ActionRegistryEmits|AmbiguousHandlerTopLevelAction|AmbiguousHandlerTopLevelEmit|WorkflowExecutionPlan|MailboxWrite|Action|TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends|TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends|TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends' -count=1`
- `go test ./internal/runtime/pipeline -run TestPipelineEnginePayloadShaper_AllowsDeclaredPayloadOnActionSurface -count=1`
- `python3 -m py_compile /Users/youmew/dev/swarm-docs/docs/specs/swarm-platform/verify.py`
- Empire consumer grep: `handler_action_with_rules_hits=0`
- `git diff --check`
- `go test ./...`
