### PR TITLE
[agent-a][issue #1314] Admit Tier5 create-flow fixtures

### DIFF
--- a/internal/runtime/cataloge2e/assertions_harness_test.go
+++ b/internal/runtime/cataloge2e/assertions_harness_test.go
@@ -762,18 +762,17 @@ func assertFlowInstanceCreated(t testing.TB, db *sql.DB, since time.Time, want m
 		return
 	}
 	instancePath := strings.Trim(strings.TrimSpace(templateID+"/"+instanceID), "/")
-	var routeCount int
+	var instanceCount int
 	if err := db.QueryRowContext(context.Background(), `
 		SELECT COUNT(*)
-		FROM routing_rules
-		WHERE flow_instance = $1
-		  AND is_materialized = true
-		  AND status = 'active'
-	`, instancePath).Scan(&routeCount); err != nil {
-		t.Fatalf("query flow instance routes: %v", err)
+		FROM flow_instances
+		WHERE instance_id = $1
+		  AND created_at >= $2
+	`, instancePath, since).Scan(&instanceCount); err != nil {
+		t.Fatalf("query flow instance row: %v", err)
 	}
-	if routeCount == 0 {
-		t.Fatalf("expected flow instance to be created")
+	if instanceCount != 1 {
+		t.Fatalf("flow instance %q count = %d, want 1", instancePath, instanceCount)
 	}
 	if config, ok := want["config"].(map[string]any); ok && len(config) > 0 {
 		var raw []byte
@@ -825,8 +824,8 @@ func assertFlowInstanceCreated(t testing.TB, db *sql.DB, since time.Time, want m
 		`, autoEmitted).Scan(&count); err != nil {
 			t.Fatalf("query flow auto-emitted event: %v", err)
 		}
-		if count == 0 {
-			t.Fatalf("expected auto-emitted event %q for flow instance", autoEmitted)
+		if count != 1 {
+			t.Fatalf("auto-emitted event %q count = %d, want 1", autoEmitted, count)
 		}
 	}
 }

--- a/internal/runtime/cataloge2e/assertions_harness_test.go
+++ b/internal/runtime/cataloge2e/assertions_harness_test.go
@@ -850,6 +850,51 @@ func assertHandlerOutcome(t testing.TB, h *runtimeHarness, want, entityID string
 	assertHandlerOutcomeForEntity(t, h, want, entityID, chainDepthExceeded)
 }
 
