### PR TITLE
[agent-c][issue #1359] Materialize workflow node route producers

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -243,14 +243,11 @@ func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
 	}
 	assertEventPublishPersistence(t, db, runID, eventID, canonicalEventName, "cli-publish:"+actorTokenID(testToken))
 	deliveries := asSlice(t, result["deliveries"])
-	if len(deliveries) != 1 {
-		t.Fatalf("deliveries = %#v, want one persisted delivery", deliveries)
+	if len(deliveries) != 2 {
+		t.Fatalf("deliveries = %#v, want typed agent and node deliveries", deliveries)
 	}
-	if delivery := asMap(t, deliveries[0]); delivery["subscriber_id"] != "repo-observer" {
-		t.Fatalf("delivery = %#v, want repo-observer", delivery)
-	} else {
-		assertEventPublishDeliveryIdentity(t, delivery, "agent", "repo-observer", "pending", 1)
-	}
+	assertEventPublishDeliveriesContain(t, deliveries, "agent", "repo-observer", "pending", 1)
+	assertEventPublishDeliveriesContain(t, deliveries, "node", "repo-observer", "pending", 1)
 	got := requireAPIV1RuntimeBusEvent(t, ch, "flow-scoped event.publish delivery")
 	if got.ID != eventID || string(got.Type) != canonicalEventName {
 		t.Fatalf("delivered event = %#v, want %s/%s", got, eventID, canonicalEventName)

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -409,6 +409,9 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 	if routes := routedConcreteNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
 		return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
 	}
+	if routes := routedScopedNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
+		return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)
+	}
 	internalRecipients := filterOutAgentIDs(recipients, persisted)
 	if len(internalRecipients) == 0 {
 		return nil
@@ -478,6 +481,96 @@ func routedConcreteNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscri
 	return events.NormalizeDeliveryRoutes(out)
 }
 
+func routedScopedNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" || !strings.Contains(eventType, "/") {
+		return nil
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	out := make([]events.DeliveryRoute, 0, len(routed))
+	for _, subscriber := range routed {
+		targetFlowInstance, ok := routedScopedNoTargetNodeDeliveryFlowInstance(evt, subscriber)
+		if !ok {
+			continue
+		}
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   strings.TrimSpace(subscriber.ID),
+			Target: events.RouteIdentity{
+				FlowInstance: targetFlowInstance,
+				EntityID:     eventEntityID,
+			},
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedScopedNoTargetNodeDeliveryFlowInstance(evt events.Event, subscriber Subscriber) (string, bool) {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+		return "", false
+	}
+	if strings.Contains(strings.TrimSpace(subscriber.MatchPattern), "*") {
+		return "", false
+	}
+	path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	if path == "" {
+		return "", false
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance == "" {
+		if routedNodeMatchesScopedNoTargetEvent(evt, subscriber) {
+			return path, true
+		}
+		return "", false
+	}
+	if routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
+		return flowInstance, true
+	}
+	if target := routedDescendantStaticFlowInstanceTarget(evt, subscriber); target != "" {
+		return target, true
+	}
+	if target := routedStaticCrossFlowInstanceTarget(evt, subscriber); target != "" {
+		return target, true
+	}
+	return "", false
+}
+
+func routedDescendantStaticFlowInstanceTarget(evt events.Event, subscriber Subscriber) string {
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
+	if flowInstance == "" || path == "" || eventType == "" || eventType != matchPattern || !strings.HasPrefix(eventType, path+"/") {
+		return ""
+	}
+	staticScope := strings.Trim(strings.TrimSpace(runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)), "/")
+	if staticScope == "" || path == staticScope || !strings.HasPrefix(path, staticScope+"/") {
+		return ""
+	}
+	return flowInstance + strings.TrimPrefix(path, staticScope)
+}
+
+func routedStaticCrossFlowInstanceTarget(evt events.Event, subscriber Subscriber) string {
+	path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
+	if path == "" || eventType == "" || eventType != matchPattern {
+		return ""
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance == "" {
+		return ""
+	}
+	staticScope := strings.Trim(strings.TrimSpace(runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)), "/")
+	if staticScope != "" && (path == staticScope || strings.HasPrefix(path, staticScope+"/")) {
+		return ""
+	}
+	return path
+}
+
 func routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
