### PR TITLE
[agent-a][issue #1297] Project auto-emit payload from config

### DIFF
--- a/internal/runtime/eventpayload/context_test.go
+++ b/internal/runtime/eventpayload/context_test.go
@@ -1,0 +1,17 @@
+package eventpayload
+
+import "testing"
+
+func TestActivationContextNamesAreNotGloballyRuntimeOwnedPayloadFields(t *testing.T) {
+	for _, key := range []string{"instance_id", "template_id", "flow_path", "parent_entity_id"} {
+		if IsRuntimeOwnedCanonicalContextField(key) {
+			t.Fatalf("%s must not be globally runtime-owned; it can be authored business payload on non-auto-emit surfaces", key)
+		}
+	}
+	payload := StripUndeclaredRuntimeOwnedCanonicalContext(map[string]any{
+		"template_id": "application-basic-v1",
+	}, map[string]struct{}{})
+	if got := payload["template_id"]; got != "application-basic-v1" {
+		t.Fatalf("template_id payload = %#v, want retained business field", got)
+	}
+}

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -16,12 +16,10 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
-	runtimeeventpayload "github.com/division-sh/swarm/internal/runtime/eventpayload"
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimerequiredagents "github.com/division-sh/swarm/internal/runtime/requiredagents"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
-	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/google/uuid"
 )
@@ -86,7 +84,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if initialState == "" {
 		initialState = "pending"
 	}
-	autoEmitEvent, autoEmitName, err := buildAutoEmitOnCreateEvent(req.ContractBundle, schema, templateID, flowPath, instanceID, flowEntityID, parentEntityID, req.Config)
+	autoEmitEvent, autoEmitName, err := buildAutoEmitOnCreateEvent(req.ContractBundle, schema, templateID, flowPath, flowEntityID, req.Config)
 	if err != nil {
 		return err
 	}
@@ -187,26 +185,19 @@ func flowInstanceActivationMetadata(instance runtimeflowidentity.Instance, flowE
 	return metadata
 }
 
-func buildAutoEmitOnCreateEvent(source semanticview.Source, schema runtimecontracts.FlowSchemaDocument, templateID, flowPath, instanceID, flowEntityID, parentEntityID string, config map[string]any) (events.Event, string, error) {
+func buildAutoEmitOnCreateEvent(source semanticview.Source, schema runtimecontracts.FlowSchemaDocument, templateID, flowPath, flowEntityID string, config map[string]any) (events.Event, string, error) {
 	autoEmit := strings.TrimSpace(schema.AutoEmitOnCreate.Event)
 	if autoEmit == "" {
 		return events.Event{}, "", nil
 	}
 	eventType := eventidentity.ExternalizeForFlow(flowPath, []string{autoEmit}, autoEmit)
-	payload := map[string]any{
-		"instance_id":      instanceID,
-		"template_id":      templateID,
-		"flow_path":        flowPath,
-		"parent_entity_id": strings.TrimSpace(parentEntityID),
-	}
+	payload := map[string]any{}
 	for key, value := range config {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
-		if _, exists := payload[key]; !exists {
-			payload[key] = value
-		}
+		payload[key] = value
 	}
 	if err := validateAutoEmitPayload(source, templateID, autoEmit, payload); err != nil {
 		return events.Event{}, autoEmit, fmt.Errorf("auto-emit %s: %w", autoEmit, err)
@@ -242,24 +233,10 @@ func validateAutoEmitPayload(source semanticview.Source, flowID, eventType strin
 		return fmt.Errorf("%w for %s: %v", runtimebus.ErrPayloadValidation, proof.EventKey(), err)
 	}
 	schema := resolution.Schema
-	validationPayload := runtimeeventpayload.StripUndeclaredRuntimeOwnedCanonicalContext(payload, autoEmitSchemaPropertyNames(schema.Schema))
-	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, validationPayload); err != nil {
+	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, payload); err != nil {
 		return fmt.Errorf("%w for %s: %v", runtimebus.ErrPayloadValidation, proof.EventKey(), err)
 	}
 	return nil
-}
-
-func autoEmitSchemaPropertyNames(schema map[string]any) map[string]struct{} {
-	props := runtimesharedjson.SchemaProperties(schema["properties"])
-	out := make(map[string]struct{}, len(props))
-	for key := range props {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-		out[key] = struct{}{}
-	}
-	return out
 }
 
 func (am *AgentManager) EnsureStaticFlowRequiredAgents(ctx context.Context, source semanticview.Source) error {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -218,14 +219,8 @@ func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"task.started": {
 				Payload: runtimecontracts.EventPayloadSpec{
-					Properties: map[string]runtimecontracts.EventFieldSpec{
-						"instance_id":      {Type: "string"},
-						"template_id":      {Type: "string"},
-						"flow_path":        {Type: "string"},
-						"parent_entity_id": {Type: "string"},
-					},
+					Properties: map[string]runtimecontracts.EventFieldSpec{},
 				},
-				Required: []string{"instance_id", "template_id", "flow_path", "parent_entity_id"},
 			},
 		},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
@@ -384,6 +379,29 @@ func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, temp
 	}
 }
 
