### PR TITLE
[agent-b][issue #1296] Render flow-instance routes with activation vars

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -224,7 +223,7 @@ func (eb *EventBus) RouteTable() *RouteTable {
 	return eb.routeTable
 }
 
-func (eb *EventBus) AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+func (eb *EventBus) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationRequest) error {
 	if eb == nil {
 		return errors.New("event bus is required")
 	}
@@ -234,14 +233,15 @@ func (eb *EventBus) AddFlowInstanceRoute(template runtimecontracts.SystemNodeCon
 	if table == nil {
 		return errors.New("route table is not initialized")
 	}
-	if err := table.AddFlowInstanceRoute(template, identity); err != nil {
+	req = req.Normalized()
+	if err := table.AddFlowInstanceRoute(req); err != nil {
 		return err
 	}
 	persister, ok := eb.store.(FlowInstanceRoutePersistence)
 	if !ok {
 		return nil
 	}
-	routes := table.MaterializedRoutes(identity)
+	routes := table.MaterializedRoutes(req.Identity)
 	if len(routes) == 0 {
 		return nil
 	}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -2441,7 +2441,7 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	eb.Subscribe("worker-inst-1")

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -146,7 +146,7 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))

--- a/internal/runtime/bus/flow_instance_route_materialization.go
+++ b/internal/runtime/bus/flow_instance_route_materialization.go
@@ -1,0 +1,59 @@
+package bus
+
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+)
+
+type FlowInstanceRouteMaterializationRequest struct {
+	Template            runtimecontracts.SystemNodeContract
+	Identity            runtimeflowidentity.Route
+	ActivationVariables map[string]string
+}
+
+func (r FlowInstanceRouteMaterializationRequest) Normalized() FlowInstanceRouteMaterializationRequest {
+	r.Identity = runtimeflowidentity.StoredRoute(r.Identity.ScopeKey, r.Identity.InstanceID, r.Identity.InstancePath)
+	r.ActivationVariables = cloneRouteActivationVariables(r.ActivationVariables)
+	return r
+}
+
+func cloneRouteActivationVariables(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func flowInstanceRouteMaterializationVars(req FlowInstanceRouteMaterializationRequest, templateFlowID string) map[string]string {
+	identity := req.Identity
+	out := cloneRouteActivationVariables(req.ActivationVariables)
+	if out == nil {
+		out = map[string]string{}
+	}
+	setRouteBuiltin(out, "flow_instance_path", identity.InstancePath)
+	setRouteBuiltin(out, "instance_id", identity.InstanceID)
+	setRouteBuiltin(out, "template_id", templateFlowID)
+	setRouteBuiltin(out, "flow_scope_key", identity.ScopeKey)
+	return out
+}
+
+func setRouteBuiltin(vars map[string]string, key, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	vars[key] = value
+}

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -118,12 +118,13 @@ func (rt *RouteTable) Resolve(eventType string) []Subscriber {
 	return out
 }
 
-func (rt *RouteTable) AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationRequest) error {
 	if rt == nil {
 		return fmt.Errorf("route table is required")
 	}
 
-	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	req = req.Normalized()
+	identity := req.Identity
 	if !identity.Valid() {
 		return fmt.Errorf("flow-instance route identity is required")
 	}
@@ -140,12 +141,7 @@ func (rt *RouteTable) AddFlowInstanceRoute(template runtimecontracts.SystemNodeC
 	if templateDef, ok := rt.templates[templateScope]; ok {
 		rt.instances[instancePath] = struct{}{}
 		rt.instanceEventPath[instancePath] = rt.addEventPathsLocked(instancePath, templateDef.LocalEvents)
-		vars := map[string]string{
-			"flow_instance_path": instancePath,
-			"instance_id":        identity.InstanceID,
-			"template_id":        templateDef.FlowID,
-			"flow_scope_key":     templateScope,
-		}
+		vars := flowInstanceRouteMaterializationVars(req, templateDef.FlowID)
 		for _, subscriberTemplate := range templateDef.Subscribers {
 			subscriber := Subscriber{
 				ID:   routeRenderTemplate(subscriberTemplate.IDTemplate, vars),
@@ -172,18 +168,19 @@ func (rt *RouteTable) AddFlowInstanceRoute(template runtimecontracts.SystemNodeC
 
 	// Compatibility fallback for the current odd handoff signature.
 	templateID := templateScope
-	if strings.TrimSpace(template.ID) == "" {
+	if strings.TrimSpace(req.Template.ID) == "" {
 		return fmt.Errorf("route template %q not found", templateID)
 	}
-	localEvents := routeNodeLocalEventSet(template)
+	localEvents := routeNodeLocalEventSet(req.Template)
 	rt.instances[instancePath] = struct{}{}
 	rt.instanceEventPath[instancePath] = rt.addEventPathsLocked(instancePath, localEvents)
+	vars := flowInstanceRouteMaterializationVars(req, templateID)
 	subscriber := Subscriber{
-		ID:   routeRenderTemplate(template.ID, map[string]string{"instance_id": identity.InstanceID}),
+		ID:   routeRenderTemplate(req.Template.ID, vars),
 		Type: "node",
 		Path: instancePath,
 	}
-	for _, rawPattern := range normalizeStringList(template.SubscribesTo) {
+	for _, rawPattern := range normalizeStringList(req.Template.SubscribesTo) {
 		for _, resolved := range routeResolveSubscriberPatterns(rt.source, templateID, nil, instancePath, localEvents, rawPattern) {
 			if strings.TrimSpace(resolved.EventPattern) == "" {
 				continue

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -17,11 +17,14 @@ func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
-		ID:           "reviewer-{instance_id}",
-		Produces:     []string{"task.started"},
-		SubscribesTo: []string{"task.started"},
-	}, runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Template: runtimecontracts.SystemNodeContract{
+			ID:           "reviewer-{instance_id}",
+			Produces:     []string{"task.started"},
+			SubscribesTo: []string{"task.started"},
+		},
+		Identity: runtimeflowidentity.DeriveRoute("review", "inst-1"),
+	}); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("review/inst-1/task.started"); len(got) != 1 || got[0].ID != "reviewer-inst-1" {
@@ -37,6 +40,7 @@ func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 
 type routePersistenceTestStore struct {
 	routes           map[string]runtimebus.FlowInstanceRouteRecord
+	deliveries       map[string][]string
 	upsertErr        error
 	deleteErr        error
 	rollbackCalls    []string
@@ -44,7 +48,11 @@ type routePersistenceTestStore struct {
 }
 
 func (*routePersistenceTestStore) AppendEvent(context.Context, events.Event) error { return nil }
-func (*routePersistenceTestStore) InsertEventDeliveries(context.Context, string, []string) error {
+func (s *routePersistenceTestStore) InsertEventDeliveries(_ context.Context, eventID string, agentIDs []string) error {
+	if s.deliveries == nil {
+		s.deliveries = map[string][]string{}
+	}
+	s.deliveries[eventID] = append([]string(nil), agentIDs...)
 	return nil
 }
 func (*routePersistenceTestStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
@@ -94,11 +102,14 @@ func TestEventBusFlowInstanceRoutesPersistAcrossAddAndRemove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
-		ID:           "reviewer-{instance_id}",
-		Produces:     []string{"task.started"},
-		SubscribesTo: []string{"task.started"},
-	}, runtimeflowidentity.DeriveRoute("review", "inst-1")); err != nil {
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Template: runtimecontracts.SystemNodeContract{
+			ID:           "reviewer-{instance_id}",
+			Produces:     []string{"task.started"},
+			SubscribesTo: []string{"task.started"},
+		},
+		Identity: runtimeflowidentity.DeriveRoute("review", "inst-1"),
+	}); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if _, ok := store.routes["review/inst-1"]; !ok {
@@ -122,11 +133,14 @@ func TestEventBusAddFlowInstanceRouteRollsBackPersistedRouteOnActiveInstallFailu
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	err = eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
-		ID:           "reviewer-{instance_id}",
-		Produces:     []string{"task.started"},
-		SubscribesTo: []string{"task.started"},
-	}, runtimeflowidentity.DeriveRoute("review", "inst-1"))
+	err = eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Template: runtimecontracts.SystemNodeContract{
+			ID:           "reviewer-{instance_id}",
+			Produces:     []string{"task.started"},
+			SubscribesTo: []string{"task.started"},
+		},
+		Identity: runtimeflowidentity.DeriveRoute("review", "inst-1"),
+	})
 	if err == nil {
 		t.Fatal("expected AddFlowInstanceRoute to fail")
 	}
@@ -141,16 +155,60 @@ func TestEventBusAddFlowInstanceRouteRollsBackPersistedRouteOnActiveInstallFailu
 	}
 }
 
+func TestEventBusFlowInstanceRoutePersistsAndDeliversRenderedActivationConfigSubscriber(t *testing.T) {
+	store := &routePersistenceTestStore{}
+	bundle := routeMaterializationConfigVarBundle()
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		ContractBundle: semanticview.Wrap(bundle),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	identity := runtimeflowidentity.DeriveRoute("operating", "11111111-1111-4111-8111-111111111111")
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Identity: identity,
+		ActivationVariables: map[string]string{
+			"vertical_id": "11111111-1111-4111-8111-111111111111",
+		},
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	route, ok := store.routes["operating/11111111-1111-4111-8111-111111111111"]
+	if !ok {
+		t.Fatalf("persisted routes = %#v, want operating instance route", store.routes)
+	}
+	if route.SubscriberID != "ceo-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("persisted subscriber_id = %q, want rendered ceo id", route.SubscriberID)
+	}
+
+	eb.Subscribe("ceo-11111111-1111-4111-8111-111111111111")
+	defer eb.Unsubscribe("ceo-11111111-1111-4111-8111-111111111111")
+	evt := events.Event{
+		ID:   "event-rendered-route-delivery",
+		Type: events.EventType("operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested"),
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := store.deliveries[evt.ID]
+	if len(got) != 1 || got[0] != "ceo-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("delivery recipients = %#v, want rendered ceo id", got)
+	}
+}
+
 func TestEventBusRemoveNestedFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{
-		ID:           "worker-{instance_id}",
-		Produces:     []string{"micro.started"},
-		SubscribesTo: []string{"micro.started"},
-	}, runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")); err != nil {
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Template: runtimecontracts.SystemNodeContract{
+			ID:           "worker-{instance_id}",
+			Produces:     []string{"micro.started"},
+			SubscribesTo: []string{"micro.started"},
+		},
+		Identity: runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1"),
+	}); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	if got := eb.RouteTable().Resolve("child/grandchild/inst-1/micro.started"); len(got) != 1 || got[0].ID != "worker-inst-1" {
@@ -209,7 +267,7 @@ func TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryP
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
-	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	got := rt.Resolve("operating/inst-1/opco.product_initialization_requested")
@@ -218,6 +276,75 @@ func TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryP
 	}
 	if got[0].ID != "lifecycle-orchestrator" || got[0].Type != "node" || got[0].Path != "operating/inst-1" {
 		t.Fatalf("resolved subscriber = %#v, want node lifecycle-orchestrator at operating/inst-1", got[0])
+	}
+}
+
+func TestRouteTableFlowInstanceRouteRendersSubscriberWithActivationConfigVars(t *testing.T) {
+	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(routeMaterializationConfigVarBundle()))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	identity := runtimeflowidentity.DeriveRoute("operating", "11111111-1111-4111-8111-111111111111")
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Identity: identity,
+		ActivationVariables: map[string]string{
+			"vertical_id": "11111111-1111-4111-8111-111111111111",
+		},
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+
+	got := rt.Resolve("operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested")
+	if len(got) != 1 {
+		t.Fatalf("resolved subscribers = %#v, want one ceo route", got)
+	}
+	if got[0].ID != "ceo-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("resolved subscriber id = %q, want rendered ceo id", got[0].ID)
+	}
+	routes := rt.MaterializedRoutes(identity)
+	if len(routes) != 1 || routes[0].SubscriberID != "ceo-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("materialized routes = %#v, want rendered ceo subscriber", routes)
+	}
+}
+
+func routeMaterializationConfigVarBundle() *runtimecontracts.WorkflowContractBundle {
+	operating := runtimecontracts.FlowContractView{
+		Path:  "operating",
+		Paths: runtimecontracts.FlowContractPaths{ID: "operating", Flow: "operating"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"opco.product_initialization_requested"}},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"opco.product_initialization_requested": {},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"ceo": {
+				ID:            "ceo-{vertical_id}",
+				Type:          "generic",
+				Role:          "ceo",
+				Subscriptions: []string{"opco.product_initialization_requested"},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{operating}}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"operating": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"operating": {
+				Mode: "template",
+				Pins: runtimecontracts.FlowPins{
+					Inputs: runtimecontracts.FlowInputPins{Events: []string{"opco.product_initialization_requested"}},
+				},
+			},
+		},
 	}
 }
 
