### PR TITLE
[agent-c][issue #1299] Materialize wildcard node routes

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -406,11 +406,18 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
 		return nil
 	}
+	var intents []RoutePlanDeliveryIntent
 	if routes := routedConcreteNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
-		return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)...)
 	}
 	if routes := routedScopedNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
-		return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)...)
+	}
+	if routes := routedWildcardStaticServiceNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)...)
+	}
+	if len(intents) > 0 {
+		return intents
 	}
 	internalRecipients := filterOutAgentIDs(recipients, persisted)
 	if len(internalRecipients) == 0 {
@@ -501,6 +508,44 @@ func routedScopedNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscribe
 			SubscriberID:   strings.TrimSpace(subscriber.ID),
 			Target: events.RouteIdentity{
 				FlowInstance: targetFlowInstance,
+				EntityID:     eventEntityID,
+			},
+		})
+	}
+	return events.NormalizeDeliveryRoutes(out)
+}
+
+func routedWildcardStaticServiceNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+	if len(routed) == 0 || len(eventDeliveryTargetRoutes(evt)) > 0 {
+		return nil
+	}
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type)), "/")
+	if eventType == "" {
+		return nil
+	}
+	eventEntityID := strings.TrimSpace(evt.EntityID())
+	out := make([]events.DeliveryRoute, 0, len(routed))
+	for _, subscriber := range routed {
+		id := strings.TrimSpace(subscriber.ID)
+		if id == "" || strings.TrimSpace(subscriber.Type) != "node" {
+			continue
+		}
+		path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+		if path == "" {
+			continue
+		}
+		matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
+		if matchPattern == "" || !strings.Contains(matchPattern, "*") || !RouteMatches(matchPattern, eventType) {
+			continue
+		}
+		if routedNodeMatchesConcreteEventTypeFlowInstance(evt, subscriber) {
+			continue
+		}
+		out = append(out, events.DeliveryRoute{
+			SubscriberType: "node",
+			SubscriberID:   id,
+			Target: events.RouteIdentity{
+				FlowInstance: path,
 				EntityID:     eventEntityID,
 			},
 		})

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -750,6 +750,66 @@ func TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope(t 
 	}
 }
 
+func TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberScope(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{
+					ID:           "repo-scaffold-node",
+					Type:         "node",
+					Path:         "repo-scaffold",
+					MatchPattern: "component-scaffold/*/opco.repo_scaffold_requested",
+					RouteSource:  "subscription",
+				}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return nil
+			},
+			resolveRoutedNodeInternalRecipients: func(events.Event, []Subscriber) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	plan, err := planner.Plan(context.Background(), (events.Event{
+		Type: "component-scaffold/component-a/opco.repo_scaffold_requested",
+	}).WithEntityID("ent-component").WithFlowInstance("component-scaffold/component-a"))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 1 {
+		t.Fatalf("delivery routes = %#v, want repo-scaffold-node wildcard static-service node route", got)
+	}
+	route := plan.DeliveryRoutes[0]
+	if route.SubscriberType != "node" || route.SubscriberID != "repo-scaffold-node" {
+		t.Fatalf("delivery route = %#v, want node/repo-scaffold-node", route)
+	}
+	if route.Target.FlowInstance != "repo-scaffold" || route.Target.EntityID != "ent-component" {
+		t.Fatalf("delivery target = %#v, want repo-scaffold ent-component", route.Target)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
+	}
+}
+
 func TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -788,6 +788,113 @@ func TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInte
 	}
 }
 