+func decodeFlowActivationEventPayload(t *testing.T, event events.Event) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode event payload: %v", err)
+	}
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	return payload
+}
+
+func findPublishedFlowActivationEvent(t *testing.T, bus *flowActivationTestBus, eventType string) events.Event {
+	t.Helper()
+	for _, event := range bus.published {
+		if string(event.Type) == eventType {
+			return event
+		}
+	}
+	t.Fatalf("published events = %#v, want %s", bus.published, eventType)
+	return events.Event{}
+}
+
 func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
@@ -433,6 +451,107 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	}
 	if got := strings.TrimSpace(autoEmit.RunID); got != runID {
 		t.Fatalf("published run_id = %q, want active run %q", got, runID)
+	}
+}
+
+func TestActivateFlowInstanceAutoEmitPublishesConfigPayloadWithoutActivationContext(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundleWithAutoEmitEntry("component.scaffold.start", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"component_id":   {Type: "string"},
+				"component_type": {Type: "string"},
+			},
+		},
+		Required: []string{"component_id", "component_type"},
+	})
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"component_id":   "component-1",
+		"component_type": "api",
+	}
+
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	event := findPublishedFlowActivationEvent(t, bus, "review/inst-1/component.scaffold.start")
+	payload := decodeFlowActivationEventPayload(t, event)
+	if got := payload["component_id"]; got != "component-1" {
+		t.Fatalf("component_id payload = %#v, want component-1", got)
+	}
+	if got := payload["component_type"]; got != "api" {
+		t.Fatalf("component_type payload = %#v, want api", got)
+	}
+	for _, key := range []string{"instance_id", "template_id", "flow_path", "parent_entity_id"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("auto-emit payload included activation context %q: %#v", key, payload)
+		}
+	}
+	if got := event.EntityID(); got != runtimepipeline.FlowInstanceEntityID("review/inst-1") {
+		t.Fatalf("auto-emit entity_id = %q, want flow instance entity", got)
+	}
+	if got := event.FlowInstance(); got != "review/inst-1" {
+		t.Fatalf("auto-emit flow_instance = %q, want review/inst-1", got)
+	}
+}
+
+func TestActivateFlowInstanceQueuedAutoEmitUsesProjectedConfigPayload(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundleWithAutoEmitEntry("component.scaffold.start", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"component_id": {Type: "string"},
+			},
+		},
+		Required: []string{"component_id"},
+	})
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommit)
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{"component_id": "component-1"}
+
+	if err := am.ActivateFlowInstance(ctx, req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(bus.published) != 0 {
+		t.Fatalf("auto-emit published before post-commit flush: %#v", bus.published)
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	event := findPublishedFlowActivationEvent(t, bus, "review/inst-1/component.scaffold.start")
+	payload := decodeFlowActivationEventPayload(t, event)
+	if got := payload["component_id"]; got != "component-1" {
+		t.Fatalf("component_id payload = %#v, want component-1", got)
+	}
+	for _, key := range []string{"instance_id", "template_id", "flow_path", "parent_entity_id"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("queued auto-emit payload included activation context %q: %#v", key, payload)
+		}
+	}
+}
+
+func TestActivateFlowInstanceAutoEmitAllowsDeclaredTemplateIDBusinessField(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundleWithAutoEmitEntry("repo.template.selected", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"template_id": {Type: "string"},
+			},
+		},
+		Required: []string{"template_id"},
+	})
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{"template_id": "application-basic-v1"}
+
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	event := findPublishedFlowActivationEvent(t, bus, "review/inst-1/repo.template.selected")
+	payload := decodeFlowActivationEventPayload(t, event)
+	if got := payload["template_id"]; got != "application-basic-v1" {
+		t.Fatalf("template_id payload = %#v, want config business value", got)
 	}
 }
 
