### PR TITLE
[agent-f][issue #1255] Route event.publish follow-ups through selected store

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -184,6 +184,14 @@ func (s storeBundle) runtimeStores() runtime.Stores {
 	}
 }
 
+func selectedAPIRunBundleContextStore(stores storeBundle) apiv1.RunBundleContextStore {
+	if stores.Postgres != nil {
+		return stores.Postgres
+	}
+	runBundleContext, _ := stores.ObservabilityStore.(apiv1.RunBundleContextStore)
+	return runBundleContext
+}
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -841,6 +849,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	var apiAgentConversations apiv1.AgentConversationReadStore
 	var apiDatabase apiv1.Pinger
 	var apiRuns apiv1.RunReadStore
+	apiRunBundleContext := selectedAPIRunBundleContextStore(stores)
 	apiObservability := stores.ObservabilityStore
 	if stores.Postgres != nil {
 		apiDatabase = stores.Postgres
@@ -904,7 +913,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		},
 		ConversationForks:   stores.Postgres,
 		ForkChatExecutor:    apiv1.NewLLMForkChatExecutor(forkChatLLM),
-		RunBundleContext:    stores.Postgres,
+		RunBundleContext:    apiRunBundleContext,
 		RunForkAvailability: runForkAvailability,
 		RunFork: apiv1.SelectedContractRunForkExecutor{
 			Store:             stores.Postgres,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -244,6 +244,27 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 }
 
+func TestBuildStoresSQLiteSelectsRunBundleContextForServedEventPublish(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dev.db")
+	stores, err := buildStores(context.Background(), storebackend.Selection{
+		Backend:          storebackend.BackendSQLite,
+		BackendSource:    storebackend.SourceFlag,
+		SQLitePath:       path,
+		SQLitePathSource: storebackend.SourceRolloutDefault,
+	}, &config.Config{})
+	if err != nil {
+		t.Fatalf("buildStores(sqlite): %v", err)
+	}
+	t.Cleanup(func() { closeDB(stores.SQLDB) })
+	runBundleContext, ok := stores.ObservabilityStore.(apiv1.RunBundleContextStore)
+	if !ok {
+		t.Fatalf("sqlite ObservabilityStore = %T, want selected run bundle context store for event.publish --run-id", stores.ObservabilityStore)
+	}
+	if got := selectedAPIRunBundleContextStore(stores); got == nil || got != runBundleContext {
+		t.Fatalf("selected API run bundle context = %T, want sqlite selected owner %T", got, runBundleContext)
+	}
+}
+
 func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "dev.db")

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -264,6 +264,9 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
 		problems = append(problems, "active_trackers must not include closed #1254 runtime_store_backend_default_and_sqlite_portability")
 	}
