### PR TITLE
[agent-c][issue #1343] Canonical EventBus RoutePlan model

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -96,39 +96,36 @@ func newDeliveryPlanner(routeResolver deliveryRouteResolver, recipientPolicy del
 }
 
 func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
-	plan := eventDeliveryPlan{Event: evt}
+	routePlan := newRoutePlan(evt)
 	if evt.Type == events.EventType("platform.runtime_log") {
-		return plan, nil
+		return routePlan.EventDeliveryPlan(), nil
 	}
 	routing := p.routeResolver.Resolve(evt)
 	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, routing.Recipients)
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
-	plan.Recipients = manifest.Recipients
-	plan.PersistedRecipients = manifest.PersistedRecipients
-	plan.DeliveryTargets = manifest.DeliveryTargets
-	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients)...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, routedNodeDeliveryRoutesForNoTargetEvent(evt, routing.RoutedRecipients, plan.Recipients, plan.PersistedRecipients)...)
-	plan.DeliveryRoutes = append(plan.DeliveryRoutes, internalDeliveryRoutesForPlan(evt, plan.Recipients, plan.PersistedRecipients, routing.RoutedRecipients)...)
-	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
-	plan.TargetFailure = manifest.TargetFailure
-	if plan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
-		plan.TargetFailure = ""
+	routePlan = routePlanFromManifest(evt, manifest, routePlanSourceAgentPolicy, routePlanReasonMatchedAgentSubscription)
+	recipients := routePlan.RecipientIDs()
+	persisted := routePlan.PersistedRecipientIDs()
+	routePlan.AddDeliveryIntents(routedRootNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
+	routePlan.AddDeliveryIntents(routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
+	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
+	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
+	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
+	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
+		routePlan.TargetFailure = ""
 	}
-	plan.RoutedRecipients = routing.RoutedRecipients
-	plan.SubscribedRecipients = routing.SubscribedRecipients
-	plan.ExtraDetail = routing.ExtraDetail
-	return plan, nil
+	routePlan.RoutedRecipients = routing.RoutedRecipients
+	routePlan.SubscribedRecipients = routing.SubscribedRecipients
+	routePlan.ExtraDetail = routing.ExtraDetail
+	return routePlan.EventDeliveryPlan(), nil
 }
 
 func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recipients []string) (eventDeliveryPlan, error) {
-	plan := eventDeliveryPlan{Event: evt}
+	routePlan := newRoutePlan(evt)
 	if evt.Type == events.EventType("platform.runtime_log") {
-		return plan, nil
+		return routePlan.EventDeliveryPlan(), nil
 	}
 	requested := uniqueStrings(recipients)
 	if len(requested) == 0 {
@@ -138,21 +135,17 @@ func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recip
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
-	plan.Recipients = manifest.Recipients
-	plan.PersistedRecipients = manifest.PersistedRecipients
-	plan.DeliveryTargets = manifest.DeliveryTargets
-	plan.DeliveryRoutes = append([]events.DeliveryRoute(nil), manifest.DeliveryRoutes...)
-	plan.TargetFailure = manifest.TargetFailure
-	plan.ExtraDetail = map[string]any{
+	routePlan = routePlanFromManifest(evt, manifest, routePlanSourceDirectPolicy, routePlanReasonDirectPublish)
+	routePlan.ExtraDetail = map[string]any{
 		"direct":                     true,
 		"requested_recipients":       append([]string(nil), requested...),
 		"requested_recipients_count": len(requested),
 	}
 	if filtered := filteredRecipients(requested, manifest.Recipients); len(filtered) > 0 {
-		plan.ExtraDetail["filtered_out_recipients"] = filtered
-		plan.ExtraDetail["filtered_out_recipients_count"] = len(filtered)
+		routePlan.ExtraDetail["filtered_out_recipients"] = filtered
+		routePlan.ExtraDetail["filtered_out_recipients_count"] = len(filtered)
 	}
-	return plan, nil
+	return routePlan.EventDeliveryPlan(), nil
 }
 
 func filteredRecipients(requested, allowed []string) []string {
@@ -387,7 +380,7 @@ func agentDeliveryRoutesForRecipients(recipients []string, deliveryTargets map[s
 	return events.NormalizeDeliveryRoutes(out)
 }
 
-func internalDeliveryRoutesForPlan(evt events.Event, recipients, persisted []string, routed []Subscriber) []events.DeliveryRoute {
+func internalDeliveryIntentsForPlan(evt events.Event, recipients, persisted []string, routed []Subscriber) []RoutePlanDeliveryIntent {
 	internalRecipients := filterOutAgentIDs(recipients, persisted)
 	if len(internalRecipients) == 0 {
 		return nil
@@ -406,10 +399,10 @@ func internalDeliveryRoutesForPlan(evt events.Event, recipients, persisted []str
 			})
 		}
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceInternalTarget, routePlanReasonInternalCarrier)
 }
 
-func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
@@ -444,10 +437,10 @@ func routedNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscri
 			},
 		})
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
 }
 
