### PR TITLE
[agent-c][issue #1293] Enforce workflow node delivery authority

### DIFF
--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -107,13 +107,13 @@ func TestRouteAuthorityMatrixRejectsStaleReferences(t *testing.T) {
 		{
 			name: "split sibling cannot be reclassified as covered",
 			mutate: func(matrix *routeAuthorityMatrix) {
-				row := routeAuthorityMatrixRowByID(t, matrix, "workflow_node_execution_admission")
+				row := routeAuthorityMatrixRowByID(t, matrix, "wildcard_static_service_route_production")
 				row.Classification = "already_covered_by_existing_proof"
 				row.Tier = "required_pr_smoke"
 				row.SplitIssue = 0
 				row.ProofDimensions = []string{"persistence_authority"}
 			},
-			want: "workflow_node_execution_admission must remain split-open issue #1293",
+			want: "wildcard_static_service_route_production must remain split-open issue #1299",
 		},
 		{
 			name: "parent closure stays false",
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340, 1293, 1299, 1301} {
+	for _, issue := range []int{1340, 1299, 1301} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))
@@ -475,7 +475,6 @@ func requiredRouteAuthorityRows() []string {
 
 func requiredRouteAuthoritySplitRows() map[string]int {
 	return map[string]int{
-		"workflow_node_execution_admission":           1293,
 		"wildcard_static_service_route_production":    1299,
 		"runtime_callback_flow_instance_localization": 1301,
 	}

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -24,9 +24,6 @@ active_trackers:
     issue: 1340
     watchlist: runtime_operations.delivery_and_replay_ownership
   - kind: github_issue
-    issue: 1293
-    watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
     issue: 1299
     watchlist: runtime_operations.delivery_and_replay_ownership
   - kind: github_issue
@@ -193,18 +190,40 @@ rows:
 
   - id: workflow_node_execution_admission
     concept: Workflow-node execution must require committed node delivery authority before handler execution.
-    classification: split_to_existing_issue
-    tier: split_open
-    split_issue: 1293
-    proof_dimensions: [persistence_authority, split_tracker]
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [persistence_authority, negative_authority, default_sqlite, explicit_postgres, required_pr_smoke]
+    invalid_authority:
+      - workflow-runtime carrier route
+      - live internal carrier subscription
+      - handler lookup
+      - processed receipts
+      - event_receipts settlement/backfill
+      - replay-scope markers
+      - API/CLI readback
     owner_refs:
       - {kind: spec_ref, path: platform-spec.yaml, ref: execution_admission}
       - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+      - {kind: artifact, path: internal/runtime/pipeline/workflow_nodes.go}
+      - {kind: artifact, path: internal/runtime/pipeline/node_system_runner.go}
+      - {kind: artifact, path: internal/runtime/pipeline/system_node_receipt_store.go}
     proof_refs:
-      - {kind: tracker, issue: 1293, watchlist: runtime_operations.delivery_and_replay_ownership}
+      - {kind: issue, issue: 1293}
+      - {kind: go_test, name: TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority}
+      - {kind: go_test, name: TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode}
+      - {kind: go_test, name: TestPipelineCoordinatorInterceptSkipsWhenCanonicalDeliveryAuthorityUnavailable}
+      - {kind: go_test, name: TestPipelineCoordinatorInterceptSettlesAuthorizedNodeDelivery}
+      - {kind: go_test, name: TestSystemNodeRunner_SkipsWithoutPersistedNodeDeliveryAuthority}
+      - {kind: go_test, name: TestSystemNodeProcessedSettlementFailsWithoutNodeDeliveryAuthority}
+      - {kind: go_test, name: TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority}
+      - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite}
+      - {kind: go_test, name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres}
     notes: >
-      #1293 remains the execution-admission sibling. Settlement, backfill,
-      receipts, and handler lookup must not become shortcuts for this row.
+      #1293 owns execution admission. Workflow nodes now consume committed
+      typed node event_deliveries authority before handler execution across the
+      coordinator and system/background runner paths. Settlement, backfill,
+      receipts, carrier dispatch, replay markers, handler lookup, and readback
+      remain invalid authority.
 
   - id: wildcard_static_service_route_production
     concept: Wildcard static-service route production is a route-production sibling, not a matrix behavior change.

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -269,6 +269,9 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	if pc.workflowNodeEventProcessed(ctx, nodeID, evt) {
 		return true, nil
 	}
+	if !pc.workflowNodeDeliveryAuthorized(ctx, nodeID, evt) {
+		return false, nil
+	}
 	ctx = withPipelineFlowScope(ctx, workflowNodeFlowID(source, nodeID))
 	if err := pc.notifyTestWorkflowNodeHandlerStarting(ctx, nodeID, evt); err != nil {
 		return false, err

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -28,8 +28,13 @@ func (s eventReceiptsCapabilityStub) resolve(context.Context) (bool, error) {
 }
 
 type typedSystemNodeReceiptStore struct {
-	processed bool
-	marked    int
+	deliveryAuthorized bool
+	processed          bool
+	marked             int
+}
+
+func (s *typedSystemNodeReceiptStore) SystemNodeDeliveryAuthorized(context.Context, string, string) (bool, error) {
+	return s.deliveryAuthorized, nil
 }
 
 func (s *typedSystemNodeReceiptStore) SystemNodeProcessed(context.Context, string, string) (bool, error) {
@@ -51,7 +56,7 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	ctx := testPipelineRunContext(t, db)
 	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
 		return errors.New("boom")
-	})
+	}, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(2, func(int) time.Duration { return 0 })
 
 	evt := events.Event{
@@ -67,6 +72,7 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	`, evt.ID, string(evt.Type), evt.EntityID(), string(evt.Payload)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "node-a")
 
 	runner.ProcessEventForTest(ctx, evt)
 
@@ -119,7 +125,8 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
 		InstanceID:      entityID,
@@ -129,6 +136,7 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "node-1")
 
 	if handled := pc.executeNodeHandlerPlan(ctx, "node-1", evt); !handled {
 		t.Fatalf("executeNodeHandlerPlan handled = false, want true")
@@ -200,10 +208,10 @@ func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
 func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *testing.T) {
 	bus := &capturingDeadLetterBus{}
 	attempts := 0
-	runner := newSystemNodeRunner("node-a", bus, nil, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+	runner := newSystemNodeRunnerWithReceiptStoreAndRetryBase("node-a", bus, nil, &typedSystemNodeReceiptStore{deliveryAuthorized: true}, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
 		attempts++
 		return runtimerterr.NewRuntimeError("invalid_contract", "pipeline", "node.handle", false, "bad handler config")
-	})
+	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(5, func(int) time.Duration { return 0 })
 
 	evt := events.Event{
@@ -255,11 +263,16 @@ func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *
 		t.Fatalf("seed event: %v", err)
 	}
 
+	attempts := 0
 	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+		attempts++
 		return nil
 	}, eventReceiptsCapabilityStub{}.resolve)
 	runner.ProcessEventForTest(ctx, evt)
 
+	if attempts != 0 {
+		t.Fatalf("attempts = %d, want 0 without canonical capability", attempts)
+	}
 	var count int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_receipts WHERE event_id = $1::uuid`, evt.ID).Scan(&count); err != nil {
 		t.Fatalf("count event_receipts: %v", err)
@@ -286,6 +299,12 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES ($1::uuid, 'node', 'node-a', 'pending', now())
+	`, evt.ID); err != nil {
+		t.Fatalf("seed node delivery: %v", err)
+	}
 
 	attempts := 0
 	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
@@ -307,9 +326,55 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 	}
 }
 
+func TestSystemNodeRunner_SkipsWithoutPersistedNodeDeliveryAuthority(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	entityID := uuid.NewString()
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		Type:        "source.evt",
+		SourceAgent: "src",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
+	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	attempts := 0
+	bus := &recordingPipelineBus{}
+	runner := newSystemNodeRunner("node-a", bus, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+		attempts++
+		return nil
+	}, eventReceiptsCapabilityStub{enabled: true}.resolve)
+	runner.ProcessEventForTest(ctx, evt)
+
+	if attempts != 0 {
+		t.Fatalf("attempts = %d, want 0 without persisted node delivery authority", attempts)
+	}
+	var receipts int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+	`, evt.ID).Scan(&receipts); err != nil {
+		t.Fatalf("count event_receipts: %v", err)
+	}
+	if receipts != 0 {
+		t.Fatalf("event_receipts rows = %d, want 0 without authority", receipts)
+	}
+	logs := bus.runtimeLogEntries()
+	if len(logs) != 1 || logs[0].Action != "delivery_authority_missing" {
+		t.Fatalf("runtime logs = %#v, want one delivery_authority_missing entry", logs)
+	}
+}
+
 func TestSystemNodeRunner_UsesTypedReceiptOwnerWithoutRawDB(t *testing.T) {
 	ctx := context.Background()
-	receipts := &typedSystemNodeReceiptStore{}
+	receipts := &typedSystemNodeReceiptStore{deliveryAuthorized: true}
 	attempts := 0
 	runner := newSystemNodeRunnerWithReceiptStoreAndRetryBase("node-a", deadLetterTestBus{}, nil, receipts, func() []events.EventType {
 		return []events.EventType{"source.evt"}
@@ -362,6 +427,7 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 				},
 			},
 		},
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	evt := (events.Event{
 		ID:          uuid.NewString(),
@@ -376,6 +442,7 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 	`, evt.ID, string(evt.Type), evt.EntityID(), string(evt.Payload)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "node-a")
 	postCommit := make([]func(), 0, 1)
 	override := &PipelineReceiptOverride{}
 	ctx := WithPipelinePostCommitActions(context.Background(), &postCommit)

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -16,6 +16,7 @@ import (
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
 )
 
 type recordingPipelineBus struct {
@@ -2059,12 +2060,13 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
 	pc := &PipelineCoordinator{
-		bus:            bus,
-		db:             db,
-		module:         module,
-		workflowStore:  store,
-		expressionEval: newWorkflowExpressionEvaluator(),
-		entityLocks:    map[string]*sync.Mutex{},
+		bus:                     bus,
+		db:                      db,
+		module:                  module,
+		workflowStore:           store,
+		expressionEval:          newWorkflowExpressionEvaluator(),
+		entityLocks:             map[string]*sync.Mutex{},
+		eventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	}
 
 	const (
@@ -2106,9 +2108,12 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	handled, err := pc.dispatchWorkflowNodeEventResult(testWorkflowStoreRunContext(t, store), events.Event{
+	evt := events.Event{
+		ID:   uuid.NewString(),
 		Type: events.EventType("child/grandchild/micro.done"),
-	}.WithEntityID(grandchildEntityID))
+	}.WithEntityID(grandchildEntityID)
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "root-collector")
+	handled, err := pc.dispatchWorkflowNodeEventResult(testWorkflowStoreRunContext(t, store), evt)
 	if err != nil {
 		t.Fatalf("executeNodeHandlerPlanResult: %v", err)
 	}

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -121,6 +121,9 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	if n.isProcessed(ctx, evt) {
 		return
 	}
+	if !n.deliveryAuthorized(ctx, evt) {
+		return
+	}
 	retryLimit := n.retryLimit
 	if retryLimit <= 0 {
 		retryLimit = DefaultSystemNodeRetryLimit
@@ -392,6 +395,13 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 	if tx == nil {
 		return nil
 	}
+	authorized, err := postgresSystemNodeDeliveryAuthorizedTx(ctx, tx, nodeID, eventID)
+	if err != nil {
+		return fmt.Errorf("query system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
@@ -418,16 +428,40 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 		return fmt.Errorf("upsert system node receipt: event %s not found", eventID)
 	}
 	if _, err := tx.ExecContext(ctx, `
-		WITH settled AS (
-			UPDATE event_deliveries
-			SET
-				status = 'delivered',
-				retry_count = COALESCE(retry_count, 0),
-				reason_code = 'node_processed',
-				last_error = NULL,
-				active_session_id = NULL,
-				started_at = COALESCE(started_at, created_at),
-				delivered_at = now()
+		UPDATE event_deliveries
+		SET
+			status = 'delivered',
+			retry_count = COALESCE(retry_count, 0),
+			reason_code = 'node_processed',
+			last_error = NULL,
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+		  )
+	`, eventID, nodeID); err != nil {
+		return fmt.Errorf("settle system node delivery: %w", err)
+	}
+	return nil
+}
+
+func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
 			WHERE event_id = $1::uuid
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
@@ -435,32 +469,9 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 				status IN ('pending', 'in_progress')
 				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
 			  )
-			RETURNING delivery_id
 		)
-		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, retry_count,
-			reason_code, last_error, active_session_id, started_at, delivered_at, created_at
-		)
-		SELECT
-			e.run_id, e.event_id, 'node', $2, 'delivered', 0,
-			'node_processed', NULL, NULL, now(), now(), now()
-		FROM events e
-		WHERE e.event_id = $1::uuid
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM settled
-		  )
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM event_deliveries d
-			WHERE d.event_id = $1::uuid
-			  AND d.subscriber_type = 'node'
-			  AND d.subscriber_id = $2
-		  )
-	`, eventID, nodeID); err != nil {
-		return fmt.Errorf("settle system node delivery: %w", err)
-	}
-	return nil
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
+	return ok, err
 }
 
 func (n *systemNodeRunner) convergeNormalRunCompletion(ctx context.Context, evt events.Event) {
@@ -504,6 +515,47 @@ func (n *systemNodeRunner) isActiveRunQuiesced(ctx context.Context, evt events.E
 	if err != nil {
 		slog.Error("system node active run quiescence check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		return true
+	}
+	return ok
+}
+
+func (n *systemNodeRunner) deliveryAuthorized(ctx context.Context, evt events.Event) bool {
+	eventID := strings.TrimSpace(evt.ID)
+	if n == nil || n.receiptStore == nil || eventID == "" {
+		return false
+	}
+	if !n.eventReceiptsAvailable(ctx) {
+		return false
+	}
+	ok, err := n.receiptStore.SystemNodeDeliveryAuthorized(ctx, n.nodeID, eventID)
+	if err != nil {
+		slog.Error("system node delivery authority check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Checking system node delivery authority failed",
+				Component: n.nodeID,
+				Action:    "delivery_authority_check_failed",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+		return false
+	}
+	if !ok {
+		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "System node delivery authority is missing; handler execution skipped",
+				Component: n.nodeID,
+				Action:    "delivery_authority_missing",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+			})
+		}
 	}
 	return ok
 }

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -160,12 +161,129 @@ func TestSystemNodeRunner_PipelineNamedNodeDoesNotMaskPlatformReceipt(t *testing
 	}
 }
 
