### PR TITLE
[agent-b][issue #1257] Normalize verify analyzer output

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1164,11 +1164,11 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 			Warnings:     verifyFindingOutputs(result.BootReport.Warnings()),
 			LintEvidence: verifyFindingOutputs(result.BootReport.LintEvidence()),
 		}
-		if err := renderCLIOutput(out, errOut, opts.output, output, func(w io.Writer) {
-			writeVerifyFindings(w, "warning", result.BootReport.Warnings())
-			writeVerifyFindings(w, "lint_evidence", result.BootReport.LintEvidence())
-			if w != nil {
-				fmt.Fprintf(w, "verify ok: contracts=%s\n", contractsRoot)
+		if err := renderCLIOutput(out, errOut, opts.output, output, func(_ io.Writer) {
+			writeVerifyFindings(errOut, result.BootReport.Warnings(), false)
+			writeVerifyFindings(errOut, result.BootReport.LintEvidence(), false)
+			if out != nil {
+				fmt.Fprintf(out, "verify ok: contracts=%s\n", contractsRoot)
 			}
 		}, func() ([]string, error) {
 			return []string{"ok"}, nil
@@ -2046,12 +2046,12 @@ func verifyWorkflowContractValidationOptions(repo string) (runtime.WorkflowContr
 	return opts, nil
 }
 
-func writeVerifyFindings(out io.Writer, label string, findings []runtimebootverify.Finding) {
+func writeVerifyFindings(out io.Writer, findings []runtimebootverify.Finding, blocking bool) {
 	if out == nil || len(findings) == 0 {
 		return
 	}
 	for _, finding := range findings {
-		fmt.Fprintf(out, "%s: %s [%s] %s\n", strings.TrimSpace(label), strings.TrimSpace(finding.CheckID), strings.TrimSpace(finding.Location), strings.TrimSpace(finding.Message))
+		fmt.Fprintln(out, runtimebootverify.FormatSurfaceFinding(finding, blocking))
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6404,9 +6404,13 @@ func TestLoadDotEnvFileRejectsMalformedLine(t *testing.T) {
 }
 
 func runVerifyCommandWithContractsForTest(ctx context.Context, repo, contractsPath string, out *bytes.Buffer) int {
+	return runVerifyCommandWithContractsOutputForTest(ctx, repo, contractsPath, out, out)
+}
+
+func runVerifyCommandWithContractsOutputForTest(ctx context.Context, repo, contractsPath string, out, errOut *bytes.Buffer) int {
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = contractsPath
-	return runVerifyCommand(ctx, repo, opts, out)
+	return runVerifyCommandWithOutput(ctx, repo, opts, out, errOut)
 }
 
 func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
@@ -6522,17 +6526,71 @@ reader:
       advances_to: done
 `)
 
-	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
+		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
 	}
-	out := buf.String()
-	if !strings.Contains(out, "lint_evidence: entity_reader_coverage [root] flow root entity_type case declares field untouched with no detected internal reader coverage") {
-		t.Fatalf("verify output missing lint evidence:\n%s", out)
+	if out := stdout.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify stdout missing success marker:\n%s", out)
+	} else if strings.Contains(out, "entity_reader_coverage") || strings.Contains(out, "lint_evidence") {
+		t.Fatalf("verify stdout contains advisory diagnostics:\n%s", out)
 	}
-	if !strings.Contains(out, "verify ok: contracts=") {
-		t.Fatalf("verify output missing success marker:\n%s", out)
+	errText := stderr.String()
+	if !strings.Contains(errText, "INFO: entity_reader_coverage [root] flow root entity_type case declares field untouched with no detected internal reader coverage") {
+		t.Fatalf("verify stderr missing lint evidence:\n%s", errText)
+	}
+	if strings.Contains(errText, "lint_evidence:") {
+		t.Fatalf("verify stderr used legacy lint_evidence prefix:\n%s", errText)
+	}
+
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.output.asJSON = true
+	stdout.Reset()
+	stderr.Reset()
+	code = runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand --json exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
+	}
+	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if len(verifyJSON.LintEvidence) == 0 || verifyJSON.LintEvidence[0].Severity != "lint_evidence" {
+		t.Fatalf("verify --json lint evidence = %#v, want canonical severity", verifyJSON.LintEvidence)
+	}
+}
+
+func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(
+		context.Background(),
+		repoRoot(),
+		filepath.Join(repoRoot(), "tests", "tier8-boot-verification", "test-boot-missing-pin"),
+		&stdout,
+		&stderr,
+	)
+	if code == 0 {
+		t.Fatalf("runVerifyCommand exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty for blocking analyzer failure", stdout.String())
+	}
+	errText := stderr.String()
+	for _, want := range []string{
+		"verify failed: boot verification blocked by policy-escalated findings:",
+		"ERROR: input_pin_wiring",
+		"no producer path was found in the authored bundle",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
+		}
+	}
+	if strings.Contains(errText, "boot verification warnings:") {
+		t.Fatalf("verify stderr used legacy fatal warning banner:\n%s", errText)
 	}
 }
 
@@ -8065,6 +8123,23 @@ const (
 	serveRuntimeReadyTimeout = 30 * time.Second
 	serveRuntimeStopTimeout  = 5 * time.Second
 )
+
+func waitForServeReadyLine(t *testing.T, out *lockedBuffer, _ <-chan int) {
+	t.Helper()
+	deadline := time.After(serveRuntimeReadyTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for serve ready line\noutput:\n%s", out.String())
+		case <-ticker.C:
+			if strings.Contains(out.String(), "[22/22]") {
+				return
+			}
+		}
+	}
+}
 
 type serveRuntimeTestProcess struct {
 	t      *testing.T

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6790,17 +6790,23 @@ closer:
 Use save_entity_field for `+"`business_brief`"+`.
 `)
 
-	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code == 0 {
-		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
+		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
 	}
-	out := buf.String()
-	if !strings.Contains(out, "entity_writer_coverage") {
-		t.Fatalf("verify output missing entity_writer_coverage:\n%s", out)
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty for hard invalidity", stdout.String())
 	}
-	if !strings.Contains(out, "business_brief") {
-		t.Fatalf("verify output missing offending field:\n%s", out)
+	errText := stderr.String()
+	for _, want := range []string{
+		"verify failed: boot verification failed:",
+		"ERROR: entity_writer_coverage",
+		"business_brief",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
+		}
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -27,6 +27,12 @@ const (
 	legacySeverityWarning     = "warning"
 )
 
+const (
+	FindingSurfaceLevelError = "ERROR"
+	FindingSurfaceLevelWarn  = "WARN"
+	FindingSurfaceLevelInfo  = "INFO"
+)
+
 type Report struct {
 	Findings []Finding
 }
@@ -183,6 +189,35 @@ func severityRank(severity string) int {
 	default:
 		return 4
 	}
+}
+
+func FindingSurfaceLevel(f Finding, blocking bool) string {
+	return SurfaceLevelForSeverity(f.Severity, blocking)
+}
+
+func SurfaceLevelForSeverity(severity string, blocking bool) string {
+	if blocking {
+		return FindingSurfaceLevelError
+	}
+	switch normalizeFindingSeverity(severity) {
+	case SeverityHardInvalidity:
+		return FindingSurfaceLevelError
+	case SeveritySemanticDriftWarn:
+		return FindingSurfaceLevelWarn
+	case SeverityAuditAnalysis, SeverityLintEvidence:
+		return FindingSurfaceLevelInfo
+	default:
+		return FindingSurfaceLevelError
+	}
+}
+
+func FormatSurfaceFinding(f Finding, blocking bool) string {
+	return fmt.Sprintf("%s: %s [%s] %s",
+		FindingSurfaceLevel(f, blocking),
+		strings.TrimSpace(f.CheckID),
+		strings.TrimSpace(f.Location),
+		strings.TrimSpace(f.Message),
+	)
 }
 
 func locationFromMessage(message string) string {

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -60,12 +60,12 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 		ModelAliases:            opts.ModelAliases,
 	})
 	if result.BootReport.HasErrors() {
-		return result, fmt.Errorf("boot verification failed:\n%s", formatWorkflowValidationFindings(result.BootReport.Errors()))
+		return result, fmt.Errorf("boot verification failed:\n%s", formatWorkflowValidationFindings(result.BootReport.Errors(), true))
 	}
 	if opts.FatalBootWarnings {
 		warnings := filterWorkflowValidationFindings(result.BootReport.Warnings(), opts.ExcludedFatalBootWarningChecks...)
 		if len(warnings) > 0 {
-			return result, fmt.Errorf("boot verification warnings:\n%s", formatWorkflowValidationFindings(warnings))
+			return result, fmt.Errorf("boot verification blocked by policy-escalated findings:\n%s", formatWorkflowValidationFindings(warnings, true))
 		}
 	}
 
@@ -99,10 +99,10 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	return result, nil
 }
 
-func formatWorkflowValidationFindings(findings []runtimebootverify.Finding) string {
+func formatWorkflowValidationFindings(findings []runtimebootverify.Finding, blocking bool) string {
 	lines := make([]string, 0, len(findings))
 	for _, finding := range findings {
-		lines = append(lines, fmt.Sprintf("%s [%s] %s", strings.TrimSpace(finding.CheckID), strings.TrimSpace(finding.Location), strings.TrimSpace(finding.Message)))
+		lines = append(lines, runtimebootverify.FormatSurfaceFinding(finding, blocking))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3463,11 +3463,29 @@ engine:
       when: boot-only
     severity_behavior:
       error: Boot aborts. System does not start.
-      warning: Boot continues. Warning logged with finding details.
+      warning: Canonical warning-level analyzer severity. Boot continues and logs finding details unless an explicitly
+        configured strict startup/verify policy escalates warning-level findings to blocking surface failures.
       hard_invalidity: Boot aborts. Deterministic Wave 1 contract drift is treated as error-level invalidity.
-      semantic_drift_warning: Boot continues. Warning logged with finding details and explicit check ID.
+      semantic_drift_warning: Canonical warning-level semantic drift finding. Boot continues and logs finding details and
+        explicit check ID unless an explicitly configured strict startup/verify policy escalates warning-level findings to
+        blocking surface failures.
       audit_analysis: Not surfaced on normal boot. Available on dedicated audit surfaces.
       lint_evidence: Informational only. Available on detailed lint/audit surfaces.
+    surface_fatality:
+      description: Analyzer finding severity and supported-surface fatality are separate concepts. A finding keeps its
+        canonical severity for JSON/scriptable consumers even when a strict policy makes the current surface block.
+      strict_warning_escalation: When strict startup or verify warning escalation is enabled, warning-level analyzer findings
+        may block startup or `swarm verify`. Human-readable output must render those findings as blocking/error-level surface
+        failures, not as non-fatal warnings.
+      text_rendering:
+        error_or_blocking: Human text lines for hard invalidities, errors, and policy-escalated warning findings use an
+          `ERROR:` prefix.
+        non_blocking_warning: Human text lines for non-blocking warning-level findings use a `WARN:` prefix.
+        informational: Human text lines for audit/informational lint evidence use an `INFO:` prefix.
+      stream_contract:
+        stdout: Successful load-bearing command result only, such as `verify ok` for human output, the single JSON document
+          for `--json`, or `ok` for `--quiet`.
+        stderr: Human-readable analyzer diagnostics, advisory lint evidence, warnings, and blocking failures.
     check_count: 43 primary checks plus 3 supplemental checks
     implementation_notes:
       framework: Each check is a named function that receives the loaded contract bundle and returns a list of findings. Each
@@ -8481,6 +8499,9 @@ cli_specification:
             verify:
               fact_owner: local contract verification
               json_shape: object with ok, contracts, warnings, and lint_evidence
+              human_text_streams:
+                stdout: "successful load-bearing `verify ok: contracts=...` result only"
+                stderr: "analyzer diagnostics and advisory findings, rendered with the boot verification surface severity prefixes `ERROR:`, `WARN:`, or `INFO:`"
               quiet_values:
               - ok
             health:


### PR DESCRIPTION
Part of #1257

## Summary

This closes the approved F-008 first slice for `cli.verify_analyzer_finding_severity_and_stream_contract`:

- separates analyzer finding severity from verify/startup surface fatality in `platform-spec.yaml`
- renders verify analyzer lines with `ERROR:`, `WARN:`, or `INFO:` from the bootverify finding owner
- moves human-mode verify diagnostics/advisory lint evidence to stderr while keeping `verify ok` on stdout
- preserves `swarm verify --json` as one stdout document with canonical finding `severity`
- preserves `swarm verify --quiet` as success-only `ok` on stdout

## Governing refs / context

Exact governing refs:

- `platform-spec.yaml` `boot_verification.severity_behavior`
- `platform-spec.yaml` `boot_verification.surface_fatality`
- `platform-spec.yaml` `static_analyzer.authority_levels`
- `platform-spec.yaml` CLI v2 shared output-mode contract for `verify`
- #1257 F-008 pre-audit and gate: strict warning escalation remains, but severity and surface fatality must be modeled separately

## Semantic migration

New canonical owner:

- Finding severity remains `internal/runtime/bootverify/report.go` (`Finding.Severity`, normalized severity groups).
- Surface text severity/fatality rendering is now centralized on the bootverify finding owner via `FormatSurfaceFinding` / `SurfaceLevelForSeverity`.
- `platform-spec.yaml` is updated as the merge-bearing authority for severity vs surface blocking/fatality.

Old non-authoritative path now invalid:

- `cmd/swarm/main.go` local string labels `warning:` / `lint_evidence:` are no longer the text rendering authority.
- `internal/runtime/workflow_validation.go` no longer emits fatal policy-escalated warning failures under the misleading `boot verification warnings:` banner.
- Human-mode advisory lint evidence no longer shares stdout with the successful `verify ok` result.

Production paths checked:

- `swarm verify` human text path
- `swarm verify --json`
- `swarm verify --quiet`
- runtime validation fatal formatting through `ValidateWorkflowContractSurface`
- bootverify finding severity grouping
- `serve` boot logging kept out of scope for F-024

Migration completeness:

- Complete for F-008 / `swarm verify` analyzer severity and stream discipline.
- #1257 remains open for F-015 typed entity table projection and F-024 boot log verbosity.

## Proof

Focused supported-surface proof:

- `go test ./cmd/swarm -run 'TestRunVerifyCommand|TestCLIOutputModesForLocalConsumers' -count=1`
- `go test ./internal/runtime -run 'WorkflowContractValidation|ValidateWorkflowContractSurface' -count=1`
- `go test ./internal/runtime/bootverify -count=1`

Full proof:

- `go test ./...`
