### PR TITLE
[agent-c][issue #1233] Canonicalize API runtimebus waits

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -70,13 +70,9 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	if count := countAPIIdempotencyRows(t, db); count != 1 {
 		t.Fatalf("api_idempotency rows = %d, want 1", count)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event.publish delivery")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "event.publish delivery")
+	if got.ID != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
 	}
 
 	replay := rpcCall(t, handler, body)
@@ -244,13 +240,9 @@ func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
 	if delivery := asMap(t, deliveries[0]); delivery["subscriber_id"] != "repo-observer" {
 		t.Fatalf("delivery = %#v, want repo-observer", delivery)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID || string(got.Type) != canonicalEventName {
-			t.Fatalf("delivered event = %#v, want %s/%s", got, eventID, canonicalEventName)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for flow-scoped event.publish delivery")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "flow-scoped event.publish delivery")
+	if got.ID != eventID || string(got.Type) != canonicalEventName {
+		t.Fatalf("delivered event = %#v, want %s/%s", got, eventID, canonicalEventName)
 	}
 }
 
@@ -378,13 +370,9 @@ func TestOperatorEventPublishHandlersUseActiveEphemeralBundleScopeForCreateNewWo
 	if got := countEventsByName(t, db, "scan.requested"); got != 1 {
 		t.Fatalf("scan.requested event count = %d, want 1", got)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event.publish delivery")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "event.publish delivery")
+	if got.ID != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID, eventID)
 	}
 }
 
