### PR TITLE
[agent-c][issue #1345] Preserve typed delivery readback identity

### DIFF
--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -46,10 +46,12 @@ type eventPublishResult struct {
 }
 
 type eventPublishDelivery struct {
-	SubscriberID string `json:"subscriber_id"`
-	SessionID    string `json:"session_id,omitempty"`
-	Status       string `json:"status"`
-	Attempt      int    `json:"attempt"`
+	DeliveryID     string `json:"delivery_id"`
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	SessionID      string `json:"session_id,omitempty"`
+	Status         string `json:"status"`
+	Attempt        int    `json:"attempt"`
 }
 
 func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
@@ -233,12 +235,17 @@ func validateEventPublishDelivery(prefix string, delivery eventPublishDelivery) 
 		name  string
 		value string
 	}{
+		{name: "delivery_id", value: delivery.DeliveryID},
+		{name: "subscriber_type", value: delivery.SubscriberType},
 		{name: "subscriber_id", value: delivery.SubscriberID},
 		{name: "status", value: delivery.Status},
 	} {
 		if strings.TrimSpace(field.value) == "" {
 			return fmt.Errorf("malformed event.publish result: %s.%s is required", prefix, field.name)
 		}
+	}
+	if _, ok := eventObservationValidSubscriberTypes[strings.TrimSpace(delivery.SubscriberType)]; !ok {
+		return fmt.Errorf("malformed event.publish result: %s.subscriber_type=%q is not a valid SubscriberType", prefix, delivery.SubscriberType)
 	}
 	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
 		return fmt.Errorf("malformed event.publish result: %s.status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
@@ -261,7 +268,9 @@ func writeEventPublishResult(out io.Writer, eventName string, result eventPublis
 		len(result.Deliveries),
 	)
 	for _, delivery := range result.Deliveries {
-		fmt.Fprintf(out, "delivery subscriber_id=%s status=%s session_id=%s attempt=%d\n",
+		fmt.Fprintf(out, "delivery delivery_id=%s subscriber=%s/%s status=%s session_id=%s attempt=%d\n",
+			delivery.DeliveryID,
+			delivery.SubscriberType,
 			delivery.SubscriberID,
 			delivery.Status,
 			eventObservationDash(delivery.SessionID),

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -67,7 +67,8 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 		"run_id=run-1",
 		"new_run_created=true",
 		"deliveries=1",
-		"delivery subscriber_id=agent-1",
+		"delivery delivery_id=delivery-1",
+		"subscriber=agent/agent-1",
 		"session_id=session-1",
 		"attempt=2",
 		"source_event_id=event-parent-1",
@@ -571,12 +572,36 @@ func TestEventPublishMalformedResultsFailClosed(t *testing.T) {
 			wantStderr: "deliveries is required",
 		},
 		{
+			name: "missing delivery id",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "delivery_id")
+			},
+			wantStderr: "deliveries[0].delivery_id is required",
+		},
+		{
+			name: "missing subscriber type",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "subscriber_type")
+			},
+			wantStderr: "deliveries[0].subscriber_type is required",
+		},
+		{
 			name: "missing subscriber",
 			mutate: func(result map[string]any) {
 				delivery := result["deliveries"].([]any)[0].(map[string]any)
 				delete(delivery, "subscriber_id")
 			},
 			wantStderr: "deliveries[0].subscriber_id is required",
+		},
+		{
+			name: "invalid subscriber type",
+			mutate: func(result map[string]any) {
+				delivery := result["deliveries"].([]any)[0].(map[string]any)
+				delivery["subscriber_type"] = "platform"
+			},
+			wantStderr: "deliveries[0].subscriber_type",
 		},
 		{
 			name: "invalid delivery status",
@@ -629,10 +654,12 @@ func eventPublishTestResult(newRunCreated bool) map[string]any {
 		"new_run_created": newRunCreated,
 		"deliveries": []any{
 			map[string]any{
-				"subscriber_id": "agent-1",
-				"session_id":    "session-1",
-				"status":        "delivered",
-				"attempt":       2,
+				"delivery_id":     "delivery-1",
+				"subscriber_type": "agent",
+				"subscriber_id":   "agent-1",
+				"session_id":      "session-1",
+				"status":          "delivered",
+				"attempt":         2,
 			},
 		},
 	}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -27,10 +27,12 @@ type eventPublishResult struct {
 }
 
 type eventPublishDelivery struct {
-	SubscriberID string `json:"subscriber_id"`
-	SessionID    string `json:"session_id,omitempty"`
-	Status       string `json:"status"`
-	Attempt      int    `json:"attempt"`
+	DeliveryID     string `json:"delivery_id"`
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	SessionID      string `json:"session_id,omitempty"`
+	Status         string `json:"status"`
+	Attempt        int    `json:"attempt"`
 }
 
 type eventPublicationParams struct {
@@ -568,10 +570,12 @@ func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDeli
 			attempt = 1
 		}
 		item := eventPublishDelivery{
-			SubscriberID: strings.TrimSpace(delivery.SubscriberID),
-			SessionID:    strings.TrimSpace(delivery.SessionID),
-			Status:       strings.TrimSpace(delivery.Status),
-			Attempt:      attempt,
+			DeliveryID:     strings.TrimSpace(delivery.DeliveryID),
+			SubscriberType: strings.TrimSpace(delivery.SubscriberType),
+			SubscriberID:   strings.TrimSpace(delivery.SubscriberID),
+			SessionID:      strings.TrimSpace(delivery.SessionID),
+			Status:         strings.TrimSpace(delivery.Status),
+			Attempt:        attempt,
 		}
 		if _, ok := seen[item]; ok {
 			continue

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -56,13 +56,11 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 		t.Fatalf("new_run_created = %#v, want true", result["new_run_created"])
 	}
 	deliveries := asSlice(t, result["deliveries"])
-	if len(deliveries) != 1 {
-		t.Fatalf("deliveries = %#v, want one persisted delivery", deliveries)
+	if len(deliveries) != 2 {
+		t.Fatalf("deliveries = %#v, want persisted node and agent deliveries", deliveries)
 	}
-	delivery := asMap(t, deliveries[0])
-	if delivery["subscriber_id"] != "scan-orchestrator" || delivery["status"] != "pending" || delivery["attempt"] != float64(1) {
-		t.Fatalf("delivery = %#v, want scan-orchestrator pending attempt 1", delivery)
-	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "scan-orchestrator", "pending", 1)
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count = %d, want 1", count)
 	}
@@ -83,6 +81,12 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 	if replayResult["event_id"] != eventID || replayResult["run_id"] != runID {
 		t.Fatalf("event.publish replay result = %#v, want original event/run", replayResult)
 	}
+	replayDeliveries := asSlice(t, replayResult["deliveries"])
+	if len(replayDeliveries) != 2 {
+		t.Fatalf("event.publish replay deliveries = %#v, want persisted node and agent deliveries", replayDeliveries)
+	}
+	assertEventPublishDeliveriesContain(t, replayDeliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, replayDeliveries, "node", "scan-orchestrator", "pending", 1)
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
 	}
