### PR TITLE
[agent-g][issue #1356] Promote trusted host native commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,15 @@ SWARM_API_TOKEN=
 SWARM_WORKSPACE_DATA_SOURCE=
 
 # Workspace backend. Docker is the default isolation backend. Set host only for
-# explicit local-dev flows that use the supported host surface:
-# platform-managed read_file/write_file and tool-result relay. Host mode does
-# not provide Docker-equivalent isolation, and host bash/native command
-# execution plus Claude/provider host execution remain unsupported/fail-closed.
+# explicit local-dev or trusted remote flows that use the supported host surface:
+# platform-managed read_file/write_file, tool-result relay, and trusted/unsafe
+# bash/native command execution when the agent contract also enables
+# native_tools.bash. Host bash is full host-user shell execution from the
+# workspace backing directory; use relative paths for workspace files, and
+# absolute paths follow the host deployment namespace and OS permissions. Host
+# mode runs commands as the host user, does not command-filter, and does not
+# provide Docker-equivalent isolation. Claude/provider host execution remains
+# unsupported/fail-closed.
 # Do not combine host mode with SWARM_WORKSPACE_VOLUMES_FROM.
 # SWARM_WORKSPACE_BACKEND=host
 # SWARM_WORKSPACE_HOST_ROOT=

--- a/README.md
+++ b/README.md
@@ -215,8 +215,16 @@ source contract.
 
 ## Development
 
-Requirements: Go 1.23. Docker is the default workspace-isolation backend; a
-host backend is available for local-dev work (see [`.env.example`](.env.example)).
+Requirements: Go 1.23. Docker is the default workspace-isolation backend; an
+explicit host backend is available for local-dev or trusted remote work (see
+[`.env.example`](.env.example)). Host backend command execution is
+trusted/unsafe: native `bash` commands run as the host user when both host
+backend selection and `native_tools.bash` authorization are present. Host bash
+is full host-user shell execution from the workspace backing directory; use
+relative paths for workspace files, and absolute paths follow the host
+deployment namespace and OS permissions. It is not command-limited or
+Docker-equivalent isolation, and Claude/provider host execution remains
+unsupported.
 Plain local `swarm run --contracts ...` uses SQLite at `.swarm/dev.db` unless
 you explicitly opt into Postgres with `SWARM_STORE_BACKEND=postgres` or
 `store.backend: postgres`. Build or pull the configured workspace image

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -194,7 +194,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, openai_compatible, or openai_responses")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
-	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend for local serve: docker (default isolation backend) or host (explicit local-dev opt-in)")
+	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend for local serve: docker (default isolation backend) or host (explicit trusted/unsafe local-dev opt-in)")
 	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2001,7 +2001,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 			t.Fatalf("workspace backend consumers missing %q: %#v", want, authority.Consumers)
 		}
 	}
