### PR TITLE
[agent-e][issue #1324] Migrate stale serve readiness helper consumer

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3698,46 +3698,26 @@ func TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot(t *
 	}
 	t.Setenv("SWARM_ARTIFACT_ROOT", rootFile)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	var out lockedBuffer
-	done := make(chan int, 1)
-	go func() {
-		done <- runServeRuntime(ctx, repoRoot(), serveOptions{
-			ConfigPath:           writeServeRuntimeTestConfig(t),
-			ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
-			PlatformSpecPath:     defaultPlatformSpecPath,
-			StoreMode:            "sqlite",
-			StoreModeSet:         true,
-			APIListenAddr:        "127.0.0.1:0",
-			MCPListenAddr:        "127.0.0.1:0",
-			SelfCheck:            true,
-			Dev:                  true,
-			RequireBundleMatch:   false,
-			NoRequireBundleMatch: true,
-			Verbose:              true,
-			Output:               &out,
-		})
-	}()
-	stopped := false
-	t.Cleanup(func() {
-		if stopped {
-			return
-		}
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Errorf("timed out stopping runServeRuntime\noutput:\n%s", out.String())
-		}
+	serve := startServeRuntimeTestProcess(t, serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            "sqlite",
+		StoreModeSet:         true,
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		Dev:                  true,
+		RequireBundleMatch:   false,
+		NoRequireBundleMatch: true,
+		Verbose:              true,
 	})
-	waitForServeReadyLine(t, &out, done)
-	cancel()
-	if code := <-done; code != 0 {
-		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, out.String())
+	serve.waitForReadyLine()
+	if code := serve.stop(); code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
-	stopped = true
-	if strings.Contains(out.String(), "artifact repo root startup validation failed") {
-		t.Fatalf("non-artifact bundle hit artifact root admission:\n%s", out.String())
+	if strings.Contains(serve.outputString(), "artifact repo root startup validation failed") {
+		t.Fatalf("non-artifact bundle hit artifact root admission:\n%s", serve.outputString())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Migrates `TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot` from the stale removed `waitForServeReadyLine` helper call to the canonical `startServeRuntimeTestProcess` / `serveRuntimeTestProcess` test harness.
- Keeps the change test-only and leaves runtime/CLI serve behavior untouched.
- Reviewed open PR #1327's helper-restore path and intentionally did not adopt it because the #1324 gate prefers removing the stale consumer instead of reviving a second readiness owner.

Closes #1324

## Governing refs / context
No exact product/runtime spec section governs an undefined Go test helper symbol. Binding context is the #1324 issue/thread and the approved independent gate. Adjacent context only: `platform-spec.yaml#cli_specification.command_catalog.serve.boot_observability` and `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`.

## Semantic migration
New canonical owner: `serveRuntimeTestProcess` / `startServeRuntimeTestProcess` in `cmd/swarm/main_test.go`.

Old path now invalid: the stale `waitForServeReadyLine` consumer in `TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot`.

Production paths checked: not applicable; this is test-only and changes no runtime, store, CLI, listener, gateway, or artifact-root behavior.

Migration completeness: complete for #1324's chosen class; no `waitForServeReadyLine` calls remain. Broader #1325 readiness/listener behavior remains split and open.

## Proof
- `rg -n "waitForServeReadyLine|done <- runServeRuntime|context.WithCancel\\(context.Background\\(\\)\\)" cmd/swarm/main_test.go cmd/swarm/cli_paths_test.go cmd/swarm/store_backend_selection_test.go`
- `git diff --check`
- `go test ./cmd/swarm -run '^TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot$' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./... -count=1`
