### PR TITLE
[agent-h][issue #1303] Fail fast on unusable artifact roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ you explicitly opt into Postgres with `SWARM_STORE_BACKEND=postgres` or
 (`swarm-workspace:latest` by default), or set `SWARM_WORKSPACE_IMAGE` to a
 compatible image before commands that start the runtime.
 
+Contracts that use `artifact_repo_commit` need a writable runtime-private
+artifact root. The default is `/var/lib/swarm/artifacts`; local machines that
+cannot write there should set `SWARM_ARTIFACT_ROOT` to an absolute writable host
+path outside `/data`, `/workspace`, and `/opt/swarm/contracts` before starting
+`swarm serve` or local foreground `swarm run`.
+
 ```bash
 # build
 go build ./cmd/swarm

--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ compatible image before commands that start the runtime.
 Contracts that use `artifact_repo_commit` need a writable runtime-private
 artifact root. The default is `/var/lib/swarm/artifacts`; local machines that
 cannot write there should set `SWARM_ARTIFACT_ROOT` to an absolute writable host
-path outside `/data`, `/workspace`, and `/opt/swarm/contracts` before starting
-`swarm serve` or local foreground `swarm run`.
+path whose `repos` child can be created and written, outside `/data`,
+`/workspace`, and `/opt/swarm/contracts` before starting `swarm serve` or local
+foreground `swarm run`.
 
 ```bash
 # build

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -546,6 +546,11 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	if err != nil {
 		return serveRuntimeBundleContext{}, err
 	}
+	if runtimepipeline.SourceUsesArtifactRepoCommit(loaded.source) {
+		if _, err := runtimepipeline.EnsureArtifactRepoRootWritable(""); err != nil {
+			return serveRuntimeBundleContext{}, fmt.Errorf("artifact repo root startup validation failed: %w", err)
+		}
+	}
 	runtimeStores := req.Stores.runtimeStores()
 	if !req.UseStartupOwnership {
 		runtimeStores.StartupOwnership = nil
@@ -781,6 +786,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			RequireBundleScopeName: len(loadedBundles) > 1,
 		})
 		if err != nil {
+			reporter.emit(5, "runtime_context", "FAILED", err.Error())
 			slog.Error("build runtime context", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
 			return 1
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3748,6 +3748,53 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifac
 	}
 }
 
