### PR TITLE
[agent-e][issue #1302] Exclude diagnostic replay candidates

### DIFF
--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -781,21 +781,18 @@ func TestRecoveryManager_DoesNotEmitAftermathLogForRuntimeLogReplayCandidate(t *
 	if len(capture.logs) != 0 {
 		t.Fatalf("runtime log aftermath entries = %#v, want none", capture.logs)
 	}
-	var receiptStatus, receiptReason string
+	var receiptCount int
 	if err := db.QueryRowContext(ctx, `
-		SELECT outcome, COALESCE(reason_code, '')
+		SELECT COUNT(*)
 		FROM event_receipts
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'platform'
 		  AND subscriber_id = 'pipeline'
-	`, eventID).Scan(&receiptStatus, &receiptReason); err != nil {
-		t.Fatalf("load runtime log receipt: %v", err)
+	`, eventID).Scan(&receiptCount); err != nil {
+		t.Fatalf("count runtime log receipt: %v", err)
 	}
-	if receiptStatus != "dead_letter" {
-		t.Fatalf("runtime log receipt outcome = %q, want dead_letter", receiptStatus)
-	}
-	if receiptReason != "pipeline_error" {
-		t.Fatalf("runtime log receipt reason = %q, want pipeline_error", receiptReason)
+	if receiptCount != 0 {
+		t.Fatalf("runtime log pipeline receipts = %d, want 0", receiptCount)
 	}
 }
 

--- a/internal/store/diagnostic_direct_replay.go
+++ b/internal/store/diagnostic_direct_replay.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+// diagnosticDirectReplayEventNames mirrors the platform-spec
+// diagnostic_direct_persisted catalog entries. These rows are persisted for
+// queryability and causality, not executable pipeline replay.
+func diagnosticDirectReplayEventNames() []string {
+	return []string{
+		"platform.runtime_log",
+		"platform.agent_directive",
+		"platform.inbound_recorded",
+	}
+}
+
+func diagnosticDirectReplayEventArgs() []any {
+	names := diagnosticDirectReplayEventNames()
+	args := make([]any, 0, len(names))
+	for _, name := range names {
+		args = append(args, name)
+	}
+	return args
+}
+
+func sqliteDiagnosticDirectReplayExclusionSQL(alias string) string {
+	return diagnosticDirectReplayColumn(alias) + " NOT IN (" + sqlitePlaceholders(len(diagnosticDirectReplayEventNames())) + ")"
+}
+
+func postgresDiagnosticDirectReplayExclusionSQL(alias string, startPlaceholder int) string {
+	names := diagnosticDirectReplayEventNames()
+	placeholders := make([]string, 0, len(names))
+	for i := range names {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", startPlaceholder+i))
+	}
+	return diagnosticDirectReplayColumn(alias) + " NOT IN (" + strings.Join(placeholders, ", ") + ")"
+}
+
+func diagnosticDirectReplayColumn(alias string) string {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return "event_name"
+	}
+	return alias + ".event_name"
+}

--- a/internal/store/diagnostic_direct_replay_test.go
+++ b/internal/store/diagnostic_direct_replay_test.go
@@ -1,0 +1,340 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestSQLiteRuntimeStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	now := time.Now().Add(-time.Minute).UTC()
+
+	runtimeLogID := persistSQLiteRuntimeLogForReplayTest(t, ctx, store, runID)
+	inboundID := uuid.NewString()
+	agentDirectiveID := uuid.NewString()
+	executableID := uuid.NewString()
+
+	appendSQLiteReplayTestEvent(t, ctx, store, events.Event{
+		ID:          inboundID,
+		RunID:       runID,
+		Type:        events.EventType("platform.inbound_recorded"),
+		SourceAgent: "github",
+		Payload:     json.RawMessage(`{"provider":"github","provider_event_id":"provider-event-1","entity_id":"` + entityID + `"}`),
+		CreatedAt:   now.Add(time.Second),
+	}.WithEntityID(entityID))
+	appendSQLiteReplayTestEvent(t, ctx, store, events.Event{
+		ID:          agentDirectiveID,
+		RunID:       runID,
+		Type:        events.EventType("platform.agent_directive"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`),
+		CreatedAt:   now.Add(2 * time.Second),
+	})
+	if err := store.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
+		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
+	}
+	appendSQLiteReplayTestEvent(t, ctx, store, events.Event{
+		ID:          executableID,
+		RunID:       runID,
+		Type:        events.EventType("workflow.executable"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"ok":true}`),
+		CreatedAt:   now.Add(3 * time.Second),
+	})
+
+	globalMissing, err := store.ListEventsMissingPipelineReceipt(ctx, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
+	}
+	assertReplayEventIDs(t, globalMissing, []string{executableID})
+
+	runMissing, err := store.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun: %v", err)
+	}
+	assertReplayEventIDs(t, runMissing, []string{executableID})
+
+	logs, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Level:     "warn",
+		Component: "diagnostic_replay",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs: %v", err)
+	}
+	if len(logs.Logs) != 1 || logs.Logs[0].LogID != runtimeLogID {
+		t.Fatalf("runtime logs = %#v, want runtime log %s", logs.Logs, runtimeLogID)
+	}
+
+	bus, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus(sqlite): %v", err)
+	}
+	swept, err := bus.SweepUndispatched(ctx, time.Hour, 20)
+	if err != nil {
+		t.Fatalf("SweepUndispatched(sqlite): %v", err)
+	}
+	if swept != 0 {
+		t.Fatalf("SweepUndispatched(sqlite) redelivered = %d, want 0", swept)
+	}
+
+	for _, diagnosticID := range []string{runtimeLogID, inboundID, agentDirectiveID} {
+		assertNoSQLitePipelineReceipt(t, ctx, store, diagnosticID)
+	}
+	assertSQLitePipelineReceipt(t, ctx, store, executableID, "dead_letter", "pipeline_error")
+}
+
+func TestPostgresStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	now := time.Now().Add(-time.Minute).UTC()
+
+	runtimeLogID := persistPostgresRuntimeLogForReplayTest(t, ctx, pg, runID)
+	inboundID := recordPostgresInboundEventForReplayTest(t, ctx, pg, runID, entityID)
+	agentDirectiveID := uuid.NewString()
+	executableID := uuid.NewString()
+
+	appendPostgresReplayTestEvent(t, ctx, pg, events.Event{
+		ID:          agentDirectiveID,
+		RunID:       runID,
+		Type:        events.EventType("platform.agent_directive"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`),
+		CreatedAt:   now.Add(2 * time.Second),
+	})
+	if err := pg.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
+		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
+	}
+	appendPostgresReplayTestEvent(t, ctx, pg, events.Event{
+		ID:          executableID,
+		RunID:       runID,
+		Type:        events.EventType("workflow.executable"),
+		SourceAgent: "runtime",
+		Payload:     json.RawMessage(`{"ok":true}`),
+		CreatedAt:   now.Add(3 * time.Second),
+	})
+
+	globalMissing, err := pg.ListEventsMissingPipelineReceipt(ctx, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
+	}
+	assertReplayEventIDs(t, globalMissing, []string{executableID})
+
+	runMissing, err := pg.ListEventsMissingPipelineReceiptForRun(ctx, runID, now.Add(-time.Hour), 20)
+	if err != nil {
+		t.Fatalf("ListEventsMissingPipelineReceiptForRun: %v", err)
+	}
+	assertReplayEventIDs(t, runMissing, []string{executableID})
+
+	logs, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Level:     "warn",
+		Component: "diagnostic_replay",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs: %v", err)
+	}
+	if len(logs.Logs) != 1 || logs.Logs[0].LogID != runtimeLogID {
+		t.Fatalf("runtime logs = %#v, want runtime log %s", logs.Logs, runtimeLogID)
+	}
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus(postgres): %v", err)
+	}
+	swept, err := bus.SweepUndispatched(ctx, time.Hour, 20)
+	if err != nil {
+		t.Fatalf("SweepUndispatched(postgres): %v", err)
+	}
+	if swept != 0 {
+		t.Fatalf("SweepUndispatched(postgres) redelivered = %d, want 0", swept)
+	}
+
+	for _, diagnosticID := range []string{runtimeLogID, inboundID, agentDirectiveID} {
+		assertNoPostgresPipelineReceipt(t, ctx, pg, diagnosticID)
+	}
+	assertPostgresPipelineReceipt(t, ctx, pg, executableID, "dead_letter", "pipeline_error")
+}
+
+func persistSQLiteRuntimeLogForReplayTest(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, runID string) string {
+	t.Helper()
+	payload := json.RawMessage(`{"log_level":"warn","message":"diagnostic replay proof","details":{"component":"diagnostic_replay","action":"proof"}}`)
+	if err := store.PersistRuntimeLog(ctx, runtimepkg.RuntimeLogPersistenceRecord{RunID: runID, Payload: payload}); err != nil {
+		t.Fatalf("PersistRuntimeLog(sqlite): %v", err)
+	}
+	var eventID string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT event_id
+		FROM events
+		WHERE run_id = ?
+		  AND event_name = 'platform.runtime_log'
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, runID).Scan(&eventID); err != nil {
+		t.Fatalf("load sqlite runtime log event_id: %v", err)
+	}
+	return eventID
+}
+
+func persistPostgresRuntimeLogForReplayTest(t *testing.T, ctx context.Context, pg *PostgresStore, runID string) string {
+	t.Helper()
+	payload := json.RawMessage(`{"log_level":"warn","message":"diagnostic replay proof","details":{"component":"diagnostic_replay","action":"proof"}}`)
+	if err := pg.PersistRuntimeLog(ctx, runtimepkg.RuntimeLogPersistenceRecord{RunID: runID, Payload: payload}); err != nil {
+		t.Fatalf("PersistRuntimeLog(postgres): %v", err)
+	}
+	var eventID string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT event_id::text
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'platform.runtime_log'
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, runID).Scan(&eventID); err != nil {
+		t.Fatalf("load postgres runtime log event_id: %v", err)
+	}
+	return eventID
+}
+
+func recordPostgresInboundEventForReplayTest(t *testing.T, ctx context.Context, pg *PostgresStore, runID, entityID string) string {
+	t.Helper()
+	inserted, err := pg.RecordInboundEvent(runtimecorrelation.WithRunID(ctx, runID), "provider-event-1", entityID, "github")
+	if err != nil {
+		t.Fatalf("RecordInboundEvent: %v", err)
+	}
+	if !inserted {
+		t.Fatal("RecordInboundEvent inserted=false, want true")
+	}
+	var eventID string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT event_id::text
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND event_name = 'platform.inbound_recorded'
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, runID).Scan(&eventID); err != nil {
+		t.Fatalf("load postgres inbound event_id: %v", err)
+	}
+	return eventID
+}
+
+func appendSQLiteReplayTestEvent(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, evt events.Event) {
+	t.Helper()
+	if err := store.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent(%s): %v", evt.Type, err)
+	}
+}
+
+func appendPostgresReplayTestEvent(t *testing.T, ctx context.Context, pg *PostgresStore, evt events.Event) {
+	t.Helper()
+	if err := pg.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent(%s): %v", evt.Type, err)
+	}
+}
+
+func assertReplayEventIDs(t *testing.T, got []events.PersistedReplayEvent, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("replay event IDs = %#v, want %#v", replayEventIDs(got), want)
+	}
+	for i, eventID := range want {
+		if got[i].Event.ID != eventID {
+			t.Fatalf("replay event IDs = %#v, want %#v", replayEventIDs(got), want)
+		}
+	}
+}
+
+func replayEventIDs(records []events.PersistedReplayEvent) []string {
+	out := make([]string, 0, len(records))
+	for _, record := range records {
+		out = append(out, record.Event.ID)
+	}
+	return out
+}
+
+func assertNoSQLitePipelineReceipt(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, eventID string) {
+	t.Helper()
+	var count int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count sqlite pipeline receipts: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("sqlite pipeline receipts for %s = %d, want 0", eventID, count)
+	}
+}
+
+func assertSQLitePipelineReceipt(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, eventID, outcome, reason string) {
+	t.Helper()
+	var gotOutcome, gotReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&gotOutcome, &gotReason); err != nil {
+		t.Fatalf("load sqlite pipeline receipt: %v", err)
+	}
+	if gotOutcome != outcome || gotReason != reason {
+		t.Fatalf("sqlite pipeline receipt for %s = outcome:%q reason:%q, want outcome:%q reason:%q", eventID, gotOutcome, gotReason, outcome, reason)
+	}
+}
+
+func assertNoPostgresPipelineReceipt(t *testing.T, ctx context.Context, pg *PostgresStore, eventID string) {
+	t.Helper()
+	var count int
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count postgres pipeline receipts: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("postgres pipeline receipts for %s = %d, want 0", eventID, count)
+	}
+}
+
+func assertPostgresPipelineReceipt(t *testing.T, ctx context.Context, pg *PostgresStore, eventID, outcome, reason string) {
+	t.Helper()
+	var gotOutcome, gotReason string
+	if err := pg.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&gotOutcome, &gotReason); err != nil {
+		t.Fatalf("load postgres pipeline receipt: %v", err)
+	}
+	if gotOutcome != outcome || gotReason != reason {
+		t.Fatalf("postgres pipeline receipt for %s = outcome:%q reason:%q, want outcome:%q reason:%q", eventID, gotOutcome, gotReason, outcome, reason)
+	}
+}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1159,6 +1159,10 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 	if caps.Events.LogRouteIdentity {
 		routeSelect = `COALESCE(e.source_route, '{}'::jsonb), COALESCE(e.target_route, '{}'::jsonb), COALESCE(e.target_set, '[]'::jsonb)`
 	}
