### PR TITLE
[agent-c][issue #1233] Canonicalize API wait owners

### DIFF
--- a/internal/apiv1/convergence_assertions_test.go
+++ b/internal/apiv1/convergence_assertions_test.go
@@ -1,0 +1,39 @@
+package apiv1
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	apiv1ConvergenceTimeout      = 5 * time.Second
+	apiv1ConvergencePollInterval = 25 * time.Millisecond
+)
+
+func requireAPIV1Convergence(t *testing.T, description string, check func() (bool, error)) {
+	t.Helper()
+	timeout := time.NewTimer(apiv1ConvergenceTimeout)
+	defer timeout.Stop()
+	poll := time.NewTicker(apiv1ConvergencePollInterval)
+	defer poll.Stop()
+
+	var lastErr error
+	for {
+		ok, err := check()
+		if ok {
+			return
+		}
+		if err != nil {
+			lastErr = err
+		}
+
+		select {
+		case <-timeout.C:
+			if lastErr != nil {
+				t.Fatalf("%s did not converge: %v", description, lastErr)
+			}
+			t.Fatalf("%s did not converge", description)
+		case <-poll.C:
+		}
+	}
+}

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -251,9 +251,7 @@ func eventReceiptsCapability(persistence any) func(context.Context) (bool, error
 
 func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql.DB, runID, eventID, backend string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
+	requireAPIV1Convergence(t, fmt.Sprintf("mailbox_write supported surface for %s", backend), func() (bool, error) {
 		listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"mailbox-list","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
 		if listed.Error != nil {
 			t.Fatalf("mailbox.list error = %#v", listed.Error)
@@ -262,24 +260,18 @@ func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql
 		if len(items) == 1 {
 			item := asMap(t, items[0])
 			if err := assertMailboxWriteSupportedSurfaceItem(t, handler, item, runID, eventID); err != nil {
-				lastErr = err
-				time.Sleep(25 * time.Millisecond)
-				continue
+				return false, err
 			}
 			assertMailboxWriteEntityState(t, db, runID, backend)
-			return
+			return true, nil
 		}
-		lastErr = fmt.Errorf("mailbox.list returned %d items", len(items))
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("mailbox_write supported surface did not converge for %s: %v", backend, lastErr)
+		return false, fmt.Errorf("mailbox.list returned %d items", len(items))
+	})
 }
 
 func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, runID, eventID string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
+	requireAPIV1Convergence(t, "rule mailbox_write supported surface", func() (bool, error) {
 		listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"rule-mailbox-list","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
 		if listed.Error != nil {
 			t.Fatalf("mailbox.list error = %#v", listed.Error)
@@ -288,16 +280,12 @@ func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, runID, e
 		if len(items) == 1 {
 			item := asMap(t, items[0])
 			if err := assertConditionalRuleMailboxItem(t, handler, item, runID, eventID); err != nil {
-				lastErr = err
-				time.Sleep(25 * time.Millisecond)
-				continue
+				return false, err
 			}
-			return
+			return true, nil
 		}
-		lastErr = fmt.Errorf("mailbox.list returned %d items", len(items))
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("rule mailbox_write supported surface did not converge: %v", lastErr)
+		return false, fmt.Errorf("mailbox.list returned %d items", len(items))
+	})
 }
 
 func assertConditionalRuleMailboxItem(t *testing.T, handler *Handler, item map[string]any, runID, eventID string) error {
@@ -370,21 +358,16 @@ func assertMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend stri
 
 func waitForConditionalRuleEntityState(t *testing.T, db *sql.DB, runID, backend, wantState string, wantAmount int) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
+	requireAPIV1Convergence(t, fmt.Sprintf("%s entity state to %s", backend, wantState), func() (bool, error) {
 		state, fields, err := loadMailboxWriteEntityState(t, db, runID, backend)
 		if err == nil {
 			if state == wantState && fields["amount"] == float64(wantAmount) {
-				return
+				return true, nil
 			}
-			lastErr = fmt.Errorf("state=%q fields=%#v", state, fields)
-		} else {
-			lastErr = err
+			return false, fmt.Errorf("state=%q fields=%#v", state, fields)
 		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("%s entity state did not converge to %s: %v", backend, wantState, lastErr)
+		return false, err
+	})
 }
 
 func loadMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string) (string, map[string]any, error) {
@@ -414,25 +397,24 @@ func loadMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string
 
 func waitForSQLitePipelineReceipt(t *testing.T, db *sql.DB) (string, string, string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		var outcome, reason, errText string
+	var outcome, reason, errText string
+	requireAPIV1Convergence(t, "sqlite pipeline receipt", func() (bool, error) {
+		var gotOutcome, gotReason, gotErrText string
 		if err := db.QueryRow(`
 			SELECT outcome, COALESCE(reason_code, ''), COALESCE(json_extract(side_effects, '$.error'), '')
 			FROM event_receipts
 			WHERE subscriber_type = 'platform' AND subscriber_id = 'pipeline'
 			ORDER BY processed_at DESC
 			LIMIT 1
-		`).Scan(&outcome, &reason, &errText); err == nil {
-			return outcome, reason, errText
+		`).Scan(&gotOutcome, &gotReason, &gotErrText); err == nil {
+			// Assign only after Scan succeeds so callers never observe partial values.
+			outcome, reason, errText = gotOutcome, gotReason, gotErrText
+			return true, nil
 		} else {
-			lastErr = err
+			return false, err
 		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("sqlite pipeline receipt did not appear: %v", lastErr)
-	return "", "", ""
+	})
+	return outcome, reason, errText
 }
 
 func bundleSourceFactForTestBundle(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle) runtimecorrelation.BundleSourceFact {

--- a/internal/apiv1/operator_run_completion_system_node_test.go
+++ b/internal/apiv1/operator_run_completion_system_node_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -142,22 +141,19 @@ func (m runCompletionSystemNodeModule) ActionRegistry() runtimepipeline.ActionRe
 
 func waitForRunGetStatus(t *testing.T, handler *Handler, runID, wantStatus string) map[string]any {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var lastStatus any
-	for time.Now().Before(deadline) {
+	var run map[string]any
+	requireAPIV1Convergence(t, fmt.Sprintf("run.get status for %s", runID), func() (bool, error) {
 		get := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"get","method":"run.get","params":{"run_id":%q}}`, runID))
 		if get.Error != nil {
 			t.Fatalf("run.get error = %#v", get.Error)
 		}
-		run := asMap(t, asMap(t, get.Result)["run"])
-		lastStatus = run["status"]
+		run = asMap(t, asMap(t, get.Result)["run"])
 		if run["status"] == wantStatus {
-			return run
+			return true, nil
 		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("run.get status for %s = %#v, want %s", runID, lastStatus, wantStatus)
-	return nil
+		return false, fmt.Errorf("status=%#v, want %s", run["status"], wantStatus)
+	})
+	return run
 }
 
 func triggerEventIDForRun(t *testing.T, db *sql.DB, runID string) string {

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -147,12 +147,7 @@ func TestHandlerWebSocketEventSubscribeUsesOwnerFilterAndReplay(t *testing.T) {
 	if got := asMap(t, notification.Params.Result)["event_id"]; got != "evt-1" {
 		t.Fatalf("event notification result = %#v, want evt-1", notification.Params.Result)
 	}
-	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-	_, raw, err := conn.ReadMessage()
-	conn.SetReadDeadline(time.Time{})
-	if err == nil {
-		t.Fatalf("unexpected payload-only event notification: %s", raw)
-	}
+	requireNoWSMessage(t, conn, apiv1WebSocketNoMessageTimeout, "payload-only event notification")
 	if observability.lastEventList.Filter.RunID != "run-1" ||
 		observability.lastEventList.Filter.EntityID != "entity-1" ||
 		observability.lastEventList.Filter.EventName != "scan.requested" ||
@@ -277,9 +272,7 @@ func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
 			"filter": map[string]any{"run_id": "run-1"},
 		},
 	})
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	defer conn.SetReadDeadline(time.Time{})
-	_, raw, err := conn.ReadMessage()
+	raw, err := readWSMessageWithTimeout(t, conn, apiv1WebSocketReadTimeout)
 	if err != nil {
 		return
 	}
@@ -290,7 +283,7 @@ func TestHandlerWebSocketSubscriptionOwnerErrorClosesConnection(t *testing.T) {
 	if subscribe.Error != nil {
 		t.Fatalf("event.subscribe response error = %#v", subscribe.Error)
 	}
-	if _, _, err := conn.ReadMessage(); err == nil {
+	if _, err := readWSMessageWithTimeout(t, conn, apiv1WebSocketReadTimeout); err == nil {
 		t.Fatal("websocket stayed open after owner read error, want fail-closed disconnect")
 	}
 }
@@ -314,9 +307,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsOwnerErrorClosesConnection(t *testi
 		"method":  "runtime.subscribe_logs",
 		"params":  map[string]any{},
 	})
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	defer conn.SetReadDeadline(time.Time{})
-	_, raw, err := conn.ReadMessage()
+	raw, err := readWSMessageWithTimeout(t, conn, apiv1WebSocketReadTimeout)
 	if err != nil {
 		return
 	}
@@ -327,7 +318,7 @@ func TestHandlerWebSocketRuntimeSubscribeLogsOwnerErrorClosesConnection(t *testi
 	if subscribe.Error != nil {
 		t.Fatalf("runtime.subscribe_logs response error = %#v", subscribe.Error)
 	}
-	if _, _, err := conn.ReadMessage(); err == nil {
+	if _, err := readWSMessageWithTimeout(t, conn, apiv1WebSocketReadTimeout); err == nil {
 		t.Fatal("websocket stayed open after runtime log owner read error, want fail-closed disconnect")
 	}
 }
@@ -672,20 +663,12 @@ func TestWebSocketSessionBackpressureAndUnsubscribeCancelState(t *testing.T) {
 	if session.enqueue(rpcResponse{JSONRPC: jsonRPCVersion, ID: "second", Result: map[string]any{"ok": true}}) {
 		t.Fatal("second enqueue succeeded, want bounded backpressure cancellation")
 	}
-	select {
-	case <-ctx.Done():
-	case <-time.After(time.Second):
-		t.Fatal("session context was not canceled on backpressure")
-	}
+	requireContextCanceled(t, ctx, "session context was not canceled on backpressure")
 
 	subCtx, subCancel := context.WithCancel(context.Background())
 	session.registerSubscription("sub-1", subCancel)
 	session.cancelSubscription("sub-1")
-	select {
-	case <-subCtx.Done():
-	case <-time.After(time.Second):
-		t.Fatal("subscription context was not canceled by unsubscribe")
-	}
+	requireContextCanceled(t, subCtx, "subscription context was not canceled by unsubscribe")
 }
 
 func dialTestWS(t *testing.T, serverURL string) *websocket.Conn {
@@ -705,14 +688,14 @@ func writeWSRequest(t *testing.T, conn *websocket.Conn, request map[string]any) 
 	}
 }
 
+const (
+	apiv1WebSocketReadTimeout      = 2 * time.Second
+	apiv1WebSocketNoMessageTimeout = 100 * time.Millisecond
+)
+
 func readWSResponse(t *testing.T, conn *websocket.Conn) rpcResponse {
 	t.Helper()
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	defer conn.SetReadDeadline(time.Time{})
-	_, raw, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("read websocket response: %v", err)
-	}
+	raw := requireWSMessage(t, conn, "websocket response")
 	var envelope map[string]any
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		t.Fatalf("decode websocket response envelope: %v raw=%s", err, raw)
@@ -729,12 +712,7 @@ func readWSResponse(t *testing.T, conn *websocket.Conn) rpcResponse {
 
 func readWSNotification(t *testing.T, conn *websocket.Conn) rpcSubscriptionNotification {
 	t.Helper()
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	defer conn.SetReadDeadline(time.Time{})
-	_, raw, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("read websocket notification: %v", err)
-	}
+	raw := requireWSMessage(t, conn, "websocket notification")
 	var notification rpcSubscriptionNotification
 	if err := json.Unmarshal(raw, &notification); err != nil {
 		t.Fatalf("decode websocket notification: %v raw=%s", err, raw)
@@ -743,6 +721,53 @@ func readWSNotification(t *testing.T, conn *websocket.Conn) rpcSubscriptionNotif
 		t.Fatalf("websocket notification = %s, want rpc.subscription", raw)
 	}
 	return notification
+}
+
+func requireWSMessage(t *testing.T, conn *websocket.Conn, description string) []byte {
+	t.Helper()
+	raw, err := readWSMessageWithTimeout(t, conn, apiv1WebSocketReadTimeout)
+	if err != nil {
+		t.Fatalf("read %s: %v", description, err)
+	}
+	return raw
+}
+
+func requireNoWSMessage(t *testing.T, conn *websocket.Conn, timeout time.Duration, description string) {
+	t.Helper()
+	raw, err := readWSMessageWithTimeout(t, conn, timeout)
+	if err == nil {
+		t.Fatalf("unexpected %s: %s", description, raw)
+	}
+}
+
+func readWSMessageWithTimeout(t *testing.T, conn *websocket.Conn, timeout time.Duration) ([]byte, error) {
+	t.Helper()
+	clearDeadline := setWSReadDeadline(t, conn, timeout)
+	defer clearDeadline()
+	_, raw, err := conn.ReadMessage()
+	return raw, err
+}
+
+func setWSReadDeadline(t *testing.T, conn *websocket.Conn, timeout time.Duration) func() {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		t.Fatalf("set websocket read deadline: %v", err)
+	}
+	return func() {
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			t.Fatalf("clear websocket read deadline: %v", err)
+		}
+	}
+}
+
+func requireContextCanceled(t *testing.T, ctx context.Context, description string) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal(description)
+	}
 }
 
 func sameJSON(a, b any) bool {


### PR DESCRIPTION
Part of #1233

## Summary

- Add a package-local `internal/apiv1` convergence assertion owner for API-visible async side effects.
- Move mailbox-write, entity-state, SQLite receipt, and `run.get` status test polling off local deadline/sleep loops.
- Move websocket no-message, close, response, notification, and cancellation wait assertions to named websocket helper owners.

## Governing Refs / Context

No exact `platform-spec.yaml` product/runtime section governs this test-only wait-helper placement. Binding context is #1233, #1196, the repaired #1233 audit at issuecomment `4603421064`, the independent gate approval at issuecomment `4604252562`, prior merged PRs #1245 and #1288, and the private process/watchlist docs.

## Semantic Migration

- New canonical owner: `internal/apiv1/convergence_assertions_test.go` for package-local API convergence assertions.
- New/confirmed websocket owner: named helpers in `internal/apiv1/subscriptions_test.go` for websocket response, notification, no-message, close/read, and synchronous cancellation assertions.
- Existing canonical owner preserved: `internal/apiv1/runtimebus_assertions_test.go` remains the PR #1288 API runtimebus assertion owner.
- Old non-authoritative paths now invalid: local `time.Sleep` polling loops in mailbox/run convergence helpers, direct websocket cancellation `time.After` fallbacks, and inline websocket `SetReadDeadline(time.Now().Add(...))` rows.
- Production paths checked for surviving old behavior: no production/runtime files changed; runtime timeout behavior and API semantics are untouched.
- Migration completeness: complete for `test_health.internal_apiv1_remaining_async_convergence_and_websocket_wait_owners` only. #1233 and #1196 remain open.

## Proof

- `rg -n "time\.After\(|time\.Sleep\(" --glob '*_test.go' internal/apiv1` -> no matches.
- `rg -n "SetReadDeadline\(time\.Now\(\)\.Add" internal/apiv1/subscriptions_test.go` -> no matches.
- `rg -n "deadline :=|time\.Now\(\)\.Add|Set(Read|Write)Deadline|context\.WithTimeout\(|time\.NewTimer\(|time\.NewTicker\(" --glob '*_test.go' internal/apiv1` -> only canonical helper-owned timers/deadlines plus the known query cutoff.
- `go test ./internal/apiv1 -run 'TestOperatorMailboxWriteSupportedSurface|TestOperatorRuleMailboxWriteSupportedSurface|TestOperatorMailboxWriteSupportedSurfaceMissingMaterializer' -count=1`
- `go test ./internal/apiv1 -run TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces -count=1`
- `go test ./internal/apiv1 -run 'TestHandlerWebSocket|TestWebSocketSessionBackpressureAndUnsubscribeCancelState' -count=1`
- `go test ./internal/apiv1 -count=1`
- `go test ./...`