+	if _, ok := activeTrackers[trackerKey(1255, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
+		problems = append(problems, "active_trackers missing #1255 runtime_store_backend_default_and_sqlite_portability")
+	}
 	if _, ok := activeTrackers[trackerKey(0, "operator_surfaces.v1_openrpc_api_conformance")]; !ok {
 		problems = append(problems, "active_trackers missing operator_surfaces.v1_openrpc_api_conformance watchlist")
 	}
@@ -649,6 +652,7 @@ func requiredPublicSurfaceRows() map[string]struct{} {
 		"status_run_get_entity_count",
 		"event_publish_api",
 		"event_publish_cli",
+		"event_publish_existing_run_followup_served_path",
 		"mailbox_read_api_after_mailbox_write",
 		"mailbox_read_cli",
 		"serve_dev_abandon_active_runs",

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -20,6 +20,9 @@ active_trackers:
   - kind: github_issue
     issue: 1239
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+  - kind: github_issue
+    issue: 1255
+    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: watchlist
     issue: 0
     watchlist: operator_surfaces.v1_openrpc_api_conformance
@@ -190,7 +193,7 @@ rows:
       broader #1239 parent tail is closed.
 
   - id: event_publish_api
-    surface: /v1/rpc event.publish creating work against SQLite and Postgres
+    surface: /v1/rpc event.publish create-new/idempotent publication against SQLite and Postgres
     classification: already_covered_by_existing_proof
     tier: required_smoke
     backends: [default_sqlite, explicit_postgres]
@@ -206,9 +209,16 @@ rows:
         name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
       - kind: go_test
         name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+      - kind: go_test
+        name: TestOperatorEventPublishRejectsCallerEntityIDForCreateEntityBeforePersistence
+    notes: >
+      This covered row is intentionally limited to create-new/idempotent
+      publication and create-entity payload identity admission. Existing-run
+      served follow-up state advance remains split to #1255 below until the
+      required supported-surface proof exists.
 
   - id: event_publish_cli
-    surface: swarm event publish
+    surface: swarm event publish create-new publication and exact v1 RPC command shape
     classification: already_covered_by_existing_proof
     tier: required_smoke
     backends: [default_sqlite, explicit_postgres]
@@ -226,6 +236,44 @@ rows:
         name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
       - kind: go_test
         name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+    notes: >
+      CLI existing-run follow-up semantics are not claimed by this covered row.
+      The exact RPC-shape proof composes with the API create-new/idempotent
+      publication proof only; served `--run-id` state-advance coverage remains
+      split to #1255.
+
+  - id: event_publish_existing_run_followup_served_path
+    surface: default SQLite served swarm event publish --run-id follow-up state advance and readback
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1255
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [event_publish]
+    api_methods: [event.publish]
+    openrpc_matrix_methods: [event.publish]
+    store_owners:
+      - cmd/swarm event publish CLI
+      - /v1/rpc event.publish
+      - apiv1.RunBundleContextStore
+      - runtimebus.EventStore
+      - event_deliveries readback owner
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, real_runtime_startup, split_tracker]
+    proof_refs:
+      - kind: go_test
+        name: TestBuildStoresSQLiteSelectsRunBundleContextForServedEventPublish
+      - kind: go_test
+        name: TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun
+      - kind: go_test
+        name: TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersistence
+      - kind: tracker
+        issue: 1255
+        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+    notes: >
+      Current proofs show selected owner wiring and lower-level API follow-up
+      behavior, but they do not prove the default SQLite served public path with
+      `swarm event publish --run-id`, system-node state advance, persisted
+      event/delivery evidence, and public readback. Keep #1255 active until
+      that proof is added or a lead-approved split records a narrower closure.
 
   - id: mailbox_read_api_after_mailbox_write
     surface: mailbox.list and mailbox.get after handler-level mailbox_write on selected stores


### PR DESCRIPTION
## Summary
- Route served API run-bundle context selection through the selected backend owner instead of always using `stores.Postgres`.
- Add a `cmd/swarm` regression proving default SQLite serve selects `SQLiteRuntimeStore` as the `/v1/rpc event.publish --run-id` bundle-context reader.
- Repair the public surface backend matrix: #1254 is no longer an active/open split, #1255 is the active selected-store tracker, and served existing-run `event.publish --run-id` state-advance proof is explicitly split rather than claimed covered.

Part of #1255

## Governing refs / context
- `platform-spec.yaml` runtime store backend selection and local/dev SQLite owner sections, including selected typed SQLite store ownership and no raw SQLite SQL handle promotion (`runtime.store_backend_selection`, `runtime.core_persistence_store_contracts`).
- `platform-spec.yaml` and OpenRPC publication for `/v1/rpc event.publish` plus CLI `swarm event publish` surface.
- #1255 Pre-Implementation Coverage Audit and lead gate comment selecting `sqlite_default_event_publish_existing_run_followup_selected_store_admission_readback_parity` with served public-path state-advance proof required before #1255 closure.
- #1239 remains the broader selected-store parity parent. #1256 remains separate client error-surface work.

## Semantic migration
- New canonical owner for this slice: selected `apiv1.RunBundleContextStore` supplied by the active backend (`PostgresStore` for explicit Postgres, `SQLiteRuntimeStore` through the selected observability/read store for default SQLite).
- Old non-authoritative path invalidated: `cmd/swarm runServeRuntime` setting `OperatorReadOptions.RunBundleContext` directly to `stores.Postgres`, which left default SQLite served `event.publish --run-id` with no selected run-bundle context reader.
- Production paths checked for surviving old behavior: `cmd/swarm` served API option wiring, SQLite `LoadRunBundleAvailability`, `/v1/rpc event.publish` selected-run admission, CLI exact RPC shape, and public surface backend matrix proof refs.
- Migration completeness: complete for the selected-store owner-selection seam only. #1255 remains open until the required served CLI/API state-advance and persisted event/delivery/readback proof lands or a lead-approved split records narrower closure.

## Validation
- PASS: `go test ./internal/apiv1 -run TestPublicSurfaceBackendMatrix -count=1`
- PASS: `go test ./cmd/swarm ./internal/apiv1 -run 'TestBuildStoresSQLiteSelectsRunBundleContextForServedEventPublish|TestEventPublishUsesEventPublishV1RPCWithBoundParams|TestEventPublishPayloadEntityIDServerRejectionMapsSupportedCLISurface|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock|TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun|TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersistence|TestOperatorEventPublishRejectsCallerEntityIDForCreateEntityBeforePersistence|TestPublicSurfaceBackendMatrix' -count=1`
- PASS: `go test ./...`
