### PR TITLE
[agent-c][issue #1337] Prove served root input delivery authority

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -200,27 +200,28 @@ func main() {
 }
 
 type serveOptions struct {
-	ConfigPath           string
-	Backend              string
-	ContractsPath        string
-	DataSource           string
-	WorkspaceBackend     string
-	WorkspaceBackendSet  bool
-	BundleHash           string
-	BundleHashes         []string
-	PlatformSpecPath     string
-	StoreMode            string
-	StoreModeSet         bool
-	APIListenAddr        string
-	MCPListenAddr        string
-	ShutdownGrace        time.Duration
-	Dev                  bool
-	SelfCheck            bool
-	RequireBundleMatch   bool
-	NoRequireBundleMatch bool
-	AbandonActiveRuns    bool
-	Verbose              bool
-	Output               io.Writer
+	ConfigPath                       string
+	Backend                          string
+	ContractsPath                    string
+	DataSource                       string
+	WorkspaceBackend                 string
+	WorkspaceBackendSet              bool
+	BundleHash                       string
+	BundleHashes                     []string
+	PlatformSpecPath                 string
+	StoreMode                        string
+	StoreModeSet                     bool
+	APIListenAddr                    string
+	MCPListenAddr                    string
+	ShutdownGrace                    time.Duration
+	Dev                              bool
+	SelfCheck                        bool
+	RequireBundleMatch               bool
+	NoRequireBundleMatch             bool
+	AbandonActiveRuns                bool
+	Verbose                          bool
+	Output                           io.Writer
+	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
 }
 
 type serveRuntimeBundle struct {
@@ -571,6 +572,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			BootProgress:                     req.BootProgress,
 			SystemContainers:                 systemWorkspaceContainers(workspaces),
 			DisablePersistentStartupRecovery: !req.UseStartupRecovery,
+			TestWorkflowNodeHandlerStartHook: req.Options.TestWorkflowNodeHandlerStartHook,
 		},
 	})
 	if err != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -28,6 +28,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -3440,23 +3441,25 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
-	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
-		ContractsPath:        contractsPath,
-		PlatformSpecPath:     defaultPlatformSpecPath,
-		APIListenAddr:        "127.0.0.1:0",
-		MCPListenAddr:        "127.0.0.1:0",
-		SelfCheck:            true,
-		RequireBundleMatch:   false,
-		NoRequireBundleMatch: true,
-		Verbose:              true,
-	})
-
 	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore(%s): %v", sqlitePath, err)
 	}
-	runServedEventPublishFollowUpProof(t, endpoint, sqliteStore.DB, "sqlite", bundleHash)
+	preHandlerProof := make(chan servedEventPublishPreHandlerProof, 1)
+	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
+		ConfigPath:                       writeServeRuntimeTestConfig(t),
+		ContractsPath:                    contractsPath,
+		PlatformSpecPath:                 defaultPlatformSpecPath,
+		APIListenAddr:                    "127.0.0.1:0",
+		MCPListenAddr:                    "127.0.0.1:0",
+		SelfCheck:                        true,
+		RequireBundleMatch:               false,
+		NoRequireBundleMatch:             true,
+		Verbose:                          true,
+		TestWorkflowNodeHandlerStartHook: servedEventPublishPreHandlerAuthorityHook(sqliteStore.DB, "sqlite", preHandlerProof),
+	})
+
+	runServedEventPublishFollowUpProof(t, endpoint, sqliteStore.DB, "sqlite", bundleHash, preHandlerProof)
 	if err := sqliteStore.Close(); err != nil {
 		t.Fatalf("close sqlite proof store: %v", err)
 	}
@@ -3468,20 +3471,22 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres(t *testing.T
 	})
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+	preHandlerProof := make(chan servedEventPublishPreHandlerProof, 1)
 	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:         writeServeRuntimeTestConfig(t),
-		ContractsPath:      contractsPath,
-		PlatformSpecPath:   defaultPlatformSpecPath,
-		StoreMode:          "postgres",
-		StoreModeSet:       true,
-		APIListenAddr:      "127.0.0.1:0",
-		MCPListenAddr:      "127.0.0.1:0",
-		SelfCheck:          true,
-		RequireBundleMatch: false,
-		Verbose:            true,
+		ConfigPath:                       writeServeRuntimeTestConfig(t),
+		ContractsPath:                    contractsPath,
+		PlatformSpecPath:                 defaultPlatformSpecPath,
+		StoreMode:                        "postgres",
+		StoreModeSet:                     true,
+		APIListenAddr:                    "127.0.0.1:0",
+		MCPListenAddr:                    "127.0.0.1:0",
+		SelfCheck:                        true,
+		RequireBundleMatch:               false,
+		Verbose:                          true,
+		TestWorkflowNodeHandlerStartHook: servedEventPublishPreHandlerAuthorityHook(db, "postgres", preHandlerProof),
 	})
 
