### PR TITLE
[agent-f][issue #1366] Preserve flow activation auto-emit lineage

### DIFF
--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -89,6 +89,9 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		return err
 	}
 	if strings.TrimSpace(autoEmitName) != "" {
+		if triggerEventID := strings.TrimSpace(req.TriggerEvent.ID); triggerEventID != "" {
+			autoEmitEvent.ParentEventID = triggerEventID
+		}
 		if runID := runtimecorrelation.RunIDFromContext(ctx); runID != "" {
 			autoEmitEvent.RunID = runID
 		}

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -383,6 +383,16 @@ func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, temp
 	}
 }
 
+func testFlowActivationTriggerEvent(eventID string) events.Event {
+	return events.Event{
+		ID:          strings.TrimSpace(eventID),
+		Type:        events.EventType("spawn.requested"),
+		SourceAgent: "spawner",
+		Payload:     json.RawMessage(`{}`),
+		CreatedAt:   time.Now().UTC(),
+	}
+}
+
 func decodeFlowActivationEventPayload(t *testing.T, event events.Event) map[string]any {
 	t.Helper()
 	var payload map[string]any
@@ -500,9 +510,12 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
 	const runID = "11111111-1111-1111-1111-111111111115"
+	const triggerEventID = "33333333-3333-3333-3333-333333333333"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.TriggerEvent = testFlowActivationTriggerEvent(triggerEventID)
 
-	err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
+	err := am.ActivateFlowInstance(ctx, req)
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -521,6 +534,29 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	}
 	if got := strings.TrimSpace(autoEmit.RunID); got != runID {
 		t.Fatalf("published run_id = %q, want active run %q", got, runID)
+	}
+	if got := strings.TrimSpace(autoEmit.ParentEventID); got != triggerEventID {
+		t.Fatalf("published parent_event_id = %q, want trigger event %q", got, triggerEventID)
+	}
+	if got, _ := autoEmit.ContextMap("")["source_event_id"].(string); got != triggerEventID {
+		t.Fatalf("event context source_event_id = %q, want trigger event %q", got, triggerEventID)
+	}
+}
+
+func TestActivateFlowInstanceAutoEmitDoesNotInventLineageWithoutTrigger(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundle("task.started")
+
+	if err := am.ActivateFlowInstance(context.Background(), testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	event := findPublishedFlowActivationEvent(t, bus, "review/inst-1/task.started")
+	if got := strings.TrimSpace(event.ParentEventID); got != "" {
+		t.Fatalf("parent_event_id = %q, want empty without concrete trigger", got)
+	}
+	if _, ok := event.ContextMap("")["source_event_id"]; ok {
+		t.Fatalf("event context included source_event_id without concrete trigger: %#v", event.ContextMap(""))
 	}
 }
 
@@ -563,6 +599,39 @@ func TestActivateFlowInstanceAutoEmitPublishesConfigPayloadWithoutActivationCont
 	}
 	if got := event.FlowInstance(); got != "review/inst-1" {
 		t.Fatalf("auto-emit flow_instance = %q, want review/inst-1", got)
+	}
+}
+
+func TestActivateFlowInstanceAutoEmitKeepsPayloadSourceEventIDNonAuthoritative(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundleWithAutoEmitEntry("component.scaffold.start", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"source_event_id": {Type: "string"},
+			},
+		},
+		Required: []string{"source_event_id"},
+	})
+	const triggerEventID = "44444444-4444-4444-4444-444444444444"
+	const payloadSourceEventID = "business-payload-source"
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.TriggerEvent = testFlowActivationTriggerEvent(triggerEventID)
+	req.Config = map[string]any{"source_event_id": payloadSourceEventID}
+
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	event := findPublishedFlowActivationEvent(t, bus, "review/inst-1/component.scaffold.start")
+	if got := strings.TrimSpace(event.ParentEventID); got != triggerEventID {
+		t.Fatalf("parent_event_id = %q, want trigger event %q", got, triggerEventID)
+	}
+	if got, _ := event.ContextMap("")["source_event_id"].(string); got != triggerEventID {
+		t.Fatalf("event context source_event_id = %q, want trigger event %q", got, triggerEventID)
+	}
+	payload := decodeFlowActivationEventPayload(t, event)
+	if got := payload["source_event_id"]; got != payloadSourceEventID {
+		t.Fatalf("payload source_event_id = %#v, want business payload value %q", got, payloadSourceEventID)
 	}
 }
 