+func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForBlockedRepoStorageBase(t *testing.T) {
+	stubServeRuntimeWorkspaceLifecycle(t)
+	unsetStoreSelectorEnv(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	artifactRoot := t.TempDir()
+	reposFile := filepath.Join(artifactRoot, "repos")
+	if err := os.WriteFile(reposFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write unusable repos base: %v", err)
+	}
+	t.Setenv("SWARM_ARTIFACT_ROOT", artifactRoot)
+
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        writeArtifactRepoCommitServeFixture(t),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            "sqlite",
+		StoreModeSet:         true,
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		Dev:                  true,
+		RequireBundleMatch:   false,
+		NoRequireBundleMatch: true,
+		Verbose:              true,
+		Output:               &out,
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{
+		"[5/22] runtime_context",
+		"artifact repo root startup validation failed",
+		artifactRoot,
+		reposFile,
+		"SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "[22/22]") {
+		t.Fatalf("serve reached readiness despite blocked artifact repo storage base:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot(t *testing.T) {
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3703,6 +3703,105 @@ func runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t *testing.T, dev bool) {
 	}
 }
 
+func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifactRoot(t *testing.T) {
+	stubServeRuntimeWorkspaceLifecycle(t)
+	unsetStoreSelectorEnv(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	rootFile := filepath.Join(t.TempDir(), "artifact-root")
+	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write unusable artifact root: %v", err)
+	}
+	t.Setenv("SWARM_ARTIFACT_ROOT", rootFile)
+
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        writeArtifactRepoCommitServeFixture(t),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            "sqlite",
+		StoreModeSet:         true,
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		Dev:                  true,
+		RequireBundleMatch:   false,
+		NoRequireBundleMatch: true,
+		Verbose:              true,
+		Output:               &out,
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{
+		"[5/22] runtime_context",
+		"artifact repo root startup validation failed",
+		rootFile,
+		"SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "[22/22]") {
+		t.Fatalf("serve reached readiness despite unusable artifact root:\n%s", out.String())
+	}
+}
+
+func TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot(t *testing.T) {
+	stubServeRuntimeWorkspaceLifecycle(t)
+	unsetStoreSelectorEnv(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	rootFile := filepath.Join(t.TempDir(), "artifact-root")
+	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write unusable artifact root: %v", err)
+	}
+	t.Setenv("SWARM_ARTIFACT_ROOT", rootFile)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
+			ConfigPath:           writeServeRuntimeTestConfig(t),
+			ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+			PlatformSpecPath:     defaultPlatformSpecPath,
+			StoreMode:            "sqlite",
+			StoreModeSet:         true,
+			APIListenAddr:        "127.0.0.1:0",
+			MCPListenAddr:        "127.0.0.1:0",
+			SelfCheck:            true,
+			Dev:                  true,
+			RequireBundleMatch:   false,
+			NoRequireBundleMatch: true,
+			Verbose:              true,
+			Output:               &out,
+		})
+	}()
+	stopped := false
+	t.Cleanup(func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out stopping runServeRuntime\noutput:\n%s", out.String())
+		}
+	})
+	waitForServeReadyLine(t, &out, done)
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	}
+	stopped = true
+	if strings.Contains(out.String(), "artifact repo root startup validation failed") {
+		t.Fatalf("non-artifact bundle hit artifact root admission:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testing.T) {
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
@@ -6951,6 +7050,93 @@ func writeWorkflowValidationFixtureFile(t *testing.T, path, contents string) {
 	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func writeArtifactRepoCommitServeFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: artifact-root-startup
+version: "1.0.0"
+platform_version: ">=1.1.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+initial_state: ready
+terminal_states: [done]
+states: [ready, done]
+pins:
+  inputs:
+    events: [artifact.requested]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+core:
+  repo_url:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  current_ref:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  file_manifest:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  status:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  failure_reason:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  last_request_id:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+  last_source_event_id:
+    type: text
+    _unused_reason: artifact startup admission proof output field
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+artifact.requested:
+  swarm:
+    source: external
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+artifact-writer:
+  id: artifact-writer
+  execution_type: system_node
+  subscribes_to: [artifact.requested]
+  event_handlers:
+    artifact.requested:
+      action:
+        id: artifact_repo_commit
+        artifact_repo:
+          provider: local_git
+          repo_id:
+            literal: "11111111-1111-1111-1111-111111111111"
+          namespace:
+            literal: local-proof
+          request_id:
+            literal: "22222222-2222-2222-2222-222222222222"
+          allowed_paths:
+            - readme.md
+          files:
+            - path:
+                literal: readme.md
+              content:
+                literal: "# Demo\n"
+              content_type: markdown
+          output:
+            repo_url: repo_url
+            current_ref: current_ref
+            file_manifest: file_manifest
+            status: status
+            failure_reason: failure_reason
+            last_request_id: last_request_id
+            last_source_event_id: last_source_event_id
+`)
+	return root
 }
 
 func writeVerifyModelAliasFixture(t *testing.T, root, model string) {

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -22,9 +22,11 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 const (
+	artifactRepoCommitActionID   = "artifact_repo_commit"
 	artifactRepoProviderLocalGit = "local_git"
 	artifactRepoPublicScheme     = "swarm-artifact://repos/"
 	defaultArtifactRoot          = "/var/lib/swarm/artifacts"
@@ -284,24 +286,107 @@ func normalizedArtifactRepoFlowInstance(value string) string {
 }
 
 func (pc *PipelineCoordinator) artifactRepoRoot() (string, error) {
+	explicit := ""
 	if pc != nil && strings.TrimSpace(pc.artifactRoot) != "" {
-		return ResolveArtifactRepoRoot(pc.artifactRoot)
+		explicit = pc.artifactRoot
 	}
-	return ResolveArtifactRepoRoot("")
+	resolution, err := EnsureArtifactRepoRootWritable(explicit)
+	if err != nil {
+		return "", err
+	}
+	return resolution.Root, nil
+}
+
+type ArtifactRepoRootResolution struct {
+	Root   string
+	Source string
 }
 
 // ResolveArtifactRepoRoot returns the validated runtime-private artifact root.
 // The explicit root has precedence over SWARM_ARTIFACT_ROOT, which has
 // precedence over the platform default.
 func ResolveArtifactRepoRoot(explicit string) (string, error) {
+	resolution, err := ResolveArtifactRepoRootWithSource(explicit)
+	if err != nil {
+		return "", err
+	}
+	return resolution.Root, nil
+}
+
+// ResolveArtifactRepoRootWithSource returns the validated root plus the source
+// selected for operator diagnostics.
+func ResolveArtifactRepoRootWithSource(explicit string) (ArtifactRepoRootResolution, error) {
 	root := strings.TrimSpace(explicit)
 	if root != "" {
-		return validateArtifactRepoRoot(root)
+		validated, err := validateArtifactRepoRoot(root)
+		return ArtifactRepoRootResolution{Root: validated, Source: "explicit runtime ArtifactRoot option"}, err
 	}
 	if env := strings.TrimSpace(os.Getenv("SWARM_ARTIFACT_ROOT")); env != "" {
-		return validateArtifactRepoRoot(env)
+		validated, err := validateArtifactRepoRoot(env)
+		return ArtifactRepoRootResolution{Root: validated, Source: "SWARM_ARTIFACT_ROOT"}, err
 	}
-	return validateArtifactRepoRoot(defaultArtifactRoot)
+	validated, err := validateArtifactRepoRoot(defaultArtifactRoot)
+	return ArtifactRepoRootResolution{Root: validated, Source: "platform default /var/lib/swarm/artifacts"}, err
+}
+
+// EnsureArtifactRepoRootWritable validates and exercises the runtime-private
+// artifact root so platform config defects surface before action execution.
+func EnsureArtifactRepoRootWritable(explicit string) (ArtifactRepoRootResolution, error) {
+	resolution, err := ResolveArtifactRepoRootWithSource(explicit)
+	if err != nil {
+		return resolution, err
+	}
+	if err := validateArtifactRepoRootWritable(resolution.Root); err != nil {
+		return resolution, fmt.Errorf("artifact root %q from %s is not writable by the runtime process: %w; set SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>", resolution.Root, resolution.Source, err)
+	}
+	return resolution, nil
+}
+
+func validateArtifactRepoRootWritable(root string) error {
+	cleaned, err := validateArtifactRepoRoot(root)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cleaned, 0o755); err != nil {
+		return err
+	}
+	cleaned, err = validateArtifactRepoRoot(cleaned)
+	if err != nil {
+		return err
+	}
+	probe, err := os.CreateTemp(cleaned, ".swarm-artifact-root-check-*")
+	if err != nil {
+		return err
+	}
+	probeName := probe.Name()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(probeName)
+		return err
+	}
+	return os.Remove(probeName)
+}
+
+func SourceUsesArtifactRepoCommit(source semanticview.Source) bool {
+	if source == nil {
+		return false
+	}
+	for _, node := range source.NodeEntries() {
+		for _, handler := range node.EventHandlers {
+			if artifactActionSpecIsCommit(handler.Action) {
+				return true
+			}
+			for _, rule := range handler.Rules {
+				if artifactActionSpecIsCommit(rule.Action) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func artifactActionSpecIsCommit(action runtimecontracts.ActionSpec) bool {
+	return strings.TrimSpace(strings.ToLower(action.ID)) == artifactRepoCommitActionID
 }
 
 func validateArtifactRepoRoot(raw string) (string, error) {

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -354,7 +354,29 @@ func validateArtifactRepoRootWritable(root string) error {
 	if err != nil {
 		return err
 	}
-	probe, err := os.CreateTemp(cleaned, ".swarm-artifact-root-check-*")
+	if err := validateArtifactRepoWritableDirectory(cleaned, ".swarm-artifact-root-check-*"); err != nil {
+		return err
+	}
+	reposRoot, err := artifactRepoLocalGitStorageBase(cleaned)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(reposRoot, 0o755); err != nil {
+		return fmt.Errorf("artifact repository storage base %q: %w", reposRoot, err)
+	}
+	if resolved, ok := artifactRootResolveExistingPrefix(reposRoot); ok {
+		if mount, ok := artifactRootAgentMount(resolved); ok {
+			return fmt.Errorf("artifact repository storage base %q resolves under agent-visible mount %s", reposRoot, mount)
+		}
+	}
+	if err := validateArtifactRepoWritableDirectory(reposRoot, ".swarm-artifact-repos-check-*"); err != nil {
+		return fmt.Errorf("artifact repository storage base %q: %w", reposRoot, err)
+	}
+	return nil
+}
+
+func validateArtifactRepoWritableDirectory(dir, pattern string) error {
+	probe, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return err
 	}
@@ -364,6 +386,18 @@ func validateArtifactRepoRootWritable(root string) error {
 		return err
 	}
 	return os.Remove(probeName)
+}
+
+func artifactRepoLocalGitStorageBase(root string) (string, error) {
+	cleaned, err := validateArtifactRepoRoot(root)
+	if err != nil {
+		return "", err
+	}
+	reposRoot := filepath.Join(cleaned, "repos")
+	if !artifactPathWithinRoot(reposRoot, cleaned) {
+		return "", fmt.Errorf("artifact repository storage base escaped artifact root")
+	}
+	return reposRoot, nil
 }
 
 func SourceUsesArtifactRepoCommit(source semanticview.Source) bool {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1147,6 +1147,28 @@ func TestEnsureArtifactRepoRootWritableRejectsUnusableRoot(t *testing.T) {
 	}
 }
 
+func TestEnsureArtifactRepoRootWritableRejectsBlockedLocalGitStorageBase(t *testing.T) {
+	t.Setenv("SWARM_ARTIFACT_ROOT", "")
+	root := t.TempDir()
+	reposFile := filepath.Join(root, "repos")
+	if err := os.WriteFile(reposFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write repos file: %v", err)
+	}
+
+	resolution, err := EnsureArtifactRepoRootWritable(root)
+	if err == nil {
+		t.Fatal("EnsureArtifactRepoRootWritable returned nil error, want blocked repos rejection")
+	}
+	if resolution.Source != "explicit runtime ArtifactRoot option" {
+		t.Fatalf("source = %q, want explicit runtime ArtifactRoot option", resolution.Source)
+	}
+	for _, want := range []string{root, reposFile, "not writable by the runtime process", "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	}
+}
+
 func TestSourceUsesArtifactRepoCommitDetectsSupportedActionSurfaces(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
@@ -1236,49 +1258,77 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifac
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoot(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
-	defer cleanup()
-	store := NewWorkflowInstanceStore(db)
-	bus := &recordingPipelineBus{}
-	rootFile := filepath.Join(t.TempDir(), "artifact-root")
-	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
-		t.Fatalf("write artifact root file: %v", err)
-	}
-	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: rootFile, bus: bus}
-	ctx := testWorkflowStoreRunContext(t, store)
-	entityID := "22222222-2222-2222-2222-222222222222"
-	initial := testArtifactRepoEntityFields()
-	if err := store.Upsert(ctx, WorkflowInstance{
-		InstanceID:      entityID,
-		StorageRef:      entityID,
-		WorkflowName:    "artifact-repo",
-		WorkflowVersion: "1.0.0",
-		CurrentState:    "ready",
-		Metadata:        cloneStringAnyMap(initial),
-	}); err != nil {
-		t.Fatalf("seed workflow instance: %v", err)
-	}
-	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+	for _, tc := range []struct {
+		name string
+		root func(t *testing.T) (root string, wantDetail string)
+	}{
+		{
+			name: "root file",
+			root: func(t *testing.T) (string, string) {
+				t.Helper()
+				rootFile := filepath.Join(t.TempDir(), "artifact-root")
+				if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
+					t.Fatalf("write artifact root file: %v", err)
+				}
+				return rootFile, rootFile
+			},
+		},
+		{
+			name: "blocked local git storage base",
+			root: func(t *testing.T) (string, string) {
+				t.Helper()
+				root := t.TempDir()
+				reposFile := filepath.Join(root, "repos")
+				if err := os.WriteFile(reposFile, []byte("not a directory"), 0o644); err != nil {
+					t.Fatalf("write repos file: %v", err)
+				}
+				return root, reposFile
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			defer cleanup()
+			store := NewWorkflowInstanceStore(db)
+			bus := &recordingPipelineBus{}
+			artifactRoot, wantDetail := tc.root(t)
+			pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: artifactRoot, bus: bus}
+			ctx := testWorkflowStoreRunContext(t, store)
+			entityID := "22222222-2222-2222-2222-222222222222"
+			initial := testArtifactRepoEntityFields()
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID:      entityID,
+				StorageRef:      entityID,
+				WorkflowName:    "artifact-repo",
+				WorkflowVersion: "1.0.0",
+				CurrentState:    "ready",
+				Metadata:        cloneStringAnyMap(initial),
+			}); err != nil {
+				t.Fatalf("seed workflow instance: %v", err)
+			}
+			action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
-	}
-	if err == nil || !strings.Contains(err.Error(), "not writable by the runtime process") || !strings.Contains(err.Error(), "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>") {
-		t.Fatalf("ExecuteAction error = %v, want unusable root remediation", err)
-	}
-	instance, _, err := store.Load(ctx, entityID)
-	if err != nil {
-		t.Fatalf("load workflow instance: %v", err)
-	}
-	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
-		t.Fatalf("status = %q, want failed", got)
-	}
-	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, rootFile) || !strings.Contains(got, "not writable by the runtime process") {
-		t.Fatalf("failure_reason = %q, want unusable root detail", got)
-	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("failure event count = %d, want 1", got)
+			ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+			if !ok {
+				t.Fatal("expected artifact_repo_commit action to be claimed")
+			}
+			if err == nil || !strings.Contains(err.Error(), "not writable by the runtime process") || !strings.Contains(err.Error(), "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>") {
+				t.Fatalf("ExecuteAction error = %v, want unusable root remediation", err)
+			}
+			instance, _, err := store.Load(ctx, entityID)
+			if err != nil {
+				t.Fatalf("load workflow instance: %v", err)
+			}
+			if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
+				t.Fatalf("status = %q, want failed", got)
+			}
+			if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, wantDetail) || !strings.Contains(got, "not writable by the runtime process") {
+				t.Fatalf("failure_reason = %q, want unusable root detail %q", got, wantDetail)
+			}
+			if got := bus.publishedCount(); got != 1 {
+				t.Fatalf("failure event count = %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1235,6 +1235,53 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifac
 	}
 }
 
+func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoot(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	store := NewWorkflowInstanceStore(db)
+	bus := &recordingPipelineBus{}
+	rootFile := filepath.Join(t.TempDir(), "artifact-root")
+	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write artifact root file: %v", err)
+	}
+	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: rootFile, bus: bus}
+	ctx := testWorkflowStoreRunContext(t, store)
+	entityID := "22222222-2222-2222-2222-222222222222"
+	initial := testArtifactRepoEntityFields()
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "artifact-repo",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "ready",
+		Metadata:        cloneStringAnyMap(initial),
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
+
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok {
+		t.Fatal("expected artifact_repo_commit action to be claimed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "not writable by the runtime process") || !strings.Contains(err.Error(), "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>") {
+		t.Fatalf("ExecuteAction error = %v, want unusable root remediation", err)
+	}
+	instance, _, err := store.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
+		t.Fatalf("status = %q, want failed", got)
+	}
+	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, rootFile) || !strings.Contains(got, "not writable by the runtime process") {
+		t.Fatalf("failure_reason = %q, want unusable root detail", got)
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("failure event count = %d, want 1", got)
+	}
+}
+
 func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEvent(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1109,6 +1109,83 @@ func TestResolveArtifactRepoRootRejectsUnsafeRoots(t *testing.T) {
 	}
 }
 
+func TestEnsureArtifactRepoRootWritableRejectsUnusableRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		explicit bool
+		source   string
+	}{
+		{name: "explicit option", explicit: true, source: "explicit runtime ArtifactRoot option"},
+		{name: "environment", explicit: false, source: "SWARM_ARTIFACT_ROOT"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootFile := filepath.Join(t.TempDir(), "artifact-root")
+			if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
+				t.Fatalf("write root file: %v", err)
+			}
+			explicit := ""
+			t.Setenv("SWARM_ARTIFACT_ROOT", "")
+			if tc.explicit {
+				explicit = rootFile
+			} else {
+				t.Setenv("SWARM_ARTIFACT_ROOT", rootFile)
+			}
+
+			resolution, err := EnsureArtifactRepoRootWritable(explicit)
+			if err == nil {
+				t.Fatal("EnsureArtifactRepoRootWritable returned nil error, want unusable root rejection")
+			}
+			if resolution.Source != tc.source {
+				t.Fatalf("source = %q, want %q", resolution.Source, tc.source)
+			}
+			for _, want := range []string{rootFile, "not writable by the runtime process", "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestSourceUsesArtifactRepoCommitDetectsSupportedActionSurfaces(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"handler": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"artifact.requested": {
+						Action: runtimecontracts.ActionSpec{ID: "artifact_repo_commit"},
+					},
+				},
+			},
+			"rule": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"artifact.routed": {
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID:     "commit",
+							Action: runtimecontracts.ActionSpec{ID: "artifact_repo_commit"},
+						}},
+					},
+				},
+			},
+		},
+	})
+	if !SourceUsesArtifactRepoCommit(source) {
+		t.Fatal("SourceUsesArtifactRepoCommit = false, want true for handler/rule action")
+	}
+	empty := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"handler": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.requested": {Action: runtimecontracts.ActionSpec{ID: "record_evidence"}},
+				},
+			},
+		},
+	})
+	if SourceUsesArtifactRepoCommit(empty) {
+		t.Fatal("SourceUsesArtifactRepoCommit = true, want false without artifact action")
+	}
+}
+
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifactRoot(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7021,6 +7021,9 @@ runtime_storage:
     requirements:
     - The resolved path MUST be an absolute runtime-private host path.
     - The resolved path MUST be writable by the runtime process when `artifact_repo_commit` executes.
+    - When a loaded bundle declares `artifact_repo_commit`, `swarm serve` and local foreground `swarm run` MUST validate
+      that the resolved artifact root is writable before runtime readiness. Bundles that do not declare
+      `artifact_repo_commit` MUST NOT fail solely because the default artifact root is currently unwritable.
     - The resolved path MUST persist across runtime restarts.
     - The resolved path MUST NOT be `/workspace`, `/data`, `/opt/swarm/contracts`, or any descendant of those agent-visible
       mounts.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7022,8 +7022,9 @@ runtime_storage:
     - The resolved path MUST be an absolute runtime-private host path.
     - The resolved path MUST be writable by the runtime process when `artifact_repo_commit` executes.
     - When a loaded bundle declares `artifact_repo_commit`, `swarm serve` and local foreground `swarm run` MUST validate
-      that the resolved artifact root is writable before runtime readiness. Bundles that do not declare
-      `artifact_repo_commit` MUST NOT fail solely because the default artifact root is currently unwritable.
+      that the resolved artifact root and its local-git storage base at `<artifact_root>/repos` are writable before runtime
+      readiness. Bundles that do not declare `artifact_repo_commit` MUST NOT fail solely because the default artifact root is
+      currently unwritable.
     - The resolved path MUST persist across runtime restarts.
     - The resolved path MUST NOT be `/workspace`, `/data`, `/opt/swarm/contracts`, or any descendant of those agent-visible
       mounts.


### PR DESCRIPTION
## Summary

Closes #1303.

This PR makes `artifact_repo_commit` bundles fail before serve/local-run readiness when the resolved local artifact root is unusable. The action path keeps the same centralized validation as a fallback for embedded/direct execution paths.

## Governing context

- `platform-spec.yaml#runtime_storage.artifact_root`
- `platform-spec.yaml#action_specification.action.valid_values.artifact_repo_commit`
- Adjacent split owner: `platform-spec.yaml#workspace_model.data_source_authority`
- Gate: #1303 approved fail-fast startup/config boundary. No default migration to `/data`, `--data`, `.swarm/data`, `/workspace`, or contracts mounts.

## Semantic owner / migration notes

- New canonical implementation owner: `internal/runtime/pipeline.ResolveArtifactRepoRootWithSource` plus `EnsureArtifactRepoRootWritable` for root source, shape, and writeability policy.
- Startup consumer: `cmd/swarm buildServeRuntimeBundleContext` only when the loaded semantic source declares `artifact_repo_commit`.
- Old path now invalid as first normal signal: late `ensureArtifactRepoInitialized` / `os.MkdirAll` failure as the first artifact-root config diagnostic.
- Surviving old behavior: action execution still validates and fails closed as fallback for embedding/direct paths that bypass serve startup.
- Migration completeness: complete for the selected #1303 fail-fast artifact-root admission class.

## Validation

- `go test ./internal/runtime/pipeline -run 'TestResolveArtifactRepoRoot|TestEnsureArtifactRepoRootWritable|TestSourceUsesArtifactRepoCommit|ArtifactRepo' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifactRoot|TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot' -count=1`
- `go test ./internal/runtime -run 'TestNewRuntimeRejectsInvalidArtifactRootEnv|ArtifactRoot' -count=1`
- `go test ./...`
