### PR TITLE
[agent-g][issue #1286] Enable host tool result relay

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2063,13 +2063,13 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	authority := spec.WorkspaceModel.WorkspaceExecutionTargetCapability
-	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_slice" {
+	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235/#1286" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_and_relay_slice" {
 		t.Fatalf("workspace execution target authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_execution_target_capability") || !strings.Contains(authority.ImplementationOwner, "internal/runtime/workspace.ExecutionTarget") {
 		t.Fatalf("workspace execution target owners = canonical:%q implementation:%q", authority.CanonicalOwner, authority.ImplementationOwner)
 	}
-	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "platform-managed native file read/write"} {
+	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "tool-result relay"} {
 		if !strings.Contains(authority.Scope, want) {
 			t.Fatalf("workspace execution target scope missing %q:\n%s", want, authority.Scope)
 		}
@@ -2090,12 +2090,12 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") {
 		t.Fatalf("host execution mode rule = %q", hostMode.Rule)
 	}
-	for _, want := range []string{string(workspace.ExecutionCapabilityFileRead), string(workspace.ExecutionCapabilityFileWrite)} {
+	for _, want := range []string{string(workspace.ExecutionCapabilityFileRead), string(workspace.ExecutionCapabilityFileWrite), string(workspace.ExecutionCapabilityToolResultRelay)} {
 		if !stringSliceContains(hostMode.Capabilities, want) {
 			t.Fatalf("host execution capabilities missing %q: %#v", want, hostMode.Capabilities)
 		}
 	}
-	for _, forbidden := range []string{string(workspace.ExecutionCapabilityNativeCommand), string(workspace.ExecutionCapabilityToolResultRelay), string(workspace.ExecutionCapabilityClaudeCLI)} {
+	for _, forbidden := range []string{string(workspace.ExecutionCapabilityNativeCommand), string(workspace.ExecutionCapabilityClaudeCLI)} {
 		if stringSliceContains(hostMode.Capabilities, forbidden) {
 			t.Fatalf("host execution capabilities include forbidden %q: %#v", forbidden, hostMode.Capabilities)
 		}
@@ -2127,21 +2127,21 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 			t.Fatalf("retired interpreters missing %q: %#v", want, authority.RetiredNonAuthoritativeInterpreters)
 		}
 	}
-	for _, want := range []string{"native command execution", "Host-local file operations fail closed", "Empty-container targets", "Docker behavior"} {
+	for _, want := range []string{"native command execution", "Host-local tool-result relay writes", "Host-local file operations fail closed", "Empty-container targets", "Docker behavior"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("failure behavior missing %q: %#v", want, authority.FailureBehavior)
 		}
 	}
-	for _, want := range []string{"host native bash", "host tool-result relay", "Claude CLI", "#1137"} {
+	for _, want := range []string{"host native bash", "Claude CLI", "#1137"} {
 		if !joinedContains(authority.SplitScope, want) {
 			t.Fatalf("split scope missing %q: %#v", want, authority.SplitScope)
 		}
 	}
 	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceExecutionTargetCapability
-	if command.PromotedBy != "#1213/#1235" || command.Owner != "workspace_model.workspace_execution_target_capability" {
+	if command.PromotedBy != "#1213/#1235/#1286" || command.Owner != "workspace_model.workspace_execution_target_capability" {
 		t.Fatalf("serve command workspace execution authority = %#v", command)
 	}
-	if !strings.Contains(command.Rule, "support only platform-managed native file read/write") {
+	if !strings.Contains(command.Rule, "tool-result relay through execution-target path authority") {
 		t.Fatalf("serve command workspace execution rule = %q", command.Rule)
 	}
 	for _, want := range []string{"native executor", "fallback-tool routing", "tool-result relay", "Claude CLI"} {

--- a/internal/runtime/llm/cli_tool_result_relay.go
+++ b/internal/runtime/llm/cli_tool_result_relay.go
@@ -90,6 +90,12 @@ func (r *ClaudeCLIRuntime) writeWorkspaceRelayFile(ctx context.Context, target *
 
 func (r *ClaudeCLIRuntime) runWorkspaceCommand(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error) {
 	execTarget := target.ExecutionTarget()
+	if err := execTarget.Require(workspace.ExecutionCapabilityClaudeCLI); err != nil {
+		if strings.EqualFold(strings.TrimSpace(execTarget.Backend), workspace.BackendHost) {
+			return nil, nil, 0, errClaudeHostWorkspaceUnsupported()
+		}
+		return nil, nil, 0, fmt.Errorf("%w: %s", ErrClaudeWorkspaceRequired, err.Error())
+	}
 	if err := execTarget.Require(workspace.ExecutionCapabilityToolResultRelay); err != nil {
 		if strings.EqualFold(strings.TrimSpace(execTarget.Backend), workspace.BackendHost) {
 			return nil, nil, 0, errClaudeHostWorkspaceUnsupported()

--- a/internal/runtime/tools/tool_result_relay.go
+++ b/internal/runtime/tools/tool_result_relay.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -41,16 +43,8 @@ func (e *Executor) PersistOversizedToolResultRelay(ctx context.Context, toolName
 	if err != nil {
 		return runtimemcp.ToolResultRelayRef{}, err
 	}
-	_, stderr, exitCode, execErr := e.runWorkspaceCommand(ctx, target, 30*time.Second, string(rawJSON), "sh", "-lc", `mkdir -p -- "$(dirname -- "$1")" && cat > "$1"`, "swarm-tool-result-relay", relayPath)
-	if execErr != nil || exitCode != 0 {
-		msg := strings.TrimSpace(string(stderr))
-		if msg == "" && execErr != nil {
-			msg = execErr.Error()
-		}
-		if msg == "" {
-			msg = "workspace relay write failed"
-		}
-		return runtimemcp.ToolResultRelayRef{}, fmt.Errorf("write tool result relay %s: %s", relayPath, msg)
+	if err := e.writeToolResultRelayFile(ctx, target, execTarget, relayPath, rawJSON); err != nil {
+		return runtimemcp.ToolResultRelayRef{}, err
 	}
 	return runtimemcp.ToolResultRelayRef{
 		Path:       relayPath,
@@ -85,16 +79,8 @@ func (e *Executor) persistChunkedReadFileRelay(ctx context.Context, target *work
 		if err != nil {
 			return runtimemcp.ToolResultRelayRef{}, true, err
 		}
-		_, stderr, exitCode, execErr := e.runWorkspaceCommand(ctx, target, 30*time.Second, chunk, "sh", "-lc", `mkdir -p -- "$(dirname -- "$1")" && cat > "$1"`, "swarm-tool-result-relay", relayPath)
-		if execErr != nil || exitCode != 0 {
-			msg := strings.TrimSpace(string(stderr))
-			if msg == "" && execErr != nil {
-				msg = execErr.Error()
-			}
-			if msg == "" {
-				msg = "workspace relay write failed"
-			}
-			return runtimemcp.ToolResultRelayRef{}, true, fmt.Errorf("write tool result relay %s: %s", relayPath, msg)
+		if err := e.writeToolResultRelayFile(ctx, target, execTarget, relayPath, []byte(chunk)); err != nil {
+			return runtimemcp.ToolResultRelayRef{}, true, err
 		}
 		relayPaths = append(relayPaths, relayPath)
 	}
@@ -104,6 +90,36 @@ func (e *Executor) persistChunkedReadFileRelay(ctx context.Context, target *work
 		Format:     "text",
 		Visibility: "workspace_mount",
 	}, true, nil
+}
+
+func (e *Executor) writeToolResultRelayFile(ctx context.Context, target *workspace.Target, execTarget workspace.ExecutionTarget, relayPath string, payload []byte) error {
+	switch execTarget.Mode {
+	case workspace.ExecutionModeHostLocal:
+		resolved, err := execTarget.ResolveHostPath(relayPath, workspace.PathAccessWrite)
+		if err != nil {
+			return fmt.Errorf("write tool result relay %s: %s", relayPath, err.Error())
+		}
+		if err := os.MkdirAll(filepath.Dir(resolved.HostPath), 0o700); err != nil {
+			return fmt.Errorf("write tool result relay %s: %s", resolved.LogicalPath, hostFileErrorMessage(err))
+		}
+		if err := os.WriteFile(resolved.HostPath, payload, 0o644); err != nil {
+			return fmt.Errorf("write tool result relay %s: %s", resolved.LogicalPath, hostFileErrorMessage(err))
+		}
+		return nil
+	default:
+		_, stderr, exitCode, execErr := e.runWorkspaceCommand(ctx, target, 30*time.Second, string(payload), "sh", "-lc", `mkdir -p -- "$(dirname -- "$1")" && cat > "$1"`, "swarm-tool-result-relay", relayPath)
+		if execErr != nil || exitCode != 0 {
+			msg := strings.TrimSpace(string(stderr))
+			if msg == "" && execErr != nil {
+				msg = execErr.Error()
+			}
+			if msg == "" {
+				msg = "workspace relay write failed"
+			}
+			return fmt.Errorf("write tool result relay %s: %s", relayPath, msg)
+		}
+		return nil
+	}
 }
 
 func toolResultRelayPath(target workspace.ExecutionTarget, actor models.AgentConfig, toolName string) (string, error) {

--- a/internal/runtime/tools/tool_result_relay_test.go
+++ b/internal/runtime/tools/tool_result_relay_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
@@ -21,13 +23,18 @@ func (s relayWorkspaceResolverStub) ResolveWorkspace(context.Context, models.Age
 	return s.target, nil
 }
 
-func TestExecutorPersistOversizedToolResultRelay_ChunksLargeReadFileResults(t *testing.T) {
+func TestExecutorPersistOversizedToolResultRelay_DockerChunksLargeReadFileResultsThroughWorkspaceCommand(t *testing.T) {
 	tmpDir := t.TempDir()
+	var commandCalls int
 	exec := &Executor{
 		workspaces: relayWorkspaceResolverStub{
 			target: &workspace.Target{Backend: workspace.BackendDocker, Container: "swarm-agent", Workdir: "/workspace"},
 		},
-		execWorkspaceFn: func(_ context.Context, _ workspace.ExecutionTarget, _ time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
+		execWorkspaceFn: func(_ context.Context, execTarget workspace.ExecutionTarget, _ time.Duration, stdin string, args ...string) ([]byte, []byte, int, error) {
+			commandCalls++
+			if execTarget.Mode != workspace.ExecutionModeDockerContainer {
+				t.Fatalf("exec target mode = %s, want docker_container", execTarget.Mode)
+			}
 			if len(args) == 0 {
 				return nil, []byte("missing args"), 1, nil
 			}
@@ -77,22 +84,151 @@ func TestExecutorPersistOversizedToolResultRelay_ChunksLargeReadFileResults(t *t
 			t.Fatalf("chunk %q length = %d, want <= %d", chunk, len(data), toolResultRelayChunkBytes)
 		}
 	}
+	if commandCalls == 0 {
+		t.Fatalf("docker relay did not use workspace command path")
+	}
 }
 
-func TestExecutorPersistOversizedToolResultRelay_FailsClosedForHostBackend(t *testing.T) {
+func TestExecutorPersistOversizedToolResultRelay_HostUsesExecutionTargetFileIO(t *testing.T) {
+	exec, actor, target := newHostRelayExecutor(t)
+	exec.execWorkspaceFn = func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+		t.Fatalf("host relay must use direct platform file I/O, not workspace command execution")
+		return nil, nil, 0, nil
+	}
+	ctx := models.WithActor(context.Background(), actor)
+
+	relay, err := exec.PersistOversizedToolResultRelay(ctx, "sql_execute", []byte(`{"blob":"hello"}`))
+	if err != nil {
+		t.Fatalf("PersistOversizedToolResultRelay: %v", err)
+	}
+	if relay.ReadTool != "read_file" || relay.Format != "json" || relay.Visibility != "workspace_mount" {
+		t.Fatalf("relay = %#v, want read_file json workspace_mount", relay)
+	}
+	if !strings.HasPrefix(relay.Path, "/workspace/"+workspaceToolResultRelayDir+"/") || !strings.HasSuffix(relay.Path, ".json") {
+		t.Fatalf("relay path = %q, want logical workspace relay path", relay.Path)
+	}
+	if strings.Contains(relay.Path, target.Workdir) {
+		t.Fatalf("relay path leaked host workdir: %q", relay.Path)
+	}
+	resolved, err := target.ExecutionTarget().ResolveHostPath(relay.Path, workspace.PathAccessRead)
+	if err != nil {
+		t.Fatalf("ResolveHostPath relay: %v", err)
+	}
+	if data, err := os.ReadFile(resolved.HostPath); err != nil || string(data) != `{"blob":"hello"}` {
+		t.Fatalf("host relay file = %q err=%v", data, err)
+	}
+	read, err := exec.Execute(ctx, "read_file", map[string]any{"path": relay.Path})
+	if err != nil {
+		t.Fatalf("Execute read_file relay path: %v", err)
+	}
+	if got := read.(map[string]any)["content"]; got != `{"blob":"hello"}` {
+		t.Fatalf("read relay content = %#v", got)
+	}
+	if _, err := exec.Execute(ctx, "bash", map[string]any{"command": "true"}); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
+		t.Fatalf("Execute bash error = %v, want host native command fail-closed", err)
+	}
+}
+
+func TestExecutorPersistOversizedToolResultRelay_HostChunksLargeReadFileResults(t *testing.T) {
+	exec, actor, target := newHostRelayExecutor(t)
+	exec.execWorkspaceFn = func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+		t.Fatalf("host chunk relay must use direct platform file I/O, not workspace command execution")
+		return nil, nil, 0, nil
+	}
+	ctx := models.WithActor(context.Background(), actor)
+	raw, err := json.Marshal(map[string]any{
+		"content":    strings.Repeat("x", toolResultRelayChunkBytes+512),
+		"size_bytes": toolResultRelayChunkBytes + 512,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	relay, err := exec.PersistOversizedToolResultRelay(ctx, "read_file", raw)
+	if err != nil {
+		t.Fatalf("PersistOversizedToolResultRelay: %v", err)
+	}
+	if len(relay.Chunks) < 2 {
+		t.Fatalf("relay chunks = %#v, want multiple chunk paths", relay.Chunks)
+	}
+	for _, chunk := range relay.Chunks {
+		if !strings.HasPrefix(chunk, "/workspace/"+workspaceToolResultRelayDir+"/") || strings.Contains(chunk, target.Workdir) {
+			t.Fatalf("chunk path = %q, want logical workspace path without host backing path", chunk)
+		}
+		resolved, err := target.ExecutionTarget().ResolveHostPath(chunk, workspace.PathAccessRead)
+		if err != nil {
+			t.Fatalf("ResolveHostPath(%q): %v", chunk, err)
+		}
+		data, err := os.ReadFile(resolved.HostPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", chunk, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("chunk %q is empty", chunk)
+		}
+		if len(data) > toolResultRelayChunkBytes {
+			t.Fatalf("chunk %q length = %d, want <= %d", chunk, len(data), toolResultRelayChunkBytes)
+		}
+	}
+	read, err := exec.Execute(ctx, "read_file", map[string]any{"path": relay.Chunks[0]})
+	if err != nil {
+		t.Fatalf("Execute read_file first chunk: %v", err)
+	}
+	if got := read.(map[string]any)["size_bytes"]; got == 0 {
+		t.Fatalf("read first chunk result = %#v, want non-empty", read)
+	}
+}
+
+func TestExecutorPersistOversizedToolResultRelay_HostWithoutBackingMountFailsClosed(t *testing.T) {
 	exec := &Executor{
 		workspaces: relayWorkspaceResolverStub{
 			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
 		},
 		execWorkspaceFn: func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
-			t.Fatalf("host relay must fail closed before workspace command execution")
+			t.Fatalf("host relay must not shell through workspace command execution")
 			return nil, nil, 0, nil
 		},
 	}
 	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "market-research-agent"})
 
 	_, err := exec.PersistOversizedToolResultRelay(ctx, "sql_execute", []byte(`{"blob":"hello"}`))
-	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support tool result relay yet") {
-		t.Fatalf("PersistOversizedToolResultRelay error = %v, want host relay fail-closed diagnostic", err)
+	if err == nil || !strings.Contains(err.Error(), "host backing path for /workspace is unavailable") {
+		t.Fatalf("PersistOversizedToolResultRelay error = %v, want host backing path fail-closed diagnostic", err)
 	}
+}
+
+func newHostRelayExecutor(t *testing.T) (*Executor, models.AgentConfig, *workspace.Target) {
+	t.Helper()
+	ctx := context.Background()
+	workspaceRoot := filepath.Join(t.TempDir(), "host-workspaces")
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("write package.yaml: %v", err)
+	}
+	manager := workspace.NewHostManager(nil)
+	manager.SetConfig(workspace.HostConfig{
+		WorkspaceRoot:       workspaceRoot,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      workspace.LogicalDataMount,
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: workspace.LogicalContractsMount,
+	})
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	if err := manager.ValidateSource(ctx, source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	if err := manager.EnsurePrereqs(ctx); err != nil {
+		t.Fatalf("EnsurePrereqs: %v", err)
+	}
+	actor := models.AgentConfig{
+		ID:          "market-research-agent",
+		NativeTools: models.NativeToolConfig{FileIO: true, Bash: true},
+	}
+	target, err := manager.ResolveWorkspace(ctx, actor)
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	return exec, actor, target
 }

--- a/internal/runtime/workspace/execution.go
+++ b/internal/runtime/workspace/execution.go
@@ -130,6 +130,7 @@ func hostExecutionTarget(workdir string, mounts []ExecutionMount) ExecutionTarge
 		capabilities: capabilitySet(
 			ExecutionCapabilityFileRead,
 			ExecutionCapabilityFileWrite,
+			ExecutionCapabilityToolResultRelay,
 		),
 	}
 }
@@ -199,8 +200,6 @@ func (e ExecutionTarget) UnsupportedMessage(capability ExecutionCapability) stri
 		switch capability {
 		case ExecutionCapabilityClaudeCLI:
 			return "host workspace backend does not support Claude CLI execution yet"
-		case ExecutionCapabilityToolResultRelay:
-			return "host workspace backend does not support tool result relay yet"
 		default:
 			return "host workspace backend does not support native tool execution yet"
 		}

--- a/internal/runtime/workspace/execution_test.go
+++ b/internal/runtime/workspace/execution_test.go
@@ -14,11 +14,11 @@ func TestExecutionTargetDistinguishesDockerHostAndEmptyContainer(t *testing.T) {
 	}
 
 	host := (&Target{Backend: BackendHost, Workdir: t.TempDir()}).ExecutionTarget()
-	if host.Mode != ExecutionModeHostLocal || !host.Supports(ExecutionCapabilityFileRead) || !host.Supports(ExecutionCapabilityFileWrite) {
-		t.Fatalf("host execution target = %#v, want explicit host file capabilities", host)
+	if host.Mode != ExecutionModeHostLocal || !host.Supports(ExecutionCapabilityFileRead) || !host.Supports(ExecutionCapabilityFileWrite) || !host.Supports(ExecutionCapabilityToolResultRelay) {
+		t.Fatalf("host execution target = %#v, want explicit host file/relay capabilities", host)
 	}
-	if host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityToolResultRelay) || host.Supports(ExecutionCapabilityClaudeCLI) {
-		t.Fatalf("host execution target = %#v, want command/relay/claude unsupported", host)
+	if host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityClaudeCLI) {
+		t.Fatalf("host execution target = %#v, want command/claude unsupported", host)
 	}
 	if err := host.Require(ExecutionCapabilityNativeCommand); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
 		t.Fatalf("host native command error = %v, want fail-closed diagnostic", err)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6916,8 +6916,8 @@ workspace_model:
     - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.
     - Host backend MUST reject `SWARM_WORKSPACE_VOLUMES_FROM`; the host backend consumes explicit path authorities, not Docker
       volume inheritance.
-    - Host backend MUST fail closed for Claude CLI, native tool execution, and tool relay surfaces unless a later gate promotes
-      safe host execution semantics.
+    - Host backend MUST fail closed for Claude CLI and native tool execution unless a later gate promotes safe host execution
+      semantics. Host tool-result relay is supported only through `workspace_execution_target_capability` path authority.
     consumers:
     - swarm serve boot workspace lifecycle
     - dynamic Builder project reload workspace lifecycle
@@ -6925,17 +6925,17 @@ workspace_model:
     split_scope:
     - '#1137 Compose/Postgres onboarding and Compose cleanup'
     - '#1136 broader local onboarding/docs'
-    - full host Claude CLI, native tool execution, and tool relay parity
+    - full host Claude CLI and native tool execution parity
     - production SQLite multi-writer semantics
   workspace_execution_target_capability:
-    promoted_by: '#1213/#1235'
-    implementation_status: implemented_host_file_slice
+    promoted_by: '#1213/#1235/#1286'
+    implementation_status: implemented_host_file_and_relay_slice
     canonical_owner: platform-spec.yaml#workspace_model.workspace_execution_target_capability
     scope: >
       Defines the canonical runtime execution-target and capability authority for workspace-backed execution surfaces after
       workspace backend selection. The owner distinguishes Docker container execution, explicit host-local targets, and
-      unsupported targets. It does not make host execution Docker-equivalent. Host-local targets support only platform-managed
-      native file read/write over logical workspace mounts; host command execution, host tool-result relay, and host
+      unsupported targets. It does not make host execution Docker-equivalent. Host-local targets support platform-managed
+      native file read/write and tool-result relay over logical workspace mounts; host command execution and host
       Claude/provider runtime support remain unsupported unless a later gate promotes those surfaces.
     implementation_owner: internal/runtime/workspace.ExecutionTarget
     target_modes:
@@ -6953,11 +6953,12 @@ workspace_model:
         rule: >
           A host target is an explicit local-dev backend target with platform-managed raw host backing paths and logical
           mount identities. Host-local targets MUST NOT infer execution support from an empty container field. Host-local
-          targets support file_read and file_write only through the platform-managed workspace execution owner; native_command,
-          tool_result_relay, and claude_cli remain unsupported.
+          targets support file_read, file_write, and tool_result_relay only through the platform-managed workspace execution
+          owner; native_command and claude_cli remain unsupported.
         capabilities:
         - file_read
         - file_write
+        - tool_result_relay
       unsupported:
         rule: >
           Nil targets, unknown backend names, Docker targets without a container, and empty targets are unsupported. They MUST
@@ -6998,8 +6999,10 @@ workspace_model:
     - nil target or empty target cwd fallback
     - ad hoc HostBackend() checks outside the execution-target owner
     failure_behavior:
-    - Host-local targets remain fail closed for native command execution, tool-result relay, and Claude/provider execution until
-      a later gate promotes and proves those surfaces.
+    - Host-local targets remain fail closed for native command execution and Claude/provider execution until a later gate promotes
+      and proves those surfaces.
+    - Host-local tool-result relay writes MUST use platform-managed host file I/O through the execution-target path owner and
+      MUST NOT use native command, shell, or provider execution.
     - Host-local file operations fail closed when the logical path is outside allowed mounts, when a write targets a read-only
       mount, when a raw host path is provided as product input, or when private backing-path resolution would escape the selected
       mount root.
@@ -7007,7 +7010,6 @@ workspace_model:
     - Docker behavior must remain regression-proven through the same typed owner.
     split_scope:
     - host native bash/command execution
-    - host tool-result relay support
     - Claude CLI/provider-native host runtime support
     - Docker-equivalent host isolation claims
     - '#1137 and #1136 docs/onboarding cleanup'
@@ -8830,12 +8832,12 @@ cli_specification:
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
       workspace_execution_target_capability:
-        promoted_by: '#1213/#1235'
+        promoted_by: '#1213/#1235/#1286'
         owner: workspace_model.workspace_execution_target_capability
         rule: >
           `swarm serve` runtime execution surfaces MUST consume the typed workspace execution target/capability owner after
-          backend selection. Host-local targets remain explicit and support only platform-managed native file read/write;
-          native command execution, tool-result relay, and Claude/provider execution remain fail closed. Docker targets continue
+          backend selection. Host-local targets remain explicit and support platform-managed native file read/write plus
+          tool-result relay through execution-target path authority; native command execution and Claude/provider execution remain fail closed. Docker targets continue
           through container execution.
         consumers:
         - native executor command/file path authority


### PR DESCRIPTION
## Summary

Closes #1286.

This PR promotes host-local tool-result relay support through the existing workspace execution-target authority while preserving the approved #1286 first-slice boundary. It does not enable host native command execution, Claude/provider host execution, Docker-equivalent isolation, or full #1213 closure.

## Governing refs / context

- `platform-spec.yaml#workspace_model.workspace_execution_target_capability`
- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#workspace_model.data_source_authority`
- `platform-spec.yaml#workspace_model.standard_mounts` / `mount_guarantees`
- #1286 Pre-Implementation Coverage Audit and independent gate outcome
- Parent context: #1213 and #1138; command execution split remains tied to #746

## Semantic migration

- New canonical owner: `platform-spec.yaml#workspace_model.workspace_execution_target_capability` and `internal/runtime/workspace.ExecutionTarget` remain the canonical owner for execution capabilities and logical/private path authority.
- Old producer / reader / writer path now invalid: host tool-result relay must not infer support from `Target.Container`, raw `Target.Workdir`, process cwd, host shell execution, `native_command`, or raw host paths. Generic host relay now writes only through `ExecutionTarget.ResolveHostPath`.
- Production paths checked for surviving old behavior: generic `tools.Executor` single relay, generic chunked `read_file` relay, Docker relay regression, LLM projection, MCP projection, Claude CLI relay helper, and host native command execution.
- Migration completeness: complete for chosen class `runtime.host_tool_result_relay_path_authority`. Parent host execution parity remains open for host command execution, Claude/provider host execution, and docs/operator polish.

## Proof

- `go test ./internal/runtime/workspace ./internal/runtime/tools ./internal/runtime/llm ./internal/runtime/mcp ./cmd/swarm -run 'Test(ExecutionTarget|ExecutorPersistOversizedToolResultRelay|NativeWorkspaceCommandFailsClosedForHostBackend|ExecutorHostFileToolsUseHostManagerSupportedSurfaceWithoutDocker|ClaudeCLIRuntime.*Host|ClaudeCLIRuntimeWorkspaceCommandRejectsHostWorkspaceBackend|ClaudeCLIRuntimePersistOversizedToolResultRelay|Conversation.*Relay|Gateway.*Relay|PlatformSpecWorkspaceExecutionTargetCapabilityPromoted)' -count=1`
- `go test ./...`
- `go test ./internal/runtime/llm ./internal/runtime/mcp -run 'Relay|Oversized|runtime_read_file' -count=1`