+func TestSystemNodeProcessedSettlementFailsWithoutNodeDeliveryAuthority(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+
+	sideEffects := systemNodeProcessedReceiptSideEffects("terminal-node", eventID)
+	err := persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, db, "terminal-node", eventID, sideEffects)
+	if !errors.Is(err, ErrSystemNodeDeliveryAuthorityMissing) {
+		t.Fatalf("persistSystemNodeProcessedReceiptAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)
+	}
+	var deliveries int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&deliveries); err != nil {
+		t.Fatalf("count node deliveries: %v", err)
+	}
+	if deliveries != 0 {
+		t.Fatalf("node deliveries = %d, want 0", deliveries)
+	}
+	var receipts int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&receipts); err != nil {
+		t.Fatalf("count node receipts: %v", err)
+	}
+	if receipts != 0 {
+		t.Fatalf("node receipts = %d, want 0", receipts)
+	}
+}
+
+func TestSystemNodeProcessedSettlementFailsWithTerminalNodeDeliveryAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     string
+		retryCount int
+	}{
+		{name: "dead_letter", status: "dead_letter", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			ctx := context.Background()
+			runID := uuid.NewString()
+			eventID := uuid.NewString()
+			entityID := uuid.NewString()
+			seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO event_deliveries (
+					run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+				) VALUES (
+					$1::uuid, $2::uuid, 'node', 'terminal-node', $3, $4, 'terminal_test', now()
+				)
+			`, runID, eventID, tc.status, tc.retryCount); err != nil {
+				t.Fatalf("seed terminal node delivery: %v", err)
+			}
+
+			sideEffects := systemNodeProcessedReceiptSideEffects("terminal-node", eventID)
+			err := persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, db, "terminal-node", eventID, sideEffects)
+			if !errors.Is(err, ErrSystemNodeDeliveryAuthorityMissing) {
+				t.Fatalf("persistSystemNodeProcessedReceiptAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)
+			}
+			var status string
+			var retryCount int
+			if err := db.QueryRowContext(ctx, `
+				SELECT COALESCE(status, ''), COALESCE(retry_count, 0)
+				FROM event_deliveries
+				WHERE event_id = $1::uuid
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = 'terminal-node'
+			`, eventID).Scan(&status, &retryCount); err != nil {
+				t.Fatalf("load terminal delivery: %v", err)
+			}
+			if status != tc.status || retryCount != tc.retryCount {
+				t.Fatalf("terminal delivery = %s/%d, want %s/%d", status, retryCount, tc.status, tc.retryCount)
+			}
+			var receipts int
+			if err := db.QueryRowContext(ctx, `
+				SELECT COUNT(*)
+				FROM event_receipts
+				WHERE event_id = $1::uuid
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = 'terminal-node'
+			`, eventID).Scan(&receipts); err != nil {
+				t.Fatalf("count node receipts: %v", err)
+			}
+			if receipts != 0 {
+				t.Fatalf("node receipts = %d, want 0", receipts)
+			}
+		})
+	}
+}
+
 func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entityID string, nodeIDs ...string) {
 	t.Helper()
 	nodeID := "terminal-node"
 	if len(nodeIDs) > 0 && nodeIDs[0] != "" {
 		nodeID = nodeIDs[0]
 	}
+	seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, 'pending', 'matched_node_subscription', now()
+		)
+	`, runID, eventID, nodeID); err != nil {
+		t.Fatalf("seed node delivery: %v", err)
+	}
+}
+
+func seedSystemNodeCompletionEventWithoutDelivery(t *testing.T, db *sql.DB, runID, eventID, entityID string) {
+	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -202,14 +320,5 @@ func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entit
 		)
 	`, runID, entityID); err != nil {
 		t.Fatalf("seed entity state: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
-		) VALUES (
-			$1::uuid, $2::uuid, 'node', $3, 'pending', 'matched_node_subscription', now()
-		)
-	`, runID, eventID, nodeID); err != nil {
-		t.Fatalf("seed node delivery: %v", err)
 	}
 }