@@ -520,9 +613,6 @@ func routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt events.Event, 
 
 func routedRootNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
-		return nil
-	}
-	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
 		return nil
 	}
 	rootNodeIDs := routedRootNodeSubscriberIDsForNoTargetEvent(evt, routed)
@@ -589,7 +679,7 @@ func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Su
 
 func routedRootNodeSubscriberIDsForNoTargetEvent(evt events.Event, routed []Subscriber) map[string]struct{} {
 	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
-	if eventType == "" || strings.Contains(eventType, "/") {
+	if eventType == "" {
 		return nil
 	}
 	out := make(map[string]struct{}, len(routed))
@@ -612,11 +702,15 @@ func routedRootNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber)
 	if strings.Trim(strings.TrimSpace(subscriber.Path), "/") != "" {
 		return false
 	}
-	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" {
 		return false
 	}
-	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
-	return eventType != "" && !strings.Contains(eventType, "/")
+	if !strings.Contains(eventType, "/") {
+		return true
+	}
+	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
+	return matchPattern != "" && !strings.Contains(matchPattern, "*") && eventType == matchPattern
 }
 
 func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber) []string {
@@ -653,6 +747,25 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 
 func routedNodeMatchesConcreteFlowInstanceEvent(evt events.Event, subscriber Subscriber) bool {
 	return routedNodeConcreteEventKey(evt, subscriber) != ""
+}
+
+func routedNodeMatchesScopedNoTargetEvent(evt events.Event, subscriber Subscriber) bool {
+	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) == "agent" {
+		return false
+	}
+	if strings.Contains(strings.TrimSpace(subscriber.MatchPattern), "*") {
+		return false
+	}
+	path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	if path == "" {
+		return false
+	}
+	if strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber)
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
+	return eventType != "" && eventType == matchPattern
 }
 
 func routedNodeMatchesConcreteEventTypeFlowInstance(evt events.Event, subscriber Subscriber) bool {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -505,6 +505,311 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 	}
 }
 