-func routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []events.DeliveryRoute {
+func routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
@@ -484,10 +477,10 @@ func routedNodeDeliveryRoutesForNoRecipientFlowInstanceEvent(evt events.Event, r
 			},
 		})
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
 }
 
-func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+func routedRootNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
@@ -505,10 +498,10 @@ func routedRootNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Sub
 			SubscriberID:   recipient,
 		})
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceRootNodeRoute, routePlanReasonRouteTableNode)
 }
 
-func routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+func routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
@@ -536,7 +529,7 @@ func routedRootInputFlowNodeDeliveryRoutesForNoTargetEvent(evt events.Event, rou
 			SubscriberID:   recipient,
 		})
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceRootInputFlowNode, routePlanReasonRouteTableNode)
 }
 
 func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber) bool {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -203,6 +203,24 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	if got := plan.PersistedRecipients[0]; got != "observer" {
 		t.Fatalf("persisted recipient = %q, want observer", got)
 	}
+	if got, want := len(plan.RoutePlan.LiveRecipients), 2; got != want {
+		t.Fatalf("route plan live recipients = %d, want %d", got, want)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 2; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	var sawObserverAgent, sawWorkerNode bool
+	for _, intent := range plan.RoutePlan.DeliveryIntents {
+		if intent.SubscriberType == "agent" && intent.SubscriberID == "observer" && intent.Source == routePlanSourceAgentPolicy && intent.Reason == routePlanReasonMatchedAgentSubscription {
+			sawObserverAgent = true
+		}
+		if intent.SubscriberType == "node" && intent.SubscriberID == "worker" && intent.Source == routePlanSourceRootNodeRoute && intent.Reason == routePlanReasonRouteTableNode {
+			sawWorkerNode = true
+		}
+	}
+	if !sawObserverAgent || !sawWorkerNode {
+		t.Fatalf("route plan delivery intents = %#v, want observer agent policy and worker node route intents", plan.RoutePlan.DeliveryIntents)
+	}
 	if got := plan.ExtraDetail["routed_recipients_count"]; got != 1 {
 		t.Fatalf("routed_recipients_count = %#v, want 1", got)
 	}
@@ -313,6 +331,14 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 		}
 		if route.Target.Empty() {
 			t.Fatalf("delivery route target is empty: %#v", route)
+		}
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 2; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	for _, intent := range plan.RoutePlan.DeliveryIntents {
+		if intent.Source != routePlanSourceInternalTarget || intent.Reason != routePlanReasonInternalCarrier {
+			t.Fatalf("route plan delivery intent = %#v, want internal target carrier source", intent)
 		}
 	}
 }

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -102,6 +102,7 @@ const deliverySendTimeout = 250 * time.Millisecond
 var ErrStaleRuntimeEpoch = errors.New("stale runtime epoch")
 
 type eventDeliveryPlan struct {
+	RoutePlan            RoutePlan
 	Event                events.Event
 	Recipients           []string
 	PersistedRecipients  []string

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -784,8 +784,9 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	if len(routes) == 0 {
 		return plan, nil
 	}
-	plan.DeliveryRoutes = events.NormalizeDeliveryRoutes(append(plan.DeliveryRoutes, routes...))
-	return plan, nil
+	routePlan := plan.CanonicalRoutePlan()
+	routePlan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceRecipientMaterializer, routePlanReasonMaterializedRoute)...)
+	return plan.WithCanonicalRoutePlan(routePlan), nil
 }
 
 func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