--- a/internal/runtime/pipeline/run_scoped_test_helpers_test.go
+++ b/internal/runtime/pipeline/run_scoped_test_helpers_test.go
@@ -3,9 +3,13 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/google/uuid"
 )
 
 const testPipelineRunID = "77777777-7777-7777-7777-777777777777"
@@ -53,4 +57,86 @@ func testPipelineCoordinatorRunContext(t *testing.T, pc *PipelineCoordinator) co
 		return testWorkflowStoreRunContext(t, pc.workflowStore)
 	}
 	return testPipelineRunContextNoSeed()
+}
+
+func seedPipelineNodeDeliveryAuthority(t *testing.T, db *sql.DB, evt events.Event, nodeID string) {
+	t.Helper()
+	if db == nil {
+		t.Fatal("seed pipeline node delivery authority requires db")
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "" {
+		t.Fatal("seed pipeline node delivery authority requires nodeID")
+	}
+	eventID := strings.TrimSpace(evt.ID)
+	if _, err := uuid.Parse(eventID); err != nil {
+		t.Fatalf("seed pipeline node delivery authority event id = %q: %v", eventID, err)
+	}
+	runID := strings.TrimSpace(evt.RunID)
+	if runID == "" {
+		runID = testPipelineRunID
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		t.Fatalf("seed pipeline node delivery authority run id = %q: %v", runID, err)
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed pipeline node delivery authority run: %v", err)
+	}
+	var entityID any
+	if raw := strings.TrimSpace(evt.EntityID()); raw != "" {
+		if _, err := uuid.Parse(raw); err == nil {
+			entityID = raw
+		}
+	}
+	payload := strings.TrimSpace(string(evt.Payload))
+	if payload == "" {
+		payload = "{}"
+	}
+	eventType := strings.TrimSpace(string(evt.Type))
+	if eventType == "" {
+		eventType = "test.event"
+	}
+	flowInstance := strings.TrimSpace(evt.FlowInstance())
+	if flowInstance == "" {
+		flowInstance = "runtime"
+	}
+	scope := strings.TrimSpace(string(evt.Scope()))
+	if scope == "" {
+		scope = "entity"
+	}
+	sourceAgent := strings.TrimSpace(evt.SourceAgent)
+	if sourceAgent == "" {
+		sourceAgent = "test"
+	}
+	createdAt := evt.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, $4::uuid, $5, $6, $7::jsonb,
+			$8, 'agent', $9
+		)
+		ON CONFLICT (event_id) DO NOTHING
+	`, eventID, runID, eventType, entityID, flowInstance, scope, payload, sourceAgent, createdAt); err != nil {
+		t.Fatalf("seed pipeline node delivery authority event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, 'pending', 'test_node_delivery_authority', now()
+		)
+		ON CONFLICT DO NOTHING
+	`, runID, eventID, nodeID); err != nil {
+		t.Fatalf("seed pipeline node delivery authority row: %v", err)
+	}
 }

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -56,6 +56,7 @@ type WorkflowInstancePersistence interface {
 }
 
 type SystemNodeReceiptPersistence interface {
+	SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string) (bool, error)
 	SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error)
 	SystemNodeDeliveryQuiesced(ctx context.Context, nodeID, eventID string) (bool, error)
 	MarkSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -959,6 +959,12 @@ func seedSelectEntitySpendEvent(t *testing.T, db *sql.DB, ctx context.Context, p
 	`, evt.ID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
 		t.Fatalf("seed select_entity spend event: %v", err)
 	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES ($1::uuid, 'node', 'treasury-orchestrator', 'pending', now())
+	`, evt.ID); err != nil {
+		t.Fatalf("seed select_entity node delivery: %v", err)
+	}
 	return evt
 }
 

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,51 @@ import (
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/google/uuid"
 )