+func TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCarrier(t *testing.T) {
+	const (
+		pattern   = "component-scaffold/*/opco.repo_scaffold_requested"
+		eventType = "component-scaffold/component-a/opco.repo_scaffold_requested"
+	)
+	rt := newRouteTable(nil)
+	rt.eventPath[eventType] = struct{}{}
+	rt.patterns = []routePattern{
+		{
+			EventPattern: eventType,
+			Subscriber: Subscriber{
+				ID:          "component-node",
+				Type:        "node",
+				Path:        "component-scaffold/component-a",
+				RouteSource: "subscription",
+			},
+		},
+		{
+			EventPattern: pattern,
+			Subscriber: Subscriber{
+				ID:          "repo-scaffold-node",
+				Type:        "node",
+				Path:        "repo-scaffold",
+				RouteSource: "subscription",
+			},
+		},
+	}
+	rt.rebuildLocked()
+
+	store := newTargetRouteMemoryStore()
+	eventID := uuid.NewString()
+	wildcardServiceRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "repo-scaffold-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "repo-scaffold",
+			EntityID:     "ent-component",
+		},
+	}
+	concreteComponentRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "component-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "component-scaffold/component-a",
+			EntityID:     "ent-component",
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		RouteTable: rt,
+		Interceptors: []EventInterceptor{materializedRoutePersistedBeforeInterceptor{
+			t:       t,
+			store:   store,
+			eventID: eventID,
+			want:    wildcardServiceRoute,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType(eventType))
+	defer eb.Unsubscribe("workflow-runtime")
+	evt := (events.Event{
+		ID:        eventID,
+		Type:      events.EventType(eventType),
+		Payload:   []byte(`{}`),
+		CreatedAt: time.Now().UTC(),
+	}).WithEntityID("ent-component").WithFlowInstance("component-scaffold/component-a")
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
+		t.Fatalf("recipients = %#v, want workflow-runtime live carrier", got)
+	}
+	if len(plan.PersistedRecipients) != 0 {
+		t.Fatalf("persisted recipients = %#v, want none for internal carrier", plan.PersistedRecipients)
+	}
+	if len(plan.RoutedRecipients) != 2 {
+		t.Fatalf("routed recipients = %#v, want component node and repo-scaffold wildcard match", plan.RoutedRecipients)
+	}
+	sawWildcardService := false
+	for _, recipient := range plan.RoutedRecipients {
+		if recipient.ID == "repo-scaffold-node" && recipient.Path == "repo-scaffold" && recipient.MatchedPattern == pattern {
+			sawWildcardService = true
+		}
+	}
+	if !sawWildcardService {
+		t.Fatalf("routed recipients = %#v, want repo-scaffold wildcard match", plan.RoutedRecipients)
+	}
+	if got := plan.DeliveryRoutes; len(got) != 2 || !deliveryRoutesContain(got, wildcardServiceRoute) || !deliveryRoutesContain(got, concreteComponentRoute) {
+		t.Fatalf("delivery routes = %#v, want wildcard service route %#v and concrete route %#v", got, wildcardServiceRoute, concreteComponentRoute)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, ch, "wildcard static-service workflow-runtime carrier delivery")
+	if got.Type != events.EventType(eventType) || got.FlowInstance() != "component-scaffold/component-a" {
+		t.Fatalf("delivered event type=%q flow=%q, want concrete component event", got.Type, got.FlowInstance())
+	}
+	routes := store.routes[evt.ID]
+	if len(routes) != 2 || !deliveryRoutesContain(routes, wildcardServiceRoute) || !deliveryRoutesContain(routes, concreteComponentRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want wildcard service route %#v and concrete route %#v", routes, wildcardServiceRoute, concreteComponentRoute)
+	}
+}
+
 func TestRouteTableRootInputFlowNodeResolvesRootInputRoute(t *testing.T) {
 	rt, err := DeriveRouteTable(semanticview.Wrap(routedRootInputFlowNodeBundle()))
 	if err != nil {

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -107,13 +107,13 @@ func TestRouteAuthorityMatrixRejectsStaleReferences(t *testing.T) {
 		{
 			name: "split sibling cannot be reclassified as covered",
 			mutate: func(matrix *routeAuthorityMatrix) {
-				row := routeAuthorityMatrixRowByID(t, matrix, "wildcard_static_service_route_production")
+				row := routeAuthorityMatrixRowByID(t, matrix, "runtime_callback_flow_instance_localization")
 				row.Classification = "already_covered_by_existing_proof"
 				row.Tier = "required_pr_smoke"
 				row.SplitIssue = 0
 				row.ProofDimensions = []string{"persistence_authority"}
 			},
-			want: "wildcard_static_service_route_production must remain split-open issue #1299",
+			want: "runtime_callback_flow_instance_localization must remain split-open issue #1301",
 		},
 		{
 			name: "parent closure stays false",
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340, 1299, 1301} {
+	for _, issue := range []int{1340, 1301} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))
@@ -475,7 +475,6 @@ func requiredRouteAuthorityRows() []string {
 
 func requiredRouteAuthoritySplitRows() map[string]int {
 	return map[string]int{
-		"wildcard_static_service_route_production":    1299,
 		"runtime_callback_flow_instance_localization": 1301,
 	}
 }

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -24,9 +24,6 @@ active_trackers:
     issue: 1340
     watchlist: runtime_operations.delivery_and_replay_ownership
   - kind: github_issue
-    issue: 1299
-    watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
     issue: 1301
     watchlist: runtime_operations.delivery_and_replay_ownership
 rows:
@@ -226,19 +223,37 @@ rows:
       remain invalid authority.
 
   - id: wildcard_static_service_route_production
-    concept: Wildcard static-service route production is a route-production sibling, not a matrix behavior change.
-    classification: split_to_existing_issue
-    tier: split_open
-    split_issue: 1299
-    proof_dimensions: [route_plan_model, split_tracker]
+    concept: Wildcard static-service route-table matches for concrete child-flow events persist typed workflow-node authority for the static service subscriber.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_plan_model, persistence_authority, negative_authority, required_pr_smoke]
+    invalid_authority:
+      - hardcoded Empire diagnostic route
+      - workflow-runtime carrier route
+      - live internal carrier subscription
+      - handler lookup
+      - event_receipts settlement/backfill
+      - replay-scope markers
+      - API/CLI readback
     owner_refs:
       - {kind: spec_ref, path: platform-spec.yaml, ref: wildcard_routes}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: workflow_node_route_authority}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_authority}