@@ -258,7 +385,7 @@ func TestRouteTableTemplateOutputPinWildcardSubscriberResolvesThroughDerivedInst
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
 	identity := runtimeflowidentity.DeriveRoute("component-scaffold", "component-a")
-	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, identity); err != nil {
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: identity}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 
@@ -582,7 +709,7 @@ func TestDeriveRouteTable_NestedTemplateInstancesPersistSemanticScopeKey(t *test
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
 	identity := runtimeflowidentity.DeriveRoute("child/grandchild", "inst-1")
-	if err := rt.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, identity); err != nil {
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: identity}); err != nil {
 		t.Fatalf("AddFlowInstance: %v", err)
 	}
 	routes := rt.MaterializedRoutes(identity)

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -33,7 +33,7 @@ type flowInstancePersistence interface {
 }
 
 type flowInstanceRouteInstaller interface {
-	AddFlowInstanceRoute(template runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error
+	AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest) error
 }
 
 type flowInstanceRouteRemover interface {
@@ -135,7 +135,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		}
 	}
 	if installer, ok := am.bus.(flowInstanceRouteInstaller); ok && installer != nil {
-		if err := installer.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, instance.Route()); err != nil {
+		if err := installer.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+			Identity:            instance.Route(),
+			ActivationVariables: vars,
+		}); err != nil {
 			return err
 		}
 	} else {

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -868,10 +868,7 @@ func staticFlowLocalEventSet(agents map[string]runtimecontracts.AgentRegistryEnt
 }
 
 func flowActivationVars(req runtimepipeline.FlowInstanceActivationRequest) map[string]string {
-	vars := map[string]string{
-		"entity_id":   strings.TrimSpace(req.Instance.EntityID),
-		"instance_id": strings.TrimSpace(req.Instance.InstanceID),
-	}
+	vars := map[string]string{}
 	for key, value := range req.Config {
 		key = strings.TrimSpace(key)
 		if key == "" {
@@ -879,7 +876,20 @@ func flowActivationVars(req runtimepipeline.FlowInstanceActivationRequest) map[s
 		}
 		vars[key] = stringifyPromptTemplateValue(value)
 	}
+	setFlowActivationBuiltin(vars, "entity_id", req.Instance.EntityID)
+	setFlowActivationBuiltin(vars, "instance_id", req.Instance.InstanceID)
+	setFlowActivationBuiltin(vars, "template_id", req.Instance.TemplateID)
+	setFlowActivationBuiltin(vars, "flow_scope_key", req.Instance.ScopeKey)
+	setFlowActivationBuiltin(vars, "flow_instance_path", req.Instance.InstancePath)
 	return vars
+}
+
+func setFlowActivationBuiltin(vars map[string]string, key, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	vars[key] = value
 }
 
 func cloneFlowConfig(in map[string]any) map[string]any {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -435,6 +435,48 @@ func TestActivateFlowInstancePassesActivationConfigToRouteMaterialization(t *tes
 	}
 }
 
+func TestActivateFlowInstanceUsesSameBuiltinsForAgentAndRouteMaterialization(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundle("")
+	bundle.FlowTree.ByID["review"].Agents["reviewer"] = runtimecontracts.AgentRegistryEntry{
+		ID:            "reviewer-{flow_instance_path}",
+		Type:          "generic",
+		Role:          "reviewer",
+		Subscriptions: []string{"task.started"},
+	}
+
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"flow_instance_path": "wrong-config-path",
+		"flow_scope_key":     "wrong-config-scope",
+		"instance_id":        "wrong-config-instance",
+		"template_id":        "wrong-config-template",
+	}
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if _, ok := am.GetAgentConfig("reviewer-review/inst-1"); !ok {
+		t.Fatalf("expected flow agent rendered with built-in flow_instance_path, configs=%#v", am.agentCfg)
+	}
+	if len(bus.addedRouteRequests) != 1 {
+		t.Fatalf("route materialization requests = %#v, want one", bus.addedRouteRequests)
+	}
+	vars := bus.addedRouteRequests[0].ActivationVariables
+	if got := vars["flow_instance_path"]; got != "review/inst-1" {
+		t.Fatalf("route activation variable flow_instance_path = %q, want review/inst-1", got)
+	}
+	if got := vars["flow_scope_key"]; got != "review" {
+		t.Fatalf("route activation variable flow_scope_key = %q, want review", got)
+	}
+	if got := vars["instance_id"]; got != "inst-1" {
+		t.Fatalf("route activation variable instance_id = %q, want inst-1", got)
+	}
+	if got := vars["template_id"]; got != "review" {
+		t.Fatalf("route activation variable template_id = %q, want review", got)
+	}
+}
+
 func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -29,13 +29,14 @@ type flowActivationRouteStore interface {
 }
 
 type flowActivationTestBus struct {
-	addedPaths   []string
-	removedPairs []string
-	published    []events.Event
-	runtimeLogs  []runtimepipeline.RuntimeLogEntry
-	unsubscribed []string
-	removeErr    error
-	routeStore   flowActivationRouteStore
+	addedPaths         []string
+	addedRouteRequests []runtimebus.FlowInstanceRouteMaterializationRequest
+	removedPairs       []string
+	published          []events.Event
+	runtimeLogs        []runtimepipeline.RuntimeLogEntry
+	unsubscribed       []string
+	removeErr          error
+	routeStore         flowActivationRouteStore
 }
 
 type flowActivationTestRouteStore struct {
@@ -178,8 +179,11 @@ func (b *flowActivationTestBus) LogRuntime(_ context.Context, entry runtimepipel
 	return nil
 }
 
-func (b *flowActivationTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+func (b *flowActivationTestBus) AddFlowInstanceRoute(req runtimebus.FlowInstanceRouteMaterializationRequest) error {
+	req = req.Normalized()
+	identity := req.Identity
 	b.addedPaths = append(b.addedPaths, identity.InstancePath)
+	b.addedRouteRequests = append(b.addedRouteRequests, req)
 	if b.routeStore != nil {
 		return b.routeStore.UpsertFlowInstanceRoute(context.Background(), runtimebus.FlowInstanceRouteRecord{
 			Identity:       identity,
@@ -404,6 +408,30 @@ func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	cfg, _ := am.GetAgentConfig("reviewer-inst-1")
 	if got := strings.TrimSpace(cfg.EntityID); got != runtimepipeline.FlowInstanceEntityID("review/inst-1") {
 		t.Fatalf("agent entity_id = %q, want %q", got, runtimepipeline.FlowInstanceEntityID("review/inst-1"))
+	}
+}
+
+func TestActivateFlowInstancePassesActivationConfigToRouteMaterialization(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundle("")
+
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Config = map[string]any{
+		"vertical_id": "11111111-1111-4111-8111-111111111111",
+	}
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(bus.addedRouteRequests) != 1 {
+		t.Fatalf("route materialization requests = %#v, want one", bus.addedRouteRequests)
+	}
+	got := bus.addedRouteRequests[0].ActivationVariables["vertical_id"]
+	if got != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("route activation variable vertical_id = %q, want config value", got)
+	}
+	if got := bus.addedRouteRequests[0].ActivationVariables["instance_id"]; got != "inst-1" {
+		t.Fatalf("route activation variable instance_id = %q, want inst-1", got)
 	}
 }
 

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
@@ -24,6 +23,7 @@ type recoveryTestBus struct {
 	storedRoutes            []runtimebus.FlowInstanceRouteRecord
 	selectedRouteRecoveries []SelectedContractRouteRecoveryRecord
 	restored                []string
+	restoredRequests        []runtimebus.FlowInstanceRouteMaterializationRequest
 	replayable              []events.PersistedReplayEvent
 	deliveries              map[string][]string
 	runtimeLogs             []runtimepipeline.RuntimeLogEntry
@@ -73,8 +73,11 @@ func (b *recoveryTestBus) ListFlowInstanceRoutes(context.Context) ([]runtimeflow
 func (b *recoveryTestBus) ListSelectedContractRouteRecoveryRecords(context.Context) ([]SelectedContractRouteRecoveryRecord, error) {
 	return append([]SelectedContractRouteRecoveryRecord(nil), b.selectedRouteRecoveries...), nil
 }
-func (b *recoveryTestBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+func (b *recoveryTestBus) AddFlowInstanceRoute(req runtimebus.FlowInstanceRouteMaterializationRequest) error {
+	req = req.Normalized()
+	identity := req.Identity
 	b.restored = append(b.restored, identity.InstancePath)
+	b.restoredRequests = append(b.restoredRequests, req)
 	return nil
 }
 
@@ -152,15 +155,35 @@ func TestRecoverRestoresPersistedFlowInstanceRoutes(t *testing.T) {
 			StartedAt: time.Now().UTC(),
 		}},
 	}
-	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+	workflowInstances := &flowActivationTestInstanceStore{
+		byStorageRef: map[string]runtimepipeline.WorkflowInstance{
+			"review/inst-1": {
+				InstanceID:   "inst-1",
+				StorageRef:   "review/inst-1",
+				WorkflowName: "review",
+				Config: map[string]any{
+					"vertical_id": "11111111-1111-4111-8111-111111111111",
+				},
+				Metadata: map[string]any{
+					"entity_id":   "ent-1",
+					"flow_path":   "review/inst-1",
+					"instance_id": "inst-1",
+				},
+			},
+		},
+	}
+	am := NewAgentManagerWithOptions(bus, func(cfg models.AgentConfig) (Agent, error) {
 		return recoveryTestAgent{id: cfg.ID}, nil
-	}, store)
+	}, AgentManagerOptions{WorkflowInstances: workflowInstances}, store)
 
 	if err := am.Recover(context.Background()); err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
 	if len(bus.restored) != 1 || bus.restored[0] != "review/inst-1" {
 		t.Fatalf("restored routes = %#v, want [review/inst-1]", bus.restored)
+	}
+	if got := bus.restoredRequests[0].ActivationVariables["vertical_id"]; got != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("restored activation variable vertical_id = %q, want persisted config value", got)
 	}
 }
 

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -13,8 +13,8 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
@@ -719,11 +719,41 @@ func (am *AgentManager) restoreFlowInstanceRoutes(ctx context.Context) error {
 		return fmt.Errorf("list persisted flow instance routes: %w", err)
 	}
 	for _, route := range routes {
-		if err := installer.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, route); err != nil {
+		req, err := am.restoredFlowInstanceRouteMaterializationRequest(ctx, route)
+		if err != nil {
+			return err
+		}
+		if err := installer.AddFlowInstanceRoute(req); err != nil {
 			return fmt.Errorf("restore flow instance route %s/%s: %w", route.ScopeKey, route.InstanceID, err)
 		}
 	}
 	return nil
+}
+
+func (am *AgentManager) restoredFlowInstanceRouteMaterializationRequest(ctx context.Context, route runtimeflowidentity.Route) (runtimebus.FlowInstanceRouteMaterializationRequest, error) {
+	route = runtimeflowidentity.StoredRoute(route.ScopeKey, route.InstanceID, route.InstancePath)
+	if !route.Valid() {
+		return runtimebus.FlowInstanceRouteMaterializationRequest{}, fmt.Errorf("flow-instance route identity is required")
+	}
+	if am.workflowInstances == nil {
+		return runtimebus.FlowInstanceRouteMaterializationRequest{}, fmt.Errorf("workflow instance store is required to restore flow instance route %s", route.InstancePath)
+	}
+	instance, ok, err := am.workflowInstances.Load(ctx, route.InstancePath)
+	if err != nil {
+		return runtimebus.FlowInstanceRouteMaterializationRequest{}, fmt.Errorf("load flow instance for route recovery %s: %w", route.InstancePath, err)
+	}
+	if !ok {
+		return runtimebus.FlowInstanceRouteMaterializationRequest{}, fmt.Errorf("flow instance not found for route recovery: %s", route.InstancePath)
+	}
+	activationInstance := runtimepipeline.StoredFlowInstance(am.semanticSource, instance)
+	vars := flowActivationVars(runtimepipeline.FlowInstanceActivationRequest{
+		Instance: activationInstance,
+		Config:   instance.Config,
+	})
+	return runtimebus.FlowInstanceRouteMaterializationRequest{
+		Identity:            route,
+		ActivationVariables: vars,
+	}, nil
 }
 
 func (am *AgentManager) retryLoop(ctx context.Context) {

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -197,7 +196,7 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) ([]store.RunForkC
 
 func installContractFrontierFlowInstanceRoutes(routeTable *runtimebus.RouteTable, source semanticview.Source, pending []store.RunForkPendingWork) error {
 	for _, route := range contractFrontierFlowInstanceRoutes(source, pending) {
-		if err := routeTable.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, route); err != nil {
+		if err := routeTable.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: route}); err != nil {
 			return fmt.Errorf("derive selected-contract flow-instance route %s: %w", route.InstancePath, err)
 		}
 	}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -52,7 +52,7 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 	case <-time.After(2 * time.Second):
 		t.Fatal("workflow runtime did not subscribe")
 	}
