### PR TITLE
[agent-c][issue #1268] Add public surface backend matrix

### DIFF
--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -124,6 +124,17 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			},
 			want: "status_run_get_entity_count must remain split_to_existing_issue with split_issue 1254",
 		},
+		{
+			name: "fail closed row requires executable proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "bundle_hash_catalog_boot_postgres_only")
+				row.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "artifact", Path: "platform-spec.yaml"},
+					{Kind: "tracker", Issue: 1239, Watchlist: "runtime_operations.runtime_store_backend_default_and_sqlite_portability"},
+				}
+			},
+			want: "bundle_hash_catalog_boot_postgres_only fail-closed row requires at least one go_test proof_ref",
+		},
 	}
 
 	for _, tc := range tests {
@@ -401,6 +412,7 @@ func validatePublicSurfaceRow(root string, row publicSurfaceMatrixRow, ctx publi
 func validatePublicSurfaceProofRefs(root, rowID string, row publicSurfaceMatrixRow, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {
 	var problems []string
 	seenSplitTracker := false
+	seenGoTest := false
 	for _, ref := range row.ProofRefs {
 		kind := strings.TrimSpace(ref.Kind)
 		if _, ok := allowedPublicSurfaceProofKinds()[kind]; !ok {
@@ -409,6 +421,7 @@ func validatePublicSurfaceProofRefs(root, rowID string, row publicSurfaceMatrixR
 		}
 		switch kind {
 		case "go_test":
+			seenGoTest = true
 			if strings.TrimSpace(ref.Name) == "" {
 				problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", rowID))
 				continue
@@ -446,6 +459,9 @@ func validatePublicSurfaceProofRefs(root, rowID string, row publicSurfaceMatrixR
 	}
 	if row.Classification == "split_to_existing_issue" && row.SplitIssue != 0 && !seenSplitTracker {
 		problems = append(problems, fmt.Sprintf("%s split row missing tracker proof_ref for issue #%d", rowID, row.SplitIssue))
+	}
+	if publicSurfaceFailClosedRow(row) && !seenGoTest {
+		problems = append(problems, fmt.Sprintf("%s fail-closed row requires at least one go_test proof_ref", rowID))
 	}
 	return problems
 }
@@ -561,6 +577,10 @@ func publicSurfaceSupported(row publicSurfaceMatrixRow) bool {
 	default:
 		return false
 	}
+}
+
+func publicSurfaceFailClosedRow(row publicSurfaceMatrixRow) bool {
+	return row.Tier == "postgres_only_fail_closed" || publicSurfaceHasValue(row.ProofDimensions, "fail_closed")
 }
 
 func publicSurfaceHasValue(values []string, want string) bool {

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -1,0 +1,644 @@
+package apiv1
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const publicSurfaceBackendMatrixPath = "internal/apiv1/testdata/public_surface_backend_matrix.yaml"
+
+type publicSurfaceBackendMatrix struct {
+	Version        int                       `yaml:"version"`
+	Kind           string                    `yaml:"kind"`
+	Issue          int                       `yaml:"issue"`
+	IssueRole      string                    `yaml:"issue_role"`
+	Source         publicSurfaceMatrixSource `yaml:"source"`
+	Policy         publicSurfaceMatrixPolicy `yaml:"policy"`
+	ActiveTrackers []complianceActiveTracker `yaml:"active_trackers"`
+	Rows           []publicSurfaceMatrixRow  `yaml:"rows"`
+}
+
+type publicSurfaceMatrixSource struct {
+	PlatformSpec          string `yaml:"platform_spec"`
+	OpenRPCArtifact       string `yaml:"openrpc_artifact"`
+	AdjacentOpenRPCMatrix string `yaml:"adjacent_openrpc_matrix"`
+}
+
+type publicSurfaceMatrixPolicy struct {
+	ClosureLevel                string `yaml:"closure_level"`
+	ClaimsParentClosure         bool   `yaml:"claims_parent_closure"`
+	NamedFullConformanceCommand string `yaml:"named_full_conformance_command"`
+	RequiredSmokePolicy         string `yaml:"required_smoke_policy"`
+}
+
+type publicSurfaceMatrixRow struct {
+	ID                   string                  `yaml:"id"`
+	Surface              string                  `yaml:"surface"`
+	Classification       string                  `yaml:"classification"`
+	Tier                 string                  `yaml:"tier"`
+	SplitIssue           int                     `yaml:"split_issue"`
+	Backends             []string                `yaml:"backends"`
+	CLICommands          []string                `yaml:"cli_commands"`
+	APIMethods           []string                `yaml:"api_methods"`
+	OpenRPCMatrixMethods []string                `yaml:"openrpc_matrix_methods"`
+	StoreOwners          []string                `yaml:"store_owners"`
+	ProofDimensions      []string                `yaml:"proof_dimensions"`
+	ProofRefs            []publicSurfaceProofRef `yaml:"proof_refs"`
+	Notes                string                  `yaml:"notes"`
+}
+
+type publicSurfaceProofRef struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name,omitempty"`
+	Path      string `yaml:"path,omitempty"`
+	Issue     int    `yaml:"issue,omitempty"`
+	Watchlist string `yaml:"watchlist,omitempty"`
+	Command   string `yaml:"command,omitempty"`
+}
+
+type publicSurfaceValidationContext struct {
+	apiMethods           map[string]struct{}
+	openRPCMethods       map[string]struct{}
+	openRPCMatrixMethods map[string]struct{}
+	cliCommands          map[string]struct{}
+	goTests              map[string]string
+}
+
+func TestPublicSurfaceBackendMatrixCoversSelectedBackendRows(t *testing.T) {
+	root := repoRoot(t)
+	matrix := loadPublicSurfaceBackendMatrix(t, root)
+	ctx := newPublicSurfaceValidationContext(t, root)
+
+	if problems := validatePublicSurfaceBackendMatrix(root, matrix, ctx); len(problems) > 0 {
+		t.Fatalf("public surface backend matrix validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
+	root := repoRoot(t)
+	ctx := newPublicSurfaceValidationContext(t, root)
+	tests := []struct {
+		name   string
+		mutate func(*publicSurfaceBackendMatrix)
+		want   string
+	}{
+		{
+			name: "stale api method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "entity_read_api")
+				row.APIMethods = []string{"entity.missing"}
+			},
+			want: "entity_read_api api_method entity.missing missing from platform method_catalog",
+		},
+		{
+			name: "stale cli command",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "entity_read_cli")
+				row.CLICommands = []string{"entity_missing"}
+			},
+			want: "entity_read_cli cli_command entity_missing missing from platform cli command_catalog",
+		},
+		{
+			name: "stale go test proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "event_publish_api")
+				row.ProofRefs[0].Name = "TestMissingPublicSurfaceProof"
+			},
+			want: "event_publish_api go_test proof_ref TestMissingPublicSurfaceProof does not resolve",
+		},
+		{
+			name: "status count cannot be marked covered",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "status_run_get_entity_count")
+				row.Classification = "already_covered_by_existing_proof"
+				row.SplitIssue = 0
+			},
+			want: "status_run_get_entity_count must remain split_to_existing_issue with split_issue 1254",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := loadPublicSurfaceBackendMatrix(t, root)
+			tc.mutate(&matrix)
+			problems := validatePublicSurfaceBackendMatrix(root, matrix, ctx)
+			if !publicSurfaceProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadPublicSurfaceBackendMatrix(t *testing.T, root string) publicSurfaceBackendMatrix {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, publicSurfaceBackendMatrixPath))
+	if err != nil {
+		t.Fatalf("read public surface backend matrix: %v", err)
+	}
+	var matrix publicSurfaceBackendMatrix
+	if err := yaml.Unmarshal(raw, &matrix); err != nil {
+		t.Fatalf("parse public surface backend matrix: %v", err)
+	}
+	return matrix
+}
+
+func newPublicSurfaceValidationContext(t *testing.T, root string) publicSurfaceValidationContext {
+	t.Helper()
+	api := loadComplianceAPISpec(t, root)
+	doc, _ := loadComplianceOpenRPC(t, complianceOpenRPCPath(root))
+	openRPCMatrix := loadComplianceMatrix(t, filepath.Join(root, "internal", "apiv1", "testdata", "openrpc_compliance_matrix.yaml"))
+	goTests, err := loadPublicSurfaceGoTests(root)
+	if err != nil {
+		t.Fatalf("load public surface go test symbols: %v", err)
+	}
+
+	apiMethods := map[string]struct{}{}
+	for name := range api.MethodCatalog {
+		apiMethods[name] = struct{}{}
+	}
+	openRPCMethods := map[string]struct{}{}
+	for _, method := range doc.Methods {
+		openRPCMethods[strings.TrimSpace(method.Name)] = struct{}{}
+	}
+	openRPCMatrixMethods := map[string]struct{}{}
+	for _, row := range openRPCMatrix.Methods {
+		openRPCMatrixMethods[strings.TrimSpace(row.Method)] = struct{}{}
+	}
+
+	return publicSurfaceValidationContext{
+		apiMethods:           apiMethods,
+		openRPCMethods:       openRPCMethods,
+		openRPCMatrixMethods: openRPCMatrixMethods,
+		cliCommands:          loadPublicSurfaceCLICommands(t, root),
+		goTests:              goTests,
+	}
+}
+
+func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackendMatrix, ctx publicSurfaceValidationContext) []string {
+	var problems []string
+	if matrix.Version != 1 {
+		problems = append(problems, fmt.Sprintf("matrix version = %d, want 1", matrix.Version))
+	}
+	if matrix.Kind != "public_surface_backend_matrix" {
+		problems = append(problems, fmt.Sprintf("matrix kind = %q, want public_surface_backend_matrix", matrix.Kind))
+	}
+	if matrix.Issue != 1268 {
+		problems = append(problems, fmt.Sprintf("matrix issue = %d, want 1268", matrix.Issue))
+	}
+	if matrix.IssueRole != "canonical_owner" {
+		problems = append(problems, fmt.Sprintf("matrix issue_role = %q, want canonical_owner", matrix.IssueRole))
+	}
+	problems = append(problems, validatePublicSurfaceSources(root, matrix.Source)...)
+	problems = append(problems, validatePublicSurfacePolicy(matrix.Policy)...)
+
+	activeTrackers := map[string]struct{}{}
+	for _, tracker := range matrix.ActiveTrackers {
+		kind := strings.TrimSpace(tracker.Kind)
+		switch kind {
+		case "github_issue":
+			if tracker.Issue == 0 {
+				problems = append(problems, "active github_issue tracker missing issue")
+			}
+		case "watchlist":
+			if tracker.Issue != 0 {
+				problems = append(problems, fmt.Sprintf("watchlist active tracker issue = %d, want 0", tracker.Issue))
+			}
+		default:
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d kind = %q is not allowed", tracker.Issue, tracker.Kind))
+		}
+		if strings.TrimSpace(tracker.Watchlist) == "" {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d missing watchlist", tracker.Issue))
+		}
+		activeTrackers[trackerKey(tracker.Issue, tracker.Watchlist)] = struct{}{}
+	}
+	if _, ok := activeTrackers[trackerKey(1239, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
+		problems = append(problems, "active_trackers missing #1239 runtime_store_backend_default_and_sqlite_portability")
+	}
+	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
+		problems = append(problems, "active_trackers missing #1254 runtime_store_backend_default_and_sqlite_portability")
+	}
+	if _, ok := activeTrackers[trackerKey(0, "operator_surfaces.v1_openrpc_api_conformance")]; !ok {
+		problems = append(problems, "active_trackers missing operator_surfaces.v1_openrpc_api_conformance watchlist")
+	}
+
+	rowsByID := map[string]publicSurfaceMatrixRow{}
+	requiredRows := requiredPublicSurfaceRows()
+	defaultSQLiteSmoke := false
+	explicitPostgresSmoke := false
+	for _, row := range matrix.Rows {
+		id := strings.TrimSpace(row.ID)
+		if id == "" {
+			problems = append(problems, "matrix row missing id")
+			continue
+		}
+		if _, exists := rowsByID[id]; exists {
+			problems = append(problems, fmt.Sprintf("matrix row %s appears more than once", id))
+		}
+		rowsByID[id] = row
+		if row.Tier == "required_smoke" && publicSurfaceHasValue(row.Backends, "default_sqlite") {
+			defaultSQLiteSmoke = true
+		}
+		if row.Tier == "required_smoke" && publicSurfaceHasValue(row.Backends, "explicit_postgres") {
+			explicitPostgresSmoke = true
+		}
+		problems = append(problems, validatePublicSurfaceRow(root, row, ctx, activeTrackers)...)
+	}
+	for rowID := range requiredRows {
+		if _, ok := rowsByID[rowID]; !ok {
+			problems = append(problems, fmt.Sprintf("matrix missing required row %s", rowID))
+		}
+	}
+	if !defaultSQLiteSmoke {
+		problems = append(problems, "matrix missing required_smoke default_sqlite row")
+	}
+	if !explicitPostgresSmoke {
+		problems = append(problems, "matrix missing required_smoke explicit_postgres row")
+	}
+	if row, ok := rowsByID["status_run_get_entity_count"]; ok {
+		if row.Classification != "split_to_existing_issue" || row.SplitIssue != 1254 || row.Tier != "split_open" {
+			problems = append(problems, "status_run_get_entity_count must remain split_to_existing_issue with split_issue 1254 and tier split_open")
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validatePublicSurfaceSources(root string, source publicSurfaceMatrixSource) []string {
+	var problems []string
+	expected := map[string]string{
+		"platform_spec":           "platform-spec.yaml",
+		"openrpc_artifact":        "openrpc.json",
+		"adjacent_openrpc_matrix": "internal/apiv1/testdata/openrpc_compliance_matrix.yaml",
+	}
+	actual := map[string]string{
+		"platform_spec":           source.PlatformSpec,
+		"openrpc_artifact":        source.OpenRPCArtifact,
+		"adjacent_openrpc_matrix": source.AdjacentOpenRPCMatrix,
+	}
+	for field, want := range expected {
+		got := strings.TrimSpace(actual[field])
+		if got != want {
+			problems = append(problems, fmt.Sprintf("source %s = %q, want %q", field, got, want))
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, filepath.Clean(got))); err != nil {
+			problems = append(problems, fmt.Sprintf("source %s path %s does not exist", field, got))
+		}
+	}
+	return problems
+}
+
+func validatePublicSurfacePolicy(policy publicSurfaceMatrixPolicy) []string {
+	var problems []string
+	if policy.ClosureLevel != "matrix_owner_first_slice_complete" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want matrix_owner_first_slice_complete", policy.ClosureLevel))
+	}
+	if policy.ClaimsParentClosure {
+		problems = append(problems, "policy claims_parent_closure = true, want false")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(policy.NamedFullConformanceCommand), "go test ./internal/runtime/cataloge2e") {
+		problems = append(problems, fmt.Sprintf("policy named_full_conformance_command = %q, want cataloge2e go test command", policy.NamedFullConformanceCommand))
+	}
+	if strings.TrimSpace(policy.RequiredSmokePolicy) == "" {
+		problems = append(problems, "policy required_smoke_policy missing")
+	}
+	return problems
+}
+
+func validatePublicSurfaceRow(root string, row publicSurfaceMatrixRow, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {
+	var problems []string
+	id := strings.TrimSpace(row.ID)
+	if strings.TrimSpace(row.Surface) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing surface", id))
+	}
+	if _, ok := allowedPublicSurfaceClassifications()[row.Classification]; !ok {
+		problems = append(problems, fmt.Sprintf("%s classification %q is not allowed", id, row.Classification))
+	}
+	if _, ok := allowedPublicSurfaceTiers()[row.Tier]; !ok {
+		problems = append(problems, fmt.Sprintf("%s tier %q is not allowed", id, row.Tier))
+	}
+	if len(row.Backends) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing backends", id))
+	}
+	for _, backend := range row.Backends {
+		if _, ok := allowedPublicSurfaceBackends()[backend]; !ok {
+			problems = append(problems, fmt.Sprintf("%s backend %q is not allowed", id, backend))
+		}
+	}
+	for _, dimension := range row.ProofDimensions {
+		if _, ok := allowedPublicSurfaceProofDimensions()[dimension]; !ok {
+			problems = append(problems, fmt.Sprintf("%s proof_dimension %q is not allowed", id, dimension))
+		}
+	}
+	if len(row.StoreOwners) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing store_owners", id))
+	}
+	if len(row.ProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing proof_refs", id))
+	}
+
+	for _, method := range row.APIMethods {
+		method = strings.TrimSpace(method)
+		if _, ok := ctx.apiMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s api_method %s missing from platform method_catalog", id, method))
+		}
+		if _, ok := ctx.openRPCMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s api_method %s missing from generated openrpc.json", id, method))
+		}
+	}
+	for _, method := range row.OpenRPCMatrixMethods {
+		method = strings.TrimSpace(method)
+		if _, ok := ctx.openRPCMatrixMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s openrpc_matrix_method %s missing from adjacent OpenRPC matrix", id, method))
+		}
+	}
+	for _, command := range row.CLICommands {
+		command = strings.TrimSpace(command)
+		if _, ok := ctx.cliCommands[command]; !ok {
+			problems = append(problems, fmt.Sprintf("%s cli_command %s missing from platform cli command_catalog", id, command))
+		}
+	}
+
+	if publicSurfaceSupported(row) && len(row.APIMethods) > 0 {
+		if !publicSurfaceHasValue(row.ProofDimensions, "real_v1_handler") {
+			problems = append(problems, fmt.Sprintf("%s supported api row missing real_v1_handler proof_dimension", id))
+		}
+		if !publicSurfaceHasValue(row.ProofDimensions, "openrpc_publication") {
+			problems = append(problems, fmt.Sprintf("%s supported api row missing openrpc_publication proof_dimension", id))
+		}
+	}
+	if publicSurfaceSupported(row) && len(row.CLICommands) > 0 {
+		if !publicSurfaceHasValue(row.ProofDimensions, "cli_v1_path") && !publicSurfaceHasValue(row.ProofDimensions, "real_runtime_startup") {
+			problems = append(problems, fmt.Sprintf("%s supported cli row missing cli_v1_path or real_runtime_startup proof_dimension", id))
+		}
+	}
+	if publicSurfaceSupported(row) && (publicSurfaceHasValue(row.Backends, "default_sqlite") || publicSurfaceHasValue(row.Backends, "explicit_postgres")) {
+		if !publicSurfaceHasValue(row.ProofDimensions, "selected_store") && !publicSurfaceHasValue(row.ProofDimensions, "backend_selection") {
+			problems = append(problems, fmt.Sprintf("%s selected-backend row missing selected_store or backend_selection proof_dimension", id))
+		}
+	}
+	if row.Classification == "split_to_existing_issue" {
+		if row.SplitIssue == 0 {
+			problems = append(problems, fmt.Sprintf("%s split row missing split_issue", id))
+		}
+		if !publicSurfaceHasValue(row.ProofDimensions, "split_tracker") {
+			problems = append(problems, fmt.Sprintf("%s split row missing split_tracker proof_dimension", id))
+		}
+	}
+	problems = append(problems, validatePublicSurfaceProofRefs(root, id, row, ctx, activeTrackers)...)
+	return problems
+}
+
+func validatePublicSurfaceProofRefs(root, rowID string, row publicSurfaceMatrixRow, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {
+	var problems []string
+	seenSplitTracker := false
+	for _, ref := range row.ProofRefs {
+		kind := strings.TrimSpace(ref.Kind)
+		if _, ok := allowedPublicSurfaceProofKinds()[kind]; !ok {
+			problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", rowID, kind))
+			continue
+		}
+		switch kind {
+		case "go_test":
+			if strings.TrimSpace(ref.Name) == "" {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", rowID))
+				continue
+			}
+			if _, ok := ctx.goTests[ref.Name]; !ok {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref %s does not resolve", rowID, ref.Name))
+			}
+		case "artifact":
+			if strings.TrimSpace(ref.Path) == "" {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref missing path", rowID))
+				continue
+			}
+			if filepath.IsAbs(ref.Path) || strings.HasPrefix(filepath.Clean(ref.Path), "..") {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s must be repo-relative", rowID, ref.Path))
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.Clean(ref.Path))); err != nil {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s does not exist", rowID, ref.Path))
+			}
+		case "tracker":
+			if ref.Issue == 0 {
+				problems = append(problems, fmt.Sprintf("%s tracker proof_ref missing issue", rowID))
+			}
+			if _, ok := activeTrackers[trackerKey(ref.Issue, ref.Watchlist)]; !ok {
+				problems = append(problems, fmt.Sprintf("%s tracker proof_ref issue #%d watchlist %q is not in active_trackers", rowID, ref.Issue, ref.Watchlist))
+			}
+			if ref.Issue == row.SplitIssue {
+				seenSplitTracker = true
+			}
+		case "manual_command":
+			if !strings.HasPrefix(strings.TrimSpace(ref.Command), "go test ") {
+				problems = append(problems, fmt.Sprintf("%s manual_command proof_ref command = %q, want go test command", rowID, ref.Command))
+			}
+		}
+	}
+	if row.Classification == "split_to_existing_issue" && row.SplitIssue != 0 && !seenSplitTracker {
+		problems = append(problems, fmt.Sprintf("%s split row missing tracker proof_ref for issue #%d", rowID, row.SplitIssue))
+	}
+	return problems
+}
+
+func loadPublicSurfaceCLICommands(t *testing.T, root string) map[string]struct{} {
+	t.Helper()
+	raw, err := os.ReadFile(compliancePlatformSpecPath(root))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse platform spec yaml: %v", err)
+	}
+	rootNode := yamlDocumentRoot(&doc)
+	commandCatalog := yamlMappingValue(yamlMappingValue(rootNode, "cli_specification"), "command_catalog")
+	if commandCatalog == nil || commandCatalog.Kind != yaml.MappingNode {
+		t.Fatal("platform spec cli_specification.command_catalog missing")
+	}
+	out := map[string]struct{}{}
+	for i := 0; i+1 < len(commandCatalog.Content); i += 2 {
+		out[commandCatalog.Content[i].Value] = struct{}{}
+	}
+	return out
+}
+
+func loadPublicSurfaceGoTests(root string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".swarm", "node_modules", "vendor":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fileSet := token.NewFileSet()
+		parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil {
+				continue
+			}
+			if name := fn.Name.Name; strings.HasPrefix(name, "Test") {
+				out[name] = rel
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func yamlDocumentRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func publicSurfaceMatrixRowByID(t *testing.T, matrix *publicSurfaceBackendMatrix, id string) *publicSurfaceMatrixRow {
+	t.Helper()
+	for i := range matrix.Rows {
+		if matrix.Rows[i].ID == id {
+			return &matrix.Rows[i]
+		}
+	}
+	t.Fatalf("matrix row %s not found", id)
+	return nil
+}
+
+func publicSurfaceProblemsContain(problems []string, want string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func publicSurfaceSupported(row publicSurfaceMatrixRow) bool {
+	switch row.Classification {
+	case "add_to_matrix", "already_covered_by_existing_proof":
+		return true
+	default:
+		return false
+	}
+}
+
+func publicSurfaceHasValue(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func requiredPublicSurfaceRows() map[string]struct{} {
+	return complianceStringSet([]string{
+		"serve_contracts_default_sqlite",
+		"serve_contracts_explicit_postgres",
+		"run_contracts_default_sqlite",
+		"run_contracts_explicit_postgres",
+		"entity_read_api",
+		"entity_read_cli",
+		"status_run_get_entity_count",
+		"event_publish_api",
+		"event_publish_cli",
+		"mailbox_read_api_after_mailbox_write",
+		"mailbox_read_cli",
+		"serve_dev_abandon_active_runs",
+		"handler_create_entity_exact_once",
+		"remaining_openrpc_selected_backend_tail",
+		"bundle_hash_catalog_boot_postgres_only",
+	})
+}
+
+func allowedPublicSurfaceClassifications() map[string]struct{} {
+	return complianceStringSet([]string{
+		"add_to_matrix",
+		"already_covered_by_existing_proof",
+		"split_to_existing_issue",
+		"different_semantic_concept_with_proof",
+	})
+}
+
+func allowedPublicSurfaceTiers() map[string]struct{} {
+	return complianceStringSet([]string{
+		"required_smoke",
+		"full_conformance",
+		"split_open",
+		"future_parent_tail",
+		"postgres_only_fail_closed",
+	})
+}
+
+func allowedPublicSurfaceBackends() map[string]struct{} {
+	return complianceStringSet([]string{
+		"default_sqlite",
+		"explicit_postgres",
+		"postgres_only",
+	})
+}
+
+func allowedPublicSurfaceProofDimensions() map[string]struct{} {
+	return complianceStringSet([]string{
+		"backend_selection",
+		"canonical_store_owner",
+		"cli_v1_path",
+		"fail_closed",
+		"full_conformance",
+		"openrpc_publication",
+		"real_runtime_startup",
+		"real_v1_handler",
+		"selected_store",
+		"split_tracker",
+	})
+}
+
+func allowedPublicSurfaceProofKinds() map[string]struct{} {
+	return complianceStringSet([]string{
+		"artifact",
+		"go_test",
+		"manual_command",
+		"tracker",
+	})
+}

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -1,0 +1,343 @@
+version: 1
+kind: public_surface_backend_matrix
+issue: 1268
+issue_role: canonical_owner
+source:
+  platform_spec: platform-spec.yaml
+  openrpc_artifact: openrpc.json
+  adjacent_openrpc_matrix: internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+policy:
+  closure_level: matrix_owner_first_slice_complete
+  claims_parent_closure: false
+  named_full_conformance_command: go test ./internal/runtime/cataloge2e -count=1
+  required_smoke_policy: >
+    Required PR smoke is row/accounting validation plus the smallest selected-backend
+    proof refs needed for launch-critical SQLite-default and explicit-Postgres
+    public surfaces. The matrix composes existing selected-store, real v1 handler,
+    and CLI exact-method proofs instead of expanding every surface into a backend
+    Cartesian product.
+active_trackers:
+  - kind: github_issue
+    issue: 1239
+    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+  - kind: github_issue
+    issue: 1254
+    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+  - kind: watchlist
+    issue: 0
+    watchlist: operator_surfaces.v1_openrpc_api_conformance
+rows:
+  - id: serve_contracts_default_sqlite
+    surface: default SQLite swarm serve --contracts readiness and API availability
+    classification: add_to_matrix
+    tier: required_smoke
+    backends: [default_sqlite]
+    cli_commands: [serve]
+    store_owners:
+      - internal/store/backendselection
+      - cmd/swarm buildStores
+      - cmd/swarm runServeRuntime
+    proof_dimensions: [backend_selection, selected_store, real_runtime_startup]
+    proof_refs:
+      - kind: go_test
+        name: TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptySQLiteBootsWithDirectAbandon
+      - kind: go_test
+        name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore
+    notes: >
+      Existing proof establishes no-selector/default SQLite selected-store startup
+      through serve-owned runtime construction. This row is required smoke/accounting,
+      not a request for a wider serve behavior repair.
+
+  - id: serve_contracts_explicit_postgres
+    surface: explicit Postgres swarm serve --contracts readiness and API availability
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [explicit_postgres]
+    cli_commands: [serve]
+    store_owners:
+      - internal/store/backendselection
+      - cmd/swarm buildStores
+      - cmd/swarm runServeRuntime
+    proof_dimensions: [backend_selection, selected_store, real_runtime_startup]
+    proof_refs:
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe
+
+  - id: run_contracts_default_sqlite
+    surface: default SQLite swarm run --contracts no-service path
+    classification: add_to_matrix
+    tier: required_smoke
+    backends: [default_sqlite]
+    cli_commands: [run]
+    api_methods: [health.check, run.start, run.get]
+    openrpc_matrix_methods: [health.check, run.start, run.get]
+    store_owners:
+      - cmd/swarm run command local serve owner
+      - internal/store/backendselection
+      - /v1/rpc health.check
+      - /v1/rpc run.start
+      - /v1/rpc run.get
+    proof_dimensions: [backend_selection, selected_store, real_v1_handler, cli_v1_path, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestRunCommandLocalForegroundConsumesServeOwnerAndV1API
+      - kind: go_test
+        name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore
+    notes: >
+      The row composes run-command local foreground proof with selected SQLite
+      store construction proof. It intentionally avoids adding a long external
+      process run smoke to every PR.
+
+  - id: run_contracts_explicit_postgres
+    surface: explicit Postgres counterpart for swarm run --contracts
+    classification: add_to_matrix
+    tier: full_conformance
+    backends: [explicit_postgres]
+    cli_commands: [run]
+    api_methods: [health.check, run.start, run.get]
+    openrpc_matrix_methods: [health.check, run.start, run.get]
+    store_owners:
+      - cmd/swarm run command local serve owner
+      - internal/store/backendselection
+      - /v1/rpc health.check
+      - /v1/rpc run.start
+      - /v1/rpc run.get
+    proof_dimensions: [backend_selection, selected_store, real_v1_handler, cli_v1_path, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestRunCommandLocalForegroundConsumesServeOwnerAndV1API
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe
+      - kind: tracker
+        issue: 1239
+        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+    notes: >
+      This row records the explicit-Postgres counterpart without making Postgres
+      startup a required Cartesian duplicate of every fast SQLite run row.
+
+  - id: entity_read_api
+    surface: /v1/rpc entity.list, entity.get, and entity.aggregate over selected stores
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    api_methods: [entity.list, entity.get, entity.aggregate]
+    openrpc_matrix_methods: [entity.list, entity.get, entity.aggregate]
+    store_owners:
+      - apiv1.EntityReadStore
+      - schema_storage.entity_state
+      - platform-spec.yaml entity_registry_policy
+    proof_dimensions: [selected_store, real_v1_handler, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite
+      - kind: go_test
+        name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres
+      - kind: go_test
+        name: TestOperatorEntityHandlersExposeEntityNativeReads
+
+  - id: entity_read_cli
+    surface: swarm entities list, swarm entity view, and swarm entity aggregate
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [entities_list, entity_view, entity_aggregate]
+    api_methods: [entity.list, entity.get, entity.aggregate]
+    openrpc_matrix_methods: [entity.list, entity.get, entity.aggregate]
+    store_owners:
+      - cmd/swarm entity CLI commands
+      - apiv1.EntityReadStore
+      - schema_storage.entity_state
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API
+      - kind: go_test
+        name: TestEntitiesListUsesEntityListV1RPCWithFilters
+      - kind: go_test
+        name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres
+    notes: >
+      The Postgres side is accounted for through the API selected-store row and
+      the CLI exact-method row. The fast tier must not duplicate every CLI
+      command across both backends.
+
+  - id: status_run_get_entity_count
+    surface: swarm status and /v1/rpc run.get entity_count correctness
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1254
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [status]
+    api_methods: [run.get]
+    openrpc_matrix_methods: [run.get]
+    store_owners:
+      - apiv1.RunReadStore
+      - RunHeader.entity_count
+      - run lifecycle count owners
+    proof_dimensions: [split_tracker, openrpc_publication, cli_v1_path]
+    proof_refs:
+      - kind: go_test
+        name: TestStatusUsesDiagnoseAndRunGet
+      - kind: tracker
+        issue: 1254
+        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+    notes: >
+      This row must remain split/open until #1254 repairs the run-header/status
+      entity-count owner. CLI path proof alone is not selected-backend count
+      correctness proof.
+
+  - id: event_publish_api
+    surface: /v1/rpc event.publish creating work against SQLite and Postgres
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    api_methods: [event.publish]
+    openrpc_matrix_methods: [event.publish]
+    store_owners:
+      - OperatorEventPublishHandlers
+      - runtimebus.EventStore
+      - internal/store API idempotency persistence
+    proof_dimensions: [selected_store, real_v1_handler, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
+      - kind: go_test
+        name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+
+  - id: event_publish_cli
+    surface: swarm event publish
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [event_publish]
+    api_methods: [event.publish]
+    openrpc_matrix_methods: [event.publish]
+    store_owners:
+      - cmd/swarm event publish CLI
+      - /v1/rpc event.publish
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestEventPublishUsesEventPublishV1RPCWithBoundParams
+      - kind: go_test
+        name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
+      - kind: go_test
+        name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+
+  - id: mailbox_read_api_after_mailbox_write
+    surface: mailbox.list and mailbox.get after handler-level mailbox_write on selected stores
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    api_methods: [mailbox.list, mailbox.get]
+    openrpc_matrix_methods: [mailbox.list, mailbox.get]
+    store_owners:
+      - runtimepipeline.MailboxWriteMaterializationStore
+      - apiv1.MailboxAPIStore
+    proof_dimensions: [selected_store, real_v1_handler, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends
+
+  - id: mailbox_read_cli
+    surface: swarm mailbox list and swarm mailbox view
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [mailbox_list, mailbox_view]
+    api_methods: [mailbox.list, mailbox.get]
+    openrpc_matrix_methods: [mailbox.list, mailbox.get]
+    store_owners:
+      - cmd/swarm mailbox CLI commands
+      - apiv1.MailboxAPIStore
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestMailboxListSendsV1RPCRequestAndRendersResult
+      - kind: go_test
+        name: TestMailboxViewSendsV1RPCRequestAndRendersDetail
+      - kind: go_test
+        name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends
+
+  - id: serve_dev_abandon_active_runs
+    surface: swarm serve --dev and --abandon-active-runs selected-store quiescence
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [serve]
+    store_owners:
+      - runtimerunquiescence.ServeAbandonStore
+      - SQLiteRuntimeStore.ApplyServeAbandonActiveRunQuiescence
+      - PostgresStore.ApplyServeAbandonActiveRunQuiescence
+    proof_dimensions: [selected_store, canonical_store_owner, real_runtime_startup]
+    proof_refs:
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptySQLiteBootsWithDevAbandon
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptySQLiteBootsWithDirectAbandon
+      - kind: go_test
+        name: TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon
+
+  - id: handler_create_entity_exact_once
+    surface: create-entity handler effect exact-once and mutation-log cardinality after #1253
+    classification: already_covered_by_existing_proof
+    tier: full_conformance
+    backends: [default_sqlite, explicit_postgres]
+    store_owners:
+      - WorkflowInstanceStore
+      - SystemNodeProcessed receipt owner
+      - mutation_log
+    proof_dimensions: [selected_store, canonical_store_owner, full_conformance]
+    proof_refs:
+      - kind: go_test
+        name: TestCatalogCreateEntityHandlerEffectCardinality
+      - kind: manual_command
+        command: go test ./internal/runtime/cataloge2e -count=1
+    notes: >
+      This is a semantic correctness/full conformance row, not a basic API or
+      CLI registration row.
+
+  - id: remaining_openrpc_selected_backend_tail
+    surface: remaining supported OpenRPC methods without selected-backend public-surface classification
+    classification: split_to_existing_issue
+    tier: future_parent_tail
+    split_issue: 1239
+    backends: [default_sqlite, explicit_postgres]
+    store_owners:
+      - internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+      - future selected-backend public-surface rows
+    proof_dimensions: [split_tracker, openrpc_publication]
+    proof_refs:
+      - kind: artifact
+        path: internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+      - kind: tracker
+        issue: 1239
+        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+    notes: >
+      The existing OpenRPC matrix remains authoritative for method publication,
+      schema, and transport proof. Backend support for every method remains a
+      parent-tail classification task, not first-slice behavior repair.
+
+  - id: bundle_hash_catalog_boot_postgres_only
+    surface: DB-loaded swarm serve --bundle-hash catalog boot
+    classification: different_semantic_concept_with_proof
+    tier: postgres_only_fail_closed
+    backends: [postgres_only]
+    cli_commands: [serve]
+    store_owners:
+      - platform-spec.yaml runtime_store_backend_selection
+      - Postgres bundle catalog boot owner
+    proof_dimensions: [backend_selection, fail_closed, split_tracker]
+    proof_refs:
+      - kind: artifact
+        path: platform-spec.yaml
+      - kind: tracker
+        issue: 1239
+        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+    notes: >
+      SQLite local/dev runtime support does not promote DB-loaded persisted
+      bundle catalog boot. That remains an intentional Postgres-only split until
+      separately gated.

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -285,20 +285,22 @@ rows:
     surface: create-entity handler effect exact-once and mutation-log cardinality after #1253
     classification: already_covered_by_existing_proof
     tier: full_conformance
-    backends: [default_sqlite, explicit_postgres]
+    backends: [postgres_only]
     store_owners:
       - WorkflowInstanceStore
       - SystemNodeProcessed receipt owner
       - mutation_log
-    proof_dimensions: [selected_store, canonical_store_owner, full_conformance]
+    proof_dimensions: [canonical_store_owner, full_conformance]
     proof_refs:
       - kind: go_test
         name: TestCatalogCreateEntityHandlerEffectCardinality
       - kind: manual_command
         command: go test ./internal/runtime/cataloge2e -count=1
     notes: >
-      This is a semantic correctness/full conformance row, not a basic API or
-      CLI registration row.
+      This is a Postgres-only semantic correctness/full conformance row, not a
+      basic API or CLI registration row. It must not be used as SQLite
+      conformance proof unless a SQLite catalog E2E harness is added under a
+      separate gate.
 
   - id: remaining_openrpc_selected_backend_tail
     surface: remaining supported OpenRPC methods without selected-backend public-surface classification

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -334,6 +334,8 @@ rows:
       - Postgres bundle catalog boot owner
     proof_dimensions: [backend_selection, fail_closed, split_tracker]
     proof_refs:
+      - kind: go_test
+        name: TestCLI_ServeBundleHashValidationAndSerialScope
       - kind: artifact
         path: platform-spec.yaml
       - kind: tracker
@@ -341,5 +343,7 @@ rows:
         watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
     notes: >
       SQLite local/dev runtime support does not promote DB-loaded persisted
-      bundle catalog boot. That remains an intentional Postgres-only split until
-      separately gated.
+      bundle catalog boot. The executable proof covers `serve --bundle-hash ...
+      --store sqlite` failing with the typed `--bundle-hash requires --store
+      postgres` diagnostic. SQLite DB-loaded bundle boot remains an intentional
+      Postgres-only split until separately gated.


### PR DESCRIPTION
## Summary
- Add `internal/apiv1/testdata/public_surface_backend_matrix.yaml` as the canonical public-surface backend conformance/accounting matrix for the #1268 first slice.
- Add a fast validator that resolves row references against `platform-spec.yaml`, root `openrpc.json`, the adjacent OpenRPC compliance matrix, repo test symbols, artifacts, and active tracker refs.
- Keep #1239 parent parity and #1254 `status` / `run.get` `entity_count` split open; no runtime/API/CLI behavior changes.

Closes #1268
Part of #1239
Related to #1254

## Governing Refs / Context
- `platform-spec.yaml#runtime_store_backend_selection`
- `platform-spec.yaml#runtime_core_persistence_store_contracts` / `selected_contracts`
- `platform-spec.yaml#schema_storage.entity_state`
- `platform-spec.yaml#entity_registry_policy`
- `platform-spec.yaml#cli_specification.command_catalog`
- `platform-spec.yaml#api_specification.method_catalog`
- root `openrpc.json`
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`
- #1268 Pre-Implementation Coverage Audit and independent gate outcome: `approved as first slice`

## Semantic Migration / Accounting Owner
- New canonical owner: `internal/apiv1/testdata/public_surface_backend_matrix.yaml`, consumed by `internal/apiv1/public_surface_backend_matrix_test.go`.
- Old proof paths now non-authoritative by themselves for selected-backend public-surface closure: store-only tests, fake API tests, CLI fake-server tests, OpenRPC-only publication/schema proof, and Postgres-only runtime tests used as implied SQLite proof.
- Checked production proof paths through matrix refs for selected backend rows, real v1 handler/API rows, CLI-to-v1 rows, OpenRPC publication, and split trackers.
- Migration is complete for `matrix_owner_first_slice_complete`; it does not close #1239 and does not repair #1254.

## Tests
- `go test ./internal/apiv1 -run 'TestPublicSurfaceBackendMatrix|TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod' -count=1`
- `go test ./internal/apiv1 -run 'TestOperator(EntityHandlers(ServeContractEntityTypesFrom(SQLite|Postgres)|ExposeEntityNativeReads)|MailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends|EventPublish(SQLiteIdempotentFirstEventPublishesWithoutLock|HandlersPersistEventReportDeliveriesAndReplayIdempotency))' -count=1`
- `go test ./cmd/swarm -run 'Test(RunServeRuntime(FreshEmptySQLiteBootsWithDirectAbandon|FreshEmptySQLiteBootsWithDevAbandon|FreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe|FreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon|HostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow|SQLiteAbandonActiveRunsQuiescesBeforeReadiness)|RunCommandLocalForegroundConsumesServeOwnerAndV1API|BuildStoresAcceptsSQLiteSelectedCoreRuntimeStore|EventPublishUsesEventPublishV1RPCWithBoundParams|Mailbox(ListSendsV1RPCRequestAndRendersResult|ViewSendsV1RPCRequestAndRendersDetail)|EntityCommandsUseSQLiteEntityReadStoreThroughV1API|EntitiesListUsesEntityListV1RPCWithFilters|StatusUsesDiagnoseAndRunGet)' -count=1`
- `go test ./internal/runtime/cataloge2e -run '^TestCatalogCreateEntityHandlerEffectCardinality$' -count=1`
- `go test ./cmd/swarm -run '^TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity$' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./cmd/swarm`
- `go test ./...`