### PR TITLE
[agent-f][issue #1295] Repair served system-node route materialization

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -110,6 +110,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
@@ -433,6 +434,46 @@ func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscri
 	}
 	out := make([]events.DeliveryRoute, 0, len(internalRecipients))
 	for _, recipient := range internalRecipients {
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   recipient,
+			Target: events.RouteIdentity{
+				FlowInstance: flowInstance,
+				EntityID:     eventEntityID,
+			},
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	if len(recipients) > 0 || len(persisted) > 0 {
+		return nil
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance == "" {
+		return nil
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	nodeIDs := make(map[string]struct{}, len(routed))
+	for _, subscriber := range routed {
+		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
+			continue
+		}
+		id := strings.TrimSpace(subscriber.ID)
+		if id == "" {
+			continue
+		}
+		nodeIDs[id] = struct{}{}
+	}
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(nodeIDs))
+	for _, recipient := range sortedStringKeys(nodeIDs) {
 		out = append(out, events.DeliveryRoute{
 			SubscriberType: "node",
 			SubscriberID:   recipient,

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -624,6 +624,51 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 	}
 }
 
+func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesSystemNodeRouteWithoutLiveSubscription(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedNodeStaticValidationBundle()),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("validation/thing.reviewed"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-validation").WithFlowInstance("validation/inst-1")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("recipients=%#v persisted=%#v, want no live subscriber recipients", plan.Recipients, plan.PersistedRecipients)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "entity-writer" || plan.RoutedRecipients[0].Path != "validation" || plan.RoutedRecipients[0].LocalizedEvent != "thing.reviewed" {
+		t.Fatalf("routed recipients = %#v, want entity-writer local thing.reviewed at semantic validation scope", plan.RoutedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want one route-table system-node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "entity-writer" {
+		t.Fatalf("delivery route = %#v, want node/entity-writer", route)
+	}
+	if route.Target.FlowInstance != "validation/inst-1" || route.Target.EntityID != "ent-validation" {
+		t.Fatalf("delivery route target = %#v, want validation/inst-1 ent-validation", route.Target)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 || routes[0].SubscriberID != "entity-writer" || routes[0].Target.FlowInstance != "validation/inst-1" {
+		t.Fatalf("persisted routes = %#v, want entity-writer concrete validation route", routes)
+	}
+}
+
 func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	source := semanticview.Wrap(loadTargetRouteTempBundle(t, routedRootNodeFixtureFiles()))


### PR DESCRIPTION
## Summary

- Materializes route-table system-node delivery authority for semantic events carrying a concrete `flow_instance` when no live subscriber recipient was selected.
- Keeps the repair in EventBus route production: stores/API/CLI/readback paths do not fabricate recipients or bypass recipient planning.
- Adds focused EventBus proof for the served-runtime residual shape where the routed node is known from the route table but no live subscriber candidate is selected.

Closes #1295

## Governing refs / context

- `platform-spec.yaml` `engine.events.routing_derivation`: local subscriptions and node ownership derive delivery rules; node-only subscriptions route to nodes.
- `platform-spec.yaml` `engine.event_identity`: EventBus stores/routes external event names while delivery identity is carried by `target_route`/`target_routes`.
- `platform-spec.yaml` `engine.cross_flow_routing.delivery_filter`: publish-time recipient construction persists narrowed recipient/delivery-route authority.
- `platform-spec.yaml` `runtime_persistence.event_deliveries`: persisted delivery authority is one row per event/subscriber with concrete delivery target route.
- #1295 reopened gate: repair served-runtime local/system-node route materialization under `semantic_scope_flow_instance_route_materialization`; preserve #1293 and do not widen #1255.

## Validation

- `go test ./internal/runtime/bus -run 'TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes(SystemNodeRouteWithoutLiveSubscription|NodeRoute)|TestEventBusPublish_SemanticScopeFlowInstanceResolvesConcreteRoute' -count=1 -v`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)' -count=1 -v` using the local #1255 proof harness, with no #1255 production/API changes included in this PR
- `git diff --check`
- `go test ./...`