@@ -630,11 +699,14 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("task.started")
 	const runID = "22222222-2222-2222-2222-222222222215"
+	const triggerEventID = "55555555-5555-5555-5555-555555555555"
 	postCommit := make([]func(), 0, 1)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommit)
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.TriggerEvent = testFlowActivationTriggerEvent(triggerEventID)
 
-	err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1"))
+	err := am.ActivateFlowInstance(ctx, req)
 	if err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
@@ -654,6 +726,9 @@ func TestActivateFlowInstanceQueuesAutoEmitUntilPostCommitWhenAvailable(t *testi
 	}
 	if got := strings.TrimSpace(bus.published[0].RunID); got != runID {
 		t.Fatalf("auto-emitted run_id = %q, want active run %q", got, runID)
+	}
+	if got := strings.TrimSpace(bus.published[0].ParentEventID); got != triggerEventID {
+		t.Fatalf("auto-emitted parent_event_id = %q, want trigger event %q", got, triggerEventID)
 	}
 }
 


### PR DESCRIPTION
Closes #1366.

## Summary

- Stamps flow activation `auto_emit_on_create` events with `ParentEventID` from `FlowInstanceActivationRequest.TriggerEvent.ID` before immediate or queued publish.
- Adds focused manager tests for immediate lineage, queued post-commit lineage, no-trigger behavior, and payload `source_event_id` remaining non-authoritative business data.
- Keeps #1367 delivery/replay timeout behavior and #1368 public `flow_instance` route-context injection out of scope.

## Governing refs / context

Exact spec authority exists in `platform-spec.yaml`:

- envelope split: runtime-owned envelope fields such as `source_event_id` are platform-populated and consumed through `event.*`, not payload fields;
- `dynamic_instance_lifecycle.auto_emit`: `auto_emit_on_create` is runtime-produced after instance startup;
- `run_model.lineage`: `source_event_id` is the direct causal parent event and reconstructs the causal chain;
- `auto_emit_on_create_surface`: runtime owns auto-emit payload construction and envelope attachment;
- `event.publish`: public `source_event_id` is external ingress lineage and persists as `events.source_event_id / ParentEventID`.

Approved gate: #1366 `Pre-Implementation Coverage Audit` and independent failure-class gate approved as first slice.

## Semantic migration / ownership

New canonical owner for this slice:

- `FlowInstanceActivationRequest.TriggerEvent.ID` is the activation trigger identity.
- `AgentManager.ActivateFlowInstance` compiles that trigger into the auto-emitted event's `ParentEventID` before publish.
- Store persistence continues to compile `events.Event.ParentEventID` to durable `events.source_event_id`.

Old invalid paths checked:

- payload `source_event_id` remains business data only and does not satisfy platform lineage;
- route metadata / flow instance / entity context are not causal parent proof;
- runtime correlation context fallback is not used as the selected owner, especially because queued post-commit publish uses `context.Background()`;
- readback/store consumers are not changed to reconstruct missing lineage.

Migration completeness:

- Complete for the approved class: flow activation `auto_emit_on_create` events emitted from a concrete trigger now carry the trigger parent in both immediate and queued publish paths.
- Broader typed event-construction architecture remains tracked separately in #1370.

## Proof

Targeted:

- `go test ./internal/runtime/manager -run 'TestActivateFlowInstance(PublishesAutoEmitEvent|AutoEmitDoesNotInventLineageWithoutTrigger|AutoEmitKeepsPayloadSourceEventIDNonAuthoritative|AutoEmitPublishesConfigPayloadWithoutActivationContext|QueuedAutoEmitUsesProjectedConfigPayload|QueuesAutoEmitUntilPostCommitWhenAvailable)' -count=1 -v`
- `go test ./internal/store -run TestPostgresStore_AppendEvent_InheritsParentRunID -count=1 -v`
- `go test ./internal/runtime/manager -count=1`
- `go test ./internal/runtime/pipeline -run TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter -count=1 -v`
- `go test ./internal/runtime/conformance -run 'TestRouteAuthorityMatrix|TestRouteAuthorityDriftInventory' -count=1 -v`

Full suite:

- `go test ./...`
