### PR TITLE
[agent-b][issue #1282] Canonical authored emit-site identity

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6894,7 +6894,9 @@ scorer:
         completion: all
       on_complete:
         - condition: "true"
-          emit: score.completed
+          emit:
+            event: score.completed
+            broadcast: true
       advances_to: complete
   state_schema:
     fields:

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -9,15 +9,6 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
-type pinEmitSite struct {
-	FlowID    string
-	NodeID    string
-	EventType string
-	Site      string
-	Spec      runtimecontracts.EmitSpec
-	Handler   runtimecontracts.SystemNodeEventHandler
-}
-
 func checkPinTargetResolution(c *checkerContext) []Finding {
 	findings := []Finding{}
 	for _, site := range pinRoutingEmitSites(c.source) {
@@ -29,7 +20,7 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 			findings = append(findings, pinTargetFinding(site, string(failure)))
 			continue
 		}
-		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && pinRoutingEventExternalSource(c.source, site.FlowID, site.EventType) {
+		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && pinRoutingEventExternalSource(c.source, site.FlowID, site.HandlerEvent) {
 			findings = append(findings, pinTargetFinding(site, "target_sender_empty_source"))
 		}
 	}
@@ -108,73 +99,22 @@ func checkMissingExternalSelectEntity(c *checkerContext) []Finding {
 	return findings
 }
 
-func pinRoutingEmitSites(source semanticview.Source) []pinEmitSite {
-	if source == nil {
-		return nil
-	}
-	out := []pinEmitSite{}
-	for flowID := range source.FlowSchemaEntries() {
-		flowID = strings.TrimSpace(flowID)
-		scope, ok := source.FlowScopeByID(flowID)
-		if !ok {
-			continue
-		}
-		for nodeID, node := range scope.Nodes {
-			nodeID = strings.TrimSpace(nodeID)
-			for eventType, handler := range node.EventHandlers {
-				eventType = strings.TrimSpace(eventType)
-				appendSite := func(site string, spec runtimecontracts.EmitSpec) {
-					if spec.Empty() {
-						return
-					}
-					out = append(out, pinEmitSite{
-						FlowID:    flowID,
-						NodeID:    nodeID,
-						EventType: eventType,
-						Site:      site,
-						Spec:      spec,
-						Handler:   handler,
-					})
-				}
-				appendSite("handler.emit", handler.Emit)
-				for _, rule := range handler.Rules {
-					appendSite("handler.rules.emit", rule.Emit)
-					if rule.FanOut != nil {
-						appendSite("handler.rules.fan_out.emit", rule.FanOut.Emit)
-					}
-				}
-				for _, rule := range handler.OnComplete {
-					appendSite("handler.on_complete.emit", rule.Emit)
-					if rule.FanOut != nil {
-						appendSite("handler.on_complete.fan_out.emit", rule.FanOut.Emit)
-					}
-				}
-				if handler.Accumulate != nil {
-					for _, rule := range handler.Accumulate.OnComplete {
-						appendSite("handler.accumulate.on_complete.emit", rule.Emit)
-						if rule.FanOut != nil {
-							appendSite("handler.accumulate.on_complete.fan_out.emit", rule.FanOut.Emit)
-						}
-					}
-					if handler.Accumulate.OnTimeout != nil {
-						appendSite("handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.Emit)
-					}
-				}
-				if handler.FanOut != nil {
-					appendSite("handler.fan_out.emit", handler.FanOut.Emit)
-				}
-			}
-		}
-	}
-	return out
+func pinRoutingEmitSites(source semanticview.Source) []semanticview.AuthoredEmitSite {
+	return semanticview.AuthoredEmitSites(source)
 }
 
-func pinTargetFinding(site pinEmitSite, reason string) Finding {
+func pinTargetFinding(site semanticview.AuthoredEmitSite, reason string) Finding {
+	scope := fmt.Sprintf("flow %s", site.FlowID)
+	location := site.FlowID
+	if strings.TrimSpace(site.FlowID) == "" {
+		scope = "root"
+		location = "root"
+	}
 	return Finding{
 		CheckID:  "pin_target_resolution",
 		Severity: "error",
-		Message:  fmt.Sprintf("flow %s %s on node %s emits pin-declared output %s without valid target mechanism: %s", site.FlowID, site.Site, site.NodeID, site.Spec.EventType(), reason),
-		Location: site.FlowID,
+		Message:  fmt.Sprintf("%s %s on node %s emits pin-declared output %s without valid target mechanism: %s", scope, site.Site, site.NodeID, site.Spec.EventType(), reason),
+		Location: location,
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -23,6 +24,91 @@ func TestPinTargetResolution_AllowsExplicitBroadcastOptOut(t *testing.T) {
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 	if reportContains(report.Errors(), "pin_target_resolution", "") {
 		t.Fatalf("unexpected pin_target_resolution error: %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		rootNodes: pinRoutingVerifyNodeYAML("root-node", "root.start", "root.ready", false),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "root handler.emit on node root-node") {
+		t.Fatalf("expected root pin_target_resolution error, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForNestedRootPinOutputWithoutTargetMechanism(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		rootNodes: pinRoutingVerifyRuleNodeYAML("root-node", "root.start", "root.ready", false),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "root handler.rules.emit on node root-node") {
+		t.Fatalf("expected nested root pin_target_resolution error, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForRootGuardEscalationPinOutput(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		rootNodes: pinRoutingVerifyGuardNodeYAML("root-node", "root.start", "root.ready"),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "root handler.guard.on_fail.escalate on node root-node") {
+		t.Fatalf("expected root guard escalation pin_target_resolution error, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_AllowsRootExplicitBroadcastOptOut(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		rootNodes: pinRoutingVerifyNodeYAML("root-node", "root.start", "root.ready", true),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "root") {
+		t.Fatalf("unexpected root pin_target_resolution error: %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_ChecksRootNodeWhenFlowNodeIDCollides(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		rootNodes:        pinRoutingVerifyNodeYAML("shared-node", "root.start", "root.ready", false),
+		supportFlowNodes: pinRoutingVerifyNodeYAML("shared-node", "support.start", "support.ready", true),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if countPinTargetFindings(report, "root handler.emit on node shared-node") != 1 {
+		t.Fatalf("expected exactly one root colliding-node finding, got %#v", pinTargetFindingMessages(report))
+	}
+}
+
+func TestPinTargetResolution_EvaluatesPackageBackedFlowOnceNotRoot(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		supportFlowNodes: pinRoutingVerifyNodeYAML("support-node", "support.start", "support.ready", false),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if countPinTargetFindings(report, "flow support handler.emit on node support-node") != 1 {
+		t.Fatalf("expected exactly one flow support finding, got %#v", pinTargetFindingMessages(report))
+	}
+	if countPinTargetFindings(report, "root handler.emit on node support-node") != 0 {
+		t.Fatalf("package-backed flow node was reported as root: %#v", pinTargetFindingMessages(report))
+	}
+}
+
+func TestPinTargetResolution_EvaluatesSoleParentPackageUnderOwningFlow(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		extrasNodes: pinRoutingVerifyNodeYAML("extras-node", "support.start", "support.ready", false),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if countPinTargetFindings(report, "flow support handler.emit on node extras-node") != 1 {
+		t.Fatalf("expected exactly one sole-parent package flow finding, got %#v", pinTargetFindingMessages(report))
+	}
+}
+
+func TestPinTargetResolution_DistinctSameFlowNodeIDSourceSitesBothConsidered(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		supportFlowNodes: pinRoutingVerifyNodeYAML("support-node", "support.start", "support.ready", false),
+		extrasNodes:      pinRoutingVerifyNodeYAML("support-node", "support.start", "support.ready", true),
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if countPinTargetFindings(report, "flow support handler.emit on node support-node") != 1 {
+		t.Fatalf("expected invalid flow-scope support-node site not to be suppressed, got %#v", pinTargetFindingMessages(report))
 	}
 }
 
@@ -85,6 +171,165 @@ worker-node:
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	return bundle
+}
+
+type pinRoutingVerifySourceFixture struct {
+	rootNodes        string
+	supportFlowNodes string
+	extrasNodes      string
+}
+
+func loadPinRoutingVerifySourceFixture(t *testing.T, opts pinRoutingVerifySourceFixture) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
+name: pin-routing-source-identity
+version: "1.0.0"
+platform_version: ">=1.6.0"
+packages:
+  - path: extras
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), `
+name: pin-routing-source-identity
+pins:
+  inputs:
+    events: [root.start]
+  outputs:
+    events: [root.ready]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "events.yaml"), `
+root.start: {}
+root.ready: {}
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "nodes.yaml"), defaultPinRoutingFixtureYAML(opts.rootNodes))
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [support.start]
+  outputs:
+    events: [support.ready]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support.start: {}
+support.ready: {}
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), defaultPinRoutingFixtureYAML(opts.supportFlowNodes))
+	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "package.yaml"), `
+name: extras
+version: "1.0.0"
+flows: []
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "nodes.yaml"), defaultPinRoutingFixtureYAML(opts.extrasNodes))
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func pinRoutingVerifyNodeYAML(nodeID, trigger, eventType string, broadcast bool) string {
+	if strings.TrimSpace(nodeID) == "" {
+		return "{}\n"
+	}
+	broadcastLine := ""
+	if broadcast {
+		broadcastLine = "        broadcast: true\n"
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      emit:
+        event: ` + eventType + `
+` + broadcastLine
+}
+
+func pinRoutingVerifyGuardNodeYAML(nodeID, trigger, eventType string) string {
+	if strings.TrimSpace(nodeID) == "" {
+		return "{}\n"
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      guard:
+        id: guard-escalate
+        check: "false"
+        on_fail: "escalate:` + eventType + `"
+`
+}
+
+func pinRoutingVerifyRuleNodeYAML(nodeID, trigger, eventType string, broadcast bool) string {
+	if strings.TrimSpace(nodeID) == "" {
+		return "{}\n"
+	}
+	broadcastLine := ""
+	if broadcast {
+		broadcastLine = "          broadcast: true\n"
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      rules:
+        - id: emit-root
+          condition: "true"
+          emit:
+            event: ` + eventType + `
+` + broadcastLine
+}
+
+func defaultPinRoutingFixtureYAML(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "{}\n"
+	}
+	return value
+}
+
+func countPinTargetFindings(report Report, messagePart string) int {
+	count := 0
+	for _, finding := range report.Errors() {
+		if finding.CheckID == "pin_target_resolution" && strings.Contains(finding.Message, messagePart) {
+			count++
+		}
+	}
+	return count
+}
+
+func pinTargetFindingMessages(report Report) []string {
+	out := []string{}
+	for _, finding := range report.Errors() {
+		if finding.CheckID == "pin_target_resolution" {
+			out = append(out, finding.Message)
+		}
+	}
+	return out
 }
 
 func writePinRoutingVerifyFile(t *testing.T, path, contents string) {

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -67,8 +67,11 @@ type Resolution struct {
 func PinDeclaredOutput(source semanticview.Source, flowID, eventType string) bool {
 	flowID = strings.TrimSpace(flowID)
 	eventType = eventidentity.Normalize(eventType)
-	if source == nil || flowID == "" || eventType == "" {
+	if source == nil || eventType == "" {
 		return false
+	}
+	if flowID == "" {
+		return rootPinDeclaredOutput(source, eventType)
 	}
 	if source.FlowHasOutputEvent(flowID, eventType) {
 		return true
@@ -84,6 +87,31 @@ func PinDeclaredOutput(source semanticview.Source, flowID, eventType string) boo
 	for _, output := range source.FlowOutputEvents(flowID) {
 		output = eventidentity.Normalize(output)
 		if output == eventType || output == resolved || output == leaf {
+			return true
+		}
+	}
+	return false
+}
+
+func rootPinDeclaredOutput(source semanticview.Source, eventType string) bool {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil || bundle.RootSchema == nil {
+		return false
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	for _, output := range bundle.RootSchema.Pins.Outputs.Events {
+		output = eventidentity.Normalize(output)
+		if output == "" {
+			continue
+		}
+		if output == eventType {
+			return true
+		}
+		resolved := eventidentity.Normalize(source.ResolveFlowEventReference("", output))
+		if resolved != "" && resolved == eventType {
 			return true
 		}
 	}

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -81,6 +81,25 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 	}
 }
 
+func TestPinDeclaredOutputRecognizesRootSchemaOutputWithoutLeafFallback(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"root.ready"},
+				},
+			},
+		},
+	})
+
+	if !PinDeclaredOutput(source, "", "root.ready") {
+		t.Fatal("root output pin was not recognized")
+	}
+	if PinDeclaredOutput(source, "", "worker/root.ready") {
+		t.Fatal("namespaced event matched root output pin by leaf name")
+	}
+}
+
 func testPinRoutingSource() semanticview.Source {
 	child := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -229,6 +229,7 @@ func authoredEmitSiteFlowScopeKey(scope FlowScope) string {
 
 func authoredPreferredFlowScopeKeys(projectScopes []ProjectScope, flowScopes []FlowScope) map[string]string {
 	out := map[string]string{}
+	flowRootProjectScopeKeys := authoredFlowRootProjectScopeKeys(flowScopes)
 	for _, scope := range projectScopes {
 		flowID := strings.TrimSpace(scope.OwningFlowID)
 		if flowID == "" {
@@ -238,7 +239,7 @@ func authoredPreferredFlowScopeKeys(projectScopes []ProjectScope, flowScopes []F
 		if key == "" {
 			continue
 		}
-		if authoredFlowScopeKeyRank(key) < 2 {
+		if _, ok := flowRootProjectScopeKeys[flowID][key]; !ok {
 			continue
 		}
 		current := out[flowID]
@@ -259,6 +260,29 @@ func authoredPreferredFlowScopeKeys(projectScopes []ProjectScope, flowScopes []F
 		if current == "" || authoredFlowScopeKeyRank(key) > authoredFlowScopeKeyRank(current) {
 			out[flowID] = key
 		}
+	}
+	return out
+}
+
+func authoredFlowRootProjectScopeKeys(flowScopes []FlowScope) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	for _, scope := range flowScopes {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" {
+			continue
+		}
+		keys := out[flowID]
+		if keys == nil {
+			keys = map[string]struct{}{}
+			out[flowID] = keys
+		}
+		if key := strings.TrimSpace(scope.PackageKey); key != "" && key != "." {
+			keys[key] = struct{}{}
+		}
+		if path := strings.Trim(strings.TrimSpace(scope.Path), "/"); path != "" && path != "." {
+			keys[path] = struct{}{}
+		}
+		keys["flows/"+flowID] = struct{}{}
 	}
 	return out
 }

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -1,0 +1,298 @@
+package semanticview
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+type AuthoredEmitSiteSourceKind string
+
+const (
+	AuthoredEmitSiteSourceProject AuthoredEmitSiteSourceKind = "project"
+	AuthoredEmitSiteSourceFlow    AuthoredEmitSiteSourceKind = "flow"
+)
+
+type AuthoredEmitSite struct {
+	ID             string
+	SourceKind     AuthoredEmitSiteSourceKind
+	SourceScopeKey string
+	FlowID         string
+	FlowPath       string
+	FlowPackageKey string
+	NodeKey        string
+	NodeID         string
+	HandlerEvent   string
+	Site           string
+	SiteKey        string
+	RuleID         string
+	Spec           runtimecontracts.EmitSpec
+	Handler        runtimecontracts.SystemNodeEventHandler
+}
+
+func AuthoredEmitSites(source Source) []AuthoredEmitSite {
+	if source == nil {
+		return nil
+	}
+	builder := authoredEmitSiteBuilder{
+		seen: map[string]struct{}{},
+	}
+	projectScopes := sortedAuthoredProjectScopes(source.ProjectScopes())
+	for _, scope := range projectScopes {
+		if authoredEmitSiteSkipsProjectScope(scope) {
+			continue
+		}
+		flowID := strings.TrimSpace(scope.OwningFlowID)
+		flowPath, flowPackageKey := authoredEmitSiteFlowIdentity(source, flowID)
+		builder.appendScope(AuthoredEmitSiteSourceProject, strings.TrimSpace(scope.Key), flowID, flowPath, flowPackageKey, scope.Nodes)
+	}
+	flowScopes := sortedAuthoredFlowScopes(source.FlowScopes())
+	preferredFlowScopeKeys := authoredPreferredFlowScopeKeys(projectScopes, flowScopes)
+	for _, scope := range flowScopes {
+		flowID := strings.TrimSpace(scope.ID)
+		scopeKey := authoredEmitSiteFlowScopeKey(scope)
+		if preferred := preferredFlowScopeKeys[flowID]; preferred != "" && scopeKey != preferred {
+			continue
+		}
+		builder.appendScope(AuthoredEmitSiteSourceFlow, scopeKey, flowID, strings.TrimSpace(scope.Path), strings.TrimSpace(scope.PackageKey), scope.Nodes)
+	}
+	sort.SliceStable(builder.sites, func(i, j int) bool {
+		return builder.sites[i].ID < builder.sites[j].ID
+	})
+	return builder.sites
+}
+
+func authoredEmitSiteSkipsProjectScope(scope ProjectScope) bool {
+	// The loader can expose a flow-owned "." project projection for the root
+	// package; the corresponding FlowScope is the canonical authored source.
+	return strings.TrimSpace(scope.Key) == "." && strings.TrimSpace(scope.OwningFlowID) != ""
+}
+
+type authoredEmitSiteBuilder struct {
+	seen  map[string]struct{}
+	sites []AuthoredEmitSite
+}
+
+func (b *authoredEmitSiteBuilder) appendScope(kind AuthoredEmitSiteSourceKind, scopeKey, flowID, flowPath, flowPackageKey string, nodes map[string]runtimecontracts.SystemNodeContract) {
+	scopeKey = strings.TrimSpace(scopeKey)
+	flowID = strings.TrimSpace(flowID)
+	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
+	flowPackageKey = strings.TrimSpace(flowPackageKey)
+	for _, nodeKey := range sortedAuthoredNodeKeys(nodes) {
+		node := nodes[nodeKey]
+		nodeID := strings.TrimSpace(node.ID)
+		if nodeID == "" {
+			nodeID = strings.TrimSpace(nodeKey)
+		}
+		for _, handlerEvent := range sortedAuthoredHandlerEvents(node.EventHandlers) {
+			handler := node.EventHandlers[handlerEvent]
+			b.appendHandlerSites(kind, scopeKey, flowID, flowPath, flowPackageKey, strings.TrimSpace(nodeKey), nodeID, handlerEvent, handler)
+		}
+	}
+}
+
+func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSourceKind, scopeKey, flowID, flowPath, flowPackageKey, nodeKey, nodeID, handlerEvent string, handler runtimecontracts.SystemNodeEventHandler) {
+	add := func(site, siteKey, ruleID string, spec runtimecontracts.EmitSpec) {
+		if spec.Empty() {
+			return
+		}
+		id := authoredEmitSiteIdentity(flowID, scopeKey, nodeKey, handlerEvent, siteKey)
+		if _, ok := b.seen[id]; ok {
+			return
+		}
+		b.seen[id] = struct{}{}
+		b.sites = append(b.sites, AuthoredEmitSite{
+			ID:             id,
+			SourceKind:     kind,
+			SourceScopeKey: scopeKey,
+			FlowID:         flowID,
+			FlowPath:       flowPath,
+			FlowPackageKey: flowPackageKey,
+			NodeKey:        nodeKey,
+			NodeID:         nodeID,
+			HandlerEvent:   strings.TrimSpace(handlerEvent),
+			Site:           site,
+			SiteKey:        siteKey,
+			RuleID:         strings.TrimSpace(ruleID),
+			Spec:           spec,
+			Handler:        handler,
+		})
+	}
+	add("handler.emit", "handler.emit", "", handler.Emit)
+	if handler.Guard != nil {
+		if eventType := authoredGuardEscalationEvent(handler.Guard.OnFail); eventType != "" {
+			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, runtimecontracts.EmitSpec{Event: eventType})
+		}
+	}
+	for idx, rule := range handler.Rules {
+		add("handler.rules.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "emit"), rule.ID, rule.Emit)
+		if rule.FanOut != nil {
+			add("handler.rules.fan_out.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+		}
+	}
+	for idx, rule := range handler.OnComplete {
+		add("handler.on_complete.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "emit"), rule.ID, rule.Emit)
+		if rule.FanOut != nil {
+			add("handler.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+		}
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			add("handler.accumulate.on_complete.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "emit"), rule.ID, rule.Emit)
+			if rule.FanOut != nil {
+				add("handler.accumulate.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			add("handler.accumulate.on_timeout.emit", "handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.Emit)
+			if handler.Accumulate.OnTimeout.FanOut != nil {
+				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.FanOut.Emit)
+			}
+		}
+	}
+	if handler.FanOut != nil {
+		add("handler.fan_out.emit", "handler.fan_out.emit", "", handler.FanOut.Emit)
+	}
+}
+
+func sortedAuthoredProjectScopes(scopes []ProjectScope) []ProjectScope {
+	out := append([]ProjectScope{}, scopes...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if strings.TrimSpace(out[i].Key) != strings.TrimSpace(out[j].Key) {
+			return strings.TrimSpace(out[i].Key) < strings.TrimSpace(out[j].Key)
+		}
+		return strings.TrimSpace(out[i].OwningFlowID) < strings.TrimSpace(out[j].OwningFlowID)
+	})
+	return out
+}
+
+func sortedAuthoredFlowScopes(scopes []FlowScope) []FlowScope {
+	out := append([]FlowScope{}, scopes...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if strings.TrimSpace(out[i].ID) != strings.TrimSpace(out[j].ID) {
+			return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
+		}
+		return strings.TrimSpace(out[i].Path) < strings.TrimSpace(out[j].Path)
+	})
+	return out
+}
+
+func sortedAuthoredNodeKeys(nodes map[string]runtimecontracts.SystemNodeContract) []string {
+	keys := make([]string, 0, len(nodes))
+	for key := range nodes {
+		if key = strings.TrimSpace(key); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedAuthoredHandlerEvents(handlers map[string]runtimecontracts.SystemNodeEventHandler) []string {
+	keys := make([]string, 0, len(handlers))
+	for key := range handlers {
+		if key = strings.TrimSpace(key); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func authoredEmitSiteFlowIdentity(source Source, flowID string) (string, string) {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return "", ""
+	}
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return "", ""
+	}
+	return strings.Trim(strings.TrimSpace(scope.Path), "/"), strings.TrimSpace(scope.PackageKey)
+}
+
+func authoredEmitSiteFlowScopeKey(scope FlowScope) string {
+	if key := strings.TrimSpace(scope.PackageKey); key != "" {
+		return key
+	}
+	path := strings.Trim(strings.TrimSpace(scope.Path), "/")
+	if path != "" {
+		return path
+	}
+	if id := strings.TrimSpace(scope.ID); id != "" {
+		return "flows/" + id
+	}
+	return ""
+}
+
+func authoredPreferredFlowScopeKeys(projectScopes []ProjectScope, flowScopes []FlowScope) map[string]string {
+	out := map[string]string{}
+	for _, scope := range projectScopes {
+		flowID := strings.TrimSpace(scope.OwningFlowID)
+		if flowID == "" {
+			continue
+		}
+		key := strings.TrimSpace(scope.Key)
+		if key == "" {
+			continue
+		}
+		if authoredFlowScopeKeyRank(key) < 2 {
+			continue
+		}
+		current := out[flowID]
+		if current == "" || authoredFlowScopeKeyRank(key) > authoredFlowScopeKeyRank(current) {
+			out[flowID] = key
+		}
+	}
+	for _, scope := range flowScopes {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" {
+			continue
+		}
+		key := authoredEmitSiteFlowScopeKey(scope)
+		if key == "" {
+			continue
+		}
+		current := out[flowID]
+		if current == "" || authoredFlowScopeKeyRank(key) > authoredFlowScopeKeyRank(current) {
+			out[flowID] = key
+		}
+	}
+	return out
+}
+
+func authoredFlowScopeKeyRank(key string) int {
+	key = strings.TrimSpace(key)
+	switch {
+	case key == "" || key == ".":
+		return 0
+	case strings.HasPrefix(key, "flows/"):
+		return 2
+	default:
+		return 1
+	}
+}
+
+func authoredEmitSiteIdentity(flowID, scopeKey, nodeKey, handlerEvent, siteKey string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(flowID),
+		strings.TrimSpace(scopeKey),
+		strings.TrimSpace(nodeKey),
+		strings.TrimSpace(handlerEvent),
+		strings.TrimSpace(siteKey),
+	}, "\x1f")
+}
+
+func indexedAuthoredEmitSiteKey(prefix string, index int, suffix string) string {
+	return prefix + "[" + strconv.Itoa(index) + "]." + suffix
+}
+
+func authoredGuardEscalationEvent(onFail string) string {
+	normalized := strings.TrimSpace(strings.ToLower(onFail))
+	if !strings.HasPrefix(normalized, "escalate:") {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(normalized, "escalate:"))
+}

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -1,0 +1,219 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestAuthoredEmitSites_EnumeratesRootAndFlowOwnedScopes(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		rootNodeID:    "root-node",
+		rootEmit:      "root.ready",
+		rootGuardEmit: "root.escalated",
+		flowNodeID:    "flow-node",
+		flowEmit:      "support.ready",
+		extrasNodeID:  "extras-node",
+		extrasEmit:    "support.ready",
+	})
+
+	sites := AuthoredEmitSites(source)
+	if countAuthoredEmitSites(sites, "", "root-node", "root.ready") != 1 {
+		t.Fatalf("expected one root authored emit site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredEmitSites(sites, "", "root-node", "root.escalated") != 1 {
+		t.Fatalf("expected one root guard escalation authored emit site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredEmitSites(sites, "support", "flow-node", "support.ready") != 1 {
+		t.Fatalf("expected one flow authored emit site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredEmitSites(sites, "support", "extras-node", "support.ready") != 1 {
+		t.Fatalf("expected one sole-parent package authored emit site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+}
+
+func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		rootNodeID:      "root-node",
+		rootEmit:        "root.ready",
+		flowNodeID:      "support-node",
+		flowEmit:        "support.ready",
+		extrasNodeID:    "support-node",
+		extrasEmit:      "support.ready",
+		extrasBroadcast: true,
+	})
+
+	sites := AuthoredEmitSites(source)
+	matches := authoredEmitSitesByFlowNodeEvent(sites, "support", "support-node", "support.ready")
+	if len(matches) != 2 {
+		t.Fatalf("expected two distinct support-node authored sites, got %d: %#v", len(matches), authoredEmitSiteSummaries(matches))
+	}
+	keys := []string{matches[0].SourceScopeKey, matches[1].SourceScopeKey}
+	sort.Strings(keys)
+	if strings.Join(keys, ",") != "extras,flows/support" {
+		t.Fatalf("source scope keys = %v, want extras and flows/support; sites=%#v", keys, authoredEmitSiteSummaries(matches))
+	}
+}
+
+func TestAuthoredEmitSites_OutsidePackageDoesNotSuppressGenericFlowScope(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		flowNodeID:      "flow-node",
+		flowEmit:        "support.ready",
+		extrasNodeID:    "extras-node",
+		extrasEmit:      "support.ready",
+		omitFlowPackage: true,
+	})
+
+	sites := AuthoredEmitSites(source)
+	if countAuthoredEmitSites(sites, "support", "flow-node", "support.ready") != 1 {
+		t.Fatalf("expected generic flow scope site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredEmitSites(sites, "support", "extras-node", "support.ready") != 1 {
+		t.Fatalf("expected outside package site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+}
+
+type authoredEmitSiteFixture struct {
+	rootNodeID      string
+	rootEmit        string
+	rootGuardEmit   string
+	rootBroadcast   bool
+	flowNodeID      string
+	flowEmit        string
+	flowBroadcast   bool
+	extrasNodeID    string
+	extrasEmit      string
+	extrasBroadcast bool
+	omitFlowPackage bool
+}
+
+func loadAuthoredEmitSiteFixture(t *testing.T, opts authoredEmitSiteFixture) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: authored-emit-site-fixture
+version: "1.0.0"
+platform_version: ">=1.6.0"
+packages:
+  - path: extras
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: authored-emit-site-fixture
+pins:
+  outputs:
+    events: [root.ready]
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), `
+root.start: {}
+root.ready: {}
+root.escalated: {}
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), authoredEmitSiteNodeYAML(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast))
+	if !opts.omitFlowPackage {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+flows: []
+`)
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [support.start]
+  outputs:
+    events: [support.ready]
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+support.start: {}
+support.ready: {}
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), authoredEmitSiteNodeYAML(opts.flowNodeID, "support.start", opts.flowEmit, "", opts.flowBroadcast))
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
+name: extras
+version: "1.0.0"
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "extras", "nodes.yaml"), authoredEmitSiteNodeYAML(opts.extrasNodeID, "support.start", opts.extrasEmit, "", opts.extrasBroadcast))
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}
+
+func authoredEmitSiteNodeYAML(nodeID, trigger, eventType, guardEventType string, broadcast bool) string {
+	if strings.TrimSpace(nodeID) == "" || strings.TrimSpace(eventType) == "" {
+		return "{}\n"
+	}
+	broadcastLine := ""
+	if broadcast {
+		broadcastLine = "        broadcast: true\n"
+	}
+	guardYAML := ""
+	if strings.TrimSpace(guardEventType) != "" {
+		guardYAML = `      guard:
+        id: guard-escalate
+        check: "false"
+        on_fail: "escalate:` + guardEventType + `"
+`
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+` + guardYAML + `
+      emit:
+        event: ` + eventType + `
+` + broadcastLine
+}
+
+func countAuthoredEmitSites(sites []AuthoredEmitSite, flowID, nodeID, eventType string) int {
+	return len(authoredEmitSitesByFlowNodeEvent(sites, flowID, nodeID, eventType))
+}
+
+func authoredEmitSitesByFlowNodeEvent(sites []AuthoredEmitSite, flowID, nodeID, eventType string) []AuthoredEmitSite {
+	out := []AuthoredEmitSite{}
+	for _, site := range sites {
+		if strings.TrimSpace(site.FlowID) == flowID &&
+			strings.TrimSpace(site.NodeID) == nodeID &&
+			strings.TrimSpace(site.Spec.EventType()) == eventType {
+			out = append(out, site)
+		}
+	}
+	return out
+}
+
+func authoredEmitSiteSummaries(sites []AuthoredEmitSite) []string {
+	out := make([]string, 0, len(sites))
+	for _, site := range sites {
+		out = append(out, strings.Join([]string{site.FlowID, site.SourceScopeKey, site.NodeID, site.HandlerEvent, site.Site, site.Spec.EventType()}, "|"))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -77,18 +77,38 @@ func TestAuthoredEmitSites_OutsidePackageDoesNotSuppressGenericFlowScope(t *test
 	}
 }
 
+func TestAuthoredEmitSites_NestedFlowPackageDoesNotSuppressMainFlowScope(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		flowNodeID:          "flow-node",
+		flowEmit:            "support.ready",
+		nestedPackageNodeID: "nested-node",
+		nestedPackageEmit:   "support.ready",
+		omitFlowPackage:     true,
+	})
+
+	sites := AuthoredEmitSites(source)
+	if countAuthoredEmitSites(sites, "support", "flow-node", "support.ready") != 1 {
+		t.Fatalf("expected main flow scope site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredEmitSites(sites, "support", "nested-node", "support.ready") != 1 {
+		t.Fatalf("expected nested package site, got %#v", authoredEmitSiteSummaries(sites))
+	}
+}
+
 type authoredEmitSiteFixture struct {
-	rootNodeID      string
-	rootEmit        string
-	rootGuardEmit   string
-	rootBroadcast   bool
-	flowNodeID      string
-	flowEmit        string
-	flowBroadcast   bool
-	extrasNodeID    string
-	extrasEmit      string
-	extrasBroadcast bool
-	omitFlowPackage bool
+	rootNodeID          string
+	rootEmit            string
+	rootGuardEmit       string
+	rootBroadcast       bool
+	flowNodeID          string
+	flowEmit            string
+	flowBroadcast       bool
+	extrasNodeID        string
+	extrasEmit          string
+	extrasBroadcast     bool
+	omitFlowPackage     bool
+	nestedPackageNodeID string
+	nestedPackageEmit   string
 }
 
 func loadAuthoredEmitSiteFixture(t *testing.T, opts authoredEmitSiteFixture) Source {
@@ -99,12 +119,17 @@ func loadAuthoredEmitSiteFixture(t *testing.T, opts authoredEmitSiteFixture) Sou
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := t.TempDir()
+	nestedPackageRef := ""
+	if strings.TrimSpace(opts.nestedPackageNodeID) != "" {
+		nestedPackageRef = "  - path: flows/support/addon\n"
+	}
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: authored-emit-site-fixture
 version: "1.0.0"
 platform_version: ">=1.6.0"
 packages:
   - path: extras
+`+nestedPackageRef+`
 flows:
   - id: support
     flow: support
@@ -157,6 +182,14 @@ version: "1.0.0"
 flows: []
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "extras", "nodes.yaml"), authoredEmitSiteNodeYAML(opts.extrasNodeID, "support.start", opts.extrasEmit, "", opts.extrasBroadcast))
+	if strings.TrimSpace(opts.nestedPackageNodeID) != "" {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "addon", "package.yaml"), `
+name: support-addon
+version: "1.0.0"
+flows: []
+`)
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "addon", "nodes.yaml"), authoredEmitSiteNodeYAML(opts.nestedPackageNodeID, "support.start", opts.nestedPackageEmit, "", false))
+	}
 
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -586,6 +586,44 @@ func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
 	}
 }
 
+func TestHandleEmitTool_RootSchemaPinOutputStillRequiresTarget(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"root.ready"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"root.ready": {
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "root-agent",
+		Role:       "root-agent",
+		EmitEvents: []string{"root.ready"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_root_ready", map[string]any{})
+	if err == nil {
+		t.Fatal("handleEmitTool error = nil, want target_required_missing")
+	}
+	if !strings.Contains(err.Error(), "target_required_missing") {
+		t.Fatalf("handleEmitTool error = %v, want target_required_missing", err)
+	}
+	if bus.count != 0 {
+		t.Fatalf("publish count = %d, want 0", bus.count)
+	}
+}
+
 func TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{

--- a/tests/tier1-primitives/test-guard-escalate/schema.yaml
+++ b/tests/tier1-primitives/test-guard-escalate/schema.yaml
@@ -4,5 +4,3 @@ states: [pending, done]
 pins:
   inputs:
     events: [check.requested]
-  outputs:
-    events: [check.escalated]

--- a/tests/tier10-policy-patterns/test-policy-counter-escalate/schema.yaml
+++ b/tests/tier10-policy-patterns/test-policy-counter-escalate/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [attempt.requested]
   outputs:
-    events: [attempt.processed, attempt.limit_hit]
+    events: [attempt.processed]

--- a/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [retry.requested]
   outputs:
-    events: [retry.dispatched, limit.reached]
+    events: [retry.dispatched]


### PR DESCRIPTION
Part of #1282

## Summary
- Adds `semanticview.AuthoredEmitSites` as the canonical source of authored workflow emit-site identity.
- Migrates bootverify `pin_target_resolution` to consume the canonical authored emit-site owner instead of rebuilding emit sites locally.
- Preserves fail-closed root pin-output behavior, including root/project emits, flow/package ownership, duplicate projection de-dupe, same `(flowID,nodeID)` authored sites, and guard escalation shorthand sites.

## Governing Refs / Context
- No exact platform-spec section names the internal canonical authored emit-site identity owner; binding context is #1282, its Pre-Implementation Coverage Audit, and Gate B approval.
- Exact downstream semantics remain governed by `platform-spec.yaml` sections:
  - `engine.workflow_contract.emit.pin_routing_activation.target_resolution.fail_closed`
  - `engine.workflow_contract.emit.pin_routing_activation.target_forms.broadcast`
  - `engine.cross_flow_routing.target_resolution_failure_taxonomy.boot_verify.target_required_missing`
  - `engine.event_identity_resolution.resolution_rules.root_events_are_global`

## Semantic Migration
- New canonical owner: `internal/runtime/semanticview.AuthoredEmitSites`.
- Old non-authoritative path now invalid: bootverify-local authored emit-site reconstruction and de-dupe in `internal/runtime/bootverify/workflow_pin_routing_checks.go`.
- Production paths checked: bootverify `pin_target_resolution`, root pin-output predicate, runtime emit-tool guard, catalog e2e guard escalation fixtures, and `cmd/swarm verify` fixture coverage.
- Migration status: complete for the approved first-slice bootverify consumer. Runtime delivery planning, runtime target resolution, action/agent/tool/auto emits, and broad strict schema migration remain outside this PR.

## Proof
- `go test ./internal/runtime/semanticview -run 'TestAuthoredEmitSites' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestPinTargetResolution' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier(1Primitive|9Composition|10Policy)' -count=1`
- `go test ./...`