+func TestDeliveryPlanner_NoTargetRootLocalEventWithFlowInstanceUsesRootNodeRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{
+					ID:           "test-node",
+					Type:         "node",
+					MatchPattern: "timer.check",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "timer.check",
+	}).WithEntityID("ent-root").WithFlowInstance("11111111-1111-4111-8111-111111111111"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want test-node root node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "test-node" {
+		t.Fatalf("delivery route = %#v, want node/test-node", route)
+	}
+	if !route.Target.Empty() {
+		t.Fatalf("delivery target = %#v, want empty root target", route.Target)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceRootNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want root route-table node source", intent)
+	}
+}
+
+func TestDeliveryPlanner_NoTargetScopedRoutedNodeUsesSemanticNodeDeliveryRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{
+					ID:           "child-intake",
+					Type:         "node",
+					Path:         "child",
+					MatchPattern: "child/child.start",
+					RouteSource:  "subscription",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "child/child.start",
+	}).WithEntityID("ent-child"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want child-intake semantic node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "child-intake" {
+		t.Fatalf("delivery route = %#v, want node/child-intake", route)
+	}
+	if route.Target.FlowInstance != "child" || route.Target.EntityID != "ent-child" {
+		t.Fatalf("delivery target = %#v, want child ent-child", route.Target)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
+	}
+}
+
+func TestDeliveryPlanner_NoTargetScopedEventPreservesPathlessRoutedNodeRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{
+					{
+						ID:           "project-observer",
+						Type:         "node",
+						MatchPattern: "child/child.start",
+						RouteSource:  "subscription",
+					},
+					{
+						ID:           "child-intake",
+						Type:         "node",
+						Path:         "child",
+						MatchPattern: "child/child.start",
+						RouteSource:  "subscription",
+					},
+				}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "child/child.start",
+	}).WithEntityID("ent-child"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 2 {
+		t.Fatalf("delivery routes = %#v, want project-observer and child-intake semantic node routes", got)
+	}
+	routes := map[string]events.RouteIdentity{}
+	for _, route := range plan.DeliveryRoutes {
+		if route.SubscriberType != "node" {
+			t.Fatalf("delivery route = %#v, want node route", route)
+		}
+		routes[route.SubscriberID] = route.Target
+	}
+	if target, ok := routes["project-observer"]; !ok || !target.Empty() {
+		t.Fatalf("project-observer target = %#v, ok=%v; want empty root target", target, ok)
+	}
+	if target, ok := routes["child-intake"]; !ok || target.FlowInstance != "child" || target.EntityID != "ent-child" {
+		t.Fatalf("child-intake target = %#v, ok=%v; want child ent-child", target, ok)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 2; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+}
+
+func TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{
+					ID:           "flow-a-node",
+					Type:         "node",
+					Path:         "flow-a",
+					MatchPattern: "flow-b/order.completed",
+					RouteSource:  "subscription",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "flow-b/order.completed",
+	}).WithEntityID("ent-flow-b").WithFlowInstance("flow-b/inst-1"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want flow-a-node semantic node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "flow-a-node" {
+		t.Fatalf("delivery route = %#v, want node/flow-a-node", route)
+	}
+	if route.Target.FlowInstance != "flow-a" || route.Target.EntityID != "ent-flow-b" {
+		t.Fatalf("delivery target = %#v, want flow-a ent-flow-b", route.Target)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
+	}
+}
+
+func TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{
+					ID:           "grandchild-worker",
+					Type:         "node",
+					Path:         "child/grandchild",
+					MatchPattern: "child/grandchild/micro.start",
+					RouteSource:  "subscription",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "child/grandchild/micro.start",
+	}).WithEntityID("ent-child").WithFlowInstance("child/inst-1"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want grandchild-worker semantic node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "grandchild-worker" {
+		t.Fatalf("delivery route = %#v, want node/grandchild-worker", route)
+	}
+	if route.Target.FlowInstance != "child/inst-1/grandchild" || route.Target.EntityID != "ent-child" {
+		t.Fatalf("delivery target = %#v, want child/inst-1/grandchild ent-child", route.Target)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
+	}
+}
+
 func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -284,9 +284,21 @@ type descriptorAwareEventStore struct {
 	listErr     error
 }
 
+type routeSetEventStore struct {
+	runtimebus.InMemoryEventStore
+	mu     sync.Mutex
+	routes map[string][]events.DeliveryRoute
+}
+
 type replayCapableAtomicStoreMissingScope struct {
 	mu         sync.Mutex
 	deliveries []string
+}
+
+func newRouteSetEventStore() *routeSetEventStore {
+	return &routeSetEventStore{
+		routes: map[string][]events.DeliveryRoute{},
+	}
 }
 
 func (*descriptorAwareEventStore) AppendEvent(context.Context, events.Event) error { return nil }
@@ -313,6 +325,22 @@ func (s *descriptorAwareEventStore) persistedDeliveries() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.deliveries...)
+}
+
+func (s *routeSetEventStore) PersistEventWithDeliveryRouteSetAndScope(_ context.Context, evt events.Event, routes []events.DeliveryRoute, _ runtimereplayclaim.CommittedReplayScope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.routes == nil {
+		s.routes = map[string][]events.DeliveryRoute{}
+	}
+	s.routes[evt.ID] = events.NormalizeDeliveryRoutes(routes)
+	return nil
+}
+
+func (s *routeSetEventStore) ListEventDeliveryRoutes(_ context.Context, eventID string) ([]events.DeliveryRoute, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]events.DeliveryRoute(nil), s.routes[eventID]...), nil
 }
 
 func (*replayCapableAtomicStoreMissingScope) AppendEvent(context.Context, events.Event) error {
@@ -1843,7 +1871,7 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 		},
 	}
 	hook := &recordingLoggerHook{}
-	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+	eb, err := runtimebus.NewEventBusWithOptions(newRouteSetEventStore(), runtimebus.EventBusOptions{
 		Logger:         hook,
 		ContractBundle: semanticview.Wrap(bundle),
 	})
@@ -1949,7 +1977,7 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 			},
 		},
 	}
