### PR TITLE
[agent-c][issue #1344] Converge route plan publish consumers

### DIFF
--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -233,7 +233,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		return err
 	} else if reason != "" {
 		queued = true
-		eb.logDispatchQueued(ictx, reason, evt, len(plan.Recipients), false, false)
+		eb.logDispatchQueued(ictx, reason, evt, len(plan.RecipientIDs()), false, false)
 		eb.logPublished(ictx, evt, int(time.Since(start)/time.Microsecond))
 		return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
 	}
@@ -302,23 +302,12 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
 		return fmt.Errorf("persist event: %w", err)
 	}
-	if err := eb.authorizePublishRecipientPlanning(txctx, evt); err != nil {
-		return err
-	}
-	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
+	inboundPlan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
 	if err != nil {
 		return err
 	}
-	inboundPlan, err = eb.materializePublishRecipientPlan(txctx, evt, inboundPlan)
-	if err != nil {
-		return err
-	}
-	if err := eb.authorizePublishRecipientPlan(txctx, evt, inboundPlan); err != nil {
-		return err
-	}
-	eb.recordPublishDiagnostic(txctx, evt, inboundPlan)
-	if len(inboundPlan.PersistedRecipients) > 0 || len(inboundPlan.DeliveryRoutes) > 0 {
-		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID, inboundPlan.PersistedRecipients, inboundPlan.DeliveryTargets, inboundPlan.DeliveryRoutes); err != nil {
+	if inboundPlan.HasPersistentDeliveries() {
+		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID, inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
 	}
@@ -339,7 +328,7 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
 		return err
 	} else if reason != "" {
-		eb.logDispatchQueued(txctx, reason, evt, len(inboundPlan.Recipients), false, true)
+		eb.logDispatchQueued(txctx, reason, evt, len(inboundPlan.RecipientIDs()), false, true)
 		return nil
 	}
 	if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
@@ -350,7 +339,8 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	return nil
 }
 
