### PR TITLE
[agent-e][issue #1287] Refresh post-1254 backend matrix accounting

### DIFF
--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -116,13 +116,40 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			want: "event_publish_api go_test proof_ref TestMissingPublicSurfaceProof does not resolve",
 		},
 		{
-			name: "status count cannot be marked covered",
+			name: "status count cannot revert to stale #1254 split",
 			mutate: func(matrix *publicSurfaceBackendMatrix) {
 				row := publicSurfaceMatrixRowByID(t, matrix, "status_run_get_entity_count")
-				row.Classification = "already_covered_by_existing_proof"
-				row.SplitIssue = 0
+				row.Classification = "split_to_existing_issue"
+				row.Tier = "split_open"
+				row.SplitIssue = 1254
+				row.ProofDimensions = []string{"split_tracker", "openrpc_publication", "cli_v1_path"}
+				row.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestStatusUsesDiagnoseAndRunGet"},
+					{Kind: "tracker", Issue: 1254, Watchlist: "runtime_operations.runtime_store_backend_default_and_sqlite_portability"},
+				}
 			},
-			want: "status_run_get_entity_count must remain split_to_existing_issue with split_issue 1254",
+			want: "status_run_get_entity_count must remain post-#1254 covered proof, not split-open issue #1254",
+		},
+		{
+			name: "status count requires closed proof refs",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "status_run_get_entity_count")
+				row.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestStatusUsesDiagnoseAndRunGet"},
+				}
+			},
+			want: "status_run_get_entity_count missing post-#1254 proof_ref TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence",
+		},
+		{
+			name: "closed #1254 cannot be active tracker",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				matrix.ActiveTrackers = append(matrix.ActiveTrackers, complianceActiveTracker{
+					Kind:      "github_issue",
+					Issue:     1254,
+					Watchlist: "runtime_operations.runtime_store_backend_default_and_sqlite_portability",
+				})
+			},
+			want: "active_trackers must not include closed #1254 runtime_store_backend_default_and_sqlite_portability",
 		},
 		{
 			name: "fail closed row requires executable proof",
@@ -234,8 +261,8 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 	if _, ok := activeTrackers[trackerKey(1239, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
 		problems = append(problems, "active_trackers missing #1239 runtime_store_backend_default_and_sqlite_portability")
 	}
-	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
-		problems = append(problems, "active_trackers missing #1254 runtime_store_backend_default_and_sqlite_portability")
+	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
+		problems = append(problems, "active_trackers must not include closed #1254 runtime_store_backend_default_and_sqlite_portability")
 	}
 	if _, ok := activeTrackers[trackerKey(0, "operator_surfaces.v1_openrpc_api_conformance")]; !ok {
 		problems = append(problems, "active_trackers missing operator_surfaces.v1_openrpc_api_conformance watchlist")
@@ -275,8 +302,18 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 		problems = append(problems, "matrix missing required_smoke explicit_postgres row")
 	}
 	if row, ok := rowsByID["status_run_get_entity_count"]; ok {
-		if row.Classification != "split_to_existing_issue" || row.SplitIssue != 1254 || row.Tier != "split_open" {
-			problems = append(problems, "status_run_get_entity_count must remain split_to_existing_issue with split_issue 1254 and tier split_open")
+		if row.Classification != "already_covered_by_existing_proof" || row.SplitIssue != 0 || row.Tier != "required_smoke" {
+			problems = append(problems, "status_run_get_entity_count must remain post-#1254 covered proof, not split-open issue #1254")
+		}
+		for _, proof := range []string{
+			"TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence",
+			"TestRunAPIReadSurface_LoadAndListRunHeaders",
+			"TestOpenRPCReadOnlyHTTPRuntimeProbes",
+			"TestStatusUsesDiagnoseAndRunGet",
+		} {
+			if !publicSurfaceHasGoTestProof(row.ProofRefs, proof) {
+				problems = append(problems, fmt.Sprintf("status_run_get_entity_count missing post-#1254 proof_ref %s", proof))
+			}
 		}
 	}
 	sort.Strings(problems)
@@ -586,6 +623,15 @@ func publicSurfaceFailClosedRow(row publicSurfaceMatrixRow) bool {
 func publicSurfaceHasValue(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func publicSurfaceHasGoTestProof(refs []publicSurfaceProofRef, want string) bool {
+	for _, ref := range refs {
+		if ref.Kind == "go_test" && ref.Name == want {
 			return true
 		}
 	}

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -20,9 +20,6 @@ active_trackers:
   - kind: github_issue
     issue: 1239
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
-  - kind: github_issue
-    issue: 1254
-    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: watchlist
     issue: 0
     watchlist: operator_surfaces.v1_openrpc_api_conformance
@@ -164,9 +161,8 @@ rows:
 
   - id: status_run_get_entity_count
     surface: swarm status and /v1/rpc run.get entity_count correctness
-    classification: split_to_existing_issue
-    tier: split_open
-    split_issue: 1254
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
     backends: [default_sqlite, explicit_postgres]
     cli_commands: [status]
     api_methods: [run.get]
@@ -174,18 +170,24 @@ rows:
     store_owners:
       - apiv1.RunReadStore
       - RunHeader.entity_count
+      - platform-spec.yaml entity_registry_policy
       - run lifecycle count owners
-    proof_dimensions: [split_tracker, openrpc_publication, cli_v1_path]
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, canonical_store_owner, openrpc_publication]
     proof_refs:
       - kind: go_test
+        name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence
+      - kind: go_test
+        name: TestRunAPIReadSurface_LoadAndListRunHeaders
+      - kind: go_test
+        name: TestOpenRPCReadOnlyHTTPRuntimeProbes
+      - kind: go_test
         name: TestStatusUsesDiagnoseAndRunGet
-      - kind: tracker
-        issue: 1254
-        watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
     notes: >
-      This row must remain split/open until #1254 repairs the run-header/status
-      entity-count owner. CLI path proof alone is not selected-backend count
-      correctness proof.
+      #1254 / PR #1278 closed the current-run entity_count class by moving
+      SQLite and Postgres run headers, lifecycle/debug owners, API run reads,
+      builder summaries, and CLI status consumers to canonical run-scoped
+      entity_state. This row consumes that closed proof without claiming the
+      broader #1239 parent tail is closed.
 
   - id: event_publish_api
     surface: /v1/rpc event.publish creating work against SQLite and Postgres


### PR DESCRIPTION
## Summary

- Reclassify `status_run_get_entity_count` from stale `split_open` #1254 accounting to post-#1254 covered proof in the public-surface backend matrix.
- Remove closed #1254 from matrix `active_trackers` while preserving #1239 parent-tail accounting.
- Update the matrix validator so stale #1254 split-open state, re-added #1254 active tracking, or missing post-#1254 proof refs fail closed.

Closes #1287
Part of #1239
Related to #1254
Related to #1268

## Governing Refs / Context

- Approved pre-audit: https://github.com/division-sh/swarm/issues/1287#issuecomment-4603057615
- Gate approval: https://github.com/division-sh/swarm/issues/1287#issuecomment-4603138033
- `platform-spec.yaml#runtime_store_backend_selection`
- `platform-spec.yaml#runtime_core_persistence_store_contracts`
- `platform-spec.yaml#entity_registry_policy`
- `platform-spec.yaml#api_specification`
- `platform-spec.yaml#api_specification.components.schemas.RunHeader`
- `platform-spec.yaml#api_specification.method_catalog.run.get`
- `platform-spec.yaml#api_specification.method_catalog.run.list`
- `platform-spec.yaml#cli_specification.command_catalog.status`
- Root `openrpc.json`
- `internal/apiv1/testdata/openrpc_compliance_matrix.yaml`
- `internal/apiv1/testdata/public_surface_backend_matrix.yaml`
- `internal/apiv1/public_surface_backend_matrix_test.go`

## Semantic Migration / Accounting Owner

- Canonical owner after change: `internal/apiv1/testdata/public_surface_backend_matrix.yaml`, consumed by `internal/apiv1/public_surface_backend_matrix_test.go`.
- Old non-authoritative path now invalid: treating closed #1254 as an active split tracker for `status_run_get_entity_count`, including `split_issue: 1254`, `tier: split_open`, stale tracker proof refs, and validator rules requiring that state.
- Production paths checked for surviving old behavior: none edited; #1287 is accounting-only. Runtime/API/CLI current-run `entity_count` behavior remains closed by #1254 / PR #1278 and is consumed only as proof through executable test refs.
- Migration status: complete for `post_1254_public_surface_backend_matrix_accounting_stale_split_refs`; #1239 remains open through `remaining_openrpc_selected_backend_tail`.

## Tests

- `go test ./internal/apiv1 -run 'TestPublicSurfaceBackendMatrix|TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod' -count=1`
- `go test ./...`