### PR TITLE
[agent-c][issue #1337] Persist served root-input node routes

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -110,6 +110,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
@@ -505,6 +506,57 @@ func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Sub
 		})
 	}
 	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	if len(filterOutAgentIDs(recipients, persisted)) == 0 {
+		return nil
+	}
+	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return nil
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" || strings.Contains(eventType, "/") {
+		return nil
+	}
+	nodeIDs := make(map[string]struct{}, len(routed))
+	for _, subscriber := range routed {
+		if !routedRootInputFlowNodeMatchesNoTargetEvent(evt, subscriber) {
+			continue
+		}
+		nodeIDs[strings.TrimSpace(subscriber.ID)] = struct{}{}
+	}
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(nodeIDs))
+	for _, recipient := range sortedStringKeys(nodeIDs) {
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   recipient,
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber) bool {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) != "node" {
+		return false
+	}
+	if strings.TrimSpace(subscriber.RouteSource) != "root_input_flow" {
+		return false
+	}
+	if strings.Trim(strings.TrimSpace(subscriber.Path), "/") == "" {
+		return false
+	}
+	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return false
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	return eventType != "" && !strings.Contains(eventType, "/")
 }
 
 func routedRootNodeSubscriberIDsForNoTargetEvent(evt events.Event, routed []Subscriber) map[string]struct{} {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -669,6 +669,143 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 	}
 }
 
+func TestRouteTableRootInputFlowNodeResolvesRootInputRoute(t *testing.T) {
+	rt, err := DeriveRouteTable(semanticview.Wrap(routedRootInputFlowNodeBundle()))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	got := rt.Resolve("thing.created")
+	if len(got) != 1 {
+		t.Fatalf("Resolve(thing.created) = %#v, want one root-input flow node route", got)
+	}
+	if got[0].ID != "entity-writer" || got[0].Type != "node" || got[0].Path != "validation" {
+		t.Fatalf("resolved subscriber = %#v, want validation/entity-writer node", got[0])
+	}
+	if got[0].MatchPattern != "thing.created" || got[0].RouteSource != "root_input_flow" {
+		t.Fatalf("resolved subscriber metadata = %#v, want root_input_flow thing.created", got[0])
+	}
+}
+
+func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "entity-writer",
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedRootInputFlowNodeBundle()),
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    want,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
+	evt := (events.Event{
+		ID:        eventID,
+		Type:      events.EventType("thing.created"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-root-input")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal root-input node carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 || got[0].SubscriberType != "node" || got[0].SubscriberID != "entity-writer" || !got[0].Target.Empty() {
+		t.Fatalf("delivery routes = %#v, want empty-target node/entity-writer route", got)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "entity-writer" || plan.RoutedRecipients[0].Path != "validation" || plan.RoutedRecipients[0].RouteSource != "root_input_flow" {
+		t.Fatalf("routed recipients = %#v, want root-input validation/entity-writer", plan.RoutedRecipients)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "root-input flow-node carrier delivery")
+	if got.FlowInstance() != "" || got.EntityID() != "ent-root-input" {
+		t.Fatalf("delivered root input identity flow=%q entity=%q, want root ent-root-input", got.FlowInstance(), got.EntityID())
+	}
+	routes := store.routes[evt.ID]
+	if !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[evt.ID]; got != replayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+}
+
+func TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "entity-writer",
+	}
+	source := semanticview.Wrap(loadTargetRouteTempBundle(t, routedRootInputProjectEventFixtureFiles()))
+	rt, err := DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	resolved := rt.Resolve("thing.created")
+	if len(resolved) != 1 || resolved[0].ID != "entity-writer" || resolved[0].Path != "validation" || resolved[0].RouteSource != "root_input_flow" {
+		t.Fatalf("resolved subscribers = %#v, want root_input_flow validation/entity-writer", resolved)
+	}
+
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: source,
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    want,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
+	evt := (events.Event{
+		ID:        eventID,
+		Type:      events.EventType("thing.created"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-loaded-root-input")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal root-input node carrier", plan.PersistedRecipients)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "entity-writer" || plan.RoutedRecipients[0].Path != "validation" || plan.RoutedRecipients[0].RouteSource != "root_input_flow" {
+		t.Fatalf("routed recipients = %#v, want loaded root-input validation/entity-writer", plan.RoutedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 || !deliveryRoutesContain(got, want) {
+		t.Fatalf("delivery routes = %#v, want empty-target node/entity-writer route", got)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "loaded root-input flow-node carrier delivery")
+	if got.FlowInstance() != "" || got.EntityID() != "ent-loaded-root-input" {
+		t.Fatalf("delivered root input identity flow=%q entity=%q, want root ent-loaded-root-input", got.FlowInstance(), got.EntityID())
+	}
+	if routes := store.routes[evt.ID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+}
+
 func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	source := semanticview.Wrap(loadTargetRouteTempBundle(t, routedRootNodeFixtureFiles()))
@@ -833,6 +970,95 @@ version: 1.0.0
   event_handlers:
     opco.spinup_requested: {}
 `,
+	}
+}
+
+func routedRootInputProjectEventFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test-root-input-project-event
+version: 1.0.0
+platform_version: ">=1.0.0"
+flows:
+  - id: validation
+    flow: validation
+    mode: static
+`,
+		"schema.yaml": `name: test-root-input-project-event
+pins:
+  inputs:
+    events: [thing.created]
+  outputs:
+    events: []
+`,
+		"events.yaml": `thing.created:
+  entity_id: string
+`,
+		"flows/validation/schema.yaml": `name: validation
+mode: static
+initial_state: ready
+terminal_states: [done]
+states: [ready, done]
+pins:
+  inputs:
+    events: [thing.created]
+  outputs:
+    events: []
+`,
+		"flows/validation/nodes.yaml": `entity-writer:
+  id: entity-writer
+  execution_type: system_node
+  subscribes_to: [thing.created]
+  event_handlers:
+    thing.created: {}
+`,
+	}
+}
+
+func routedRootInputFlowNodeBundle() *runtimecontracts.WorkflowContractBundle {
+	validation := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "validation", Flow: "validation"},
+		Path:  "validation",
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "static",
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"thing.created"}},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"thing.created": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"entity-writer": {
+				ID:            "entity-writer",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"thing.created"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"thing.created": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{validation}}
+	return &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"thing.created"}},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs: map[string][]string{
+				"validation": []string{"thing.created"},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"validation": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"validation": validation.Schema,
+		},
 	}
 }
 

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -24,6 +24,7 @@ type RouteTable struct {
 	mu                sync.RWMutex
 	source            semanticview.Source
 	routes            map[string][]Subscriber
+	rootInputRoutes   map[string][]Subscriber
 	patterns          []routePattern
 	eventPath         map[string]struct{}
 	templates         map[string]routeFlowTemplate
@@ -85,6 +86,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		rt.addNodePatternsLocked(source, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Nodes)
 	}
 