-	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+	eb, err := runtimebus.NewEventBusWithOptions(newRouteSetEventStore(), runtimebus.EventBusOptions{
 		ContractBundle: semanticview.Wrap(bundle),
 	})
 	if err != nil {
@@ -2009,7 +2037,8 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -2157,7 +2186,8 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -2285,7 +2315,8 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -2384,7 +2415,7 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 			},
 		},
 	}
-	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+	eb, err := runtimebus.NewEventBusWithOptions(newRouteSetEventStore(), runtimebus.EventBusOptions{
 		ContractBundle: semanticview.Wrap(bundle),
 	})
 	if err != nil {
@@ -2440,7 +2471,7 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 			},
 		},
 	}
-	eb, err := runtimebus.NewEventBusWithOptions(runtimebus.InMemoryEventStore{}, runtimebus.EventBusOptions{
+	eb, err := runtimebus.NewEventBusWithOptions(newRouteSetEventStore(), runtimebus.EventBusOptions{
 		ContractBundle: semanticview.Wrap(bundle),
 	})
 	if err != nil {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -666,8 +666,8 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 		t.Fatalf("delivery routes = %#v, want one concrete node route", got)
 	}
 	route := plan.DeliveryRoutes[0]
-	if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
-		t.Fatalf("delivery route = %#v, want node/workflow-runtime carrier", route)
+	if route.SubscriberType != "node" || route.SubscriberID != "entity-writer" {
+		t.Fatalf("delivery route = %#v, want node/entity-writer", route)
 	}
 	if route.Target.FlowInstance != "validation/inst-1" || route.Target.EntityID != "ent-validation" {
 		t.Fatalf("delivery route target = %#v, want validation/inst-1 ent-validation", route.Target)
@@ -684,8 +684,8 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 		t.Fatalf("delivered route identity flow=%q entity=%q, want validation/inst-1 ent-validation", got.FlowInstance(), got.EntityID())
 	}
 	routes := store.routes[evt.ID]
-	if len(routes) != 1 || routes[0].Target.FlowInstance != "validation/inst-1" {
-		t.Fatalf("persisted routes = %#v, want concrete validation route", routes)
+	if len(routes) != 1 || routes[0].SubscriberID != "entity-writer" || routes[0].Target.FlowInstance != "validation/inst-1" {
+		t.Fatalf("persisted routes = %#v, want entity-writer concrete validation route", routes)
 	}
 }
 
@@ -731,6 +731,60 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 	routes := store.routes[evt.ID]
 	if len(routes) != 1 || routes[0].SubscriberID != "entity-writer" || routes[0].Target.FlowInstance != "validation/inst-1" {
 		t.Fatalf("persisted routes = %#v, want entity-writer concrete validation route", routes)
+	}
+}
+
+func TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInternalCarrier(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(routedNodeStaticChildBundle()),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("child/child.start"))
+	evt := (events.Event{
+		ID:        uuid.NewString(),
+		Type:      events.EventType("child/child.start"),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-child")
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "child-intake",
+		Target: events.RouteIdentity{
+			FlowInstance: "child",
+			EntityID:     "ent-child",
+		},
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "child-intake" || plan.RoutedRecipients[0].Path != "child" {
+		t.Fatalf("routed recipients = %#v, want child/child-intake", plan.RoutedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 || !deliveryRoutesContain(got, want) {
+		t.Fatalf("delivery routes = %#v, want child-intake scoped route %#v", got, want)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "static scoped workflow-runtime carrier delivery")
+	if got.FlowInstance() != "" || got.EntityID() != "ent-child" {
+		t.Fatalf("delivered identity flow=%q entity=%q, want root projection ent-child", got.FlowInstance(), got.EntityID())
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 1 || !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
 	}
 }
 
@@ -1370,6 +1424,38 @@ func routedNodeStaticValidationBundle() *runtimecontracts.WorkflowContractBundle
 		},
 		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
 			"validation": {},
+		},
+	}
+}
+
+func routedNodeStaticChildBundle() *runtimecontracts.WorkflowContractBundle {
+	child := runtimecontracts.FlowContractView{
+		Path:  "child",
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child.start": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"child-intake": {
+				ID:            "child-intake",
+				ExecutionType: "system_node",
+				SubscribesTo:  []string{"child.start"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"child.start": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{child}}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"child": &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"child": {},
 		},
 	}
 }

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -15,6 +15,7 @@ const (
 	routePlanSourceDirectPolicy          = "direct_policy"
 	routePlanSourceInternalTarget        = "internal_target_route"
 	routePlanSourceConcreteNodeRoute     = "concrete_node_route"
+	routePlanSourceScopedNodeRoute       = "scoped_node_route"
 	routePlanSourceRootNodeRoute         = "root_node_route"
 	routePlanSourceRootInputFlowNode     = "root_input_flow_node_route"
 	routePlanSourceRecipientMaterializer = "recipient_plan_materializer"

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -466,7 +466,32 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, flowID s
 					Subscriber:   subscriber,
 				})
 			}
