### PR TITLE
[agent-h][issue #1322] Gate schema inventory detail behind verbose

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -84,7 +84,9 @@ func newRuntimeProjectSupervisor(
 		validateSource: func(ctx context.Context, source semanticview.Source) error {
 			return verifyBundle(ctx, source)
 		},
-		initStateStores: initializeStateStores,
+		initStateStores: func(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
+			return initializeStateStores(ctx, stores, bundle, false)
+		},
 		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
 			return configuredWorkspaceLifecycleForBackend(stores.SQLDB, contractsRoot, source, mountSources, workspaceBackend)
 		},

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -510,7 +510,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	stateStoreSummary := strings.TrimSpace(req.StateStoreSummary)
 	if stateStoreSummary == "" {
 		var err error
-		stateStoreSummary, err = initializeStateStores(req.Ctx, req.Stores, loaded.bundle)
+		stateStoreSummary, err = initializeStateStores(req.Ctx, req.Stores, loaded.bundle, req.Options.Verbose)
 		if err != nil {
 			return serveRuntimeBundleContext{}, err
 		}
@@ -672,7 +672,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			log.Printf("resolve pre-catalog platform spec: %v", err)
 			return 1
 		}
-		if _, err := initializeServePlatformStateStores(ctx, stores, preCatalogPlatformSpecPath); err != nil {
+		if _, err := initializeServePlatformStateStores(ctx, stores, preCatalogPlatformSpecPath, opts.Verbose); err != nil {
 			reporter.emit(4, "bundle_load", "FAILED", err.Error())
 			log.Printf("initialize platform state stores: %v", err)
 			return 1
@@ -703,7 +703,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
 	stateStoreSummaries := make([]string, len(loadedBundles))
 	if stores.SchemaBootstrapper != nil {
-		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles)
+		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles, opts.Verbose)
 		if err != nil {
 			slog.Error("initialize state stores", "error", err)
 			return 1
@@ -2599,7 +2599,7 @@ func uniqueTrimmedServeBundleHashes(values []string) []string {
 	return out
 }
 
-func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
+func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle, verbose bool) (string, error) {
 	if stores.SchemaBootstrapper == nil || bundle == nil {
 		return "store wiring ready", nil
 	}
@@ -2620,10 +2620,10 @@ func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runt
 	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
 		return "", err
 	}
-	return summarizeServeSchemaPlans(plans), nil
+	return summarizeServeSchemaPlans(plans, verbose), nil
 }
 
-func initializeServePlatformStateStores(ctx context.Context, stores storeBundle, platformSpecPath string) (string, error) {
+func initializeServePlatformStateStores(ctx context.Context, stores storeBundle, platformSpecPath string, verbose bool) (string, error) {
 	if stores.SchemaBootstrapper == nil {
 		return "store wiring ready", nil
 	}
@@ -2638,13 +2638,13 @@ func initializeServePlatformStateStores(ctx context.Context, stores storeBundle,
 	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
 		return "", err
 	}
-	return summarizeServeSchemaPlans(plans), nil
+	return summarizeServeSchemaPlans(plans, verbose), nil
 }
 
-func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBundle, loaded []serveRuntimeBundle) ([]string, error) {
+func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBundle, loaded []serveRuntimeBundle, verbose bool) ([]string, error) {
 	summaries := make([]string, len(loaded))
 	for i, bundle := range loaded {
-		summary, err := initializeStateStores(ctx, stores, bundle.bundle)
+		summary, err := initializeStateStores(ctx, stores, bundle.bundle, verbose)
 		if err != nil {
 			return nil, fmt.Errorf("bundle %s state stores: %w", bundle.serveIdentityDetail(), err)
 		}
@@ -2692,7 +2692,19 @@ func loadServePlatformSpecDocument(platformSpecPath string) (runtimecontracts.Pl
 	return spec, nil
 }
 
-func summarizeServeSchemaPlans(plans []store.SchemaTableDDL) string {
+type serveSchemaPlanSummary struct {
+	tableCount  int
+	columnCount int
+	detail      string
+}
+
+func summarizeServeSchemaPlans(plans []store.SchemaTableDDL, verbose bool) string {
+	summary := newServeSchemaPlanSummary(plans)
+	slog.Info("swarm boot state stores", "tables", summary.tableCount, "columns", summary.columnCount)
+	return summary.text(verbose)
+}
+
+func newServeSchemaPlanSummary(plans []store.SchemaTableDDL) serveSchemaPlanSummary {
 	tableNames := make([]string, 0, len(plans))
 	totalColumns := 0
 	for _, plan := range plans {
@@ -2700,11 +2712,22 @@ func summarizeServeSchemaPlans(plans []store.SchemaTableDDL) string {
 		totalColumns += plan.ColumnCount
 	}
 	sort.Strings(tableNames)
-	slog.Info("swarm boot state stores", "tables", len(plans), "columns", totalColumns, "detail", strings.Join(tableNames, ", "))
-	if len(tableNames) == 0 {
+	return serveSchemaPlanSummary{
+		tableCount:  len(plans),
+		columnCount: totalColumns,
+		detail:      strings.Join(tableNames, ", "),
+	}
+}
+
+func (summary serveSchemaPlanSummary) text(verbose bool) string {
+	if summary.tableCount == 0 {
 		return "verified 0 generated tables"
 	}
-	return fmt.Sprintf("verified %d generated tables (%s)", len(plans), strings.Join(tableNames, ", "))
+	base := fmt.Sprintf("verified %d generated tables", summary.tableCount)
+	if verbose && strings.TrimSpace(summary.detail) != "" {
+		return fmt.Sprintf("%s (%s)", base, summary.detail)
+	}
+	return base
 }
 
 func serveStateStoreSummaryAt(summaries []string, index int) string {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -7287,6 +7288,156 @@ func TestServeBootRegistryDetail_UsesRuntimeToolInventoryCount(t *testing.T) {
 	}
 }
 
+func TestSummarizeServeSchemaPlansDefaultOmitsTableBreakdown(t *testing.T) {
+	plans := []store.SchemaTableDDL{
+		{TableName: "events", ColumnCount: 17},
+		{TableName: "runs", ColumnCount: 14},
+	}
+
+	summary, logOutput := captureServeSchemaPlanSummary(t, plans, false)
+
+	if summary != "verified 2 generated tables" {
+		t.Fatalf("summary = %q, want concise generated-table count", summary)
+	}
+	for _, forbidden := range []string{"events(17)", "runs(14)", "detail="} {
+		if strings.Contains(summary, forbidden) || strings.Contains(logOutput, forbidden) {
+			t.Fatalf("default schema summary leaked %q\nsummary=%s\nlog=%s", forbidden, summary, logOutput)
+		}
+	}
+	for _, want := range []string{"swarm boot state stores", "tables=2", "columns=31"} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("default schema log missing %q:\n%s", want, logOutput)
+		}
+	}
+}
+
+func TestSummarizeServeSchemaPlansVerboseRetainsTableBreakdown(t *testing.T) {
+	plans := []store.SchemaTableDDL{
+		{TableName: "runs", ColumnCount: 14},
+		{TableName: "events", ColumnCount: 17},
+	}
+
+	summary, logOutput := captureServeSchemaPlanSummary(t, plans, true)
+
+	if summary != "verified 2 generated tables (events(17), runs(14))" {
+		t.Fatalf("summary = %q, want sorted verbose table breakdown", summary)
+	}
+	for _, forbidden := range []string{"events(17)", "runs(14)", "detail="} {
+		if strings.Contains(logOutput, forbidden) {
+			t.Fatalf("process log leaked verbose schema detail %q:\n%s", forbidden, logOutput)
+		}
+	}
+}
+
+func TestSummarizeServeSchemaPlansZeroPlans(t *testing.T) {
+	summary, logOutput := captureServeSchemaPlanSummary(t, nil, true)
+
+	if summary != "verified 0 generated tables" {
+		t.Fatalf("summary = %q, want zero generated-table summary", summary)
+	}
+	for _, want := range []string{"tables=0", "columns=0"} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("zero-plan schema log missing %q:\n%s", want, logOutput)
+		}
+	}
+	if strings.Contains(logOutput, "detail=") {
+		t.Fatalf("zero-plan schema log emitted empty detail:\n%s", logOutput)
+	}
+}
+
+func TestInitializeServeSchemaStateStoresConsumeVerboseOwner(t *testing.T) {
+	ctx := context.Background()
+	bundle := loadStoreBackendSelectionWorkflowBundle(t)
+	stores := storeBundle{SchemaBootstrapper: recordingSchemaBootstrapper{}}
+
+	defaultSummary, err := initializeStateStores(ctx, stores, bundle, false)
+	if err != nil {
+		t.Fatalf("initializeStateStores(default): %v", err)
+	}
+	if strings.Contains(defaultSummary, "(") {
+		t.Fatalf("default loaded-bundle state store summary leaked table detail:\n%s", defaultSummary)
+	}
+
+	verboseSummary, err := initializeStateStores(ctx, stores, bundle, true)
+	if err != nil {
+		t.Fatalf("initializeStateStores(verbose): %v", err)
+	}
+	if !strings.Contains(verboseSummary, "(") || !strings.Contains(verboseSummary, ")") {
+		t.Fatalf("verbose loaded-bundle state store summary missing table detail:\n%s", verboseSummary)
+	}
+
+	loadedDefaultSummaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, []serveRuntimeBundle{{bundle: bundle}, {bundle: bundle}}, false)
+	if err != nil {
+		t.Fatalf("initializeLoadedServeRuntimeStateStores(default): %v", err)
+	}
+	for _, summary := range loadedDefaultSummaries {
+		if strings.Contains(summary, "(") {
+			t.Fatalf("default loaded runtime state store summary leaked table detail:\n%v", loadedDefaultSummaries)
+		}
+	}
+
+	loadedVerboseSummaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, []serveRuntimeBundle{{bundle: bundle}}, true)
+	if err != nil {
+		t.Fatalf("initializeLoadedServeRuntimeStateStores(verbose): %v", err)
+	}
+	if len(loadedVerboseSummaries) != 1 || !strings.Contains(loadedVerboseSummaries[0], "(") || !strings.Contains(loadedVerboseSummaries[0], ")") {
+		t.Fatalf("verbose loaded runtime state store summary missing table detail:\n%v", loadedVerboseSummaries)
+	}
+
+	defaultPlatformSummary, err := initializeServePlatformStateStores(ctx, stores, filepath.Join(repoRoot(), defaultPlatformSpecPath), false)
+	if err != nil {
+		t.Fatalf("initializeServePlatformStateStores(default): %v", err)
+	}
+	if strings.Contains(defaultPlatformSummary, "(") {
+		t.Fatalf("default pre-catalog platform state store summary leaked table detail:\n%s", defaultPlatformSummary)
+	}
+
+	verbosePlatformSummary, err := initializeServePlatformStateStores(ctx, stores, filepath.Join(repoRoot(), defaultPlatformSpecPath), true)
+	if err != nil {
+		t.Fatalf("initializeServePlatformStateStores(verbose): %v", err)
+	}
+	if !strings.Contains(verbosePlatformSummary, "(") || !strings.Contains(verbosePlatformSummary, ")") {
+		t.Fatalf("verbose pre-catalog platform state store summary missing table detail:\n%s", verbosePlatformSummary)
+	}
+}
+
+func TestServeRuntimeStateStoreSummaryDedupesSchemaSummaries(t *testing.T) {
+	got := serveRuntimeStateStoreSummary([]serveRuntimeBundleContext{
+		{stateStoreSummary: "verified 2 generated tables"},
+		{stateStoreSummary: "verified 2 generated tables"},
+		{stateStoreSummary: "verified 2 generated tables (events(17), runs(14))"},
+		{stateStoreSummary: " "},
+	})
+
+	if strings.Count(got, "verified 2 generated tables") != 2 {
+		t.Fatalf("summary = %q, want one concise and one verbose summary after de-dupe", got)
+	}
+	if strings.Count(got, "events(17)") != 1 {
+		t.Fatalf("summary = %q, want one verbose table detail after de-dupe", got)
+	}
+}
+
+func captureServeSchemaPlanSummary(t *testing.T, plans []store.SchemaTableDDL, verbose bool) (string, string) {
+	t.Helper()
+	var logOutput bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	return summarizeServeSchemaPlans(plans, verbose), logOutput.String()
+}
+
+type recordingSchemaBootstrapper struct{}
+
+func (recordingSchemaBootstrapper) EnsureSchemaTables(context.Context, []store.SchemaTableDDL) error {
+	return nil
+}
+
+func (recordingSchemaBootstrapper) ResolveSchemaCapabilities(context.Context) (store.StoreSchemaCapabilities, error) {
+	return store.StoreSchemaCapabilities{}, nil
+}
+
 func TestWaitForServeHealthEndpointsProvesHealthAndReadyRoutes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -8079,6 +8230,25 @@ func (b *lockedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+func waitForServeReadyLine(t *testing.T, out *lockedBuffer, done <-chan int) {
+	t.Helper()
+	deadline := time.After(serveRuntimeReadyTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case code := <-done:
+			t.Fatalf("runServeRuntime exited before ready line with code %d\noutput:\n%s", code, out.String())
+		case <-deadline:
+			t.Fatalf("timed out waiting for serve ready line\noutput:\n%s", out.String())
+		case <-ticker.C:
+			if strings.Contains(out.String(), "[22/22]") {
+				return
+			}
+		}
+	}
 }
 
 const (

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -63,6 +63,9 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 		if serveOpts.ConfigPath != configPath || serveOpts.Backend != "claude_cli" || serveOpts.ContractsPath != filepath.Join(repo, "contracts") || serveOpts.DataSource != "reference-data" || serveOpts.PlatformSpecPath != filepath.Join(repo, "platform.yaml") {
 			t.Errorf("serve opts = %#v", serveOpts)
 		}
+		if serveOpts.Verbose {
+			t.Errorf("local run serve opts Verbose = true, want default non-verbose schema summary owner")
+		}
 		<-ctx.Done()
 		close(serveCanceled)
 		return 0
@@ -144,6 +147,9 @@ func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	}
 	if serveOpts.DataSource != "" {
 		t.Fatalf("data source = %q, want unset so serve resolver owns default selection", serveOpts.DataSource)
+	}
+	if serveOpts.Verbose {
+		t.Fatalf("serve verbose = true, want local run default to consume non-verbose serve boot owner")
 	}
 }
 

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -292,7 +292,7 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwne
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want construction blocker removed after mailbox_write owner", runtimeStores.ConstructionBlocker)
 	}
 	bundle := loadStoreBackendSelectionWorkflowBundle(t)
