### PR TITLE
[agent-a][issue #1328] Refresh OpenAI Responses operator docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ SWARM_WORKSPACE_DATA_SOURCE=
 CLAUDE_CODE_OAUTH_TOKEN=
 ANTHROPIC_API_KEY=
 OPENAI_COMPATIBLE_API_KEY=
+OPENAI_API_KEY=
 
 # External Postgres opt-in. Leave unset for the local/dev SQLite default. To use
 # a user-managed Postgres service, pass `--store postgres` or set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ until v1.0. Each entry below lists the platform-spec version it ships against.
 
 ## [Unreleased]
 
+### Changed
+
+- Operator setup docs now list native OpenAI Responses alongside the existing
+  Anthropic API, Claude CLI, and OpenAI-compatible Chat Completions backends,
+  including the required `OPENAI_API_KEY` credential example. Backend selection
+  remains `--backend`, then `llm.backend`, then the default `anthropic`.
+
 ## [1.6.0] - 2026-06-01
 
 First public open-source release. Engine is Phase 11 (handler-first execution for

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Swarm runs fleets of LLM agents as a durable, stateful system. You declare it in
 
 More than a simple orchestrator that decides which agent runs next, Swarm runs the system around it. Work is modeled as entities (an order, a ticket, a candidate business) moving through a state machine you declare: the runtime schedules hundreds at once, keeps them isolated, meters their spend, persists their state, and resumes them after a crash, days later if a timer or a human kept them waiting. Any run can be replayed or forked from the log. Deterministic routing is one piece; the rest is the operating system.
 
-Single Go binary, local/dev SQLite by default with Postgres as a production opt-in. Multiple LLM backends ship today: the Anthropic API, the Claude CLI, and any OpenAI Chat Completions endpoint.
+Single Go binary, local/dev SQLite by default with Postgres as a production opt-in. Multiple LLM backends ship today: the Anthropic API, the Claude CLI, OpenAI-compatible Chat Completions endpoints, and native OpenAI Responses.
 
 **Long-term direction:** entire divisions (engineering, support, operations) running as autonomous Swarm flows. Humans in the loop where judgment is required; agents and deterministic system nodes everywhere else.
 


### PR DESCRIPTION
## Summary

- Add `OPENAI_API_KEY` to the repo-local backend credential example now that `openai_responses` is an active backend profile.
- Update README shipped-backend prose to include native OpenAI Responses while preserving the OpenAI-compatible Chat Completions distinction.
- Add Unreleased CHANGELOG accounting for the operator docs/release artifact update.

Closes #1328
Part of #983

## Governing Context

- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1328#issuecomment-4624032568
- Independent Gate A approval: https://github.com/division-sh/swarm/issues/1328#issuecomment-4624166456
- Binding spec owner: `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`
- Binding native Responses owner: `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority.native_openai_responses_source_authority`
- Implementation owner consumed, not changed: `internal/runtime/llm/selection`

This PR stays inside the approved repo-local first slice. It does not change runtime/provider behavior, provider matrix scope, `openai_compatible` semantics, native Responses feature scope, `cli_test` migration, or private docs files.

## Proof

- `python3 -c 'import yaml; yaml.safe_load(open("platform-spec.yaml")); print("platform-spec.yaml parsed")'`
- Static spec-vs-`.env.example` credential comparison: active credentials are `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_COMPATIBLE_API_KEY`, `OPENAI_API_KEY`; missing `none`; `SWARM_LLM_BACKEND` not present in `.env.example`.
- `go run ./cmd/swarm serve --help | rg -- '--backend|anthropic|claude_cli|openai_compatible|openai_responses|SWARM_LLM_BACKEND'`
- `go run ./cmd/swarm run --help | rg -- '--backend|anthropic|claude_cli|openai_compatible|openai_responses|SWARM_LLM_BACKEND'`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "OPENAI_API_KEY|OPENAI_COMPATIBLE_API_KEY|ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|SWARM_LLM_BACKEND|openai_responses|OpenAI Responses|openai_compatible|OpenAI-compatible|Chat Completions" .env.example README.md CHANGELOG.md platform-spec.yaml openrpc.json`
- `git diff --check`
- `go test ./internal/runtime/llm/selection ./internal/config -count=1`
- `go test ./... -count=1`
