### PR TITLE
[agent-c][issue #1340] Consolidate workflow node route authority

### DIFF
--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -558,6 +558,7 @@ func eventPublishPublishError(params eventPublicationParams, err error) error {
 
 func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDelivery {
 	out := make([]eventPublishDelivery, 0, len(in))
+	seen := map[eventPublishDelivery]struct{}{}
 	for _, delivery := range in {
 		if strings.TrimSpace(delivery.SubscriberID) == "__runtime_replay_scope__" {
 			continue
@@ -566,12 +567,17 @@ func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDeli
 		if attempt < 1 {
 			attempt = 1
 		}
-		out = append(out, eventPublishDelivery{
+		item := eventPublishDelivery{
 			SubscriberID: strings.TrimSpace(delivery.SubscriberID),
 			SessionID:    strings.TrimSpace(delivery.SessionID),
 			Status:       strings.TrimSpace(delivery.Status),
 			Attempt:      attempt,
-		})
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
 	}
 	return out
 }

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -110,7 +110,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	plan.DeliveryTargets = manifest.DeliveryTargets
 	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
+	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
 	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
@@ -508,11 +508,8 @@ func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Sub
 	return events.NormalizeDeliveryRoutes(out)
 }
 
-func routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+func routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
-		return nil
-	}
-	if len(filterOutAgentIDs(recipients, persisted)) == 0 {
 		return nil
 	}
 	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -743,6 +743,57 @@ func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch(t *testing
 	}
 }
 
+func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutInternalCarrier(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "entity-writer",
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedRootInputFlowNodeBundle()),
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    want,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := (events.Event{
+		ID:        eventID,
+		Type:      events.EventType("thing.created"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-root-input")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("recipients=%#v persisted=%#v, want no live carrier recipients", plan.Recipients, plan.PersistedRecipients)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "entity-writer" || plan.RoutedRecipients[0].Path != "validation" || plan.RoutedRecipients[0].RouteSource != "root_input_flow" {
+		t.Fatalf("routed recipients = %#v, want root-input validation/entity-writer", plan.RoutedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 || !deliveryRoutesContain(got, want) {
+		t.Fatalf("delivery routes = %#v, want empty-target node/entity-writer route", got)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[evt.ID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[evt.ID]; got != replayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+}
+
 func TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eventID := uuid.NewString()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -337,6 +337,7 @@ contract_formats:
         dual_delivery: If a node AND agents subscribe → route to both
         consuming: If only a node subscribes → route to node only
         passthrough: If no node subscribes → pure agent delivery
+        workflow_node_route_authority: Workflow-node delivery route authority is derived from semantic route topology at publish time and persisted as typed event_deliveries rows before workflow-node execution. Live internal carriers, interceptors, handler lookup, receipts, settlement, replay markers, and API/CLI readback are consumers or evidence only; they MUST NOT be required or used as the authority that creates a workflow-node delivery route.
   persistence_model:
     description: Agents do not have raw database access. The platform derives agent-facing persistence tools from the
       authoritative flow-owned entity contracts in entities.yaml, agents.yaml entity_writes declarations, and the shared


### PR DESCRIPTION
## Summary

- Promotes root-input workflow-node route authority to EventBus publish-time semantic route topology instead of live/internal carrier evidence.
- Persists typed workflow-node `event_deliveries` before interceptor/workflow-node execution when `root_input_flow` topology routes a no-target root input event.
- Normalizes `event.publish` response projection so duplicated physical typed rows with the same legacy response shape do not appear as duplicate public deliveries.

Part of #1340.
#1340 remains open for the full typed route-plan authority model.
Related to #1293 and #1337.

## Governing Refs

- `platform-spec.yaml` `contract_formats.routing_derivation.delivery_rules`
- `platform-spec.yaml` `engine.events.routing_derivation.delivery_rules`
- `platform-spec.yaml` `engine.events.delivery_filter`
- `platform-spec.yaml` `engine.event_loop`
- `platform-spec.yaml` `persistence_schema.event_deliveries`
- `platform-spec.yaml` `persistence_schema.event_receipts`
- `platform-spec.yaml` `runtime_ingress_state.queued_not_dispatched`
- `platform-spec.yaml` `api_specification.method_catalog.event.publish`
- `platform-spec.yaml` `cli_specification.command_catalog.event_publish`
- #1340 Pre-Implementation Coverage Audit and gate outcome: `workflow_node_route_plan_authority_source_consolidation`

## Semantic Migration

- New canonical owner: EventBus publish-time typed route-plan authority consuming semantic `RouteTable` topology and producing persisted typed `event_deliveries` rows before workflow-node execution.
- Old invalid authority path: live internal carrier/subscriber presence gating root-input workflow-node route rows.
- Still non-authoritative: interceptor execution, handler/descriptor lookup, receipts, settlement/backfill, replay markers, API/CLI readback.
- Production paths checked: `CheckPublishRecipientPlan`, `Publish`, served `/v1/rpc event.publish` default SQLite and explicit Postgres, API readback projection.
- Migration complete for `workflow_node_route_plan_authority_source_consolidation`; #1299 and #1301 remain split sibling route-production tails.

## Validation

- `go test ./internal/runtime/bus -run 'TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutInternalCarrier|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch|TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch|TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInternalSubscription|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesSystemNodeRouteWithoutLiveSubscription' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock|TestOperatorEventPublishExistingRunRoutesFollowUpToSelectedRun|TestOperatorEventPublishSQLiteExistingRunRoutesFollowUpToSelectedRun' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./...`