-	if _, err := initializeStateStores(ctx, stores, bundle); err != nil {
+	if _, err := initializeStateStores(ctx, stores, bundle, false); err != nil {
 		t.Fatalf("initializeStateStores(sqlite): %v", err)
 	}
 	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -9333,6 +9333,11 @@ cli_specification:
           By default `swarm serve` remains quiet except for readiness and errors. With `--verbose` or `-v`, serve prints
           the numbered boot-progress sequence to stdout as the canonical serve/runtime boot phases complete. The CLI
           owns stdout rendering; runtime owns the boot-progress facts and the persisted `platform.boot` payload.
+        schema_inventory_detail: >
+          Default serve and local foreground run process logs may report concise generated state-store schema counts
+          such as `tables=N` and `columns=M`, but MUST NOT dump per-table `table(column_count)` inventory details.
+          Per-table generated schema inventory is diagnostic boot detail owned by the explicit serve verbose channel
+          (`swarm serve --verbose/-v`, and `--dev` through its verbose composition).
         boot_progress_sequence:
           total_steps: 22
           steps:


### PR DESCRIPTION
## Summary
- Centralizes serve schema-plan summary rendering so default process logs keep only generated schema counts.
- Keeps per-table `table(column_count)` schema inventory available through existing serve verbose diagnostics (`swarm serve --verbose/-v` and `--dev`).
- Updates `platform-spec.yaml` to make the default concise vs verbose detail boundary authoritative.
- Restores the missing `waitForServeReadyLine` test helper required by #1324 so `cmd/swarm` proof can compile; this is test-only.

Closes #1322
Part of #1257
Related to #1324

## Governing refs / context
- `platform-spec.yaml#cli_specification.foundations.output_contract.exception_rules.serve_daemon_process`
- `platform-spec.yaml#cli_specification.foundations.cli_logging_policy`
- `platform-spec.yaml#cli_specification.foundations.cli_logging_policy.serve_boundary`
- `platform-spec.yaml#cli_specification.command_catalog.serve.boot_observability`
- Binding issue context: #1322 pre-audit and independent gate approved `operator_boot.schema_inventory_detail_default_noise` as the F-024 first slice only.

## Semantic owner / migration notes
- Canonical owner after this PR: `cmd/swarm` serve schema-plan summary rendering centered on `summarizeServeSchemaPlans` / `serveSchemaPlanSummary`.
- Old invalid path: default `slog.Info("swarm boot state stores", ..., "detail", <per-table breakdown>)` as normal boot output.
- Checked production consumers: pre-catalog platform bootstrap, loaded bundle state-store initialization, fallback bundle-context initialization, multi-bundle state-store summary de-dupe, default local foreground `swarm run`, `serve --verbose/-v`, and `--dev`.
- Migration complete for F-024. #1257 remains open for split residuals such as F-008 and F-015.

## Validation
- `go test ./cmd/swarm -run 'TestSummarizeServeSchemaPlans|TestInitializeServeSchemaStateStores|TestServeRuntimeStateStoreSummaryDedupesSchemaSummaries|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestStartLocalRunServeConsumesContractPathConfigResolver' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`