+
+var ErrSystemNodeDeliveryAuthorityMissing = errors.New("system node delivery authority missing")
+
+func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string) (bool, error) {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	if _, err := uuid.Parse(eventID); err != nil {
+		return false, nil
+	}
+	if s.isSQLite() {
+		var ok bool
+		err := dbQueryRowContext(ctx, s.db, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM event_deliveries
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+				  )
+			)
+		`, eventID, nodeID).Scan(&ok)
+		return ok, err
+	}
+	var ok bool
+	err := dbQueryRowContext(ctx, s.db, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+			  )
+		)
+	`, eventID, nodeID).Scan(&ok)
+	return ok, err
+}
 
 func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error) {
 	nodeID = strings.TrimSpace(nodeID)
@@ -101,6 +147,13 @@ func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDelivery(ctx con
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
 	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
 		now := time.Now().UTC()
 		res, err := tx.ExecContext(txctx, `
 			INSERT INTO event_receipts (
@@ -150,28 +203,32 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 		if rows, _ := res.RowsAffected(); rows > 0 {
 			return nil
 		}
-		if _, err := tx.ExecContext(txctx, `
-			INSERT INTO event_deliveries (
-				delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count,
-				reason_code, last_error, active_session_id, started_at, delivered_at, created_at
-			)
-			SELECT
-				?, e.run_id, e.event_id, 'node', ?, 'delivered', 0,
-				'node_processed', NULL, NULL, ?, ?, ?
-			FROM events e
-			WHERE e.event_id = ?
-			  AND NOT EXISTS (
-				SELECT 1
-				FROM event_deliveries d
-				WHERE d.event_id = e.event_id
-				  AND d.subscriber_type = 'node'
-				  AND d.subscriber_id = ?
-			  )
-		`, uuid.NewString(), nodeID, now, now, now, eventID, nodeID); err != nil {
-			return fmt.Errorf("insert sqlite settled system node delivery: %w", err)
-		}
 		return nil
 	})
+}
+
+func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+			  )
+		)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
+	return ok, err
 }
 
 func sqliteNodeJSON(raw string) string {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
 )
 
 func testCreateFlowInstanceContext(trigger workflowTriggerContext) values.Context {
@@ -511,6 +513,7 @@ opco.ceo_ready:
 `,
 	})
 	evt := (events.Event{
+		ID:      uuid.NewString(),
 		Type:    events.EventType("operating/inst-1/opco.product_initialization_requested"),
 		Payload: []byte(`{"entity_id":"ent-operating"}`),
 	}).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
@@ -525,14 +528,19 @@ opco.ceo_ready:
 		t.Fatalf("handler event key = %q, want opco.product_initialization_requested", got)
 	}
 