@@ -509,11 +628,10 @@ func TestActivateFlowInstanceFailsClosedOnAutoEmitMissingRequiredField(t *testin
 	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
 		Payload: runtimecontracts.EventPayloadSpec{
 			Properties: map[string]runtimecontracts.EventFieldSpec{
-				"instance_id": {Type: "string"},
-				"reason":      {Type: "string"},
+				"reason": {Type: "string"},
 			},
 		},
-		Required: []string{"instance_id", "reason"},
+		Required: []string{"reason"},
 	})
 
 	err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
@@ -570,6 +688,28 @@ func TestActivateFlowInstanceQueuedAutoEmitFailsClosedOnUndeclaredConfigField(t 
 	}
 	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
 		t.Fatal("unexpected activated agent config after queued auto-emit schema failure")
+	}
+}
+
+func TestActivateFlowInstanceAutoEmitFailsClosedOnUndeclaredEnvelopeLikeConfigField(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	instances := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, instances)
+	bundle := testFlowBundle("task.started")
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"entity_id": "business-value",
+	}
+
+	err := am.ActivateFlowInstance(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "auto-emit task.started") || !strings.Contains(err.Error(), "entity_id is not allowed") {
+		t.Fatalf("ActivateFlowInstance error = %v, want undeclared envelope-like config field failure", err)
+	}
+	if len(bus.published) != 0 {
+		t.Fatalf("published events = %#v, want none", bus.published)
+	}
+	if len(instances.creates) != 0 {
+		t.Fatalf("instance creates = %#v, want none", instances.creates)
 	}
 }
 
@@ -689,15 +829,10 @@ func TestActivateFlowInstancePersistsFlowInstanceConfig(t *testing.T) {
 	bundle := testFlowBundleWithAutoEmitEntry("task.started", runtimecontracts.EventCatalogEntry{
 		Payload: runtimecontracts.EventPayloadSpec{
 			Properties: map[string]runtimecontracts.EventFieldSpec{
-				"instance_id":      {Type: "string"},
-				"template_id":      {Type: "string"},
-				"flow_path":        {Type: "string"},
-				"parent_entity_id": {Type: "string"},
-				"name":             {Type: "string"},
-				"priority":         {Type: "integer"},
+				"name":     {Type: "string"},
+				"priority": {Type: "integer"},
 			},
 		},
-		Required: []string{"instance_id", "template_id", "flow_path", "parent_entity_id"},
 	})
 
 	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -740,7 +740,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 		ID:            "evt-123",
 		Type:          "spawn.requested",
 		ParentEventID: "source-evt-1",
-		Payload:       []byte(`{"instance_id":"inst-42","name":"alpha"}`),
+		Payload:       []byte(`{"instance_id":"inst-42","name":"alpha","template_id":"application-basic-v1"}`),
 	}).WithEnvelope(events.EventEnvelope{
 		EntityID: "ent-1",
 		Source: events.RouteIdentity{
@@ -764,6 +764,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 				"source_flow":     "event.source.flow_id",
 				"correlation_id":  "event.source_event_id",
 				"name":            "payload.name",
+				"template_id":     "payload.template_id",
 				"parent_entity":   "entity.entity_id",
 			},
 		},
@@ -789,6 +790,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 		"source_flow":     "parent-flow",
 		"correlation_id":  "source-evt-1",
 		"name":            "alpha",
+		"template_id":     "application-basic-v1",
 		"parent_entity":   "ent-1",
 	} {
 		if got := captured.Config[key]; got != want {

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -150,6 +151,7 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
 	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, autoEventID)
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_receipts
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
@@ -166,10 +168,11 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
 	`, 0, autoEventID)
-	waitRuntimeDBCount(t, ctx, db, `
-		SELECT COUNT(*) FROM events
+	componentEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/component_scaffold.spawn_requested'
-	`, 1)
+	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, componentEventID)
 }
 
 func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {
@@ -265,6 +268,7 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInterna
 		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
 	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, autoEventID)
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_receipts
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
@@ -277,10 +281,11 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInterna
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
 	`, 1, autoEventID)