-func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Event, inboundPlan eventDeliveryPlan) {
+func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Event, inboundPlan RoutePlan) {
+	inboundPlan = inboundPlan.Normalized()
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
 	afterPublishActions := make([]func(), 0, 4)
@@ -370,13 +360,14 @@ func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Ev
 	runtimepipeline.FlushDeferredPipelineTransitions(ctx, deferredTransitions)
 
 	if passthrough {
-		if len(inboundPlan.Recipients) > 0 {
-			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
-			if err := eb.deliverToRecipientsWithRoutes(ctx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
+		recipients := inboundPlan.RecipientIDs()
+		if len(recipients) > 0 {
+			eb.logQueuedDeliveries(ctx, evt, inboundPlan.PersistedRecipientIDs(), "matched_agent_subscription", inboundPlan.ExtraDetail)
+			if err := eb.deliverToRecipientsWithRoutes(ctx, evt, recipients, inboundPlan.DeliveryRoutes()); err != nil {
 				eb.recordCommittedPublishReceipt(ctx, evt, err)
 				return
 			}
-			eb.logDelivery(ctx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
+			eb.logDelivery(ctx, evt, recipients, inboundPlan.ExtraDetail)
 		}
 		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
 			if err := eb.publishDeferred(ctx, *inboundPlan.CycleEscalation); err != nil {
@@ -480,23 +471,12 @@ func (eb *EventBus) publishTransactional(
 		return fmt.Errorf("persist event: %w", err)
 	}
 
-	if err := eb.authorizePublishRecipientPlanning(txctx, evt); err != nil {
-		return err
-	}
-	inboundPlan, err := eb.deliveryPlanner.Plan(txctx, evt)
+	inboundPlan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
 	if err != nil {
 		return err
 	}
-	inboundPlan, err = eb.materializePublishRecipientPlan(txctx, evt, inboundPlan)
-	if err != nil {
-		return err
-	}
-	if err := eb.authorizePublishRecipientPlan(txctx, evt, inboundPlan); err != nil {
-		return err
-	}
-	eb.recordPublishDiagnostic(txctx, evt, inboundPlan)
-	if len(inboundPlan.PersistedRecipients) > 0 || len(inboundPlan.DeliveryRoutes) > 0 {
-		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID, inboundPlan.PersistedRecipients, inboundPlan.DeliveryTargets, inboundPlan.DeliveryRoutes); err != nil {
+	if inboundPlan.HasPersistentDeliveries() {
+		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID, inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
 	}
@@ -530,7 +510,7 @@ func (eb *EventBus) publishTransactional(
 			return fmt.Errorf("commit publish tx: %w", err)
 		}
 		committed = true
-		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.Recipients), false, false)
+		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.RecipientIDs()), false, false)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
 	}
@@ -556,13 +536,14 @@ func (eb *EventBus) publishTransactional(
 	}
 
 	if passthrough {
-		if len(inboundPlan.Recipients) > 0 {
-			eb.logQueuedDeliveries(dispatchCtx, evt, inboundPlan.PersistedRecipients, "matched_agent_subscription", inboundPlan.ExtraDetail)
-			if err := eb.deliverToRecipientsWithRoutes(dispatchCtx, evt, inboundPlan.Recipients, inboundPlan.DeliveryRoutes); err != nil {
+		recipients := inboundPlan.RecipientIDs()
+		if len(recipients) > 0 {
+			eb.logQueuedDeliveries(dispatchCtx, evt, inboundPlan.PersistedRecipientIDs(), "matched_agent_subscription", inboundPlan.ExtraDetail)
+			if err := eb.deliverToRecipientsWithRoutes(dispatchCtx, evt, recipients, inboundPlan.DeliveryRoutes()); err != nil {
 				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
 				return nil
 			}
-			eb.logDelivery(dispatchCtx, evt, inboundPlan.Recipients, inboundPlan.ExtraDetail)
+			eb.logDelivery(dispatchCtx, evt, recipients, inboundPlan.ExtraDetail)
 		}
 		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
 			if err := eb.publishDeferred(dispatchCtx, *inboundPlan.CycleEscalation); err != nil {
@@ -704,7 +685,7 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		return err
 	} else if reason != "" {
 		queued = true
-		eb.logDispatchQueued(ctx, reason, evt, len(plan.Recipients), false, false)
+		eb.logDispatchQueued(ctx, reason, evt, len(plan.RecipientIDs()), false, false)
 		eb.logPublished(ctx, evt, 0)
 		return nil
 	}
@@ -747,23 +728,30 @@ func (eb *EventBus) publishSubscribedNonTransactional(ctx context.Context, evt e
 	return eb.deliverSubscribedPublishPlan(ctx, evt, plan)
 }
 
-func (eb *EventBus) planSubscribedPublish(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
+func (eb *EventBus) planSubscribedPublish(ctx context.Context, evt events.Event) (RoutePlan, error) {
+	return eb.planSubscribedRoutePlan(ctx, evt, true)
+}
+
+func (eb *EventBus) planSubscribedRoutePlan(ctx context.Context, evt events.Event, recordDiagnostic bool) (RoutePlan, error) {
 	if err := eb.authorizePublishRecipientPlanning(ctx, evt); err != nil {
-		return eventDeliveryPlan{}, err
+		return RoutePlan{}, err
 	}
 	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
 	if err != nil {
-		return eventDeliveryPlan{}, err
+		return RoutePlan{}, err
 	}
 	plan, err = eb.materializePublishRecipientPlan(ctx, evt, plan)
 	if err != nil {
-		return eventDeliveryPlan{}, err
+		return RoutePlan{}, err
 	}
 	if err := eb.authorizePublishRecipientPlan(ctx, evt, plan); err != nil {
-		return eventDeliveryPlan{}, err
+		return RoutePlan{}, err
 	}
-	eb.recordPublishDiagnostic(ctx, evt, plan)
-	return plan, nil
+	routePlan := plan.CanonicalRoutePlan()
+	if recordDiagnostic {
+		eb.recordPublishDiagnostic(ctx, evt, routePlan)
+	}
+	return routePlan, nil
 }
 
 func (eb *EventBus) authorizePublishRecipientPlanning(ctx context.Context, evt events.Event) error {
@@ -777,7 +765,7 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	if eb == nil || eb.recipientPlanMaterializer == nil {
 		return plan, nil
 	}
-	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, plan))
+	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan()))
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
@@ -793,11 +781,11 @@ func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt event
 	if eb == nil || eb.recipientPlanGuard == nil {
 		return nil
 	}
-	return eb.recipientPlanGuard(ctx, evt, eb.publishRecipientPlan(evt, plan))
+	return eb.recipientPlanGuard(ctx, evt, eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan()))
 }
 
-func (eb *EventBus) publishRecipientPlan(evt events.Event, plan eventDeliveryPlan) PublishRecipientPlan {
-	routePlan := plan.CanonicalRoutePlan()
+func (eb *EventBus) publishRecipientPlan(evt events.Event, routePlan RoutePlan) PublishRecipientPlan {
+	routePlan = routePlan.Normalized()
 	out := PublishRecipientPlan{
 		Recipients:             routePlan.RecipientIDs(),
 		PersistedRecipients:    routePlan.PersistedRecipientIDs(),
@@ -811,8 +799,8 @@ func (eb *EventBus) publishRecipientPlan(evt events.Event, plan eventDeliveryPla
 	return out
 }
 
-func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {
-	routePlan := plan.CanonicalRoutePlan()
+func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events.Event, routePlan RoutePlan) error {
+	routePlan = routePlan.Normalized()
 	persistedRecipients := routePlan.PersistedRecipientIDs()
 	if err := eb.persistEventRecord(ctx, evt, persistedRecipients, routePlan.DeliveryTargets(), routePlan.DeliveryRoutes(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
@@ -821,14 +809,14 @@ func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events
 	return nil
 }
 
-func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) (bool, error) {
+func (eb *EventBus) deliverSubscribedPublishPlan(ctx context.Context, evt events.Event, routePlan RoutePlan) (bool, error) {
 	if reason, err := eb.dispatchQueueReason(ctx, evt); err != nil {
 		return false, err
 	} else if reason != "" {
-		eb.logDispatchQueued(ctx, reason, evt, len(plan.Recipients), false, false)
+		eb.logDispatchQueued(ctx, reason, evt, len(routePlan.RecipientIDs()), false, false)
 		return true, nil
 	}
-	routePlan := plan.CanonicalRoutePlan()
+	routePlan = routePlan.Normalized()
 	recipients := routePlan.RecipientIDs()
 	if len(recipients) > 0 {
 		if err := eb.deliverToRecipientsWithRoutes(ctx, evt, recipients, routePlan.DeliveryRoutes()); err != nil {
@@ -1076,12 +1064,12 @@ func (eb *EventBus) localizedSubscriberEvent(eventType string, subscriber Subscr
 	return ""
 }
 
-func (eb *EventBus) recordPublishDiagnostic(ctx context.Context, evt events.Event, plan eventDeliveryPlan) {
+func (eb *EventBus) recordPublishDiagnostic(ctx context.Context, evt events.Event, routePlan RoutePlan) {
 	rec, ok := EmittedEventsRecorderFromContext(ctx)
 	if !ok || rec == nil {
 		return
 	}
-	routePlan := plan.CanonicalRoutePlan()
+	routePlan = routePlan.Normalized()
 	rec.AppendPublish(PublishDiagnostic{
 		EventID:                strings.TrimSpace(evt.ID),
 		EventType:              strings.TrimSpace(string(evt.Type)),
@@ -1090,6 +1078,14 @@ func (eb *EventBus) recordPublishDiagnostic(ctx context.Context, evt events.Even
 		RoutedRecipients:       eb.describeSubscribersForEvent(string(evt.Type), routePlan.RoutedRecipients),
 		SubscriptionRecipients: uniqueStrings(routePlan.SubscribedRecipients),
 	})
+}
+
+func (eb *EventBus) planDirectRoutePlan(ctx context.Context, evt events.Event, recipients []string) (RoutePlan, error) {
+	plan, err := eb.deliveryPlanner.PlanDirect(ctx, evt, recipients)
+	if err != nil {
+		return RoutePlan{}, err
+	}
+	return plan.CanonicalRoutePlan(), nil
 }
 
 // PublishDirect persists an event and delivers it to an explicit caller-supplied
@@ -1134,11 +1130,11 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		evt.CreatedAt = time.Now()
 	}
 	ctx, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
-	plan, err := eb.deliveryPlanner.PlanDirect(ctx, evt, recipients)
+	plan, err := eb.planDirectRoutePlan(ctx, evt, recipients)
 	if err != nil {
 		return err
 	}
-	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipients, plan.DeliveryTargets, plan.DeliveryRoutes, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
+	if err := eb.persistEventRecord(ctx, evt, plan.PersistedRecipientIDs(), plan.DeliveryTargets(), plan.DeliveryRoutes(), runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		return err
 	}
 	persisted = true
@@ -1148,20 +1144,21 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
 	}
-	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipients, "direct_publish", plan.ExtraDetail)
+	eb.logQueuedDeliveries(ctx, evt, plan.PersistedRecipientIDs(), "direct_publish", plan.ExtraDetail)
 	if reason, err := eb.dispatchQueueReason(ctx, evt); err != nil {
 		return err
 	} else if reason != "" {
 		queued = true
-		eb.logDispatchQueued(ctx, reason, evt, len(plan.Recipients), true, false)
+		eb.logDispatchQueued(ctx, reason, evt, len(plan.RecipientIDs()), true, false)
 		return nil
 	}
-	if err := eb.deliverToRecipientsWithRoutes(ctx, evt, plan.Recipients, plan.DeliveryRoutes); err != nil {
+	recipients = plan.RecipientIDs()
+	if err := eb.deliverToRecipientsWithRoutes(ctx, evt, recipients, plan.DeliveryRoutes()); err != nil {
 		return err
 	}
 	detail := map[string]any{
 		"direct":           true,
-		"recipients_count": len(plan.Recipients),
+		"recipients_count": len(recipients),
 		"parent_event_id":  strings.TrimSpace(evt.ParentEventID),
 	}
 	for k, v := range plan.ExtraDetail {
@@ -1193,18 +1190,19 @@ func (eb *EventBus) CheckDirectRecipients(ctx context.Context, evt events.Event,
 			return status, fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type)), err)
 		}
 	}
-	plan, err := eb.deliveryPlanner.PlanDirect(ctx, evt, requested)
+	plan, err := eb.planDirectRoutePlan(ctx, evt, requested)
 	if err != nil {
 		return status, err
 	}
-	status.Recipients = append([]string(nil), plan.Recipients...)
-	status.Filtered = filteredRecipients(requested, plan.Recipients)
-	liveRecipients := eb.snapshotRecipientChans(plan.Recipients)
+	plannedRecipients := plan.RecipientIDs()
+	status.Recipients = append([]string(nil), plannedRecipients...)
+	status.Filtered = filteredRecipients(requested, plannedRecipients)
+	liveRecipients := eb.snapshotRecipientChans(plannedRecipients)
 	live := make(map[string]struct{}, len(liveRecipients))
 	for _, recipient := range liveRecipients {
 		live[recipient.agentID] = struct{}{}
 	}
-	for _, recipient := range plan.Recipients {
+	for _, recipient := range plannedRecipients {
 		if _, ok := live[recipient]; !ok {
 			status.Missing = append(status.Missing, recipient)
 		}
@@ -1232,18 +1230,8 @@ func (eb *EventBus) CheckPublishRecipientPlan(ctx context.Context, evt events.Ev
 			return PublishRecipientPlan{}, fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type)), err)
 		}
 	}
-	if err := eb.authorizePublishRecipientPlanning(ctx, evt); err != nil {
-		return PublishRecipientPlan{}, err
-	}
-	plan, err := eb.deliveryPlanner.Plan(ctx, evt)
+	plan, err := eb.planSubscribedRoutePlan(ctx, evt, false)
 	if err != nil {
-		return PublishRecipientPlan{}, err
-	}
-	plan, err = eb.materializePublishRecipientPlan(ctx, evt, plan)
-	if err != nil {
-		return PublishRecipientPlan{}, err
-	}
-	if err := eb.authorizePublishRecipientPlan(ctx, evt, plan); err != nil {
 		return PublishRecipientPlan{}, err
 	}
 	return eb.publishRecipientPlan(evt, plan), nil
@@ -1368,7 +1356,7 @@ func (eb *EventBus) deliveryRoutesForEvent(ctx context.Context, eventID string) 
 	return deliveryRoutesFromTargetMap(recipients, "agent", targets)
 }
 
-func (eb *EventBus) recordTargetDeliveryFailure(ctx context.Context, evt events.Event, plan eventDeliveryPlan) {
+func (eb *EventBus) recordTargetDeliveryFailure(ctx context.Context, evt events.Event, plan RoutePlan) {
 	failure := runtimepinrouting.TargetFailure(strings.TrimSpace(string(plan.TargetFailure)))
 	if failure == "" {
 		return
@@ -1385,7 +1373,7 @@ func (eb *EventBus) recordTargetDeliveryFailure(ctx context.Context, evt events.
 	}
 }
 
-func (eb *EventBus) recordTargetDeliveryFailureTx(ctx context.Context, tx *sql.Tx, evt events.Event, plan eventDeliveryPlan) {
+func (eb *EventBus) recordTargetDeliveryFailureTx(ctx context.Context, tx *sql.Tx, evt events.Event, plan RoutePlan) {
 	failure := runtimepinrouting.TargetFailure(strings.TrimSpace(string(plan.TargetFailure)))
 	if failure == "" {
 		return
@@ -1402,7 +1390,8 @@ func (eb *EventBus) recordTargetDeliveryFailureTx(ctx context.Context, tx *sql.T
 	}
 }
 
-func targetDeliveryFailureRecord(evt events.Event, plan eventDeliveryPlan, failure runtimepinrouting.TargetFailure) (string, map[string]any, runtimedeadletters.Record) {
+func targetDeliveryFailureRecord(evt events.Event, plan RoutePlan, failure runtimepinrouting.TargetFailure) (string, map[string]any, runtimedeadletters.Record) {
+	plan = plan.Normalized()
 	message := targetDeliveryFailureMessage(failure)
 	target := evt.TargetRoute()
 	targetSet := evt.TargetRoutes()
@@ -1411,9 +1400,10 @@ func targetDeliveryFailureRecord(evt events.Event, plan eventDeliveryPlan, failu
 		"source":                evt.SourceRoute(),
 		"target":                target,
 		"target_set":            targetSet,
-		"recipients":            append([]string(nil), plan.Recipients...),
-		"persisted_recipients":  append([]string(nil), plan.PersistedRecipients...),
-		"delivery_targets":      cloneRouteTargetMap(plan.DeliveryTargets),
+		"recipients":            plan.RecipientIDs(),
+		"persisted_recipients":  plan.PersistedRecipientIDs(),
+		"delivery_targets":      cloneRouteTargetMap(plan.DeliveryTargets()),
+		"delivery_routes":       plan.DeliveryRoutes(),
 	}
 	targetContext, _ := json.Marshal(detail)
 	deadLetterRoute := target

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -224,7 +224,7 @@ func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *te
 	if intent.Source != routePlanSourceRecipientMaterializer || intent.Reason != routePlanReasonMaterializedRoute {
 		t.Fatalf("route plan materializer source/reason = %q/%q, want materializer route", intent.Source, intent.Reason)
 	}
-	projected := eb.publishRecipientPlan(evt, plan)
+	projected := eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan())
 	if !deliveryRoutesContain(projected.DeliveryRoutes, want) {
 		t.Fatalf("projected delivery routes = %#v, want materialized route %#v", projected.DeliveryRoutes, want)
 	}
@@ -322,15 +322,23 @@ func mixedNodeAgentDeliveryPlanner(nodeID, agentID string) deliveryPlanner {
 	)
 }
 
-func nodeOnlyDeliveryPlan(evt events.Event, nodeID string) eventDeliveryPlan {
-	return eventDeliveryPlan{
-		Event:      evt,
-		Recipients: []string{nodeID},
-		DeliveryRoutes: []events.DeliveryRoute{{
-			SubscriberType: "node",
-			SubscriberID:   nodeID,
-		}},
-	}
+func nodeOnlyDeliveryPlan(evt events.Event, nodeID string) RoutePlan {
+	plan := newRoutePlan(evt)
+	plan.AddLiveRecipients(RoutePlanLiveRecipient{
+		RecipientID:       nodeID,
+		SubscriberType:    routePlanSubscriberInternal,
+		PersistAsDelivery: false,
+		Source:            "test",
+		Reason:            "test",
+	})
+	plan.AddDeliveryIntents(RoutePlanDeliveryIntent{
+		SubscriberType: "node",
+		SubscriberID:   nodeID,
+		Source:         "test",
+		Reason:         "test",
+		Persist:        true,
+	})
+	return plan.Normalized()
 }
 
 func TestEventBusPublish_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -62,7 +62,7 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if err := txStore.AppendEventTx(ctx, tx, intent.Event); err != nil {
 			return fmt.Errorf("persist event: %w", err)
 		}
-		if err := o.bus.insertEventDeliveriesTx(ctx, txStore, tx, intent.Event.ID, plan.PersistedRecipients, plan.DeliveryTargets, plan.DeliveryRoutes); err != nil {
+		if err := o.bus.insertEventDeliveriesTx(ctx, txStore, tx, intent.Event.ID, plan.PersistedRecipientIDs(), plan.DeliveryTargets(), plan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
 		if scopeWriter, ok := o.bus.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
@@ -77,36 +77,21 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
 			failedEvent := intent.Event
-			failedPlan := eventDeliveryPlan{
-				Event:               failedEvent,
-				PersistedRecipients: plan.PersistedRecipients,
-				DeliveryTargets:     plan.DeliveryTargets,
-				DeliveryRoutes:      plan.DeliveryRoutes,
-				TargetFailure:       plan.TargetFailure,
-			}
+			failedPlan := plan
 			runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
 				o.bus.recordTargetDeliveryFailure(context.WithoutCancel(ctx), failedEvent, failedPlan)
 			})
 		}
-		o.bus.setPendingInternalDeliveryRoutes(intent.Event.ID, internalDeliveryRoutesForEventPlan(plan))
+		o.bus.setPendingInternalDeliveryRoutes(intent.Event.ID, plan.InternalDeliveryRoutes())
 	}
 	return nil
 }
 
-func (o engineOutbox) deliveryPlanForIntent(ctx context.Context, intent runtimeengine.EmitIntent) (eventDeliveryPlan, error) {
+func (o engineOutbox) deliveryPlanForIntent(ctx context.Context, intent runtimeengine.EmitIntent) (RoutePlan, error) {
 	if len(intent.Recipients) > 0 {
-		plan, err := o.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
-		if err != nil {
-			return eventDeliveryPlan{}, err
-		}
-		return plan, nil
+		return o.bus.planDirectRoutePlan(ctx, intent.Event, intent.Recipients)
 	}
-	plan, err := o.bus.deliveryPlanner.Plan(ctx, intent.Event)
-	if err != nil {
-		return eventDeliveryPlan{}, err
-	}
-	o.bus.recordPublishDiagnostic(ctx, intent.Event, plan)
-	return plan, nil
+	return o.bus.planSubscribedRoutePlan(ctx, intent.Event, true)
 }
 
 func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runtimeengine.EmitIntent) error {
@@ -225,7 +210,9 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 	if len(liveRecipients) == 0 {
 		d.bus.clearPendingInternalDeliveryRoutes(intent.Event.ID)
 		if intent.Event.HasTargetRoute() {
-			plan := eventDeliveryPlan{Event: intent.Event, TargetFailure: runtimepinrouting.FailureTargetNotSubscribed}
+			plan := newRoutePlan(intent.Event)
+			plan.TargetFailure = runtimepinrouting.FailureTargetNotSubscribed
+			plan = plan.Normalized()
 			d.bus.recordTargetDeliveryFailure(ctx, intent.Event, plan)
 			d.bus.markPipelineReceipt(ctx, intent.Event.ID, "dead_letter", targetDeliveryFailureMessage(plan.TargetFailure))
 			return true, nil
@@ -253,16 +240,17 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 }
 
 func (d engineDispatcher) dispatchExplicitDirectIntent(ctx context.Context, intent runtimeengine.EmitIntent) error {
-	plan, err := d.bus.deliveryPlanner.PlanDirect(ctx, intent.Event, intent.Recipients)
+	plan, err := d.bus.planDirectRoutePlan(ctx, intent.Event, intent.Recipients)
 	if err != nil {
 		return err
 	}
-	if err := d.bus.deliverToRecipientsWithRoutes(ctx, intent.Event, plan.Recipients, plan.DeliveryRoutes); err != nil {
+	recipients := plan.RecipientIDs()
+	if err := d.bus.deliverToRecipientsWithRoutes(ctx, intent.Event, recipients, plan.DeliveryRoutes()); err != nil {
 		return err
 	}
 	detail := map[string]any{
 		"direct":           true,
-		"recipients_count": len(plan.Recipients),
+		"recipients_count": len(recipients),
 		"parent_event_id":  strings.TrimSpace(intent.Event.ParentEventID),
 	}
 	for k, v := range plan.ExtraDetail {
@@ -287,34 +275,6 @@ func replayScopeForEmitIntent(intent runtimeengine.EmitIntent) runtimereplayclai
 		return runtimereplayclaim.CommittedReplayScopeDirect
 	}
 	return runtimereplayclaim.CommittedReplayScopeSubscribed
-}
-
-func internalDeliveryRoutesForEventPlan(plan eventDeliveryPlan) []events.DeliveryRoute {
-	internalRecipients := filterOutAgentIDs(plan.Recipients, plan.PersistedRecipients)
-	if len(internalRecipients) == 0 {
-		return nil
-	}
-	known := events.NormalizeDeliveryRoutes(plan.DeliveryRoutes)
-	out := make([]events.DeliveryRoute, 0, len(known))
-	internalSet := make(map[string]struct{}, len(internalRecipients))
-	for _, recipient := range internalRecipients {
-		internalSet[strings.TrimSpace(recipient)] = struct{}{}
-	}
-	for _, route := range known {
-		if _, ok := internalSet[strings.TrimSpace(route.SubscriberID)]; !ok {
-			continue
-		}
-		out = append(out, route)
-	}
-	if len(out) == 0 {
-		for _, recipient := range internalRecipients {
-			out = append(out, events.DeliveryRoute{
-				SubscriberType: "node",
-				SubscriberID:   recipient,
-			})
-		}
-	}
-	return events.NormalizeDeliveryRoutes(out)
 }
 
 func (eb *EventBus) setPendingInternalDeliveryRoutes(eventID string, deliveryRoutes []events.DeliveryRoute) {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -26,6 +26,7 @@ type directRecipientTransactionalStore struct {
 	descriptors []runtimebus.ActiveAgentDescriptor
 	events      []events.Event
 	deliveries  map[string][]string
+	routes      map[string][]events.DeliveryRoute
 }
 
 func (s *recordingEventStore) AppendEvent(_ context.Context, evt events.Event) error {
@@ -92,8 +93,44 @@ func (s *directRecipientTransactionalStore) InsertEventDeliveriesTx(ctx context.
 	return s.InsertEventDeliveries(ctx, eventID, agentIDs)
 }
 
+func (s *directRecipientTransactionalStore) InsertEventDeliveryRoutesTx(_ context.Context, _ *sql.Tx, eventID string, routes []events.DeliveryRoute) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.routes == nil {
+		s.routes = map[string][]events.DeliveryRoute{}
+	}
+	if s.deliveries == nil {
+		s.deliveries = map[string][]string{}
+	}
+	s.routes[eventID] = events.NormalizeDeliveryRoutes(routes)
+	for _, route := range s.routes[eventID] {
+		if route.SubscriberType != "agent" {
+			continue
+		}
+		s.deliveries[eventID] = append(s.deliveries[eventID], route.SubscriberID)
+	}
+	return nil
+}
+
 func (*directRecipientTransactionalStore) UpsertPipelineReceiptTx(context.Context, *sql.Tx, string, string, string) error {
 	return nil
+}
+
+func (s *directRecipientTransactionalStore) deliveryRoutes(eventID string) []events.DeliveryRoute {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]events.DeliveryRoute(nil), s.routes[eventID]...)
+}
+
+func deliveryRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRoute) bool {
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberType == want.SubscriberType &&
+			route.SubscriberID == want.SubscriberID &&
+			route.Target.Normalized() == want.Target.Normalized() {
+			return true
+		}
+	}
+	return false
 }
 
 type interceptingTestHandler struct{}
@@ -365,6 +402,79 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	}
 	if strings.Join(gotPersisted, ",") != "reviewer" {
 		t.Fatalf("persisted recipients = %v, want [reviewer]", gotPersisted)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "target-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "review/inst-1",
+		},
+	}
+	guardSawMaterializedRoute := false
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		RecipientPlanMaterializer: func(ctx context.Context, evt events.Event, plan runtimebus.PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("pre-materialized delivery routes = %#v, want none", plan.DeliveryRoutes)
+			}
+			return []events.DeliveryRoute{want}, nil
+		},
+		RecipientPlanGuard: func(ctx context.Context, evt events.Event, plan runtimebus.PublishRecipientPlan) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if !deliveryRoutesContain(plan.DeliveryRoutes, want) {
+				t.Fatalf("guard delivery routes = %#v, want %#v", plan.DeliveryRoutes, want)
+			}
+			guardSawMaterializedRoute = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	intent := runtimeengine.EmitIntent{
+		Event: events.Event{
+			ID:        "evt-outbox-materialized-route",
+			Type:      events.EventType("review/inst-1/task.started"),
+			Payload:   []byte(`{}`),
+			CreatedAt: time.Now().UTC(),
+		},
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if !guardSawMaterializedRoute {
+		t.Fatal("recipient plan guard did not see materialized route")
+	}
+	if got := store.deliveryRoutes(intent.Event.ID); !deliveryRoutesContain(got, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", got, want)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -148,6 +148,46 @@ func (p RoutePlan) DeliveryRoutes() []events.DeliveryRoute {
 	return events.NormalizeDeliveryRoutes(out)
 }
 
+func (p RoutePlan) HasPersistentDeliveries() bool {
+	return len(p.PersistedRecipientIDs()) > 0 || len(p.DeliveryRoutes()) > 0
+}
+
+func (p RoutePlan) InternalDeliveryRoutes() []events.DeliveryRoute {
+	p = p.Normalized()
+	internalRecipients := make([]string, 0, len(p.LiveRecipients))
+	for _, recipient := range p.LiveRecipients {
+		if recipient.PersistAsDelivery {
+			continue
+		}
+		internalRecipients = append(internalRecipients, recipient.RecipientID)
+	}
+	internalRecipients = uniqueStrings(internalRecipients)
+	if len(internalRecipients) == 0 {
+		return nil
+	}
+	known := p.DeliveryRoutes()
+	out := make([]events.DeliveryRoute, 0, len(known))
+	internalSet := make(map[string]struct{}, len(internalRecipients))
+	for _, recipient := range internalRecipients {
+		internalSet[strings.TrimSpace(recipient)] = struct{}{}
+	}
+	for _, route := range known {
+		if _, ok := internalSet[strings.TrimSpace(route.SubscriberID)]; !ok {
+			continue
+		}
+		out = append(out, route)
+	}
+	if len(out) == 0 {
+		for _, recipient := range internalRecipients {
+			out = append(out, events.DeliveryRoute{
+				SubscriberType: "node",
+				SubscriberID:   recipient,
+			})
+		}
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
 func (p RoutePlan) EventDeliveryPlan() eventDeliveryPlan {
 	p = p.Normalized()
 	return eventDeliveryPlan{


### PR DESCRIPTION
## Summary

Converges EventBus publish-time consumers onto the canonical typed `RoutePlan` introduced by #1343:

- routes `CheckPublishRecipientPlan`, `Publish`, `PublishTx`, transactional publish, deferred publish, outbox write, outbox direct fallback, `PublishDirect`, and `CheckDirectRecipients` through typed `RoutePlan` projections
- persists typed delivery rows/routes from `RoutePlan` before interceptor/post-commit dispatch paths consume the event
- removes the outbox `internalDeliveryRoutesForEventPlan` adapter path and derives internal pending routes from `RoutePlan`
- adds outbox proof that subscribed outbox intents consume the materializer/guard path and persist typed routes in the transaction

Closes #1344.
Part of #1340.

## Governing refs

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#engine.cross_flow_routing.delivery_filter`
- `platform-spec.yaml#persistence_schema.event_deliveries`
- `platform-spec.yaml#persistence_schema.event_receipts`
- `platform-spec.yaml#/v1/rpc event.publish`
- #1344 pre-audit and gate: `route_plan_publish_preflight_deferred_outbox_consumer_convergence`

## Semantic migration

New canonical owner: `internal/runtime/bus.RoutePlan`, backed by `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`.

Old paths now invalid as publish-time route authority:

- direct consumer reads of `eventDeliveryPlan.Recipients`, `PersistedRecipients`, `DeliveryTargets`, and `DeliveryRoutes`
- duplicate route-plan assembly in `CheckPublishRecipientPlan`, `PublishTx`, transactional publish, and outbox subscribed intent handling
- outbox internal pending-route derivation from legacy live-vs-persisted recipient fields

Production paths checked/moved:

- `CheckPublishRecipientPlan`
- non-transactional `Publish` and `publishDeferred`
- caller-owned `PublishTx`
- owned transactional publish and post-commit dispatch
- `PublishDirect` and `CheckDirectRecipients`
- `engineOutbox.WriteOutbox`, `deliveryPlanForIntent`, and explicit direct fallback dispatch

Migration status: complete for the approved #1344 EventBus publish-time consumer class. #1293, #1299, #1301, #1345, and #1346 remain split.

## Proof

- `go test ./internal/runtime/bus -run 'TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors|TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan|TestEventBusCheckPublishRecipientPlanReportsSubscribedPublishWithoutDelivery|TestEventBusPublishTxRunsInterceptorsAfterCallerCommit|TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan|TestEngineOutboxPersistsEventsAndDeliveriesInTransaction|TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedManifest|TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPersisted|TestEventBusPublishTxDispatch_NodeOnlyRouteDoesNotRequireAgentChannel' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1`
- `go test ./...`