+	_, db, _ := testutil.StartPostgres(t)
 	bus := &recordingPipelineBus{}
 	pc := &PipelineCoordinator{
-		bus:            bus,
-		expressionEval: newWorkflowExpressionEvaluator(),
-		entityLocks:    map[string]*sync.Mutex{},
-		module:         staticSemanticWorkflowModule{source: source},
+		bus:                     bus,
+		db:                      db,
+		workflowStore:           NewWorkflowInstanceStore(db),
+		expressionEval:          newWorkflowExpressionEvaluator(),
+		entityLocks:             map[string]*sync.Mutex{},
+		module:                  staticSemanticWorkflowModule{source: source},
+		eventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	}
-	handled, err := pc.executeNodeHandlerPlanResult(context.Background(), "lifecycle-orchestrator", evt)
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "lifecycle-orchestrator")
+	handled, err := pc.executeNodeHandlerPlanResult(testPipelineCoordinatorRunContext(t, pc), "lifecycle-orchestrator", evt)
 	if err != nil {
 		t.Fatalf("executeNodeHandlerPlanResult: %v", err)
 	}

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -1,0 +1,302 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pc, bus := newDeliveryAuthorityCoordinator(t, db)
+	runCtx := testPipelineCoordinatorRunContext(t, pc)
+	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+
+	postCommit := make([]func(), 0, 1)
+	ictx := WithPipelinePostCommitActions(ctx, &postCommit)
+	passthrough, _, err := pc.Intercept(ictx, evt)
+	if err != nil {
+		t.Fatalf("Intercept: %v", err)
+	}
+	if !passthrough {
+		t.Fatal("Intercept passthrough = false, want true when node delivery authority is missing")
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("published events = %d, want 0 without node delivery authority", got)
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID, "node-a", 0)
+	assertDeliveryAuthorityDeliveryCount(t, db, evt.ID, "node-a", 0)
+	logs := bus.runtimeLogEntries()
+	if len(logs) != 1 || logs[0].Action != "delivery_authority_missing" {
+		t.Fatalf("runtime logs = %#v, want one delivery_authority_missing entry", logs)
+	}
+}
+
+func TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pc, bus := newDeliveryAuthorityCoordinator(t, db)
+	runCtx := testPipelineCoordinatorRunContext(t, pc)
+	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+	seedDeliveryAuthorityNodeDelivery(t, db, evt.ID, "__runtime_replay_scope__")
+
+	postCommit := make([]func(), 0, 1)
+	ictx := WithPipelinePostCommitActions(ctx, &postCommit)
+	passthrough, _, err := pc.Intercept(ictx, evt)
+	if err != nil {
+		t.Fatalf("Intercept: %v", err)
+	}
+	if !passthrough {
+		t.Fatal("Intercept passthrough = false, want true when replay scope marker lacks concrete node authority")
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("published events = %d, want 0 with replay scope marker only", got)
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID, "node-a", 0)
+	assertDeliveryAuthorityDeliveryCount(t, db, evt.ID, "node-a", 0)
+	assertDeliveryAuthorityDeliveryCount(t, db, evt.ID, "__runtime_replay_scope__", 1)
+	logs := bus.runtimeLogEntries()
+	if len(logs) != 1 || logs[0].Action != "delivery_authority_missing" {
+		t.Fatalf("runtime logs = %#v, want one delivery_authority_missing entry", logs)
+	}
+}
+
+func TestPipelineCoordinatorInterceptTerminalNodeDeliveryDoesNotAuthorizeExecution(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     string
+		retryCount int
+	}{
+		{name: "dead_letter", status: "dead_letter", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			ctx := context.Background()
+			pc, bus := newDeliveryAuthorityCoordinator(t, db)
+			runCtx := testPipelineCoordinatorRunContext(t, pc)
+			evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+			seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+			seedDeliveryAuthorityNodeDeliveryStatus(t, db, evt.ID, "node-a", tc.status, tc.retryCount)
+
+			postCommit := make([]func(), 0, 1)
+			ictx := WithPipelinePostCommitActions(ctx, &postCommit)
+			passthrough, _, err := pc.Intercept(ictx, evt)
+			if err != nil {
+				t.Fatalf("Intercept: %v", err)
+			}
+			if !passthrough {
+				t.Fatal("Intercept passthrough = false, want true when terminal node delivery is non-executable")
+			}
+			if got := bus.publishedCount(); got != 0 {
+				t.Fatalf("published events = %d, want 0 for terminal node delivery", got)
+			}
+			assertDeliveryAuthorityReceiptCount(t, db, evt.ID, "node-a", 0)
+			assertDeliveryAuthorityDeliveryCount(t, db, evt.ID, "node-a", 1)
+			logs := bus.runtimeLogEntries()
+			if len(logs) != 1 || logs[0].Action != "delivery_authority_missing" {
+				t.Fatalf("runtime logs = %#v, want one delivery_authority_missing entry", logs)
+			}
+		})
+	}
+}
+
+func TestPipelineCoordinatorInterceptSkipsWhenCanonicalDeliveryAuthorityUnavailable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pc, bus := newDeliveryAuthorityCoordinatorWithReceipts(t, db, false)
+	runCtx := testPipelineCoordinatorRunContext(t, pc)
+	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+	seedDeliveryAuthorityNodeDelivery(t, db, evt.ID, "node-a")
+
+	postCommit := make([]func(), 0, 1)
+	ictx := WithPipelinePostCommitActions(ctx, &postCommit)
+	passthrough, _, err := pc.Intercept(ictx, evt)
+	if err != nil {
+		t.Fatalf("Intercept: %v", err)
+	}
+	if !passthrough {
+		t.Fatal("Intercept passthrough = false, want true when delivery authority owner is unavailable")
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("published events = %d, want 0 when delivery authority owner is unavailable", got)
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID, "node-a", 0)
+}
+
+func TestPipelineCoordinatorInterceptSettlesAuthorizedNodeDelivery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pc, _ := newDeliveryAuthorityCoordinator(t, db)
+	runCtx := testPipelineCoordinatorRunContext(t, pc)
+	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+	seedDeliveryAuthorityNodeDelivery(t, db, evt.ID, "node-a")
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(runCtx, evt)
+	if err != nil {
+		t.Fatalf("dispatchWorkflowNodeEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("dispatchWorkflowNodeEventResult handled = false, want true for authorized node delivery")
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID, "node-a", 1)
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-a'
+	`, evt.ID).Scan(&status); err != nil {
+		t.Fatalf("load authorized node delivery: %v", err)
+	}
+	if status != "delivered" {
+		t.Fatalf("authorized node delivery status = %q, want delivered", status)
+	}
+}
+
+func newDeliveryAuthorityCoordinator(t *testing.T, db *sql.DB) (*PipelineCoordinator, *recordingPipelineBus) {
+	t.Helper()
+	return newDeliveryAuthorityCoordinatorWithReceipts(t, db, true)
+}
+
+func newDeliveryAuthorityCoordinatorWithReceipts(t *testing.T, db *sql.DB, receiptsEnabled bool) (*PipelineCoordinator, *recordingPipelineBus) {
+	t.Helper()
+	bus := &recordingPipelineBus{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"node-a": {
+					"source.evt": {
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID:         "complete",
+							Condition:  "true",
+							AdvancesTo: "done",
+						}},
+					},
+				},
+			},
+		},
+	}
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{
+			bundle: bundle,
+			workflow: NewWorkflowDefinition("delivery-authority", []WorkflowStage{
+				{Name: "queued"},
+				{Name: "done", Terminal: true},
+			}, []WorkflowTransition{{
+				Name: "complete",
+				From: []WorkflowStateID{"queued"},
+				To:   "done",
+				Node: "node-a",
+			}}),
+			workflowNodes: []WorkflowNode{{
+				ID:            "node-a",
+				Subscriptions: []events.EventType{"source.evt"},
+				Policies: map[string]WorkflowEventPolicy{
+					"source.evt": {Consume: true},
+				},
+			}},
+		},
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: receiptsEnabled}.resolve,
+	})
+	return pc, bus
+}
+
+func seedDeliveryAuthorityEvent(t *testing.T, db *sql.DB, ctx context.Context) events.Event {
+	t.Helper()
+	entityID := uuid.NewString()
+	evt := (events.Event{
+		ID:          uuid.NewString(),
+		RunID:       testPipelineRunID,
+		Type:        events.EventType("source.evt"),
+		SourceAgent: "src",
+		Payload:     []byte(`{"entity_id":"` + entityID + `"}`),
+		CreatedAt:   time.Now().UTC(),
+	}).WithEntityID(entityID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, $4::uuid, 'runtime', 'entity', $5::jsonb,
+			'src', 'agent', now()
+		)
+	`, evt.ID, evt.RunID, string(evt.Type), entityID, string(evt.Payload)); err != nil {
+		t.Fatalf("seed delivery authority event: %v", err)
+	}
+	return evt
+}
+
+func seedDeliveryAuthorityWorkflowInstance(t *testing.T, pc *PipelineCoordinator, ctx context.Context, entityID string) {
+	t.Helper()
+	if err := pc.workflowStore.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "delivery-authority",
+		WorkflowVersion: "v-test",
+		CurrentState:    "queued",
+	}); err != nil {
+		t.Fatalf("seed delivery authority workflow instance: %v", err)
+	}
+}
+
+func seedDeliveryAuthorityNodeDelivery(t *testing.T, db *sql.DB, eventID, nodeID string) {
+	t.Helper()
+	seedDeliveryAuthorityNodeDeliveryStatus(t, db, eventID, nodeID, "pending", 0)
+}
+
+func seedDeliveryAuthorityNodeDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, status string, retryCount int) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, retry_count, created_at)
+		VALUES ($1::uuid, $2::uuid, 'node', $3, $4, $5, now())
+	`, testPipelineRunID, eventID, nodeID, status, retryCount); err != nil {
+		t.Fatalf("seed delivery authority node delivery: %v", err)
+	}
+}
+
+func assertDeliveryAuthorityReceiptCount(t *testing.T, db *sql.DB, eventID, nodeID string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&got); err != nil {
+		t.Fatalf("count delivery authority node receipts: %v", err)
+	}
+	if got != want {
+		t.Fatalf("delivery authority node receipts = %d, want %d", got, want)
+	}
+}
+
+func assertDeliveryAuthorityDeliveryCount(t *testing.T, db *sql.DB, eventID, nodeID string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&got); err != nil {
+		t.Fatalf("count delivery authority node deliveries: %v", err)
+	}
+	if got != want {
+		t.Fatalf("delivery authority node deliveries = %d, want %d", got, want)
+	}
+}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -855,6 +855,56 @@ func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, no
 	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
 }
 
+func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Context, nodeID string, evt events.Event) bool {
+	if pc == nil {
+		return false
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "" {
+		return false
+	}
+	if !pc.eventReceiptsAvailable(ctx) {
+		return false
+	}
+	if pc.workflowStore == nil {
+		return false
+	}
+	eventID := strings.TrimSpace(evt.ID)
+	if eventID == "" {
+		return false
+	}
+	ok, err := pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID)
+	if err != nil {
+		if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Checking workflow node delivery authority failed",
+				Component: nodeID,
+				Action:    "delivery_authority_check_failed",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+				Error:     strings.TrimSpace(err.Error()),
+			})
+		}
+		return false
+	}
+	if !ok {
+		if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
+			logger.LogRuntime(ctx, RuntimeLogEntry{
+				Level:     "error",
+				Message:   "Workflow node delivery authority is missing; handler execution skipped",
+				Component: nodeID,
+				Action:    "delivery_authority_missing",
+				EventID:   eventID,
+				EventType: strings.TrimSpace(string(evt.Type)),
+				EntityID:  workflowEventEntityID(evt),
+			})
+		}
+	}
+	return ok
+}
+
 func (pc *PipelineCoordinator) workflowNodeEventProcessed(ctx context.Context, nodeID string, evt events.Event) bool {
 	if pc == nil || pc.workflowStore == nil {
 		return false

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
 )
 
 type recordingSchedulePersistence struct {
@@ -78,7 +79,10 @@ func (*recordingSchedulePersistence) CompleteScheduleFireExact(context.Context, 
 }
 
 func newTimerLifecycleCoordinator(bus Bus, db *sql.DB, module WorkflowModule, store SchedulePersistence) *PipelineCoordinator {
-	opts := PipelineCoordinatorOptions{Module: module}
+	opts := PipelineCoordinatorOptions{
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	}
 	if store != nil {
 		opts.TimerScheduler = NewScheduler()
 		opts.TimerScheduleStore = store
@@ -128,12 +132,13 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 	}
 
 	evt := events.Event{
-		ID:          "evt-start",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("timer.scheduled"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
 	if handled := pc.executeNodeHandlerPlan(txctx, "test-node", evt); !handled {
@@ -193,12 +198,13 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	}
 
 	evt := events.Event{
-		ID:          "evt-start",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("timer.scheduled"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	_, handled := pc.interceptPolicy("timer.scheduled", evt)
 	if !handled {
@@ -406,7 +412,8 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -422,12 +429,13 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 	}
 
 	evt := events.Event{
-		ID:          "evt-child-done",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/task.done"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "listener")
 
 	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "dispatcher", evt); handled {
 		t.Fatal("dispatcher should not handle child/task.done")
@@ -492,12 +500,13 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 
 	start := time.Now().UTC()
 	evt := events.Event{
-		ID:          "evt-item-a",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("item.arrived"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001","item_id":"a"}`),
 		CreatedAt:   start,
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
 	if handled := pc.executeNodeHandlerPlan(txctx, "test-node", evt); !handled {
@@ -641,18 +650,19 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	}
 
 	evt := events.Event{
-		ID:          "evt-item-a",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("item.arrived"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001","item_id":"a"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 	if handled := pc.executeNodeHandlerPlan(ctx, "test-node", evt); !handled {
 		t.Fatal("expected item.arrived handler to be handled")
 	}
 
 	timeoutEvt := events.Event{
-		ID:          "evt-timeout",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("accumulate.timeout"),
 		SourceAgent: runtimeWorkflowID,
 		Payload: mustJSON(map[string]any{
@@ -667,6 +677,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		}),
 		CreatedAt: time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, timeoutEvt, "test-node")
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
 	if handled := pc.executeNodeHandlerPlan(txctx, "test-node", timeoutEvt); !handled {
 		t.Fatal("expected accumulate.timeout handler to be handled")
@@ -701,7 +712,8 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -716,12 +728,13 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	}
 
 	trigger := events.Event{
-		ID:          "evt-work-requested",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("work.requested"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, trigger, "child-worker")
 
 	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "child-worker", trigger); !handled {
 		t.Fatal("child-worker should handle work.requested through the input-pin alias")
@@ -739,12 +752,13 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 
 	listenerCtx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child")
 	completion := events.Event{
-		ID:          "evt-child-work-completed",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/work.completed"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	handler, ok := pc.SemanticSource().NodeEventHandler("parent-listener", "child/work.completed")
 	if !ok {
 		t.Fatal("parent-listener handler missing for child/work.completed")
@@ -792,7 +806,8 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -808,12 +823,13 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 	}
 
 	completion := events.Event{
-		ID:          "evt-child-work-completed",
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/work.completed"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"ent-001"}`),
 		CreatedAt:   time.Now().UTC(),
 	}.WithEntityID("ent-001")
+	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
@@ -843,7 +859,8 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -880,13 +897,15 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
 
-	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), (events.Event{
-		ID:          "evt-nested-done",
+	completion := (events.Event{
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"` + grandchildEntityID + `"}`),
 		CreatedAt:   time.Now().UTC(),
-	}).WithEntityID(grandchildEntityID))
+	}).WithEntityID(grandchildEntityID)
+	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
 	}
@@ -926,7 +945,8 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -964,13 +984,15 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), (events.Event{
-		ID:          "evt-nested-done-parent-targeted",
+	completion := (events.Event{
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"` + childRowID + `"}`),
 		CreatedAt:   time.Now().UTC(),
-	}).WithEntityID(childRowID))
+	}).WithEntityID(childRowID)
+	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
+	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
 	}
