### PR TITLE
[agent-c][issue #1295] Repair nested semantic route aliases

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -516,7 +516,8 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 		}
 		eventType := routedNodeConcreteEventKey(evt, subscriber)
 		instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
-		if instancePath == "" || !strings.HasPrefix(eventType, instancePath+"/") {
+		flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+		if instancePath == "" || instancePath != flowInstance || !strings.HasPrefix(eventType, instancePath+"/") {
 			continue
 		}
 		localEvent := strings.TrimPrefix(eventType, instancePath+"/")

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -369,6 +369,58 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRou
 	}
 }
 
+func TestRoutedNodeInternalSubscriptionAliases_NestedSemanticScopeDoesNotLeakParentConcreteRoute(t *testing.T) {
+	evt := (events.Event{
+		Type: events.EventType("child/grandchild/micro.started"),
+	}).WithFlowInstance("child/grandchild/inst-1")
+
+	aliases := routedNodeInternalSubscriptionAliases(evt, []Subscriber{{
+		ID:   "grandchild-worker",
+		Type: "node",
+		Path: "child/grandchild",
+	}})
+
+	for _, alias := range aliases {
+		if alias == "child/inst-1/micro.started" {
+			t.Fatalf("aliases = %#v, leaked parent concrete route alias", aliases)
+		}
+	}
+	want := map[string]struct{}{
+		"child/grandchild/micro.started":        {},
+		"child/grandchild/inst-1/micro.started": {},
+	}
+	if len(aliases) != len(want) {
+		t.Fatalf("aliases = %#v, want exactly semantic and concrete route aliases", aliases)
+	}
+	for _, alias := range aliases {
+		if _, ok := want[alias]; !ok {
+			t.Fatalf("aliases = %#v, unexpected alias %q", aliases, alias)
+		}
+	}
+}
+
+func TestResolveInternalRecipientsForRoutedNodePlanning_DoesNotSelectParentConcreteRouteForNestedSemanticScope(t *testing.T) {
+	eb, err := NewEventBus(InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	eb.SubscribeInternal("parent-carrier", events.EventType("child/inst-1/micro.started"))
+	defer eb.Unsubscribe("parent-carrier")
+
+	evt := (events.Event{
+		Type: events.EventType("child/grandchild/micro.started"),
+	}).WithFlowInstance("child/grandchild/inst-1")
+	got := eb.resolveInternalRecipientsForRoutedNodePlanning(evt, []Subscriber{{
+		ID:   "grandchild-worker",
+		Type: "node",
+		Path: "child/grandchild",
+	}})
+
+	if len(got) != 0 {
+		t.Fatalf("internal recipients = %#v, want none for parent concrete route", got)
+	}
+}
+
 func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{


### PR DESCRIPTION
## Summary

Repair for the review comment left after PR #1330 was accidentally merged.

This keeps the #1295 route-materialization scope unchanged and only fixes the nested semantic-scope alias leak called out by lead review: semantic-scope subscribers must not derive parent/static concrete aliases such as `child/inst-1/micro.started` from `child/grandchild/inst-1/micro.started`.

Related to #1295.
Repair for #1330.
Lead comment: https://github.com/division-sh/swarm/pull/1330#issuecomment-4624006403
Review checklist: https://github.com/division-sh/swarm/pull/1330#issuecomment-4624008436

## What Changed

- `routedNodeInternalSubscriptionAliases` now derives parent/static-scope aliases only when the subscriber path is the actual concrete `flow_instance` path.
- Nested semantic-scope subscribers now keep only the semantic event key and concrete `flow_instance` key.
- Added regression coverage proving a nested semantic-scope subscriber cannot select a parent concrete internal carrier.

## Validation

- `go test ./internal/runtime/bus -run 'NestedSemanticScope|SemanticScopeFlowInstance|NoTargetConcreteRoutedNode' -count=1`
- `git diff --check`
- `go test ./internal/runtime/bus -count=1`
- `go test ./...`
