### PR TITLE
[agent-a][issue #1241] Route root node deliveries from route table

### DIFF
--- a/internal/runtime/bus/committed_replay_scope.go
+++ b/internal/runtime/bus/committed_replay_scope.go
@@ -43,9 +43,8 @@ func (eb *EventBus) replayRecipientsForCommittedEvent(
 	persisted = uniqueStrings(persisted)
 	persistedRoutes := eb.deliveryRoutesForEvent(ctx, evt.ID)
 	if scope == runtimereplayclaim.CommittedReplayScopeDirect && len(persistedRoutes) > 0 {
-		live := deliveryRouteRecipientIDs(persistedRoutes)
 		internal := []string(nil)
-		live = deliveryRouteRecipientIDsByType(persistedRoutes, "agent")
+		live := deliveryRouteRecipientIDsByType(persistedRoutes, "agent")
 		if len(live) > 0 {
 			return live, internal, persistedRoutes, nil
 		}
@@ -56,20 +55,14 @@ func (eb *EventBus) replayRecipientsForCommittedEvent(
 			return nil, nil, nil, err
 		}
 		live := uniqueStrings(append(deliveryRouteRecipientIDsByType(persistedRoutes, "agent"), internal...))
-		if len(live) == 0 {
-			live = deliveryRouteRecipientIDs(persistedRoutes)
-			internal = deliveryRouteRecipientIDsByType(persistedRoutes, "node")
-		}
-		if len(live) > 0 {
-			routes := append([]events.DeliveryRoute(nil), persistedRoutes...)
-			for _, recipient := range internal {
-				if hasDeliveryRouteRecipient(routes, "node", recipient) {
-					continue
-				}
-				routes = append(routes, events.DeliveryRoute{SubscriberType: "node", SubscriberID: recipient})
+		routes := append([]events.DeliveryRoute(nil), persistedRoutes...)
+		for _, recipient := range internal {
+			if hasDeliveryRouteRecipient(routes, "node", recipient) {
+				continue
 			}
-			return live, internal, events.NormalizeDeliveryRoutes(routes), nil
+			routes = append(routes, events.DeliveryRoute{SubscriberType: "node", SubscriberID: recipient})
 		}
+		return live, internal, events.NormalizeDeliveryRoutes(routes), nil
 	}
 	switch scope {
 	case runtimereplayclaim.CommittedReplayScopeDirect:

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -109,7 +109,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.PersistedRecipients = manifest.PersistedRecipients
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
@@ -403,7 +403,7 @@ func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscri
 	return events.NormalizeDeliveryRoutes(out)
 }
 
-func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
@@ -412,10 +412,6 @@ func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Sub
 	}
 	rootNodeIDs := routedRootNodeSubscriberIDsForNoTargetEvent(evt, routed)
 	if len(rootNodeIDs) == 0 {
-		return nil
-	}
-	internalRecipients := filterOutAgentIDs(recipients, persisted)
-	if len(internalRecipients) == 0 {
 		return nil
 	}
 	out := make([]events.DeliveryRoute, 0, len(rootNodeIDs))
@@ -447,7 +443,7 @@ func routedRootNodeSubscriberIDsForNoTargetEvent(evt events.Event, routed []Subs
 }
 
 func routedRootNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber) bool {
-	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) != "node" {
 		return false
 	}
 	if strings.Trim(strings.TrimSpace(subscriber.Path), "/") != "" {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -380,7 +380,7 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 				}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
-				return []deliveryRecipientCandidate{{ID: "portfolio-node", PersistAsDelivery: false}}
+				return nil
 			},
 			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
 				return nil
@@ -399,8 +399,8 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
-	if got := plan.Recipients; len(got) != 1 || got[0] != "portfolio-node" {
-		t.Fatalf("recipients = %#v, want [portfolio-node]", got)
+	if got := plan.Recipients; len(got) != 0 {
+		t.Fatalf("recipients = %#v, want none without an internal carrier", got)
 	}
 	if len(plan.PersistedRecipients) != 0 {
 		t.Fatalf("persisted recipients = %#v, want none for internal node", plan.PersistedRecipients)

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -281,6 +281,22 @@ func TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInter
 	if got := store.scopes[evt.ID]; got != replayclaim.CommittedReplayScopeSubscribed {
 		t.Fatalf("committed replay scope = %q, want subscribed", got)
 	}
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, replayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("replay live recipients = %#v, want none without an internal carrier", live)
+	}
+	if len(internal) != 0 {
+		t.Fatalf("replay internal recipients = %#v, want none without an internal carrier", internal)
+	}
+	if len(replayRoutes) != 1 || replayRoutes[0].SubscriberType != "node" || replayRoutes[0].SubscriberID != "portfolio-node" {
+		t.Fatalf("replay routes = %#v, want retained semantic node/portfolio-node evidence", replayRoutes)
+	}
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients without internal carrier: %v", err)
+	}
 }
 
 func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntityIDs ...string) {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -250,6 +250,39 @@ func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 	}
 }
 
