### PR TITLE
[agent-g][issue #1320] Canonicalize SQLite route fixture

### DIFF
--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -329,6 +329,12 @@ func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *test
 	}
 	assertSQLiteActivatedAgentIDs(t, agents, "reviewer-inst-1")
 	assertSQLiteAddedRoutes(t, bus, "review/inst-1")
+	assertSQLiteRouteMaterializationVars(t, bus, "review/inst-1", map[string]string{
+		"flow_instance_path": "review/inst-1",
+		"flow_scope_key":     "review",
+		"instance_id":        "inst-1",
+		"template_id":        "review",
+	})
 }
 
 func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T) {
@@ -381,16 +387,28 @@ func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T
 	}
 	assertSQLiteActivatedAgentIDs(t, agents, "reviewer-component-a", "reviewer-component-b")
 	assertSQLiteAddedRoutes(t, bus, "review/component-a", "review/component-b")
+	assertSQLiteRouteMaterializationVars(t, bus, "review/component-a", map[string]string{
+		"flow_instance_path": "review/component-a",
+		"flow_scope_key":     "review",
+		"instance_id":        "component-a",
+		"template_id":        "review",
+	})
+	assertSQLiteRouteMaterializationVars(t, bus, "review/component-b", map[string]string{
+		"flow_instance_path": "review/component-b",
+		"flow_scope_key":     "review",
+		"instance_id":        "component-b",
+		"template_id":        "review",
+	})
 	if logs := bus.runtimeLogEntries(); len(logs) != 0 {
 		t.Fatalf("runtime logs = %#v, want no activation dead-letter/runtime errors", logs)
 	}
 }
 
 type sqliteFlowActivationBus struct {
-	mu          sync.Mutex
-	runtimeLog  []runtimepipeline.RuntimeLogEntry
-	addedRoutes []string
-	published   []events.Event
+	mu            sync.Mutex
+	runtimeLog    []runtimepipeline.RuntimeLogEntry
+	routeRequests []runtimebus.FlowInstanceRouteMaterializationRequest
+	published     []events.Event
 }
 
 func (b *sqliteFlowActivationBus) Publish(_ context.Context, evt events.Event) error {
@@ -425,10 +443,10 @@ func (b *sqliteFlowActivationBus) LogRuntime(_ context.Context, entry runtimepip
 	return nil
 }
 
-func (b *sqliteFlowActivationBus) AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route) error {
+func (b *sqliteFlowActivationBus) AddFlowInstanceRoute(req runtimebus.FlowInstanceRouteMaterializationRequest) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.addedRoutes = append(b.addedRoutes, strings.TrimSpace(identity.InstancePath))
+	b.routeRequests = append(b.routeRequests, req.Normalized())
 	return nil
 }
 
@@ -443,8 +461,18 @@ func (b *sqliteFlowActivationBus) runtimeLogEntries() []runtimepipeline.RuntimeL
 func (b *sqliteFlowActivationBus) routePaths() []string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	out := make([]string, len(b.addedRoutes))
-	copy(out, b.addedRoutes)
+	out := make([]string, 0, len(b.routeRequests))
+	for _, req := range b.routeRequests {
+		out = append(out, strings.TrimSpace(req.Identity.InstancePath))
+	}
+	return out
+}
+
+func (b *sqliteFlowActivationBus) materializationRequests() []runtimebus.FlowInstanceRouteMaterializationRequest {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]runtimebus.FlowInstanceRouteMaterializationRequest, len(b.routeRequests))
+	copy(out, b.routeRequests)
 	return out
 }
 
@@ -521,6 +549,22 @@ func assertSQLiteAddedRoutes(t *testing.T, bus *sqliteFlowActivationBus, wantPat
 			t.Fatalf("added route paths = %#v, missing %q", got, want)
 		}
 	}
+}
+
+func assertSQLiteRouteMaterializationVars(t *testing.T, bus *sqliteFlowActivationBus, wantPath string, wantVars map[string]string) {
+	t.Helper()
+	for _, req := range bus.materializationRequests() {
+		if strings.TrimSpace(req.Identity.InstancePath) != wantPath {
+			continue
+		}
+		for key, want := range wantVars {
+			if got := strings.TrimSpace(req.ActivationVariables[key]); got != want {
+				t.Fatalf("route materialization vars for %s key %s = %q, want %q; all vars=%#v", wantPath, key, got, want, req.ActivationVariables)
+			}
+		}
+		return
+	}
+	t.Fatalf("route materialization request for %s not found; got %#v", wantPath, bus.materializationRequests())
 }
 
 func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1320.

