### PR TITLE
[agent-c][issue #1355] Materialize root project node delivery routes

### DIFF
--- a/internal/builder/handler_run_start_test.go
+++ b/internal/builder/handler_run_start_test.go
@@ -26,6 +26,10 @@ func (*runStartAppendStore) InsertEventDeliveries(context.Context, string, []str
 	return nil
 }
 
+func (*runStartAppendStore) InsertEventDeliveryRoutes(context.Context, string, []events.DeliveryRoute) error {
+	return nil
+}
+
 func (*runStartAppendStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return nil, nil
 }

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -851,6 +851,27 @@ func (eb *EventBus) persistEventRecord(
 		}
 		return nil
 	}
+	if deliveryRouteSetPersistenceRequired(deliveryRoutes) {
+		if _, ok := eb.store.(EventDeliveryRouteSetPersistence); !ok {
+			return fmt.Errorf("persist typed event delivery routes: %w", errMissingEventDeliveryRouteSetPersistence)
+		}
+		if err := eb.store.AppendEvent(ctx, evt); err != nil {
+			return fmt.Errorf("persist event: %w", err)
+		}
+		if err := eb.insertEventDeliveries(ctx, evt.ID, recipients, deliveryTargets, deliveryRoutes); err != nil {
+			return fmt.Errorf("persist event deliveries: %w", err)
+		}
+		if scopeWriter, ok := eb.store.(EventReplayScopePersistence); ok && scopeWriter != nil {
+			if err := scopeWriter.UpsertCommittedReplayScope(ctx, evt.ID, scope); err != nil {
+				return fmt.Errorf("persist committed replay scope: %w", err)
+			}
+			return nil
+		}
+		if replayScopePersistenceRequired(eb.store) {
+			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		}
+		return nil
+	}
 	if atomicStore, ok := eb.store.(AtomicEventRoutePersistence); ok {
 		if err := atomicStore.PersistEventWithDeliveryRoutesAndScope(ctx, evt, recipients, deliveryTargets, scope); err != nil {
 			return fmt.Errorf("persist event transaction: %w", err)
@@ -903,6 +924,9 @@ func (eb *EventBus) insertEventDeliveries(ctx context.Context, eventID string, r
 	if store, ok := eb.store.(EventDeliveryRouteSetPersistence); ok && store != nil && len(deliveryRoutes) > 0 {
 		return store.InsertEventDeliveryRoutes(ctx, eventID, deliveryRoutes)
 	}
+	if deliveryRouteSetPersistenceRequired(deliveryRoutes) {
+		return errMissingEventDeliveryRouteSetPersistence
+	}
 	if store, ok := eb.store.(EventDeliveryRoutePersistence); ok && store != nil {
 		return store.InsertEventDeliveriesWithTargets(ctx, eventID, recipients, deliveryTargets)
 	}
@@ -922,10 +946,24 @@ func (eb *EventBus) insertEventDeliveriesTx(
 	if store, ok := txStore.(TransactionalEventDeliveryRouteSetPersistence); ok && store != nil && len(deliveryRoutes) > 0 {
 		return store.InsertEventDeliveryRoutesTx(ctx, tx, eventID, deliveryRoutes)
 	}
+	if deliveryRouteSetPersistenceRequired(deliveryRoutes) {
+		return errMissingEventDeliveryRouteSetPersistence
+	}
 	if store, ok := txStore.(TransactionalEventDeliveryRoutePersistence); ok && store != nil {
 		return store.InsertEventDeliveriesWithTargetsTx(ctx, tx, eventID, recipients, deliveryTargets)
 	}
 	return txStore.InsertEventDeliveriesTx(ctx, tx, eventID, recipients)
+}
+
+var errMissingEventDeliveryRouteSetPersistence = errors.New("event store does not support typed delivery route persistence")
+
+func deliveryRouteSetPersistenceRequired(routes []events.DeliveryRoute) bool {
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if strings.TrimSpace(route.SubscriberType) != routePlanSubscriberAgent {
+			return true
+		}
+	}
+	return false
 }
 
 func (eb *EventBus) logDelivery(ctx context.Context, evt events.Event, recipients []string, extra map[string]any) {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -1029,6 +1029,92 @@ func TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInter
 	}
 }
 
+func TestRouteTableTopLevelProjectNodeResolvesProgrammaticRootInputRoute(t *testing.T) {
+	rt, err := DeriveRouteTable(semanticview.Wrap(routedTopLevelProjectNodeBundle()))
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	got := rt.Resolve("thing.created")
+	if len(got) != 1 {
+		t.Fatalf("Resolve(thing.created) = %#v, want one top-level project node route", got)
+	}
+	if got[0].ID != "reviewer" || got[0].Type != "node" || got[0].Path != "" || got[0].MatchPattern != "thing.created" || got[0].RouteSource != "root_input_project" {
+		t.Fatalf("resolved subscriber = %#v, want root input project reviewer route", got[0])
+	}
+}
+
+func TestEventBusPublish_TopLevelProjectNodePersistsRouteBeforeInterceptor(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	reviewerRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "reviewer",
+	}
+	workflowRuntimeRoute := events.DeliveryRoute{
+		SubscriberType: "agent",
+		SubscriberID:   "workflow-runtime",
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedTopLevelProjectNodeBundle()),
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    reviewerRoute,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eb.RegisterRuntimeActiveAgentDescriptor(ActiveAgentDescriptor{AgentID: "workflow-runtime"})
+	ch := eb.Subscribe("workflow-runtime", events.EventType("thing.created"))
+	evt := (events.Event{
+		ID:        eventID,
+		Type:      events.EventType("thing.created"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-project")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got := plan.PersistedRecipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("persisted recipients = %#v, want workflow-runtime carrier", got)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, reviewerRoute) || !deliveryRoutesContain(plan.DeliveryRoutes, workflowRuntimeRoute) {
+		t.Fatalf("delivery routes = %#v, want workflow-runtime agent and reviewer node routes", plan.DeliveryRoutes)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "workflow-runtime carrier delivery")
+	if got.EntityID() != "ent-project" {
+		t.Fatalf("delivered entity_id = %q, want ent-project", got.EntityID())
+	}
+	if routes := store.routes[eventID]; !deliveryRoutesContain(routes, reviewerRoute) || !deliveryRoutesContain(routes, workflowRuntimeRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want workflow-runtime agent and reviewer node routes", routes)
+	}
+}
+
+func TestEventBusPublish_NodeRouteFailsClosedWithoutRouteSetPersistence(t *testing.T) {
+	eb, err := NewEventBusWithOptions(InMemoryEventStore{}, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedTopLevelProjectNodeBundle()),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.Publish(context.Background(), events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("thing.created"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}); err == nil || !strings.Contains(err.Error(), "typed delivery route persistence") {
+		t.Fatalf("Publish error = %v, want typed delivery route persistence failure", err)
+	}
+}
+
 func assertTargetRouteDeliveries(t *testing.T, ch <-chan events.Event, wantEntityIDs ...string) {
 	t.Helper()
 	seen := map[string]struct{}{}
@@ -1174,6 +1260,41 @@ func routedRootInputFlowNodeBundle() *runtimecontracts.WorkflowContractBundle {
 		},
 		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
 			"validation": validation.Schema,
+		},
+	}
+}
+
+func routedTopLevelProjectNodeBundle() *runtimecontracts.WorkflowContractBundle {
+	handler := runtimecontracts.SystemNodeEventHandler{AdvancesTo: "done"}
+	return &runtimecontracts.WorkflowContractBundle{
+		Package: runtimecontracts.ProjectPackageDocument{
+			Name:    "top-level-project-node",
+			Version: "1.0.0",
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"thing.created"}},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "top-level-project-node",
+			Version: "1.0.0",
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"reviewer": {"thing.created": handler},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"thing.created": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"reviewer": {
+				ID:            "reviewer",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"thing.created"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"thing.created": handler,
+				},
+			},
 		},
 	}
 }

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -86,6 +86,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		rt.addNodePatternsLocked(source, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Nodes)
 	}
 
