### PR TITLE
README: honest framing on conformance-suite scripted harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The static analyzer's refusal to boot on a half-finished contract is a feature i
 
 - Platform specification: **v1.6.0**, complete. See [`platform-spec.yaml`](platform-spec.yaml).
 - Engine: Go, Phase 11. Handler-first execution for the proven-safe subset; full handler-first execution in progress.
-- Conformance suite: **12 tiers, 200+ distinct test contract bundles** spanning primitives, accumulation, atomic event-loop semantics, composition, boot verification, runtime fork, and policy patterns. The suite runs against a scripted LLM, so it doesn't pay an LLM bill.
+- Conformance suite: **12 tiers, 200+ distinct test contract bundles** spanning primitives, accumulation, atomic event-loop semantics, composition, boot verification, runtime fork, and policy patterns. The suite runs against an internal scripted harness, so it doesn't cost LLM tokens to exercise the engine. A user-selectable scripted backend is on the roadmap.
 - Used internally to power autonomous multi-agent workflows. External use at your own risk.
 
 The trajectory points at running whole company divisions as autonomous flows. The shipped surface today covers a much smaller scope: deterministic multi-agent orchestration with human-in-the-loop, on a single deployment. Distributed execution, multi-tenant isolation, and a flow marketplace are not yet in scope.


### PR DESCRIPTION
One-line reframe on the Project status \"conformance suite\" bullet.

## What changes

Before:
> The suite runs against a scripted LLM, so it doesn't pay an LLM bill.

After:
> The suite runs against an internal scripted harness, so it doesn't cost LLM tokens to exercise the engine. A user-selectable scripted backend is on the roadmap.

## Why

The original line is true for maintainers running the internal Go test harness, but reads to external users as \"I can test my agent flow for free.\" The reality today is the opposite: any external-user-driven exercise of an agent flow costs real tokens, because there is no user-selectable scripted backend yet.

The change:
- \`scripted LLM\` → \`internal scripted harness\` (drops the connotation that this is something the reader has access to)
- Adds the roadmap signal (sets expectations correctly; the sentence stops over-promising)

The bullet's role (a fact about how the suite is tested) is preserved; only the misleading consumer-facing implication is removed.

## Origin

Surfaced by the QA reference-tier audit (the F-006 cluster) and queued during the docs polishing sweep. Standalone PR, no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)