This PR updates the `internal/store` SQLite dynamic flow activation proof fixture to consume the canonical dynamic flow route-materialization owner, `runtimebus.FlowInstanceRouteMaterializationRequest`, instead of the obsolete local two-argument `AddFlowInstanceRoute(SystemNodeContract, Route)` helper shape.

The focused failing tests now reach the SQLite activation assertions and additionally verify the route materialization request carries the spec-required activation built-ins for each dynamic flow instance.

## Governing Refs / Context

Exact governing spec refs:

- `platform-spec.yaml` route model target resolution: template/dynamic-instance routing requires explicit publish-time target resolution or structural `ParentRoute`, and must fail closed for missing/ambiguous targets.
- `platform-spec.yaml` `runtime_composition.dynamic_instance_lifecycle.creation.process`: `create_flow_instance` registers runtime nodes/agents/events, expands subscriptions, records parent route, and creates entity state.
- `platform-spec.yaml` `runtime_composition.dynamic_instance_lifecycle.creation.route_materialization.subscriber_identity_variables`: route subscribers must render from the same activation variable set used to materialize child agents, including `instance_id`, `template_id`, `flow_scope_key`, and `flow_instance_path`.
- `platform-spec.yaml` `runtime_composition.dynamic_instance_lifecycle.creation.route_materialization.persisted_truth`: rendered materialized route truth is authoritative; consumers must not independently reinterpret authored templates.
- `platform-spec.yaml` store schema `routing_rules.lifecycle.create_flow_instance`: wildcard subscriptions expand into concrete materialized rows using the dynamic instance activation variable set.

Binding issue context:

- #1320 issue body and focused repro.
- #1320 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1320#issuecomment-4622722100
- #1320 independent gate approval: https://github.com/division-sh/swarm/issues/1320#issuecomment-4622772350

## Semantic Migration

New canonical owner:

- `internal/runtime/bus.FlowInstanceRouteMaterializationRequest`
- consumed by `internal/runtime/manager.AgentManager.ActivateFlowInstance` through `AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest)`.

Old path now invalid:

- `internal/store/sqlite_runtime_test.go` `sqliteFlowActivationBus.AddFlowInstanceRoute(_ runtimecontracts.SystemNodeContract, identity runtimeflowidentity.Route)`.

Production paths checked for surviving old behavior:

- `git grep -n 'AddFlowInstanceRoute' -- internal` shows production and test consumers use `FlowInstanceRouteMaterializationRequest`; no old internal two-argument consumer remains.

Migration complete:

- Yes, for the approved #1320 chosen class. The only same-concept stale consumer found by pre-audit and implementation grep was the SQLite store proof fixture, and it is now canonicalized.

## Proof

Focused repeated repro:

```text
go test ./internal/store -run 'TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction|TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist' -count=20
ok   github.com/division-sh/swarm/internal/store 1.673s
```

Store package proof:

```text
go test ./internal/store
ok   github.com/division-sh/swarm/internal/store 23.082s
```

Adjacent manager route-materialization owner proof:

```text
go test ./internal/runtime/manager -run 'TestActivateFlowInstance(PassesActivationConfigToRouteMaterialization|UsesSameBuiltinsForAgentAndRouteMaterialization|AddsDerivedRouteTableInstance)' -count=1
ok   github.com/division-sh/swarm/internal/runtime/manager 0.332s
```

Adjacent bus route-materialization owner proof:

```text
go test ./internal/runtime/bus -run 'Test(EventBus|RouteTable).*FlowInstance|TestEventBusAddFlowInstanceRouteRollsBackPersistedRouteOnActiveInstallFailure' -count=1
ok   github.com/division-sh/swarm/internal/runtime/bus 0.404s
```

Stale owner proof:

```text
git grep -n 'AddFlowInstanceRoute' -- internal
```

Result: no internal old-signature `AddFlowInstanceRoute(SystemNodeContract, Route)` consumer remains; `internal/store/sqlite_runtime_test.go` now uses `AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest)`.

Full suite:

```text
go test ./...
ok   github.com/division-sh/swarm/cmd/swarm 28.820s
ok   github.com/division-sh/swarm/internal/store (cached)
...
ok   github.com/division-sh/swarm/internal/testutil 2.933s
```

Full command exited successfully.