@@ -434,11 +422,7 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 	if count := countAPIIdempotencyRows(t, db); count != 1 {
 		t.Fatalf("api_idempotency rows after readback failure = %d, want 1", count)
 	}
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event delivery after readback failure")
-	}
+	requireAPIV1RuntimeBusEvent(t, ch, "event delivery after readback failure")
 
 	replay := rpcCall(t, handler, body)
 	if replay.Error != nil {
@@ -505,11 +489,7 @@ func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *
 	if !containsMissingPipelineReceiptEvent(missing, eventID) {
 		t.Fatalf("missing pipeline receipt events = %#v, want %s", missing, eventID)
 	}
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event delivery after post-commit receipt failure")
-	}
+	requireAPIV1RuntimeBusEvent(t, ch, "event delivery after post-commit receipt failure")
 
 	replay := rpcCall(t, handler, body)
 	if replay.Error != nil {
@@ -564,11 +544,7 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 	if outcome != "dead_letter" || !strings.Contains(errText, "simulated normal-run completion failure") {
 		t.Fatalf("pipeline receipt outcome=%q error=%q, want dead_letter with completion failure", outcome, errText)
 	}
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event delivery after post-commit completion failure")
-	}
+	requireAPIV1RuntimeBusEvent(t, ch, "event delivery after post-commit completion failure")
 
 	replay := rpcCall(t, handler, body)
 	if replay.Error != nil {
@@ -641,11 +617,7 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 		t.Fatalf("initial event.publish error = %#v", initial.Error)
 	}
 	runID := stringValue(t, asMap(t, initial.Result)["run_id"], "run_id")
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for initial explicit-run target delivery")
-	}
+	requireAPIV1RuntimeBusEvent(t, ch, "initial explicit-run target delivery")
 
 	targeted := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"second"}`, "operator-test", "idem-existing-run"))
 	if targeted.Error != nil {
@@ -662,13 +634,9 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
 		t.Fatalf("scan.requested events after targeted publish = %d, want 2", count)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != targetedEventID || got.RunID != runID {
-			t.Fatalf("targeted delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, targetedEventID, runID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for targeted explicit-run delivery")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "targeted explicit-run delivery")
+	if got.ID != targetedEventID || got.RunID != runID {
+		t.Fatalf("targeted delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, targetedEventID, runID)
 	}
 
 	mismatch := rpcCall(t, handler, eventPublishBody(runID, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "scan.requested", `{"topic":"mismatch"}`, "", "idem-existing-run-mismatch"))
@@ -730,11 +698,7 @@ func TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersisten
 	if initialResult["new_run_created"] != true {
 		t.Fatalf("initial result = %#v, want new run", initialResult)
 	}
-	select {
-	case <-initialCh:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for initial delivery")
-	}
+	requireAPIV1RuntimeBusEvent(t, initialCh, "initial delivery")
 
 	followUp := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.followup", `{"topic":"second"}`, "operator-test", "idem-followup-existing"))
 	if followUp.Error != nil {
@@ -765,13 +729,9 @@ func TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersisten
 	if got := countEventDeliveriesForEvent(t, ctx, db, followUpEventID); got != 1 {
 		t.Fatalf("event_deliveries for follow-up = %d, want 1", got)
 	}
-	select {
-	case got := <-followUpCh:
-		if got.ID != followUpEventID || got.RunID != runID {
-			t.Fatalf("follow-up delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, followUpEventID, runID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for follow-up delivery")
+	got := requireAPIV1RuntimeBusEvent(t, followUpCh, "follow-up delivery")
+	if got.ID != followUpEventID || got.RunID != runID {
+		t.Fatalf("follow-up delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, followUpEventID, runID)
 	}
 
 	rejected := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.unhandled", `{"topic":"lost"}`, "operator-test", "idem-followup-unhandled"))
@@ -813,11 +773,7 @@ func TestOperatorEventPublishExplicitRunRequiresRecipientPlanCheckerBeforePersis
 		t.Fatalf("initial event.publish error = %#v", initial.Error)
 	}
 	runID := stringValue(t, asMap(t, initial.Result)["run_id"], "run_id")
-	select {
-	case <-initialCh:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for initial delivery")
-	}
+	requireAPIV1RuntimeBusEvent(t, initialCh, "initial delivery")
 
 	noCheckerHandler := eventPublishTestHandlerWithStores(t, pg, pg, pg, failingRunStartPublisher{}, source)
 	rejected := rpcCall(t, noCheckerHandler, eventPublishBody(runID, runStartTestFingerprint, "scan.followup", `{"topic":"second"}`, "operator-test", "idem-followup-missing-plan"))
@@ -864,11 +820,7 @@ func TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun(t *testing
 		t.Fatalf("sqlite initial event.publish error = %#v", initial.Error)
 	}
 	runID := stringValue(t, asMap(t, initial.Result)["run_id"], "run_id")
-	select {
-	case <-initialCh:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for sqlite initial delivery")
-	}
+	requireAPIV1RuntimeBusEvent(t, initialCh, "sqlite initial delivery")
 
 	followUp := rpcCall(t, handler, eventPublishBody(runID, runStartTestFingerprint, "scan.followup", `{"topic":"second"}`, "operator-test", "idem-sqlite-followup-existing"))
 	if followUp.Error != nil {
@@ -891,13 +843,9 @@ func TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun(t *testing
 	if got := len(asSlice(t, result["deliveries"])); got != 1 {
 		t.Fatalf("sqlite follow-up deliveries = %d, want 1", got)
 	}
-	select {
-	case got := <-followUpCh:
-		if got.ID != eventID || got.RunID != runID {
-			t.Fatalf("sqlite follow-up delivered id/run = %s/%s, want %s/%s", got.ID, got.RunID, eventID, runID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for sqlite follow-up delivery")
+	got := requireAPIV1RuntimeBusEvent(t, followUpCh, "sqlite follow-up delivery")
+	if got.ID != eventID || got.RunID != runID {
+		t.Fatalf("sqlite follow-up delivered id/run = %s/%s, want %s/%s", got.ID, got.RunID, eventID, runID)
 	}
 }
 
@@ -996,11 +944,7 @@ func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) 
 	parentResult := asMap(t, parent.Result)
 	parentEventID := stringValue(t, parentResult["event_id"], "event_id")
 	parentRunID := stringValue(t, parentResult["run_id"], "run_id")
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for parent source_event_id delivery")
-	}
+	requireAPIV1RuntimeBusEvent(t, ch, "parent source_event_id delivery")
 
 	child := rpcCall(t, handler, eventPublishBodyWithSource(parentRunID, parentEventID, runStartTestFingerprint, "scan.requested", `{"topic":"checkpoint"}`, "operator-test", "idem-source-child"))
 	if child.Error != nil {
@@ -1021,13 +965,9 @@ func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) 
 	if count := countAPIIdempotencyRows(t, db); count != 2 {
 		t.Fatalf("api_idempotency rows after sourced publish = %d, want 2", count)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != childEventID || got.RunID != parentRunID {
-			t.Fatalf("child delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, childEventID, parentRunID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for child source_event_id delivery")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "child source_event_id delivery")
+	if got.ID != childEventID || got.RunID != parentRunID {
+		t.Fatalf("child delivered event id/run = %s/%s, want %s/%s", got.ID, got.RunID, childEventID, parentRunID)
 	}
 }
 
@@ -1307,11 +1247,7 @@ func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
 	if got := len(asSlice(t, asMap(t, published.Result)["deliveries"])); got != 1 {
 		t.Fatalf("paused event.publish deliveries = %d, want 1", got)
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("paused event.publish delivered event %s before resume", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoAPIV1RuntimeBusEvent(t, ch, "paused event.publish before resume")
 	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("paused event deliveries = %d, want 1", got)
 	}
@@ -1330,13 +1266,9 @@ func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
 	if resumed.ReleasedCount != 1 {
 		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != eventID {
-			t.Fatalf("released event = %s, want %s", got.ID, eventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for queued event.publish release")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "queued event.publish release")
+	if got.ID != eventID {
+		t.Fatalf("released event = %s, want %s", got.ID, eventID)
 	}
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts after resume = %d, want 1", got)

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -633,23 +633,15 @@ func agentReplayBody(eventID, agentID, idempotencyKey string) string {
 
 func assertReplayEventDelivered(t *testing.T, ch <-chan events.Event, replayEventID, originalEventID string) {
 	t.Helper()
-	select {
-	case got := <-ch:
-		if got.ID != replayEventID || got.ParentEventID != originalEventID {
-			t.Fatalf("delivered replay event id=%s parent=%s, want id=%s parent=%s", got.ID, got.ParentEventID, replayEventID, originalEventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for replay event %s", replayEventID)
+	got := requireAPIV1RuntimeBusEvent(t, ch, "replay event "+replayEventID)
+	if got.ID != replayEventID || got.ParentEventID != originalEventID {
+		t.Fatalf("delivered replay event id=%s parent=%s, want id=%s parent=%s", got.ID, got.ParentEventID, replayEventID, originalEventID)
 	}
 }
 
 func assertNoReplayEvent(t *testing.T, ch <-chan events.Event) {
 	t.Helper()
-	select {
-	case got := <-ch:
-		t.Fatalf("unexpected replay event delivered: %#v", got)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoAPIV1RuntimeBusEvent(t, ch, "replay assertion")
 }
 
 func fillAgentChannel(t *testing.T, ctx context.Context, bus *runtimebus.EventBus, agentID string, count int) {
@@ -670,11 +662,7 @@ func fillAgentChannel(t *testing.T, ctx context.Context, bus *runtimebus.EventBu
 func drainAgentChannel(t *testing.T, ch <-chan events.Event, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		select {
-		case <-ch:
-		case <-time.After(time.Second):
-			t.Fatalf("timed out draining agent channel at item %d", i)
-		}
+		requireAPIV1RuntimeBusEvent(t, ch, fmt.Sprintf("agent channel drain item %d", i))
 	}
 }
 

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -614,11 +614,7 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	if interceptorCalls != 0 {
 		t.Fatalf("interceptor calls while paused = %d, want 0", interceptorCalls)
 	}
-	select {
-	case got := <-ch:
-		t.Fatalf("paused mailbox approval delivered event %s before resume", got.ID)
-	case <-time.After(150 * time.Millisecond):
-	}
+	requireNoAPIV1RuntimeBusEvent(t, ch, "paused mailbox approval before resume")
 	if got := countEventDeliveriesForEvent(t, ctx, db, downstreamID); got != 1 {
 		t.Fatalf("mailbox approval event deliveries while paused = %d, want 1", got)
 	}
@@ -651,13 +647,9 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	if resumed.ReleasedCount != 1 {
 		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
 	}
-	select {
-	case got := <-ch:
-		if got.ID != downstreamID {
-			t.Fatalf("released mailbox approval event = %s, want %s", got.ID, downstreamID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for queued mailbox approval release")
+	got := requireAPIV1RuntimeBusEvent(t, ch, "queued mailbox approval release")
+	if got.ID != downstreamID {
+		t.Fatalf("released mailbox approval event = %s, want %s", got.ID, downstreamID)
 	}
 	if interceptorCalls != 0 {
 		t.Fatalf("interceptor calls after resume release = %d, want 0", interceptorCalls)
@@ -770,13 +762,9 @@ func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing
 	if downstreamID == "" {
 		t.Fatalf("mailbox.approve downstream event id = %#v", approved.Result)
 	}
-	select {
-	case got := <-interceptorCalls:
-		if got != downstreamID {
-			t.Fatalf("interceptor event id = %s, want %s", got, downstreamID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for mailbox approval post-commit dispatch")
+	got := requireAPIV1RuntimeBusSignal(t, interceptorCalls, "mailbox approval post-commit dispatch")
+	if got != downstreamID {
+		t.Fatalf("interceptor event id = %s, want %s", got, downstreamID)
 	}
 	if got := countEventsByName(t, db, "mailbox.item_decided"); got != 1 {
 		t.Fatalf("mailbox.item_decided event count = %d, want 1", got)
@@ -794,11 +782,7 @@ func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing
 	if got := asMap(t, replay.Result)["downstream_event_id"]; got != downstreamID {
 		t.Fatalf("replay downstream_event_id = %v, want %s", got, downstreamID)
 	}
-	select {
-	case got := <-interceptorCalls:
-		t.Fatalf("idempotency replay re-dispatched mailbox event %s", got)
-	default:
-	}
+	requireNoAPIV1RuntimeBusSignal(t, interceptorCalls, "mailbox approval idempotency replay")
 	if got := countEventsByName(t, db, "mailbox.item_decided"); got != 1 {
 		t.Fatalf("mailbox.item_decided event count after replay = %d, want 1", got)
 	}

--- a/internal/apiv1/operator_runtime_context_test.go
+++ b/internal/apiv1/operator_runtime_context_test.go
@@ -47,19 +47,11 @@ func TestOperatorRuntimeContextManagerRoutesCreateNewWorkToSelectedBundle(t *tes
 	if got := countEventsByName(t, fixture.db, "triage.requested"); got != 1 {
 		t.Fatalf("triage.requested count after event.publish = %d, want 1", got)
 	}
-	select {
-	case got := <-chSelected:
-		if got.ID != publishedEventID {
-			t.Fatalf("selected context delivered event = %s, want %s", got.ID, publishedEventID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for selected context delivery")
+	got := requireAPIV1RuntimeBusEvent(t, chSelected, "selected context delivery")
+	if got.ID != publishedEventID {
+		t.Fatalf("selected context delivered event = %s, want %s", got.ID, publishedEventID)
 	}
-	select {
-	case got := <-chPrimary:
-		t.Fatalf("primary context unexpectedly delivered selected bundle event %s", got.ID)
-	default:
-	}
+	requireNoAPIV1RuntimeBusEvent(t, chPrimary, "primary context selected bundle route")
 
 	runID := uuid.NewString()
 	started := rpcCall(t, handler, runStartBodyWithBundleHash(runID, runtimeContextTestBundleHashB, "triage.requested", `{"topic":"context-b-start"}`, "idem-context-start"))
@@ -82,13 +74,9 @@ func TestOperatorRuntimeContextManagerRoutesExistingRunByStoredBundle(t *testing
 	if started.Error != nil {
 		t.Fatalf("seed run.start error = %#v", started.Error)
 	}
-	select {
-	case got := <-chSelected:
-		if got.RunID != runID {
-			t.Fatalf("seed existing-run delivery run = %s, want %s", got.RunID, runID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for seed existing-run delivery")
+	got := requireAPIV1RuntimeBusEvent(t, chSelected, "seed existing-run delivery")
+	if got.RunID != runID {
+		t.Fatalf("seed existing-run delivery run = %s, want %s", got.RunID, runID)
 	}
 
 	body := fmt.Sprintf(
@@ -108,13 +96,9 @@ func TestOperatorRuntimeContextManagerRoutesExistingRunByStoredBundle(t *testing
 		t.Fatalf("event rows for existing run = %d, want 2", got)
 	}
 	assertRunBundleIdentity(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
-	select {
-	case got := <-chSelected:
-		if got.ID != eventID || got.RunID != runID {
-			t.Fatalf("existing-run delivery id/run = %s/%s, want %s/%s", got.ID, got.RunID, eventID, runID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for existing-run selected-context delivery")
+	got = requireAPIV1RuntimeBusEvent(t, chSelected, "existing-run selected-context delivery")
+	if got.ID != eventID || got.RunID != runID {
+		t.Fatalf("existing-run delivery id/run = %s/%s, want %s/%s", got.ID, got.RunID, eventID, runID)
 	}
 }
 

--- a/internal/apiv1/runtimebus_assertions_test.go
+++ b/internal/apiv1/runtimebus_assertions_test.go
@@ -1,0 +1,55 @@
+package apiv1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+const apiv1RuntimeBusAssertionTimeout = time.Second
+
+func requireAPIV1RuntimeBusEvent(t *testing.T, ch <-chan events.Event, description string) events.Event {
+	t.Helper()
+	return requireAPIV1RuntimeBusValue[events.Event](t, ch, description)
+}
+
+func requireNoAPIV1RuntimeBusEvent(t *testing.T, ch <-chan events.Event, description string) {
+	t.Helper()
+	requireNoAPIV1RuntimeBusValue[events.Event](t, ch, description)
+}
+
+func requireAPIV1RuntimeBusSignal(t *testing.T, ch <-chan string, description string) string {
+	t.Helper()
+	return requireAPIV1RuntimeBusValue[string](t, ch, description)
+}
+
+func requireNoAPIV1RuntimeBusSignal(t *testing.T, ch <-chan string, description string) {
+	t.Helper()
+	requireNoAPIV1RuntimeBusValue[string](t, ch, description)
+}
+
+func requireAPIV1RuntimeBusValue[T any](t *testing.T, ch <-chan T, description string) T {
+	t.Helper()
+	timer := time.NewTimer(apiv1RuntimeBusAssertionTimeout)
+	defer timer.Stop()
+
+	select {
+	case got := <-ch:
+		return got
+	case <-timer.C:
+		t.Fatalf("timed out waiting for %s", description)
+	}
+
+	var zero T
+	return zero
+}
+
+func requireNoAPIV1RuntimeBusValue[T any](t *testing.T, ch <-chan T, description string) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		t.Fatalf("%s delivered unexpected runtimebus value: %#v", description, got)
+	default:
+	}
+}

--- a/internal/apiv1/runtimebus_assertions_test.go
+++ b/internal/apiv1/runtimebus_assertions_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 const apiv1RuntimeBusAssertionTimeout = time.Second
+const apiv1RuntimeBusAbsenceTimeout = 150 * time.Millisecond
 
 func requireAPIV1RuntimeBusEvent(t *testing.T, ch <-chan events.Event, description string) events.Event {
 	t.Helper()
@@ -47,9 +48,12 @@ func requireAPIV1RuntimeBusValue[T any](t *testing.T, ch <-chan T, description s
 
 func requireNoAPIV1RuntimeBusValue[T any](t *testing.T, ch <-chan T, description string) {
 	t.Helper()
+	timer := time.NewTimer(apiv1RuntimeBusAbsenceTimeout)
+	defer timer.Stop()
+
 	select {
 	case got := <-ch:
 		t.Fatalf("%s delivered unexpected runtimebus value: %#v", description, got)
-	default:
+	case <-timer.C:
 	}
 }


### PR DESCRIPTION
Part of #1233

## Summary

- Add a package-local `internal/apiv1` runtimebus assertion helper for expected event, expected no-event, and dispatch signal checks.
- Move the approved `operator_event_publish`, `operator_event_replay`, `operator_mailbox`, and `operator_runtime_context` runtimebus channel assertions off inline `time.After` / fixed absence waits.
- Leave the gate-split API polling/websocket rows untouched: mailbox-write convergence, `run.get` status polling, and subscription cancellation waits.

## Governing Refs / Context

No exact `platform-spec.yaml` product/runtime section governs test wait helper placement. Binding context is #1233, #1196, the #1233 residual refresh audit, the independent gate approving `test_health.apiv1_runtimebus_channel_wait_assertions`, PR #1245 bus wait closure, and the private process/watchlist docs.

## Semantic Migration

- New canonical owner: package-local `internal/apiv1/runtimebus_assertions_test.go` for API runtimebus channel delivery/no-delivery and dispatch signal assertions.
- Old non-authoritative paths now invalid for this child: inline API test `select` blocks with `time.After` or fixed absence windows for returned-call runtimebus assertions in the four selected files.
- Production paths checked: no production/runtime files changed; no runtime timeout semantics, bus helper ownership, API polling convergence, dashboard, CLI, store, pipeline, manager, catalog, LLM, #1218/#1230, or #1220 work changed.
- Migration completeness: complete for the approved API runtimebus channel assertion child only. #1233 and #1196 remain open.

## Proof

- `rg -n "time\.After|time\.Sleep" internal/apiv1/operator_event_publish_test.go internal/apiv1/operator_event_replay_test.go internal/apiv1/operator_mailbox_test.go internal/apiv1/operator_runtime_context_test.go` -> no matches.
- `rg -n "time\.After|time\.Sleep" --glob '*_test.go' internal/apiv1` -> only the explicitly split mailbox-write polling, `run.get` polling, and subscriptions websocket waits remain.
- `rg -n "time\.After|time\.Sleep" --glob '*_test.go' internal/runtime/bus` -> no matches; PR #1245 bus closure remains untouched.
- `go test ./internal/apiv1 -run 'TestOperator(EventPublish|EventReplay|Mailbox|RuntimeContext)' -count=1`
- `go test ./internal/apiv1 -run TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./...`