+	rt.addTopLevelRootInputNodeRoutesLocked(source)
 	rt.addRootInputFlowNodeRoutesLocked(source)
 	rt.rebuildLocked()
 	return rt, nil
@@ -291,6 +292,60 @@ func newRouteTable(source semanticview.Source) *RouteTable {
 		instances:         make(map[string]struct{}),
 		instanceEventPath: make(map[string][]string),
 	}
+}
+
+func (rt *RouteTable) addTopLevelRootInputNodeRoutesLocked(source semanticview.Source) {
+	if rt == nil || source == nil {
+		return
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil || len(bundle.Nodes) == 0 {
+		return
+	}
+	rootInputs := routeRootInputEventSet(source)
+	if len(rootInputs) == 0 {
+		return
+	}
+	for _, eventType := range sortedStringKeys(rootInputs) {
+		for _, key := range sortedStringKeys(bundle.Nodes) {
+			entry := bundle.Nodes[key]
+			nodeID := strings.TrimSpace(entry.ID)
+			if nodeID == "" {
+				nodeID = strings.TrimSpace(key)
+			}
+			if nodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(nodeID), eventType) {
+				continue
+			}
+			if rootInputFlowOwnsNodeRoute(source, nodeID, eventType) {
+				continue
+			}
+			rt.rootInputRoutes[eventType] = appendUniqueRootInputSubscriber(rt.rootInputRoutes[eventType], Subscriber{
+				ID:           nodeID,
+				Type:         "node",
+				MatchPattern: eventType,
+				RouteSource:  "root_input_project",
+			})
+		}
+	}
+}
+
+func rootInputFlowOwnsNodeRoute(source semanticview.Source, nodeID string, eventType string) bool {
+	for _, scope := range source.FlowScopes() {
+		if strings.EqualFold(scope.Mode, "template") || !normalizedStringListContains(scope.InputEvents, eventType) {
+			continue
+		}
+		for _, key := range sortedStringKeys(scope.Nodes) {
+			entry := scope.Nodes[key]
+			scopedNodeID := strings.TrimSpace(entry.ID)
+			if scopedNodeID == "" {
+				scopedNodeID = strings.TrimSpace(key)
+			}
+			if scopedNodeID == nodeID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (rt *RouteTable) addRootInputFlowNodeRoutesLocked(source semanticview.Source) {

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -128,6 +128,41 @@ rows:
       node result is accepted. #1293 remains the separate execution-admission
       consumer of that persisted authority.
 
+  - id: top_level_project_node_event_publish_materialization
+    concept: Top-level project workflow-node routes are materialized into typed event_deliveries before admission, even when a live workflow-runtime carrier also exists.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_plan_model, default_sqlite, explicit_postgres, real_v1_handler, persistence_authority, negative_authority, required_pr_smoke]
+    invalid_authority:
+      - workflow-runtime carrier route
+      - live internal carrier subscription
+      - handler lookup
+      - event_receipts settlement/backfill
+      - replay-scope markers
+      - legacy InsertEventDeliveries agent-only fallback
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/routing_derivation.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_publish.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_target_routes_test.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_authority}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+    proof_refs:
+      - {kind: issue, issue: 1355}
+      - {kind: go_test, name: TestRouteTableTopLevelProjectNodeResolvesProgrammaticRootInputRoute}
+      - {kind: go_test, name: TestEventBusPublish_TopLevelProjectNodePersistsRouteBeforeInterceptor}
+      - {kind: go_test, name: TestEventBusPublish_NodeRouteFailsClosedWithoutRouteSetPersistence}
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends}
+      - {kind: go_test, name: TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends}
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud}
+      - {kind: go_test, name: TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows}
+    notes: >
+      #1355 closes the first producer/materialization slice exposed by #1293:
+      programmatic/top-level project nodes are part of the root project route
+      topology, and non-agent typed delivery routes require the route-set
+      persistence owner instead of lossy legacy agent-only fallback. This row
+      does not claim #1293 execution admission, #1299 wildcard route production,
+      or #1301 runtime callback localization closed.
+
   - id: concrete_template_no_target_node_delivery_route_materialization
     concept: Already-concrete no-target flow-instance events persist semantic workflow-node authority separately from workflow-runtime carrier dispatch.
     classification: already_covered_by_existing_proof

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -18,6 +18,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -711,6 +712,14 @@ func (s routeMaterializationDBProofStore) AppendEvent(ctx context.Context, evt e
 
 func (s routeMaterializationDBProofStore) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
 	return s.pg.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (s routeMaterializationDBProofStore) InsertEventDeliveryRoutes(ctx context.Context, eventID string, routes []events.DeliveryRoute) error {
+	return s.pg.InsertEventDeliveryRoutes(ctx, eventID, routes)
+}
+
+func (s routeMaterializationDBProofStore) PersistEventWithDeliveryRouteSetAndScope(ctx context.Context, evt events.Event, routes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
+	return s.pg.PersistEventWithDeliveryRouteSetAndScope(ctx, evt, routes, scope)
 }
 
 func (s routeMaterializationDBProofStore) ListEventDeliveryRecipients(ctx context.Context, eventID string) ([]string, error) {


### PR DESCRIPTION
Part of #1355

## Summary
- Materialize top-level project/root-input workflow-node routes into the publish-time route table for programmatic bundles that do not already have a concrete flow-owned root-input route.
- Require the typed route-set persistence owner when a RoutePlan contains non-agent delivery routes; legacy agent-only delivery insertion now fails closed for typed workflow-node routes instead of silently dropping them.
- Extend route-authority conformance coverage and update proof-store/test fakes to consume the typed route-set owner.

## Governing refs / context
Exact governing spec exists in `platform-spec.yaml`:
- `contract_formats.event_schema.routing_derivation.route_plan_authority`
- `contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `contract_formats.event_schema.routing_derivation.route_plan_authority.authority_boundaries`
- `api_surface.openrpc.methods.event.publish`

This PR enforces the existing spec; it does not change authoritative platform architecture/spec semantics.

## Semantic migration notes
- New canonical owner used here: publish-time RoutePlan derivation in `internal/runtime/bus/routing_derivation.go`, publish-time typed route persistence in `internal/runtime/bus/eventbus_publish.go`, and durable typed `event_deliveries` route-set persistence.
- Old invalid paths: top-level programmatic workflow nodes absent from root-input route derivation; legacy `InsertEventDeliveries(eventID, agentIDs)` fallback for non-agent typed routes; workflow-runtime carrier presence, handler lookup, receipts, settlement/backfill, replay markers, and API readback as route authority.
- Production paths checked for surviving old behavior: real v1 API mailbox-write SQLite default and explicit Postgres paths, runtime config-subscriber proof-store path, loaded flow-root route path, builder run.start fake-store path, and route-authority matrix.
- Migration completeness: complete for the approved #1355 first slice. #1293 execution admission, #1299 wildcard/static-service routes, #1301 runtime callback localization, #1255 readback, and #1300 accounting remain split.

## Tests
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/apiv1 -run 'TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends|TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends|TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud' -count=1 -timeout=120s -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime -run TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows -count=1 -timeout=90s -v`
- `go test ./internal/runtime/bus -run 'TestRouteTableTopLevelProjectNodeResolvesProgrammaticRootInputRoute|TestEventBusPublish_TopLevelProjectNodePersistsRouteBeforeInterceptor|TestEventBusPublish_NodeRouteFailsClosedWithoutRouteSetPersistence|TestEventBusPublish_NoTargetRootRoutedNode|TestEventBusPublish_RootInputFlowNode|TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch' -count=1 -v`
- `go test ./internal/runtime/conformance -run TestRouteAuthorityMatrix -count=1 -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime ./internal/apiv1 ./internal/runtime/bus ./internal/builder -count=1 -timeout=180s`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...`