+      - {kind: artifact, path: internal/runtime/bus/delivery_planner.go}
       - {kind: artifact, path: internal/runtime/bus/routing_derivation_internal_test.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_target_routes_test.go}
     proof_refs:
-      - {kind: tracker, issue: 1299, watchlist: runtime_operations.delivery_and_replay_ownership}
+      - {kind: issue, issue: 1299}
+      - {kind: go_test, name: TestRouteTableResolve_WildcardSubscriberMatchesActiveConcreteChildEventWithoutMaterializedKey}
+      - {kind: go_test, name: TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberScope}
+      - {kind: go_test, name: TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCarrier}
     notes: >
-      #1299 owns concrete wildcard static-service route production. #1346
-      classifies it only.
+      #1299 owns concrete wildcard static-service route production, for example
+      component-scaffold/*/opco.repo_scaffold_requested matching
+      component-scaffold/<id>/opco.repo_scaffold_requested and persisting the
+      static service node delivery row. RouteTable remains the wildcard matcher;
+      RoutePlan owns typed delivery materialization; live carriers, receipts,
+      replay markers, and readback are not authority.
 
   - id: runtime_callback_flow_instance_localization
     concept: Runtime callback flow_instance localization is a route-production sibling, not a matrix behavior change.


### PR DESCRIPTION
## Summary

Closes #1299.

This closes the `wildcard_static_service_route_production` child by making the EventBus RoutePlan/delivery-planner path materialize wildcard static-service node subscribers into typed `event_deliveries` authority rows.

The route table remains the wildcard matcher/topology owner: `RouteTable.Resolve` returns the matched node subscriber with `MatchPattern`. The planner now turns that resolved wildcard node subscriber into a durable `node/<subscriber>` delivery route targeted at the subscriber static flow path, and it accumulates concrete, scoped, and wildcard node route families instead of short-circuiting after the first one.

## Governing Refs

Exact binding spec refs:

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#engine.dynamic_instance_lifecycle.wildcard_subscriptions`
- `platform-spec.yaml#runtime_persistence.routing_rules`
- `platform-spec.yaml#runtime_persistence.event_deliveries`
- `platform-spec.yaml#engine.event_loop`

## Semantic Migration

New canonical owner:

- Wildcard matching/topology stays in `RouteTable.Resolve` / `eventidentity.MatchPattern`.
- Typed wildcard static-service delivery materialization is owned by `internal/runtime/bus` RoutePlan delivery planning.
- Durable authority remains `event_deliveries` through the existing EventBus persistence path.

Old producer / reader / writer path now invalid:

- hardcoded Empire diagnostic routes
- live `workflow-runtime` carrier rows
- handler lookup / descriptor lookup
- replay markers / replay scope
- receipts, settlement, or backfill
- API/CLI/dashboard readback
- the old scoped helper behavior that rejected wildcard `MatchPattern` before materializing a node route

Production paths checked for surviving old behavior:

- `CheckPublishRecipientPlan` consumes the same RoutePlan and now reports the wildcard static-service node delivery route.
- `Publish` persists the wildcard node route before interceptors/dispatch.
- `PublishTx`, deferred publish, and outbox paths remain consumers of the same canonical RoutePlan package path covered by the existing #1344 package tests.
- #1293 admission remains row-consumer-only; no fallback or admission weakening was added.

Migration complete for the approved #1299 class: the known wildcard static-service route-production shape now persists typed node authority through the canonical route plan.

## Proof

- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus -run TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberScope -count=1 -v` failed before the fix with empty `DeliveryRoutes`, then passed after the fix.
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus -run 'TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberScope|TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCarrier|Wildcard|NoTargetScopedRoutedNode|NoTargetCrossFlowStaticRoutedNode|RouteTableTemplateOutputPinWildcard' -count=1 -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/conformance -run TestRouteAuthorityMatrix -count=1 -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/bus ./internal/runtime/conformance -count=1`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./internal/runtime/cataloge2e -run 'TestTier7CompositionCatalogFixtures_RealRuntime/test-wildcard-cross-flow|TestTier5LifecycleCatalogFixtures_RealRuntime/test-wildcard-subscription' -count=1 -timeout=180s -v`
- `SWARM_TOOL_GATEWAY_URL= SWARM_TOOL_GATEWAY_CONTAINER_URL= SWARM_TOOL_GATEWAY_TOKEN= go test ./...`