-	for _, want := range []string{"#1137", "#1136", "full host Claude CLI", "production SQLite"} {
+	for _, want := range []string{"#1137", "#1136", "full host Claude CLI/provider", "production SQLite"} {
 		if !joinedContains(authority.SplitScope, want) {
 			t.Fatalf("workspace backend split scope missing %q: %#v", want, authority.SplitScope)
 		}
@@ -2065,13 +2065,13 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	authority := spec.WorkspaceModel.WorkspaceExecutionTargetCapability
-	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235/#1286" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_and_relay_slice" {
+	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235/#1286/#1356" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_relay_and_trusted_command_slice" {
 		t.Fatalf("workspace execution target authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_execution_target_capability") || !strings.Contains(authority.ImplementationOwner, "internal/runtime/workspace.ExecutionTarget") {
 		t.Fatalf("workspace execution target owners = canonical:%q implementation:%q", authority.CanonicalOwner, authority.ImplementationOwner)
 	}
-	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "tool-result relay"} {
+	for _, want := range []string{"Docker container execution", "explicit host-local targets", "unsupported targets", "trusted/unsafe", "tool-result relay"} {
 		if !strings.Contains(authority.Scope, want) {
 			t.Fatalf("workspace execution target scope missing %q:\n%s", want, authority.Scope)
 		}
@@ -2089,15 +2089,15 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 		}
 	}
 	hostMode := authority.TargetModes[string(workspace.ExecutionModeHostLocal)]
-	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") {
+	if !strings.Contains(hostMode.Rule, "MUST NOT infer execution support from an empty container") || !strings.Contains(hostMode.Rule, "trusted/unsafe native_command") {
 		t.Fatalf("host execution mode rule = %q", hostMode.Rule)
 	}
-	for _, want := range []string{string(workspace.ExecutionCapabilityFileRead), string(workspace.ExecutionCapabilityFileWrite), string(workspace.ExecutionCapabilityToolResultRelay)} {
+	for _, want := range []string{string(workspace.ExecutionCapabilityNativeCommand), string(workspace.ExecutionCapabilityFileRead), string(workspace.ExecutionCapabilityFileWrite), string(workspace.ExecutionCapabilityToolResultRelay)} {
 		if !stringSliceContains(hostMode.Capabilities, want) {
 			t.Fatalf("host execution capabilities missing %q: %#v", want, hostMode.Capabilities)
 		}
 	}
-	for _, forbidden := range []string{string(workspace.ExecutionCapabilityNativeCommand), string(workspace.ExecutionCapabilityClaudeCLI)} {
+	for _, forbidden := range []string{string(workspace.ExecutionCapabilityClaudeCLI)} {
 		if stringSliceContains(hostMode.Capabilities, forbidden) {
 			t.Fatalf("host execution capabilities include forbidden %q: %#v", forbidden, hostMode.Capabilities)
 		}
@@ -2129,21 +2129,21 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 			t.Fatalf("retired interpreters missing %q: %#v", want, authority.RetiredNonAuthoritativeInterpreters)
 		}
 	}
-	for _, want := range []string{"native command execution", "Host-local tool-result relay writes", "Host-local file operations fail closed", "Empty-container targets", "Docker behavior"} {
+	for _, want := range []string{"explicit host backend selection", "native_tools.bash", "Docker target failures", "Host-local tool-result relay writes", "Host-local file operations fail closed", "Empty-container targets", "Docker behavior"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("failure behavior missing %q: %#v", want, authority.FailureBehavior)
 		}
 	}
-	for _, want := range []string{"host native bash", "Claude CLI", "#1137"} {
+	for _, want := range []string{"Claude CLI", "Docker-equivalent host isolation", "#1137"} {
 		if !joinedContains(authority.SplitScope, want) {
 			t.Fatalf("split scope missing %q: %#v", want, authority.SplitScope)
 		}
 	}
 	command := spec.CLISpecification.CommandCatalog.Serve.WorkspaceExecutionTargetCapability
-	if command.PromotedBy != "#1213/#1235/#1286" || command.Owner != "workspace_model.workspace_execution_target_capability" {
+	if command.PromotedBy != "#1213/#1235/#1286/#1356" || command.Owner != "workspace_model.workspace_execution_target_capability" {
 		t.Fatalf("serve command workspace execution authority = %#v", command)
 	}
-	if !strings.Contains(command.Rule, "tool-result relay through execution-target path authority") {
+	if !strings.Contains(command.Rule, "trusted/unsafe native command execution") || !strings.Contains(command.Rule, "Claude/provider execution remains fail closed") {
 		t.Fatalf("serve command workspace execution rule = %q", command.Rule)
 	}
 	for _, want := range []string{"native executor", "fallback-tool routing", "tool-result relay", "Claude CLI"} {

--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -364,19 +364,33 @@ func promptModeFromEvent(evt events.Event) string {
 	return strings.TrimSpace(sharedjson.AsString(payload["mode"]))
 }
 
-const promptEnvironmentPostamble = "## Environment\n\nWorking directory: /workspace (read-write)\nReference data: /data (read-only)\nContracts: /opt/swarm/contracts (read-only)"
+const promptEnvironmentPostamble = "## Environment\n\nWorkspace: /workspace (read-write logical path)\nReference data: /data (read-only logical path)\nContracts: /opt/swarm/contracts (read-only logical path)\nDocker-backed command execution exposes these as OS paths. Trusted host bash is full host-user shell execution from the workspace backing directory; use relative paths for workspace files, and absolute path availability follows the host deployment namespace and OS permissions."
 
 func appendPromptPostamble(prompt string) string {
 	prompt = strings.TrimSpace(prompt)
 	if prompt == "" {
 		return ""
 	}
-	if strings.Contains(prompt, "Working directory: /workspace") &&
-		strings.Contains(prompt, "Reference data: /data") &&
-		strings.Contains(prompt, "Contracts: /opt/swarm/contracts") {
+	if promptHasEnvironmentPostambleContract(prompt) {
 		return prompt
 	}
 	return prompt + "\n\n" + promptEnvironmentPostamble
+}
+
+func promptHasEnvironmentPostambleContract(prompt string) bool {
+	for _, required := range []string{
+		"Workspace: /workspace (read-write logical path)",
+		"Reference data: /data (read-only logical path)",
+		"Contracts: /opt/swarm/contracts (read-only logical path)",
+		"Docker-backed command execution exposes these as OS paths",
+		"Trusted host bash is full host-user shell execution from the workspace backing directory",
+		"absolute path availability follows the host deployment namespace and OS permissions",
+	} {
+		if !strings.Contains(prompt, required) {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *LLMAgent) resetConversationScopeIfNeeded(evt events.Event) {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -261,14 +261,23 @@ func TestResolvePromptForMode_ExpandsConfigVariables(t *testing.T) {
 	if strings.Contains(got, "{{team_name}}") {
 		t.Fatalf("expected resolved prompt to expand team_name token, got %q", got)
 	}
-	if !strings.Contains(got, "Working directory: /workspace (read-write)") {
+	if !strings.Contains(got, "Workspace: /workspace (read-write logical path)") {
 		t.Fatalf("expected prompt postamble in resolved prompt, got %q", got)
 	}
-	if !strings.Contains(got, "Reference data: /data (read-only)") {
+	if !strings.Contains(got, "Reference data: /data (read-only logical path)") {
 		t.Fatalf("expected prompt postamble in resolved prompt, got %q", got)
 	}
-	if !strings.Contains(got, "Contracts: /opt/swarm/contracts (read-only)") {
+	if !strings.Contains(got, "Contracts: /opt/swarm/contracts (read-only logical path)") {
 		t.Fatalf("expected prompt postamble in resolved prompt, got %q", got)
+	}
+	if strings.Contains(got, "Trusted host bash starts in the workspace backing directory") {
+		t.Fatalf("expected legacy prompt postamble guard to be absent from resolved prompt, got %q", got)
+	}
+	if !strings.Contains(got, "Trusted host bash is full host-user shell execution from the workspace backing directory") {
+		t.Fatalf("expected host bash full-power postamble in resolved prompt, got %q", got)
+	}
+	if !strings.Contains(got, "absolute path availability follows the host deployment namespace and OS permissions") {
+		t.Fatalf("expected host path namespace caveat in resolved prompt, got %q", got)
 	}
 }
 
@@ -1036,6 +1045,28 @@ func TestAppendPromptPostamble_IsIdempotent(t *testing.T) {
 	}
 }
 
+func TestAppendPromptPostamble_AppendsWhenPartialPostambleMissingRequiredMounts(t *testing.T) {
+	partial := strings.Join([]string{
+		"You are helpful.",
+		"Workspace: /workspace (read-write logical path)",
+		"Trusted host bash is full host-user shell execution from the workspace backing directory; use relative paths for workspace files, and absolute path availability follows the host deployment namespace and OS permissions.",
+	}, "\n")
+
+	got := appendPromptPostamble(partial)
+	if got == partial {
+		t.Fatalf("expected canonical postamble appended to partial environment prompt, got unchanged %q", got)
+	}
+	for _, want := range []string{
+		"Reference data: /data (read-only logical path)",
+		"Contracts: /opt/swarm/contracts (read-only logical path)",
+		"Docker-backed command execution exposes these as OS paths",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected appended canonical postamble to include %q, got %q", want, got)
+		}
+	}
+}
+
 type nativeCapabilityRuntimeStub struct {
 	llm.NoopRuntime
 	caps llm.NativeToolCapabilities
@@ -1073,6 +1104,19 @@ func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testi
 			t.Fatalf("expected native fallback tool %s in %v", want, names)
 		}
 	}
+	for _, tool := range agent.conversation.Tools {
+		if tool.Name != "bash" {
+			continue
+		}
+		if !strings.Contains(tool.Usage, "trusted host bash is full host-user shell execution from the workspace backing directory") {
+			t.Fatalf("bash usage = %q, want trusted host path contract", tool.Usage)
+		}
+		if !strings.Contains(tool.Usage, "absolute paths follow the host deployment namespace and OS permissions") {
+			t.Fatalf("bash usage = %q, want host namespace caveat", tool.Usage)
+		}
+		return
+	}
+	t.Fatal("bash native fallback tool missing")
 }
 
 func TestNewLLMAgent_DoesNotInjectNativeFallbackToolsWhenProviderSupportsCapability(t *testing.T) {

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -323,6 +323,9 @@ func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Ta
 	if len(args) == 0 {
 		return nil, nil, -1, fmt.Errorf("workspace command args are required")
 	}
+	if strings.TrimSpace(args[0]) == "" {
+		return nil, nil, -1, fmt.Errorf("workspace command executable is required")
+	}
 	if e != nil && e.execWorkspaceFn != nil {
 		return e.execWorkspaceFn(runCtx, execTarget, timeout, stdin, args...)
 	}
@@ -340,6 +343,13 @@ func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Ta
 		dockerArgs = append(dockerArgs, strings.TrimSpace(execTarget.Container))
 		dockerArgs = append(dockerArgs, args...)
 		cmd = exec.CommandContext(runCtx, dockerBin, dockerArgs...)
+	case workspace.ExecutionModeHostLocal:
+		hostWorkdir, err := hostNativeCommandWorkdir(execTarget)
+		if err != nil {
+			return nil, nil, -1, err
+		}
+		cmd = exec.CommandContext(runCtx, strings.TrimSpace(args[0]), args[1:]...)
+		cmd.Dir = hostWorkdir
 	default:
 		return nil, nil, -1, fmt.Errorf("%s", execTarget.UnsupportedMessage(workspace.ExecutionCapabilityNativeCommand))
 	}
@@ -362,6 +372,18 @@ func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Ta
 		}
 	}
 	return stdout.Bytes(), stderr.Bytes(), exitCode, err
+}
+
+func hostNativeCommandWorkdir(execTarget workspace.ExecutionTarget) (string, error) {
+	workdir := strings.TrimSpace(execTarget.Workdir)
+	if workdir == "" {
+		workdir = workspace.LogicalWorkspaceMount
+	}
+	resolved, err := execTarget.ResolveHostPath(workdir, workspace.PathAccessWrite)
+	if err != nil {
+		return "", fmt.Errorf("host native command workspace path is unavailable: %w", err)
+	}
+	return resolved.HostPath, nil
 }
 
 func resolveNativeReadPath(target *workspace.Target, raw string) (string, error) {

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -15,17 +15,73 @@ import (
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
-func TestNativeWorkspaceCommandFailsClosedForHostBackend(t *testing.T) {
+func TestNativeWorkspaceCommandRunsInExplicitHostBackendWorkdir(t *testing.T) {
+	workspaceDir := t.TempDir()
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	exec := &Executor{}
+	stdout, stderr, exitCode, err := exec.runWorkspaceCommand(context.Background(), &workspace.Target{
+		Workdir: workspaceDir,
+		Backend: workspace.BackendHost,
+		Mounts: []workspace.ExecutionMount{
+			{LogicalPath: workspace.LogicalWorkspaceMount, HostPath: workspaceDir, Access: workspace.MountAccessReadWrite},
+			{LogicalPath: workspace.LogicalDataMount, HostPath: dataDir, Access: workspace.MountAccessReadOnly},
+			{LogicalPath: workspace.LogicalContractsMount, HostPath: contractsDir, Access: workspace.MountAccessReadOnly},
+		},
+	}, time.Second, "", "sh", "-lc", "mkdir -p nested && printf host-ok > nested/out.txt && printf done")
+	if err != nil {
+		t.Fatalf("runWorkspaceCommand host error = %v stderr=%s", err, stderr)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d stdout=%s stderr=%s, want 0", exitCode, stdout, stderr)
+	}
+	if string(stdout) != "done" {
+		t.Fatalf("stdout = %q, want done", stdout)
+	}
+	data, err := os.ReadFile(filepath.Join(workspaceDir, "nested", "out.txt"))
+	if err != nil {
+		t.Fatalf("read host command output: %v", err)
+	}
+	if string(data) != "host-ok" {
+		t.Fatalf("host command output file = %q, want host-ok", data)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "nested", "out.txt")); !os.IsNotExist(err) {
+		t.Fatalf("host command wrote outside workspace dataDir err=%v", err)
+	}
+}
+
+func TestNativeWorkspaceCommandFailsClosedForHostTargetWithoutBackingPath(t *testing.T) {
 	exec := &Executor{}
 	_, _, exitCode, err := exec.runWorkspaceCommand(context.Background(), &workspace.Target{
 		Workdir: t.TempDir(),
 		Backend: workspace.BackendHost,
 	}, time.Second, "", "sh", "-lc", "true")
-	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("runWorkspaceCommand error = %v, want host backend fail-closed error", err)
+	if err == nil || !strings.Contains(err.Error(), "host native command workspace path is unavailable") {
+		t.Fatalf("runWorkspaceCommand error = %v, want host backing path fail-closed error", err)
 	}
 	if exitCode != -1 {
-		t.Fatalf("exit code = %d, want -1 for fail-closed host backend", exitCode)
+		t.Fatalf("exit code = %d, want -1 for fail-closed host backing path", exitCode)
+	}
+}
+
+func TestNativeWorkspaceCommandDoesNotFallbackFromDockerToHost(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "fallback-marker")
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
+	t.Setenv("SWARM_DOCKER_BIN", missingDocker)
+	exec := &Executor{}
+	_, _, exitCode, err := exec.runWorkspaceCommand(context.Background(), &workspace.Target{
+		Backend:   workspace.BackendDocker,
+		Container: "swarm-agent",
+		Workdir:   workspace.LogicalWorkspaceMount,
+	}, time.Second, "", "sh", "-lc", "printf fallback > "+shellQuote(marker))
+	if err == nil {
+		t.Fatal("runWorkspaceCommand docker with missing binary succeeded, want fail closed")
+	}
+	if exitCode != -1 {
+		t.Fatalf("exit code = %d, want -1 for missing Docker binary", exitCode)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("docker failure fell back to host command; marker stat err=%v", statErr)
 	}
 }
 
@@ -221,10 +277,62 @@ func TestExecutorHostFileToolsUseHostManagerSupportedSurfaceWithoutDocker(t *tes
 	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
 		t.Fatalf("Execute read_file symlink error = %v, want escape rejection", err)
 	}
+}
 
-	_, err = exec.Execute(actorCtx, "bash", map[string]any{"command": "true"})
-	if err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("Execute bash error = %v, want host native command fail-closed", err)
+func TestExecutorHostNativeBashUsesExplicitHostManagerTarget(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := filepath.Join(t.TempDir(), "host-workspaces")
+	dataDir := t.TempDir()
+	contractsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("contracts content"), 0o644); err != nil {
+		t.Fatalf("write contracts package: %v", err)
+	}
+
+	manager := workspace.NewHostManager(nil)
+	manager.SetConfig(workspace.HostConfig{
+		WorkspaceRoot:       workspaceRoot,
+		SharedDataSource:    dataDir,
+		DataMountPoint:      workspace.LogicalDataMount,
+		ContractsSource:     contractsDir,
+		ContractsMountPoint: workspace.LogicalContractsMount,
+	})
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	if err := manager.ValidateSource(ctx, source); err != nil {
+		t.Fatalf("ValidateSource: %v", err)
+	}
+	if err := manager.EnsurePrereqs(ctx); err != nil {
+		t.Fatalf("EnsurePrereqs: %v", err)
+	}
+
+	actor := models.AgentConfig{
+		ID:          "host-bash-agent",
+		NativeTools: models.NativeToolConfig{Bash: true},
+	}
+	target, err := manager.ResolveWorkspace(ctx, actor)
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	actorCtx := models.WithActor(ctx, actor)
+
+	out, err := exec.Execute(actorCtx, "bash", map[string]any{
+		"command": "mkdir -p cmd && printf host-bash > cmd/out.txt && printf ok",
+	})
+	if err != nil {
+		t.Fatalf("Execute bash host: %v", err)
+	}
+	result := out.(map[string]any)
+	if got := result["stdout"]; got != "ok" {
+		t.Fatalf("host bash stdout = %#v, want ok", got)
+	}
+	if got := result["exit_code"]; got != 0 {
+		t.Fatalf("host bash exit_code = %#v, want 0", got)
+	}
+	if data, err := os.ReadFile(filepath.Join(target.Workdir, "cmd", "out.txt")); err != nil || string(data) != "host-bash" {
+		t.Fatalf("host bash workspace file = %q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "cmd", "out.txt")); !os.IsNotExist(err) {
+		t.Fatalf("host bash wrote outside workspace dataDir err=%v", err)
 	}
 }
 
@@ -309,33 +417,48 @@ func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T)
 	}
 
 	defs := exec.ToolDefinitionsForActorInContext(context.Background(), actor)
-	for _, denied := range []string{"bash"} {
-		if containsToolDefinition(defs, denied) {
-			t.Fatalf("context definitions contain %q for host backend: %#v", denied, defs)
-		}
-	}
-	for _, allowed := range []string{"read_file", "write_file", "web_search"} {
+	for _, allowed := range []string{"bash", "read_file", "write_file", "web_search"} {
 		if !containsToolDefinition(defs, allowed) {
 			t.Fatalf("context definitions missing %q: %#v", allowed, defs)
 		}
 	}
 
 	caps := exec.ToolCapabilitiesForActorInContext(context.Background(), actor, []string{"bash", "read_file", "write_file", "web_search"}, nil)
-	for _, denied := range []string{"bash"} {
-		cap := caps.ByName[denied]
-		if cap.Visible || cap.Callable || !strings.Contains(cap.DenialReason, "host workspace backend does not support native tool execution yet") {
-			t.Fatalf("capability %s = %#v, want host workspace execution denial", denied, cap)
-		}
-	}
-	for _, allowed := range []string{"read_file", "write_file"} {
+	for _, allowed := range []string{"bash", "read_file", "write_file"} {
 		cap := caps.ByName[allowed]
 		if !cap.Visible || !cap.Callable || cap.DenialReason != "" {
-			t.Fatalf("capability %s = %#v, want visible/callable host file operation", allowed, cap)
+			t.Fatalf("capability %s = %#v, want visible/callable host native operation", allowed, cap)
 		}
 	}
 	web := caps.ByName["web_search"]
 	if !web.Visible || !web.Callable {
 		t.Fatalf("web_search capability = %#v, want visible/callable", web)
+	}
+}
+
+func TestNativeWorkspaceCommandRequiresActorBashAuthorization(t *testing.T) {
+	workspaceDir := t.TempDir()
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkspaceResolver: relayWorkspaceResolverStub{
+			target: &workspace.Target{
+				Backend: workspace.BackendHost,
+				Workdir: workspaceDir,
+				Mounts: []workspace.ExecutionMount{
+					{LogicalPath: workspace.LogicalWorkspaceMount, HostPath: workspaceDir, Access: workspace.MountAccessReadWrite},
+				},
+			},
+		},
+	})
+	actorCtx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "host-no-bash",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	})
+	_, err := exec.Execute(actorCtx, "bash", map[string]any{"command": "printf should-not-run > denied.txt"})
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("Execute bash without native_tools.bash error = %v, want authorization denial", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workspaceDir, "denied.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("unauthorized host bash created file; stat err=%v", statErr)
 	}
 }
 
@@ -346,4 +469,8 @@ func containsToolDefinition(defs []llm.ToolDefinition, name string) bool {
 		}
 	}
 	return false
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }

--- a/internal/runtime/tools/tool_result_relay_test.go
+++ b/internal/runtime/tools/tool_result_relay_test.go
@@ -124,9 +124,6 @@ func TestExecutorPersistOversizedToolResultRelay_HostUsesExecutionTargetFileIO(t
 	if got := read.(map[string]any)["content"]; got != `{"blob":"hello"}` {
 		t.Fatalf("read relay content = %#v", got)
 	}
-	if _, err := exec.Execute(ctx, "bash", map[string]any{"command": "true"}); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("Execute bash error = %v, want host native command fail-closed", err)
-	}
 }
 
 func TestExecutorPersistOversizedToolResultRelay_HostChunksLargeReadFileResults(t *testing.T) {

--- a/internal/runtime/tools/usage.go
+++ b/internal/runtime/tools/usage.go
@@ -32,7 +32,7 @@ var builtinToolUsageHints = map[string]string{
 }
 
 var nativeFallbackUsageHints = map[string]string{
-	"bash":       "Use only for local workspace commands. Provide command as a string and timeout_seconds when needed. Do not use for workflow event emission or entity persistence.",
+	"bash":       "Use only for local workspace commands. Provide command as a string and timeout_seconds when needed. Docker-backed bash exposes /workspace, /data, and /opt/swarm/contracts as OS paths; trusted host bash is full host-user shell execution from the workspace backing directory. Use relative paths for workspace files; absolute paths follow the host deployment namespace and OS permissions. Do not use for workflow event emission or entity persistence.",
 	"web_search": "Use for external web research only. Provide a concise query and max_results when needed. Do not use it to read Swarm entity state; use entity tools for that.",
 	"read_file":  "Read files by exact path from the workspace or mounted read-only data/contracts paths. Do not use for entity_state reads.",
 	"write_file": "Write files only within the agent workspace. Do not use file writes as a substitute for emit_* event publication or save_entity_field persistence.",

--- a/internal/runtime/workspace/execution.go
+++ b/internal/runtime/workspace/execution.go
@@ -128,6 +128,7 @@ func hostExecutionTarget(workdir string, mounts []ExecutionMount) ExecutionTarge
 		Workdir: LogicalWorkspaceMount,
 		Mounts:  executionMountsOrDefault(mounts),
 		capabilities: capabilitySet(
+			ExecutionCapabilityNativeCommand,
 			ExecutionCapabilityFileRead,
 			ExecutionCapabilityFileWrite,
 			ExecutionCapabilityToolResultRelay,

--- a/internal/runtime/workspace/execution_test.go
+++ b/internal/runtime/workspace/execution_test.go
@@ -14,14 +14,17 @@ func TestExecutionTargetDistinguishesDockerHostAndEmptyContainer(t *testing.T) {
 	}
 
 	host := (&Target{Backend: BackendHost, Workdir: t.TempDir()}).ExecutionTarget()
-	if host.Mode != ExecutionModeHostLocal || !host.Supports(ExecutionCapabilityFileRead) || !host.Supports(ExecutionCapabilityFileWrite) || !host.Supports(ExecutionCapabilityToolResultRelay) {
-		t.Fatalf("host execution target = %#v, want explicit host file/relay capabilities", host)
+	if host.Mode != ExecutionModeHostLocal || !host.Supports(ExecutionCapabilityNativeCommand) || !host.Supports(ExecutionCapabilityFileRead) || !host.Supports(ExecutionCapabilityFileWrite) || !host.Supports(ExecutionCapabilityToolResultRelay) {
+		t.Fatalf("host execution target = %#v, want explicit trusted host command/file/relay capabilities", host)
 	}
-	if host.Supports(ExecutionCapabilityNativeCommand) || host.Supports(ExecutionCapabilityClaudeCLI) {
-		t.Fatalf("host execution target = %#v, want command/claude unsupported", host)
+	if host.Supports(ExecutionCapabilityClaudeCLI) {
+		t.Fatalf("host execution target = %#v, want claude unsupported", host)
 	}
-	if err := host.Require(ExecutionCapabilityNativeCommand); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support native tool execution yet") {
-		t.Fatalf("host native command error = %v, want fail-closed diagnostic", err)
+	if err := host.Require(ExecutionCapabilityNativeCommand); err != nil {
+		t.Fatalf("host native command capability error = %v, want explicit trusted host support", err)
+	}
+	if err := host.Require(ExecutionCapabilityClaudeCLI); err == nil || !strings.Contains(err.Error(), "host workspace backend does not support Claude CLI execution yet") {
+		t.Fatalf("host Claude error = %v, want fail-closed diagnostic", err)
 	}
 
 	empty := (&Target{Workdir: t.TempDir()}).ExecutionTarget()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3103,10 +3103,10 @@ engine:
     native_tools:
       description: Optional agent contract field. Declares which host-level capabilities the agent may use. Default all false
         (omitted = no native capabilities). The native_tools field is the sole authorization gate — no separate permission
-        entry is required. Native tools are not part of the tools system. They are runtime-level capabilities. On the shipped
-        CLI runtime, `bash`, `web_search`, and `file_io` are provider-native only; the platform does not satisfy native_tools
-        by injecting fallback tools, and visible native-tool surface must equal callable truth. Other runtimes may still use
-        runtime-specific fallback paths outside this CLI-specific rule.
+        entry is required. Native tools are not part of the tools system. They are runtime-level capabilities. Provider-native
+        CLI runtimes may expose native tools only when their provider/runtime can actually call them; platform fallback native
+        tools may be exposed only when the selected workspace execution target supports the matching capability, and visible
+        native-tool surface must equal callable truth on the same turn.
       contract_field:
         field: native_tools
         type: object
@@ -3121,18 +3121,24 @@ engine:
       relationship_to_tool_filtering:
         description: Native tools are NOT part of the tools filtering system. tools controls what the platform
           injects as platform/MCP/HTTP tools. Native tools control runtime-level capabilities. They are separate channels.
-          On CLI, the platform must not inject a platform tool, MCP shim, or local fallback execution path to satisfy a
-          native_tools declaration. The visible native-tool surface for a turn must equal callable truth on that same turn.
+          On provider-native CLI runtimes, the platform must not inject a platform tool, MCP shim, or local fallback execution
+          path to satisfy a native_tools declaration. Platform fallback native tools must consume the same actor authorization
+          plus workspace execution-target capability owner. The visible native-tool surface for a turn must equal callable truth
+          on that same turn.
       capabilities:
         bash:
-          description: Shell command execution. On supporting runtimes, bash runs provider-natively and always executes locally
-            on the platform host, in the agent's workspace directory with workspace mounts active (/workspace read-write, /data
-            read-only, /opt/swarm/contracts read-only).
+          description: Shell command execution. On supporting provider-native runtimes, bash runs provider-natively. On the
+            platform fallback host workspace runtime, bash is trusted/unsafe host-user execution and is available only when the
+            host backend is explicitly selected and the workspace execution target supports native_command. It runs with the
+            agent's workspace backing directory as the process cwd, does not command-filter shell input, and does not provide
+            Docker-equivalent isolation.
           tool_schema:
             input:
               command: string — shell command to execute
               timeout_seconds: integer — optional, default 30
-              working_dir: string — always /workspace for the agent's workspace scope. Not overridable by the agent.
+              working_dir: string — Docker-backed bash uses /workspace as the process cwd. Trusted host fallback bash starts
+                in the workspace backing directory resolved from logical /workspace; that backing path is not overridable by
+                the agent, and absolute paths follow the host deployment namespace and OS permissions.
             output:
               stdout: string
               stderr: string
@@ -3213,7 +3219,10 @@ engine:
         description: All native tool execution is local to the platform host and respects the workspace model.
         rules:
         - All native tool execution runs locally on the platform host. There is no remote execution case.
-        - bash cwd is /workspace for the agent's workspace class scope
+        - bash cwd is /workspace for Docker-backed command execution. Trusted host fallback bash is full host-user shell
+          execution from the resolved workspace backing directory and MUST NOT claim Docker-equivalent absolute mount paths.
+          The runtime does not command-filter host bash input; command and absolute-path access follow the host deployment
+          namespace and OS permissions.
         - file_io is scoped to /workspace (read-write) and /data (read-only). Writes outside /workspace are rejected.
         - On CLI, workspace scoping is guaranteed on the provider-native runtime path. The platform does not satisfy native_tools
           by switching to a separate fallback execution path.
@@ -4177,17 +4186,26 @@ prompt_templating:
       - Always included. Every agent gets workspace context.
       - Does NOT list tools or native capabilities — those are conveyed via tool definitions, not prompt text.
       - Generated at session creation time from the agent's workspace_class. Not editable by the product author.
-    template: "## Environment\n\nWorking directory: /workspace (read-write)\nReference data: /data (read-only)\nContracts:
-      /opt/swarm/contracts (read-only)"
-    normative_content: The three workspace lines (/workspace, /data, /opt/swarm/contracts with their access levels) are
-      required. The exact wording is not normative — the content requirements are. The implementation may rephrase as long as
-      the paths and access levels are communicated.
+    template: |
+      ## Environment
+
+      Workspace: /workspace (read-write logical path)
+      Reference data: /data (read-only logical path)
+      Contracts: /opt/swarm/contracts (read-only logical path)
+      Docker-backed command execution exposes these as OS paths. Trusted host bash is full host-user shell execution from the workspace backing directory; use relative paths for workspace files, and absolute path availability follows the host deployment namespace and OS permissions.
+    normative_content: >
+      The three logical workspace paths (/workspace, /data, /opt/swarm/contracts with their access levels) are required. The
+      postamble MUST distinguish logical platform paths from host native bash process paths: Docker-backed command execution
+      exposes the logical paths as OS mount paths, while trusted host bash is full host-user shell execution from the workspace
+      backing directory, does not synthesize absolute /workspace, /data, or /opt/swarm/contracts OS paths, and must not be
+      described as a reduced or platform-file-only command surface. The exact wording is not normative — the content
+      requirements are.
     native_tools_in_postamble: No. Native tools are NOT described in the postamble. They are conveyed via tool definitions
       in the LLM API call, same as all other tools. The platform must not hide a fallback/native distinction by advertising
       native tools the current turn cannot actually call.
-    note: The workspace paths are the same for all workspace classes — only the /workspace scope differs (per-agent vs
-      per-flow-instance). The postamble does not vary by scope — it tells the agent the paths, the platform enforces the
-      scoping.
+    note: The logical workspace paths are the same for all workspace classes — only the /workspace scope differs (per-agent vs
+      per-flow-instance). The postamble does not vary by scope — it tells the agent the logical paths, the platform enforces
+      scoping, and host native bash must not be represented as Docker-equivalent mount isolation.
 flow_model:
   description: A Flow is the universal building block. Every level of the system is a flow — from the root flow down to the
     smallest sub-flow. A flow can contain child flows. The root flow is what others call "the root flow." There is no separate
@@ -7328,8 +7346,11 @@ workspace_model:
         behavior: >
           Explicit local-dev opt-in. Startup consumes the selected `/data` source from
           `workspace_model.data_source_authority`, the loaded contracts source, and a platform-managed host workspace root.
-          It MUST NOT require Docker, build Docker images, or create containers. It MUST fail closed for unsupported execution
-          surfaces until those host execution semantics are explicitly promoted.
+          It MUST NOT require Docker, build Docker images, or create containers. It supports trusted/unsafe native command
+          execution only through `workspace_execution_target_capability` after explicit host backend selection and actor
+          `native_tools.bash` authorization. Host native command execution is full host-user shell execution and must not be
+          command-filtered by the runtime. It MUST fail closed for unsupported execution surfaces until those host execution
+          semantics are explicitly promoted.
         workspace_root:
           env_var: SWARM_WORKSPACE_HOST_ROOT
           default: ~/.swarm/workspaces
@@ -7344,8 +7365,11 @@ workspace_model:
     - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.
     - Host backend MUST reject `SWARM_WORKSPACE_VOLUMES_FROM`; the host backend consumes explicit path authorities, not Docker
       volume inheritance.
-    - Host backend MUST fail closed for Claude CLI and native tool execution unless a later gate promotes safe host execution
-      semantics. Host tool-result relay is supported only through `workspace_execution_target_capability` path authority.
+    - Host backend MUST fail closed for Claude CLI/provider execution. Host native command execution is supported only as
+      trusted/unsafe explicit host-mode execution through `workspace_execution_target_capability`; unsupported native tool
+      execution MUST still fail closed.
+    - Docker target failures, missing containers, nil targets, empty targets, unknown backends, and non-host-authorized
+      contexts MUST NOT silently fall back to host native command execution.
     consumers:
     - swarm serve boot workspace lifecycle
     - dynamic Builder project reload workspace lifecycle
@@ -7353,18 +7377,20 @@ workspace_model:
     split_scope:
     - '#1137 Compose/Postgres onboarding and Compose cleanup'
     - '#1136 broader local onboarding/docs'
-    - full host Claude CLI and native tool execution parity
+    - full host Claude CLI/provider execution parity
     - production SQLite multi-writer semantics
   workspace_execution_target_capability:
-    promoted_by: '#1213/#1235/#1286'
-    implementation_status: implemented_host_file_and_relay_slice
+    promoted_by: '#1213/#1235/#1286/#1356'
+    implementation_status: implemented_host_file_relay_and_trusted_command_slice
     canonical_owner: platform-spec.yaml#workspace_model.workspace_execution_target_capability
     scope: >
       Defines the canonical runtime execution-target and capability authority for workspace-backed execution surfaces after
       workspace backend selection. The owner distinguishes Docker container execution, explicit host-local targets, and
-      unsupported targets. It does not make host execution Docker-equivalent. Host-local targets support platform-managed
-      native file read/write and tool-result relay over logical workspace mounts; host command execution and host
-      Claude/provider runtime support remain unsupported unless a later gate promotes those surfaces.
+      unsupported targets. It does not make host execution Docker-equivalent. Host-local targets support trusted/unsafe
+      native command execution, platform-managed native file read/write, and tool-result relay over logical workspace mounts.
+      Host native command execution is full host-user shell execution from the workspace backing directory; command and
+      absolute-path access follow the host deployment namespace and OS permissions. Host Claude/provider runtime support
+      remains unsupported unless a later gate promotes that surface.
     implementation_owner: internal/runtime/workspace.ExecutionTarget
     target_modes:
       docker_container:
@@ -7381,9 +7407,10 @@ workspace_model:
         rule: >
           A host target is an explicit local-dev backend target with platform-managed raw host backing paths and logical
           mount identities. Host-local targets MUST NOT infer execution support from an empty container field. Host-local
-          targets support file_read, file_write, and tool_result_relay only through the platform-managed workspace execution
-          owner; native_command and claude_cli remain unsupported.
+          targets support trusted/unsafe native_command, file_read, file_write, and tool_result_relay only through the
+          platform-managed workspace execution owner; claude_cli remains unsupported.
         capabilities:
+        - native_command
         - file_read
         - file_write
         - tool_result_relay
@@ -7427,8 +7454,12 @@ workspace_model:
     - nil target or empty target cwd fallback
     - ad hoc HostBackend() checks outside the execution-target owner
     failure_behavior:
-    - Host-local targets remain fail closed for native command execution and Claude/provider execution until a later gate promotes
-      and proves those surfaces.
+    - Host-local native command execution MUST require explicit host backend selection, actor `native_tools.bash`
+      authorization, and execution-target path authority. It is trusted/unsafe host-user execution and MUST NOT be described
+      as Docker-equivalent isolation or as a command-filtered/platform-file-only surface.
+    - Host-local targets remain fail closed for Claude/provider execution until a later gate promotes and proves that surface.
+    - Docker target failures, Docker targets without containers, unsupported targets, and unauthorized actors MUST NOT fall
+      back to host native command execution.
     - Host-local tool-result relay writes MUST use platform-managed host file I/O through the execution-target path owner and
       MUST NOT use native command, shell, or provider execution.
     - Host-local file operations fail closed when the logical path is outside allowed mounts, when a write targets a read-only
@@ -7437,7 +7468,6 @@ workspace_model:
     - Empty-container targets MUST NOT authorize local host execution.
     - Docker behavior must remain regression-proven through the same typed owner.
     split_scope:
-    - host native bash/command execution
     - Claude CLI/provider-native host runtime support
     - Docker-equivalent host isolation claims
     - '#1137 and #1136 docs/onboarding cleanup'
@@ -7486,12 +7516,16 @@ workspace_model:
   mount_guarantees:
     description: Rules the runtime MUST enforce.
     rules:
-    - Every agent session executes with all three standard mounts active. No mount may be missing.
+    - Every agent session has all three standard logical mounts available through platform workspace/file surfaces. Docker-backed
+      command execution exposes those logical mounts as OS paths; trusted host native command execution is full host-user shell
+      execution from the resolved workspace backing directory and does not synthesize absolute OS mount paths.
     - /data is the SAME mount point across all workspace classes. An agent in any class sees identical /data contents.
     - /workspace isolation follows the workspace_scope declared by the agent's workspace class. per-agent workspaces are never
       visible to other agents. per-flow-instance workspaces are visible to all agents in that flow instance only.
-    - Read-only mounts are enforced at the filesystem level (read-only bind mount, or equivalent). Agents cannot write to /data
-      or /opt/swarm/contracts.
+    - Read-only mounts are enforced at the filesystem level for backends that expose the logical mounts as OS paths
+      (read-only bind mount, or equivalent). Platform-managed host file operations enforce read-only /data and
+      /opt/swarm/contracts through logical path authority. Trusted host native commands are full host-user shell execution
+      and do not provide Docker-equivalent read-only mount isolation.
     - The runtime MUST NOT vary mount availability based on conversation_mode, model, or any other agent property. Workspace
       class is the sole determinant of /workspace scope.
   boot_validation:
@@ -7504,7 +7538,8 @@ workspace_model:
     failure: Boot aborts if any workspace mount cannot be satisfied. Error message identifies the failing mount, workspace class,
       and agent.
   deployment_mapping:
-    description: How standard mounts map to deployment environments. Mount paths are invariant — only backing storage changes.
+    description: How standard logical mounts map to deployment environments. Platform logical paths are invariant; command
+      process namespace behavior differs by backend as explicitly documented.
     local_dev:
       /data: Host directory bind-mounted read-only. Same path for all agent processes.
       /workspace: Host directory under a platform-managed root (e.g., ~/.swarm/workspaces/{scope}/{id}).
@@ -9268,13 +9303,13 @@ cli_specification:
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
       workspace_execution_target_capability:
-        promoted_by: '#1213/#1235/#1286'
+        promoted_by: '#1213/#1235/#1286/#1356'
         owner: workspace_model.workspace_execution_target_capability
         rule: >
           `swarm serve` runtime execution surfaces MUST consume the typed workspace execution target/capability owner after
-          backend selection. Host-local targets remain explicit and support platform-managed native file read/write plus
-          tool-result relay through execution-target path authority; native command execution and Claude/provider execution remain fail closed. Docker targets continue
-          through container execution.
+          backend selection. Host-local targets remain explicit and support trusted/unsafe native command execution,
+          platform-managed native file read/write, and tool-result relay through execution-target path authority; Claude/provider
+          execution remains fail closed. Docker targets continue through container execution.
         consumers:
         - native executor command/file path authority
         - native fallback tool-surface truth


### PR DESCRIPTION
## Summary

Promotes host-local native command execution as the approved explicit trusted/unsafe host-mode slice from #1356.

Closes #1356.

## Governing Refs / Context

- #1356 issue body, Pre-Implementation Coverage Audit, and independent gate approval.
- #746 remains the broader native/bash execution-boundary and isolation/source-authority parent.
- #1138/#1213 remain broader host workspace backend/execution parity parents.
- `platform-spec.yaml#workspace_model.workspace_backend_selection`.
- `platform-spec.yaml#workspace_model.workspace_execution_target_capability`.
- `platform-spec.yaml#agent_contract.native_tools`.
- `internal/runtime/workspace.ExecutionTarget`.
- `internal/runtime/tools.Executor.runWorkspaceCommand`.

## Semantic Migration

New canonical owner: `platform-spec.yaml#workspace_model.workspace_execution_target_capability`, implemented by `internal/runtime/workspace.ExecutionTarget`.

Old producer/reader/writer path now invalid: host-local `native_command` as categorically unsupported and any host command interpretation outside the typed `ExecutionTarget` owner.

Production paths checked for surviving old behavior:
- Docker target command execution still uses `docker exec` and remains default.
- Empty/nil/unknown/no-container targets remain unsupported and do not fall back to host execution.
- Native fallback tool visibility/callability consumes `ExecutionTarget` plus actor `native_tools.bash` authorization.
- Claude/provider host execution remains fail-closed through `claude_cli` capability.
- Host file read/write and tool-result relay remain separate path-authority consumers.

Migration completeness: complete for the approved #1356 child class. #746 and Claude/provider host execution remain explicitly open/split.

## Proof

- `go test ./internal/runtime/workspace ./internal/runtime/tools ./internal/runtime/llm ./cmd/swarm -run 'Test(ExecutionTarget|NativeWorkspaceCommand|ExecutorHost|NativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget|NativeFileToolsKeepDockerWorkspaceCommandExecution|ExecutorPersistOversizedToolResultRelay_Host|ClaudeCLIRuntimeRejectsHostWorkspaceBackend|ClaudeCLIRuntimeWorkspaceCommandRejectsHostWorkspaceBackend|ResolveWorkspaceBackendPrecedence|CLI_ServeWorkspaceBackendFlagFeedsServeOptions|PlatformSpecWorkspaceExecutionTargetCapabilityPromoted|PlatformSpecWorkspaceBackendSelectionPromoted)' -count=1`
- `go test ./internal/runtime/workspace ./internal/runtime/tools ./internal/runtime/llm ./cmd/swarm`
- `go run ./cmd/swarm-openrpc-gen --check`
- stale unsupported-text audit across repo and `/Users/youmew/dev/swarm-docs/docs`
- private watchlist YAML validation for `/Users/youmew/dev/swarm-docs/docs/watchlists/runtime-operations.yaml`
- `go test ./...`

OpenRPC/API artifact decision: no OpenRPC artifact changed because #1356 changes runtime workspace command capability semantics and docs/spec tests, not an exported JSON-RPC method/schema.