+	exclusionArgs := diagnosticDirectReplayEventArgs()
+	limitPlaceholder := 2 + len(exclusionArgs)
+	args := append([]any{since}, exclusionArgs...)
+	args = append(args, limit)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			e.event_id::text, %s, e.event_name, COALESCE(e.produced_by, ''),
@@ -1172,9 +1176,10 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptSpec(ctx context.Context
 			AND r.subscriber_id = 'pipeline'
 		WHERE r.event_id IS NULL
 		  AND e.created_at >= $1
+		  AND %s
 		ORDER BY e.created_at ASC
-		LIMIT $2
-	`, runIDExpr, routeSelect), since, limit)
+		LIMIT $%d
+	`, runIDExpr, routeSelect, postgresDiagnosticDirectReplayExclusionSQL("e", 2), limitPlaceholder), args...)
 	if err != nil {
 		return nil, fmt.Errorf("list events missing pipeline receipt: %w", err)
 	}
@@ -1222,6 +1227,10 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptForRunSpec(ctx context.C
 	if caps.Events.LogRouteIdentity {
 		routeSelect = `COALESCE(e.source_route, '{}'::jsonb), COALESCE(e.target_route, '{}'::jsonb), COALESCE(e.target_set, '[]'::jsonb)`
 	}
+	exclusionArgs := diagnosticDirectReplayEventArgs()
+	limitPlaceholder := 3 + len(exclusionArgs)
+	args := append([]any{runID, since}, exclusionArgs...)
+	args = append(args, limit)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			e.event_id::text, COALESCE(e.run_id::text, ''), e.event_name, COALESCE(e.produced_by, ''),
@@ -1236,9 +1245,10 @@ func (s *PostgresStore) listEventsMissingPipelineReceiptForRunSpec(ctx context.C
 		WHERE r.event_id IS NULL
 		  AND e.run_id = $1::uuid
 		  AND e.created_at >= $2
+		  AND %s
 		ORDER BY e.created_at ASC
-		LIMIT $3
-	`, routeSelect), runID, since, limit)
+		LIMIT $%d
+	`, routeSelect, postgresDiagnosticDirectReplayExclusionSQL("e", 3), limitPlaceholder), args...)
 	if err != nil {
 		return nil, fmt.Errorf("list run events missing pipeline receipt: %w", err)
 	}

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -376,7 +376,9 @@ func (s *SQLiteRuntimeStore) ListEventsMissingPipelineReceiptForRun(ctx context.
 }
 
 func (s *SQLiteRuntimeStore) listSQLiteEventsMissingPipelineReceipt(ctx context.Context, where string, args []any, limit int) ([]events.PersistedReplayEvent, error) {
-	args = append(append([]any{}, args...), limit)
+	queryArgs := append([]any{}, args...)
+	queryArgs = append(queryArgs, diagnosticDirectReplayEventArgs()...)
+	queryArgs = append(queryArgs, limit)
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
 			e.event_id,
@@ -399,9 +401,10 @@ func (s *SQLiteRuntimeStore) listSQLiteEventsMissingPipelineReceipt(ctx context.
 			AND r.subscriber_id = 'pipeline'
 		WHERE r.event_id IS NULL
 		  AND `+where+`
+		  AND `+sqliteDiagnosticDirectReplayExclusionSQL("e")+`
 		ORDER BY e.created_at ASC, e.event_id ASC
 		LIMIT ?
-	`, args...)
+	`, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list sqlite events missing pipeline receipt: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes #1302.

This PR stops spec-declared diagnostic-direct platform events from being selected as executable persisted pipeline replay work. The corrected replay-candidate owner now excludes:

- `platform.runtime_log`
- `platform.inbound_recorded`
- `platform.agent_directive`

The normal committed replay-scope path remains strict for real executable events.

## Governing Context

Exact governing spec refs:

- `platform-spec.yaml#runtime_core_persistence_store_contracts.runtime_diagnostics_log_rows`
- `platform-spec.yaml#runtime_core_persistence_store_contracts.event_delivery_receipt_and_replay_rows`
- `platform-spec.yaml#platform_tables.diagnostics_encoding.runtime_log_encoding`
- `platform-spec.yaml#platform_events.catalog.platform.runtime_log`
- `platform-spec.yaml#platform_events.routing_rules`
- `platform-spec.yaml#platform_tables.event_receipts`

No `platform-spec.yaml` update is included because the authoritative spec already says diagnostic events including `platform.runtime_log`, `platform.inbound_recorded`, and `platform.agent_directive` bypass the event loop and are persisted for queryability/causality rather than subscriber routing.

## Semantic Migration

New canonical owner for this PR's class:

- replay-candidate selection in SQLite/Postgres `ListEventsMissingPipelineReceipt` and `ListEventsMissingPipelineReceiptForRun`, backed by the shared diagnostic-direct replay exclusion helper in `internal/store`.

Old non-authoritative behavior now invalid:

- generic missing-pipeline selectors treated every `events` row without a platform/pipeline receipt as replay-eligible, including directly persisted diagnostic platform rows.
- startup recovery test expectations that accepted `platform.runtime_log` pipeline dead-letter receipts as normal proof output.

Production paths checked for surviving old behavior:

- SQLite global and run-scoped missing-pipeline selectors.
- Postgres global and run-scoped missing-pipeline selectors.
- EventBus sweeper consumption through the corrected selectors.
- Startup recovery consumption through the corrected selectors.
- Runtime log query/read path remains available.

Migration complete for the chosen class: yes.

## Validation

- `go test ./internal/store -run 'Test(SQLiteRuntimeStore|PostgresStore)ListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents' -count=1`
- `go test ./internal/store -run 'Test(SQLiteRuntimeStore|PostgresStore)ListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents|TestPostgresStore_PipelineReceipts_MissingEventsQuery|TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics' -count=1`
- `go test ./internal/runtime/pipeline -run 'TestRecoveryManager_DoesNotEmitAftermathLogForRuntimeLogReplayCandidate|TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients' -count=1`
- `go test ./internal/runtime/bus -run 'TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinues|TestEventBusPublish_RuntimeLogBypassesContradictionRouting' -count=1`
- `env -u SWARM_TOOL_GATEWAY_URL go test ./...`

Note: an initial raw `go test ./...` run failed in `cmd/swarm` because an ambient `SWARM_TOOL_GATEWAY_URL` pointed at a stale MCP listener port. The clean-env full suite above passed.
