### PR TITLE
[agent-c][issue #1294] Persist concrete template node delivery routes

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -406,6 +406,9 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
+	if routes := routedConcreteNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
+		return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
+	}
 	internalRecipients := filterOutAgentIDs(recipients, persisted)
 	if len(internalRecipients) == 0 {
 		return nil
@@ -438,6 +441,41 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 		})
 	}
 	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
+}
+
+func routedConcreteNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if flowInstance == "" || eventType == "" || !strings.HasPrefix(eventType, flowInstance+"/") {
+		return nil
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	nodeIDs := make(map[string]struct{}, len(routed))
+	for _, subscriber := range routed {
+		if !routedNodeMatchesConcreteEventTypeFlowInstance(evt, subscriber) {
+			continue
+		}
+		id := strings.TrimSpace(subscriber.ID)
+		if id == "" {
+			continue
+		}
+		nodeIDs[id] = struct{}{}
+	}
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(nodeIDs))
+	for _, recipient := range sortedStringKeys(nodeIDs) {
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   recipient,
+			Target: events.RouteIdentity{
+				FlowInstance: flowInstance,
+				EntityID:     eventEntityID,
+			},
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
 }
 
 func routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {
@@ -615,6 +653,19 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 
 func routedNodeMatchesConcreteFlowInstanceEvent(evt events.Event, subscriber Subscriber) bool {
 	return routedNodeConcreteEventKey(evt, subscriber) != ""
+}
+
+func routedNodeMatchesConcreteEventTypeFlowInstance(evt events.Event, subscriber Subscriber) bool {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+		return false
+	}
+	instancePath := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if instancePath == "" || flowInstance == "" || eventType == "" {
+		return false
+	}
+	return instancePath == flowInstance && strings.HasPrefix(eventType, flowInstance+"/")
 }
 
 func routedNodeConcreteEventKey(evt events.Event, subscriber Subscriber) string {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -343,7 +343,7 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	}
 }
 
-func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRoute(t *testing.T) {
+func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
 			resolveRoutedSubscribers: func(events.Event) []Subscriber {
@@ -381,17 +381,24 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodeUsesInternalCarrierAndNodeRou
 		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
 	}
 	if got := plan.DeliveryRoutes; len(got) != 1 {
-		t.Fatalf("delivery routes = %#v, want workflow-runtime carrier route", got)
+		t.Fatalf("delivery routes = %#v, want lifecycle-orchestrator semantic node route", got)
 	}
 	route := plan.DeliveryRoutes[0]
-	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
-		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
+	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
+		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator semantic authority", route)
 	}
 	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
 		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)
 	}
 	if plan.TargetFailure != "" {
 		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceConcreteNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want concrete route-table semantic node source", intent)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -531,7 +531,7 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	assertTargetRouteDeliveries(t, ch, "ent-a", "ent-b")
 }
 
-func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDeliveryRoute(t *testing.T) {
+func TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	source := semanticview.Wrap(routedNodeTemplateBundle())
 	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
@@ -559,11 +559,11 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 
 	routes := store.routes[evt.ID]
 	if len(routes) != 1 {
-		t.Fatalf("persisted delivery routes = %#v, want one workflow-runtime carrier route", routes)
+		t.Fatalf("persisted delivery routes = %#v, want one lifecycle-orchestrator semantic route", routes)
 	}
 	route := routes[0]
-	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
-		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
+	if route.SubscriberType != "node" || route.SubscriberID != "lifecycle-orchestrator" {
+		t.Fatalf("delivery route = %#v, want node/lifecycle-orchestrator semantic authority", route)
 	}
 	if route.Target.FlowInstance != "operating/inst-1" || route.Target.EntityID != "ent-operating" {
 		t.Fatalf("delivery target = %#v, want operating/inst-1 ent-operating", route.Target)
@@ -579,8 +579,21 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodeUsesWorkflowCarrierAndNodeDel
 	if len(internal) != 1 || internal[0] != "workflow-runtime" {
 		t.Fatalf("replay internal recipients = %#v, want workflow-runtime", internal)
 	}
-	if len(replayRoutes) != 1 || replayRoutes[0].SubscriberID != "workflow-runtime" {
-		t.Fatalf("replay routes = %#v, want workflow-runtime carrier route", replayRoutes)
+	if !deliveryRoutesContain(replayRoutes, events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "lifecycle-orchestrator",
+		Target: events.RouteIdentity{
+			FlowInstance: "operating/inst-1",
+			EntityID:     "ent-operating",
+		},
+	}) {
+		t.Fatalf("replay routes = %#v, want lifecycle-orchestrator semantic route", replayRoutes)
+	}
+	if !deliveryRoutesContain(replayRoutes, events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "workflow-runtime",
+	}) {
+		t.Fatalf("replay routes = %#v, want workflow-runtime replay carrier route", replayRoutes)
 	}
 }
 

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -128,6 +128,34 @@ rows:
       node result is accepted. #1293 remains the separate execution-admission
       consumer of that persisted authority.
 