-	runServedEventPublishFollowUpProof(t, endpoint, db, "postgres", bundleHash)
+	runServedEventPublishFollowUpProof(t, endpoint, db, "postgres", bundleHash, preHandlerProof)
 }
 
 func writeServedEventPublishFollowUpFixture(t *testing.T) string {
@@ -3623,7 +3628,66 @@ func startServedEventPublishFollowUpRuntime(t *testing.T, opts serveOptions) str
 	return "http://" + serveRuntimeAPIListenerFromOutput(t, out.String()) + "/v1/rpc"
 }
 
-func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.DB, backend, bundleHash string) {
+type servedEventPublishPreHandlerProof struct {
+	RunID   string
+	EventID string
+	NodeID  string
+	Count   int
+	Err     error
+}
+
+func servedEventPublishPreHandlerAuthorityHook(db *sql.DB, backend string, proofs chan<- servedEventPublishPreHandlerProof) runtimepipeline.WorkflowNodeHandlerStartHook {
+	var once sync.Once
+	return func(ctx context.Context, nodeID string, evt events.Event) error {
+		if strings.TrimSpace(nodeID) != "entity-writer" {
+			return nil
+		}
+		eventType := strings.TrimPrefix(strings.TrimSpace(string(evt.Type)), "validation/")
+		if eventType != "thing.created" {
+			return nil
+		}
+		once.Do(func() {
+			runID := strings.TrimSpace(evt.RunID)
+			if runID == "" {
+				runID = runtimecorrelation.RunIDFromContext(ctx)
+			}
+			eventID := strings.TrimSpace(evt.ID)
+			count, err := servedEventPublishNodeDeliveryCountValue(ctx, db, backend, runID, eventID, nodeID)
+			proof := servedEventPublishPreHandlerProof{
+				RunID:   runID,
+				EventID: eventID,
+				NodeID:  strings.TrimSpace(nodeID),
+				Count:   count,
+				Err:     err,
+			}
+			select {
+			case proofs <- proof:
+			default:
+			}
+		})
+		return nil
+	}
+}
+
+func requireServedEventPublishPreHandlerProof(t *testing.T, backend string, proofs <-chan servedEventPublishPreHandlerProof, runID, eventID, nodeID string) {
+	t.Helper()
+	select {
+	case proof := <-proofs:
+		if proof.Err != nil {
+			t.Fatalf("%s pre-handler node delivery authority query failed: %v", backend, proof.Err)
+		}
+		if proof.RunID != runID || proof.EventID != eventID || proof.NodeID != nodeID {
+			t.Fatalf("%s pre-handler node delivery authority proof = %#v, want run=%s event=%s node=%s", backend, proof, runID, eventID, nodeID)
+		}
+		if proof.Count == 0 {
+			t.Fatalf("%s pre-handler root-input node deliveries = %d, want committed node/%s authority before handler execution", backend, proof.Count, nodeID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s pre-handler root-input node delivery authority hook did not run", backend)
+	}
+}
+
+func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.DB, backend, bundleHash string, preHandlerProof <-chan servedEventPublishPreHandlerProof) {
 	t.Helper()
 	beforeCreateRejectEvents := servedEventPublishScalarCount(t, db, backend, "events_all", "", "")
 	beforeCreateRejectIdempotency := servedEventPublishScalarCount(t, db, backend, "api_idempotency_all", "", "")
@@ -3661,7 +3725,12 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if got := servedEventPublishRowCount(t, db, backend, "runs", runID, ""); got != 1 {
 		t.Fatalf("%s runs for initial run = %d, want 1", backend, got)
 	}
+	requireServedEventPublishPreHandlerProof(t, backend, preHandlerProof, runID, initialEventID, "entity-writer")
+	if got := servedEventPublishNodeDeliveryCount(t, db, backend, runID, initialEventID, "entity-writer"); got == 0 {
+		t.Fatalf("%s initial root-input node deliveries = %d, want persisted node/entity-writer authority", backend, got)
+	}
 	entityID := requireServedEventPublishEntityState(t, db, backend, runID, "", "waiting")
+	requireServedEventReadback(t, endpoint, initialEventID, runID, runID, "thing.created", "entity-writer")
 	requireServedEntityReadback(t, endpoint, runID, entityID, "waiting")
 
 	followUpStdout, followUpStderr, code := runServedCLICommand(t, endpoint, []string{
@@ -3885,7 +3954,7 @@ func requireServedEventReadback(t *testing.T, endpoint, eventID, runID, entityID
 	}
 	requireServedJSONRPCResult(t, endpoint, "event.get", map[string]any{"event_id": eventID}, &event)
 	if event.EventID != eventID || event.RunID != runID || event.EntityID != entityID || event.EventName != eventName {
-		t.Fatalf("event.get result = %#v, want follow-up event on selected run", event)
+		t.Fatalf("event.get result = %#v, want event %s on selected run", event, eventName)
 	}
 	for _, delivery := range event.Deliveries {
 		if delivery.SubscriberType == "node" && delivery.SubscriberID == subscriberID && delivery.Status == "delivered" {
@@ -4097,6 +4166,49 @@ func servedEventPublishScalarCount(t *testing.T, db *sql.DB, backend, scope, run
 		t.Fatalf("%s count %s: %v", backend, scope, err)
 	}
 	return count
+}
+
+func servedEventPublishNodeDeliveryCount(t *testing.T, db *sql.DB, backend, runID, eventID, subscriberID string) int {
+	t.Helper()
+	count, err := servedEventPublishNodeDeliveryCountValue(context.Background(), db, backend, runID, eventID, subscriberID)
+	if err != nil {
+		t.Fatalf("%s count node delivery %s/%s: %v", backend, eventID, subscriberID, err)
+	}
+	return count
+}
+
+func servedEventPublishNodeDeliveryCountValue(ctx context.Context, db *sql.DB, backend, runID, eventID, subscriberID string) (int, error) {
+	var sqlText string
+	var args []any
+	switch backend {
+	case "postgres":
+		sqlText = `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE run_id = $1::uuid
+			  AND event_id = $2::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $3
+		`
+		args = []any{runID, eventID, subscriberID}
+	case "sqlite":
+		sqlText = `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE run_id = ?
+			  AND event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+		`
+		args = []any{runID, eventID, subscriberID}
+	default:
+		return 0, fmt.Errorf("unknown proof backend %q", backend)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, sqlText, args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func servedEventPublishEntityState(t *testing.T, db *sql.DB, backend, runID, entityID, wantState string) (string, string) {

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340, 1337, 1293, 1299, 1301} {
+	for _, issue := range []int{1340, 1293, 1299, 1301} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))
@@ -475,10 +475,9 @@ func requiredRouteAuthorityRows() []string {
 
 func requiredRouteAuthoritySplitRows() map[string]int {
 	return map[string]int{
-		"served_root_input_event_publish_supported_surfaces": 1337,
-		"workflow_node_execution_admission":                  1293,
-		"wildcard_static_service_route_production":           1299,
-		"runtime_callback_flow_instance_localization":        1301,
+		"workflow_node_execution_admission":           1293,
+		"wildcard_static_service_route_production":    1299,
+		"runtime_callback_flow_instance_localization": 1301,
 	}
 }
 

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -24,9 +24,6 @@ active_trackers:
     issue: 1340
     watchlist: runtime_operations.delivery_and_replay_ownership
   - kind: github_issue
-    issue: 1337
-    watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
     issue: 1293
     watchlist: runtime_operations.delivery_and_replay_ownership
   - kind: github_issue
@@ -113,21 +110,23 @@ rows:
       explicitly consumer proof only, not route authority proof.
 
   - id: served_root_input_event_publish_supported_surfaces
-    concept: Served root-input event.publish --run-id proof exists for SQLite and Postgres, but tracker #1337 remains open.
-    classification: split_to_existing_issue
-    tier: split_open
-    split_issue: 1337
-    proof_dimensions: [default_sqlite, explicit_postgres, real_v1_handler, cli_v1_path, split_tracker]
+    concept: Served root-input event.publish proof persists typed workflow-node authority for SQLite and Postgres.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [default_sqlite, explicit_postgres, real_v1_handler, cli_v1_path, persistence_authority, required_pr_smoke]
     owner_refs:
       - {kind: artifact, path: internal/apiv1/testdata/public_surface_backend_matrix.yaml}
       - {kind: spec_ref, path: platform-spec.yaml, ref: event.publish}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
     proof_refs:
       - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite}
       - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres}
-      - {kind: tracker, issue: 1337, watchlist: runtime_operations.delivery_and_replay_ownership}
+      - {kind: issue, issue: 1337}
     notes: >
-      Current master proves this served path passes, but #1337 is still open.
-      This row preserves that tracker state instead of silently closing it.
+      The served proof asserts that the initial root-input publication persists
+      typed node/entity-writer event_deliveries authority before the workflow
+      node result is accepted. #1293 remains the separate execution-admission
+      consumer of that persisted authority.
 
   - id: workflow_node_execution_admission
     concept: Workflow-node execution must require committed node delivery authority before handler execution.

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -60,22 +60,26 @@ type PipelineCoordinator struct {
 	artifactRoot            string
 	bundleFingerprint       string
 
-	testSubscribeHook   func()
-	testEntityStateHook func(entityID, state string)
+	testSubscribeHook                func()
+	testEntityStateHook              func(entityID, state string)
+	testWorkflowNodeHandlerStartHook WorkflowNodeHandlerStartHook
 }
 
+type WorkflowNodeHandlerStartHook func(context.Context, string, events.Event) error
+
 type PipelineCoordinatorOptions struct {
-	ShardPlanner            any
-	Module                  WorkflowModule
-	WorkflowStore           *WorkflowInstanceStore
-	InstanceActivator       FlowInstanceActivator
-	InstanceDeactivator     FlowInstanceDeactivator
-	TimerScheduler          *Scheduler
-	TimerScheduleStore      SchedulePersistence
-	MailboxMaterializer     MailboxWriteMaterializationStore
-	EventReceiptsCapability func(context.Context) (bool, error)
-	ArtifactRoot            string
-	BundleFingerprint       string
+	ShardPlanner                     any
+	Module                           WorkflowModule
+	WorkflowStore                    *WorkflowInstanceStore
+	InstanceActivator                FlowInstanceActivator
+	InstanceDeactivator              FlowInstanceDeactivator
+	TimerScheduler                   *Scheduler
+	TimerScheduleStore               SchedulePersistence
+	MailboxMaterializer              MailboxWriteMaterializationStore
+	EventReceiptsCapability          func(context.Context) (bool, error)
+	ArtifactRoot                     string
+	BundleFingerprint                string
+	TestWorkflowNodeHandlerStartHook WorkflowNodeHandlerStartHook
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -91,20 +95,21 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		workflowStore = NewWorkflowInstanceStore(db)
 	}
 	return &PipelineCoordinator{
-		bus:                     bus,
-		db:                      db,
-		module:                  module,
-		workflowStore:           workflowStore,
-		expressionEval:          newWorkflowExpressionEvaluator(),
-		instanceActivator:       opts.InstanceActivator,
-		instanceDeactivator:     opts.InstanceDeactivator,
-		timerScheduler:          opts.TimerScheduler,
-		timerScheduleStore:      opts.TimerScheduleStore,
-		mailboxMaterializer:     opts.MailboxMaterializer,
-		eventReceiptsCapability: opts.EventReceiptsCapability,
-		artifactRoot:            strings.TrimSpace(opts.ArtifactRoot),
-		bundleFingerprint:       strings.TrimSpace(opts.BundleFingerprint),
-		entityLocks:             make(map[string]*sync.Mutex),
+		bus:                              bus,
+		db:                               db,
+		module:                           module,
+		workflowStore:                    workflowStore,
+		expressionEval:                   newWorkflowExpressionEvaluator(),
+		instanceActivator:                opts.InstanceActivator,
+		instanceDeactivator:              opts.InstanceDeactivator,
+		timerScheduler:                   opts.TimerScheduler,
+		timerScheduleStore:               opts.TimerScheduleStore,
+		mailboxMaterializer:              opts.MailboxMaterializer,
+		eventReceiptsCapability:          opts.EventReceiptsCapability,
+		artifactRoot:                     strings.TrimSpace(opts.ArtifactRoot),
+		bundleFingerprint:                strings.TrimSpace(opts.BundleFingerprint),
+		testWorkflowNodeHandlerStartHook: opts.TestWorkflowNodeHandlerStartHook,
+		entityLocks:                      make(map[string]*sync.Mutex),
 	}
 }
 
@@ -127,6 +132,15 @@ func (pc *PipelineCoordinator) SetTestEntityStateHook(fn func(entityID, state st
 	}
 	pc.mu.Lock()
 	pc.testEntityStateHook = fn
+	pc.mu.Unlock()
+}
+
+func (pc *PipelineCoordinator) SetTestWorkflowNodeHandlerStartHook(fn WorkflowNodeHandlerStartHook) {
+	if pc == nil {
+		return
+	}
+	pc.mu.Lock()
+	pc.testWorkflowNodeHandlerStartHook = fn
 	pc.mu.Unlock()
 }
 
@@ -256,6 +270,9 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 		return true, nil
 	}
 	ctx = withPipelineFlowScope(ctx, workflowNodeFlowID(source, nodeID))
+	if err := pc.notifyTestWorkflowNodeHandlerStarting(ctx, nodeID, evt); err != nil {
+		return false, err
+	}
 	result, err := pc.executeNodeContractHandler(ctx, nodeID, handler, workflowTriggerContext{
 		Event:           evt,
 		HandlerEventKey: handlerEventKey,
@@ -452,6 +469,19 @@ func (pc *PipelineCoordinator) notifyTestEntityStateUpdated(entityID, state stri
 	if hook != nil {
 		hook(strings.TrimSpace(entityID), strings.TrimSpace(state))
 	}
+}
+
+func (pc *PipelineCoordinator) notifyTestWorkflowNodeHandlerStarting(ctx context.Context, nodeID string, evt events.Event) error {
+	if pc == nil {
+		return nil
+	}
+	pc.mu.Lock()
+	hook := pc.testWorkflowNodeHandlerStartHook
+	pc.mu.Unlock()
+	if hook == nil {
+		return nil
+	}
+	return hook(ctx, strings.TrimSpace(nodeID), evt)
 }
 
 func (pc *PipelineCoordinator) publish(ctx context.Context, eventType, entityID string, payload map[string]any) error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -77,6 +77,7 @@ type RuntimeOptions struct {
 	BootProgress                     func(BootProgressEvent)
 	SystemContainers                 []string
 	DisablePersistentStartupRecovery bool
+	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
 }
 
 // RuntimeDeps is the canonical dependency graph for NewRuntime boot wiring.
@@ -453,12 +454,13 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 				}
 				return managerRef.DeactivateFlowInstanceModel(ctx, req)
 			},
-			TimerScheduler:          rt.Scheduler,
-			TimerScheduleStore:      stores.ScheduleStore,
-			MailboxMaterializer:     stores.MailboxMaterializer,
-			EventReceiptsCapability: boot.EventReceiptCapability,
-			ArtifactRoot:            artifactRoot,
-			BundleFingerprint:       opts.BundleFingerprint,
+			TimerScheduler:                   rt.Scheduler,
+			TimerScheduleStore:               stores.ScheduleStore,
+			MailboxMaterializer:              stores.MailboxMaterializer,
+			EventReceiptsCapability:          boot.EventReceiptCapability,
+			ArtifactRoot:                     artifactRoot,
+			BundleFingerprint:                opts.BundleFingerprint,
+			TestWorkflowNodeHandlerStartHook: opts.TestWorkflowNodeHandlerStartHook,
 		})
 		if rt.Pipeline != nil {
 			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodesWithReceiptStore(rt.Bus, stores.SQLDB, pipelineStore)...)


### PR DESCRIPTION
## Summary

Closes #1337.

This PR repairs the #1337 supported-surface proof after the route-authority matrix work in #1346/#1351:

- strengthens the served SQLite/Postgres `event.publish` proof so the initial root-input `thing.created` event must persist a typed `node/entity-writer` `event_deliveries` row
- verifies `event.get` reads that initial node delivery from persisted event state while keeping the created entity-state check separate
- updates the route-authority matrix and validator so #1337 is no longer modeled as split-open, while #1293, #1299, and #1301 remain active split siblings

No runtime admission, settlement/backfill, receipt, replay-marker, API readback, or public schema behavior is changed.

## Governing Context

Exact governing refs:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.outputs.persistence_requirements`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.authority_boundaries`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`
- `platform-spec.yaml#cli_specification.command_catalog.event_publish`

Binding issue/gate context:

- #1337 pre-audit and approved first-slice gate
- #1337 residual refresh after #1346/#1351
- #1337 gate after #1346/#1351: `served_root_input_event_publish_node_delivery_route_materialization`
- #1340/#1346 route-authority parent/matrix classification

## Semantic Migration

No semantic migration or production owner move is performed in this PR.

Canonical owner after this PR remains:

- route production/materialization: EventBus `RoutePlan`, RouteTable, delivery planner, publish recipient materialization, and store `event_deliveries` route writers
- public readback: API/CLI consume persisted `event_deliveries`; they do not create route authority
- execution admission: #1293 remains the separate consumer of committed delivery authority

Old invalid authority paths remain invalid: settlement/backfill, processed receipts, replay markers, live carriers/interceptors, handler lookup, and API delivery counts are not route-authority producers.

## Validation

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/conformance -run 'TestRouteAuthorityMatrix' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus -run 'TestRouteTableRootInputFlowNodeResolvesRootInputRoute|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch|TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutInternalCarrier|TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch|TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInternalSubscription|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesSystemNodeRouteWithoutLiveSubscription|TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/apiv1 -run 'TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock' -count=1
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...
```