-	waitRuntimeDBCount(t, ctx, db, `
-		SELECT COUNT(*) FROM events
+	componentEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/component_scaffold.spawn_requested'
-	`, 1)
+	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, componentEventID)
 }
 
 func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect(t *testing.T) {
@@ -363,6 +368,7 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyle
 		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
 	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, autoEventID)
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_receipts
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator' AND outcome = 'no_op'
@@ -375,10 +381,11 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyle
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = '__runtime_replay_scope__'
 	`, 1, autoEventID)
-	waitRuntimeDBCount(t, ctx, db, `
-		SELECT COUNT(*) FROM events
+	componentEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
 		WHERE event_name = 'operating/component_scaffold.spawn_requested'
-	`, 1)
+	`, nil)
+	assertRuntimeEventPayloadProductOnly(t, ctx, db, componentEventID)
 }
 
 type runtimeTestWorkflowModule struct {
@@ -510,16 +517,8 @@ auto_emit_on_create:
   event: opco.product_initialization_requested
 `,
 		"flows/operating/events.yaml": `opco.product_initialization_requested:
-  instance_id: string
-  template_id: string
-  flow_path: string
-  parent_entity_id: string
   product_id: string
 component_scaffold.spawn_requested:
-  instance_id: string
-  template_id: string
-  flow_path: string
-  parent_entity_id: string
   product_id: string
 `,
 		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
@@ -529,7 +528,10 @@ component_scaffold.spawn_requested:
   produces: [component_scaffold.spawn_requested]
   event_handlers:
     opco.product_initialization_requested:
-      emit: component_scaffold.spawn_requested
+      emit:
+        event: component_scaffold.spawn_requested
+        fields:
+          product_id: payload.product_id
 `,
 	}
 }
@@ -584,16 +586,8 @@ auto_emit_on_create:
   event: opco.product_initialization_requested
 `,
 		"flows/operating/events.yaml": `opco.product_initialization_requested:
-  instance_id: string
-  template_id: string
-  flow_path: string
-  parent_entity_id: string
   product_id: string
 component_scaffold.spawn_requested:
-  instance_id: string
-  template_id: string
-  flow_path: string
-  parent_entity_id: string
   product_id: string
 `,
 		"flows/operating/nodes.yaml": `lifecycle-orchestrator:
@@ -603,7 +597,10 @@ component_scaffold.spawn_requested:
   produces: [component_scaffold.spawn_requested]
   event_handlers:
     opco.product_initialization_requested:
-      emit: component_scaffold.spawn_requested
+      emit:
+        event: component_scaffold.spawn_requested
+        fields:
+          product_id: payload.product_id
 `,
 	}
 }
@@ -655,6 +652,29 @@ func waitRuntimeEventID(t *testing.T, ctx context.Context, db *sql.DB, query str
 			t.Fatalf("timed out waiting for event id from query %s", strings.TrimSpace(query))
 		}
 		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func assertRuntimeEventPayloadProductOnly(t *testing.T, ctx context.Context, db *sql.DB, eventID string) {
+	t.Helper()
+	var raw string
+	if err := db.QueryRowContext(ctx, `
+		SELECT payload::text FROM events
+		WHERE event_id = $1::uuid
+	`, eventID).Scan(&raw); err != nil {
+		t.Fatalf("query event payload: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode event payload %s: %v", eventID, err)
+	}
+	if got := payload["product_id"]; got != "product-1" {
+		t.Fatalf("payload product_id = %#v, want product-1: %#v", got, payload)
+	}
+	for _, key := range []string{"instance_id", "template_id", "flow_path", "parent_entity_id"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("payload includes hidden activation context %q: %#v", key, payload)
+		}
 	}
 }
 

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -664,6 +664,49 @@ func TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField(t *testing.T) {
 	}
 }
 
+func TestHandleEmitTool_AllowsDeclaredTemplateIDBusinessPayload(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"repo.template.selected": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Type: "object",
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"template_id": {Type: "string"},
+					},
+					Required: []string{"template_id"},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	emitRegistry := NewEmitRegistry(source, nil)
+
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+	actor := models.AgentConfig{
+		ID:         "repo-agent",
+		Role:       "repo_agent",
+		EmitEvents: []string{"repo.template.selected"},
+	}
+
+	_, err := exec.handleEmitTool(context.Background(), actor, "emit_repo_template_selected", map[string]any{
+		"template_id": "application-basic-v1",
+	})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.event.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal payload: %v", err)
+	}
+	if got := payload["template_id"]; got != "application-basic-v1" {
+		t.Fatalf("payload template_id = %#v, want business value", got)
+	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
+}
+
 func TestHandleEmitTool_AllowsValidWave1EventPayloadTypes(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6887,21 +6887,27 @@ observation_model:
             envelope-owned fields back into payload.
       auto_emit_on_create_surface:
         construction_order:
-        - 1. Start from lifecycle-owned activation fields: instance_id, template_id, flow_path, parent_entity_id
-        - 2. Overlay create_flow_instance config entries only for keys not already owned by the lifecycle surface
-        - 3. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
-        collision_priority: lifecycle-owned payload fields > create_flow_instance config; runtime-owned envelope context is separate
-          from payload
+        - 1. Start from the resolved create_flow_instance config entries as the authored/config business payload.
+        - '2. Keep activation lifecycle context, including instance_id, template_id, flow_path, and parent_entity_id, on runtime
+          activation metadata and event envelope context; do not synthesize it into payload.'
+        - 3. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload.
+        collision_priority: create_flow_instance config owns the business payload. Activation lifecycle context is separate
+          from payload, so same-named config fields such as template_id remain business fields when the target schema declares
+          them.
         note: This surface is authored only as `auto_emit_on_create.event`, so runtime owns the payload construction. It still
-          must satisfy the active event schema fail-closed. Lifecycle-owned fields are explicit runtime payload on this surface;
-          create_flow_instance config does not silently widen the event contract; envelope fields remain accessible through event.*.
+          must satisfy the active event schema fail-closed. Hidden activation lifecycle context does not silently widen the
+          event contract and is not published as payload merely because the runtime needed it to create the instance; envelope
+          fields remain accessible through event.*.
         runtime_validation:
           description: Runtime validates the constructed auto-emit payload fail-closed before either immediate publish or queued
             post-commit publish.
           validation_view: Validate the constructed payload carrier against the target event schema after canonical Wave 1 type-aware
             schema lowering. Runtime-owned envelope fields are not synthesized into payload for validation.
-          rejection_rule: If any lifecycle/config-authored field is undeclared or violates the schema, flow activation fails. Runtime
-            does not downgrade auto_emit_on_create schema violations into warning-only success on the queued post-commit branch.
+          rejection_rule: If any config-authored business field is undeclared or violates the schema, flow activation fails.
+            Hidden activation lifecycle context fields do not fail validation merely because the target schema omits same-named
+            payload fields. If an event schema declares a lifecycle-shaped field name such as template_id as business payload,
+            the config payload must supply it explicitly. Runtime does not downgrade auto_emit_on_create schema violations into
+            warning-only success on the queued post-commit branch.
   entity_state:
     description: The entity document after handler execution commits.
     observable_fields:


### PR DESCRIPTION
Closes #1297

## Summary

- Repair `platform-spec.yaml` source authority for `auto_emit_on_create_surface`: authored/config business payload is projected from resolved `create_flow_instance` config, while activation lifecycle context (`instance_id`, `template_id`, `flow_path`, `parent_entity_id`) remains runtime metadata/envelope context and is not synthesized into payload.
- Update runtime auto-emit construction and validation so validation checks the exact emitted payload, not a validation-only stripped view.
- Add regression proof for direct activation, queued post-commit activation, config business `template_id`, undeclared config fail-closed behavior, no global reservation of activation-context-shaped field names, normal non-auto-emit authored `template_id` payloads, and migrated Empire-style delivery fixtures.

## Governing refs / context

- #1297 body and repro: Empire component-scaffold auto-emit failed with `$.template_id is not allowed`.
- #1297 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1297#issuecomment-4604246160
- #1297 independent gate: https://github.com/division-sh/swarm/issues/1297#issuecomment-4618106962
- PR review thread addressed: https://github.com/division-sh/swarm/pull/1307#discussion_r3352913367
- `platform-spec.yaml` `dynamic_instance_lifecycle.creation.auto_emit`.
- `platform-spec.yaml` `event_schema.strict_payload_contract`.
- `platform-spec.yaml` `observation_model.payload_rules.auto_emit_on_create_surface`.

## Semantic migration

- New canonical source authority: `platform-spec.yaml` `observation_model.payload_rules.auto_emit_on_create_surface` now defines auto-emit payload as resolved config/business payload only; activation lifecycle context is hidden runtime metadata/envelope context.
- Runtime canonical owner after change: `internal/runtime/manager/flow_activation.go` `buildAutoEmitOnCreateEvent` and `validateAutoEmitPayload`.
- Old producer path now invalid: auto-emit construction that synthesized `instance_id`, `template_id`, `flow_path`, and `parent_entity_id` into payload, then validated/published them as payload fields.
- Old validation path now invalid: validation-only runtime-context stripping that could validate a different carrier than the payload actually published.
- Production paths checked for surviving old behavior: direct `ActivateFlowInstance`, queued post-commit activation, pipeline `create_flow_instance.config_from`, Empire-style delivery fixtures, normal authored payload validation for declared `template_id`, eventpayload global runtime-owned context helper, and duplicate-create no-auto-emit behavior.
- Migration complete for the approved #1297 child class. #1296 route rendering and #1304 dynamic-agent transaction/persistence remain explicit sibling issues.

## Proof

- `go test ./internal/runtime -run 'TestTemplateInstance(AutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect|RootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect|RootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect)' -count=1`
- `go test ./internal/runtime/manager -run 'TestActivateFlowInstance(PublishesAutoEmitEvent|AutoEmitPublishesConfigPayloadWithoutActivationContext|QueuedAutoEmitUsesProjectedConfigPayload|AutoEmitAllowsDeclaredTemplateIDBusinessField|QueuedAutoEmitFailsClosedOnUndeclaredConfigField|AutoEmitFailsClosedOnUndeclaredEnvelopeLikeConfigField|FailsClosedOnAutoEmitMissingRequiredField|RejectsDuplicateInstanceIDBeforeSideEffects|PersistsFlowInstanceConfig)|TestValidateAutoEmitPayload' -count=1`
- `go test ./internal/runtime/eventpayload -count=1`
- `go test ./internal/runtime/pipeline -run 'TestCreateFlowInstanceResolvesConfigFromHandlerEventContext|TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextForConfigFrom' -count=1`
- `go test ./internal/runtime/tools -run 'TestHandleEmitTool_(AllowsDeclaredTemplateIDBusinessPayload|RejectsUndeclaredPayloadField|AllowsValidWave1EventPayloadTypes)' -count=1`
- `go test ./internal/runtime/tools -run 'TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent|TestHandleEmitTool_RejectsUndeclaredPayloadField|TestHandleEmitTool_AllowsValidWave1EventPayloadTypes' -count=1`
- `go test ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime/eventpayload ./internal/runtime/tools -count=1`
- `go test ./internal/runtime ./internal/runtime/manager ./internal/runtime/pipeline ./internal/runtime/eventpayload ./internal/runtime/tools -count=1`
- `go test ./internal/runtime ./internal/runtime/bootverify ./internal/runtime/swarmflowtest -count=1`
- `go test ./internal/apispec ./internal/store -run 'TestPlatformSpec|TestPlatformAPISpecValidationCoverage|TestGeneratedOpenRPCArtifactMatchesPlatformSpec' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check origin/master`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`

Note: one pre-review full-suite attempt hit unrelated `cmd/swarm` serve-test readiness/listener flakiness. After the review fix and rebase, `go test ./... -count=1` passed cleanly.
