### PR TITLE
[agent-c][issue #1313] Materialize selected fork node deliveries

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -43,6 +43,7 @@ type EventBus struct {
 	semanticSource              semanticview.Source
 	payloadValidator            PayloadValidator
 	recipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
+	recipientPlanMaterializer   PublishRecipientPlanMaterializer
 	recipientPlanGuard          PublishRecipientPlanGuard
 	runtimeIngressDispatchGate  RuntimeIngressDispatchGate
 	runDispatchGate             RunDispatchGate
@@ -69,6 +70,7 @@ type DirectRecipientStatus struct {
 }
 
 type PublishRecipientPlanAdmissionGuard func(context.Context, events.Event) error
+type PublishRecipientPlanMaterializer func(context.Context, events.Event, PublishRecipientPlan) ([]events.DeliveryRoute, error)
 type PublishRecipientPlanGuard func(context.Context, events.Event, PublishRecipientPlan) error
 
 type RuntimeIngressDispatchGate interface {
@@ -87,6 +89,7 @@ type EventBusOptions struct {
 	RouteTable                  *RouteTable
 	PayloadValidator            PayloadValidator
 	RecipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
+	RecipientPlanMaterializer   PublishRecipientPlanMaterializer
 	RecipientPlanGuard          PublishRecipientPlanGuard
 	RuntimeIngressDispatchGate  RuntimeIngressDispatchGate
 	RunDispatchGate             RunDispatchGate
@@ -158,6 +161,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		semanticSource:              semanticSource,
 		payloadValidator:            opts.PayloadValidator,
 		recipientPlanAdmissionGuard: opts.RecipientPlanAdmissionGuard,
+		recipientPlanMaterializer:   opts.RecipientPlanMaterializer,
 		recipientPlanGuard:          opts.RecipientPlanGuard,
 		runtimeIngressDispatchGate:  opts.RuntimeIngressDispatchGate,
 		runDispatchGate:             opts.RunDispatchGate,

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -309,6 +309,10 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	if err != nil {
 		return err
 	}
+	inboundPlan, err = eb.materializePublishRecipientPlan(txctx, evt, inboundPlan)
+	if err != nil {
+		return err
+	}
 	if err := eb.authorizePublishRecipientPlan(txctx, evt, inboundPlan); err != nil {
 		return err
 	}
@@ -480,6 +484,10 @@ func (eb *EventBus) publishTransactional(
 		return err
 	}
 	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
+	if err != nil {
+		return err
+	}
+	inboundPlan, err = eb.materializePublishRecipientPlan(txctx, evt, inboundPlan)
 	if err != nil {
 		return err
 	}
@@ -747,6 +755,10 @@ func (eb *EventBus) planSubscribedPublish(ctx context.Context, evt events.Event)
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
+	plan, err = eb.materializePublishRecipientPlan(ctx, evt, plan)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
 	if err := eb.authorizePublishRecipientPlan(ctx, evt, plan); err != nil {
 		return eventDeliveryPlan{}, err
 	}
@@ -759,6 +771,21 @@ func (eb *EventBus) authorizePublishRecipientPlanning(ctx context.Context, evt e
 		return nil
 	}
 	return eb.recipientPlanAdmissionGuard(ctx, evt)
+}
+
+func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) (eventDeliveryPlan, error) {
+	if eb == nil || eb.recipientPlanMaterializer == nil {
+		return plan, nil
+	}
+	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, plan))
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	if len(routes) == 0 {
+		return plan, nil
+	}
+	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(append(plan.DeliveryRoutes, routes...))
+	return plan, nil
 }
 
 func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
@@ -1202,6 +1229,10 @@ func (eb *EventBus) CheckPublishRecipientPlan(ctx context.Context, evt events.Ev
 		return PublishRecipientPlan{}, err
 	}
 	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	if err != nil {
+		return PublishRecipientPlan{}, err
+	}
+	plan, err = eb.materializePublishRecipientPlan(ctx, evt, plan)
 	if err != nil {
 		return PublishRecipientPlan{}, err
 	}

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -185,7 +185,7 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 	for _, recipient := range expected {
 		expectedSet[recipient] = struct{}{}
 	}
