### PR TITLE
[agent-c][issue #1346] Build route authority proof matrix

### DIFF
--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -130,6 +130,22 @@ func TestRouteAuthorityMatrixRejectsStaleReferences(t *testing.T) {
 			},
 			want: "live_carriers_handler_lookup_descriptors_not_authority negative authority row missing invalid_authority",
 		},
+		{
+			name: "spec refs must reject absolute paths",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				row := routeAuthorityMatrixRowByID(t, matrix, "route_plan_spec_contract")
+				row.OwnerRefs[0].Path = "/tmp/platform-spec.yaml"
+			},
+			want: "route_plan_spec_contract spec_ref proof_ref path /tmp/platform-spec.yaml must be repo-relative",
+		},
+		{
+			name: "spec refs must reject parent traversal",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				row := routeAuthorityMatrixRowByID(t, matrix, "route_plan_spec_contract")
+				row.OwnerRefs[0].Path = "../platform-spec.yaml"
+			},
+			want: "route_plan_spec_contract spec_ref proof_ref path ../platform-spec.yaml must be repo-relative",
+		},
 	}
 
 	for _, tc := range tests {
@@ -378,7 +394,12 @@ func validateRouteAuthorityProofRef(root, rowID string, ref routeAuthorityProofR
 			problems = append(problems, fmt.Sprintf("%s spec_ref proof_ref missing path/ref", rowID))
 			return problems
 		}
-		raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(ref.Path)))
+		cleaned := filepath.Clean(ref.Path)
+		if filepath.IsAbs(ref.Path) || strings.HasPrefix(cleaned, "..") {
+			problems = append(problems, fmt.Sprintf("%s spec_ref proof_ref path %s must be repo-relative", rowID, ref.Path))
+			return problems
+		}
+		raw, err := os.ReadFile(filepath.Join(root, cleaned))
 		if err != nil {
 			problems = append(problems, fmt.Sprintf("%s spec_ref path %s cannot be read: %v", rowID, ref.Path, err))
 			return problems

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -1,0 +1,554 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const routeAuthorityMatrixPath = "internal/runtime/conformance/testdata/route_authority_matrix.yaml"
+
+type routeAuthorityMatrix struct {
+	Version        int                           `yaml:"version"`
+	Kind           string                        `yaml:"kind"`
+	Issue          int                           `yaml:"issue"`
+	ParentIssue    int                           `yaml:"parent_issue"`
+	Source         routeAuthorityMatrixSource    `yaml:"source"`
+	Policy         routeAuthorityMatrixPolicy    `yaml:"policy"`
+	ActiveTrackers []routeAuthorityActiveTracker `yaml:"active_trackers"`
+	Rows           []routeAuthorityMatrixRow     `yaml:"rows"`
+}
+
+type routeAuthorityMatrixSource struct {
+	PlatformSpec               string `yaml:"platform_spec"`
+	OpenRPCArtifact            string `yaml:"openrpc_artifact"`
+	PublicSurfaceBackendMatrix string `yaml:"public_surface_backend_matrix"`
+	MultiBundleMatrix          string `yaml:"multi_bundle_matrix"`
+	CatalogTiers               string `yaml:"catalog_tiers"`
+}
+
+type routeAuthorityMatrixPolicy struct {
+	ClosureLevel                string `yaml:"closure_level"`
+	ClaimsParentClosure         bool   `yaml:"claims_parent_closure"`
+	NamedFullConformanceCommand string `yaml:"named_full_conformance_command"`
+	RequiredSmokePolicy         string `yaml:"required_smoke_policy"`
+}
+
+type routeAuthorityActiveTracker struct {
+	Kind      string `yaml:"kind"`
+	Issue     int    `yaml:"issue"`
+	Watchlist string `yaml:"watchlist"`
+}
+
+type routeAuthorityMatrixRow struct {
+	ID               string                   `yaml:"id"`
+	Concept          string                   `yaml:"concept"`
+	Classification   string                   `yaml:"classification"`
+	Tier             string                   `yaml:"tier"`
+	SplitIssue       int                      `yaml:"split_issue"`
+	Replacement      string                   `yaml:"replacement"`
+	ProofDimensions  []string                 `yaml:"proof_dimensions"`
+	InvalidAuthority []string                 `yaml:"invalid_authority"`
+	OwnerRefs        []routeAuthorityProofRef `yaml:"owner_refs"`
+	ProofRefs        []routeAuthorityProofRef `yaml:"proof_refs"`
+	Notes            string                   `yaml:"notes"`
+}
+
+type routeAuthorityProofRef struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name,omitempty"`
+	Path      string `yaml:"path,omitempty"`
+	Ref       string `yaml:"ref,omitempty"`
+	Method    string `yaml:"method,omitempty"`
+	Issue     int    `yaml:"issue,omitempty"`
+	PR        int    `yaml:"pr,omitempty"`
+	Watchlist string `yaml:"watchlist,omitempty"`
+	Command   string `yaml:"command,omitempty"`
+}
+
+type routeAuthorityValidationContext struct {
+	openRPCMethods map[string]bool
+	goTests        map[string]bool
+}
+
+func TestRouteAuthorityMatrixCoversApprovedRows(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	matrix := loadRouteAuthorityMatrix(t, root)
+	ctx := newRouteAuthorityValidationContext(t, root, matrix)
+
+	if problems := validateRouteAuthorityMatrix(root, matrix, ctx); len(problems) > 0 {
+		t.Fatalf("route authority matrix validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestRouteAuthorityMatrixRejectsStaleReferences(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	base := loadRouteAuthorityMatrix(t, root)
+	ctx := newRouteAuthorityValidationContext(t, root, base)
+
+	tests := []struct {
+		name   string
+		mutate func(*routeAuthorityMatrix)
+		want   string
+	}{
+		{
+			name: "stale go test",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				row := routeAuthorityMatrixRowByID(t, matrix, "eventbus_route_plan_model")
+				row.ProofRefs[1].Name = "TestMissingRouteAuthorityProof"
+			},
+			want: "eventbus_route_plan_model go_test proof_ref TestMissingRouteAuthorityProof does not resolve",
+		},
+		{
+			name: "split sibling cannot be reclassified as covered",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				row := routeAuthorityMatrixRowByID(t, matrix, "workflow_node_execution_admission")
+				row.Classification = "already_covered_by_existing_proof"
+				row.Tier = "required_pr_smoke"
+				row.SplitIssue = 0
+				row.ProofDimensions = []string{"persistence_authority"}
+			},
+			want: "workflow_node_execution_admission must remain split-open issue #1293",
+		},
+		{
+			name: "parent closure stays false",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				matrix.Policy.ClaimsParentClosure = true
+			},
+			want: "policy claims_parent_closure = true, want false",
+		},
+		{
+			name: "negative authority row must name invalid carriers",
+			mutate: func(matrix *routeAuthorityMatrix) {
+				row := routeAuthorityMatrixRowByID(t, matrix, "live_carriers_handler_lookup_descriptors_not_authority")
+				row.InvalidAuthority = nil
+			},
+			want: "live_carriers_handler_lookup_descriptors_not_authority negative authority row missing invalid_authority",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := base
+			matrix.Rows = append([]routeAuthorityMatrixRow(nil), base.Rows...)
+			tc.mutate(&matrix)
+			problems := validateRouteAuthorityMatrix(root, matrix, ctx)
+			if !routeAuthorityProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadRouteAuthorityMatrix(t *testing.T, root string) routeAuthorityMatrix {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, routeAuthorityMatrixPath))
+	if err != nil {
+		t.Fatalf("read route authority matrix: %v", err)
+	}
+	var matrix routeAuthorityMatrix
+	if err := yaml.Unmarshal(raw, &matrix); err != nil {
+		t.Fatalf("parse route authority matrix yaml: %v", err)
+	}
+	return matrix
+}
+
+func newRouteAuthorityValidationContext(t *testing.T, root string, matrix routeAuthorityMatrix) routeAuthorityValidationContext {
+	t.Helper()
+	return routeAuthorityValidationContext{
+		openRPCMethods: loadMatrixOpenRPCMethods(t, filepath.Join(root, matrix.Source.OpenRPCArtifact)),
+		goTests:        collectGoTestNames(t, root),
+	}
+}
+
+func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx routeAuthorityValidationContext) []string {
+	var problems []string
+	if matrix.Version != 1 {
+		problems = append(problems, fmt.Sprintf("matrix version = %d, want 1", matrix.Version))
+	}
+	if matrix.Kind != "route_authority_conformance_matrix" {
+		problems = append(problems, fmt.Sprintf("matrix kind = %q, want route_authority_conformance_matrix", matrix.Kind))
+	}
+	if matrix.Issue != 1346 || matrix.ParentIssue != 1340 {
+		problems = append(problems, fmt.Sprintf("matrix issue/parent = #%d/#%d, want #1346/#1340", matrix.Issue, matrix.ParentIssue))
+	}
+	problems = append(problems, validateRouteAuthoritySources(root, matrix.Source)...)
+	problems = append(problems, validateRouteAuthorityPolicy(matrix.Policy)...)
+
+	activeTrackers := map[string]struct{}{}
+	for _, tracker := range matrix.ActiveTrackers {
+		if tracker.Kind != "github_issue" {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d kind = %q, want github_issue", tracker.Issue, tracker.Kind))
+		}
+		if tracker.Issue <= 0 {
+			problems = append(problems, "active github_issue tracker missing issue")
+		}
+		if strings.TrimSpace(tracker.Watchlist) == "" {
+			problems = append(problems, fmt.Sprintf("active tracker issue #%d missing watchlist", tracker.Issue))
+		}
+		key := routeAuthorityTrackerKey(tracker.Issue, tracker.Watchlist)
+		if _, exists := activeTrackers[key]; exists {
+			problems = append(problems, fmt.Sprintf("active tracker %s appears more than once", key))
+		}
+		activeTrackers[key] = struct{}{}
+	}
+	for _, issue := range []int{1340, 1337, 1293, 1299, 1301} {
+		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
+		if _, ok := activeTrackers[key]; !ok {
+			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))
+		}
+	}
+
+	rowsByID := map[string]routeAuthorityMatrixRow{}
+	for _, row := range matrix.Rows {
+		id := strings.TrimSpace(row.ID)
+		if id == "" {
+			problems = append(problems, "matrix row missing id")
+			continue
+		}
+		if _, exists := rowsByID[id]; exists {
+			problems = append(problems, fmt.Sprintf("matrix row %s appears more than once", id))
+		}
+		rowsByID[id] = row
+		problems = append(problems, validateRouteAuthorityRow(root, row, ctx, activeTrackers)...)
+	}
+	for _, rowID := range requiredRouteAuthorityRows() {
+		if _, ok := rowsByID[rowID]; !ok {
+			problems = append(problems, fmt.Sprintf("matrix missing required row %s", rowID))
+		}
+	}
+	for rowID, splitIssue := range requiredRouteAuthoritySplitRows() {
+		if row, ok := rowsByID[rowID]; ok {
+			if row.Classification != "split_to_existing_issue" || row.Tier != "split_open" || row.SplitIssue != splitIssue {
+				problems = append(problems, fmt.Sprintf("%s must remain split-open issue #%d", rowID, splitIssue))
+			}
+		}
+	}
+	for _, rowID := range requiredRouteAuthorityNegativeRows() {
+		if row, ok := rowsByID[rowID]; ok && len(row.InvalidAuthority) == 0 {
+			problems = append(problems, fmt.Sprintf("%s negative authority row missing invalid_authority", rowID))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validateRouteAuthoritySources(root string, source routeAuthorityMatrixSource) []string {
+	expected := map[string]string{
+		"platform_spec":                 "platform-spec.yaml",
+		"openrpc_artifact":              "openrpc.json",
+		"public_surface_backend_matrix": "internal/apiv1/testdata/public_surface_backend_matrix.yaml",
+		"multi_bundle_matrix":           "internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml",
+		"catalog_tiers":                 "internal/runtime/cataloge2e/README.md",
+	}
+	actual := map[string]string{
+		"platform_spec":                 source.PlatformSpec,
+		"openrpc_artifact":              source.OpenRPCArtifact,
+		"public_surface_backend_matrix": source.PublicSurfaceBackendMatrix,
+		"multi_bundle_matrix":           source.MultiBundleMatrix,
+		"catalog_tiers":                 source.CatalogTiers,
+	}
+	var problems []string
+	for field, want := range expected {
+		got := strings.TrimSpace(actual[field])
+		if got != want {
+			problems = append(problems, fmt.Sprintf("source %s = %q, want %q", field, got, want))
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, filepath.Clean(got))); err != nil {
+			problems = append(problems, fmt.Sprintf("source %s path %s does not exist", field, got))
+		}
+	}
+	return problems
+}
+
+func validateRouteAuthorityPolicy(policy routeAuthorityMatrixPolicy) []string {
+	var problems []string
+	if policy.ClosureLevel != "matrix_owner_first_slice_complete" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want matrix_owner_first_slice_complete", policy.ClosureLevel))
+	}
+	if policy.ClaimsParentClosure {
+		problems = append(problems, "policy claims_parent_closure = true, want false")
+	}
+	command := strings.TrimSpace(policy.NamedFullConformanceCommand)
+	for _, fragment := range []string{
+		"go test",
+		"./internal/runtime/bus",
+		"./internal/runtime/pipeline",
+		"./internal/apiv1",
+		"./cmd/swarm",
+		"./internal/dashboard/server",
+		"./internal/runtime/cataloge2e",
+		"-count=1",
+	} {
+		if !strings.Contains(command, fragment) {
+			problems = append(problems, fmt.Sprintf("policy named_full_conformance_command missing %q", fragment))
+		}
+	}
+	if strings.TrimSpace(policy.RequiredSmokePolicy) == "" {
+		problems = append(problems, "policy required_smoke_policy missing")
+	}
+	return problems
+}
+
+func validateRouteAuthorityRow(root string, row routeAuthorityMatrixRow, ctx routeAuthorityValidationContext, activeTrackers map[string]struct{}) []string {
+	var problems []string
+	id := strings.TrimSpace(row.ID)
+	if strings.TrimSpace(row.Concept) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing concept", id))
+	}
+	if _, ok := allowedRouteAuthorityClassifications()[row.Classification]; !ok {
+		problems = append(problems, fmt.Sprintf("%s classification %q is not allowed", id, row.Classification))
+	}
+	if _, ok := allowedRouteAuthorityTiers()[row.Tier]; !ok {
+		problems = append(problems, fmt.Sprintf("%s tier %q is not allowed", id, row.Tier))
+	}
+	for _, dimension := range row.ProofDimensions {
+		if _, ok := allowedRouteAuthorityProofDimensions()[dimension]; !ok {
+			problems = append(problems, fmt.Sprintf("%s proof_dimension %q is not allowed", id, dimension))
+		}
+	}
+	if len(row.OwnerRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing owner_refs", id))
+	}
+	if len(row.ProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing proof_refs", id))
+	}
+	if routeAuthorityHasValue(row.ProofDimensions, "negative_authority") && len(row.InvalidAuthority) == 0 {
+		problems = append(problems, fmt.Sprintf("%s negative authority row missing invalid_authority", id))
+	}
+	if row.Classification == "split_to_existing_issue" {
+		if row.SplitIssue == 0 {
+			problems = append(problems, fmt.Sprintf("%s split row missing split_issue", id))
+		}
+		if row.Tier != "split_open" {
+			problems = append(problems, fmt.Sprintf("%s split row tier = %q, want split_open", id, row.Tier))
+		}
+		if !routeAuthorityHasValue(row.ProofDimensions, "split_tracker") {
+			problems = append(problems, fmt.Sprintf("%s split row missing split_tracker proof_dimension", id))
+		}
+	}
+	if row.Classification == "obsolete_duplicate" && strings.TrimSpace(row.Replacement) == "" {
+		problems = append(problems, fmt.Sprintf("%s obsolete duplicate row missing replacement", id))
+	}
+
+	seenSplitTracker := false
+	seenExecutableProof := false
+	for _, ref := range append(row.OwnerRefs, row.ProofRefs...) {
+		problems = append(problems, validateRouteAuthorityProofRef(root, id, ref, ctx, activeTrackers)...)
+		if routeAuthorityExecutableProofKind(ref.Kind) {
+			seenExecutableProof = true
+		}
+		if ref.Kind == "tracker" && row.SplitIssue != 0 && ref.Issue == row.SplitIssue {
+			seenSplitTracker = true
+		}
+	}
+	if row.Classification == "split_to_existing_issue" && row.SplitIssue != 0 && !seenSplitTracker {
+		problems = append(problems, fmt.Sprintf("%s split row missing tracker proof_ref for issue #%d", id, row.SplitIssue))
+	}
+	if row.Tier == "required_pr_smoke" && row.Classification != "obsolete_duplicate" && !seenExecutableProof {
+		problems = append(problems, fmt.Sprintf("%s required_pr_smoke row requires at least one executable proof ref", id))
+	}
+	return problems
+}
+
+func validateRouteAuthorityProofRef(root, rowID string, ref routeAuthorityProofRef, ctx routeAuthorityValidationContext, activeTrackers map[string]struct{}) []string {
+	var problems []string
+	switch ref.Kind {
+	case "artifact":
+		if strings.TrimSpace(ref.Path) == "" {
+			problems = append(problems, fmt.Sprintf("%s artifact proof_ref missing path", rowID))
+			return problems
+		}
+		cleaned := filepath.Clean(ref.Path)
+		if filepath.IsAbs(ref.Path) || strings.HasPrefix(cleaned, "..") {
+			problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s must be repo-relative", rowID, ref.Path))
+			return problems
+		}
+		if _, err := os.Stat(filepath.Join(root, cleaned)); err != nil {
+			problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s does not exist", rowID, ref.Path))
+		}
+	case "spec_ref":
+		if strings.TrimSpace(ref.Path) == "" || strings.TrimSpace(ref.Ref) == "" {
+			problems = append(problems, fmt.Sprintf("%s spec_ref proof_ref missing path/ref", rowID))
+			return problems
+		}
+		raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(ref.Path)))
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s spec_ref path %s cannot be read: %v", rowID, ref.Path, err))
+			return problems
+		}
+		if !strings.Contains(string(raw), ref.Ref) {
+			problems = append(problems, fmt.Sprintf("%s spec_ref %s#%s does not resolve by text search", rowID, ref.Path, ref.Ref))
+		}
+	case "go_test":
+		if strings.TrimSpace(ref.Name) == "" {
+			problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", rowID))
+			return problems
+		}
+		if !ctx.goTests[ref.Name] {
+			problems = append(problems, fmt.Sprintf("%s go_test proof_ref %s does not resolve", rowID, ref.Name))
+		}
+	case "openrpc_method":
+		if strings.TrimSpace(ref.Method) == "" {
+			problems = append(problems, fmt.Sprintf("%s openrpc_method proof_ref missing method", rowID))
+			return problems
+		}
+		if !ctx.openRPCMethods[ref.Method] {
+			problems = append(problems, fmt.Sprintf("%s openrpc_method proof_ref %s does not resolve", rowID, ref.Method))
+		}
+	case "tracker":
+		if ref.Issue <= 0 {
+			problems = append(problems, fmt.Sprintf("%s tracker proof_ref missing issue", rowID))
+		}
+		if _, ok := activeTrackers[routeAuthorityTrackerKey(ref.Issue, ref.Watchlist)]; !ok {
+			problems = append(problems, fmt.Sprintf("%s tracker proof_ref issue #%d watchlist %q is not in active_trackers", rowID, ref.Issue, ref.Watchlist))
+		}
+	case "issue":
+		if ref.Issue <= 0 {
+			problems = append(problems, fmt.Sprintf("%s issue proof_ref missing issue", rowID))
+		}
+	case "pr":
+		if ref.PR <= 0 {
+			problems = append(problems, fmt.Sprintf("%s pr proof_ref missing pr", rowID))
+		}
+	case "command":
+		command := strings.TrimSpace(ref.Command)
+		if command == "" {
+			problems = append(problems, fmt.Sprintf("%s command proof_ref missing command", rowID))
+		}
+		if command != "" && !strings.Contains(command, "go test ") && !strings.HasPrefix(command, "go run ") {
+			problems = append(problems, fmt.Sprintf("%s command proof_ref command = %q, want go test or go run command", rowID, command))
+		}
+	default:
+		problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", rowID, ref.Kind))
+	}
+	return problems
+}
+
+func requiredRouteAuthorityRows() []string {
+	return []string{
+		"route_plan_spec_contract",
+		"eventbus_route_plan_model",
+		"publish_preflight_deferred_outbox_consumers",
+		"public_operator_typed_readback",
+		"served_root_input_event_publish_supported_surfaces",
+		"workflow_node_execution_admission",
+		"wildcard_static_service_route_production",
+		"runtime_callback_flow_instance_localization",
+		"live_carriers_handler_lookup_descriptors_not_authority",
+		"receipts_settlement_backfill_not_authority",
+		"replay_markers_not_authority",
+		"readback_not_authority",
+		"subscriber_id_only_not_authority",
+		"replay_recovery_fork_consumers",
+		"catalog_e2e_route_behavior",
+		"diagnostic_catalog_probe_duplicate",
+	}
+}
+
+func requiredRouteAuthoritySplitRows() map[string]int {
+	return map[string]int{
+		"served_root_input_event_publish_supported_surfaces": 1337,
+		"workflow_node_execution_admission":                  1293,
+		"wildcard_static_service_route_production":           1299,
+		"runtime_callback_flow_instance_localization":        1301,
+	}
+}
+
+func requiredRouteAuthorityNegativeRows() []string {
+	return []string{
+		"live_carriers_handler_lookup_descriptors_not_authority",
+		"receipts_settlement_backfill_not_authority",
+		"replay_markers_not_authority",
+		"readback_not_authority",
+		"subscriber_id_only_not_authority",
+	}
+}
+
+func allowedRouteAuthorityClassifications() map[string]struct{} {
+	return map[string]struct{}{
+		"add_to_matrix":                     {},
+		"already_covered_by_existing_proof": {},
+		"obsolete_duplicate":                {},
+		"split_to_existing_issue":           {},
+	}
+}
+
+func allowedRouteAuthorityTiers() map[string]struct{} {
+	return map[string]struct{}{
+		"required_pr_smoke":               {},
+		"full_conformance_manual_nightly": {},
+		"touched_surface_only":            {},
+		"split_open":                      {},
+		"obsolete_duplicate":              {},
+	}
+}
+
+func allowedRouteAuthorityProofDimensions() map[string]struct{} {
+	return map[string]struct{}{
+		"catalog_tiering":       {},
+		"cli_v1_path":           {},
+		"default_sqlite":        {},
+		"explicit_postgres":     {},
+		"full_conformance":      {},
+		"negative_authority":    {},
+		"openrpc_publication":   {},
+		"obsolete_duplicate":    {},
+		"persistence_authority": {},
+		"public_projection":     {},
+		"real_v1_handler":       {},
+		"replay_recovery":       {},
+		"required_pr_smoke":     {},
+		"route_plan_model":      {},
+		"source_authority":      {},
+		"split_tracker":         {},
+	}
+}
+
+func routeAuthorityMatrixRowByID(t *testing.T, matrix *routeAuthorityMatrix, id string) *routeAuthorityMatrixRow {
+	t.Helper()
+	for i := range matrix.Rows {
+		if matrix.Rows[i].ID == id {
+			return &matrix.Rows[i]
+		}
+	}
+	t.Fatalf("matrix row %s not found", id)
+	return nil
+}
+
+func routeAuthorityTrackerKey(issue int, watchlist string) string {
+	return fmt.Sprintf("%d:%s", issue, strings.TrimSpace(watchlist))
+}
+
+func routeAuthorityHasValue(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func routeAuthorityExecutableProofKind(kind string) bool {
+	switch kind {
+	case "go_test", "openrpc_method", "command":
+		return true
+	default:
+		return false
+	}
+}
+
+func routeAuthorityProblemsContain(problems []string, want string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -1,0 +1,324 @@
+version: 1
+kind: route_authority_conformance_matrix
+issue: 1346
+parent_issue: 1340
+source:
+  platform_spec: platform-spec.yaml
+  openrpc_artifact: openrpc.json
+  public_surface_backend_matrix: internal/apiv1/testdata/public_surface_backend_matrix.yaml
+  multi_bundle_matrix: internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml
+  catalog_tiers: internal/runtime/cataloge2e/README.md
+policy:
+  closure_level: matrix_owner_first_slice_complete
+  claims_parent_closure: false
+  named_full_conformance_command: SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/apiv1 ./cmd/swarm ./internal/dashboard/server ./internal/runtime/cataloge2e -count=1
+  required_smoke_policy: >
+    Required PR smoke proves the matrix owner, the RoutePlan contract/model,
+    the covered publish/readback consumers, and the smallest SQLite-default plus
+    explicit-Postgres served evidence needed for route-authority accounting.
+    Full catalog/replay/fork coverage stays in the named full conformance
+    command so route authority does not become a backend x surface x route
+    Cartesian suite.
+active_trackers:
+  - kind: github_issue
+    issue: 1340
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1337
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1293
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1299
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1301
+    watchlist: runtime_operations.delivery_and_replay_ownership
+rows:
+  - id: route_plan_spec_contract
+    concept: RoutePlan is the publish-time typed authority and event_deliveries is the durable authority sink.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [source_authority, openrpc_publication, persistence_authority, required_pr_smoke]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_authority}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+      - {kind: artifact, path: openrpc.json}
+    proof_refs:
+      - {kind: pr, pr: 1347}
+      - {kind: go_test, name: TestGeneratedOpenRPCArtifactMatchesPlatformSpec}
+      - {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}
+      - {kind: command, command: "go run ./cmd/swarm-openrpc-gen --check"}
+    notes: >
+      Closed #1342 owns the merge-bearing spec/OpenRPC contract. This matrix
+      cites it as source authority and does not redefine route semantics.
+
+  - id: eventbus_route_plan_model
+    concept: EventBus owns the canonical internal RoutePlan model and materializer.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_plan_model, source_authority, required_pr_smoke]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/route_plan.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_target_routes_test.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_authority}
+    proof_refs:
+      - {kind: pr, pr: 1348}
+      - {kind: go_test, name: TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan}
+      - {kind: go_test, name: TestRouteTableRootInputFlowNodeResolvesRootInputRoute}
+    notes: >
+      Closed #1343 owns the runtime model row. Consumers must cite RoutePlan or
+      persisted event_deliveries, not reconstruct recipient authority locally.
+
+  - id: publish_preflight_deferred_outbox_consumers
+    concept: Publish, PublishTx, preflight, deferred publish, and outbox paths consume one RoutePlan authority.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_plan_model, persistence_authority, required_pr_smoke]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/eventbus_publish.go}
+      - {kind: artifact, path: internal/runtime/bus/outbox.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: persistence_requirements}
+    proof_refs:
+      - {kind: pr, pr: 1349}
+      - {kind: go_test, name: TestEventBusCheckPublishRecipientPlanReportsSubscribedPublishWithoutDelivery}
+      - {kind: go_test, name: TestEventBusPublishTxDispatch_NodeOnlyRouteDoesNotRequireAgentChannel}
+      - {kind: go_test, name: TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan}
+    notes: >
+      Closed #1344 owns these publish-side consumer rows. They are required
+      smoke because they prove the main write path consumes the same RoutePlan.
+
+  - id: public_operator_typed_readback
+    concept: API, CLI, OpenRPC, and dashboard readback consume persisted typed delivery identity without creating authority.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [public_projection, real_v1_handler, cli_v1_path, openrpc_publication, required_pr_smoke]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: public_projection_policy}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: operator_api_disposition}
+      - {kind: artifact, path: internal/apiv1/testdata/public_surface_backend_matrix.yaml}
+    proof_refs:
+      - {kind: pr, pr: 1350}
+      - {kind: openrpc_method, method: event.publish}
+      - {kind: openrpc_method, method: event.list}
+      - {kind: openrpc_method, method: event.get}
+      - {kind: openrpc_method, method: event.subscribe}
+      - {kind: go_test, name: TestEventPublishUsesEventPublishV1RPCWithBoundParams}
+      - {kind: go_test, name: TestEventPublishMalformedResultsFailClosed}
+      - {kind: go_test, name: TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity}
+      - {kind: go_test, name: TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows}
+    notes: >
+      Closed #1345 owns public/operator typed readback. Green readback is
+      explicitly consumer proof only, not route authority proof.
+
+  - id: served_root_input_event_publish_supported_surfaces
+    concept: Served root-input event.publish --run-id proof exists for SQLite and Postgres, but tracker #1337 remains open.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1337
+    proof_dimensions: [default_sqlite, explicit_postgres, real_v1_handler, cli_v1_path, split_tracker]
+    owner_refs:
+      - {kind: artifact, path: internal/apiv1/testdata/public_surface_backend_matrix.yaml}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: event.publish}
+    proof_refs:
+      - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite}
+      - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres}
+      - {kind: tracker, issue: 1337, watchlist: runtime_operations.delivery_and_replay_ownership}
+    notes: >
+      Current master proves this served path passes, but #1337 is still open.
+      This row preserves that tracker state instead of silently closing it.
+
+  - id: workflow_node_execution_admission
+    concept: Workflow-node execution must require committed node delivery authority before handler execution.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1293
+    proof_dimensions: [persistence_authority, split_tracker]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: execution_admission}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+    proof_refs:
+      - {kind: tracker, issue: 1293, watchlist: runtime_operations.delivery_and_replay_ownership}
+    notes: >
+      #1293 remains the execution-admission sibling. Settlement, backfill,
+      receipts, and handler lookup must not become shortcuts for this row.
+
+  - id: wildcard_static_service_route_production
+    concept: Wildcard static-service route production is a route-production sibling, not a matrix behavior change.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1299
+    proof_dimensions: [route_plan_model, split_tracker]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: wildcard_routes}
+      - {kind: artifact, path: internal/runtime/bus/routing_derivation_internal_test.go}
+    proof_refs:
+      - {kind: tracker, issue: 1299, watchlist: runtime_operations.delivery_and_replay_ownership}
+    notes: >
+      #1299 owns concrete wildcard static-service route production. #1346
+      classifies it only.
+
+  - id: runtime_callback_flow_instance_localization
+    concept: Runtime callback flow_instance localization is a route-production sibling, not a matrix behavior change.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1301
+    proof_dimensions: [route_plan_model, split_tracker]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: runtime_callback_routes}
+      - {kind: artifact, path: internal/runtime/bus/delivery_planner.go}
+    proof_refs:
+      - {kind: tracker, issue: 1301, watchlist: runtime_operations.delivery_and_replay_ownership}
+    notes: >
+      #1301 owns runtime callback localization. The matrix keeps it visible as
+      open route-production work.
+
+  - id: live_carriers_handler_lookup_descriptors_not_authority
+    concept: Live carriers, interceptors, handler lookup, and active descriptors are consumers or observations only.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [negative_authority, route_plan_model, required_pr_smoke]
+    invalid_authority:
+      - live internal carriers
+      - workflow-runtime interceptors
+      - handler lookup
+      - active descriptors
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: live_dispatch}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_topology}
+    proof_refs:
+      - {kind: go_test, name: TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutInternalCarrier}
+      - {kind: go_test, name: TestEventBusPublish_NodeOnlyRouteDoesNotRequireAgentChannel}
+      - {kind: go_test, name: TestDeliveryRecipientPolicy_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning}
+    notes: >
+      These paths may dispatch or observe work after authority exists. They
+      must not create, repair, or replace missing typed RoutePlan recipients.
+
+  - id: receipts_settlement_backfill_not_authority
+    concept: Receipts, settlement, backfill, processed markers, dead letters, and retry counters describe post-authority work.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [negative_authority, persistence_authority, required_pr_smoke]
+    invalid_authority:
+      - event_receipts
+      - settlement and backfill
+      - processed markers
+      - dead-letter state
+      - retry counters
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: completion_evidence}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: event_receipts}
+    proof_refs:
+      - {kind: go_test, name: TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately}
+      - {kind: go_test, name: TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCompletion}
+      - {kind: go_test, name: TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecordsReceipt}
+    notes: >
+      Completion evidence remains after-the-fact evidence. It cannot authorize
+      workflow-node delivery when the committed event_deliveries row is absent.
+
+  - id: replay_markers_not_authority
+    concept: Replay-scope markers and replay lineage are gated replay evidence, not arbitrary fresh recipient authority.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [negative_authority, replay_recovery, required_pr_smoke]
+    invalid_authority:
+      - replay markers
+      - replay-scope markers
+      - source delivery lineage
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: replay_scope_expectations}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: replay_recovery}
+    proof_refs:
+      - {kind: go_test, name: TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner}
+      - {kind: go_test, name: TestRecoveryManager_FailsClosedWithoutReplayClaimOwner}
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionRejectsTaxonomyReadyWithoutOwnerWork}
+    notes: >
+      Replay can consume persisted route authority or explicitly gated replay
+      owners. Markers alone do not authorize new workflow-node work.
+
+  - id: readback_not_authority
+    concept: API, CLI, dashboard, OpenRPC, and event read surfaces expose persisted owner data without replanning.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [negative_authority, public_projection, required_pr_smoke]
+    invalid_authority:
+      - API readback
+      - CLI readback
+      - dashboard readback
+      - delivery count reconstruction
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: readback}
+      - {kind: artifact, path: internal/apiv1/testdata/public_surface_backend_matrix.yaml}
+    proof_refs:
+      - {kind: go_test, name: TestEventPublishUsesEventPublishV1RPCWithBoundParams}
+      - {kind: go_test, name: TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity}
+      - {kind: go_test, name: TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows}
+    notes: >
+      Public/operator surfaces prove typed projection only. They do not create,
+      fabricate, or backfill delivery authority.
+
+  - id: subscriber_id_only_not_authority
+    concept: subscriber_id by itself is not recipient identity; route authority requires typed subscriber identity.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [negative_authority, public_projection, required_pr_smoke]
+    invalid_authority:
+      - string-only subscriber_id coincidence
+      - untyped delivery filters
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: typed_recipients}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: subscriber_type}
+    proof_refs:
+      - {kind: go_test, name: TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets}
+      - {kind: go_test, name: TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity}
+      - {kind: go_test, name: TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows}
+    notes: >
+      A matching raw subscriber_id is not enough when agent and node recipients
+      can share names. Typed subscriber identity is the read and write boundary.
+
+  - id: replay_recovery_fork_consumers
+    concept: Replay, retry, sweeper, fork, and recovery consume persisted RoutePlan output or explicitly gated replay/fork owners.
+    classification: add_to_matrix
+    tier: full_conformance_manual_nightly
+    proof_dimensions: [replay_recovery, full_conformance, persistence_authority]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: replay_recovery}
+      - {kind: artifact, path: internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml}
+    proof_refs:
+      - {kind: go_test, name: TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions}
+      - {kind: go_test, name: TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteReportsSourceAdvancedBranchJSON}
+      - {kind: go_test, name: TestTier12RuntimeFork_SelectedContractForkExecutionFixture}
+      - {kind: command, command: "SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/apiv1 ./cmd/swarm ./internal/dashboard/server ./internal/runtime/cataloge2e -count=1"}
+    notes: >
+      This row belongs to full/touched-surface conformance. It should not expand
+      every PR into a replay/fork/catalog Cartesian test suite.
+
+  - id: catalog_e2e_route_behavior
+    concept: Catalog route behavior remains covered by catalog E2E tiering and is cited rather than duplicated.
+    classification: already_covered_by_existing_proof
+    tier: full_conformance_manual_nightly
+    proof_dimensions: [catalog_tiering, full_conformance]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/cataloge2e/README.md}
+    proof_refs:
+      - {kind: go_test, name: TestTier11FlowCompositionCatalogFixtures_RealRuntime}
+      - {kind: go_test, name: TestTier12RuntimeFork_SelectedContractForkExecutionFixture}
+      - {kind: command, command: "go test ./internal/runtime/cataloge2e -count=1"}
+    notes: >
+      Catalog E2E tiering stays the full behavior proof owner. #1346 only names
+      how route-authority audits should cite it.
+
+  - id: diagnostic_catalog_probe_duplicate
+    concept: One-off diagnostic catalog probes are duplicate proof once catalog tiering and the route-authority matrix exist.
+    classification: obsolete_duplicate
+    tier: obsolete_duplicate
+    replacement: catalog_e2e_route_behavior
+    proof_dimensions: [obsolete_duplicate, catalog_tiering]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/cataloge2e/README.md}
+    proof_refs:
+      - {kind: command, command: "go test ./internal/runtime/cataloge2e -count=1"}
+    notes: >
+      Ad hoc probes can remain useful locally, but closure-bearing route proof
+      should name the catalog tier row or the focused RoutePlan rows above.


