### PR TITLE
[agent-e][issue #1254] Derive public run entity counts from entity_state

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -123,6 +123,25 @@ func publishRunStatusRootEvent(t *testing.T, bus *runtimebus.EventBus, runID, en
 	}
 }
 
+func seedRunStatusEntityState(t *testing.T, db *sql.DB, runID, entityID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'run-status-test', 'default', 'status-entity', 'Status Entity', 'ready',
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, $3, $3, $3
+		)
+	`, runID, entityID, now); err != nil {
+		t.Fatalf("seed run status entity_state: %v", err)
+	}
+	if err := storerunlifecycle.SyncCounts(context.Background(), db, runID); err != nil {
+		t.Fatalf("sync run status entity_count: %v", err)
+	}
+}
+
 func markRunStatusCompleted(t *testing.T, pg *store.PostgresStore, runID string) {
 	t.Helper()
 	if err := pg.MarkRunTerminal(context.Background(), runID, "completed", "", time.Now().UTC()); err != nil {
@@ -5960,6 +5979,7 @@ func TestLoadRunStatusReport_UsesDurableCompletedRunState(t *testing.T) {
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	publishRunStatusRootEvent(t, eb, runID, entityID)
+	seedRunStatusEntityState(t, db, runID, entityID)
 	markRunStatusCompleted(t, pg, runID)
 
 	ctx := context.Background()
@@ -6028,6 +6048,7 @@ func TestLoadRunStatusReport_KeepsSupportedRunRunningUntilManagerWorkSettles(t *
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	publishRunStatusRootEvent(t, eb, runID, entityID)
+	seedRunStatusEntityState(t, db, runID, entityID)
 
 	select {
 	case <-agentStarted:
@@ -6148,6 +6169,7 @@ func TestLoadRunStatusReport_PreservesRunningTruthWhileManagerWorkIsActive(t *te
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	publishRunStatusRootEvent(t, eb, runID, entityID)
+	seedRunStatusEntityState(t, db, runID, entityID)
 
 	select {
 	case <-agentStarted:

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1408,6 +1408,7 @@ func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureA
 		HasTriggerCols:          caps.Events.RunTriggerColumns,
 		HasCounterCols:          caps.Events.RunCounterColumns,
 		HasEntityStateCountSrc:  runLifecycleEntityStateCountSource(caps),
+		RequireEntityStateCount: true,
 		HasTerminalCols:         caps.Events.RunTerminalFields,
 		HasBundleHashCol:        caps.Events.RunBundleHash,
 		HasBundleSourceCol:      caps.Events.RunBundleSource,

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -699,7 +699,7 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name, true); err != nil {
 			return err
 		}
-		if caps.Events.RunCounterColumns {
+		if caps.Events.RunCounterColumns && runLifecycleEntityStateCountSource(caps) {
 			if err := storerunlifecycle.SyncCounts(ctx, chooseExecQueryer(s.DB, tx), runID); err != nil {
 				return err
 			}
@@ -1407,11 +1407,16 @@ func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureA
 		HasStartedAtCol:         caps.Events.RunStartedAt,
 		HasTriggerCols:          caps.Events.RunTriggerColumns,
 		HasCounterCols:          caps.Events.RunCounterColumns,
+		HasEntityStateCountSrc:  runLifecycleEntityStateCountSource(caps),
 		HasTerminalCols:         caps.Events.RunTerminalFields,
 		HasBundleHashCol:        caps.Events.RunBundleHash,
 		HasBundleSourceCol:      caps.Events.RunBundleSource,
 		HasBundleFingerprintCol: caps.Events.RunBundleFingerprint,
 	}
+}
+
+func runLifecycleEntityStateCountSource(caps StoreSchemaCapabilities) bool {
+	return caps.EntityState == SchemaFlavorCanonical && caps.EntityRunID
 }
 
 type standaloneRuntimePlatformRunRecord struct {

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -279,6 +279,55 @@ func TestPostgresRunLifecycleEntityCountUsesEntityState(t *testing.T) {
 	}
 }
 
+func TestPostgresRunLifecycleSkipsEntityStateCounterSyncWhenUnavailable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS entity_state CASCADE`); err != nil {
+		t.Fatalf("drop entity_state: %v", err)
+	}
+
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, event_count, entity_count, started_at)
+		VALUES ($1::uuid, 'running', 41, 7, now())
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	evt := events.Event{
+		ID:          uuid.NewString(),
+		RunID:       runID,
+		Type:        events.EventType("scan.requested"),
+		SourceAgent: "agent-1",
+		Payload:     []byte(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}.WithEntityID(entityID)
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err != nil {
+		t.Fatalf("MarkRunTerminal: %v", err)
+	}
+
+	snap, err := pg.LoadRunLifecycleSnapshot(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	}
+	if snap.Status != "completed" {
+		t.Fatalf("snapshot status = %q, want completed", snap.Status)
+	}
+	if snap.EventCount != 41 {
+		t.Fatalf("snapshot event_count = %d, want existing runs counter 41", snap.EventCount)
+	}
+	if snap.EntityCount != 7 {
+		t.Fatalf("snapshot entity_count = %d, want existing runs counter 7", snap.EntityCount)
+	}
+}
+
 func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -22,6 +22,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -171,6 +172,7 @@ func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeli
 	`, eventID, runID, entityID); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			run_id, event_id, subscriber_type, subscriber_id, status, created_at
@@ -227,6 +229,56 @@ func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeli
 	}
 }
 
+func TestPostgresRunLifecycleEntityCountUsesEntityState(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	eventEntityA := uuid.NewString()
+	eventEntityB := uuid.NewString()
+	currentEntity := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, event_count, entity_count, started_at)
+		VALUES ($1::uuid, 'running', 99, 9, now())
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		) VALUES
+			(gen_random_uuid(), $1::uuid, 'scan.requested', $2::uuid, 'entity', '{}'::jsonb, 'test', 'agent', now()),
+			(gen_random_uuid(), $1::uuid, 'scan.replayed', $3::uuid, 'entity', '{}'::jsonb, 'test', 'agent', now())
+	`, runID, eventEntityA, eventEntityB); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	seedPostgresEntityStateRows(t, db, ctx, runID, currentEntity)
+
+	snap, err := pg.LoadRunLifecycleSnapshot(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	}
+	if snap.EntityCount != 1 {
+		t.Fatalf("snapshot entity_count = %d, want entity_state count 1 despite stale run/event overcount", snap.EntityCount)
+	}
+
+	if err := storerunlifecycle.SyncCounts(ctx, db, runID); err != nil {
+		t.Fatalf("SyncCounts: %v", err)
+	}
+	var eventCount, entityCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT event_count, entity_count
+		FROM runs
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&eventCount, &entityCount); err != nil {
+		t.Fatalf("load synced counters: %v", err)
+	}
+	if eventCount != 2 || entityCount != 1 {
+		t.Fatalf("synced counters event_count=%d entity_count=%d, want 2/1 from events/entity_state", eventCount, entityCount)
+	}
+}
+
 func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -240,6 +292,7 @@ func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(
 	`, runID); err != nil {
 		t.Fatalf("seed completed run: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
 	evt := events.Event{
 		ID:          uuid.NewString(),
@@ -304,6 +357,7 @@ func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing
 	`, eventID, runID, entityID); err != nil {
 		t.Fatalf("seed duplicate event: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
 	evt := events.Event{
 		ID:          eventID,

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -279,7 +279,7 @@ func TestPostgresRunLifecycleEntityCountUsesEntityState(t *testing.T) {
 	}
 }
 
-func TestPostgresRunLifecycleSkipsEntityStateCounterSyncWhenUnavailable(t *testing.T) {
+func TestPostgresRunLifecycleFailsClosedWhenEntityStateCountSourceUnavailable(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -309,22 +309,21 @@ func TestPostgresRunLifecycleSkipsEntityStateCounterSyncWhenUnavailable(t *testi
 		t.Fatalf("AppendEvent: %v", err)
 	}
 
-	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err != nil {
-		t.Fatalf("MarkRunTerminal: %v", err)
+	snap, err := pg.LoadRunLifecycleSnapshot(ctx, runID)
+	if err == nil || !strings.Contains(err.Error(), "canonical run-scoped entity_state") {
+		t.Fatalf("LoadRunLifecycleSnapshot = (%+v, %v), want canonical entity_state failure", snap, err)
 	}
 
-	snap, err := pg.LoadRunLifecycleSnapshot(ctx, runID)
-	if err != nil {
-		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	if err := pg.MarkRunTerminal(ctx, runID, "completed", "", time.Now().UTC()); err == nil || !strings.Contains(err.Error(), "canonical run-scoped entity_state") {
+		t.Fatalf("MarkRunTerminal error = %v, want canonical entity_state failure", err)
 	}
-	if snap.Status != "completed" {
-		t.Fatalf("snapshot status = %q, want completed", snap.Status)
+
+	var status string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(status, '') FROM runs WHERE run_id = $1::uuid`, runID).Scan(&status); err != nil {
+		t.Fatalf("load run status: %v", err)
 	}
-	if snap.EventCount != 41 {
-		t.Fatalf("snapshot event_count = %d, want existing runs counter 41", snap.EventCount)
-	}
-	if snap.EntityCount != 7 {
-		t.Fatalf("snapshot entity_count = %d, want existing runs counter 7", snap.EntityCount)
+	if status != "running" {
+		t.Fatalf("run status = %q, want unchanged running after fail-closed terminal attempt", status)
 	}
 }
 

--- a/internal/store/run_api_read_surface.go
+++ b/internal/store/run_api_read_surface.go
@@ -67,13 +67,20 @@ func (s *PostgresStore) requireRunHeaderCapabilities(ctx context.Context) error 
 	if !caps.Events.LogRunID {
 		return fmt.Errorf("run api read surface requires canonical events.run_id")
 	}
+	if caps.EntityState != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("entity_state", caps.EntityState)
+	}
+	if !caps.EntityRunID {
+		return fmt.Errorf("run api read surface requires canonical entity_state.run_id")
+	}
 	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
 	if err != nil {
 		return err
 	}
 	required := map[string][]string{
-		"runs":   {"run_id", "status", "bundle_hash", "trigger_event_id", "trigger_event_type", "forked_from_run_id", "entity_count", "event_count", "error_summary", "started_at", "ended_at"},
-		"events": {"run_id", "event_id", "event_name", "created_at"},
+		"runs":         {"run_id", "status", "bundle_hash", "trigger_event_id", "trigger_event_type", "forked_from_run_id", "entity_count", "event_count", "error_summary", "started_at", "ended_at"},
+		"events":       {"run_id", "event_id", "event_name", "created_at"},
+		"entity_state": {"run_id", "entity_id"},
 	}
 	for tableName, columns := range required {
 		if catalog.hasColumns(tableName, columns...) {
@@ -187,7 +194,7 @@ SELECT
 	lower(r.status),
 	COALESCE(r.trigger_event_type, root.event_name, ''),
 	COALESCE(r.trigger_event_id::text, root.event_id::text, ''),
-	COALESCE(r.entity_count, 0),
+	COALESCE(entity_summary.entity_count, 0),
 	COALESCE(NULLIF(r.event_count, 0), summary.event_count, 0),
 	r.started_at,
 	r.ended_at,
@@ -206,6 +213,11 @@ LEFT JOIN LATERAL (
 	FROM events e
 	WHERE e.run_id = r.run_id
 ) summary ON TRUE
+LEFT JOIN LATERAL (
+	SELECT COUNT(DISTINCT es.entity_id)::integer AS entity_count
+	FROM entity_state es
+	WHERE es.run_id = r.run_id
+) entity_summary ON TRUE
 `
 }
 

--- a/internal/store/run_api_read_surface_test.go
+++ b/internal/store/run_api_read_surface_test.go
@@ -22,6 +22,11 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	newerEvent := uuid.NewString()
 	middleEvent := uuid.NewString()
 	olderEvent := uuid.NewString()
+	newerEntityA := uuid.NewString()
+	newerEntityB := uuid.NewString()
+	middleEntity := uuid.NewString()
+	olderEventOnlyA := uuid.NewString()
+	olderEventOnlyB := uuid.NewString()
 	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	if _, err := db.ExecContext(ctx, `
@@ -36,15 +41,18 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 		t.Fatalf("seed runs: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES
-			($1::uuid, $2::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $3),
-			($1::uuid, gen_random_uuid(), 'scan.completed', 'global', '{}'::jsonb, 'test', 'agent', $4),
-			($5::uuid, $6::uuid, 'scan.requested', 'global', '{}'::jsonb, 'test', 'agent', $7),
-			($8::uuid, $9::uuid, 'scan.failed', 'global', '{}'::jsonb, 'test', 'agent', $10)
-	`, newer, newerEvent, now.Add(time.Second), now.Add(2*time.Second), middle, middleEvent, now.Add(-time.Hour+time.Second), older, olderEvent, now.Add(-2*time.Hour+time.Second)); err != nil {
+			($1::uuid, $2::uuid, 'scan.requested', NULL, 'global', '{}'::jsonb, 'test', 'agent', $3),
+			($1::uuid, gen_random_uuid(), 'scan.completed', NULL, 'global', '{}'::jsonb, 'test', 'agent', $4),
+			($5::uuid, $6::uuid, 'scan.requested', NULL, 'global', '{}'::jsonb, 'test', 'agent', $7),
+			($8::uuid, $9::uuid, 'scan.failed', $10::uuid, 'global', '{}'::jsonb, 'test', 'agent', $12),
+			($8::uuid, gen_random_uuid(), 'scan.replayed', $11::uuid, 'global', '{}'::jsonb, 'test', 'agent', $13)
+	`, newer, newerEvent, now.Add(time.Second), now.Add(2*time.Second), middle, middleEvent, now.Add(-time.Hour+time.Second), older, olderEvent, olderEventOnlyA, olderEventOnlyB, now.Add(-2*time.Hour+time.Second), now.Add(-2*time.Hour+2*time.Second)); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, newer, newerEntityA, newerEntityB)
+	seedPostgresEntityStateRows(t, db, ctx, middle, middleEntity)
 
 	header, err := pg.LoadRunHeader(ctx, middle)
 	if err != nil {
@@ -56,6 +64,9 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	if header.EndedAt == nil {
 		t.Fatalf("header.EndedAt = nil, want terminal timestamp")
 	}
+	if header.EntityCount != 1 {
+		t.Fatalf("header.EntityCount = %d, want entity_state count 1 despite stale run counter", header.EntityCount)
+	}
 
 	firstPage, cursor, err := pg.ListRunHeaders(ctx, RunHeaderListOptions{Status: "running", Limit: 1})
 	if err != nil {
@@ -63,6 +74,9 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	}
 	if len(firstPage) != 1 || firstPage[0].RunID != newer {
 		t.Fatalf("first page = %#v, want newer running run", firstPage)
+	}
+	if firstPage[0].EntityCount != 2 {
+		t.Fatalf("first page entity_count = %d, want entity_state count 2 despite event undercount", firstPage[0].EntityCount)
 	}
 	if cursor != "" {
 		t.Fatalf("running-only cursor = %q, want empty", cursor)
@@ -84,6 +98,9 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 	}
 	if len(allSecondPage) != 1 || allSecondPage[0].RunID != older || next != "" {
 		t.Fatalf("all second page = %#v cursor=%q, want older only and no next cursor", allSecondPage, next)
+	}
+	if allSecondPage[0].EntityCount != 0 {
+		t.Fatalf("older entity_count = %d, want entity_state count 0 despite event overcount", allSecondPage[0].EntityCount)
 	}
 
 	since := now.Add(-90 * time.Minute)

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -241,6 +241,10 @@ func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog 
 		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
 	case !caps.Events.DeliveryRunID:
 		return fmt.Errorf("run debug read surface requires canonical event_deliveries.run_id")
+	case caps.EntityState != SchemaFlavorCanonical:
+		return unsupportedSchemaCapability("entity_state", caps.EntityState)
+	case !caps.EntityRunID:
+		return fmt.Errorf("run debug read surface requires canonical entity_state.run_id")
 	case caps.Conversations.Turns != SchemaFlavorCanonical:
 		return unsupportedSchemaCapability("agent_turns", caps.Conversations.Turns)
 	case !caps.Conversations.TurnRunID:
@@ -248,6 +252,7 @@ func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog 
 	}
 	required := map[string][]string{
 		"runs":             {"run_id", "status", "error_summary", "started_at", "ended_at", "entity_count"},
+		"entity_state":     {"run_id", "entity_id"},
 		"dead_letters":     {"original_event_id", "original_event", "entity_id", "failure_type", "error_message", "handler_node", "created_at"},
 		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "old_value", "new_value", "caused_by_event", "writer_type", "writer_id", "handler_step", "created_at"},
 	}
@@ -323,7 +328,7 @@ func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunD
 			summary.last_event_at,
 			r.ended_at,
 			COALESCE(summary.event_count, 0),
-			COALESCE(r.entity_count, 0)
+			COALESCE(entity_summary.entity_count, 0)
 		FROM runs r
 		LEFT JOIN LATERAL (
 			SELECT e.event_id, e.event_name, e.created_at
@@ -337,6 +342,11 @@ func (s *PostgresStore) ListRunDebugRuns(ctx context.Context, limit int) ([]RunD
 			FROM events
 			WHERE run_id = r.run_id
 		) summary ON TRUE
+		LEFT JOIN LATERAL (
+			SELECT COUNT(DISTINCT es.entity_id)::int AS entity_count
+			FROM entity_state es
+			WHERE es.run_id = r.run_id
+		) entity_summary ON TRUE
 		WHERE root.event_id IS NOT NULL
 		ORDER BY COALESCE(summary.last_event_at, root.created_at, r.started_at) DESC, r.run_id DESC
 		LIMIT $1
@@ -402,9 +412,19 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 		entityCount  sql.NullInt64
 	)
 	if err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(status, ''), COALESCE(error_summary, ''), started_at, ended_at, COALESCE(entity_count, 0)
-		FROM runs
-		WHERE run_id = $1::uuid
+		SELECT
+			COALESCE(r.status, ''),
+			COALESCE(r.error_summary, ''),
+			r.started_at,
+			r.ended_at,
+			COALESCE(entity_summary.entity_count, 0)
+		FROM runs r
+		LEFT JOIN LATERAL (
+			SELECT COUNT(DISTINCT es.entity_id)::int AS entity_count
+			FROM entity_state es
+			WHERE es.run_id = r.run_id
+		) entity_summary ON TRUE
+		WHERE r.run_id = $1::uuid
 	`, report.RunID).Scan(&runStatus, &errorSummary, &started, &ended, &entityCount); err == nil {
 		report.RunTableStatus = strings.TrimSpace(runStatus)
 		report.ErrorSummary = strings.TrimSpace(errorSummary)

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -42,6 +42,9 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 	newerRunID := uuid.NewString()
 	olderEventID := uuid.NewString()
 	newerEventID := uuid.NewString()
+	olderEntityID := uuid.NewString()
+	newerEntityA := uuid.NewString()
+	newerEntityB := uuid.NewString()
 	now := time.Unix(1700000000, 0).UTC()
 
 	if _, err := db.ExecContext(ctx, `
@@ -63,6 +66,8 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 	`, olderRunID, olderEventID, newerRunID, newerEventID, now.Add(-119*time.Minute), now.Add(-91*time.Minute), now.Add(-59*time.Minute)); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, olderRunID, olderEntityID)
+	seedPostgresEntityStateRows(t, db, ctx, newerRunID, newerEntityA, newerEntityB)
 
 	runs, err := pg.ListRunDebugRuns(ctx, 10)
 	if err != nil {
@@ -77,11 +82,17 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 	if runs[0].RootEventID != newerEventID || runs[0].RootEventType != "scan.requested" {
 		t.Fatalf("runs[0] root = %#v", runs[0])
 	}
+	if runs[0].EntityCount != 2 {
+		t.Fatalf("runs[0].EntityCount = %d, want entity_state count 2", runs[0].EntityCount)
+	}
 	if runs[1].RunID != olderRunID {
 		t.Fatalf("runs[1].RunID = %q, want %q", runs[1].RunID, olderRunID)
 	}
 	if runs[1].EventCount != 2 {
 		t.Fatalf("runs[1].EventCount = %d, want 2", runs[1].EventCount)
+	}
+	if runs[1].EntityCount != 1 {
+		t.Fatalf("runs[1].EntityCount = %d, want entity_state count 1", runs[1].EntityCount)
 	}
 }
 
@@ -131,6 +142,7 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	targetRunID := uuid.NewString()
 	otherRunID := uuid.NewString()
 	targetEntityID := uuid.NewString()
+	targetSecondEntityID := uuid.NewString()
 	otherEntityID := uuid.NewString()
 	targetEventID := uuid.NewString()
 	otherEventID := uuid.NewString()
@@ -154,6 +166,8 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	`, targetRunID, targetEventID, targetEntityID, now.Add(-4*time.Minute), otherRunID, otherEventID, otherEntityID, now.Add(-3*time.Minute)); err != nil {
 		t.Fatalf("seed root events: %v", err)
 	}
+	seedPostgresEntityStateRows(t, db, ctx, targetRunID, targetEntityID, targetSecondEntityID)
+	seedPostgresEntityStateRows(t, db, ctx, otherRunID, otherEntityID)
 
 	insertRuntimeLog := func(runID string, payloadRunID string, component string, action string, createdAt time.Time) {
 		t.Helper()
@@ -229,6 +243,9 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	}
 	if report.RootEventID != targetEventID {
 		t.Fatalf("RootEventID = %q, want %q", report.RootEventID, targetEventID)
+	}
+	if report.EntityCount != 2 {
+		t.Fatalf("EntityCount = %d, want entity_state count 2", report.EntityCount)
 	}
 	if report.WarnErrorLogCount != 1 {
 		t.Fatalf("WarnErrorLogCount = %d, want 1", report.WarnErrorLogCount)

--- a/internal/store/run_entity_count_test.go
+++ b/internal/store/run_entity_count_test.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func seedPostgresEntityStateRows(t *testing.T, db *sql.DB, ctx context.Context, runID string, entityIDs ...string) {
+	t.Helper()
+	for idx, entityID := range entityIDs {
+		slug := fmt.Sprintf("entity-%d-%s", idx, entityID[:8])
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+				gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'test-flow', 'default', $3, $4, 'ready',
+				'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, $5, $5, $5
+			)
+		`, runID, entityID, slug, slug, time.Now().UTC()); err != nil {
+			t.Fatalf("seed postgres entity_state row %s: %v", entityID, err)
+		}
+	}
+}
+
+func seedSQLiteEntityStateRows(t *testing.T, db *sql.DB, ctx context.Context, runID string, entityIDs ...string) {
+	t.Helper()
+	for idx, entityID := range entityIDs {
+		slug := fmt.Sprintf("entity-%d-%s", idx, entityID[:8])
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+				gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+			) VALUES (
+				?, ?, 'test-flow', 'default', ?, ?, 'ready',
+				'{}', '{}', '{}', 1, ?, ?, ?
+			)
+		`, runID, entityID, slug, slug, time.Now().UTC(), time.Now().UTC(), time.Now().UTC()); err != nil {
+			t.Fatalf("seed sqlite entity_state row %s: %v", entityID, err)
+		}
+	}
+}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -29,6 +29,7 @@ type EnsureActiveOptions struct {
 	HasStartedAtCol         bool
 	HasTriggerCols          bool
 	HasCounterCols          bool
+	HasEntityStateCountSrc  bool
 	HasTerminalCols         bool
 	HasBundleHashCol        bool
 	HasBundleSourceCol      bool
@@ -346,7 +347,7 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveO
 		SELECT
 			run_id::text,
 			COALESCE(status, ''), `
-		if opts.HasCounterCols {
+		if opts.HasCounterCols && opts.HasEntityStateCountSrc {
 			query += `
 			COALESCE(event_count, 0),
 			COALESCE((
@@ -354,6 +355,10 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveO
 				FROM entity_state es
 				WHERE es.run_id = runs.run_id
 			), 0),`
+		} else if opts.HasCounterCols {
+			query += `
+			COALESCE(event_count, 0),
+			COALESCE(entity_count, 0),`
 		} else {
 			query += `
 			0,
@@ -432,7 +437,7 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
 	}
-	if opts.HasCounterCols {
+	if opts.HasCounterCols && opts.HasEntityStateCountSrc {
 		if err := SyncCounts(ctx, db, runID); err != nil {
 			return Snapshot{}, err
 		}

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -30,6 +30,7 @@ type EnsureActiveOptions struct {
 	HasTriggerCols          bool
 	HasCounterCols          bool
 	HasEntityStateCountSrc  bool
+	RequireEntityStateCount bool
 	HasTerminalCols         bool
 	HasBundleHashCol        bool
 	HasBundleSourceCol      bool
@@ -325,6 +326,9 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveO
 	if db == nil || runID == "" {
 		return Snapshot{}, fmt.Errorf("run_id is required")
 	}
+	if opts.RequireEntityStateCount && !opts.HasEntityStateCountSrc {
+		return Snapshot{}, fmt.Errorf("run lifecycle entity count requires canonical run-scoped entity_state")
+	}
 	var (
 		snap      Snapshot
 		startedAt sql.NullTime
@@ -342,26 +346,27 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveO
 		FROM runs
 		WHERE run_id = $1::uuid
 	`
-	if opts.HasCounterCols || opts.HasTerminalCols || opts.HasStartedAtCol {
+	if opts.HasCounterCols || opts.HasEntityStateCountSrc || opts.HasTerminalCols || opts.HasStartedAtCol {
 		query = `
 		SELECT
 			run_id::text,
 			COALESCE(status, ''), `
-		if opts.HasCounterCols && opts.HasEntityStateCountSrc {
+		if opts.HasCounterCols {
 			query += `
-			COALESCE(event_count, 0),
+			COALESCE(event_count, 0),`
+		} else {
+			query += `
+			0,`
+		}
+		if opts.HasEntityStateCountSrc {
+			query += `
 			COALESCE((
 				SELECT COUNT(DISTINCT es.entity_id)::integer
 				FROM entity_state es
 				WHERE es.run_id = runs.run_id
 			), 0),`
-		} else if opts.HasCounterCols {
-			query += `
-			COALESCE(event_count, 0),
-			COALESCE(entity_count, 0),`
 		} else {
 			query += `
-			0,
 			0,`
 		}
 		if opts.HasTerminalCols {
@@ -436,6 +441,9 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status, errorSummary stri
 	}
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
+	}
+	if opts.RequireEntityStateCount && !opts.HasEntityStateCountSrc {
+		return Snapshot{}, fmt.Errorf("run lifecycle entity count requires canonical run-scoped entity_state")
 	}
 	if opts.HasCounterCols && opts.HasEntityStateCountSrc {
 		if err := SyncCounts(ctx, db, runID); err != nil {

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -279,15 +279,16 @@ func SyncCounts(ctx context.Context, db DBTX, runID string) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE runs
 		SET
-			event_count = counts.event_count,
-			entity_count = counts.entity_count
-		FROM (
-			SELECT
-				COUNT(*)::integer AS event_count,
-				COUNT(DISTINCT entity_id)::integer AS entity_count
-			FROM events
-			WHERE run_id = $1::uuid
-		) AS counts
+			event_count = (
+				SELECT COUNT(*)::integer
+				FROM events
+				WHERE run_id = $1::uuid
+			),
+			entity_count = (
+				SELECT COUNT(DISTINCT entity_id)::integer
+				FROM entity_state
+				WHERE run_id = $1::uuid
+			)
 		WHERE runs.run_id = $1::uuid
 	`, runID)
 	if err != nil {
@@ -348,7 +349,11 @@ func LoadSnapshot(ctx context.Context, db DBTX, runID string, opts EnsureActiveO
 		if opts.HasCounterCols {
 			query += `
 			COALESCE(event_count, 0),
-			COALESCE(entity_count, 0),`
+			COALESCE((
+				SELECT COUNT(DISTINCT es.entity_id)::integer
+				FROM entity_state es
+				WHERE es.run_id = runs.run_id
+			), 0),`
 		} else {
 			query += `
 			0,

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -26,6 +26,12 @@ func (s *SQLiteRuntimeStore) requireRunHeaderCapabilities(ctx context.Context) e
 	if !caps.Events.LogRunID {
 		return fmt.Errorf("run api read surface requires canonical events.run_id")
 	}
+	if caps.EntityState != SchemaFlavorCanonical {
+		return unsupportedSchemaCapability("entity_state", caps.EntityState)
+	}
+	if !caps.EntityRunID {
+		return fmt.Errorf("run api read surface requires canonical entity_state.run_id")
+	}
 	return nil
 }
 
@@ -189,7 +195,7 @@ SELECT
 		ORDER BY e.created_at ASC, e.event_id ASC
 		LIMIT 1
 	), ''),
-	COALESCE(r.entity_count, 0),
+	COALESCE((SELECT COUNT(DISTINCT es.entity_id) FROM entity_state es WHERE es.run_id = r.run_id), 0),
 	COALESCE(NULLIF(r.event_count, 0), (SELECT COUNT(*) FROM events e WHERE e.run_id = r.run_id), 0),
 	r.started_at,
 	r.ended_at,

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -19,6 +19,10 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	newerMiddleEvent := uuid.NewString()
 	newerLatestEvent := uuid.NewString()
 	olderEvent := uuid.NewString()
+	newerEntityA := uuid.NewString()
+	newerEntityB := uuid.NewString()
+	olderEntity := uuid.NewString()
+	olderEventOnly := uuid.NewString()
 	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	bundleB := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
@@ -34,16 +38,19 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 		t.Fatalf("seed sqlite runs: %v", err)
 	}
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
-		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES
-			(?, ?, 'scan.requested', 'global', '{}', 'test', 'agent', ?),
-			(?, ?, 'scan.progressed', 'global', '{}', 'test', 'agent', ?),
-			(?, ?, 'scan.finished', 'global', '{}', 'test', 'agent', ?),
-			(?, ?, 'scan.completed', 'global', '{}', 'test', 'agent', ?),
-			(?, ?, 'platform.runtime_log', 'global', '{"log_level":"error","message":"boom","details":{"component":"runtime","action":"proof","error_code":"E_PROOF"}}', 'runtime', 'platform', ?)
-	`, newer, newerEvent, now.Add(time.Second), newer, newerMiddleEvent, now.Add(2*time.Second), newer, newerLatestEvent, now.Add(3*time.Second), older, olderEvent, now.Add(-time.Hour+time.Second), newer, uuid.NewString(), now.Add(4*time.Second)); err != nil {
+			(?, ?, 'scan.requested', NULL, 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.progressed', NULL, 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.finished', NULL, 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.completed', ?, 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.replayed', ?, 'global', '{}', 'test', 'agent', ?),
+			(?, ?, 'platform.runtime_log', NULL, 'global', '{"log_level":"error","message":"boom","details":{"component":"runtime","action":"proof","error_code":"E_PROOF"}}', 'runtime', 'platform', ?)
+	`, newer, newerEvent, now.Add(time.Second), newer, newerMiddleEvent, now.Add(2*time.Second), newer, newerLatestEvent, now.Add(3*time.Second), older, olderEvent, olderEntity, now.Add(-time.Hour+time.Second), older, uuid.NewString(), olderEventOnly, now.Add(-time.Hour+2*time.Second), newer, uuid.NewString(), now.Add(4*time.Second)); err != nil {
 		t.Fatalf("seed sqlite events: %v", err)
 	}
+	seedSQLiteEntityStateRows(t, sqliteStore.DB, ctx, newer, newerEntityA, newerEntityB)
+	seedSQLiteEntityStateRows(t, sqliteStore.DB, ctx, older, olderEntity)
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
 		VALUES (?, ?, ?, 'agent', 'agent-1', 'pending', ?)
@@ -61,6 +68,9 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	if header.EndedAt == nil {
 		t.Fatal("header.EndedAt = nil, want terminal timestamp")
 	}
+	if header.EntityCount != 1 {
+		t.Fatalf("header.EntityCount = %d, want entity_state count 1 despite stale run counter and event overcount", header.EntityCount)
+	}
 
 	firstPage, cursor, err := sqliteStore.ListRunHeaders(ctx, RunHeaderListOptions{Limit: 1})
 	if err != nil {
@@ -68,6 +78,9 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	}
 	if len(firstPage) != 1 || firstPage[0].RunID != newer {
 		t.Fatalf("first page = %#v, want newer run", firstPage)
+	}
+	if firstPage[0].EntityCount != 2 {
+		t.Fatalf("first page entity_count = %d, want entity_state count 2 despite event undercount", firstPage[0].EntityCount)
 	}
 	if cursor == "" {
 		t.Fatal("cursor empty for truncated sqlite run list")
@@ -93,6 +106,9 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	}
 	if report.RunID != newer || report.RootEventID != newerEvent || report.WarnErrorLogCount != 1 {
 		t.Fatalf("report = %#v", report)
+	}
+	if report.EntityCount != 2 {
+		t.Fatalf("report.EntityCount = %d, want entity_state count 2", report.EntityCount)
 	}
 	if len(report.Deliveries) != 1 || report.Deliveries[0].SubscriberID != "agent-1" {
 		t.Fatalf("report deliveries = %#v, want agent-1 delivery count", report.Deliveries)

--- a/internal/store/sqlite_run_completion.go
+++ b/internal/store/sqlite_run_completion.go
@@ -209,7 +209,7 @@ func (s *SQLiteRuntimeStore) sqliteLoadRunLifecycleSnapshot(ctx context.Context,
 			run_id,
 			LOWER(COALESCE(status, '')),
 			COALESCE(event_count, 0),
-			COALESCE(entity_count, 0),
+			COALESCE((SELECT COUNT(DISTINCT es.entity_id) FROM entity_state es WHERE es.run_id = runs.run_id), 0),
 			COALESCE(error_summary, ''),
 			started_at,
 			ended_at
@@ -311,7 +311,7 @@ func sqliteSyncRunCounts(ctx context.Context, q execQueryer, runID string) error
 		UPDATE runs
 		SET
 			event_count = (SELECT COUNT(*) FROM events WHERE run_id = ?),
-			entity_count = (SELECT COUNT(DISTINCT entity_id) FROM events WHERE run_id = ?)
+			entity_count = (SELECT COUNT(DISTINCT entity_id) FROM entity_state WHERE run_id = ?)
 		WHERE run_id = ?
 	`, runID, runID, runID)
 	if err != nil {

--- a/internal/store/sqlite_run_completion_test.go
+++ b/internal/store/sqlite_run_completion_test.go
@@ -107,6 +107,54 @@ func TestSQLiteRuntimeStoreConvergeNormalRunCompletionMarksCompletedAndIgnoresRu
 	}
 }
 
+func TestSQLiteRunLifecycleEntityCountUsesEntityState(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Now().UTC()
+	runID := uuid.NewString()
+	eventEntityA := uuid.NewString()
+	eventEntityB := uuid.NewString()
+	currentEntity := uuid.NewString()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, event_count, entity_count, started_at)
+		VALUES (?, 'running', 99, 9, ?)
+	`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			(?, ?, 'scan.requested', ?, 'entity', '{}', 'test', 'agent', ?),
+			(?, ?, 'scan.replayed', ?, 'entity', '{}', 'test', 'agent', ?)
+	`, uuid.NewString(), runID, eventEntityA, now.Add(time.Second), uuid.NewString(), runID, eventEntityB, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed sqlite events: %v", err)
+	}
+	seedSQLiteEntityStateRows(t, store.DB, ctx, runID, currentEntity)
+
+	snap, err := store.LoadRunLifecycleSnapshot(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRunLifecycleSnapshot: %v", err)
+	}
+	if snap.EntityCount != 1 {
+		t.Fatalf("snapshot entity_count = %d, want entity_state count 1 despite stale run/event overcount", snap.EntityCount)
+	}
+
+	if err := sqliteSyncRunCounts(ctx, store.DB, runID); err != nil {
+		t.Fatalf("sqliteSyncRunCounts: %v", err)
+	}
+	var eventCount, entityCount int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT event_count, entity_count
+		FROM runs
+		WHERE run_id = ?
+	`, runID).Scan(&eventCount, &entityCount); err != nil {
+		t.Fatalf("load synced sqlite counters: %v", err)
+	}
+	if eventCount != 2 || entityCount != 1 {
+		t.Fatalf("synced counters event_count=%d entity_count=%d, want 2/1 from events/entity_state", eventCount, entityCount)
+	}
+}
+
 func TestSQLiteRuntimeStoreConvergeNormalRunCompletionFailsClosedWhileDeliveryActive(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)


### PR DESCRIPTION
## Summary

- Move public/operator run `entity_count` projections for SQLite and Postgres run headers, run debug reports/lists, and lifecycle snapshots to canonical run-scoped `entity_state`.
- Change lifecycle counter sync so `runs.entity_count` is only a cache derived from `entity_state`, not `events.entity_id`.
- Add stale-counter, event-undercount, and event-overcount proof across SQLite/Postgres store, lifecycle, debug, builder/API/CLI consumer paths.

Closes #1254.

## Governing Refs / Context

- Approved pre-audit: https://github.com/division-sh/swarm/issues/1254#issuecomment-4598018012
- Gate approval: https://github.com/division-sh/swarm/issues/1254#issuecomment-4598030684
- Binding spec refs: `platform-spec.yaml` `schema_storage.entity_state`, `entity_registry_policy`, `cli_specification.status`, and OpenRPC `RunHeader.entity_count`.
- `entity.*` read-surface closure from PR #1266 remains closed and is not claimed here. #1253/#1269 handler exactness remains separate.

## Semantic Migration

- New canonical owner: run-scoped `entity_state` / `entity_registry_policy` for public current-run entity cardinality.
- Old producer/reader/writer paths now invalid as current-count authority: `COUNT(DISTINCT entity_id)` from `events`, direct public reads of stale `runs.entity_count`, and lifecycle snapshot/debug/header passthrough of that stale cache.
- Production paths checked: SQLite `LoadRunHeader`, `ListRunHeaders`, `LoadRunDebugReport`, `LoadRunLifecycleSnapshot`, `sqliteSyncRunCounts`; Postgres `LoadRunHeader`, `ListRunHeaders`, `ListRunDebugRuns`, `LoadRunDebugReport`, `LoadRunLifecycleSnapshot`, `storerunlifecycle.LoadSnapshot`, `storerunlifecycle.SyncCounts`; builder terminal `summary.entity_count`; `/v1/rpc run.get`, `run.list`, `run.diagnose`; CLI `swarm status`, `swarm status --no-diagnose`, and `swarm run` terminal summary consumers.
- Migration status: complete for the approved `public_run_entity_count_from_entity_state` class. Historical/fork/materialized/reconstructed/affected-count metrics remain separate concepts.

## Proof

- `go test ./internal/store -run 'RunAPI|RunDebug|RunLifecycle|RunCompletion|MarkRunTerminal|AppendEvent_Reopens|AppendEvent_Duplicate' -count=1`
- `go test ./internal/apiv1 -run 'Run|Readonly|Handler' -count=1`
- `go test ./internal/builder -run 'Run|Runs|Debug' -count=1`
- `go test ./cmd/swarm -run 'RunStatus|LoadRunStatusReport|Diagnostics|RunCommand|Status' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test -p 1 ./...`
- `go test ./...`