+	rt.addRootInputFlowNodeRoutesLocked(source)
 	rt.rebuildLocked()
 	return rt, nil
 }
@@ -100,6 +102,9 @@ func (rt *RouteTable) Resolve(eventType string) []Subscriber {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 	out := cloneSubscribers(rt.routes[eventType])
+	for _, subscriber := range rt.rootInputRoutes[eventType] {
+		out = appendUniqueRootInputSubscriber(out, subscriber)
+	}
 	if _, active := rt.eventPath[eventType]; !active {
 		return out
 	}
@@ -280,11 +285,66 @@ func newRouteTable(source semanticview.Source) *RouteTable {
 	return &RouteTable{
 		source:            source,
 		routes:            make(map[string][]Subscriber),
+		rootInputRoutes:   make(map[string][]Subscriber),
 		eventPath:         make(map[string]struct{}),
 		templates:         make(map[string]routeFlowTemplate),
 		instances:         make(map[string]struct{}),
 		instanceEventPath: make(map[string][]string),
 	}
+}
+
+func (rt *RouteTable) addRootInputFlowNodeRoutesLocked(source semanticview.Source) {
+	if rt == nil || source == nil {
+		return
+	}
+	rootInputs := routeRootInputEventSet(source)
+	if len(rootInputs) == 0 {
+		return
+	}
+	for _, scope := range source.FlowScopes() {
+		if strings.EqualFold(scope.Mode, "template") {
+			continue
+		}
+		flowID := strings.TrimSpace(scope.ID)
+		flowPath := strings.Trim(strings.TrimSpace(routeFlowPath(source, flowID)), "/")
+		if flowID == "" || flowPath == "" {
+			continue
+		}
+		for _, eventType := range sortedStringKeys(rootInputs) {
+			if !normalizedStringListContains(scope.InputEvents, eventType) {
+				continue
+			}
+			for _, key := range sortedStringKeys(scope.Nodes) {
+				entry := scope.Nodes[key]
+				nodeID := strings.TrimSpace(entry.ID)
+				if nodeID == "" {
+					nodeID = strings.TrimSpace(key)
+				}
+				if nodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(nodeID), eventType) {
+					continue
+				}
+				rt.rootInputRoutes[eventType] = appendUniqueSubscriber(rt.rootInputRoutes[eventType], Subscriber{
+					ID:           nodeID,
+					Type:         "node",
+					Path:         flowPath,
+					MatchPattern: eventType,
+					RouteSource:  "root_input_flow",
+				})
+			}
+		}
+	}
+}
+
+func routeRootInputEventSet(source semanticview.Source) map[string]struct{} {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil || bundle.RootSchema == nil {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, eventType := range normalizeStringList(bundle.RootSchema.Pins.Inputs.Events) {
+		out[eventType] = struct{}{}
+	}
+	return out
 }
 
 func (rt *RouteTable) addEventPathsLocked(basePath string, localEvents map[string]struct{}) []string {
@@ -620,9 +680,35 @@ func routeRenderTemplate(raw string, vars map[string]string) string {
 	return strings.NewReplacer(replacements...).Replace(raw)
 }
 
+func normalizedStringListContains(values []string, needle string) bool {
+	needle = eventidentity.Normalize(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if eventidentity.Normalize(value) == needle {
+			return true
+		}
+	}
+	return false
+}
+
 func appendUniqueSubscriber(in []Subscriber, subscriber Subscriber) []Subscriber {
 	for _, existing := range in {
 		if existing.ID == subscriber.ID && existing.Type == subscriber.Type && existing.Path == subscriber.Path {
+			return in
+		}
+	}
+	return append(in, subscriber)
+}
+
+func appendUniqueRootInputSubscriber(in []Subscriber, subscriber Subscriber) []Subscriber {
+	for idx, existing := range in {
+		if existing.ID == subscriber.ID && existing.Type == subscriber.Type && existing.Path == subscriber.Path {
+			if strings.TrimSpace(subscriber.RouteSource) == "root_input_flow" {
+				in[idx].MatchPattern = subscriber.MatchPattern
+				in[idx].RouteSource = subscriber.RouteSource
+			}
 			return in
 		}
 	}


### PR DESCRIPTION
Closes #1337
Part of #1293

## Summary
- Teach the EventBus route-table owner to expose root-input flow-node consumers for declared root schema inputs.
- Materialize a typed `event_deliveries` node route for no-target root-input publishes when an internal workflow-node carrier is present, so workflow execution has persisted authority before dispatch.
- Add route-table and EventBus proofs that the root-input node row is planned and persisted before interceptors/dispatch.

## Governing Refs
- `platform-spec.yaml#engine.events.routing_derivation.delivery_rules`: system nodes are first-class routed delivery consumers.
- `platform-spec.yaml#engine.events.delivery_filter`: publish-time recipient construction persists the narrowed recipient list and downstream paths inherit it.
- `platform-spec.yaml#engine.event_loop`: events are persisted, subscribers are resolved, then handlers execute.
- `platform-spec.yaml#persistence_schema.event_deliveries`: delivery authority is the typed event/subscriber row.
- `platform-spec.yaml#persistence_schema.event_receipts`: receipts are completion acknowledgement, not pre-execution authority.
- `platform-spec.yaml#api_specification.method_catalog.event.publish`: API consumes the EventBus/store owner and reads delivery results from persisted `event_deliveries`.
- `platform-spec.yaml#cli_specification.command_catalog.event_publish`: CLI is a thin `/v1/rpc event.publish` consumer.
- Binding issue/gate: #1337 pre-audit and `C Gate 1337 - failure-class verification`.

## Semantic Migration
- New canonical owner for this slice: `internal/runtime/bus.RouteTable` plus `deliveryPlanner.Plan` root-input route materialization.
- Old non-authoritative paths now invalid for this class: root-input admission alone, live internal subscription alone, API/CLI readback, receipts, settlement/backfill, or replay-scope markers as workflow-node execution authority.
- Checked production consumers: `/v1/rpc event.publish`, CLI `swarm event publish`, the shared create-new helper used by deprecated `run.start`, EventBus `Publish`/`PublishTx`, `CheckPublishRecipientPlan`, and persisted route writers. No API/CLI/schema/OpenRPC behavior is changed.
- Migration complete for the chosen `served_root_input_event_publish_node_delivery_route_materialization` class; #1293, #1299, and #1301 remain separate parent/sibling work.

## Proof
- `go test ./internal/runtime/bus -run 'TestRouteTableRootInputFlowNodeResolvesRootInputRoute|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch|TestEventBusPublish_NoTargetRootRoutedNode|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock' -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./...`