@@ -1002,7 +1024,8 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
-		Module: module,
+		Module:                  module,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
 	if pc == nil {
 		t.Fatal("expected coordinator")
@@ -1041,13 +1064,15 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	t.Cleanup(func() { _ = tx.Rollback() })
 	ctx := WithPipelineSQLTxContext(testPipelineCoordinatorRunContext(t, pc), tx)
 
-	passThrough, emitted, err := pc.Intercept(ctx, (events.Event{
-		ID:          "evt-nested-done-tx",
+	completion := (events.Event{
+		ID:          uuid.NewString(),
 		Type:        events.EventType("child/grandchild/micro.done"),
 		SourceAgent: "cataloge2e",
 		Payload:     []byte(`{"entity_id":"` + childRowID + `"}`),
 		CreatedAt:   time.Now().UTC(),
-	}).WithEntityID(childRowID))
+	}).WithEntityID(childRowID)
+	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
+	passThrough, emitted, err := pc.Intercept(ctx, completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)
 	}

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -963,6 +963,118 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	}
 }
 
+func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	eventID := uuid.NewString()
+	evt := events.Event{
+		ID:          eventID,
+		RunID:       runID,
+		Type:        events.EventType("company.scanned"),
+		SourceAgent: "agent-1",
+		Payload:     json.RawMessage(`{"ok":true}`),
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := store.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`)
+	if !errors.Is(err, runtimepipeline.ErrSystemNodeDeliveryAuthorityMissing) {
+		t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)
+	}
+	var deliveries, receipts int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&deliveries); err != nil {
+		t.Fatalf("count sqlite node deliveries: %v", err)
+	}
+	if deliveries != 0 {
+		t.Fatalf("sqlite node deliveries = %d, want 0", deliveries)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&receipts); err != nil {
+		t.Fatalf("count sqlite node receipts: %v", err)
+	}
+	if receipts != 0 {
+		t.Fatalf("sqlite node receipts = %d, want 0", receipts)
+	}
+}
+
+func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     string
+		retryCount int
+	}{
+		{name: "dead_letter", status: "dead_letter", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+			runID := uuid.NewString()
+			ctx = runtimecorrelation.WithRunID(ctx, runID)
+			eventID := uuid.NewString()
+			evt := events.Event{
+				ID:          eventID,
+				RunID:       runID,
+				Type:        events.EventType("company.scanned"),
+				SourceAgent: "agent-1",
+				Payload:     json.RawMessage(`{"ok":true}`),
+				CreatedAt:   time.Now().UTC(),
+			}
+			if err := store.AppendEvent(ctx, evt); err != nil {
+				t.Fatalf("AppendEvent: %v", err)
+			}
+			if _, err := store.DB.ExecContext(ctx, `
+				INSERT INTO event_deliveries (
+					delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+				) VALUES (
+					?, ?, ?, 'node', 'background-node', ?, ?, 'terminal_test', ?
+				)
+			`, uuid.NewString(), runID, eventID, tc.status, tc.retryCount, time.Now().UTC()); err != nil {
+				t.Fatalf("seed sqlite terminal node delivery: %v", err)
+			}
+			owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+			err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`)
+			if !errors.Is(err, runtimepipeline.ErrSystemNodeDeliveryAuthorityMissing) {
+				t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)
+			}
+			var status string
+			var retryCount int
+			if err := store.DB.QueryRowContext(ctx, `
+				SELECT COALESCE(status, ''), COALESCE(retry_count, 0)
+				FROM event_deliveries
+				WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+			`, eventID).Scan(&status, &retryCount); err != nil {
+				t.Fatalf("load sqlite terminal delivery: %v", err)
+			}
+			if status != tc.status || retryCount != tc.retryCount {
+				t.Fatalf("sqlite terminal delivery = %s/%d, want %s/%d", status, retryCount, tc.status, tc.retryCount)
+			}
+			var receipts int
+			if err := store.DB.QueryRowContext(ctx, `
+				SELECT COUNT(*)
+				FROM event_receipts
+				WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+			`, eventID).Scan(&receipts); err != nil {
+				t.Fatalf("count sqlite node receipts: %v", err)
+			}
+			if receipts != 0 {
+				t.Fatalf("sqlite node receipts = %d, want 0", receipts)
+			}
+		})
+	}
+}
+
 func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)


