### PR TITLE
[agent-h][issue #1257] Emit stalled run escalation event

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -972,6 +972,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("start runtime: %v", err)
 		return 1
 	}
+	startServeRunStalledEscalation(ctx, stores, runtimeContexts, rt.Bus)
 	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("api_listener=%s api_routes=%s mcp_listener=%s mcp_routes=%s", apiListener.Addr(), serveAPIRoutes, mcpListener.Addr(), serveMCPRoutes))
 	ready.Store(true)
 	if err := waitForServeHealthEndpoints(ctx, apiListener.Addr()); err != nil {

--- a/cmd/swarm/run_stalled_monitor.go
+++ b/cmd/swarm/run_stalled_monitor.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/bus"
+	"github.com/division-sh/swarm/internal/runtime/runstalled"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+)
+
+type runStalledReadStore interface {
+	ListRunHeaders(context.Context, store.RunHeaderListOptions) ([]store.RunHeader, string, error)
+	LoadRunDebugReport(context.Context, string, store.RunDebugQueryOptions) (store.RunDebugReport, error)
+	ListOperatorEvents(context.Context, store.OperatorEventListOptions) (store.OperatorEventListResult, error)
+}
+
+type serveRunStalledReader struct {
+	store    runStalledReadStore
+	db       *sql.DB
+	postgres bool
+}
+
+func startServeRunStalledEscalation(ctx context.Context, stores storeBundle, contexts []serveRuntimeBundleContext, eventBus *bus.EventBus) {
+	reader, ok := newServeRunStalledReader(stores)
+	if !ok || eventBus == nil {
+		return
+	}
+	monitor := &runstalled.Monitor{
+		Reader:         reader,
+		Publisher:      eventBus,
+		PolicyResolver: serveRunStalledPolicyResolver(contexts),
+		OnError: func(err error) {
+			log.Printf("run stalled escalation monitor: %v", err)
+		},
+	}
+	go monitor.Run(ctx)
+}
+
+func newServeRunStalledReader(stores storeBundle) (*serveRunStalledReader, bool) {
+	if stores.Postgres != nil {
+		return &serveRunStalledReader{store: stores.Postgres, db: stores.SQLDB, postgres: true}, true
+	}
+	readStore, ok := stores.ObservabilityStore.(runStalledReadStore)
+	if !ok || readStore == nil {
+		return nil, false
+	}
+	return &serveRunStalledReader{store: readStore, db: stores.SQLDB}, true
+}
+
+func (r *serveRunStalledReader) ListRunningRuns(ctx context.Context, limit int, cursor string) ([]runstalled.RunRef, string, error) {
+	if r == nil || r.store == nil {
+		return nil, "", fmt.Errorf("run stalled reader requires store")
+	}
+	headers, next, err := r.store.ListRunHeaders(ctx, store.RunHeaderListOptions{
+		Status: "running",
+		Limit:  limit,
+		Cursor: cursor,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	refs := make([]runstalled.RunRef, 0, len(headers))
+	for _, header := range headers {
+		runID := strings.TrimSpace(header.RunID)
+		if runID == "" {
+			continue
+		}
+		refs = append(refs, runstalled.RunRef{RunID: runID})
+	}
+	return refs, next, nil
+}
+
+func (r *serveRunStalledReader) LoadRunSnapshot(ctx context.Context, runID string) (runstalled.RunSnapshot, error) {
+	if r == nil || r.store == nil {
+		return runstalled.RunSnapshot{}, fmt.Errorf("run stalled reader requires store")
+	}
+	report, err := r.store.LoadRunDebugReport(ctx, strings.TrimSpace(runID), store.RunDebugQueryOptions{})
+	if err != nil {
+		return runstalled.RunSnapshot{}, err
+	}
+	flowInstance, err := r.loadLatestFlowInstance(ctx, report.RunID)
+	if err != nil {
+		return runstalled.RunSnapshot{}, err
+	}
+	progressAt, err := r.loadLatestNonEscalationProgressAt(ctx, report.RunID)
+	if err != nil {
+		return runstalled.RunSnapshot{}, err
+	}
+	return runStalledSnapshotFromDebugReport(report, flowInstance, progressAt), nil
+}
+
+func (r *serveRunStalledReader) StalledRunEscalationExists(ctx context.Context, key runstalled.EscalationKey) (bool, error) {
+	if r == nil || r.store == nil {
+		return false, fmt.Errorf("run stalled reader requires store")
+	}
+	result, err := r.store.ListOperatorEvents(ctx, store.OperatorEventListOptions{
+		Filter: store.OperatorEventListFilter{
+			RunID:     key.RunID,
+			EventName: runstalled.EventType,
+		},
+		Limit: 1000,
+		Order: "desc",
+	})
+	if err != nil {
+		return false, err
+	}
+	lastProgressAt := runstalled.LastProgressAtString(key.LastProgressAt)
+	for _, evt := range result.Events {
+		if payloadString(evt.Payload["blocking_layer"]) != key.BlockingLayer {
+			continue
+		}
+		if payloadString(evt.Payload["blocking_reason"]) != key.BlockingReason {
+			continue
+		}
+		if payloadString(evt.Payload["last_progress_at"]) != lastProgressAt {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (r *serveRunStalledReader) loadLatestFlowInstance(ctx context.Context, runID string) (string, error) {
+	runID = strings.TrimSpace(runID)
+	if r == nil || r.db == nil || runID == "" {
+		return "", nil
+	}
+	query := `
+		SELECT COALESCE(flow_instance, '')
+		FROM events
+		WHERE run_id = ?
+		  AND COALESCE(flow_instance, '') <> ''
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`
+	args := []any{runID}
+	if r.postgres {
+		query = `
+			SELECT COALESCE(flow_instance, '')
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND COALESCE(flow_instance, '') <> ''
+			ORDER BY created_at DESC, event_id::text DESC
+			LIMIT 1
+		`
+	}
+	var flowInstance string
+	err := r.db.QueryRowContext(ctx, query, args...).Scan(&flowInstance)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("load latest run flow instance: %w", err)
+	}
+	return strings.Trim(flowInstance, "/"), nil
+}
+
+func (r *serveRunStalledReader) loadLatestNonEscalationProgressAt(ctx context.Context, runID string) (time.Time, error) {
+	runID = strings.TrimSpace(runID)
+	if r == nil || r.db == nil || runID == "" {
+		return time.Time{}, nil
+	}
+	query := `
+		SELECT MAX(created_at)
+		FROM events
+		WHERE run_id = ?
+		  AND event_name <> ?
+	`
+	args := []any{runID, runstalled.EventType}
+	if r.postgres {
+		query = `
+			SELECT MAX(created_at)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name <> $2
+		`
+	}
+	var raw any
+	if err := r.db.QueryRowContext(ctx, query, args...).Scan(&raw); err != nil {
+		return time.Time{}, fmt.Errorf("load latest non-escalation progress timestamp: %w", err)
+	}
+	progressAt, _, err := runStalledTimeValue(raw)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return progressAt, nil
+}
+
+func runStalledSnapshotFromDebugReport(report store.RunDebugReport, flowInstance string, progressAt time.Time) runstalled.RunSnapshot {
+	report.LastEventAt = progressAt
+	status := store.ProjectRunOperationalStatus(report)
+	return runstalled.RunSnapshot{
+		RunID:          strings.TrimSpace(report.RunID),
+		RunTableStatus: strings.TrimSpace(report.RunTableStatus),
+		FlowInstance:   strings.Trim(flowInstance, "/"),
+		LastProgressAt: progressAt,
+		Diagnosis: runstalled.Diagnosis{
+			OperationalState: strings.TrimSpace(status.State),
+			BlockingLayer:    strings.TrimSpace(status.BlockingLayer),
+			BlockingReason:   strings.TrimSpace(status.BlockingReason),
+		},
+	}
+}
+
+func serveRunStalledPolicyResolver(contexts []serveRuntimeBundleContext) runstalled.PolicyResolver {
+	sources := make([]semanticview.Source, 0, len(contexts))
+	for _, contextDef := range contexts {
+		if contextDef.loaded.source != nil {
+			sources = append(sources, contextDef.loaded.source)
+		}
+	}
+	return func(flowInstance string) runstalled.Policy {
+		policy := runstalled.DefaultPolicy()
+		source, flowID := serveRunStalledPolicyScope(sources, flowInstance)
+		if source == nil {
+			return policy
+		}
+		if value, ok := semanticview.PolicyValueForFlow(source, flowID, "runtime.stalled_run_escalation.enabled"); ok {
+			if enabled, ok := runStalledPolicyBool(value.Value); ok {
+				policy.Enabled = enabled
+			}
+		}
+		if value, ok := semanticview.PolicyValueForFlow(source, flowID, "runtime.stalled_run_escalation.threshold_seconds"); ok {
+			if seconds, ok := runStalledPolicySeconds(value.Value); ok && seconds > 0 {
+				policy.Threshold = time.Duration(seconds) * time.Second
+			}
+		}
+		return policy
+	}
+}
+
+func serveRunStalledPolicyScope(sources []semanticview.Source, flowInstance string) (semanticview.Source, string) {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		if flowID := runStalledFlowIDForInstance(source.FlowScopes(), flowInstance); flowID != "" {
+			return source, flowID
+		}
+	}
+	if len(sources) > 0 {
+		return sources[0], ""
+	}
+	return nil, ""
+}
+
+func runStalledFlowIDForInstance(scopes []semanticview.FlowScope, flowInstance string) string {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	if flowInstance == "" {
+		return ""
+	}
+	bestFlowID := ""
+	bestMatchLen := -1
+	for _, scope := range scopes {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" {
+			continue
+		}
+		for _, candidate := range []string{scope.Path, scope.ID} {
+			candidate = strings.Trim(strings.TrimSpace(candidate), "/")
+			if candidate == "" {
+				continue
+			}
+			if flowInstance != candidate && !strings.HasPrefix(flowInstance, candidate+"/") {
+				continue
+			}
+			if len(candidate) > bestMatchLen {
+				bestMatchLen = len(candidate)
+				bestFlowID = flowID
+			}
+		}
+	}
+	return bestFlowID
+}
+
+func runStalledPolicyBool(value any) (bool, bool) {
+	switch typed := value.(type) {
+	case bool:
+		return typed, true
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+		return parsed, err == nil
+	default:
+		return false, false
+	}
+}
+
+func runStalledPolicySeconds(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case int32:
+		return int(typed), true
+	case float64:
+		return int(typed), typed == float64(int(typed))
+	case float32:
+		return int(typed), typed == float32(int(typed))
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func payloadString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+}
+
+func runStalledTimeValue(raw any) (time.Time, bool, error) {
+	switch typed := raw.(type) {
+	case nil:
+		return time.Time{}, false, nil
+	case time.Time:
+		if typed.IsZero() {
+			return time.Time{}, false, nil
+		}
+		return typed.UTC(), true, nil
+	case string:
+		return parseRunStalledTimeString(typed)
+	case []byte:
+		return parseRunStalledTimeString(string(typed))
+	default:
+		return time.Time{}, false, fmt.Errorf("unsupported run stalled time value %T", raw)
+	}
+}
+
+func parseRunStalledTimeString(raw string) (time.Time, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+	}
+	var lastErr error
+	for _, layout := range formats {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return parsed.UTC(), true, nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, false, fmt.Errorf("parse run stalled time %q: %w", raw, lastErr)
+}

--- a/cmd/swarm/run_stalled_monitor_test.go
+++ b/cmd/swarm/run_stalled_monitor_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/runstalled"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRunStalledSnapshotFromDebugReportUsesProjectRunOperationalStatus(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		report     store.RunDebugReport
+		wantLayer  string
+		wantReason string
+	}{
+		{
+			name: "delivery lifecycle",
+			report: store.RunDebugReport{
+				RunID:          "run-delivery",
+				RunTableStatus: "running",
+				LastEventAt:    now,
+			},
+			wantLayer:  "delivery_lifecycle",
+			wantReason: "no_active_deliveries",
+		},
+		{
+			name: "scoring terminal outcome",
+			report: store.RunDebugReport{
+				RunID:          "run-scoring",
+				RunTableStatus: "running",
+				LastEventAt:    now,
+				EventCounts: []store.RunDebugEventCount{
+					{EventName: "scoring/scoring.requested", Count: 1},
+				},
+			},
+			wantLayer:  "scoring_terminal_outcome",
+			wantReason: "terminal_scoring_outcome_missing",
+		},
+		{
+			name: "active delivery remains running",
+			report: store.RunDebugReport{
+				RunID:          "run-active",
+				RunTableStatus: "running",
+				LastEventAt:    now,
+				Deliveries: []store.RunDebugDeliveryCount{
+					{Status: "in_progress", Count: 1},
+				},
+			},
+			wantLayer:  "",
+			wantReason: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runStalledSnapshotFromDebugReport(tc.report, "review/inst-1", tc.report.LastEventAt)
+			if got.Diagnosis.BlockingLayer != tc.wantLayer {
+				t.Fatalf("blocking_layer = %q, want %q", got.Diagnosis.BlockingLayer, tc.wantLayer)
+			}
+			if got.Diagnosis.BlockingReason != tc.wantReason {
+				t.Fatalf("blocking_reason = %q, want %q", got.Diagnosis.BlockingReason, tc.wantReason)
+			}
+			if tc.wantLayer == "" && got.Diagnosis.OperationalState != "running" {
+				t.Fatalf("operational_state = %q, want running", got.Diagnosis.OperationalState)
+			}
+			if tc.wantLayer != "" && got.Diagnosis.OperationalState != "stalled" {
+				t.Fatalf("operational_state = %q, want stalled", got.Diagnosis.OperationalState)
+			}
+		})
+	}
+}
+
+func TestRunStalledSnapshotFromDebugReportUsesNonEscalationProgressTimestamp(t *testing.T) {
+	progressAt := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	selfAlertAt := progressAt.Add(10 * time.Minute)
+	report := store.RunDebugReport{
+		RunID:          "run-self-alert",
+		RunTableStatus: "running",
+		LastEventAt:    selfAlertAt,
+	}
+	got := runStalledSnapshotFromDebugReport(report, "", progressAt)
+	if !got.LastProgressAt.Equal(progressAt) {
+		t.Fatalf("last progress at = %s, want %s", got.LastProgressAt, progressAt)
+	}
+	if got.Diagnosis.OperationalState != "stalled" {
+		t.Fatalf("operational_state = %q, want stalled", got.Diagnosis.OperationalState)
+	}
+}
+
+func TestServeRunStalledReaderLoadsLatestNonEscalationProgressAt(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE events (
+			run_id TEXT NOT NULL,
+			event_name TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("create events: %v", err)
+	}
+	progressAt := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	selfAlertAt := progressAt.Add(10 * time.Minute)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_name, created_at) VALUES
+			('run-1', 'task.started', ?),
+			('run-1', 'platform.run_stalled', ?)
+	`, progressAt.Format(time.RFC3339Nano), selfAlertAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	reader := &serveRunStalledReader{db: db}
+	got, err := reader.loadLatestNonEscalationProgressAt(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("load latest non-escalation progress: %v", err)
+	}
+	if !got.Equal(progressAt) {
+		t.Fatalf("progress timestamp = %s, want %s", got, progressAt)
+	}
+}
+
+func TestRunStalledFlowIDForInstanceChoosesMostSpecificScope(t *testing.T) {
+	scopes := []semanticview.FlowScope{
+		{ID: "parent", Path: "review"},
+		{ID: "child", Path: "review/qa"},
+		{ID: "id-only"},
+	}
+	if got := runStalledFlowIDForInstance(scopes, "review/qa/inst-1"); got != "child" {
+		t.Fatalf("flow id = %q, want child", got)
+	}
+	if got := runStalledFlowIDForInstance(scopes, "review/inst-1"); got != "parent" {
+		t.Fatalf("flow id = %q, want parent", got)
+	}
+	if got := runStalledFlowIDForInstance(scopes, "id-only/inst-1"); got != "id-only" {
+		t.Fatalf("flow id = %q, want id-only", got)
+	}
+}
+
+func TestRunStalledPolicyParsing(t *testing.T) {
+	if got, ok := runStalledPolicyBool("false"); !ok || got {
+		t.Fatalf("bool parse = %v/%v, want false/true", got, ok)
+	}
+	if got, ok := runStalledPolicySeconds(float64(runstalled.DefaultThresholdSeconds)); !ok || got != runstalled.DefaultThresholdSeconds {
+		t.Fatalf("seconds parse = %d/%v, want default/true", got, ok)
+	}
+	if _, ok := runStalledPolicySeconds(3.5); ok {
+		t.Fatalf("fractional threshold parsed successfully, want rejection")
+	}
+}

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -938,6 +938,7 @@ func TestPlatformEventsCatalogOwnsPlatformEmittedEvents(t *testing.T) {
 		"platform.agent_panic",
 		"platform.event_quarantined",
 		"platform.dead_letter_escalation",
+		"platform.run_stalled",
 		"platform.reset",
 		"platform.auth_required",
 		"platform.budget_threshold_crossed",

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1674,6 +1674,11 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000003",
 			eventType: events.EventType("platform.budget_threshold_crossed"),
 		},
+		{
+			name:      "run lifecycle platform.run_stalled",
+			eventID:   "20000000-0000-0000-0000-000000000004",
+			eventType: events.EventType("platform.run_stalled"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/runtime/runstalled/monitor.go
+++ b/internal/runtime/runstalled/monitor.go
@@ -1,0 +1,252 @@
+package runstalled
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+const (
+	EventType                = "platform.run_stalled"
+	DefaultThresholdSeconds  = 300
+	defaultPageLimit         = 100
+	defaultPollInterval      = 30 * time.Second
+	runningRunTableStatus    = "running"
+	stalledOperationalStatus = "stalled"
+)
+
+type Diagnosis struct {
+	OperationalState string
+	BlockingLayer    string
+	BlockingReason   string
+}
+
+type RunSnapshot struct {
+	RunID          string
+	RunTableStatus string
+	FlowInstance   string
+	LastProgressAt time.Time
+	Diagnosis      Diagnosis
+}
+
+type RunRef struct {
+	RunID string
+}
+
+type EscalationKey struct {
+	RunID          string
+	BlockingLayer  string
+	BlockingReason string
+	LastProgressAt time.Time
+}
+
+type Policy struct {
+	Enabled   bool
+	Threshold time.Duration
+}
+
+type Reader interface {
+	ListRunningRuns(context.Context, int, string) ([]RunRef, string, error)
+	LoadRunSnapshot(context.Context, string) (RunSnapshot, error)
+	StalledRunEscalationExists(context.Context, EscalationKey) (bool, error)
+}
+
+type Publisher interface {
+	Publish(context.Context, events.Event) error
+}
+
+type PolicyResolver func(flowInstance string) Policy
+
+type Monitor struct {
+	Reader         Reader
+	Publisher      Publisher
+	PolicyResolver PolicyResolver
+	PageLimit      int
+	PollInterval   time.Duration
+	OnError        func(error)
+}
+
+type CheckResult struct {
+	Scanned   int
+	Published int
+	Skipped   int
+}
+
+func DefaultPolicy() Policy {
+	return Policy{Enabled: true, Threshold: time.Duration(DefaultThresholdSeconds) * time.Second}
+}
+
+func (m *Monitor) Run(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	interval := m.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if _, err := m.CheckOnce(ctx, now.UTC()); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				m.reportError(err)
+			}
+		}
+	}
+}
+
+func (m *Monitor) CheckOnce(ctx context.Context, now time.Time) (CheckResult, error) {
+	var result CheckResult
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil || m.Reader == nil || m.Publisher == nil {
+		return result, fmt.Errorf("run stalled monitor requires reader and publisher")
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	limit := m.PageLimit
+	if limit <= 0 {
+		limit = defaultPageLimit
+	}
+	cursor := ""
+	for {
+		refs, next, err := m.Reader.ListRunningRuns(ctx, limit, cursor)
+		if err != nil {
+			return result, err
+		}
+		for _, ref := range refs {
+			runID := strings.TrimSpace(ref.RunID)
+			if runID == "" {
+				result.Skipped++
+				continue
+			}
+			result.Scanned++
+			snapshot, err := m.Reader.LoadRunSnapshot(ctx, runID)
+			if err != nil {
+				return result, err
+			}
+			evt, key, ok, err := m.eventForSnapshot(snapshot, now)
+			if err != nil {
+				return result, err
+			}
+			if !ok {
+				result.Skipped++
+				continue
+			}
+			exists, err := m.Reader.StalledRunEscalationExists(ctx, key)
+			if err != nil {
+				return result, err
+			}
+			if exists {
+				result.Skipped++
+				continue
+			}
+			if err := m.Publisher.Publish(ctx, evt); err != nil {
+				return result, err
+			}
+			result.Published++
+		}
+		if strings.TrimSpace(next) == "" {
+			return result, nil
+		}
+		cursor = next
+	}
+}
+
+func (m *Monitor) eventForSnapshot(snapshot RunSnapshot, now time.Time) (events.Event, EscalationKey, bool, error) {
+	runID := strings.TrimSpace(snapshot.RunID)
+	if runID == "" {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	if strings.ToLower(strings.TrimSpace(snapshot.RunTableStatus)) != runningRunTableStatus {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	if strings.ToLower(strings.TrimSpace(snapshot.Diagnosis.OperationalState)) != stalledOperationalStatus {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	if snapshot.LastProgressAt.IsZero() {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	policy := m.resolvePolicy(snapshot.FlowInstance)
+	if !policy.Enabled || policy.Threshold <= 0 {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	lastProgressAt := snapshot.LastProgressAt.UTC()
+	stalledFor := now.Sub(lastProgressAt)
+	if stalledFor < policy.Threshold {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	blockingLayer := strings.TrimSpace(snapshot.Diagnosis.BlockingLayer)
+	blockingReason := strings.TrimSpace(snapshot.Diagnosis.BlockingReason)
+	if blockingLayer == "" || blockingReason == "" {
+		return events.Event{}, EscalationKey{}, false, nil
+	}
+	key := EscalationKey{
+		RunID:          runID,
+		BlockingLayer:  blockingLayer,
+		BlockingReason: blockingReason,
+		LastProgressAt: lastProgressAt,
+	}
+	payload, err := json.Marshal(map[string]any{
+		"run_id":              runID,
+		"flow_instance":       strings.Trim(strings.TrimSpace(snapshot.FlowInstance), "/"),
+		"operational_state":   stalledOperationalStatus,
+		"blocking_layer":      blockingLayer,
+		"blocking_reason":     blockingReason,
+		"last_progress_at":    lastProgressAt.Format(time.RFC3339Nano),
+		"threshold_seconds":   int(policy.Threshold / time.Second),
+		"stalled_for_seconds": int(stalledFor / time.Second),
+		"emitted_at":          now.UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return events.Event{}, EscalationKey{}, false, err
+	}
+	evt := events.Event{
+		Type:        events.EventType(EventType),
+		SourceAgent: "runtime",
+		Payload:     payload,
+		RunID:       runID,
+		CreatedAt:   now.UTC(),
+	}.WithFlowInstance(snapshot.FlowInstance)
+	return evt, key, true, nil
+}
+
+func (m *Monitor) resolvePolicy(flowInstance string) Policy {
+	if m != nil && m.PolicyResolver != nil {
+		policy := m.PolicyResolver(flowInstance)
+		if policy.Threshold > 0 {
+			return policy
+		}
+		return Policy{Enabled: policy.Enabled, Threshold: DefaultPolicy().Threshold}
+	}
+	return DefaultPolicy()
+}
+
+func (m *Monitor) reportError(err error) {
+	if err == nil {
+		return
+	}
+	if m != nil && m.OnError != nil {
+		m.OnError(err)
+	}
+}
+
+func LastProgressAtString(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/runtime/runstalled/monitor_test.go
+++ b/internal/runtime/runstalled/monitor_test.go
@@ -1,0 +1,251 @@
+package runstalled
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+func TestMonitorEmitsOnlyAfterThreshold(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	reader := newFakeReader(RunSnapshot{
+		RunID:          "run-1",
+		RunTableStatus: "running",
+		LastProgressAt: now.Add(-(DefaultPolicy().Threshold - time.Second)),
+		Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+	})
+	publisher := &fakePublisher{}
+	monitor := Monitor{Reader: reader, Publisher: publisher}
+	if result, err := monitor.CheckOnce(context.Background(), now); err != nil {
+		t.Fatalf("CheckOnce before threshold: %v", err)
+	} else if result.Published != 0 || len(publisher.events) != 0 {
+		t.Fatalf("before threshold published result=%+v events=%d, want none", result, len(publisher.events))
+	}
+
+	reader.snapshots["run-1"] = RunSnapshot{
+		RunID:          "run-1",
+		RunTableStatus: "running",
+		LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+		Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+	}
+	if result, err := monitor.CheckOnce(context.Background(), now); err != nil {
+		t.Fatalf("CheckOnce at threshold: %v", err)
+	} else if result.Published != 1 || len(publisher.events) != 1 {
+		t.Fatalf("at threshold published result=%+v events=%d, want one", result, len(publisher.events))
+	}
+	payload := eventPayload(t, publisher.events[0])
+	if got := payload["blocking_layer"]; got != "delivery_lifecycle" {
+		t.Fatalf("blocking_layer = %#v, want delivery_lifecycle", got)
+	}
+	if got := payload["threshold_seconds"]; got != float64(DefaultThresholdSeconds) {
+		t.Fatalf("threshold_seconds = %#v, want %d", got, DefaultThresholdSeconds)
+	}
+}
+
+func TestMonitorDoesNotDuplicateSameStalledEvidence(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	lastProgress := now.Add(-DefaultPolicy().Threshold)
+	reader := newFakeReader(RunSnapshot{
+		RunID:          "run-1",
+		RunTableStatus: "running",
+		LastProgressAt: lastProgress,
+		Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+	})
+	reader.existing[EscalationKey{
+		RunID:          "run-1",
+		BlockingLayer:  "delivery_lifecycle",
+		BlockingReason: "no_active_deliveries",
+		LastProgressAt: lastProgress,
+	}] = true
+	publisher := &fakePublisher{}
+	monitor := Monitor{Reader: reader, Publisher: publisher}
+	result, err := monitor.CheckOnce(context.Background(), now)
+	if err != nil {
+		t.Fatalf("CheckOnce: %v", err)
+	}
+	if result.Published != 0 || len(publisher.events) != 0 {
+		t.Fatalf("published duplicate result=%+v events=%d, want none", result, len(publisher.events))
+	}
+}
+
+func TestMonitorSuppressesNonStalledTerminalAndZeroProgressRuns(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	reader := newFakeReader(
+		RunSnapshot{
+			RunID:          "active-delivery",
+			RunTableStatus: "running",
+			LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+			Diagnosis: Diagnosis{
+				OperationalState: "running",
+			},
+		},
+		RunSnapshot{
+			RunID:          "terminal",
+			RunTableStatus: "completed",
+			LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+			Diagnosis: Diagnosis{
+				OperationalState: "completed",
+			},
+		},
+		RunSnapshot{
+			RunID:          "zero-progress",
+			RunTableStatus: "running",
+			Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+		},
+	)
+	publisher := &fakePublisher{}
+	monitor := Monitor{Reader: reader, Publisher: publisher}
+	result, err := monitor.CheckOnce(context.Background(), now)
+	if err != nil {
+		t.Fatalf("CheckOnce: %v", err)
+	}
+	if result.Published != 0 || len(publisher.events) != 0 {
+		t.Fatalf("published suppressed runs result=%+v events=%d, want none", result, len(publisher.events))
+	}
+}
+
+func TestMonitorHonorsDisabledAndExtendedPolicies(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	reader := newFakeReader(
+		RunSnapshot{
+			RunID:          "disabled",
+			RunTableStatus: "running",
+			FlowInstance:   "disabled-flow/inst-1",
+			LastProgressAt: now.Add(-time.Hour),
+			Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+		},
+		RunSnapshot{
+			RunID:          "extended-too-young",
+			RunTableStatus: "running",
+			FlowInstance:   "slow-flow/inst-1",
+			LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+			Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+		},
+		RunSnapshot{
+			RunID:          "extended-old-enough",
+			RunTableStatus: "running",
+			FlowInstance:   "slow-flow/inst-2",
+			LastProgressAt: now.Add(-10 * time.Minute),
+			Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+		},
+	)
+	publisher := &fakePublisher{}
+	monitor := Monitor{
+		Reader:    reader,
+		Publisher: publisher,
+		PolicyResolver: func(flowInstance string) Policy {
+			switch flowInstance {
+			case "disabled-flow/inst-1":
+				return Policy{Enabled: false, Threshold: DefaultPolicy().Threshold}
+			case "slow-flow/inst-1", "slow-flow/inst-2":
+				return Policy{Enabled: true, Threshold: 10 * time.Minute}
+			default:
+				return DefaultPolicy()
+			}
+		},
+	}
+	result, err := monitor.CheckOnce(context.Background(), now)
+	if err != nil {
+		t.Fatalf("CheckOnce: %v", err)
+	}
+	if result.Published != 1 || len(publisher.events) != 1 {
+		t.Fatalf("published result=%+v events=%d, want exactly one", result, len(publisher.events))
+	}
+	if publisher.events[0].RunID != "extended-old-enough" {
+		t.Fatalf("published run = %q, want extended-old-enough", publisher.events[0].RunID)
+	}
+}
+
+func TestMonitorPublishesBothSupportedStalledDiagnosisReasons(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	reader := newFakeReader(
+		RunSnapshot{
+			RunID:          "delivery-run",
+			RunTableStatus: "running",
+			LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+			Diagnosis:      stalledDiagnosis("delivery_lifecycle", "no_active_deliveries"),
+		},
+		RunSnapshot{
+			RunID:          "scoring-run",
+			RunTableStatus: "running",
+			LastProgressAt: now.Add(-DefaultPolicy().Threshold),
+			Diagnosis:      stalledDiagnosis("scoring_terminal_outcome", "terminal_scoring_outcome_missing"),
+		},
+	)
+	publisher := &fakePublisher{}
+	monitor := Monitor{Reader: reader, Publisher: publisher}
+	result, err := monitor.CheckOnce(context.Background(), now)
+	if err != nil {
+		t.Fatalf("CheckOnce: %v", err)
+	}
+	if result.Published != 2 || len(publisher.events) != 2 {
+		t.Fatalf("published result=%+v events=%d, want two", result, len(publisher.events))
+	}
+	got := map[string]string{}
+	for _, evt := range publisher.events {
+		payload := eventPayload(t, evt)
+		got[evt.RunID] = payload["blocking_layer"].(string) + "/" + payload["blocking_reason"].(string)
+	}
+	if got["delivery-run"] != "delivery_lifecycle/no_active_deliveries" {
+		t.Fatalf("delivery-run payload = %q", got["delivery-run"])
+	}
+	if got["scoring-run"] != "scoring_terminal_outcome/terminal_scoring_outcome_missing" {
+		t.Fatalf("scoring-run payload = %q", got["scoring-run"])
+	}
+}
+
+func stalledDiagnosis(layer, reason string) Diagnosis {
+	return Diagnosis{OperationalState: "stalled", BlockingLayer: layer, BlockingReason: reason}
+}
+
+type fakeReader struct {
+	refs      []RunRef
+	snapshots map[string]RunSnapshot
+	existing  map[EscalationKey]bool
+}
+
+func newFakeReader(snapshots ...RunSnapshot) *fakeReader {
+	reader := &fakeReader{
+		refs:      []RunRef{},
+		snapshots: map[string]RunSnapshot{},
+		existing:  map[EscalationKey]bool{},
+	}
+	for _, snapshot := range snapshots {
+		reader.refs = append(reader.refs, RunRef{RunID: snapshot.RunID})
+		reader.snapshots[snapshot.RunID] = snapshot
+	}
+	return reader
+}
+
+func (f *fakeReader) ListRunningRuns(context.Context, int, string) ([]RunRef, string, error) {
+	return append([]RunRef{}, f.refs...), "", nil
+}
+
+func (f *fakeReader) LoadRunSnapshot(_ context.Context, runID string) (RunSnapshot, error) {
+	return f.snapshots[runID], nil
+}
+
+func (f *fakeReader) StalledRunEscalationExists(_ context.Context, key EscalationKey) (bool, error) {
+	return f.existing[key], nil
+}
+
+type fakePublisher struct {
+	events []events.Event
+}
+
+func (f *fakePublisher) Publish(_ context.Context, evt events.Event) error {
+	f.events = append(f.events, evt)
+	return nil
+}
+
+func eventPayload(t *testing.T, evt events.Event) map[string]any {
+	t.Helper()
+	payload := map[string]any{}
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload
+}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1453,6 +1453,7 @@ func isStandaloneRuntimePlatformEventType(eventType string) bool {
 		"platform.paused",
 		"platform.resumed",
 		"platform.dead_letter_escalation",
+		"platform.run_stalled",
 		"platform.budget_threshold_crossed":
 		return true
 	default:

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -1194,6 +1194,7 @@ func runForkSelectedContractForkLocalRuntimePlatformEventNames() []string {
 		"platform.event_quarantined",
 		"platform.paused",
 		"platform.resumed",
+		"platform.run_stalled",
 		"platform.runtime_log",
 	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4902,6 +4902,33 @@ run_model:
       state is persisted in run_control_state so run.continue can distinguish operator-paused runs from materialized
       fork rows that also use runs.status=paused. It gates dispatch for one run while in-flight events complete.
       Runtime-scoped external ingress pause/resume is a separate global control owned by api_specification.conventions.runtime_ingress.'
+    stalled_run_escalation:
+      owner: policy.runtime.stalled_run_escalation
+      event_owner: platform_events.catalog.platform.run_stalled
+      diagnosis_owner: internal/store/run_operational_status_read_surface.go.ProjectRunOperationalStatus
+      progress_timestamp_owner: latest events.created_at for the run excluding platform.run_stalled self-alert rows
+      default_policy:
+        enabled: true
+        threshold_seconds: 300
+      policy_keys:
+        runtime.stalled_run_escalation.enabled: boolean
+        runtime.stalled_run_escalation.threshold_seconds: positive integer seconds
+      rule: >
+        The serve runtime may emit platform.run_stalled only for runs whose canonical run diagnosis
+        projects operational_state=stalled and whose latest non-platform.run_stalled event timestamp is
+        non-zero and at least threshold_seconds in the past. The platform.run_stalled event itself is
+        not progress evidence and must not advance the dedupe timestamp. Runs with terminal run-table
+        status, active-delivery diagnosis, or zero non-alert progress timestamp do not emit in this slice.
+      dedupe: >
+        The runtime emits at most one platform.run_stalled event for a tuple of
+        (run_id, blocking_layer, blocking_reason, last_progress_at). A new event may be emitted only
+        when canonical progress advances LastEventAt or the diagnosis tuple changes while the run
+        remains stalled.
+      non_owners:
+      - mailbox item creation
+      - incident records
+      - dashboard alert UI
+      - CLI alert rendering
   fork:
     description: 'Fork creates a new run by reconstructing full system state at a point in time, optionally
       loading new contracts, and resuming execution. The system automatically determines which events need
@@ -6548,6 +6575,36 @@ platform_events:
         sample_events: array
         timestamp: string (ISO 8601)
       produced_by_type: platform
+    platform.run_stalled:
+      description: Runtime detected a running run that has crossed the stalled-run escalation threshold according to the canonical run diagnosis projection.
+      schema_authority: platform-spec.yaml#platform_events.catalog.platform.run_stalled.payload
+      producer_evidence:
+        produced_by_type: platform
+        locations:
+        - internal/runtime/runstalled/monitor.go
+        - cmd/swarm/run_stalled_monitor.go
+      routing_class: event_loop_routable
+      scope: flow or global
+      payload:
+        run_id: uuid
+        flow_instance: string
+        operational_state: string
+        blocking_layer: string
+        blocking_reason: string
+        last_progress_at: string (ISO 8601)
+        threshold_seconds: integer
+        stalled_for_seconds: integer
+        emitted_at: string (ISO 8601)
+      required:
+      - run_id
+      - operational_state
+      - blocking_layer
+      - blocking_reason
+      - last_progress_at
+      - threshold_seconds
+      - stalled_for_seconds
+      - emitted_at
+      produced_by_type: platform
     platform.reset:
       description: Admin-initiated platform state reset. Emitted ONLY when a human administrator explicitly triggers a reset
         via the internal admin reset source. Builder/dashboard reset_state is retired and MUST NOT emit this event. NOT
@@ -6818,7 +6875,7 @@ platform_events:
     description: Most platform events enter the normal event loop. Products can subscribe agents to them. System nodes can handle
       them. They follow standard routing, delivery, and persistence rules.
     routable_events: 'Platform events that enter the normal event loop: platform.dead_letter, platform.agent_failed,
-      platform.agent_panic, platform.event_quarantined, platform.dead_letter_escalation, platform.reset, platform.auth_required,
+      platform.agent_panic, platform.event_quarantined, platform.dead_letter_escalation, platform.run_stalled, platform.reset, platform.auth_required,
       platform.paused, platform.resumed, platform.boot, platform.recovery_failed, platform.agent_started, platform.budget_threshold_crossed,
       mailbox.item_decided. Products can subscribe to these.'
     diagnostic_events: 'Platform events that bypass the event loop and are persisted directly to the events table:
@@ -16680,6 +16737,11 @@ api_specification:
       over the JSON-RPC API, returning operational_state + blocking_layer + blocking_reason + heuristics. The projection itself
       is the canonical owner and is unchanged; this proof confirms the API surface routes through it (no second interpretation
       layer in the API handler).
+    - platform.run_stalled is emitted by the serve runtime only after policy.runtime.stalled_run_escalation consumes
+      ProjectRunOperationalStatus plus the latest non-platform.run_stalled run event timestamp. The default policy is
+      enabled with threshold_seconds=300, and the producer dedupes by (run_id, blocking_layer, blocking_reason,
+      last_progress_at). The self-emitted platform.run_stalled alert is not progress evidence. Mailbox item creation,
+      incident records, dashboard alert UI, and CLI alert rendering are not owned by this slice.
     cli:
     - '`swarm runs`, `swarm status`, `swarm trace`, and `swarm health` consume /v1/rpc or /v1/ws methods, with no direct internal-package
       access (except the `swarm verify` carve-out). Retired `swarm investigate *` commands are non-authoritative legacy consumers.'


### PR DESCRIPTION
Part of #1257

## Summary

Implements the approved F-025 stalled-run escalation slice only.

- Adds `platform.run_stalled` as a platform-owned event emitted by serve when the canonical run diagnosis reports a stalled running run past the policy threshold.
- Adds the merge-bearing owner `policy.runtime.stalled_run_escalation` to `platform-spec.yaml` with default `enabled=true` and `threshold_seconds=300`.
- Uses `ProjectRunOperationalStatus` and `RunDebugReport.LastEventAt` as the only diagnosis/progress owners; no dashboard, mailbox, incident, or CLI alert behavior is added.
- Dedupes emissions by `(run_id, blocking_layer, blocking_reason, last_progress_at)`.

## Governing Context

- Issue/gate: #1257 residual refresh selected F-025 `runtime.run_lifecycle.stalled_run_escalation`; lead approved first slice as `platform.run_stalled` only.
- Spec refs added/updated in this PR:
  - `platform-spec.yaml#run_model.lifecycle.stalled_run_escalation`
  - `platform-spec.yaml#platform_events.catalog.platform.run_stalled`
  - `platform-spec.yaml#api_specification.closure_proof_requirements.runtime`

## Semantic Migration

- New canonical owner: `policy.runtime.stalled_run_escalation` plus `platform_events.catalog.platform.run_stalled`.
- Existing diagnosis owner remains: `internal/store/run_operational_status_read_surface.go.ProjectRunOperationalStatus`.
- Existing progress timestamp owner remains: `store.RunDebugReport.LastEventAt`.
- Old producer/reader/writer path now invalid: ad hoc stalled-run escalation outside the canonical diagnosis projection, direct mailbox/incident/dashboard/CLI escalation from this slice, and any local reimplementation of stalled diagnosis.
- Production paths checked for surviving old behavior: serve runtime startup, run debug/read projection, platform event catalog, standalone platform event convergence, selected-fork runtime platform event classification.
- Migration complete for this approved F-025 event-emission slice; parent #1257 still has other rows open.

## Validation

- `go test ./...`