+  - id: concrete_template_no_target_node_delivery_route_materialization
+    concept: Already-concrete no-target flow-instance events persist semantic workflow-node authority separately from workflow-runtime carrier dispatch.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_plan_model, persistence_authority, negative_authority, required_pr_smoke]
+    invalid_authority:
+      - workflow-runtime carrier route
+      - live internal carrier subscription
+      - event_receipts settlement/backfill
+      - replay-scope markers
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/delivery_planner.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_target_routes_test.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_authority}
+    proof_refs:
+      - {kind: issue, issue: 1294}
+      - {kind: go_test, name: TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute}
+      - {kind: go_test, name: TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute}
+      - {kind: go_test, name: TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately}
+    notes: >
+      #1294 owns the already-concrete no-target template flow-instance shape,
+      for example operating/inst-1/opco.product_initialization_requested with
+      flow_instance=operating/inst-1. The persisted route-authority row is the
+      semantic workflow node, such as node/lifecycle-orchestrator. A live
+      workflow-runtime carrier may dispatch the event, but it is not the
+      executable delivery authority consumed by #1293.
+
   - id: workflow_node_execution_admission
     concept: Workflow-node execution must require committed node delivery authority before handler execution.
     classification: split_to_existing_issue

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -75,7 +75,7 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 	assertRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
-	`, 1, eventID)
+	`, 0, eventID)
 	assertRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM event_deliveries
 		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
@@ -88,6 +88,54 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 		SELECT COUNT(*) FROM events
 		WHERE event_name = 'operating/opco.ceo_ready'
 	`, 1)
+}
+
+func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandlerExecution(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceDeliveryFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := bus.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	ch := bus.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
+	eventID := "99999999-9999-4999-8999-999999999903"
+	evt := (events.Event{
+		ID:        eventID,
+		RunID:     templateInstanceDeliveryRunID,
+		Type:      events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		Payload:   []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("11111111-1111-4111-8111-111111111111").WithFlowInstance("operating/inst-1")
+	if err := bus.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got.FlowInstance() != "operating/inst-1" || got.EntityID() != "11111111-1111-4111-8111-111111111111" {
+			t.Fatalf("delivered route identity flow=%q entity=%q, want operating/inst-1 product entity", got.FlowInstance(), got.EntityID())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow-runtime carrier did not receive concrete template event")
+	}
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 1, eventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'workflow-runtime'
+	`, 0, eventID)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'lifecycle-orchestrator'
+	`, 0, eventID)
 }
 
 func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(t *testing.T) {


### PR DESCRIPTION
## Summary

- Persist the routed semantic workflow-node delivery row for already-concrete no-target template flow-instance events before workflow-node execution.
- Keep `workflow-runtime` as the live/internal carrier rather than the executable delivery-authority row.
- Add focused EventBus/runtime proofs and attach #1294 to the route-authority matrix.

Closes #1294.
Part of #1340.
Related to #1293 and #1353.

## Governing Refs / Context

Exact governing spec references:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#persistence_schema.event_deliveries`

Binding issue/gate context:

- #1294 gate outcome: `approved as first slice` for `concrete_template_no_target_node_delivery_route_materialization`.
- #1353 residual model audit: executable delivery authority must stay distinct from dispatch/carrier transport.

## Semantic Migration

New canonical owner:

- `internal/runtime/bus.deliveryPlanner` / EventBus `RoutePlan` delivery intents for already-concrete no-target workflow-node events.

Old producer / reader / writer path now invalid:

- `routedNodeDeliveryIntentsForNoTargetEvent` using `filterOutAgentIDs(recipients, persisted)` to persist `node/workflow-runtime` as the concrete no-target route-authority row.
- Post-handler settlement/backfill creating the semantic node row after execution as a substitute for pre-execution authority.

Production paths checked for surviving old behavior:

- EventBus `Publish` and `CheckPublishRecipientPlan` concrete no-target route planning.
- Runtime Postgres concrete template event publish with a live `workflow-runtime` carrier and no handler runner.
- Existing semantic-scope-plus-`flow_instance` path remains split/covered by #1295.
- #1299 wildcard static-service route production and #1301 runtime callback localization remain split.

Migration completeness:

- Complete for the approved #1294 chosen class: already-concrete no-target template flow-instance events now persist semantic workflow-node authority before execution. Parent tails remain open in #1293, #1299, #1301, and #1353.

## Tests

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute|TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesNodeRoute|TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializesSystemNodeRouteWithoutLiveSubscription' -count=1

SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime -run 'TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandlerExecution|TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect' -count=1

SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/conformance -run TestRouteAuthorityMatrix -count=1

SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime ./internal/runtime/conformance -count=1

SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...
```