-	if err := bus.AddFlowInstanceRoute(runtimecontracts.SystemNodeContract{}, runtimeflowidentity.DeriveRoute("operating", "inst-1")); err != nil {
+	if err := bus.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	eventID := "99999999-9999-4999-8999-999999999902"
@@ -170,6 +170,74 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 		SELECT COUNT(*) FROM events
 		WHERE event_name = 'operating/component_scaffold.spawn_requested'
 	`, 1)
+}
+
+func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceActivationConfigSubscriberFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	proofStore := routeMaterializationDBProofStore{pg: pg}
+	bus, err := runtimebus.NewEventBusWithOptions(proofStore, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:            module,
+		InstanceActivator: manager.ActivateFlowInstance,
+		WorkflowStore:     workflowStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	bus.SetInterceptors(pc)
+
+	spinup := (events.Event{
+		ID:        "99999999-9999-4999-8999-999999999930",
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("opco.spinup_requested"),
+		Payload:   []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("22222222-2222-4222-8222-222222222222")
+	if err := bus.Publish(ctx, spinup); err != nil {
+		t.Fatalf("Publish spinup: %v", err)
+	}
+	autoEventID := waitRuntimeEventID(t, ctx, db, `
+		SELECT event_id::text FROM events
+		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
+	`, nil)
+
+	renderedAgentID := "ceo-product-1"
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM routing_rules
+		WHERE flow_instance = 'operating/11111111-1111-4111-8111-111111111111'
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $1
+		  AND status = 'active'
+	`, 1, renderedAgentID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM routing_rules
+		WHERE flow_instance = 'operating/11111111-1111-4111-8111-111111111111'
+		  AND subscriber_id = 'ceo-{product_id}'
+	`, 0)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, 1, autoEventID, renderedAgentID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_id = 'ceo-{product_id}'
+	`, 0, autoEventID)
 }
 
 func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {
@@ -532,6 +600,83 @@ component_scaffold.spawn_requested:
       emit: component_scaffold.spawn_requested
 `,
 	}
+}
+
+func templateInstanceActivationConfigSubscriberFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"events.yaml": `opco.spinup_requested:
+  entity_id: string
+  instance_id: string
+  product_id: string
+`,
+		"nodes.yaml": `portfolio-node:
+  id: portfolio-node
+  execution_type: system_node
+  subscribes_to: [opco.spinup_requested]
+  event_handlers:
+    opco.spinup_requested:
+      action: create_flow_instance
+      template: operating
+      instance_id_from: payload.instance_id
+      config_from:
+        product_id: payload.product_id
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+auto_emit_on_create:
+  event: opco.product_initialization_requested
+`,
+		"flows/operating/events.yaml": `opco.product_initialization_requested:
+  instance_id: string
+  template_id: string
+  flow_path: string
+  parent_entity_id: string
+  product_id: string
+`,
+		"flows/operating/agents.yaml": `ceo:
+  id: ceo-{product_id}
+  type: generic
+  role: ceo
+  subscriptions: [opco.product_initialization_requested]
+`,
+	}
+}
+
+type routeMaterializationDBProofStore struct {
+	pg *store.PostgresStore
+}
+
+func (s routeMaterializationDBProofStore) AppendEvent(ctx context.Context, evt events.Event) error {
+	return s.pg.AppendEvent(ctx, evt)
+}
+
+func (s routeMaterializationDBProofStore) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	return s.pg.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (s routeMaterializationDBProofStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {
+	return s.pg.ListEventDeliveryRecipients(ctx, eventID)
+}
+
+func (s routeMaterializationDBProofStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
+	return s.pg.UpsertFlowInstanceRoute(ctx, route)
+}
+
+func (s routeMaterializationDBProofStore) DeleteFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error {
+	return s.pg.DeleteFlowInstanceRoute(ctx, identity)
+}
+
+func (s routeMaterializationDBProofStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error) {
+	return s.pg.ListFlowInstanceRoutes(ctx)
 }
 
 func templateInstanceEmpireOutboxFixtureFiles() map[string]string {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1763,6 +1763,17 @@ engine:
         incomplete_policy: A child instance with incomplete ParentRoute metadata MUST fail closed with parent_route_incomplete
           before emitting a structurally routed pin output.
         single_parent_v1: Each child has exactly one ParentRoute in v1. Multiple parents are v2.
+      route_materialization:
+        subscriber_identity_variables: Dynamic flow-instance route subscribers MUST render from the same activation variable
+          set used to materialize the child instance's agents. That set includes `config_from` values plus runtime built-ins
+          `instance_id`, `template_id`, `flow_scope_key`, and `flow_instance_path`; built-ins remain authoritative for their
+          reserved names.
+        persisted_truth: Materialized `routing_rules.subscriber_id` rows store concrete rendered subscriber IDs. Route
+          persistence, delivery planning, active-agent lookup, and runtime recovery consume that materialized route truth and
+          MUST NOT independently reinterpret authored subscriber templates.
+        recovery: Startup recovery of active flow-instance routes MUST reconstruct the same activation variable set from the
+          persisted flow instance config, or recover from persisted rendered route truth. It MUST fail closed rather than
+          re-render route subscribers from route identity alone.
       auto_emit: Flow schemas may declare auto_emit_on_create. When the platform creates an instance, it automatically emits
         the declared event after the instance is fully started. Duplicate create failures MUST NOT auto-emit. This bootstraps
         the flow without requiring an external trigger.
@@ -4501,7 +4512,8 @@ platform_tables:
       lifecycle:
         boot: Load contract subscriptions → INSERT pattern rows. Clear stale materialized rows from previous boot.
         create_flow_instance: For each wildcard pattern matching the new instance path → INSERT materialized row with concrete
-          flow_instance.
+          flow_instance and rendered subscriber_id using the dynamic_instance_lifecycle.route_materialization activation variable
+          set.
         terminate_flow_instance: UPDATE materialized rows for this flow_instance → status = inactive.
         event_dispatch: SELECT WHERE event_pattern matches AND status = active. Concrete rows (is_materialized) take priority
           over wildcards.


### PR DESCRIPTION
Closes #1296

## Summary
- Promotes flow-instance route installation to a canonical `FlowInstanceRouteMaterializationRequest` carrying the concrete route identity plus activation variables.
- Passes `create_flow_instance` activation vars into route materialization and reconstructs them from persisted workflow instance config during startup route recovery.
- Updates `platform-spec.yaml` to make dynamic route subscriber variable ownership and recovery behavior authoritative.

## Governing Refs
- #1296 pre-audit and approved first-slice gate.
- `platform-spec.yaml` `handler_specification.action.valid_values.create_flow_instance.required_sibling_fields.config_from`.
- `platform-spec.yaml` `engine.dynamic_instance_lifecycle.creation.route_materialization`.
- `platform-spec.yaml` `platform_tables.persistent_schema.routing_rules.lifecycle.create_flow_instance`.

## Semantic Migration
- New canonical owner: `runtimebus.FlowInstanceRouteMaterializationRequest` consumed by `EventBus.AddFlowInstanceRoute` and `RouteTable.AddFlowInstanceRoute`.
- Old producer/interpreter invalidated: identity-only `AddFlowInstanceRoute(template, identity)` calls from activation and recovery.
- Production paths checked: `AgentManager.ActivateFlowInstance`, `AgentManager.restoreFlowInstanceRoutes`, `EventBus.AddFlowInstanceRoute`, `RouteTable.AddFlowInstanceRoute`, route persistence, delivery planning, and selected-contract route admission compile fallout.
- Migration completeness: complete for the approved #1296 child class; selected-contract route reconstruction remains explicitly separate and is not claimed closed.

## Verification
- `go test ./internal/runtime/bus ./internal/runtime/manager ./internal/runtime/runforkadmission`
- `go test ./internal/runtime/bus ./internal/runtime/manager ./internal/runtime/runforkadmission ./internal/runtime -run 'FlowInstanceRoute|ActivateFlowInstancePassesActivationConfigToRouteMaterialization|RecoverRestoresPersistedFlowInstanceRoutes|TemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows' -count=1`
- `go test ./cmd/swarm -run TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe -count=1 -v`
- `go test ./cmd/swarm -run TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity -count=1 -v`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
