### PR TITLE
[agent-c][issue #1295] Materialize semantic flow routes

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -23,14 +23,14 @@ type deliveryRecipientCandidate struct {
 }
 
 type deliveryRouteResolver struct {
-	resolveRoutedSubscribers            func(string) []Subscriber
+	resolveRoutedSubscribers            func(events.Event) []Subscriber
 	resolveSubscribedRecipients         func(string) []deliveryRecipientCandidate
 	resolveRoutedNodeInternalRecipients func(events.Event, []Subscriber) []deliveryRecipientCandidate
 	describeSubscribersForEvent         func(string, []Subscriber) []PublishDiagnosticRecipient
 }
 
 func (r deliveryRouteResolver) Resolve(evt events.Event) deliveryRoutingResult {
-	routedRecipients := r.resolveRoutedSubscribers(string(evt.Type))
+	routedRecipients := r.resolveRoutedSubscribers(evt)
 	subscribedRecipients := r.resolveSubscribedRecipients(string(evt.Type))
 	routedCandidates := routedSubscriberCandidates(routedRecipients)
 	if r.resolveRoutedNodeInternalRecipients != nil {
@@ -174,7 +174,7 @@ func filteredRecipients(requested, allowed []string) []string {
 func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers:            eb.resolveRoutedSubscribers,
+			resolveRoutedSubscribers:            eb.resolveRoutedSubscribersForEvent,
 			resolveSubscribedRecipients:         eb.resolveSubscribedRecipientsForPlanning,
 			resolveRoutedNodeInternalRecipients: eb.resolveInternalRecipientsForRoutedNodePlanning,
 			describeSubscribersForEvent:         eb.describeSubscribersForEvent,
@@ -238,6 +238,48 @@ func agentDeliveryRecipientCandidates(in []string) []deliveryRecipientCandidate 
 		}
 	}
 	return normalizeDeliveryRecipientCandidates(out)
+}
+
+func routedEventKeysForPlan(evt events.Event) []string {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" {
+		return nil
+	}
+	out := []string{eventType}
+	if concrete := concreteFlowInstanceEventKey(evt); concrete != "" {
+		out = append(out, concrete)
+	}
+	return uniqueStrings(out)
+}
+
+func concreteFlowInstanceEventKey(evt events.Event) string {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if eventType == "" || flowInstance == "" {
+		return ""
+	}
+	staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)
+	if staticScope == "" {
+		return ""
+	}
+	localEvent := semanticScopedLocalEvent(eventType, staticScope)
+	if localEvent == "" {
+		return ""
+	}
+	return flowInstance + "/" + localEvent
+}
+
+func semanticScopedLocalEvent(eventType, staticScope string) string {
+	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
+	staticScope = strings.Trim(strings.TrimSpace(staticScope), "/")
+	if eventType == "" || staticScope == "" || !strings.HasPrefix(eventType, staticScope+"/") {
+		return ""
+	}
+	localEvent := strings.TrimPrefix(eventType, staticScope+"/")
+	if localEvent == "" || strings.Contains(localEvent, "/") {
+		return ""
+	}
+	return localEvent
 }
 
 func deliveryRecipientIDs(in []deliveryRecipientCandidate) []string {
@@ -465,10 +507,14 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 		return nil
 	}
 	out := []string{eventType}
+	if concrete := concreteFlowInstanceEventKey(evt); concrete != "" {
+		out = append(out, concrete)
+	}
 	for _, subscriber := range routed {
 		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
 			continue
 		}
+		eventType := routedNodeConcreteEventKey(evt, subscriber)
 		instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
 		if instancePath == "" || !strings.HasPrefix(eventType, instancePath+"/") {
 			continue
@@ -484,16 +530,29 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 }
 
 func routedNodeMatchesConcreteFlowInstanceEvent(evt events.Event, subscriber Subscriber) bool {
+	return routedNodeConcreteEventKey(evt, subscriber) != ""
+}
+
+func routedNodeConcreteEventKey(evt events.Event, subscriber Subscriber) string {
 	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
-		return false
+		return ""
 	}
 	instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
 	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
 	if instancePath == "" || flowInstance == "" || instancePath != flowInstance {
-		return false
+		staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)
+		if staticScope == "" || instancePath != staticScope {
+			return ""
+		}
 	}
 	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