### PR DESCRIPTION
## Summary

Enforces workflow-node execution admission against committed typed node delivery authority.

Workflow-node handlers now run only when the runtime can prove a committed `event_deliveries` row for `(event_id, subscriber_type='node', subscriber_id=<node>)`. Settlement no longer creates missing node delivery authority after handler execution.

Closes #1293.

## Governing refs / context

Exact merge-bearing spec refs:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#engine.event_loop`
- `platform-spec.yaml#persistence_schema.event_deliveries`
- `platform-spec.yaml#persistence_schema.event_receipts`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`
- `platform-spec.yaml#runtime_ingress_state.queued_not_dispatched`

Binding issue/gate context:

- #1293 Pre-Implementation Coverage Audit and approved gate for `workflow_node_delivery_authority_execution_admission`.
- #1359 / PR #1360 producer/materialization prerequisite is merged first.
- #1299 wildcard/static-service routing and #1301 runtime callback localization remain split.

## Semantic migration

New canonical consumer owner:

- `internal/runtime/pipeline.WorkflowInstanceStore.SystemNodeDeliveryAuthorized`
- `PipelineCoordinator.workflowNodeDeliveryAuthorized`
- `systemNodeRunner.deliveryAuthorized`

Old non-authoritative paths now invalid:

- workflow-runtime carrier/internal subscription delivery
- live handler lookup or semantic subscription match
- processed receipts
- settlement/backfill delivery insertion
- replay-scope marker rows as concrete node authority
- API/CLI/readback projections

Production paths checked for surviving old behavior:

- PipelineCoordinator interceptor/dispatch path.
- System/background node runner path.
- Postgres settlement path.
- SQLite settlement path.
- Runtime/catalog/runfork/event.publish supported surfaces via full-suite proof.

Migration status: complete for the approved #1293 execution-admission class. Route-production siblings #1299/#1301 remain tracked separately.

## Validation

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= \
  go test ./internal/runtime/pipeline ./internal/runtime ./internal/store ./internal/runtime/conformance ./cmd/swarm ./internal/apiv1 -count=1 -timeout=300s
```

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= \
  go test ./internal/runtime/bus ./internal/runtime/cataloge2e ./internal/runtime/runforkexecution -count=1 -timeout=300s
```

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= \
  go test ./internal/runtime -run 'TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately|TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandlerExecution|TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect|TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows' -count=1 -timeout=120s -v
```

```sh
SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...
```
