### PR TITLE
[agent-g][issue #1298] Keep SQLite activation writes in pipeline tx

### DIFF
--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -1,0 +1,236 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/google/uuid"
+)
+
+func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	workflowStore := NewSQLiteWorkflowInstanceStore(db)
+	ctx := sqliteExactOnceRunContext(t, db)
+	pc, bus := newSQLiteDynamicActivationCoordinator(t, db, workflowStore)
+
+	parent := events.Event{
+		ID:   uuid.NewString(),
+		Type: events.EventType("component_scaffold.batch_requested"),
+		Payload: mustJSON(map[string]any{
+			"components": []any{
+				map[string]any{"component_id": "component-a"},
+				map[string]any{"component_id": "component-b"},
+			},
+		}),
+		CreatedAt: time.Now().UTC(),
+		RunID:     runtimecorrelation.RunIDFromContext(ctx),
+	}.WithEntityID("parent-ent").WithFlowInstance("root/parent")
+	if err := workflowStore.Create(ctx, WorkflowInstance{
+		InstanceID:      "parent-ent",
+		StorageRef:      "parent-ent",
+		WorkflowName:    "root",
+		WorkflowVersion: "v-test",
+		CurrentState:    "pending",
+		Metadata:        map[string]any{"entity_type": "parent"},
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed parent workflow instance: %v", err)
+	}
+	seedExactOnceEventDelivery(t, workflowStore, ctx, parent, "fanout-node")
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(ctx, parent)
+	if err != nil {
+		t.Fatalf("dispatch parent fan-out event: %v", err)
+	}
+	if !handled {
+		t.Fatal("parent fan-out dispatch handled=false, want true")
+	}
+	if got := bus.publishedCount(); got != 2 {
+		t.Fatalf("published child events = %d, want 2", got)
+	}
+	assertDeliveryStatusCount(t, workflowStore, ctx, parent.ID, "fanout-node", "delivered", 1)
+
+	children := []events.Event{bus.publishedEvent(0), bus.publishedEvent(1)}
+	for idx, child := range children {
+		if got := strings.TrimSpace(child.ParentEventID); got != parent.ID {
+			t.Fatalf("child %s parent_event_id = %q, want %q", child.ID, got, parent.ID)
+		}
+		if strings.TrimSpace(child.ID) == "" {
+			child.ID = uuid.NewString()
+		}
+		if strings.TrimSpace(child.RunID) == "" {
+			child.RunID = runtimecorrelation.RunIDFromContext(ctx)
+		}
+		children[idx] = child
+		seedExactOnceEventDelivery(t, workflowStore, ctx, child, "spawn-node")
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, len(children))
+	var wg sync.WaitGroup
+	for _, child := range children {
+		child := child
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			handled, err := pc.dispatchWorkflowNodeEventResult(ctx, child)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !handled {
+				errs <- fmt.Errorf("child event %s type %s was not handled", child.ID, child.Type)
+				return
+			}
+			errs <- nil
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("dispatch concurrent child create_flow_instance event: %v", err)
+		}
+	}
+
+	assertSQLiteWorkflowInstancePersisted(t, workflowStore, ctx, "review/component-a")
+	assertSQLiteWorkflowInstancePersisted(t, workflowStore, ctx, "review/component-b")
+	for _, child := range children {
+		assertDeliveryStatusCount(t, workflowStore, ctx, child.ID, "spawn-node", "delivered", 1)
+		assertDeliveryStatusCount(t, workflowStore, ctx, child.ID, "spawn-node", "dead_letter", 0)
+	}
+	if logs := bus.runtimeLogEntries(); len(logs) != 0 {
+		t.Fatalf("runtime logs = %#v, want none", logs)
+	}
+}
+
+func newSQLiteDynamicActivationCoordinator(t *testing.T, db *sql.DB, workflowStore *WorkflowInstanceStore) (*PipelineCoordinator, *recordingPipelineBus) {
+	t.Helper()
+	bus := &recordingPipelineBus{}
+	bundle := sqliteDynamicActivationBundle()
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		WorkflowStore: workflowStore,
+		InstanceActivator: func(ctx context.Context, req FlowInstanceActivationRequest) error {
+			return workflowStore.Create(ctx, WorkflowInstance{
+				InstanceID:      strings.TrimSpace(req.Instance.InstanceID),
+				StorageRef:      strings.TrimSpace(req.Instance.InstancePath),
+				WorkflowName:    strings.TrimSpace(req.Instance.TemplateID),
+				WorkflowVersion: "v-test",
+				CurrentState:    "pending",
+				Config:          cloneStringAnyMap(req.Config),
+				Metadata: map[string]any{
+					"component_id":         req.Config["component_id"],
+					"instance_kind":        "dynamic_flow",
+					"last_source_event":    strings.TrimSpace(req.TriggerEvent.ID),
+					"parent_entity_id":     strings.TrimSpace(req.Instance.ParentEntityID),
+					"parent_flow_id":       strings.TrimSpace(req.Instance.ParentRoute.FlowID),
+					"parent_flow_instance": strings.TrimSpace(req.Instance.ParentRoute.FlowInstance),
+				},
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			})
+		},
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+		Module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("root", []WorkflowStage{
+				{Name: "pending"},
+			}, nil),
+			workflowNodes: []WorkflowNode{
+				{
+					ID:            "fanout-node",
+					Subscriptions: []events.EventType{"component_scaffold.batch_requested"},
+					Produces:      []events.EventType{"component_scaffold.spawn_requested"},
+				},
+				{
+					ID:            "spawn-node",
+					Subscriptions: []events.EventType{"component_scaffold.spawn_requested"},
+				},
+			},
+		},
+	})
+	return pc, bus
+}
+
+func sqliteDynamicActivationBundle() *runtimecontracts.WorkflowContractBundle {
+	reviewFlow := &runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review"},
+	}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{*reviewFlow},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review": reviewFlow,
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"review": {
+				Name:         "review",
+				Mode:         "template",
+				InitialState: "pending",
+				States:       []string{"pending"},
+				Pins: runtimecontracts.FlowPins{
+					Inputs: runtimecontracts.FlowInputPins{Events: []string{"component_scaffold.spawn_requested"}},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Version: "v-test",
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"fanout-node": {
+					"component_scaffold.batch_requested": {
+						FanOut: &runtimecontracts.FanOutSpec{
+							ItemsFrom: "payload.components",
+							Emit: runtimecontracts.EmitSpec{
+								Event: "component_scaffold.spawn_requested",
+								Fields: map[string]runtimecontracts.ExpressionValue{
+									"component_id": runtimecontracts.CELExpression("fan_out.item.component_id"),
+								},
+							},
+						},
+					},
+				},
+				"spawn-node": {
+					"component_scaffold.spawn_requested": {
+						Action: runtimecontracts.ActionSpec{
+							ID:             "create_flow_instance",
+							Template:       "review",
+							InstanceIDFrom: "payload.component_id",
+							ConfigFrom: &runtimecontracts.ConfigFromSpec{
+								Bindings: map[string]string{
+									"component_id": "payload.component_id",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func assertSQLiteWorkflowInstancePersisted(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, storageRef string) {
+	t.Helper()
+	instance, ok, err := store.Load(ctx, storageRef)
+	if err != nil {
+		t.Fatalf("load workflow instance %s: %v", storageRef, err)
+	}
+	if !ok || strings.TrimSpace(instance.StorageRef) != storageRef {
+		t.Fatalf("workflow instance %s loaded=%v value=%+v", storageRef, ok, instance)
+	}
+}

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -19,6 +19,8 @@ func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID,
 		return false, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		var ok bool
 		err := dbQueryRowContext(ctx, s.db, `
 			SELECT EXISTS(
@@ -54,6 +56,8 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryQuiesced(ctx context.Context, 
 		return false, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		var ok bool
 		err := dbQueryRowContext(ctx, s.db, `
 			SELECT EXISTS (

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -94,8 +95,9 @@ type workflowInstancePersistedControl struct {
 }
 
 type WorkflowInstanceStore struct {
-	db      *sql.DB
-	dialect workflowStoreDialect
+	db                 *sql.DB
+	dialect            workflowStoreDialect
+	sqlitePipelineTxMu sync.Mutex
 }
 
 type WorkflowInstanceFieldSelector struct {
@@ -161,6 +163,8 @@ func (s *WorkflowInstanceStore) Load(ctx context.Context, instanceID string) (Wo
 		return WorkflowInstance{}, false, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		return s.loadSQLite(ctx, instanceID)
 	}
 	keys := workflowInstanceLookupKeys(instanceID)
@@ -175,6 +179,8 @@ func (s *WorkflowInstanceStore) List(ctx context.Context) ([]WorkflowInstance, e
 		return nil, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		return s.listSQLite(ctx)
 	}
 	return s.listSpec(ctx)
@@ -189,6 +195,8 @@ func (s *WorkflowInstanceStore) SelectActiveByFields(ctx context.Context, scopeK
 		return nil, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		return s.selectActiveByFieldsSQLite(ctx, scopeKey, selectors, excludedStates)
 	}
 	return s.selectActiveByFieldsSpec(ctx, scopeKey, selectors, excludedStates)
@@ -329,6 +337,8 @@ func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef s
 		return nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		return s.markTerminatedSQLite(ctx, storageRef, terminatedAt)
 	}
 	storageRef = strings.TrimSpace(storageRef)
@@ -383,6 +393,17 @@ func (s *WorkflowInstanceStore) isSQLite() bool {
 	return s != nil && s.dialect == workflowStoreDialectSQLite
 }
 
+func (s *WorkflowInstanceStore) lockSQLitePipelineOperation(ctx context.Context) func() {
+	if !s.isSQLite() {
+		return func() {}
+	}
+	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
+		return func() {}
+	}
+	s.sqlitePipelineTxMu.Lock()
+	return s.sqlitePipelineTxMu.Unlock
+}
+
 func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	if fn == nil {
 		return nil
@@ -393,6 +414,11 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
 		return fn(ctx, tx)
 	}
+	// SQLite has a single writer. Keep the local-dev pipeline transaction
+	// boundary authoritative instead of letting sibling handler activations
+	// race into SQLITE_BUSY at the first persisted row.
+	unlock := s.lockSQLitePipelineOperation(ctx)
+	defer unlock()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -415,6 +441,8 @@ func (s *WorkflowInstanceStore) QueryEntityCount(ctx context.Context, runID stri
 		return 0, nil
 	}
 	if s.isSQLite() {
+		unlock := s.lockSQLitePipelineOperation(ctx)
+		defer unlock()
 		return s.queryEntityStateCountSQLite(ctx, runID, source, contract, predicate)
 	}
 	return queryEntityStateCount(runID, s.db, source, contract, predicate)

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -304,7 +304,11 @@ func (s *SQLiteRuntimeStore) UpsertAgent(ctx context.Context, rec runtimemanager
 	if startedAt.IsZero() {
 		startedAt = time.Now().UTC()
 	}
-	_, err = s.DB.ExecContext(ctx, `
+	q := execQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok {
+		q = tx
+	}
+	_, err = q.ExecContext(ctx, `
 		INSERT INTO agents (
 			agent_id, flow_instance, role, model, llm_backend, conversation_mode,
 			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -2,17 +2,22 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
@@ -20,6 +25,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/google/uuid"
@@ -236,6 +242,284 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	})
 	if !errors.Is(err, ErrAPIIdempotencyConflict) {
 		t.Fatalf("idempotency conflict err = %v, want ErrAPIIdempotencyConflict", err)
+	}
+}
+
+func TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction(t *testing.T) {
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+
+	tx, err := store.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin sqlite tx: %v", err)
+	}
+	committed := false
+	t.Cleanup(func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	})
+
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runtimecorrelation.RunIDFromContext(ctx), now); err != nil {
+		t.Fatalf("seed active sqlite write transaction: %v", err)
+	}
+
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	if err := store.UpsertAgent(txctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:               "agent-in-pipeline-tx",
+			Role:             "worker",
+			Mode:             "global",
+			Model:            "regular",
+			LLMBackend:       "anthropic",
+			ConversationMode: "task",
+			Config:           json.RawMessage(`{"system_prompt":"tx-owned agent","tools":[]}`),
+		},
+		Status:    "active",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAgent with active pipeline transaction: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit sqlite tx: %v", err)
+	}
+	committed = true
+
+	agents, err := store.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Config.ID != "agent-in-pipeline-tx" {
+		t.Fatalf("agents = %#v, want agent-in-pipeline-tx", agents)
+	}
+}
+
+func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *testing.T) {
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB)
+	bus := &sqliteFlowActivationBus{}
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+		LLMBackend:        "anthropic",
+	}, sqliteStore)
+	bundle := sqliteFlowActivationBundle()
+
+	req := sqliteFlowActivationRequest(bundle, "review", "inst-1", "parent-ent", "review/inst-1")
+	if err := workflowStore.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		return manager.ActivateFlowInstance(txctx, req)
+	}); err != nil {
+		t.Fatalf("ActivateFlowInstance inside sqlite pipeline transaction: %v", err)
+	}
+
+	loaded, ok, err := workflowStore.Load(ctx, "review/inst-1")
+	if err != nil {
+		t.Fatalf("Load workflow instance: %v", err)
+	}
+	if !ok || strings.TrimSpace(loaded.StorageRef) != "review/inst-1" {
+		t.Fatalf("workflow instance loaded=%v value=%+v, want review/inst-1", ok, loaded)
+	}
+	agents, err := sqliteStore.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	assertSQLiteActivatedAgentIDs(t, agents, "reviewer-inst-1")
+	assertSQLiteAddedRoutes(t, bus, "review/inst-1")
+}
+
+func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T) {
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB)
+	bus := &sqliteFlowActivationBus{}
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+		LLMBackend:        "anthropic",
+	}, sqliteStore)
+	bundle := sqliteFlowActivationBundle()
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, instanceID := range []string{"component-a", "component-b"} {
+		instanceID := instanceID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := sqliteFlowActivationRequest(bundle, "review", instanceID, "parent-ent", "review/"+instanceID)
+			errs <- workflowStore.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+				return manager.ActivateFlowInstance(txctx, req)
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent fan-out activation: %v", err)
+		}
+	}
+
+	for _, storageRef := range []string{"review/component-a", "review/component-b"} {
+		loaded, ok, err := workflowStore.Load(ctx, storageRef)
+		if err != nil {
+			t.Fatalf("Load workflow instance %s: %v", storageRef, err)
+		}
+		if !ok || strings.TrimSpace(loaded.StorageRef) != storageRef {
+			t.Fatalf("workflow instance %s loaded=%v value=%+v", storageRef, ok, loaded)
+		}
+	}
+	agents, err := sqliteStore.LoadAgents(ctx)
+	if err != nil {
+		t.Fatalf("LoadAgents: %v", err)
+	}
+	assertSQLiteActivatedAgentIDs(t, agents, "reviewer-component-a", "reviewer-component-b")
+	assertSQLiteAddedRoutes(t, bus, "review/component-a", "review/component-b")
+	if logs := bus.runtimeLogEntries(); len(logs) != 0 {
+		t.Fatalf("runtime logs = %#v, want no activation dead-letter/runtime errors", logs)
+	}
+}
+
+type sqliteFlowActivationBus struct {
+	mu          sync.Mutex
+	runtimeLog  []runtimepipeline.RuntimeLogEntry
+	addedRoutes []string
+	published   []events.Event
+}
+
+func (b *sqliteFlowActivationBus) Publish(_ context.Context, evt events.Event) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.published = append(b.published, evt)
+	return nil
+}
+
+func (*sqliteFlowActivationBus) PublishDirect(context.Context, events.Event, []string) error {
+	return nil
+}
+
+func (*sqliteFlowActivationBus) PublishPersistedRecipients(context.Context, events.Event, []string) error {
+	return nil
+}
+
+func (*sqliteFlowActivationBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+
+func (*sqliteFlowActivationBus) Unsubscribe(string) {}
+
+func (*sqliteFlowActivationBus) Store() runtimebus.EventStore { return nil }
+
+func (*sqliteFlowActivationBus) ResetInMemoryState() error { return nil }
+
+func (b *sqliteFlowActivationBus) LogRuntime(_ context.Context, entry runtimepipeline.RuntimeLogEntry) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.runtimeLog = append(b.runtimeLog, entry)
+	return nil
+}
+
+func (b *sqliteFlowActivationBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.addedRoutes = append(b.addedRoutes, strings.TrimSpace(identity.InstancePath))
+	return nil
+}
+
+func (b *sqliteFlowActivationBus) runtimeLogEntries() []runtimepipeline.RuntimeLogEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]runtimepipeline.RuntimeLogEntry, len(b.runtimeLog))
+	copy(out, b.runtimeLog)
+	return out
+}
+
+func (b *sqliteFlowActivationBus) routePaths() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.addedRoutes))
+	copy(out, b.addedRoutes)
+	return out
+}
+
+func sqliteFlowActivationBundle() *runtimecontracts.WorkflowContractBundle {
+	reviewFlow := &runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"reviewer": {
+				ID:            "reviewer-{instance_id}",
+				Type:          "generic",
+				Role:          "reviewer",
+				Model:         "regular",
+				Subscriptions: []string{"task.started"},
+			},
+		},
+	}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{*reviewFlow},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review": reviewFlow,
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"review": {
+				Mode: "template",
+				Pins: runtimecontracts.FlowPins{
+					Inputs: runtimecontracts.FlowInputPins{Events: []string{"task.started"}},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{Version: "v-test"},
+	}
+}
+
+func sqliteFlowActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, templateID, instanceID, parentEntityID, flowPath string) runtimepipeline.FlowInstanceActivationRequest {
+	instance := runtimeflowidentity.Stored(
+		semanticview.Wrap(bundle),
+		templateID,
+		flowPath,
+		instanceID,
+		runtimepipeline.FlowInstanceEntityID(flowPath),
+		parentEntityID,
+	)
+	return runtimepipeline.FlowInstanceActivationRequest{
+		ContractBundle: semanticview.Wrap(bundle),
+		Instance:       instance,
+	}
+}
+
+func assertSQLiteActivatedAgentIDs(t *testing.T, agents []runtimemanager.PersistedAgent, wantIDs ...string) {
+	t.Helper()
+	got := map[string]struct{}{}
+	for _, rec := range agents {
+		got[strings.TrimSpace(rec.Config.ID)] = struct{}{}
+	}
+	for _, want := range wantIDs {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("activated agent ids = %#v, missing %q", got, want)
+		}
+	}
+}
+
+func assertSQLiteAddedRoutes(t *testing.T, bus *sqliteFlowActivationBus, wantPaths ...string) {
+	t.Helper()
+	got := map[string]struct{}{}
+	for _, path := range bus.routePaths() {
+		got[strings.TrimSpace(path)] = struct{}{}
+	}
+	for _, want := range wantPaths {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("added route paths = %#v, missing %q", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1298.
Closes #1304.

This PR keeps SQLite dynamic flow activation materialization on the runtime pipeline transaction/operation owner. SQLite workflow-store operations that run without an active transaction are serialized through the selected `WorkflowInstanceStore`, nested workflow-store writes reuse `PipelineSQLTxFromContext`, and `SQLiteRuntimeStore.UpsertAgent` consumes that same active transaction for required-agent materialization.

## Governing refs / context

Exact platform spec references:

- `platform-spec.yaml`: `handler_specification.atomicity`
- `platform-spec.yaml`: `handler_specification.handler_fields.action.valid_values.create_flow_instance`
- `platform-spec.yaml`: `runtime_composition.dynamic_instance_lifecycle.creation`
- `platform-spec.yaml`: `runtime_composition.runtime_core_persistence_store_contracts.selected_contracts.manager_agent_and_entity_schema_rows`
- `platform-spec.yaml`: `runtime_composition.runtime_core_persistence_store_contracts.selected_contracts.pipeline_coordination_workflow_instance_and_replay_rows`

Binding issue/gate context:

- #1298 Pre-Implementation Coverage Audit
- #1298 lead gate comment approving `sqlite_dynamic_flow_activation_materialization_boundary` as first slice
- #1304 mandatory same-class sibling: required-agent materialization during handler-driven dynamic activation must not bypass the parent pipeline transaction

## Semantic migration

- New canonical owner consumed here: the SQLite `WorkflowInstanceStore` runtime pipeline transaction/operation boundary, with nested active SQL transactions exposed by `runtimepipeline.PipelineSQLTxFromContext`.
- Old paths now invalid: concurrent SQLite workflow-store reads/writes opening independent operations during handler-side dynamic activation, and `SQLiteRuntimeStore.UpsertAgent` directly using `s.DB.ExecContext` while a pipeline transaction is active.
- Production paths checked for surviving old behavior: workflow instance/entity rows, system-node receipt reads/settlement, required-agent materialization, route materialization, auto-emit post-commit, static/recovery agent upserts without an active pipeline transaction, and unchanged Postgres store behavior.
- Migration completeness: complete for the approved #1298/#1304 child class. Broader SQLite production multi-writer/fencing, timer/schedule sibling auditing, and unrelated startup/store classes remain outside this PR.

## Proof

- `go test ./internal/runtime/pipeline -run 'TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter' -count=20 -timeout=30s`
- `go test ./internal/store -run 'TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction|TestSQLiteDynamicFlowActivation(RequiredAgentsUsePipelineTransaction|ConcurrentFanOutChildrenPersist)' -count=20`
- `go test ./internal/runtime/pipeline -run 'TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter|TestPipelineEngineActionRunner_CreateFlowInstance|Test.*FlowInstanceActivation|Test.*WorkflowInstanceStore'`
- `go test ./internal/runtime/manager -run 'TestActivateFlowInstance'`
- `go test ./internal/runtime/pipeline ./internal/store`
- `go test ./...`