-	return eventType != "" && strings.HasPrefix(eventType, instancePath+"/")
+	if eventType != "" && strings.HasPrefix(eventType, flowInstance+"/") {
+		if instancePath == flowInstance {
+			return eventType
+		}
+		return ""
+	}
+	return concreteFlowInstanceEventKey(evt)
 }
 
 func matchedInternalDeliveryTargets(evt events.Event, subscribers []Subscriber) []events.RouteIdentity {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing.T) {
 	resolver := deliveryRouteResolver{
-		resolveRoutedSubscribers: func(string) []Subscriber {
+		resolveRoutedSubscribers: func(events.Event) []Subscriber {
 			return []Subscriber{{
 				ID:           "scan-orchestrator",
 				Type:         "node",
@@ -170,7 +170,7 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetDoesNotSubscribe(t 
 func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{ID: "worker", Type: "node"}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
@@ -211,7 +211,7 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{ID: "parent-listener", Type: "node"}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate { return nil },
@@ -240,7 +240,7 @@ func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *test
 func TestDeliveryPlanner_PreservesTargetFailureWhenRoutedNodeDoesNotMatchTarget(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{ID: "unrelated-listener", Type: "node", Path: "other-flow"}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate { return nil },
@@ -269,7 +269,7 @@ func TestDeliveryPlanner_PreservesTargetFailureWhenRoutedNodeDoesNotMatchTarget(
 func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{
 					{ID: "child-a-listener", Type: "node", Path: "child-a/inst-1"},
 					{ID: "child-b-listener", Type: "node", Path: "child-b/inst-1"},
@@ -320,7 +320,7 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{
 					ID:   "lifecycle-orchestrator",
 					Type: "node",
@@ -372,7 +372,7 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRou
 func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{
 					ID:           "portfolio-node",
 					Type:         "node",
@@ -423,7 +423,7 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber { return nil },
+			resolveRoutedSubscribers: func(events.Event) []Subscriber { return nil },
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
 				return []deliveryRecipientCandidate{{ID: "worker", PersistAsDelivery: true}}
 			},

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -129,11 +129,15 @@ func filterRecipientsForExplicitAgentScope(evt events.Event, recipients []string
 }
 
 func (eb *EventBus) resolveRoutedSubscribers(eventType string) []Subscriber {
+	return eb.resolveRoutedSubscribersForEvent(events.Event{Type: events.EventType(eventType)})
+}
+
+func (eb *EventBus) resolveRoutedSubscribersForEvent(evt events.Event) []Subscriber {
 	if eb == nil {
 		return nil
 	}
-	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
-	if eventType == "" {
+	eventKeys := routedEventKeysForPlan(evt)
+	if len(eventKeys) == 0 {
 		return nil
 	}
 	eb.mu.RLock()
@@ -141,13 +145,19 @@ func (eb *EventBus) resolveRoutedSubscribers(eventType string) []Subscriber {
 	eb.mu.RUnlock()
 	out := make([]Subscriber, 0, 8)
 	if table != nil {
-		out = append(out, table.Resolve(eventType)...)
+		for _, eventType := range eventKeys {
+			out = append(out, table.Resolve(eventType)...)
+		}
 	}
 	return dedupeSubscribers(out)
 }
 
 func (eb *EventBus) resolveRoutedRecipients(eventType string) []string {
-	subscribers := eb.resolveRoutedSubscribers(eventType)
+	return eb.resolveRoutedRecipientsForEvent(events.Event{Type: events.EventType(eventType)})
+}
+
+func (eb *EventBus) resolveRoutedRecipientsForEvent(evt events.Event) []string {
+	subscribers := eb.resolveRoutedSubscribersForEvent(evt)
 	if len(subscribers) == 0 {
 		return nil
 	}
@@ -348,7 +358,7 @@ func (eb *EventBus) snapshotRecipientChans(agentIDs []string) []agentRecipient {
 
 func (eb *EventBus) deliverByType(evt events.Event) {
 	recipients := uniqueStrings(append(
-		eb.resolveRoutedRecipients(string(evt.Type)),
+		eb.resolveRoutedRecipientsForEvent(evt),
 		eb.resolveSubscribedRecipients(string(evt.Type))...,
 	))
 	_ = eb.deliverToAgents(context.Background(), evt, recipients)

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -236,7 +236,7 @@ func (s *targetRouteMemoryStore) LoadCommittedReplayScope(_ context.Context, eve
 func nodeOnlyDeliveryPlanner(nodeID string) deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{ID: nodeID, Type: "node"}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
@@ -257,7 +257,7 @@ func nodeOnlyDeliveryPlanner(nodeID string) deliveryPlanner {
 func mixedNodeAgentDeliveryPlanner(nodeID, agentID string) deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{{ID: nodeID, Type: "node"}}
 			},
 			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
@@ -418,7 +418,7 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	}
 	eb.deliveryPlanner = newDeliveryPlanner(
 		deliveryRouteResolver{
-			resolveRoutedSubscribers: func(string) []Subscriber {
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
 				return []Subscriber{
 					{ID: "child-a-listener", Type: "node", Path: "child-a/inst-1"},
 					{ID: "child-b-listener", Type: "node", Path: "child-b/inst-1"},
@@ -529,6 +529,98 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 	}
 	if len(replayRoutes) != 1 || replayRoutes[0].SubscriberID != "workflow-runtime" {
 		t.Fatalf("replay routes = %#v, want workflow-runtime carrier route", replayRoutes)
+	}
+}
+
+func TestEventBusPublish_SemanticScopeFlowInstanceResolvesConcreteRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	source := semanticview.Wrap(routedNodeTemplateBundle())
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("operating/opco.product_initialization_requested"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].Path != "operating/inst-1" {
+		t.Fatalf("routed recipients = %#v, want concrete operating/inst-1 route", plan.RoutedRecipients)
+	}
+	if len(plan.DeliveryRoutes) != 1 || plan.DeliveryRoutes[0].Target.FlowInstance != "operating/inst-1" {
+		t.Fatalf("delivery routes = %#v, want one concrete operating route", plan.DeliveryRoutes)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "semantic-scope routed node event delivery")
+	if got.FlowInstance() != "operating/inst-1" {
+		t.Fatalf("delivered flow instance = %q, want operating/inst-1", got.FlowInstance())
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 || routes[0].Target.FlowInstance != "operating/inst-1" {
+		t.Fatalf("persisted delivery routes = %#v, want concrete operating route", routes)
+	}
+}
+
+func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesNodeRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedNodeStaticValidationBundle()),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("validation/thing.reviewed"))
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("validation/thing.reviewed"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-validation").WithFlowInstance("validation/inst-1")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal workflow node carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want one concrete node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
+		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
+	}
+	if route.Target.FlowInstance != "validation/inst-1" || route.Target.EntityID != "ent-validation" {
+		t.Fatalf("delivery route target = %#v, want validation/inst-1 ent-validation", route.Target)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "entity-writer" || plan.RoutedRecipients[0].Path != "validation" {
+		t.Fatalf("routed recipients = %#v, want entity-writer at semantic validation scope", plan.RoutedRecipients)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "semantic-scope concrete route event delivery")
+	if got.FlowInstance() != "validation/inst-1" || got.EntityID() != "ent-validation" {
+		t.Fatalf("delivered route identity flow=%q entity=%q, want validation/inst-1 ent-validation", got.FlowInstance(), got.EntityID())
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 || routes[0].Target.FlowInstance != "validation/inst-1" {
+		t.Fatalf("persisted routes = %#v, want concrete validation route", routes)
 	}
 }
 
@@ -738,6 +830,38 @@ func routedNodeTemplateBundle() *runtimecontracts.WorkflowContractBundle {
 					Event: "opco.product_initialization_requested",
 				},
 			},
+		},
+	}
+}
+
+func routedNodeStaticValidationBundle() *runtimecontracts.WorkflowContractBundle {
+	validation := runtimecontracts.FlowContractView{
+		Path:  "validation",
+		Paths: runtimecontracts.FlowContractPaths{ID: "validation", Flow: "validation"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"thing.reviewed": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"entity-writer": {
+				ID:            "entity-writer",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"thing.reviewed"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"thing.reviewed": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{validation}}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"validation": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"validation": {},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1295.

This PR closes the approved `semantic_scope_flow_instance_route_materialization` slice. EventBus routed-recipient planning now considers the event envelope when resolving route-table subscribers: a semantic-scoped event type such as `<flow>/<event>` with `flow_instance=<flow>/<instance>` also resolves the concrete route key `<flow>/<instance>/<event>`. Node delivery-route materialization now accepts both concrete instance subscribers and semantic-scope subscribers for that approved event shape, producing persisted node delivery route evidence before execution.

No API, CLI, store, schema, OpenRPC, #1255 readback, #1293 guard, #1294, #1299, or #1301 behavior is implemented in this PR.

## Governing Context

Spec references used as binding context:
- `platform-spec.yaml` `engine.events.routing_derivation`: local subscriptions and node ownership derive delivery rules.
- `platform-spec.yaml` `engine.event_identity`: event bus stores/routes external names; route identity is separate from lineage identity.
- `platform-spec.yaml` `engine.cross_flow_routing.delivery_filter`: publish-time recipient construction persists narrowed recipient route evidence.
- `platform-spec.yaml` `runtime_persistence.event_deliveries`: persisted delivery authority is one row per event x subscriber with concrete `delivery_target_route`.
- `platform-spec.yaml` `/v1/rpc event.publish` and CLI `swarm event publish`: existing-run publication must preflight the canonical EventBus recipient plan; API/CLI do not re-plan subscribers.
- `platform-spec.yaml` `runtime_persistence.routing_rules`: concrete materialized instance routes are routing evidence.

Issue/gate context:
- #1295 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1295#issuecomment-4623305475
- #1295 independent gate: https://github.com/division-sh/swarm/issues/1295#issuecomment-4623484488

## Semantic Owner / Migration Notes

Canonical owner after the change:
- Route topology remains `internal/runtime/bus.RouteTable` (`DeriveRouteTable`, `AddFlowInstanceRoute`, `Resolve`).
- Publish-time route production is `internal/runtime/bus.deliveryRouteResolver` plus `deliveryPlanner.Plan`.
- Persisted delivery authority remains `events.DeliveryRoute` and store `InsertEventDeliveryRoutes` / `PersistEventWithDeliveryRouteSetAndScope`.

Old path now invalid:
- The delivery planner no longer calls the string-only routed-subscriber resolver as the authoritative route-production path.
- `resolveRoutedSubscribers(string)` / `resolveRoutedRecipients(string)` remain as compatibility/dead-end delegates only; current EventBus planning uses `resolveRoutedSubscribersForEvent(events.Event)`.

Production paths checked for surviving old behavior:
- `EventBus.Publish`
- `EventBus.PublishTx`
- `engineOutbox.deliveryPlanForIntent`
- `EventBus.CheckPublishRecipientPlan`
- `currentInternalRecipientsForCommittedEvent`
- `deliverByType` now delegates to the event-aware routed-recipient helper.

Migration complete for the approved child class: yes. Parent #1293 and siblings #1294/#1299/#1301 remain open/split.

## Validation

- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/bus -run 'SemanticScopeFlowInstance|NoTargetConcreteRoutedNode|DeliveryRouteResolver' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun|TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersistence|TestPublicSurfaceBackendMatrix' -count=1`
- `git diff --check`
- `go test ./...`