@@ -120,6 +124,11 @@ func TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock(t *t
 	if result["new_run_created"] != true {
 		t.Fatalf("sqlite new_run_created = %#v, want true", result["new_run_created"])
 	}
+	deliveries := asSlice(t, result["deliveries"])
+	if len(deliveries) != 1 {
+		t.Fatalf("sqlite deliveries = %#v, want one persisted delivery", deliveries)
+	}
+	assertEventPublishDeliveryIdentity(t, asMap(t, deliveries[0]), "node", "scan-orchestrator", "pending", 1)
 	assertSQLiteEventPublishRows(t, sqliteStore.DB, runID, eventID, "scan.requested", "cli-publish:"+actorTokenID(testToken))
 	if count := countSQLiteAPIIdempotencyRows(t, sqliteStore.DB); count != 1 {
 		t.Fatalf("sqlite api_idempotency rows = %d, want 1", count)
@@ -239,6 +248,8 @@ func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
 	}
 	if delivery := asMap(t, deliveries[0]); delivery["subscriber_id"] != "repo-observer" {
 		t.Fatalf("delivery = %#v, want repo-observer", delivery)
+	} else {
+		assertEventPublishDeliveryIdentity(t, delivery, "agent", "repo-observer", "pending", 1)
 	}
 	got := requireAPIV1RuntimeBusEvent(t, ch, "flow-scoped event.publish delivery")
 	if got.ID != eventID || string(got.Type) != canonicalEventName {
@@ -440,9 +451,12 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 	if count := countEventsByName(t, db, "scan.requested"); count != 1 {
 		t.Fatalf("scan.requested event count after replay = %d, want 1", count)
 	}
-	if got := len(asSlice(t, replayResult["deliveries"])); got != 1 {
-		t.Fatalf("replay deliveries = %d, want persisted delivery result", got)
+	deliveries := asSlice(t, replayResult["deliveries"])
+	if len(deliveries) != 2 {
+		t.Fatalf("replay deliveries = %#v, want typed persisted delivery results", deliveries)
 	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "scan-orchestrator", "pending", 1)
 }
 
 func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *testing.T) {
@@ -628,9 +642,12 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 	if targetedResult["run_id"] != runID || targetedResult["new_run_created"] != false {
 		t.Fatalf("targeted result = %#v, want existing run", targetedResult)
 	}
-	if got := len(asSlice(t, targetedResult["deliveries"])); got != 1 {
-		t.Fatalf("targeted deliveries = %d, want 1", got)
+	deliveries := asSlice(t, targetedResult["deliveries"])
+	if len(deliveries) != 2 {
+		t.Fatalf("targeted deliveries = %#v, want typed agent and node deliveries", deliveries)
 	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "scan-orchestrator", "pending", 1)
 	if count := countEventsByName(t, db, "scan.requested"); count != 2 {
 		t.Fatalf("scan.requested events after targeted publish = %d, want 2", count)
 	}
@@ -715,6 +732,8 @@ func TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersisten
 	}
 	if delivery := asMap(t, deliveries[0]); delivery["subscriber_id"] != "scan-orchestrator" {
 		t.Fatalf("follow-up delivery = %#v, want scan-orchestrator", delivery)
+	} else {
+		assertEventPublishDeliveryIdentity(t, delivery, "agent", "scan-orchestrator", "pending", 1)
 	}
 	assertEventPublishEventRow(t, db, runID, followUpEventID, "scan.followup", "operator-test")
 	if got := countRunRowsByID(t, db, runID); got != 1 {
@@ -840,9 +859,11 @@ func TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun(t *testing
 	if got := countSQLiteEventsByName(t, sqliteStore.DB, "scan.followup"); got != 1 {
 		t.Fatalf("sqlite scan.followup rows = %d, want 1", got)
 	}
-	if got := len(asSlice(t, result["deliveries"])); got != 1 {
-		t.Fatalf("sqlite follow-up deliveries = %d, want 1", got)
+	deliveries := asSlice(t, result["deliveries"])
+	if len(deliveries) != 1 {
+		t.Fatalf("sqlite follow-up deliveries = %#v, want 1", deliveries)
 	}
+	assertEventPublishDeliveryIdentity(t, asMap(t, deliveries[0]), "agent", "scan-orchestrator", "pending", 1)
 	got := requireAPIV1RuntimeBusEvent(t, followUpCh, "sqlite follow-up delivery")
 	if got.ID != eventID || got.RunID != runID {
 		t.Fatalf("sqlite follow-up delivered id/run = %s/%s, want %s/%s", got.ID, got.RunID, eventID, runID)
@@ -1244,12 +1265,15 @@ func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
 		t.Fatalf("paused event.publish error = %#v", published.Error)
 	}
 	eventID := stringValue(t, asMap(t, published.Result)["event_id"], "event_id")
-	if got := len(asSlice(t, asMap(t, published.Result)["deliveries"])); got != 1 {
-		t.Fatalf("paused event.publish deliveries = %d, want 1", got)
+	deliveries := asSlice(t, asMap(t, published.Result)["deliveries"])
+	if len(deliveries) != 2 {
+		t.Fatalf("paused event.publish deliveries = %#v, want typed agent and node deliveries", deliveries)
 	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "scan-orchestrator", "pending", 1)
 	requireNoAPIV1RuntimeBusEvent(t, ch, "paused event.publish before resume")
 	if got := countEventDeliveriesForEvent(t, ctx, db, eventID); got != 1 {
-		t.Fatalf("paused event deliveries = %d, want 1", got)
+		t.Fatalf("paused event deliveries = %d, want 1 queued route", got)
 	}
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
 		t.Fatalf("paused pipeline receipts = %d, want 0", got)
@@ -1839,6 +1863,43 @@ func stringValue(t *testing.T, value any, field string) string {
 		t.Fatalf("%s = %#v, want non-empty string", field, value)
 	}
 	return strings.TrimSpace(text)
+}
+
+func assertEventPublishDeliveryIdentity(t *testing.T, delivery map[string]any, wantSubscriberType, wantSubscriberID, wantStatus string, wantAttempt int) {
+	t.Helper()
+	if strings.TrimSpace(stringValue(t, delivery["delivery_id"], "delivery_id")) == "" {
+		t.Fatalf("delivery = %#v, want non-empty delivery_id", delivery)
+	}
+	if delivery["subscriber_type"] != wantSubscriberType ||
+		delivery["subscriber_id"] != wantSubscriberID ||
+		delivery["status"] != wantStatus ||
+		delivery["attempt"] != float64(wantAttempt) {
+		t.Fatalf("delivery = %#v, want %s/%s %s attempt %d", delivery, wantSubscriberType, wantSubscriberID, wantStatus, wantAttempt)
+	}
+}
+
+func assertEventPublishDeliveriesContain(t *testing.T, deliveries []any, wantSubscriberType, wantSubscriberID, wantStatus string, wantAttempt int) {
+	t.Helper()
+	for _, raw := range deliveries {
+		delivery := asMap(t, raw)
+		if delivery["subscriber_type"] == wantSubscriberType &&
+			delivery["subscriber_id"] == wantSubscriberID &&
+			delivery["status"] == wantStatus &&
+			delivery["attempt"] == float64(wantAttempt) {
+			assertEventPublishDeliveryIdentity(t, delivery, wantSubscriberType, wantSubscriberID, wantStatus, wantAttempt)
+			return
+		}
+	}
+	t.Fatalf("deliveries = %#v, want %s/%s %s attempt %d", deliveries, wantSubscriberType, wantSubscriberID, wantStatus, wantAttempt)
+}
+
+func validEventPublishSubscriberType(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "agent", "node":
+		return true
+	default:
+		return false
+	}
 }
 
 func asSlice(t *testing.T, value any) []any {

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -72,6 +72,9 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 			seenReviewer := false
 			for _, rawDelivery := range deliveries {
 				delivery := asMap(t, rawDelivery)
+				if strings.TrimSpace(stringValue(t, delivery["delivery_id"], "delivery_id")) == "" || !validEventPublishSubscriberType(fmt.Sprint(delivery["subscriber_type"])) {
+					t.Fatalf("event.publish delivery identity = %#v, want persisted typed delivery identity", delivery)
+				}
 				switch delivery["subscriber_id"] {
 				case "workflow-runtime":
 					seenWorkflowRuntime = delivery["status"] == "pending"

--- a/internal/apiv1/operator_runtime_context_test.go
+++ b/internal/apiv1/operator_runtime_context_test.go
@@ -89,9 +89,12 @@ func TestOperatorRuntimeContextManagerRoutesExistingRunByStoredBundle(t *testing
 	}
 	result := asMap(t, resp.Result)
 	eventID := stringValue(t, result["event_id"], "event_id")
-	if got := len(asSlice(t, result["deliveries"])); got != 1 {
-		t.Fatalf("event.publish existing run deliveries = %d, want 1", got)
+	deliveries := asSlice(t, result["deliveries"])
+	if len(deliveries) != 2 {
+		t.Fatalf("event.publish existing run deliveries = %#v, want typed agent and node rows", deliveries)
 	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "scan-orchestrator", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "scan-orchestrator", "pending", 1)
 	if got := countEventRowsByRunID(t, fixture.db, runID); got != 2 {
 		t.Fatalf("event rows for existing run = %d, want 2", got)
 	}

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -10,11 +10,12 @@ import (
 )
 
 type EventFilter struct {
-	Type       string
-	Source     string
-	EntityID   string
-	Subscriber string
-	After      time.Time
+	Type           string
+	Source         string
+	EntityID       string
+	SubscriberID   string
+	SubscriberType string
+	After          time.Time
 }
 
 type RuntimeLogFilter struct {
@@ -162,9 +163,10 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 	owner := &store.PostgresStore{DB: r.db}
 	result, err := owner.ListOperatorEvents(ctx, store.OperatorEventListOptions{
 		Filter: store.OperatorEventListFilter{
-			EntityID:     filter.EntityID,
-			EventName:    filter.Type,
-			SubscriberID: filter.Subscriber,
+			EntityID:       filter.EntityID,
+			EventName:      filter.Type,
+			SubscriberID:   filter.SubscriberID,
+			SubscriberType: filter.SubscriberType,
 		},
 		Source:             filter.Source,
 		Since:              dashboardTimePtr(filter.After),

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -37,10 +37,12 @@ type IncidentFilter struct {
 }
 
 type eventDeliveryRecord struct {
-	AgentID    string `json:"agent_id,omitempty"`
-	Status     string `json:"status,omitempty"`
-	Error      string `json:"error,omitempty"`
-	RetryCount int    `json:"retry_count,omitempty"`
+	DeliveryID     string `json:"delivery_id,omitempty"`
+	SubscriberType string `json:"subscriber_type,omitempty"`
+	SubscriberID   string `json:"subscriber_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	Error          string `json:"error,omitempty"`
+	RetryCount     int    `json:"retry_count,omitempty"`
 }
 
 type deliveryLifecycleSummary struct {
@@ -280,10 +282,12 @@ func dashboardEventRecord(event store.OperatorEventFull) eventRecord {
 	}
 	for _, delivery := range event.Deliveries {
 		record.Deliveries = append(record.Deliveries, eventDeliveryRecord{
-			AgentID:    delivery.SubscriberID,
-			Status:     delivery.Status,
-			Error:      delivery.LastError,
-			RetryCount: delivery.RetryCount,
+			DeliveryID:     delivery.DeliveryID,
+			SubscriberType: delivery.SubscriberType,
+			SubscriberID:   delivery.SubscriberID,
+			Status:         delivery.Status,
+			Error:          delivery.LastError,
+			RetryCount:     delivery.RetryCount,
 		})
 		record.DeliveryLifecycle.record(delivery.Status)
 	}

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -99,6 +99,14 @@ func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *tes
 	if got.PendingCount != 1 || got.ErrorCount != 1 || got.DeadCount != 1 {
 		t.Fatalf("legacy counts = pending=%d error=%d dead=%d", got.PendingCount, got.ErrorCount, got.DeadCount)
 	}
+	if len(got.Deliveries) != 5 {
+		t.Fatalf("deliveries len = %d, want 5", len(got.Deliveries))
+	}
+	for _, item := range got.Deliveries {
+		if strings.TrimSpace(item.DeliveryID) == "" || item.SubscriberType != "agent" || strings.TrimSpace(item.SubscriberID) == "" {
+			t.Fatalf("delivery identity = %#v, want delivery_id and agent subscriber identity", item)
+		}
+	}
 }
 
 func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T) {
@@ -152,7 +160,7 @@ func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T)
 	if len(got.Deliveries) != 1 {
 		t.Fatalf("deliveries len = %d, want 1", len(got.Deliveries))
 	}
-	if item := got.Deliveries[0]; item.AgentID != "agent-a" || item.Status != "pending" || item.RetryCount != 1 || item.Error != "delivery-wins" {
+	if item := got.Deliveries[0]; strings.TrimSpace(item.DeliveryID) == "" || item.SubscriberType != "agent" || item.SubscriberID != "agent-a" || item.Status != "pending" || item.RetryCount != 1 || item.Error != "delivery-wins" {
 		t.Fatalf("delivery = %#v", item)
 	}
 }

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -109,6 +109,70 @@ func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *tes
 	}
 }
 
+func TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
+	ctx := context.Background()
+
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	type deliverySeed struct {
+		subscriberType string
+		subscriberID   string
+	}
+	seedEvent := func(eventName string, at time.Time, deliveries ...deliverySeed) string {
+		t.Helper()
+		eventID := uuid.NewString()
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, $3, 'global', '{}'::jsonb, 'runtime', 'agent', $4
+			)
+		`, eventID, runID, eventName, at.UTC()); err != nil {
+			t.Fatalf("seed event %s: %v", eventName, err)
+		}
+		for _, delivery := range deliveries {
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO event_deliveries (
+					run_id, event_id, subscriber_type, subscriber_id, status, created_at
+				) VALUES (
+					$1::uuid, $2::uuid, $3, $4, 'pending', $5
+				)
+			`, runID, eventID, delivery.subscriberType, delivery.subscriberID, at.UTC()); err != nil {
+				t.Fatalf("seed delivery %s/%s: %v", delivery.subscriberType, delivery.subscriberID, err)
+			}
+		}
+		return eventID
+	}
+
+	base := time.Unix(1700000600, 0).UTC()
+	wantAgentEvent := seedEvent("typed.agent", base,
+		deliverySeed{subscriberType: "agent", subscriberID: "colliding-subscriber"},
+	)
+	seedEvent("typed.node", base.Add(time.Second),
+		deliverySeed{subscriberType: "node", subscriberID: "colliding-subscriber"},
+	)
+	seedEvent("typed.cross-product", base.Add(2*time.Second),
+		deliverySeed{subscriberType: "node", subscriberID: "colliding-subscriber"},
+		deliverySeed{subscriberType: "agent", subscriberID: "different-subscriber"},
+	)
+
+	rows, err := reader.ListEvents(ctx, EventFilter{
+		SubscriberID:   "colliding-subscriber",
+		SubscriberType: "agent",
+	}, 10)
+	if err != nil {
+		t.Fatalf("ListEvents typed subscriber filter: %v", err)
+	}
+	if len(rows) != 1 || rows[0].EventID != wantAgentEvent {
+		t.Fatalf("typed subscriber filtered rows = %#v, want only %s", rows, wantAgentEvent)
+	}
+}
+
 func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})

--- a/internal/dashboard/server/server.go
+++ b/internal/dashboard/server/server.go
@@ -545,13 +545,11 @@ func (h *Handler) handleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	rows := []eventRecord{}
 	if h.observability != nil {
-		filter := EventFilter{
-			Type:       strings.TrimSpace(r.URL.Query().Get("type")),
-			Source:     strings.TrimSpace(r.URL.Query().Get("source")),
-			EntityID:   strings.TrimSpace(r.URL.Query().Get("entity_id")),
-			Subscriber: strings.TrimSpace(r.URL.Query().Get("subscriber")),
+		filter, err := dashboardEventFilterFromRequest(r)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, err)
+			return
 		}
-		var err error
 		rows, err = h.observability.ListEvents(r.Context(), filter, intQuery(r, "limit", 200))
 		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, err)
@@ -710,6 +708,14 @@ func (h *Handler) handleRunTrace(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleEventStream(w http.ResponseWriter, r *http.Request) {
+	includeRuntime := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_runtime")), "true")
+	eventFilter, err := dashboardEventFilterFromRequest(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err)
+		return
+	}
+	eventFilter.After = time.Now().UTC().Add(-2 * time.Second)
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeJSONError(w, http.StatusInternalServerError, errors.New("streaming is not supported"))
@@ -721,14 +727,6 @@ func (h *Handler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	includeRuntime := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_runtime")), "true")
-	eventFilter := EventFilter{
-		Type:       strings.TrimSpace(r.URL.Query().Get("type")),
-		Source:     strings.TrimSpace(r.URL.Query().Get("source")),
-		EntityID:   strings.TrimSpace(r.URL.Query().Get("entity_id")),
-		Subscriber: strings.TrimSpace(r.URL.Query().Get("subscriber")),
-		After:      time.Now().UTC().Add(-2 * time.Second),
-	}
 	logFilter := RuntimeLogFilter{
 		Type:      strings.TrimSpace(r.URL.Query().Get("type")),
 		Source:    strings.TrimSpace(r.URL.Query().Get("source")),
@@ -779,6 +777,36 @@ func (h *Handler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+func dashboardEventFilterFromRequest(r *http.Request) (EventFilter, error) {
+	query := r.URL.Query()
+	subscriberID := strings.TrimSpace(query.Get("subscriber_id"))
+	legacySubscriber := strings.TrimSpace(query.Get("subscriber"))
+	if subscriberID != "" && legacySubscriber != "" && subscriberID != legacySubscriber {
+		return EventFilter{}, errors.New("subscriber and subscriber_id must match")
+	}
+	if subscriberID == "" {
+		subscriberID = legacySubscriber
+	}
+	subscriberType := strings.TrimSpace(query.Get("subscriber_type"))
+	if subscriberType != "" {
+		if _, ok := dashboardEventSubscriberTypes[subscriberType]; !ok {
+			return EventFilter{}, fmt.Errorf("subscriber_type=%q is not a valid SubscriberType", subscriberType)
+		}
+	}
+	return EventFilter{
+		Type:           strings.TrimSpace(query.Get("type")),
+		Source:         strings.TrimSpace(query.Get("source")),
+		EntityID:       strings.TrimSpace(query.Get("entity_id")),
+		SubscriberID:   subscriberID,
+		SubscriberType: subscriberType,
+	}, nil
+}
+
+var dashboardEventSubscriberTypes = map[string]struct{}{
+	"agent": {},
+	"node":  {},
 }
 
 func (h *Handler) handleMailbox(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1221,8 +1221,10 @@ func TestHandler_ConversationsAndAggregates(t *testing.T) {
 					EventID: "evt-1",
 					Type:    "task.completed",
 					Deliveries: []eventDeliveryRecord{{
-						AgentID: "agent-1",
-						Status:  "success",
+						DeliveryID:     "delivery-1",
+						SubscriberType: "agent",
+						SubscriberID:   "agent-1",
+						Status:         "success",
 					}},
 				},
 			},

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -108,6 +108,38 @@ func setOperatorAuth(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+testOperatorAuthToken)
 }
 
+func TestDashboardEventFilterFromRequestPreservesTypedSubscriberIdentity(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/events?type=task.completed&source=runtime&entity_id=entity-1&subscriber=worker-1&subscriber_id=worker-1&subscriber_type=node", nil)
+
+	filter, err := dashboardEventFilterFromRequest(req)
+	if err != nil {
+		t.Fatalf("dashboardEventFilterFromRequest: %v", err)
+	}
+	if filter.Type != "task.completed" ||
+		filter.Source != "runtime" ||
+		filter.EntityID != "entity-1" ||
+		filter.SubscriberID != "worker-1" ||
+		filter.SubscriberType != "node" {
+		t.Fatalf("filter = %#v", filter)
+	}
+}
+
+func TestDashboardEventFilterFromRequestRejectsInvalidSubscriberType(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/events?subscriber=worker-1&subscriber_type=platform", nil)
+
+	if _, err := dashboardEventFilterFromRequest(req); err == nil || !strings.Contains(err.Error(), "subscriber_type") {
+		t.Fatalf("dashboardEventFilterFromRequest error = %v, want subscriber_type rejection", err)
+	}
+}
+
+func TestDashboardEventFilterFromRequestRejectsConflictingSubscriberAliases(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/events?subscriber=worker-1&subscriber_id=worker-2&subscriber_type=agent", nil)
+
+	if _, err := dashboardEventFilterFromRequest(req); err == nil || !strings.Contains(err.Error(), "subscriber and subscriber_id must match") {
+		t.Fatalf("dashboardEventFilterFromRequest error = %v, want alias conflict rejection", err)
+	}
+}
+
 type stubAgents struct {
 	rows []runtimemanager.PersistedAgent
 }

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -226,17 +226,24 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 		n := add(opts.Source)
 		where = append(where, fmt.Sprintf("COALESCE(e.produced_by, '') = $%d", n))
 	}
+	deliveryWhere := make([]string, 0, 3)
 	if opts.Filter.DeliveryStatus != "" {
 		n := add(opts.Filter.DeliveryStatus)
-		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.status = $%d)", n))
+		deliveryWhere = append(deliveryWhere, fmt.Sprintf("d.status = $%d", n))
 	}
 	if opts.Filter.SubscriberID != "" {
 		n := add(opts.Filter.SubscriberID)
-		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.subscriber_id = $%d)", n))
+		deliveryWhere = append(deliveryWhere, fmt.Sprintf("d.subscriber_id = $%d", n))
 	}
 	if opts.Filter.SubscriberType != "" {
 		n := add(opts.Filter.SubscriberType)
-		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND d.subscriber_type = $%d)", n))
+		deliveryWhere = append(deliveryWhere, fmt.Sprintf("d.subscriber_type = $%d", n))
+	}
+	if len(deliveryWhere) > 0 {
+		where = append(where, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM event_deliveries d WHERE d.event_id = e.event_id AND %s)",
+			strings.Join(deliveryWhere, " AND "),
+		))
 	}
 	if opts.Filter.ReasonCode != "" {
 		n := add(opts.Filter.ReasonCode)

--- a/openrpc.json
+++ b/openrpc.json
@@ -9547,6 +9547,9 @@
             "minimum": 1,
             "type": "integer"
           },
+          "delivery_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
           "session_id": {
             "type": "string"
           },
@@ -9555,9 +9558,14 @@
           },
           "subscriber_id": {
             "type": "string"
+          },
+          "subscriber_type": {
+            "$ref": "#/components/schemas/SubscriberType"
           }
         },
         "required": [
+          "delivery_id",
+          "subscriber_type",
           "subscriber_id",
           "status",
           "attempt"

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -492,7 +492,9 @@ contract_formats:
             subscriber_type, and subscriber_id. They remain non-authoritative
             readback surfaces and must not re-plan subscribers, fabricate rows,
             or expose delivery_target_route unless a separately gated public
-            schema change promotes route-target identity.
+            schema change promotes route-target identity. Dashboard event-list
+            subscriber selectors consume the same typed subscriber_id +
+            subscriber_type delivery identity as the canonical event.list owner.
           split_owner: '#1345 owns the public/operator readback projection for delivery_id, subscriber_type, and subscriber_id; route-target public exposure remains split.'
         split_children:
           runtime_model: '#1343 owns the canonical internal EventBus RoutePlan model.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -487,11 +487,13 @@ contract_formats:
         public_projection_policy:
           current_boundary: |
             The internal and persisted RoutePlan authority is typed. Public
-            event.publish delivery projection remains a non-authoritative
-            readback surface unless a separately gated API/OpenRPC change
-            promotes subscriber_type or route-target identity into that public
-            result.
-          split_owner: '#1345 owns any event.publish/OpenRPC/CLI readback shape change for subscriber_type or typed route identity.'
+            event.publish, dashboard, and operator delivery readback projections
+            expose persisted typed delivery identity as delivery_id,
+            subscriber_type, and subscriber_id. They remain non-authoritative
+            readback surfaces and must not re-plan subscribers, fabricate rows,
+            or expose delivery_target_route unless a separately gated public
+            schema change promotes route-target identity.
+          split_owner: '#1345 owns the public/operator readback projection for delivery_id, subscriber_type, and subscriber_id; route-target public exposure remains split.'
         split_children:
           runtime_model: '#1343 owns the canonical internal EventBus RoutePlan model.'
           publish_consumers: '#1344 owns Publish, PublishTx, deferred/outbox publish, and CheckPublishRecipientPlan consumption of one RoutePlan authority.'
@@ -10520,7 +10522,10 @@ cli_specification:
         maps_to: idempotency_key
         behavior: Optional v1 API idempotency key for this mutating publish request.
       output:
-        success_detail: One publish summary line with event_id, event_name, run_id, new_run_created, and delivery count, followed by persisted delivery rows containing subscriber_id, status, session_id, and attempt, and source_event_id when server-owned lineage was supplied.
+        success_detail: >-
+          One publish summary line with event_id, event_name, run_id, new_run_created, and delivery count,
+          followed by persisted delivery rows containing delivery_id, subscriber_type, subscriber_id, status,
+          session_id, and attempt, and source_event_id when server-owned lineage was supplied.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -10549,7 +10554,7 @@ cli_specification:
       - existing-run follow-up publish with no selected persisted delivery recipient or delivery route produces server EVENT_NOT_DECLARED before event/idempotency persistence; the CLI exits through publish_rejected and never reports deliveries=0 as success for that path
       - payload.entity_id on a create_entity event produces server PAYLOAD_VALIDATION_FAILED before event/idempotency persistence; the CLI exits through publish_rejected and does not treat payload.entity_id as target/entity routing authority
       - missing/blank event name, invalid or non-object --payload-json, blank optional flags, malformed bundle_hash, malformed bundle fingerprint, both bundle identity flags together, invalid args, and missing explicit token for non-loopback API targets make zero API calls
-      - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and delivery rows
+      - success output renders only server-owned EventPublishResult event_id, run_id, source_event_id when present, new_run_created, and typed persisted delivery rows
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, publish rejection errors, auth/HTTP/RPC failures, and malformed EventPublishResult values fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/dashboard/Builder reads or writes and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.start, event.replay, agent.replay, or agent.replay_backlog usage
       relation_to_run_start: '`run.start` remains usable for #743 until a separate migration changes the CLI internals to event.publish.'
@@ -12261,10 +12266,16 @@ api_specification:
         type: object
         additionalProperties: false
         required:
+        - delivery_id
+        - subscriber_type
         - subscriber_id
         - status
         - attempt
         properties:
+          delivery_id:
+            $ref: '#/components/schemas/OpaqueId'
+          subscriber_type:
+            $ref: '#/components/schemas/SubscriberType'
           subscriber_id:
             type: string
           session_id:


### PR DESCRIPTION
Closes #1345
Part of #1340

## Summary
- Preserve typed persisted delivery identity in `event.publish` public readback: `delivery_id`, `subscriber_type`, and `subscriber_id`.
- Make CLI `swarm event publish` validate/render the same typed delivery shape.
- Move dashboard event delivery rows from legacy `agent_id` projection to typed `delivery_id`/`subscriber_type`/`subscriber_id` readback.
- Update authoritative `platform-spec.yaml` and regenerated `openrpc.json` for the promoted public projection.

## Governing refs/context
- `platform-spec.yaml` `contract_formats.event_schema.routing_derivation.route_plan_authority.public_projection_policy`
- `platform-spec.yaml` `api_specification.components.schemas.EventPublishDelivery`
- `platform-spec.yaml` `api_specification.method_catalog.event.publish`
- `platform-spec.yaml` `cli_specification.command_catalog.event_publish`
- #1345 pre-audit, audit repair, and approved gate outcome

## Semantic migration
- New canonical public readback owner: persisted `event_deliveries` typed identity projected through `store.OperatorEventFull`/`OperatorEventDelivery`.
- Old non-authoritative paths now invalid: API/CLI `subscriber_id`-only `event.publish` delivery projection and dashboard `agent_id`-only delivery projection.
- Production paths checked: API `event.publish`, CLI `swarm event publish`, dashboard `/api/events` list/detail projection, existing typed `EventFull` consumers, SQLite/Postgres store read owners, and generated OpenRPC/spec output.
- Migration is complete for the approved #1345 class. `delivery_target_route` public exposure and replay/source-lineage projection remain split.

## Proof
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/apiv1 -count=1`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./cmd/swarm -run 'TestEventPublishUsesEventPublishV1RPCWithBoundParams|TestEventPublishMalformedResultsFailClosed|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle|TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows' -count=1`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/apispec -count=1`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go run ./cmd/swarm-openrpc-gen --check`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...`