-	targetsByRecipient := deliveryRouteTargetsByRecipient(deliveryRoutes)
+	targetsByRecipient := deliveryRouteTargetsBySubscriber(deliveryRoutes)
 	recipients := eb.snapshotRecipientChans(dispatchRecipients)
 	delivered := make([]string, 0, len(recipients))
 	seen := make(map[string]struct{}, len(recipients))
@@ -200,7 +200,7 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 	}
 	timedOut := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
-		targets := targetsByRecipient[strings.TrimSpace(recipient.agentID)]
+		targets := targetsByRecipient[recipient.deliveryRouteTargetKey()]
 		if len(targets) == 0 {
 			targets = []events.RouteIdentity{{}}
 		}
@@ -272,21 +272,31 @@ func deliveryRoutesFromTargetMap(recipients []string, subscriberType string, del
 	return events.NormalizeDeliveryRoutes(out)
 }
 
-func deliveryRouteTargetsByRecipient(deliveryRoutes []events.DeliveryRoute) map[string][]events.RouteIdentity {
+type deliveryRouteTargetKey struct {
+	subscriberType string
+	subscriberID   string
+}
+
+func deliveryRouteTargetsBySubscriber(deliveryRoutes []events.DeliveryRoute) map[deliveryRouteTargetKey][]events.RouteIdentity {
 	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
 	if len(deliveryRoutes) == 0 {
 		return nil
 	}
-	out := make(map[string][]events.RouteIdentity, len(deliveryRoutes))
+	out := make(map[deliveryRouteTargetKey][]events.RouteIdentity, len(deliveryRoutes))
 	for _, route := range deliveryRoutes {
+		subscriberType := strings.TrimSpace(route.SubscriberType)
 		recipient := strings.TrimSpace(route.SubscriberID)
-		if recipient == "" {
+		if subscriberType == "" || recipient == "" {
 			continue
 		}
 		if route.Target.Empty() {
 			continue
 		}
-		out[recipient] = append(out[recipient], route.Target.Normalized())
+		key := deliveryRouteTargetKey{
+			subscriberType: subscriberType,
+			subscriberID:   recipient,
+		}
+		out[key] = append(out[key], route.Target.Normalized())
 	}
 	if len(out) == 0 {
 		return nil
@@ -297,6 +307,18 @@ func deliveryRouteTargetsByRecipient(deliveryRoutes []events.DeliveryRoute) map[
 type agentRecipient struct {
 	agentID string
 	ch      chan events.Event
+	kind    inMemorySubscriberKind
+}
+
+func (r agentRecipient) deliveryRouteTargetKey() deliveryRouteTargetKey {
+	subscriberType := "agent"
+	if r.kind == inMemorySubscriberInternal {
+		subscriberType = "node"
+	}
+	return deliveryRouteTargetKey{
+		subscriberType: subscriberType,
+		subscriberID:   strings.TrimSpace(r.agentID),
+	}
 }
 
 func (eb *EventBus) snapshotRecipientChans(agentIDs []string) []agentRecipient {
@@ -315,7 +337,11 @@ func (eb *EventBus) snapshotRecipientChans(agentIDs []string) []agentRecipient {
 		if !ok {
 			continue
 		}
-		out = append(out, agentRecipient{agentID: id, ch: ch})
+		kind := eb.subscriptionKinds[id]
+		if kind == "" {
+			kind = inMemorySubscriberAgent
+		}
+		out = append(out, agentRecipient{agentID: id, ch: ch, kind: kind})
 	}
 	return out
 }

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -108,6 +108,94 @@ func (l targetRouteMemoryLease) Release(context.Context) error {
 	return nil
 }
 
+type materializedRoutePersistedBeforeInterceptor struct {
+	t       *testing.T
+	store   *targetRouteMemoryStore
+	eventID string
+	want    events.DeliveryRoute
+}
+
+func (i materializedRoutePersistedBeforeInterceptor) Intercept(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
+	i.t.Helper()
+	if evt.ID != i.eventID {
+		i.t.Fatalf("interceptor event_id = %q, want %q", evt.ID, i.eventID)
+	}
+	routes, err := i.store.ListEventDeliveryRoutes(ctx, i.eventID)
+	if err != nil {
+		i.t.Fatalf("ListEventDeliveryRoutes: %v", err)
+	}
+	if !deliveryRoutesContain(routes, i.want) {
+		i.t.Fatalf("persisted routes before interceptor = %#v, want %#v", routes, i.want)
+	}
+	return true, nil, nil
+}
+
+func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "target-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "review/inst-1",
+		},
+	}
+	guardSawMaterializedRoute := false
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		RecipientPlanMaterializer: func(ctx context.Context, evt events.Event, plan PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if evt.ID != eventID {
+				t.Fatalf("materializer event_id = %q, want %q", evt.ID, eventID)
+			}
+			if len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("pre-materialized delivery routes = %#v, want none", plan.DeliveryRoutes)
+			}
+			return []events.DeliveryRoute{want}, nil
+		},
+		RecipientPlanGuard: func(ctx context.Context, evt events.Event, plan PublishRecipientPlan) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if !deliveryRoutesContain(plan.DeliveryRoutes, want) {
+				t.Fatalf("guard delivery routes = %#v, want materialized %#v", plan.DeliveryRoutes, want)
+			}
+			guardSawMaterializedRoute = true
+			return nil
+		},
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    want,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.Publish(context.Background(), events.Event{
+		ID:        eventID,
+		Type:      events.EventType("review/inst-1/task.started"),
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !guardSawMaterializedRoute {
+		t.Fatal("recipient plan guard did not see materialized route")
+	}
+}
+
+func deliveryRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRoute) bool {
+	want = want.Normalized()
+	for _, got := range events.NormalizeDeliveryRoutes(routes) {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *targetRouteMemoryStore) LoadCommittedReplayScope(_ context.Context, eventID string) (replayclaim.CommittedReplayScope, error) {
 	scope := s.scopes[eventID]
 	if scope == "" {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -186,6 +186,35 @@ func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *te
 	}
 }
 
+func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("shared-subscriber", events.EventType("review/inst-1/task.started"))
+	defer eb.Unsubscribe("shared-subscriber")
+
+	evt := events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("review/inst-1/task.started"),
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := eb.deliverToRecipientsWithRoutes(context.Background(), evt, []string{"shared-subscriber"}, []events.DeliveryRoute{{
+		SubscriberType: "node",
+		SubscriberID:   "shared-subscriber",
+		Target: events.RouteIdentity{
+			FlowInstance: "review/inst-1",
+		},
+	}}); err != nil {
+		t.Fatalf("deliverToRecipientsWithRoutes: %v", err)
+	}
+	got := requireBusEvent(t, ch, "same-id agent delivery")
+	if got.HasTargetRoute() || got.FlowInstance() != "" {
+		t.Fatalf("agent delivery target = route:%#v flow:%q, want no node target leakage", got.TargetRoute(), got.FlowInstance())
+	}
+}
+
 func deliveryRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRoute) bool {
 	want = want.Normalized()
 	for _, got := range events.NormalizeDeliveryRoutes(routes) {

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -48,6 +48,15 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 	sourceEventID := uuid.NewString()
 	at := time.Unix(1700002200, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET subscriber_id = 'source-only-node'
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+		  AND subscriber_type = 'node'
+	`, sourceRunID, sourceEventID); err != nil {
+		t.Fatalf("stamp source-only delivery identity: %v", err)
+	}
 	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
@@ -166,15 +175,32 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 		t.Fatalf("copied source event ids into fork run = %d, want 0", sourceCopiedEvents)
 	}
 
-	var forkReceipts, forkDeliveries int
+	var forkReceipts, targetNodeDeliveries, sourceNodeDeliveries int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, forkEventID).Scan(&forkReceipts); err != nil {
 		t.Fatalf("count fork receipts: %v", err)
 	}
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid AND event_id = $2::uuid`, result.Materialization.ForkRunID, forkEventID).Scan(&forkDeliveries); err != nil {
-		t.Fatalf("count fork deliveries: %v", err)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'test-node'
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&targetNodeDeliveries); err != nil {
+		t.Fatalf("count target node fork deliveries: %v", err)
 	}
-	if forkReceipts == 0 || forkDeliveries == 0 {
-		t.Fatalf("fork outcomes = receipts:%d deliveries:%d, want fork-local writes", forkReceipts, forkDeliveries)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = $1::uuid
+		  AND event_id = $2::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'source-only-node'
+	`, result.Materialization.ForkRunID, forkEventID).Scan(&sourceNodeDeliveries); err != nil {
+		t.Fatalf("count source node fork deliveries: %v", err)
+	}
+	if forkReceipts == 0 || targetNodeDeliveries != 1 || sourceNodeDeliveries != 0 {
+		t.Fatalf("fork outcomes = receipts:%d targetNodeDeliveries:%d sourceNodeDeliveries:%d, want target node only", forkReceipts, targetNodeDeliveries, sourceNodeDeliveries)
 	}
 
 	var emittedFollowUps int
@@ -1669,6 +1695,66 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan(t *tes
 	})
 	if err != nil {
 		t.Fatalf("Authorize canonical recipient plan: %v", err)
+	}
+}
+
+func TestSelectedContractRecipientPlanPublishGuardMaterializesTargetNodeDeliveryRoutes(t *testing.T) {
+	planning := store.RunForkSelectedContractRecipientPlanning{
+		Owner:                      store.RunForkSelectedContractRecipientPlanningOwner,
+		FutureExecutionOwner:       store.RunForkSelectedContractExecutionOwner,
+		NonMutating:                true,
+		RecipientPlanningSupported: true,
+		DeliveryWritesSupported:    false,
+		RecipientPlanEvents: []store.RunForkSelectedContractRecipientPlanEvent{{
+			SourceEventID: "source-event",
+			EventName:     "item.received",
+			Recipients: []store.RunForkContractFrontierRecipient{
+				{
+					SubscriberType: "agent",
+					SubscriberID:   "target-agent",
+					RouteSource:    "selected_contracts",
+				},
+				{
+					SubscriberType: "node",
+					SubscriberID:   "test-node",
+					RouteSource:    "selected_contracts",
+				},
+			},
+			Disposition: store.RunForkSelectedContractDispositionForkLocalTruth,
+		}},
+	}
+	guard, err := newSelectedContractRecipientPlanPublishGuard(planning)
+	if err != nil {
+		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
+	}
+	guard.ExpectForkEvent("fork-event", "source-event")
+
+	routes, err := guard.MaterializeNodeDeliveryRoutes(context.Background(), events.Event{
+		ID:          "fork-event",
+		Type:        "item.received",
+		SourceAgent: store.RunForkSelectedContractExecutionOwner,
+	}, bus.PublishRecipientPlan{
+		RoutedRecipients: []bus.PublishDiagnosticRecipient{
+			{
+				Type:        "agent",
+				ID:          "target-agent",
+				RouteSource: "selected_contracts",
+			},
+			{
+				Type:        "node",
+				ID:          "test-node",
+				RouteSource: "selected_contracts",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeNodeDeliveryRoutes: %v", err)
+	}
+	if len(routes) != 1 ||
+		routes[0].SubscriberType != "node" ||
+		routes[0].SubscriberID != "test-node" ||
+		!routes[0].Target.Empty() {
+		t.Fatalf("materialized routes = %#v, want target node route only", routes)
 	}
 }
 

--- a/internal/runtime/runforkexecution/recipient_planning.go
+++ b/internal/runtime/runforkexecution/recipient_planning.go
@@ -382,6 +382,23 @@ func (g *selectedContractRecipientPlanPublishGuard) Authorize(ctx context.Contex
 	return nil
 }
 
+func (g *selectedContractRecipientPlanPublishGuard) MaterializeNodeDeliveryRoutes(ctx context.Context, evt events.Event, actual runtimebus.PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !g.authorizesSourceAgent(evt.SourceAgent) {
+		return nil, nil
+	}
+	if err := g.Authorize(ctx, evt, actual); err != nil {
+		return nil, err
+	}
+	_, expected, err := g.expectedRecipientPlanEvent(evt)
+	if err != nil {
+		return nil, err
+	}
+	return selectedContractNodeDeliveryRoutes(expected.Recipients), nil
+}
+
 func (g *selectedContractRecipientPlanPublishGuard) authorizesSourceAgent(sourceAgent string) bool {
 	if g == nil {
 		return false
@@ -404,6 +421,31 @@ func (g *selectedContractRecipientPlanPublishGuard) expectedRecipientPlanEvent(e
 		return "", store.RunForkSelectedContractRecipientPlanEvent{}, fmt.Errorf("selected-contract publish event type mismatch for source event %s: got %q want %q", sourceEventID, evt.Type, expected.EventName)
 	}
 	return sourceEventID, expected, nil
+}
+
+func selectedContractNodeDeliveryRoutes(in []store.RunForkContractFrontierRecipient) []events.DeliveryRoute {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(in))
+	for _, recipient := range in {
+		if strings.TrimSpace(recipient.SubscriberType) != "node" {
+			continue
+		}
+		id := strings.TrimSpace(recipient.SubscriberID)
+		if id == "" {
+			continue
+		}
+		route := events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   id,
+		}
+		if path := strings.Trim(strings.TrimSpace(recipient.Path), "/"); path != "" {
+			route.Target.FlowInstance = path
+		}
+		out = append(out, route)
+	}
+	return events.NormalizeDeliveryRoutes(out)
 }
 
 func expectedRecipientKeys(in []store.RunForkContractFrontierRecipient) []string {

--- a/internal/runtime/runforkexecution/runtime_container.go
+++ b/internal/runtime/runforkexecution/runtime_container.go
@@ -146,6 +146,7 @@ func (c selectedContractForkLocalRuntimeContainer) Publish(ctx context.Context) 
 		ContractBundle:              req.LoadedSource.Source,
 		Logger:                      selectedContractRuntimeContainerLogger(req.Store),
 		RecipientPlanAdmissionGuard: guard.AuthorizeEvent,
+		RecipientPlanMaterializer:   guard.MaterializeNodeDeliveryRoutes,
 		RecipientPlanGuard:          guard.Authorize,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #1313.

Implements the approved first-slice class `selected_contract_fork_local_target_node_delivery_materialization`.

- Adds a guarded EventBus recipient-plan materializer hook that runs after normal planning and before recipient-plan authorization / delivery persistence.
- Wires only the selected-contract fork-local runtime container to materialize node `event_deliveries` routes from `runtime.run_fork.selected_contract_recipient_planning`.
- Strengthens selected-contract proofs to assert exact target node delivery identity and absence of copied source node identity.

## Governing refs / context

Exact governing spec sections exist and are binding:

- `platform-spec.yaml#engine.events.routing_derivation.delivery_rules`: system nodes are first-class routed delivery consumers.
- `platform-spec.yaml#engine.events.delivery_filter`: publish-time recipient construction persists the narrowed recipient list; downstream paths inherit that persisted list.
- `platform-spec.yaml#persistence_schema.run_fork_selected_contract_bindings`: selected-contract binding is prerequisite metadata only.
- `platform-spec.yaml#persistence_schema.run_fork_selected_contract_executions`: selected execution publishes fresh fork-local events; source events/deliveries/receipts are lineage only.
- `platform-spec.yaml#persistence_schema.run_fork_selected_contract_route_recoveries`: route recovery is evidence, not delivery replay or handler authority.
- `platform-spec.yaml#persistence_schema.event_deliveries`: one typed row per event x subscriber.
- `platform-spec.yaml#api_specification.method_catalog.run.fork`: selected `bundle_hash` executes against the selected target BundleContext.

## Semantic owner notes

Canonical owner after this PR:

- Expected recipient plan: `runtime.run_fork.selected_contract_recipient_planning` remains non-mutating and `DeliveryWritesSupported=false`.
- Live selected-fork target node delivery materialization: `runtime.run_fork.selected_contract_execution.fork_local_runtime_container`.
- Physical delivery row sink: `internal/runtime/bus.EventBus.Publish` / store `event_deliveries` writers.

Old invalid paths remain invalid:

- Source `event_deliveries` are not copied into the fork run.
- Public API target selection, route recovery evidence, receipts, and settlement do not own selected target node delivery authority.
- Generic delivery planning remains a downstream guarded sink, not the selected-contract canonical owner.

Migration completeness: this is not a schema/data migration. It completes the approved live selected-contract fork-local target node materialization child; parent #1293 and siblings #1294/#1295/#1296/#1299/#1301/#1300/#1255 remain split as approved.

## Proof

- `go test ./internal/runtime/bus -run TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors -count=1`
- `go test ./internal/runtime/runforkexecution -run 'TestSelectedContractRecipientPlanPublishGuardMaterializesTargetNodeDeliveryRoutes|TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage' -count=1`
- `go test ./cmd/swarm -run TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/runforkexecution`
- `go test ./...`