+func (h *runtimeHarness) assertTriggerReceipt(step catalogTriggerStep) {
+	wantOutcome := strings.TrimSpace(strings.ToLower(step.ReceiptOutcome))
+	wantError := strings.TrimSpace(step.ReceiptErrorContains)
+	if wantOutcome == "" && wantError == "" {
+		return
+	}
+	h.t.Helper()
+	if h == nil || h.db == nil {
+		h.t.Fatal("database is required for trigger receipt assertions")
+	}
+	eventIDs := h.publishedEventIDs(triggerPayloadEntityID(step.Payload))
+	for _, eventID := range eventIDs {
+		var subscriberID, outcome, sideEffects string
+		err := h.db.QueryRowContext(context.Background(), `
+			SELECT subscriber_id, outcome, COALESCE(side_effects::text, '')
+			FROM event_receipts
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'platform'
+			  AND (
+				subscriber_id = 'pipeline'
+				OR subscriber_id LIKE 'pipeline:%'
+			  )
+			ORDER BY processed_at DESC
+			LIMIT 1
+		`, strings.TrimSpace(eventID)).Scan(&subscriberID, &outcome, &sideEffects)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			h.t.Fatalf("query trigger receipt for event %s: %v", eventID, err)
+		}
+		if wantOutcome != "" {
+			gotOutcome := strings.TrimSpace(strings.ToLower(outcome))
+			if gotOutcome != wantOutcome {
+				h.t.Fatalf("trigger receipt outcome for %s/%s = %q, want %q", eventID, subscriberID, gotOutcome, wantOutcome)
+			}
+		}
+		if wantError != "" && !strings.Contains(sideEffects, wantError) {
+			h.t.Fatalf("trigger receipt side_effects for %s/%s = %s, want error containing %q", eventID, subscriberID, sideEffects, wantError)
+		}
+		return
+	}
+	h.t.Fatalf("trigger receipt %q could not be asserted: no platform pipeline receipt found", wantOutcome)
+}
+
 func assertHandlerOutcomeForEntity(t testing.TB, h *runtimeHarness, want, entityID string, chainDepthExceeded bool) {
 	t.Helper()
 	if h == nil || h.db == nil {

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -34,6 +34,8 @@ type catalogTriggerStep struct {
 	Payload                       map[string]any `yaml:"payload"`
 	AssertPersistedBeforeDelivery bool           `yaml:"assert_persisted_before_delivery"`
 	ErrorContains                 string         `yaml:"error_contains"`
+	ReceiptOutcome                string         `yaml:"receipt_outcome"`
+	ReceiptErrorContains          string         `yaml:"receipt_error_contains"`
 }
 
 type catalogExpectedDocument struct {
@@ -276,6 +278,7 @@ func (h *runtimeHarness) publishAndWait(step catalogTriggerStep, timeout time.Du
 		return
 	}
 	h.publishRuntimeEvent(eventType, "cataloge2e", payload, timeout, true, true)
+	h.assertTriggerReceipt(step)
 	if eventType == "flow.created" {
 		if autoEmit := h.rootAutoEmitOnCreateEvent(); autoEmit != "" {
 			h.publishRuntimeEvent(autoEmit, "flow-instance-activator", payload, timeout, true, false)

--- a/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
@@ -28,8 +28,7 @@ var tier5LifecycleFixtures = []string{
 	"test-wildcard-subscription",
 }
 
-var tier5ExcludedFixtures = map[string]catalogExcludedFixture{
-}
+var tier5ExcludedFixtures = map[string]catalogExcludedFixture{}
 
 func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)

--- a/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
@@ -15,6 +15,9 @@ type catalogExcludedFixture struct {
 
 var tier5LifecycleFixtures = []string{
 	"test-auto-emit-on-create",
+	"test-create-flow-instance",
+	"test-create-flow-instance-config",
+	"test-create-flow-instance-duplicate",
 	"test-template-no-boot-instance",
 	"test-terminal-state-preserves",
 	"test-terminal-state-rejects",
@@ -26,9 +29,6 @@ var tier5LifecycleFixtures = []string{
 }
 
 var tier5ExcludedFixtures = map[string]catalogExcludedFixture{
-	"test-create-flow-instance":           {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
-	"test-create-flow-instance-config":    {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
-	"test-create-flow-instance-duplicate": {reason: "legacy create_flow_instance action shape now rejected; fixture migration belongs to #416"},
 }
 
 func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
@@ -39,7 +39,12 @@ func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			startRuntime := fixtureName == "test-auto-emit-on-create" || fixtureName == "test-timer-fire" || fixtureName == "test-timer-recurring"
+			startRuntime := fixtureName == "test-auto-emit-on-create" ||
+				fixtureName == "test-create-flow-instance" ||
+				fixtureName == "test-create-flow-instance-config" ||
+				fixtureName == "test-create-flow-instance-duplicate" ||
+				fixtureName == "test-timer-fire" ||
+				fixtureName == "test-timer-recurring"
 			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
 			h.seedEntityFields(expected)
 			if expected.Trigger.Boot || strings.TrimSpace(expected.Expected.BootResult) != "" {

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -25,10 +25,12 @@ import (
 )
 
 type catalogTriggerStep struct {
-	Event         string         `yaml:"event"`
-	Payload       map[string]any `yaml:"payload"`
-	Sender        string         `yaml:"sender"`
-	ErrorContains string         `yaml:"error_contains"`
+	Event                string         `yaml:"event"`
+	Payload              map[string]any `yaml:"payload"`
+	Sender               string         `yaml:"sender"`
+	ErrorContains        string         `yaml:"error_contains"`
+	ReceiptOutcome       string         `yaml:"receipt_outcome"`
+	ReceiptErrorContains string         `yaml:"receipt_error_contains"`
 }
 
 type catalogExpectedDocument struct {

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/expected.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/expected.yaml
@@ -12,3 +12,10 @@ expected:
   entity_state: spawned
   emitted_events:
     - flow.spawned
+  flow_instance_created:
+    template: worker-flow
+    instance_id: worker-cfg-001
+    config:
+      max_retries: 3
+      timeout_ms: 5000
+    auto_emitted: worker-flow/worker-cfg-001/worker.ready

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/events.yaml
@@ -1,2 +1,3 @@
 worker.ready:
-  entity_id: string
+  max_retries: integer
+  timeout_ms: integer

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/nodes.yaml
@@ -1,1 +1,7 @@
-{}
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [worker.ready]
+  event_handlers:
+    worker.ready:
+      advances_to: complete

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/expected.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/expected.yaml
@@ -8,6 +8,8 @@ trigger:
       payload:
         entity_id: 22222222-2222-4222-8222-222222222222
         instance_id: worker-dup
+      receipt_outcome: dead_letter
+      receipt_error_contains: "flow instance already exists: worker-flow/worker-dup"
 
 expected:
   handler_outcome: success

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/expected.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/expected.yaml
@@ -14,3 +14,9 @@ expected:
   entity_state: spawned
   emitted_events:
     - flow.spawned
+  flow_instance_created:
+    template: worker-flow
+    instance_id: worker-dup
+    config:
+      entity_id: 11111111-1111-4111-8111-111111111111
+    auto_emitted: worker-flow/worker-dup/worker.ready

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/nodes.yaml
@@ -1,1 +1,7 @@
-{}
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [worker.ready]
+  event_handlers:
+    worker.ready:
+      advances_to: complete

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/nodes.yaml
@@ -8,6 +8,8 @@ test-node:
       action: create_flow_instance
       template: worker-flow
       instance_id_from: payload.instance_id
+      config_from:
+        entity_id: payload.entity_id
       emit:
         event: flow.spawned
         broadcast: true

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/expected.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/expected.yaml
@@ -9,3 +9,9 @@ expected:
   entity_state: spawned
   emitted_events:
     - flow.spawned
+  flow_instance_created:
+    template: worker-flow
+    instance_id: worker-001
+    config:
+      entity_id: 11111111-1111-4111-8111-111111111111
+    auto_emitted: worker-flow/worker-001/worker.ready

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/nodes.yaml
@@ -1,1 +1,7 @@
-{}
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [worker.ready]
+  event_handlers:
+    worker.ready:
+      advances_to: complete

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/nodes.yaml
@@ -8,6 +8,8 @@ test-node:
       action: create_flow_instance
       template: worker-flow
       instance_id_from: payload.instance_id
+      config_from:
+        entity_id: payload.entity_id
       emit:
         event: flow.spawned
         broadcast: true


### PR DESCRIPTION
Closes #1314

## Governing Context
- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1314#issuecomment-4618501913
- Independent gate: https://github.com/division-sh/swarm/issues/1314#issuecomment-4618513193
- Binding spec/context: `platform-spec.yaml` `create_flow_instance` required fields, dynamic lifecycle creation, `config_from_payload_alignment`, and `auto_emit_on_create_surface`.

## Scope
- Admits all three Tier5 `create_flow_instance` fixtures together: base, config, and duplicate.
- Migrates base and duplicate fixtures to non-empty `config_from`.
- Aligns config fixture auto-emitted event schema with resolved `config_from` business payload only.
- Removes stale closed-#416 Tier5 exclusion accounting.
- Tightens catalog proof to assert one persisted `flow_instances` row and one auto-emitted event for the exact created instance.

## Semantic Migration
- New canonical owner: current `platform-spec.yaml` plus boot/runtime validation for `create_flow_instance` and auto-emit payload authority.
- Old invalid path: closed-#416 Tier5 exclusion entries, missing `config_from` fixture authoring, hidden lifecycle payload synthesis assumptions, and route-row-only `flow_instance_created` proof.
- Production paths checked: Tier5 catalog real-runtime admission, boot/runtime fixture execution, persisted flow instance rows, auto-emitted event rows, and sibling Tier9/Tier11 `flow_instance_created` fixture assertions.
- Migration complete for the approved #1314 child. Tier4/Tier11 stale #416 entries and #1304 remain split per gate.

## Proof
- `go test ./internal/runtime/cataloge2e -run 'TestTier5LifecycleCatalogFixtures_RealRuntime/(test-create-flow-instance|test-create-flow-instance-config|test-create-flow-instance-duplicate)$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier5LifecycleCatalogFixtures_(AreExplicitlyClassified|RealRuntime)$' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier(9|11)' -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./internal/runtime/swarmflowtest -run 'TestCatalogFixtures_UseCanonicalCreateFlowInstanceAuthoring|TestValidateCatalogExpectedDocument' -count=1`
- `git diff --check`

## Full Suite Status
- Ran `go test ./... -count=1`.
- It failed only in `internal/store` on `TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction` and `TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist` with `event bus does not support derived flow-instance routing ...`.
- This PR has no `internal/store` diff; the focused failing package rerun reproduces the same failures outside the approved #1314 boundary.
