### PR TITLE
[agent-c][issue #1364] Add route authority drift inventory

### DIFF
--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -1,0 +1,590 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const routeAuthorityDriftInventoryPath = "internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml"
+
+type routeAuthorityDriftInventory struct {
+	Version            int                                  `yaml:"version"`
+	Kind               string                               `yaml:"kind"`
+	Issue              int                                  `yaml:"issue"`
+	ParentIssues       []int                                `yaml:"parent_issues"`
+	Watchlist          string                               `yaml:"watchlist"`
+	Policy             routeAuthorityDriftInventoryPolicy   `yaml:"policy"`
+	Sources            routeAuthorityDriftInventorySources  `yaml:"sources"`
+	SearchDimensions   []routeAuthorityDriftSearchDimension `yaml:"search_dimensions"`
+	SeamFamilies       []routeAuthorityDriftSeamFamily      `yaml:"seam_families"`
+	GuardrailProposals []routeAuthorityDriftGuardrail       `yaml:"guardrail_proposals"`
+	FollowUpDecision   routeAuthorityDriftFollowUpDecision  `yaml:"follow_up_decision"`
+}
+
+type routeAuthorityDriftInventoryPolicy struct {
+	ClosureLevel                  string `yaml:"closure_level"`
+	ClaimsParentClosure           bool   `yaml:"claims_parent_closure"`
+	ClaimsRuntimeBehaviorClosure  bool   `yaml:"claims_runtime_behavior_closure"`
+	RuntimeBehaviorChangesAllowed bool   `yaml:"runtime_behavior_changes_allowed"`
+	ExhaustiveRequirement         string `yaml:"exhaustive_requirement"`
+}
+
+type routeAuthorityDriftInventorySources struct {
+	PlatformSpec               string `yaml:"platform_spec"`
+	RouteAuthorityMatrix       string `yaml:"route_authority_matrix"`
+	OpenRPCArtifact            string `yaml:"openrpc_artifact"`
+	PublicSurfaceBackendMatrix string `yaml:"public_surface_backend_matrix"`
+	WatchlistNote              string `yaml:"watchlist_note"`
+}
+
+type routeAuthorityDriftSearchDimension struct {
+	ID                   string   `yaml:"id"`
+	Pattern              string   `yaml:"pattern"`
+	MinimumMatchingFiles int      `yaml:"minimum_matching_files"`
+	RequiredPaths        []string `yaml:"required_paths"`
+	CanonicalLayer       string   `yaml:"canonical_layer"`
+}
+
+type routeAuthorityDriftSeamFamily struct {
+	ID               string   `yaml:"id"`
+	Layer            string   `yaml:"layer"`
+	Classification   string   `yaml:"classification"`
+	Paths            []string `yaml:"paths"`
+	SearchDimensions []string `yaml:"search_dimensions"`
+	InvalidAuthority []string `yaml:"invalid_authority"`
+	Notes            string   `yaml:"notes"`
+}
+
+type routeAuthorityDriftGuardrail struct {
+	ID                  string   `yaml:"id"`
+	ImplementationState string   `yaml:"implementation_state"`
+	Target              string   `yaml:"target"`
+	Prevents            []string `yaml:"prevents"`
+}
+
+type routeAuthorityDriftFollowUpDecision struct {
+	TrackerState                    string `yaml:"tracker_state"`
+	NewChildRequiredBeforeCoding    bool   `yaml:"new_child_required_before_coding"`
+	RuntimeBehaviorChildRequiredNow bool   `yaml:"runtime_behavior_child_required_now"`
+	Notes                           string `yaml:"notes"`
+}
+
+type routeAuthorityDriftRepoFile struct {
+	Path string
+	Raw  []byte
+}
+
+type routeAuthorityDriftValidationCorpus struct {
+	Files         []routeAuthorityDriftRepoFile
+	MatchesByExpr map[string][]string
+}
+
+func TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	if problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory); len(problems) > 0 {
+		t.Fatalf("route authority drift inventory validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	base := loadRouteAuthorityDriftInventory(t, root)
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+
+	tests := []struct {
+		name   string
+		mutate func(*routeAuthorityDriftInventory)
+		want   string
+	}{
+		{
+			name: "missing required search dimension",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.SearchDimensions = routeAuthorityDriftSearchDimensionsExcept(inventory.SearchDimensions, "event_deliveries")
+			},
+			want: "missing required search_dimension event_deliveries",
+		},
+		{
+			name: "required path must match the audited pattern",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				dim := routeAuthorityDriftSearchDimensionByID(t, inventory, "event_deliveries")
+				dim.RequiredPaths = []string{"go.mod"}
+			},
+			want: "event_deliveries required_path go.mod does not match pattern",
+		},
+		{
+			name: "no implemented guardrail is not enough",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				for i := range inventory.GuardrailProposals {
+					inventory.GuardrailProposals[i].ImplementationState = "ready_for_followup"
+				}
+			},
+			want: "guardrail_proposals missing implemented_in_this_pr guardrail",
+		},
+		{
+			name: "runtime behavior closure claim is invalid",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.Policy.ClaimsRuntimeBehaviorClosure = true
+			},
+			want: "policy claims_runtime_behavior_closure = true, want false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inventory := base
+			inventory.SearchDimensions = append([]routeAuthorityDriftSearchDimension(nil), base.SearchDimensions...)
+			inventory.SeamFamilies = append([]routeAuthorityDriftSeamFamily(nil), base.SeamFamilies...)
+			inventory.GuardrailProposals = append([]routeAuthorityDriftGuardrail(nil), base.GuardrailProposals...)
+			tc.mutate(&inventory)
+			problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
+			if !routeAuthorityProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadRouteAuthorityDriftInventory(t *testing.T, root string) routeAuthorityDriftInventory {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, routeAuthorityDriftInventoryPath))
+	if err != nil {
+		t.Fatalf("read route authority drift inventory: %v", err)
+	}
+	var inventory routeAuthorityDriftInventory
+	if err := yaml.Unmarshal(raw, &inventory); err != nil {
+		t.Fatalf("parse route authority drift inventory yaml: %v", err)
+	}
+	return inventory
+}
+
+func validateRouteAuthorityDriftInventory(root string, inventory routeAuthorityDriftInventory) []string {
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	return validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
+}
+
+func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAuthorityDriftValidationCorpus, inventory routeAuthorityDriftInventory) []string {
+	var problems []string
+	if inventory.Version != 1 {
+		problems = append(problems, fmt.Sprintf("inventory version = %d, want 1", inventory.Version))
+	}
+	if inventory.Kind != "route_authority_drift_inventory" {
+		problems = append(problems, fmt.Sprintf("inventory kind = %q, want route_authority_drift_inventory", inventory.Kind))
+	}
+	if inventory.Issue != 1364 {
+		problems = append(problems, fmt.Sprintf("inventory issue = #%d, want #1364", inventory.Issue))
+	}
+	for _, issue := range []int{1340, 1353} {
+		if !routeAuthorityDriftHasInt(inventory.ParentIssues, issue) {
+			problems = append(problems, fmt.Sprintf("inventory parent_issues missing #%d", issue))
+		}
+	}
+	if inventory.Watchlist != "runtime_operations.delivery_and_replay_ownership" {
+		problems = append(problems, fmt.Sprintf("inventory watchlist = %q, want runtime_operations.delivery_and_replay_ownership", inventory.Watchlist))
+	}
+	problems = append(problems, validateRouteAuthorityDriftPolicy(inventory.Policy)...)
+	problems = append(problems, validateRouteAuthorityDriftSources(root, inventory.Sources)...)
+
+	dimensionsByID := map[string]routeAuthorityDriftSearchDimension{}
+	for _, dimension := range inventory.SearchDimensions {
+		id := strings.TrimSpace(dimension.ID)
+		if id == "" {
+			problems = append(problems, "search_dimension missing id")
+			continue
+		}
+		if _, exists := dimensionsByID[id]; exists {
+			problems = append(problems, fmt.Sprintf("search_dimension %s appears more than once", id))
+		}
+		dimensionsByID[id] = dimension
+		problems = append(problems, validateRouteAuthorityDriftSearchDimension(root, corpus, dimension)...)
+	}
+	for _, id := range requiredRouteAuthorityDriftSearchDimensions() {
+		if _, ok := dimensionsByID[id]; !ok {
+			problems = append(problems, fmt.Sprintf("missing required search_dimension %s", id))
+		}
+	}
+
+	familiesByID := map[string]routeAuthorityDriftSeamFamily{}
+	for _, family := range inventory.SeamFamilies {
+		id := strings.TrimSpace(family.ID)
+		if id == "" {
+			problems = append(problems, "seam_family missing id")
+			continue
+		}
+		if _, exists := familiesByID[id]; exists {
+			problems = append(problems, fmt.Sprintf("seam_family %s appears more than once", id))
+		}
+		familiesByID[id] = family
+		problems = append(problems, validateRouteAuthorityDriftSeamFamily(root, family, dimensionsByID)...)
+	}
+	for _, id := range requiredRouteAuthorityDriftSeamFamilies() {
+		if _, ok := familiesByID[id]; !ok {
+			problems = append(problems, fmt.Sprintf("missing required seam_family %s", id))
+		}
+	}
+	problems = append(problems, validateRouteAuthorityDriftGuardrails(root, inventory.GuardrailProposals)...)
+	if inventory.FollowUpDecision.NewChildRequiredBeforeCoding {
+		problems = append(problems, "follow_up_decision new_child_required_before_coding = true, want false for approved audit slice")
+	}
+	if inventory.FollowUpDecision.RuntimeBehaviorChildRequiredNow {
+		problems = append(problems, "follow_up_decision runtime_behavior_child_required_now = true, want false for approved audit slice")
+	}
+	if strings.TrimSpace(inventory.FollowUpDecision.TrackerState) == "" {
+		problems = append(problems, "follow_up_decision tracker_state missing")
+	}
+	if strings.TrimSpace(inventory.FollowUpDecision.Notes) == "" {
+		problems = append(problems, "follow_up_decision notes missing")
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validateRouteAuthorityDriftPolicy(policy routeAuthorityDriftInventoryPolicy) []string {
+	var problems []string
+	if policy.ClosureLevel != "repo_wide_inventory_and_guardrail_proposal" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want repo_wide_inventory_and_guardrail_proposal", policy.ClosureLevel))
+	}
+	if policy.ClaimsParentClosure {
+		problems = append(problems, "policy claims_parent_closure = true, want false")
+	}
+	if policy.ClaimsRuntimeBehaviorClosure {
+		problems = append(problems, "policy claims_runtime_behavior_closure = true, want false")
+	}
+	if policy.RuntimeBehaviorChangesAllowed {
+		problems = append(problems, "policy runtime_behavior_changes_allowed = true, want false")
+	}
+	if strings.TrimSpace(policy.ExhaustiveRequirement) == "" {
+		problems = append(problems, "policy exhaustive_requirement missing")
+	}
+	for _, fragment := range []string{"producers", "consumers", "interpreters", "test fixtures"} {
+		if !strings.Contains(policy.ExhaustiveRequirement, fragment) {
+			problems = append(problems, fmt.Sprintf("policy exhaustive_requirement missing %q", fragment))
+		}
+	}
+	return problems
+}
+
+func validateRouteAuthorityDriftSources(root string, source routeAuthorityDriftInventorySources) []string {
+	expected := map[string]string{
+		"platform_spec":                 source.PlatformSpec,
+		"route_authority_matrix":        source.RouteAuthorityMatrix,
+		"openrpc_artifact":              source.OpenRPCArtifact,
+		"public_surface_backend_matrix": source.PublicSurfaceBackendMatrix,
+	}
+	var problems []string
+	for name, path := range expected {
+		if strings.TrimSpace(path) == "" {
+			problems = append(problems, fmt.Sprintf("source %s missing", name))
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, filepath.Clean(path))); err != nil {
+			problems = append(problems, fmt.Sprintf("source %s path %s does not exist", name, path))
+		}
+	}
+	if !strings.HasPrefix(source.WatchlistNote, "private:") || !strings.Contains(source.WatchlistNote, "delivery_and_replay_ownership") {
+		problems = append(problems, "source watchlist_note must reference private delivery_and_replay_ownership mapping")
+	}
+	return problems
+}
+
+func validateRouteAuthorityDriftSearchDimension(root string, corpus *routeAuthorityDriftValidationCorpus, dimension routeAuthorityDriftSearchDimension) []string {
+	var problems []string
+	id := strings.TrimSpace(dimension.ID)
+	pattern := strings.TrimSpace(dimension.Pattern)
+	if pattern == "" {
+		return append(problems, fmt.Sprintf("%s search_dimension missing pattern", id))
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return append(problems, fmt.Sprintf("%s search_dimension pattern %q does not compile: %v", id, pattern, err))
+	}
+	if _, ok := allowedRouteAuthorityDriftLayers()[dimension.CanonicalLayer]; !ok {
+		problems = append(problems, fmt.Sprintf("%s canonical_layer %q is not allowed", id, dimension.CanonicalLayer))
+	}
+	matches := routeAuthorityDriftMatchingFiles(corpus, pattern, re)
+	if len(matches) < dimension.MinimumMatchingFiles {
+		problems = append(problems, fmt.Sprintf("%s matched %d files, want at least %d", id, len(matches), dimension.MinimumMatchingFiles))
+	}
+	for _, path := range dimension.RequiredPaths {
+		if strings.TrimSpace(path) == "" {
+			problems = append(problems, fmt.Sprintf("%s required_path missing", id))
+			continue
+		}
+		if !routeAuthorityDriftPathMatches(root, path, re) {
+			problems = append(problems, fmt.Sprintf("%s required_path %s does not match pattern", id, path))
+		}
+	}
+	return problems
+}
+
+func validateRouteAuthorityDriftSeamFamily(root string, family routeAuthorityDriftSeamFamily, dimensions map[string]routeAuthorityDriftSearchDimension) []string {
+	var problems []string
+	id := strings.TrimSpace(family.ID)
+	if _, ok := allowedRouteAuthorityDriftLayers()[family.Layer]; !ok {
+		problems = append(problems, fmt.Sprintf("%s layer %q is not allowed", id, family.Layer))
+	}
+	if _, ok := allowedRouteAuthorityDriftClassifications()[family.Classification]; !ok {
+		problems = append(problems, fmt.Sprintf("%s classification %q is not allowed", id, family.Classification))
+	}
+	if len(family.Paths) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing paths", id))
+	}
+	for _, path := range family.Paths {
+		if _, err := os.Stat(filepath.Join(root, filepath.Clean(path))); err != nil {
+			problems = append(problems, fmt.Sprintf("%s path %s does not exist", id, path))
+		}
+	}
+	if len(family.SearchDimensions) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing search_dimensions", id))
+	}
+	for _, dimension := range family.SearchDimensions {
+		if _, ok := dimensions[dimension]; !ok {
+			problems = append(problems, fmt.Sprintf("%s references unknown search_dimension %s", id, dimension))
+		}
+	}
+	if strings.Contains(family.Layer, "non_authority") && len(family.InvalidAuthority) == 0 {
+		problems = append(problems, fmt.Sprintf("%s non-authority family missing invalid_authority", id))
+	}
+	if strings.TrimSpace(family.Notes) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing notes", id))
+	}
+	return problems
+}
+
+func validateRouteAuthorityDriftGuardrails(root string, guardrails []routeAuthorityDriftGuardrail) []string {
+	var problems []string
+	if len(guardrails) == 0 {
+		return append(problems, "guardrail_proposals missing")
+	}
+	implemented := false
+	readyForFollowup := false
+	for _, guardrail := range guardrails {
+		id := strings.TrimSpace(guardrail.ID)
+		if id == "" {
+			problems = append(problems, "guardrail missing id")
+		}
+		switch guardrail.ImplementationState {
+		case "implemented_in_this_pr":
+			implemented = true
+		case "ready_for_followup":
+			readyForFollowup = true
+		default:
+			problems = append(problems, fmt.Sprintf("%s implementation_state %q is not allowed", id, guardrail.ImplementationState))
+		}
+		if strings.TrimSpace(guardrail.Target) == "" {
+			problems = append(problems, fmt.Sprintf("%s guardrail missing target", id))
+		} else if !strings.Contains(guardrail.Target, "conformance") {
+			problems = append(problems, fmt.Sprintf("%s guardrail target %q must be conformance-backed", id, guardrail.Target))
+		} else if guardrail.ImplementationState == "implemented_in_this_pr" {
+			if _, err := os.Stat(filepath.Join(root, filepath.Clean(guardrail.Target))); err != nil {
+				problems = append(problems, fmt.Sprintf("%s implemented guardrail target %s does not exist", id, guardrail.Target))
+			}
+		}
+		if len(guardrail.Prevents) == 0 {
+			problems = append(problems, fmt.Sprintf("%s guardrail missing prevents", id))
+		}
+	}
+	if !implemented {
+		problems = append(problems, "guardrail_proposals missing implemented_in_this_pr guardrail")
+	}
+	if !readyForFollowup {
+		problems = append(problems, "guardrail_proposals missing ready_for_followup guardrail")
+	}
+	return problems
+}
+
+func routeAuthorityDriftNewValidationCorpus(root string) *routeAuthorityDriftValidationCorpus {
+	return &routeAuthorityDriftValidationCorpus{
+		Files:         routeAuthorityDriftRepoFiles(root),
+		MatchesByExpr: map[string][]string{},
+	}
+}
+
+func routeAuthorityDriftRepoFiles(root string) []routeAuthorityDriftRepoFile {
+	var files []routeAuthorityDriftRepoFile
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "node_modules", "tmp":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !routeAuthorityDriftScannableFile(path) {
+			return nil
+		}
+		if rel, err := filepath.Rel(root, path); err == nil {
+			relPath := filepath.ToSlash(rel)
+			if routeAuthorityDriftSelfAuditFile(relPath) {
+				return nil
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			files = append(files, routeAuthorityDriftRepoFile{Path: relPath, Raw: raw})
+		}
+		return nil
+	})
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+func routeAuthorityDriftMatchingFiles(corpus *routeAuthorityDriftValidationCorpus, pattern string, re *regexp.Regexp) []string {
+	if matches, ok := corpus.MatchesByExpr[pattern]; ok {
+		return matches
+	}
+	var matches []string
+	for _, file := range corpus.Files {
+		if re.Match(file.Raw) {
+			matches = append(matches, file.Path)
+		}
+	}
+	sort.Strings(matches)
+	corpus.MatchesByExpr[pattern] = matches
+	return matches
+}
+
+func routeAuthorityDriftSelfAuditFile(path string) bool {
+	switch path {
+	case routeAuthorityDriftInventoryPath, "internal/runtime/conformance/route_authority_drift_inventory_test.go":
+		return true
+	default:
+		return false
+	}
+}
+
+func routeAuthorityDriftPathMatches(root, path string, re *regexp.Regexp) bool {
+	raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(path)))
+	if err != nil {
+		return false
+	}
+	return re.Match(raw)
+}
+
+func routeAuthorityDriftScannableFile(path string) bool {
+	switch filepath.Ext(path) {
+	case ".go", ".yaml", ".yml", ".json", ".md":
+		return true
+	default:
+		return false
+	}
+}
+
+func routeAuthorityDriftSearchDimensionByID(t *testing.T, inventory *routeAuthorityDriftInventory, id string) *routeAuthorityDriftSearchDimension {
+	t.Helper()
+	for i := range inventory.SearchDimensions {
+		if inventory.SearchDimensions[i].ID == id {
+			return &inventory.SearchDimensions[i]
+		}
+	}
+	t.Fatalf("search dimension %s not found", id)
+	return nil
+}
+
+func routeAuthorityDriftSearchDimensionsExcept(dimensions []routeAuthorityDriftSearchDimension, exclude string) []routeAuthorityDriftSearchDimension {
+	out := make([]routeAuthorityDriftSearchDimension, 0, len(dimensions))
+	for _, dimension := range dimensions {
+		if dimension.ID != exclude {
+			out = append(out, dimension)
+		}
+	}
+	return out
+}
+
+func routeAuthorityDriftHasInt(values []int, want int) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func requiredRouteAuthorityDriftSearchDimensions() []string {
+	return []string{
+		"event_deliveries",
+		"delivery_route_model",
+		"route_plan",
+		"flow_instance",
+		"event_name_type",
+		"semantic_scope",
+		"entity_context",
+		"run_source_event_context",
+		"route_event_key_derivation",
+		"target_set",
+		"target_context",
+		"workflow_runtime_carrier",
+		"internal_subscriptions",
+		"event_receipts",
+		"settlement_backfill",
+		"replay_scope",
+		"handler_descriptor_lookup",
+		"public_readback",
+		"delivery_target_route",
+		"delivery_authority_writers",
+		"execution_admission_settlement",
+		"publish_plan_consumers",
+	}
+}
+
+func requiredRouteAuthorityDriftSeamFamilies() []string {
+	return []string{
+		"spec_route_authority_contract",
+		"event_context_inputs",
+		"route_topology_and_table",
+		"eventbus_route_plan_authority",
+		"durable_delivery_authority_writers",
+		"workflow_node_execution_admission",
+		"live_carriers_internal_subscriptions",
+		"receipts_settlement_backfill",
+		"replay_recovery_and_fork_consumers",
+		"public_operator_readback_projection",
+		"store_and_cli_direct_sql_fixtures",
+		"catalog_and_fixture_route_behavior",
+		"route_authority_conformance_artifacts",
+	}
+}
+
+func allowedRouteAuthorityDriftLayers() map[string]struct{} {
+	return map[string]struct{}{
+		"spec_authority":                    {},
+		"event_context":                     {},
+		"route_topology":                    {},
+		"route_plan_authority":              {},
+		"route_plan_consumers":              {},
+		"durable_delivery_authority":        {},
+		"execution_admission":               {},
+		"live_dispatch_non_authority":       {},
+		"completion_evidence_non_authority": {},
+		"replay_recovery_consumers":         {},
+		"public_projection_non_authority":   {},
+		"invalid_old_authority":             {},
+		"test_fixture_semantics":            {},
+		"conformance_guardrails":            {},
+	}
+}
+
+func allowedRouteAuthorityDriftClassifications() map[string]struct{} {
+	return map[string]struct{}{
+		"canonical_owner":                       {},
+		"valid_consumer":                        {},
+		"non_authoritative_observer_projection": {},
+		"invalid_old_authority_path":            {},
+		"separate_semantic_concept":             {},
+		"split_open_sibling":                    {},
+	}
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,0 +1,456 @@
+version: 1
+kind: route_authority_drift_inventory
+issue: 1364
+parent_issues: [1340, 1353]
+watchlist: runtime_operations.delivery_and_replay_ownership
+policy:
+  closure_level: repo_wide_inventory_and_guardrail_proposal
+  claims_parent_closure: false
+  claims_runtime_behavior_closure: false
+  runtime_behavior_changes_allowed: false
+  exhaustive_requirement: >
+    This artifact inventories route-authority producers, consumers,
+    interpreters, observers, projections, replay/recovery paths, store
+    readers/writers, public readback, and test fixtures across the repository.
+    It explicitly covers event name/type, semantic scope, entity/run/source
+    event context, and route/event-key derivation helpers. It must not be used
+    as proof that runtime behavior changed.
+sources:
+  platform_spec: platform-spec.yaml
+  route_authority_matrix: internal/runtime/conformance/testdata/route_authority_matrix.yaml
+  openrpc_artifact: openrpc.json
+  public_surface_backend_matrix: internal/apiv1/testdata/public_surface_backend_matrix.yaml
+  watchlist_note: private:/Users/youmew/dev/swarm-docs/docs/watchlists/runtime-operations.yaml#delivery_and_replay_ownership
+search_dimensions:
+  - id: event_deliveries
+    pattern: '\bevent_deliveries\b|EventDeliveries'
+    minimum_matching_files: 110
+    required_paths:
+      - platform-spec.yaml
+      - internal/store/event_receipt_store.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+      - cmd/swarm/main_test.go
+    canonical_layer: durable_delivery_authority
+  - id: delivery_route_model
+    pattern: '\bDeliveryRoute\b|delivery routes|delivery route'
+    minimum_matching_files: 23
+    required_paths:
+      - internal/events/types.go
+      - internal/runtime/bus/eventbus.go
+      - internal/store/events.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+    canonical_layer: route_plan_authority
+  - id: route_plan
+    pattern: '\bRoutePlan\b|route_plan|route plan'
+    minimum_matching_files: 9
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    canonical_layer: route_plan_authority
+  - id: flow_instance
+    pattern: 'flow_instance|FlowInstance|flow instance|flow-instance'
+    minimum_matching_files: 282
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/pipeline/workflow_instance_activation.go
+      - internal/store/sqlite_runtime.go
+      - tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
+    canonical_layer: event_context
+  - id: event_name_type
+    pattern: 'event_name|event type|EventType|EventName|\.Type|TriggerEventType'
+    minimum_matching_files: 369
+    required_paths:
+      - platform-spec.yaml
+      - openrpc.json
+      - internal/events/types.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/apiv1/operator_event_publish.go
+      - cmd/swarm/event_publish.go
+    canonical_layer: event_context
+  - id: semantic_scope
+    pattern: 'EventScope|semantic scope|inferEventScope|Scope\(\)|ScopeEntity|ScopeFlow|ScopeGlobal|scope inference'
+    minimum_matching_files: 42
+    required_paths:
+      - platform-spec.yaml
+      - internal/events/types.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/bus/delivery_planner_test.go
+    canonical_layer: event_context
+  - id: entity_context
+    pattern: 'entity_id|EntityID|EffectiveEntityID'
+    minimum_matching_files: 704
+    required_paths:
+      - platform-spec.yaml
+      - openrpc.json
+      - internal/events/types.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/apiv1/operator_event_publish.go
+      - cmd/swarm/event_publish_test.go
+    canonical_layer: event_context
+  - id: run_source_event_context
+    pattern: 'run_id|RunID|source_event_id|SourceEventID|ParentEventID|source event'
+    minimum_matching_files: 348
+    required_paths:
+      - platform-spec.yaml
+      - openrpc.json
+      - internal/events/types.go
+      - internal/store/events.go
+      - internal/apiv1/operator_event_publish.go
+      - cmd/swarm/event_publish.go
+    canonical_layer: event_context
+  - id: route_event_key_derivation
+    pattern: 'routedEventKeysForPlan|concreteFlowInstanceEventKey|eventContextLocalEventForFlowInstance|route key|event key|eventKeys|routeKey'
+    minimum_matching_files: 10
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/bus/delivery_planner_test.go
+    canonical_layer: route_topology
+  - id: target_set
+    pattern: '\btarget_set\b'
+    minimum_matching_files: 11
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+    canonical_layer: event_context
+  - id: target_context
+    pattern: '(?i)target|delivery_target_route|target_set'
+    minimum_matching_files: 260
+    required_paths:
+      - platform-spec.yaml
+      - internal/events/types.go
+      - internal/runtime/bus/route_plan.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+    canonical_layer: event_context
+  - id: workflow_runtime_carrier
+    pattern: 'workflow-runtime'
+    minimum_matching_files: 16
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    canonical_layer: live_dispatch_non_authority
+  - id: internal_subscriptions
+    pattern: '\bSubscribeInternal\b|agentChans|internal subscription'
+    minimum_matching_files: 12
+    required_paths:
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_publish_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+    canonical_layer: live_dispatch_non_authority
+  - id: event_receipts
+    pattern: '\bevent_receipts\b'
+    minimum_matching_files: 63
+    required_paths:
+      - platform-spec.yaml
+      - internal/store/event_receipt_store.go
+      - internal/store/sqlite_schema.go
+      - cmd/swarm/main_test.go
+    canonical_layer: completion_evidence_non_authority
+  - id: settlement_backfill
+    pattern: '(?i)settlement|backfill|SettleDelivery'
+    minimum_matching_files: 18
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/pipeline/system_node_receipt_store.go
+    canonical_layer: completion_evidence_non_authority
+  - id: replay_scope
+    pattern: 'replay_scope|replay-scope|replay scope|CommittedReplayScope'
+    minimum_matching_files: 37
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/committed_replay_scope.go
+      - internal/runtime/bus/outbox.go
+      - internal/store/run_fork_replay_resume_admission.go
+    canonical_layer: replay_recovery_consumers
+  - id: handler_descriptor_lookup
+    pattern: '(?i)handler lookup|descriptor lookup|active descriptor'
+    minimum_matching_files: 4
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    canonical_layer: invalid_old_authority
+  - id: public_readback
+    pattern: 'LoadOperatorEvent|eventPublishResultFromStore|event\.list|event\.get|event\.subscribe'
+    minimum_matching_files: 10
+    required_paths:
+      - platform-spec.yaml
+      - openrpc.json
+      - internal/apiv1/operator_event_publish.go
+      - internal/store/operator_observability_read_surface.go
+    canonical_layer: public_projection_non_authority
+  - id: delivery_target_route
+    pattern: 'delivery_target_route'
+    minimum_matching_files: 7
+    required_paths:
+      - platform-spec.yaml
+      - internal/store/sqlite_runtime_delivery_replay.go
+      - internal/store/events.go
+    canonical_layer: durable_delivery_authority
+  - id: delivery_authority_writers
+    pattern: 'InsertEventDelivery|PersistEventWithDelivery|PublishPersistedRecipients'
+    minimum_matching_files: 23
+    required_paths:
+      - internal/store/events.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/template_instance_delivery_test.go
+    canonical_layer: durable_delivery_authority
+  - id: execution_admission_settlement
+    pattern: 'MarkSystemNodeProcessed|SettleDelivery|SystemNodeProcessed|delivery authority'
+    minimum_matching_files: 7
+    required_paths:
+      - internal/runtime/pipeline/node_system_runner.go
+      - internal/runtime/pipeline/system_node_receipt_store.go
+      - internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+    canonical_layer: execution_admission
+  - id: publish_plan_consumers
+    pattern: 'CheckPublishRecipientPlan|PublishRecipientPlanMaterializer|PublishTx|publishDeferred'
+    minimum_matching_files: 7
+    required_paths:
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/outbox.go
+    canonical_layer: route_plan_consumers
+seam_families:
+  - id: spec_route_authority_contract
+    layer: spec_authority
+    classification: canonical_owner
+    paths:
+      - platform-spec.yaml
+      - openrpc.json
+    search_dimensions: [route_plan, event_deliveries, public_readback]
+    notes: >
+      The authoritative runtime contract defines RoutePlan as publish-time typed
+      authority, event_deliveries as durable authority, runtime callback
+      context normalization, public readback as projection, and replay/redelivery
+      boundaries.
+  - id: event_context_inputs
+    layer: event_context
+    classification: canonical_owner
+    paths:
+      - internal/events/types.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/pipeline/workflow_instance_activation.go
+      - internal/apiv1/operator_event_publish.go
+      - cmd/swarm/main_test.go
+    search_dimensions: [event_name_type, semantic_scope, entity_context, run_source_event_context, flow_instance, target_set, target_context]
+    notes: >
+      Event producers and adapters stamp event name/type, semantic scope,
+      flow_instance, target, target_set, entity, run, and source event context.
+      They are inputs to planning, not route authority by themselves.
+  - id: route_topology_and_table
+    layer: route_topology
+    classification: canonical_owner
+    paths:
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [route_plan, route_event_key_derivation, event_name_type, semantic_scope, flow_instance, workflow_runtime_carrier]
+    notes: >
+      Route tables, routing rules, and route/event-key derivation helpers own
+      semantic subscriber facts. They feed RoutePlan and must not be replaced by
+      live subscriber or handler lookup.
+  - id: eventbus_route_plan_authority
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/outbox.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+    search_dimensions: [route_plan, route_event_key_derivation, event_name_type, delivery_route_model, publish_plan_consumers]
+    notes: >
+      EventBus owns the canonical RoutePlan model, typed delivery intents, and
+      materializers. Publish, preflight, transactional, deferred, and outbox
+      paths consume this owner.
+  - id: durable_delivery_authority_writers
+    layer: durable_delivery_authority
+    classification: canonical_owner
+    paths:
+      - internal/store/events.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+      - internal/store/event_delivery_routes_test.go
+      - internal/store/postgres.go
+      - internal/store/sqlite_schema.go
+    search_dimensions: [event_deliveries, delivery_route_model, delivery_authority_writers, delivery_target_route]
+    notes: >
+      Store writers persist typed delivery authority and delivery targets. They
+      are the physical sink, not independent route planners.
+  - id: workflow_node_execution_admission
+    layer: execution_admission
+    classification: valid_consumer
+    paths:
+      - internal/runtime/pipeline/workflow_nodes.go
+      - internal/runtime/pipeline/node_system_runner.go
+      - internal/runtime/pipeline/system_node_receipt_store.go
+      - internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+    search_dimensions: [event_deliveries, execution_admission_settlement]
+    notes: >
+      Workflow-node execution consumes committed typed node delivery authority
+      and fails closed when authority is missing. It must not produce route
+      authority.
+  - id: live_carriers_internal_subscriptions
+    layer: live_dispatch_non_authority
+    classification: non_authoritative_observer_projection
+    paths:
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/eventbus_publish_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [workflow_runtime_carrier, internal_subscriptions]
+    invalid_authority:
+      - workflow-runtime carrier row
+      - live internal subscription state
+      - current EventBus channel state
+    notes: >
+      Carriers and live subscriptions wake consumers after authority exists.
+      They must not create, replace, or repair typed workflow-node delivery
+      authority.
+  - id: receipts_settlement_backfill
+    layer: completion_evidence_non_authority
+    classification: non_authoritative_observer_projection
+    paths:
+      - internal/store/event_receipt_store.go
+      - internal/store/manager_retry_policy_test.go
+      - internal/runtime/pipeline/system_node_receipt_store.go
+      - internal/runtime/pipeline/node_system_runner_completion_test.go
+      - platform-spec.yaml
+    search_dimensions: [event_receipts, settlement_backfill, execution_admission_settlement]
+    invalid_authority:
+      - event_receipts
+      - processed receipts
+      - settlement
+      - backfill
+      - retry counters
+    notes: >
+      Receipts and settlement are completion evidence. They cannot authorize a
+      handler or backfill missing pre-execution node delivery rows.
+  - id: replay_recovery_and_fork_consumers
+    layer: replay_recovery_consumers
+    classification: valid_consumer
+    paths:
+      - internal/runtime/bus/committed_replay_scope.go
+      - internal/runtime/bus/outbox.go
+      - internal/runtime/bus/sweeper_test.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/runforkexecution/recipient_planning.go
+      - internal/store/run_fork_delivery_event_replay.go
+      - internal/store/run_fork_selected_contract_execution.go
+      - internal/store/run_fork_replay_resume_admission.go
+    search_dimensions: [event_deliveries, replay_scope]
+    invalid_authority:
+      - replay markers alone
+      - source event_deliveries as fresh fork truth
+      - current live subscriptions as recovery truth
+    notes: >
+      Replay, recovery, and fork paths consume persisted RoutePlan output or an
+      explicitly gated replay/fork owner. Source rows are lineage or blockers
+      unless their owner produces fresh authority.
+  - id: public_operator_readback_projection
+    layer: public_projection_non_authority
+    classification: non_authoritative_observer_projection
+    paths:
+      - internal/apiv1/operator_event_publish.go
+      - internal/apiv1/operator_event_replay.go
+      - internal/apiv1/operator_read.go
+      - internal/store/operator_observability_read_surface.go
+      - internal/dashboard/server/observability_sql.go
+      - cmd/swarm/main_test.go
+      - openrpc.json
+    search_dimensions: [public_readback, event_name_type, entity_context, run_source_event_context, event_deliveries, event_receipts]
+    invalid_authority:
+      - API readback
+      - CLI readback
+      - dashboard readback
+      - OpenRPC projection
+      - delivery count reconstruction
+    notes: >
+      Public/operator surfaces project persisted delivery identity and status.
+      They must not re-plan subscribers or fabricate delivery rows.
+  - id: store_and_cli_direct_sql_fixtures
+    layer: test_fixture_semantics
+    classification: valid_consumer
+    paths:
+      - cmd/swarm/main_test.go
+      - internal/store/run_fork_selected_contract_execution_mutation_test.go
+      - internal/store/manager_retry_policy_test.go
+      - internal/store/run_control_test.go
+      - internal/runtime/template_instance_delivery_test.go
+    search_dimensions: [event_name_type, entity_context, run_source_event_context, event_deliveries, event_receipts, delivery_authority_writers]
+    notes: >
+      Direct SQL fixtures remain proof consumers only when they assert typed
+      semantic recipient identity and do not redefine route authority from row
+      counts alone.
+  - id: catalog_and_fixture_route_behavior
+    layer: test_fixture_semantics
+    classification: valid_consumer
+    paths:
+      - internal/runtime/cataloge2e/README.md
+      - internal/runtime/cataloge2e/runtime_harness_test.go
+      - internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+      - internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+      - internal/runtime/swarmflowtest/catalog_runner_test.go
+      - tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
+      - tests/tier5-flow-lifecycle/test-create-flow-instance/expected.yaml
+    search_dimensions: [flow_instance, event_deliveries, replay_scope]
+    notes: >
+      Catalog and fixture proofs are broader behavior consumers. Required PR
+      smoke must cite focused rows; full route behavior stays in named full
+      conformance/catalog tiers.
+  - id: route_authority_conformance_artifacts
+    layer: conformance_guardrails
+    classification: canonical_owner
+    paths:
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+      - internal/runtime/conformance/route_authority_matrix_test.go
+      - internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+    search_dimensions: [route_plan, event_deliveries, workflow_runtime_carrier]
+    notes: >
+      The matrix proves selected route-authority rows. This inventory proves
+      the repo-wide drift audit boundary and identifies guardrails that should
+      prevent future narrow closure.
+guardrail_proposals:
+  - id: drift_inventory_search_dimension_guard
+    implementation_state: implemented_in_this_pr
+    target: internal/runtime/conformance/route_authority_drift_inventory_test.go
+    prevents:
+      - deleting required search dimensions from the exhaustive inventory
+      - letting required route-authority file families disappear from the audit
+      - treating a package-local audit as #1364 closure
+  - id: route_authority_matrix_active_tracker_guard
+    implementation_state: ready_for_followup
+    target: internal/runtime/conformance/route_authority_matrix_test.go
+    prevents:
+      - marking parent route-authority closure while #1364-class drift inventory remains open
+      - covering rows without a matrix or inventory proof reference
+  - id: negative_authority_static_scan
+    implementation_state: ready_for_followup
+    target: internal/runtime/conformance
+    prevents:
+      - workflow-runtime carriers, live subscriptions, receipts, replay markers, or readback from becoming execution authority
+      - new helper names that imply route authority outside EventContext or RoutePlan owners
+  - id: direct_sql_fixture_classification_guard
+    implementation_state: ready_for_followup
+    target: internal/runtime/conformance
+    prevents:
+      - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
+      - store fixtures from becoming undocumented route-authority interpreters
+follow_up_decision:
+  tracker_state: "#1340 and #1353 remain sufficient parent trackers."
+  new_child_required_before_coding: false
+  runtime_behavior_child_required_now: false
+  notes: >
+    No runtime behavior is selected in #1364. Concrete bypasses discovered
+    after this inventory must open or update a child issue and receive an
+    independent implementation gate before coding.


### PR DESCRIPTION
Closes #1364

## Summary

Adds a repo-wide route-authority drift inventory artifact and a conformance guardrail that validates the inventory cannot collapse back to a narrow package-local audit.

This PR intentionally makes no runtime behavior change. It closes only the approved `repo_wide_route_authority_drift_inventory_and_guardrails` audit/guardrail slice.

## Governing Refs / Context

- `platform-spec.yaml` route-authority contract around EventContext inputs, RoutePlan authority, event_deliveries durable authority, workflow-node execution admission, public readback projection, replay/fork consumers, and invalid non-authority evidence.
- `internal/runtime/conformance/testdata/route_authority_matrix.yaml`
- `internal/apiv1/testdata/public_surface_backend_matrix.yaml`
- `openrpc.json`
- #1364 approved gate comment: `repo_wide_route_authority_drift_inventory_and_guardrails`
- Parent context: #1340 and #1353
- Watchlist mapping: `runtime_operations.delivery_and_replay_ownership`

## Semantic Migration

No production semantic migration is performed in this PR.

- New canonical audit/guardrail artifact: `internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml`
- Old producer/reader/writer path invalidated: none by code change; the artifact classifies non-authoritative route evidence such as live carriers, receipts, settlement/backfill, replay markers, public readback, and direct SQL fixtures.
- Production paths checked for surviving old behavior: inventoried as seams only; no runtime behavior was changed under this gate.
- Migration complete: complete for the approved inventory/guardrail slice only; route runtime parent work remains tracked by #1340/#1353 and any concrete children.

## Proof

- `go test ./internal/runtime/conformance -run TestRouteAuthorityDriftInventory -count=1`
- `go test ./internal/runtime/conformance -run 'TestRouteAuthorityDriftInventory|TestRouteAuthorityMatrix' -count=1`
- `go test ./internal/runtime/conformance -count=1`
- `go test ./...`
