### PR TITLE
[agent-h][issue #1257] Align bundle register contracts shorthand

### DIFF
--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -470,7 +470,11 @@ func (opts bundleRegisterCommandOptions) contractsDirectoryParams(args []string)
 	if err != nil {
 		return nil, err
 	}
-	upload, err := runtimecontracts.BuildBundleRegistrationDirectoryUpload(repoRoot, paths.ContractsPath, paths.PlatformSpecPath)
+	contractsRoot, err := normalizeContractsRoot(paths.ContractsPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve contracts: %w", err)
+	}
+	upload, err := runtimecontracts.BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, paths.PlatformSpecPath)
 	if err != nil {
 		return nil, fmt.Errorf("package contracts directory: %w", err)
 	}

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -481,6 +481,48 @@ func TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders(t *testing.T
 	}
 }
 
+func TestBundleRegisterContractsPackageFileShorthandUsesCanonicalRPC(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	bundleHash := validBundleHash("8")
+	contractsDir := writeBundleRegisterContractsFixture(t)
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validBundleRegistrationResult(bundleHash))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"bundle", "register",
+		"--contracts", filepath.Join(contractsDir, "package.yaml"),
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != bundleRegisterMethod {
+		t.Fatalf("method = %q, want %q", captured.Method, bundleRegisterMethod)
+	}
+	contentYAML, ok := captured.Params["content_yaml"].(string)
+	if !ok || !strings.Contains(contentYAML, "package.yaml") || !strings.Contains(contentYAML, "flows/alpha/schema.yaml") {
+		t.Fatalf("content_yaml = %#v", captured.Params["content_yaml"])
+	}
+	if _, ok := captured.Params["data_blob"]; !ok {
+		t.Fatalf("data_blob missing from params: %#v", captured.Params)
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestBundleRegisterPreparedEnvelopeUsesCanonicalRPCAndRenders(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	bundleHash := validBundleHash("e")
@@ -603,8 +645,8 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register blank idempotency", args: []string{"bundle", "register", envelopePath, "--data-blob", dataBlobPath, "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
 		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
-		{name: "register contracts typo child under bundle", args: []string{"bundle", "register", "--contracts", invalidChildContractsDir}, wantStderr: "package contracts directory"},
-		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "package contracts directory"},
+		{name: "register contracts typo child under bundle", args: []string{"bundle", "register", "--contracts", invalidChildContractsDir}, wantStderr: "resolve contracts"},
+		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "resolve contracts"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			calls.Store(0)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6310,9 +6310,10 @@ multi_bundle_persistence:
         inputs under every discovered flow data directory to data_blob, including root flows/<flow>/data/...,
         package flows such as packages/<package>/flows/<flow>/data/..., and nested flow packages such as
         flows/<parent>/flows/<child>/data/.... Empty raw-data files are represented as empty base64 strings. The
-        `--contracts` value is an explicit operator input: it MUST name the selected contracts directory itself and
-        MUST NOT fall back to a parent bundle when the supplied path is a typo/non-root child. Archive packaging
-        remains split until archive format and extraction safety rules are promoted.
+        `--contracts` value is an explicit operator input: it MUST name either the selected contracts directory itself
+        or that directory's `package.yaml` file shorthand, and MUST NOT fall back to a parent bundle when the supplied
+        path is a typo/non-root child. Archive packaging remains split until archive format and extraction safety rules
+        are promoted.
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev


### PR DESCRIPTION
## Summary

Part of #1257.

Follow-up to merged PR #1272. This addresses the PR #1272 review blocker: `swarm bundle register --contracts <dir>/package.yaml` did not consume the same explicit contracts path normalization as `swarm verify --contracts <dir>/package.yaml`.

This PR keeps the approved F-002 boundary only. It does not implement F-008, F-015, F-024, or F-025.

## Governing refs / context

- Approved gate: #1257 `Gate F failure-class verification for #1257`.
- Pre-audit: #1257 `Pre-Implementation Coverage Audit`.
- Prior implementation PR: #1272.
- Exact spec owner: `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`.
- Bundle-register owner: `platform-spec.yaml#multi_bundle_persistence.cli_surface.bundle_register_directory_packager`.

## Semantic migration

- Canonical owner: explicit local contract path validation through the shared CLI resolver and `normalizeContractsRoot`.
- Old path now invalid/inconsistent: `bundle register --contracts <dir>/package.yaml` rejecting the package-file shorthand while `verify --contracts <dir>/package.yaml` accepts it.
- New behavior: bundle register normalizes `--contracts` through the same owner before packaging, so exact directory paths and that directory's `package.yaml` shorthand both package the selected directory; typo/non-root children still fail closed.
- Production paths checked: `swarm bundle register --contracts`, the shared resolver, and the existing F-002 verify/serve/run owner from #1272.
- Migration completeness: completes the PR #1272 review blocker for the F-002 approved class. Parent #1257 remains open for sibling rows.

## Verification

- `go test ./cmd/swarm -run 'TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders|TestBundleRegisterContractsPackageFileShorthandUsesCanonicalRPC|TestBundleCommandsRejectInvalidInputBeforeRequest' -count=1`
- Manual probe:
  - `go run ./cmd/swarm verify --contracts tests/tier8-boot-verification/test-boot-success/package.yaml` succeeds.
  - `SWARM_API_TOKEN=test-token go run ./cmd/swarm bundle register --api-server http://127.0.0.1:1 --contracts tests/tier8-boot-verification/test-boot-success/package.yaml` gets past packaging and fails only on the intentionally unreachable RPC endpoint, proving the old `contracts root ... package.yaml is not a directory` failure is gone.
- `go test ./cmd/swarm -count=1`
- `go test ./...`