### PR DESCRIPTION
## Summary

Closes #1346.
Part of #1340.

Adds the route-authority conformance matrix owner for the approved `route_authority_conformance_matrix_owner` slice. The matrix classifies the closed #1342/#1343/#1344/#1345 proof rows, preserves #1337/#1293/#1299/#1301 as explicit split/open tracker rows, names negative authority evidence, and preserves a full route-authority conformance command without expanding required PR smoke into a Cartesian suite.

## Governing Refs / Context

Exact governing spec refs:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.public_projection_policy`
- `platform-spec.yaml#persistence_schema.event_deliveries`
- `platform-spec.yaml#persistence_schema.event_receipts`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`, `event.list`, `event.get`, and `event.subscribe`
- `platform-spec.yaml#operator_api_disposition`

Binding issue context: #1346 pre-audit and gate, #1340 parent decomposition, #1342/#1343/#1344/#1345 closeouts, and split/open #1337/#1293/#1299/#1301 tracker state.

## Semantic Migration

- New canonical owner: `internal/runtime/conformance/testdata/route_authority_matrix.yaml` plus `TestRouteAuthorityMatrix*` validator.
- Old proof path now non-authoritative: scattered issue comments and ad hoc citations of individual tests/readback/receipts as closure-bearing route-authority proof.
- Production paths checked for surviving old behavior: RoutePlan spec/model, EventBus publish/preflight/outbox consumers, public/operator readback, served SQLite/Postgres event.publish probes, replay/fork/catalog proof owners. No runtime behavior changed.
- Migration complete for this matrix-owner class only. #1340 remains open; #1337/#1293/#1299/#1301 remain split/open rows.

## Validation

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/conformance -run 'TestRouteAuthorityMatrix' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus -run 'TestRouteTableRootInputFlowNodeResolvesRootInputRoute|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutInternalCarrier|TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch|TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInternalSubscription|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesSystemNodeRouteWithoutLiveSubscription|TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres|TestEventPublishUsesEventPublishV1RPCWithBoundParams|TestEventPublishMalformedResultsFailClosed' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity|TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/apispec -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go run ./cmd/swarm-openrpc-gen --check
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/apiv1 ./cmd/swarm ./internal/dashboard/server ./internal/runtime/cataloge2e -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...
```