+func TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInternalSubscription(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	source := semanticview.Wrap(loadTargetRouteTempBundle(t, routedRootNodeFixtureFiles()))
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("opco.spinup_requested"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-root")
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want one semantic root node route without an internal subscription", routes)
+	}
+	route := routes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "portfolio-node" {
+		t.Fatalf("delivery route = %#v, want node/portfolio-node", route)
+	}
+	if !route.Target.Empty() {
+		t.Fatalf("delivery target = %#v, want empty root target", route.Target)
+	}
+	if got := store.scopes[evt.ID]; got != replayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+}
+
 func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntityIDs ...string) {
 	t.Helper()
 	seen := map[string]struct{}{}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -125,6 +125,27 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 	if err := bus.Publish(ctx, spinup); err != nil {
 		t.Fatalf("Publish spinup: %v", err)
 	}
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node' AND outcome = 'no_op'
+	`, 1, spinup.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node'
+	`, 1, spinup.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node'
+		  AND delivered_at IS NOT NULL AND created_at < delivered_at
+	`, 1, spinup.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, spinup.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, spinup.ID)
 	autoEventID := waitRuntimeEventID(t, ctx, db, `
 		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
@@ -145,6 +166,117 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
 	`, 0, autoEventID)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM events
+		WHERE event_name = 'operating/component_scaffold.spawn_requested'
+	`, 1)
+}
+
+func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireOutboxFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	var pc *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:            module,
+		InstanceActivator: manager.ActivateFlowInstance,
+		WorkflowStore:     workflowStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+
+	mailbox := (events.Event{
+		ID:        "99999999-9999-4999-8999-999999999913",
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("mailbox.item_decided"),
+		Payload:   []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("22222222-2222-4222-8222-222222222222")
+	if err := bus.Publish(ctx, mailbox); err != nil {
+		t.Fatalf("Publish mailbox: %v", err)
+	}
+
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'approval-router' AND outcome = 'no_op'
+	`, 1, mailbox.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'approval-router'
+	`, 1, mailbox.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'approval-router'
+		  AND delivered_at IS NOT NULL AND created_at < delivered_at
+	`, 1, mailbox.ID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, mailbox.ID)
+
+	spinupEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'opco.spinup_requested'
+	`, nil)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node' AND outcome = 'no_op'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node'
+		  AND delivered_at IS NOT NULL AND created_at < delivered_at
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, spinupEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, spinupEventID)
+
+	autoEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
+	`, nil)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 1, autoEventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
+	`, 1, autoEventID)
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM events
 		WHERE event_name = 'operating/component_scaffold.spawn_requested'


### PR DESCRIPTION
Closes #1241

## Summary

This PR closes the reopened approved first-slice class `runtime.root_no_target_routed_system_node_delivery_planning`.

Root no-target events that resolve through the route table to root system-node subscribers now produce semantic `node/<id>` delivery routes without requiring a pre-seeded in-memory internal subscription carrier. Replay-scope evidence remains separate.

## Governing Refs

- `platform-spec.yaml#engine.events.routing_derivation`
- `platform-spec.yaml#engine.events.routing_derivation.delivery_rules`
- `platform-spec.yaml#engine.event_identity_resolution.resolution_rules.root_events_are_global`
- `platform-spec.yaml#engine.event_identity_resolution.resolution_rules.handler_lookup_localizes`
- Pre-audit: https://github.com/division-sh/swarm/issues/1241#issuecomment-4596928594
- Gate: https://github.com/division-sh/swarm/issues/1241#issuecomment-4596976877
- Reopen evidence: https://github.com/division-sh/swarm/issues/1241#issuecomment-4598166270

No `platform-spec.yaml` update is included because this PR implements existing authoritative spec semantics: root events are global and node subscribers are authoritative routing/delivery consumers.

## Semantic Migration

- New canonical behavior: `internal/runtime/bus/delivery_planner.go` consumes route-table `Type=node`, root-path subscribers directly for root no-target events when producing semantic `events.DeliveryRoute` rows.
- Old invalid path: root routed system-node delivery was gated on `filterOutAgentIDs(recipients, persisted)`, so a production serve/outbox path without `SubscribeInternal("portfolio-node", ...)` could persist only `node/__runtime_replay_scope__`.
- Production paths checked for surviving old behavior: planner unit path, EventBus publish route persistence without internal subscription, runtime interceptor/outbox path, concrete template-instance path, target/target_set path, and agent delivery policy path.
- Migration completeness: complete for the approved root no-target routed system-node delivery class. #1258 remains split for static root emit target-required verification.

## Validation

- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute|TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInternalSubscription|TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute' -count=1 -v`
- `go test ./internal/runtime -run 'TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect|TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect|TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect' -count=1 -v`
- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient|TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute|TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes|TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute|TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest' -count=1 -v`
- `go test ./internal/runtime -run 'TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect|TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect|TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect' -count=1 -v`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./... -count=1`