+			if resolved := routeResolveNodeCanonicalPattern(source, basePath, nodeID, rawPattern); strings.TrimSpace(resolved.EventPattern) != "" {
+				subscriber.RouteSource = resolved.RouteSource
+				rt.patterns = append(rt.patterns, routePattern{
+					EventPattern: resolved.EventPattern,
+					Subscriber:   subscriber,
+				})
+			}
 		}
+	}
+}
+
+func routeResolveNodeCanonicalPattern(source semanticview.Source, basePath, nodeID, rawPattern string) routeResolvedPattern {
+	if source == nil || strings.Trim(strings.TrimSpace(basePath), "/") == "" || strings.TrimSpace(nodeID) == "" {
+		return routeResolvedPattern{}
+	}
+	rawPattern = eventidentity.Normalize(rawPattern)
+	if rawPattern == "" || strings.Contains(rawPattern, "*") {
+		return routeResolvedPattern{}
+	}
+	resolved := eventidentity.Normalize(source.ResolveNodeEventReference(nodeID, rawPattern))
+	if resolved == "" || resolved == rawPattern || strings.Contains(resolved, "*") {
+		return routeResolvedPattern{}
+	}
+	return routeResolvedPattern{
+		EventPattern: resolved,
+		RouteSource:  "subscription",
 	}
 }
 

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -2,6 +2,7 @@ package bus_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
@@ -508,6 +509,110 @@ func TestDeriveRouteTable_HandlerOnlyInputPinsAutoWireFromProducerOutput(t *test
 	got := rt.Resolve("producer/scan.requested")
 	if len(got) != 1 || got[0].ID != "consumer-node" {
 		t.Fatalf("Resolve(producer/scan.requested) = %#v, want consumer-node", got)
+	}
+}
+
+func TestDeriveRouteTable_StaticChildFlowInputSubscriptionsResolveCanonicalNodeOwners(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	for _, tc := range []struct {
+		fixture    string
+		eventType  string
+		nodeID     string
+		flowPath   string
+		routeMatch string
+	}{
+		{
+			fixture:    "test-child-flow-local-events",
+			eventType:  "child/child.start",
+			nodeID:     "child-intake",
+			flowPath:   "child",
+			routeMatch: "child/child.start",
+		},
+		{
+			fixture:    "test-nested-three-levels",
+			eventType:  "child/step.begin",
+			nodeID:     "child-relay",
+			flowPath:   "child",
+			routeMatch: "child/step.begin",
+		},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", tc.fixture)
+			bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+			if err != nil {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+			}
+			rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+			if err != nil {
+				t.Fatalf("DeriveRouteTable: %v", err)
+			}
+			got := rt.Resolve(tc.eventType)
+			if len(got) != 1 ||
+				got[0].ID != tc.nodeID ||
+				got[0].Type != "node" ||
+				got[0].Path != tc.flowPath ||
+				got[0].MatchPattern != tc.routeMatch ||
+				got[0].RouteSource != "subscription" {
+				t.Fatalf("Resolve(%s) = %#v, want %s %s %s", tc.eventType, got, tc.nodeID, tc.flowPath, tc.routeMatch)
+			}
+		})
+	}
+}
+
+func TestDeriveRouteTable_RuntimeProducedFollowUpSubscriptionsResolveCanonicalNodeOwners(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	for _, tc := range []struct {
+		name       string
+		fixture    string
+		eventType  string
+		nodeID     string
+		flowPath   string
+		routeMatch string
+	}{
+		{
+			name:       "root-local timer follow-up",
+			fixture:    filepath.Join("tests", "tier5-flow-lifecycle", "test-timer-fire"),
+			eventType:  "timer.check",
+			nodeID:     "test-node",
+			flowPath:   "",
+			routeMatch: "timer.check",
+		},
+		{
+			name:       "cross-flow static subscriber",
+			fixture:    filepath.Join("tests", "tier7-composition", "test-cross-flow-subscription"),
+			eventType:  "flow-b/order.completed",
+			nodeID:     "flow-a-node",
+			flowPath:   "flow-a",
+			routeMatch: "flow-b/order.completed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixtureRoot := filepath.Join(repoRoot, tc.fixture)
+			bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+			if err != nil {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+			}
+			rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
+			if err != nil {
+				t.Fatalf("DeriveRouteTable: %v", err)
+			}
+			got := rt.Resolve(tc.eventType)
+			found := false
+			for _, subscriber := range got {
+				if subscriber.ID == tc.nodeID &&
+					subscriber.Type == "node" &&
+					subscriber.Path == tc.flowPath &&
+					subscriber.MatchPattern == tc.routeMatch {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("Resolve(%s) = %#v, want %s %s %s", tc.eventType, got, tc.nodeID, tc.flowPath, tc.routeMatch)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #1359.

## Summary
- Materialize route-table workflow-node matches as typed `node/<subscriber_id>` delivery routes before internal carrier dispatch across the approved repo-wide producer class.
- Cover root-local runtime follow-ups with root flow-instance envelopes, static child-flow input subscriptions, descendant child/grandchild follow-ups, and cross-flow static subscribers.
- Preserve split boundaries for wildcard/static-service routing (#1299), runtime callback localization (#1301), and the #1293 admission guard.
- Update typed `event.publish` readback proof where an agent and workflow node intentionally share `repo-observer` as an id but remain distinct by `subscriber_type`.

## Governing refs / context
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.authority_boundaries`
- `platform-spec.yaml#engine.event_loop`
- `platform-spec.yaml#platform_tables.tables.event_deliveries`
- `platform-spec.yaml#platform_tables.tables.event_receipts`
- `platform-spec.yaml#api_specification.methods.event.publish`
- Binding issue/gate context: #1359 pre-audit and approved broad lead gate for `repo_wide_workflow_node_route_producer_materialization_before_admission`.

## Semantic migration
- New canonical owner used here: `EventBus` publish-time `RoutePlan` construction through `deliveryPlanner` consuming semantic `RouteTable` topology and persisting typed delivery routes through route-set persistence.
- Old non-authoritative path now invalid for this class: durable `workflow-runtime`/internal-carrier rows, live subscription dispatch, replay scope, receipts, settlement/backfill, or readback as workflow-node delivery authority.
- Production paths checked for surviving old behavior: EventBus publish/preflight route plan, API `event.publish` projection, catalog E2E runtime producers, selected-contract runfork execution consumers, and the preserved #1293 admission-guard WIP proof.
- Migration completeness: complete for the approved non-split repo-wide workflow-node route producer materialization class; #1299, #1301, and #1293 remain separate by gate.

## Tests
- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetRootLocalEventWithFlowInstanceUsesRootNodeRoute|TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope|TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRoute|TestDeriveRouteTable_RuntimeProducedFollowUpSubscriptionsResolveCanonicalNodeOwners|TestDeriveRouteTable_StaticChildFlowInputSubscriptionsResolveCanonicalNodeOwners' -count=1 -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/cataloge2e ./internal/runtime/runforkexecution -count=1 -timeout=300s`
- Combined guard-active proof in `/tmp/swarm-1360-1293-proof.ODh31Q`: `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/cataloge2e ./internal/runtime/runforkexecution -count=1 -timeout=300s` with #1293 WIP applied and temp-only bus harness receipt-capability wiring so the guard reaches producer rows.
- `go test ./...`