@@ -796,24 +797,27 @@ func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt event
 }
 
 func (eb *EventBus) publishRecipientPlan(evt events.Event, plan eventDeliveryPlan) PublishRecipientPlan {
+	routePlan := plan.CanonicalRoutePlan()
 	out := PublishRecipientPlan{
-		Recipients:             uniqueStrings(plan.Recipients),
-		PersistedRecipients:    uniqueStrings(plan.PersistedRecipients),
-		SubscriptionRecipients: uniqueStrings(plan.SubscribedRecipients),
-		DeliveryRoutes:         events.NormalizeDeliveryRoutes(plan.DeliveryRoutes),
-		TargetFailure:          strings.TrimSpace(string(plan.TargetFailure)),
+		Recipients:             routePlan.RecipientIDs(),
+		PersistedRecipients:    routePlan.PersistedRecipientIDs(),
+		SubscriptionRecipients: uniqueStrings(routePlan.SubscribedRecipients),
+		DeliveryRoutes:         routePlan.DeliveryRoutes(),
+		TargetFailure:          strings.TrimSpace(string(routePlan.TargetFailure)),
 	}
 	if eb != nil {
-		out.RoutedRecipients = eb.describeSubscribersForEvent(string(evt.Type), plan.RoutedRecipients)
+		out.RoutedRecipients = eb.describeSubscribersForEvent(string(evt.Type), routePlan.RoutedRecipients)
 	}
 	return out
 }
 
 func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, plan.DeliveryTargets, plan.DeliveryRoutes, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+	routePlan := plan.CanonicalRoutePlan()
+	persistedRecipients := routePlan.PersistedRecipientIDs()
+	if err := eb.persistEventRecord(ctx, evt, persistedRecipients, routePlan.DeliveryTargets(), routePlan.DeliveryRoutes(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
 	}
-	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "matched_agent_subscription", plan.ExtraDetail)
+	eb.logQueuedDeliveries(ctx, evt, persistedRecipients, "matched_agent_subscription", routePlan.ExtraDetail)
 	return nil
 }
 
@@ -824,19 +828,21 @@ func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events
 		eb.logDispatchQueued(ctx, reason, evt, len(plan.Recipients), false, false)
 		return true, nil
 	}
-	if len(plan.Recipients) > 0 {
-		if err := eb.deliverToRecipientsWithRoutes(ctx, evt, plan.Recipients, plan.DeliveryRoutes); err != nil {
+	routePlan := plan.CanonicalRoutePlan()
+	recipients := routePlan.RecipientIDs()
+	if len(recipients) > 0 {
+		if err := eb.deliverToRecipientsWithRoutes(ctx, evt, recipients, routePlan.DeliveryRoutes()); err != nil {
 			return false, err
 		}
-		eb.logDelivery(ctx, evt, plan.Recipients, plan.ExtraDetail)
+		eb.logDelivery(ctx, evt, recipients, routePlan.ExtraDetail)
 	}
-	if plan.BlockedByCycle && plan.CycleEscalation != nil {
-		if err := eb.publishDeferred(ctx, *plan.CycleEscalation); err != nil {
+	if routePlan.BlockedByCycle && routePlan.CycleEscalation != nil {
+		if err := eb.publishDeferred(ctx, *routePlan.CycleEscalation); err != nil {
 			return false, err
 		}
 	}
-	if strings.TrimSpace(plan.ContradictionReason) != "" {
-		_ = eb.emitContradiction(ctx, evt, plan.ContradictionReason)
+	if strings.TrimSpace(routePlan.ContradictionReason) != "" {
+		_ = eb.emitContradiction(ctx, evt, routePlan.ContradictionReason)
 	}
 	return false, nil
 }
@@ -1075,13 +1081,14 @@ func (eb *EventBus) recordPublishDiagnostic(ctx context.Context, evt events.Even
 	if !ok || rec == nil {
 		return
 	}
+	routePlan := plan.CanonicalRoutePlan()
 	rec.AppendPublish(PublishDiagnostic{
 		EventID:                strings.TrimSpace(evt.ID),
 		EventType:              strings.TrimSpace(string(evt.Type)),
 		EntityID:               strings.TrimSpace(evt.EntityID()),
 		ParentEventID:          strings.TrimSpace(evt.ParentEventID),
-		RoutedRecipients:       eb.describeSubscribersForEvent(string(evt.Type), plan.RoutedRecipients),
-		SubscriptionRecipients: uniqueStrings(plan.SubscribedRecipients),
+		RoutedRecipients:       eb.describeSubscribersForEvent(string(evt.Type), routePlan.RoutedRecipients),
+		SubscriptionRecipients: uniqueStrings(routePlan.SubscribedRecipients),
 	})
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -186,6 +186,50 @@ func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *te
 	}
 }
 
+func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *testing.T) {
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "target-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "review/inst-1",
+		},
+	}
+	eb, err := NewEventBusWithOptions(InMemoryEventStore{}, EventBusOptions{
+		RecipientPlanMaterializer: func(ctx context.Context, evt events.Event, plan PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("pre-materialized delivery routes = %#v, want none", plan.DeliveryRoutes)
+			}
+			return []events.DeliveryRoute{want}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.Event{ID: uuid.NewString(), Type: events.EventType("review/inst-1/task.started")}
+
+	plan, err := eb.materializePublishRecipientPlan(context.Background(), evt, newRoutePlan(evt).EventDeliveryPlan())
+	if err != nil {
+		t.Fatalf("materializePublishRecipientPlan: %v", err)
+	}
+	if got, wantLen := len(plan.RoutePlan.DeliveryIntents), 1; got != wantLen {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, wantLen)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.SubscriberType != want.SubscriberType || intent.SubscriberID != want.SubscriberID || intent.Target != want.Target {
+		t.Fatalf("route plan delivery intent = %#v, want route %#v", intent, want)
+	}
+	if intent.Source != routePlanSourceRecipientMaterializer || intent.Reason != routePlanReasonMaterializedRoute {
+		t.Fatalf("route plan materializer source/reason = %q/%q, want materializer route", intent.Source, intent.Reason)
+	}
+	projected := eb.publishRecipientPlan(evt, plan)
+	if !deliveryRoutesContain(projected.DeliveryRoutes, want) {
+		t.Fatalf("projected delivery routes = %#v, want materialized route %#v", projected.DeliveryRoutes, want)
+	}
+}
+
 func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eb, err := NewEventBus(store)

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -1,0 +1,381 @@
+package bus
+
+import (
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+)
+
+const (
+	routePlanSubscriberAgent    = "agent"
+	routePlanSubscriberInternal = "internal"
+
+	routePlanSourceAgentPolicy           = "agent_policy"
+	routePlanSourceDirectPolicy          = "direct_policy"
+	routePlanSourceInternalTarget        = "internal_target_route"
+	routePlanSourceConcreteNodeRoute     = "concrete_node_route"
+	routePlanSourceRootNodeRoute         = "root_node_route"
+	routePlanSourceRootInputFlowNode     = "root_input_flow_node_route"
+	routePlanSourceRecipientMaterializer = "recipient_plan_materializer"
+	routePlanSourceLegacyProjection      = "legacy_projection"
+
+	routePlanReasonMatchedAgentSubscription = "matched_agent_subscription"
+	routePlanReasonDirectPublish            = "direct_publish"
+	routePlanReasonInternalCarrier          = "internal_carrier"
+	routePlanReasonRouteTableNode           = "route_table_node"
+	routePlanReasonMaterializedRoute        = "materialized_route"
+)
+
+// RoutePlan is the EventBus-owned publish-time route authority. It records the
+// typed delivery intents that should be persisted and the live dispatch
+// recipients that remain only projections/consumers of that authority.
+type RoutePlan struct {
+	Event                events.Event
+	LiveRecipients       []RoutePlanLiveRecipient
+	DeliveryIntents      []RoutePlanDeliveryIntent
+	RoutedRecipients     []Subscriber
+	SubscribedRecipients []string
+	ExtraDetail          map[string]any
+	TargetFailure        runtimepinrouting.TargetFailure
+	ContradictionReason  string
+	BlockedByCycle       bool
+	CycleEscalation      *events.Event
+}
+
+type RoutePlanLiveRecipient struct {
+	RecipientID       string
+	SubscriberType    string
+	PersistAsDelivery bool
+	Source            string
+	Reason            string
+}
+
+type RoutePlanDeliveryIntent struct {
+	SubscriberType string
+	SubscriberID   string
+	Target         events.RouteIdentity
+	Source         string
+	Reason         string
+	Persist        bool
+}
+
+func newRoutePlan(evt events.Event) RoutePlan {
+	return RoutePlan{Event: evt}
+}
+
+func (p RoutePlan) Normalized() RoutePlan {
+	p.LiveRecipients = normalizeRoutePlanLiveRecipients(p.LiveRecipients)
+	p.DeliveryIntents = normalizeRoutePlanDeliveryIntents(p.DeliveryIntents)
+	p.RoutedRecipients = append([]Subscriber(nil), p.RoutedRecipients...)
+	p.SubscribedRecipients = uniqueStrings(p.SubscribedRecipients)
+	p.ExtraDetail = cloneStringAnyMap(p.ExtraDetail)
+	p.TargetFailure = runtimepinrouting.TargetFailure(strings.TrimSpace(string(p.TargetFailure)))
+	p.ContradictionReason = strings.TrimSpace(p.ContradictionReason)
+	if p.CycleEscalation != nil {
+		evt := *p.CycleEscalation
+		p.CycleEscalation = &evt
+	}
+	return p
+}
+
+func (p *RoutePlan) AddLiveRecipients(recipients ...RoutePlanLiveRecipient) {
+	if p == nil {
+		return
+	}
+	p.LiveRecipients = normalizeRoutePlanLiveRecipients(append(p.LiveRecipients, recipients...))
+}
+
+func (p *RoutePlan) AddDeliveryIntents(intents ...RoutePlanDeliveryIntent) {
+	if p == nil {
+		return
+	}
+	p.DeliveryIntents = normalizeRoutePlanDeliveryIntents(append(p.DeliveryIntents, intents...))
+}
+
+func (p RoutePlan) RecipientIDs() []string {
+	p = p.Normalized()
+	out := make([]string, 0, len(p.LiveRecipients))
+	for _, recipient := range p.LiveRecipients {
+		out = append(out, recipient.RecipientID)
+	}
+	return uniqueStrings(out)
+}
+
+func (p RoutePlan) PersistedRecipientIDs() []string {
+	p = p.Normalized()
+	out := make([]string, 0, len(p.LiveRecipients))
+	for _, recipient := range p.LiveRecipients {
+		if !recipient.PersistAsDelivery {
+			continue
+		}
+		out = append(out, recipient.RecipientID)
+	}
+	return uniqueStrings(out)
+}
+
+func (p RoutePlan) DeliveryTargets() map[string]events.RouteIdentity {
+	p = p.Normalized()
+	out := map[string]events.RouteIdentity{}
+	for _, intent := range p.DeliveryIntents {
+		if intent.SubscriberType != routePlanSubscriberAgent {
+			continue
+		}
+		if intent.Target.Empty() {
+			continue
+		}
+		out[intent.SubscriberID] = intent.Target.Normalized()
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (p RoutePlan) DeliveryRoutes() []events.DeliveryRoute {
+	p = p.Normalized()
+	out := make([]events.DeliveryRoute, 0, len(p.DeliveryIntents))
+	for _, intent := range p.DeliveryIntents {
+		if !intent.Persist {
+			continue
+		}
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: intent.SubscriberType,
+			SubscriberID:   intent.SubscriberID,
+			Target:         intent.Target,
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func (p RoutePlan) EventDeliveryPlan() eventDeliveryPlan {
+	p = p.Normalized()
+	return eventDeliveryPlan{
+		RoutePlan:            p,
+		Event:                p.Event,
+		Recipients:           p.RecipientIDs(),
+		PersistedRecipients:  p.PersistedRecipientIDs(),
+		DeliveryTargets:      p.DeliveryTargets(),
+		DeliveryRoutes:       p.DeliveryRoutes(),
+		RoutedRecipients:     append([]Subscriber(nil), p.RoutedRecipients...),
+		SubscribedRecipients: uniqueStrings(p.SubscribedRecipients),
+		ExtraDetail:          cloneStringAnyMap(p.ExtraDetail),
+		TargetFailure:        p.TargetFailure,
+		ContradictionReason:  p.ContradictionReason,
+		BlockedByCycle:       p.BlockedByCycle,
+		CycleEscalation:      p.CycleEscalation,
+	}
+}
+
+func (p eventDeliveryPlan) CanonicalRoutePlan() RoutePlan {
+	if len(p.RoutePlan.LiveRecipients) > 0 || len(p.RoutePlan.DeliveryIntents) > 0 || p.RoutePlan.Event.Type != "" || p.RoutePlan.Event.ID != "" {
+		plan := p.RoutePlan.Normalized()
+		if plan.Event.Type == "" && plan.Event.ID == "" {
+			plan.Event = p.Event
+		}
+		return plan
+	}
+	return routePlanFromLegacyEventDeliveryPlan(p)
+}
+
+func (p eventDeliveryPlan) WithCanonicalRoutePlan(routePlan RoutePlan) eventDeliveryPlan {
+	routePlan = routePlan.Normalized()
+	if strings.TrimSpace(p.ContradictionReason) != "" {
+		routePlan.ContradictionReason = p.ContradictionReason
+	}
+	if p.BlockedByCycle {
+		routePlan.BlockedByCycle = true
+	}
+	if p.CycleEscalation != nil {
+		evt := *p.CycleEscalation
+		routePlan.CycleEscalation = &evt
+	}
+	return routePlan.EventDeliveryPlan()
+}
+
+func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
+	out := newRoutePlan(plan.Event)
+	persisted := make(map[string]struct{}, len(plan.PersistedRecipients))
+	for _, recipient := range uniqueStrings(plan.PersistedRecipients) {
+		persisted[recipient] = struct{}{}
+	}
+	for _, recipient := range uniqueStrings(plan.Recipients) {
+		subscriberType := routePlanSubscriberInternal
+		persist := false
+		if _, ok := persisted[recipient]; ok {
+			subscriberType = routePlanSubscriberAgent
+			persist = true
+		}
+		out.AddLiveRecipients(RoutePlanLiveRecipient{
+			RecipientID:       recipient,
+			SubscriberType:    subscriberType,
+			PersistAsDelivery: persist,
+			Source:            routePlanSourceLegacyProjection,
+			Reason:            routePlanSourceLegacyProjection,
+		})
+	}
+	for recipient := range persisted {
+		if containsString(out.RecipientIDs(), recipient) {
+			continue
+		}
+		out.AddLiveRecipients(RoutePlanLiveRecipient{
+			RecipientID:       recipient,
+			SubscriberType:    routePlanSubscriberAgent,
+			PersistAsDelivery: true,
+			Source:            routePlanSourceLegacyProjection,
+			Reason:            routePlanSourceLegacyProjection,
+		})
+	}
+	out.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(plan.DeliveryRoutes, routePlanSourceLegacyProjection, routePlanSourceLegacyProjection)...)
+	out.RoutedRecipients = append([]Subscriber(nil), plan.RoutedRecipients...)
+	out.SubscribedRecipients = uniqueStrings(plan.SubscribedRecipients)
+	out.ExtraDetail = cloneStringAnyMap(plan.ExtraDetail)
+	out.TargetFailure = plan.TargetFailure
+	out.ContradictionReason = plan.ContradictionReason
+	out.BlockedByCycle = plan.BlockedByCycle
+	out.CycleEscalation = plan.CycleEscalation
+	return out.Normalized()
+}
+
+func routePlanLiveRecipientsFromManifest(manifest deliveryRecipientManifest, source, reason string) []RoutePlanLiveRecipient {
+	persisted := make(map[string]struct{}, len(manifest.PersistedRecipients))
+	for _, recipient := range uniqueStrings(manifest.PersistedRecipients) {
+		persisted[recipient] = struct{}{}
+	}
+	recipientIDs := uniqueStrings(append(append([]string(nil), manifest.Recipients...), manifest.PersistedRecipients...))
+	out := make([]RoutePlanLiveRecipient, 0, len(recipientIDs))
+	for _, recipient := range recipientIDs {
+		subscriberType := routePlanSubscriberInternal
+		persist := false
+		if _, ok := persisted[recipient]; ok {
+			subscriberType = routePlanSubscriberAgent
+			persist = true
+		}
+		out = append(out, RoutePlanLiveRecipient{
+			RecipientID:       recipient,
+			SubscriberType:    subscriberType,
+			PersistAsDelivery: persist,
+			Source:            source,
+			Reason:            reason,
+		})
+	}
+	return normalizeRoutePlanLiveRecipients(out)
+}
+
+func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, reason string) []RoutePlanDeliveryIntent {
+	routes = events.NormalizeDeliveryRoutes(routes)
+	if len(routes) == 0 {
+		return nil
+	}
+	out := make([]RoutePlanDeliveryIntent, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, RoutePlanDeliveryIntent{
+			SubscriberType: route.SubscriberType,
+			SubscriberID:   route.SubscriberID,
+			Target:         route.Target,
+			Source:         source,
+			Reason:         reason,
+			Persist:        true,
+		})
+	}
+	return normalizeRoutePlanDeliveryIntents(out)
+}
+
+func routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, source, reason string) RoutePlan {
+	plan := newRoutePlan(evt)
+	plan.AddLiveRecipients(routePlanLiveRecipientsFromManifest(manifest, source, reason)...)
+	plan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(manifest.DeliveryRoutes, source, reason)...)
+	plan.TargetFailure = manifest.TargetFailure
+	return plan.Normalized()
+}
+
+func normalizeRoutePlanLiveRecipients(in []RoutePlanLiveRecipient) []RoutePlanLiveRecipient {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RoutePlanLiveRecipient, 0, len(in))
+	indexByKey := make(map[string]int, len(in))
+	for _, recipient := range in {
+		recipient.RecipientID = strings.TrimSpace(recipient.RecipientID)
+		recipient.SubscriberType = strings.TrimSpace(recipient.SubscriberType)
+		recipient.Source = strings.TrimSpace(recipient.Source)
+		recipient.Reason = strings.TrimSpace(recipient.Reason)
+		if recipient.RecipientID == "" {
+			continue
+		}
+		if recipient.SubscriberType == "" {
+			if recipient.PersistAsDelivery {
+				recipient.SubscriberType = routePlanSubscriberAgent
+			} else {
+				recipient.SubscriberType = routePlanSubscriberInternal
+			}
+		}
+		key := strings.Join([]string{recipient.SubscriberType, recipient.RecipientID}, "\x00")
+		if idx, ok := indexByKey[key]; ok {
+			out[idx].PersistAsDelivery = out[idx].PersistAsDelivery || recipient.PersistAsDelivery
+			if out[idx].Source == "" {
+				out[idx].Source = recipient.Source
+			}
+			if out[idx].Reason == "" {
+				out[idx].Reason = recipient.Reason
+			}
+			continue
+		}
+		indexByKey[key] = len(out)
+		out = append(out, recipient)
+	}
+	return out
+}
+
+func normalizeRoutePlanDeliveryIntents(in []RoutePlanDeliveryIntent) []RoutePlanDeliveryIntent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RoutePlanDeliveryIntent, 0, len(in))
+	indexByKey := make(map[string]int, len(in))
+	for _, intent := range in {
+		intent.SubscriberType = strings.TrimSpace(intent.SubscriberType)
+		intent.SubscriberID = strings.TrimSpace(intent.SubscriberID)
+		intent.Target = intent.Target.Normalized()
+		intent.Source = strings.TrimSpace(intent.Source)
+		intent.Reason = strings.TrimSpace(intent.Reason)
+		if intent.SubscriberType == "" || intent.SubscriberID == "" {
+			continue
+		}
+		key := strings.Join([]string{intent.SubscriberType, intent.SubscriberID, intent.Target.FlowID, intent.Target.FlowInstance, intent.Target.EntityID}, "\x00")
+		if idx, ok := indexByKey[key]; ok {
+			out[idx].Persist = out[idx].Persist || intent.Persist
+			if out[idx].Source == "" {
+				out[idx].Source = intent.Source
+			}
+			if out[idx].Reason == "" {
+				out[idx].Reason = intent.Reason
+			}
+			continue
+		}
+		indexByKey[key] = len(out)
+		out = append(out, intent)
+	}
+	return out
+}
+
+func cloneStringAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func containsString(in []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, item := range in {
+		if strings.TrimSpace(item) == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Introduces the EventBus-owned internal `RoutePlan` model with typed live-recipient projections and persisted delivery intents.
- Makes subscribed/direct delivery planning and helper-produced workflow-node routes normalize through that model before legacy projections are exposed.
- Normalizes `RecipientPlanMaterializer` output into the canonical plan so materialized selected-contract routes are not independent authority.

## Issue Links

Closes #1343
Part of #1340

## Governing Refs / Context

Binding spec references:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#engine.cross_flow_routing.delivery_filter`
- `platform-spec.yaml#persistence_schema.event_deliveries`
- `platform-spec.yaml#persistence_schema.event_receipts`

Gate context:

- #1343 Pre-Implementation Coverage Audit
- #1343 gate outcome: `approved as first slice` for `eventbus_route_plan_internal_model_canonicalization`

## Semantic Migration Notes

New canonical owner:

- `internal/runtime/bus.RoutePlan` as the EventBus route-production authority for this child slice.

Old producer / reader / writer paths now invalid as canonical authority:

- loose recipient string slices by themselves;
- helper-level ad hoc `[]events.DeliveryRoute` fragments;
- `PublishRecipientPlan` as route authority rather than projection;
- selected-contract materializer output outside EventBus normalization.

Production paths checked:

- subscribed publish planning;
- direct publish planning;
- helper-produced root/root-input/concrete/target-set node routes;
- selected-contract materializer route output;
- `CheckPublishRecipientPlan` projection;
- subscribed persistence/dispatch adapter paths.

Migration completeness:

- Complete for the approved #1343 internal producer/model slice.
- Not claiming #1340 parent closure; #1344/#1345/#1346/#1293/#1299/#1301 remain live by gate.

## Proof

- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/runforkexecution -run 'RecipientPlan|Materialize|SelectedContract' -count=1`
- `go test ./...`
