### PR TITLE
[agent-b][issue #1369] Align runtime log source parity

### DIFF
--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -468,12 +468,13 @@ func writeRuntimeLogListResult(out io.Writer, result runtimeLogListResult) {
 		fmt.Fprintln(out, "No runtime logs match the filter.")
 		return
 	}
-	fmt.Fprintln(out, "TIME\tLEVEL\tCOMPONENT\tSOURCE\tRUN\tENTITY\tSESSION\tERROR\tMESSAGE")
+	fmt.Fprintln(out, "TIME\tLEVEL\tCOMPONENT\tACTION\tSOURCE\tRUN\tENTITY\tSESSION\tERROR\tMESSAGE")
 	for _, log := range result.Logs {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			log.TS,
 			log.Level,
 			log.Component,
+			runtimeLogDash(runtimeLogAction(log)),
 			log.Source,
 			runtimeLogDash(log.RunID),
 			runtimeLogDash(log.EntityID),
@@ -496,8 +497,11 @@ func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry) {
 		"ts=" + log.TS,
 		"level=" + log.Level,
 		"component=" + log.Component,
-		"source=" + log.Source,
 	}
+	if action := runtimeLogAction(log); action != "" {
+		fields = append(fields, "action="+action)
+	}
+	fields = append(fields, "source="+log.Source)
 	if log.RunID != "" {
 		fields = append(fields, "run_id="+log.RunID)
 	}
@@ -531,6 +535,14 @@ func runtimeLogDash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+func runtimeLogAction(log runtimeLogEntry) string {
+	if len(log.Details) == 0 {
+		return ""
+	}
+	action, _ := log.Details["action"].(string)
+	return strings.TrimSpace(action)
 }
 
 func runtimeLogMessage(log runtimeLogEntry) string {

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -74,7 +74,7 @@ func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"TIME", "log message", "run-1", "entity-1", "session-1", "DELIVERY_FAILED", "next_cursor=log-cursor-2"} {
+	for _, want := range []string{"TIME", "ACTION", "delivery_failed", "log message", "run-1", "entity-1", "session-1", "DELIVERY_FAILED", "next_cursor=log-cursor-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -128,7 +128,7 @@ func TestLogsFollowUsesRuntimeSubscribeLogsV1WS(t *testing.T) {
 	if !reflect.DeepEqual(req.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
 	}
-	for _, want := range []string{"log log_id=log-live-1", "run_id=run-1", "message=log message", "details={\"attempt\":2}"} {
+	for _, want := range []string{"log log_id=log-live-1", "action=delivery_failed", "run_id=run-1", "message=log message", "details={\"action\":\"delivery_failed\",\"attempt\":2}"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -293,6 +293,32 @@ func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantCode:   3,
 			wantStderr: "message is required",
 		},
+		{
+			name: "malformed log row missing source exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				log := validRuntimeLogEntry("log-1")
+				delete(log, "source")
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"logs": []any{log}})
+			},
+			wantCode:   3,
+			wantStderr: "source is required",
+		},
+		{
+			name: "malformed log row blank source exits three",
+			args: []string{"logs"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				log := validRuntimeLogEntry("log-1")
+				log["source"] = " "
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"logs": []any{log}})
+			},
+			wantCode:   3,
+			wantStderr: "source is required",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -345,6 +371,17 @@ func TestLogsFollowMalformedWSFailsClosed(t *testing.T) {
 			},
 			wantStderr: "message is required",
 		},
+		{
+			name: "malformed notification blank source",
+			logs: []map[string]any{
+				func() map[string]any {
+					log := validRuntimeLogEntry("log-1")
+					log["source"] = " "
+					return log
+				}(),
+			},
+			wantStderr: "source is required",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -364,6 +401,36 @@ func TestLogsFollowMalformedWSFailsClosed(t *testing.T) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
 			}
 		})
+	}
+}
+
+func TestLogsRenderMissingActionGracefully(t *testing.T) {
+	message := "without action"
+	log := runtimeLogEntry{
+		LogID:     "log-no-action",
+		TS:        "2026-05-19T10:00:01Z",
+		Level:     "info",
+		Component: "scheduler",
+		Source:    "runtime",
+		Message:   &message,
+		Details:   map[string]any{"attempt": float64(1)},
+	}
+
+	var snapshot bytes.Buffer
+	writeRuntimeLogListResult(&snapshot, runtimeLogListResult{Logs: []runtimeLogEntry{log}})
+	for _, want := range []string{"ACTION", "scheduler\t-\truntime", "without action"} {
+		if !strings.Contains(snapshot.String(), want) {
+			t.Fatalf("snapshot missing %q:\n%s", want, snapshot.String())
+		}
+	}
+
+	var follow bytes.Buffer
+	writeRuntimeLogFollowEntry(&follow, log)
+	if strings.Contains(follow.String(), "action=") {
+		t.Fatalf("follow = %q, want no action field", follow.String())
+	}
+	if !strings.Contains(follow.String(), "source=runtime") {
+		t.Fatalf("follow = %q, want source", follow.String())
 	}
 }
 
@@ -509,6 +576,7 @@ func validRuntimeLogEntry(logID string) map[string]any {
 		"message":    "log message",
 		"details": map[string]any{
 			"attempt": 2,
+			"action":  "delivery_failed",
 		},
 	}
 }

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -43,6 +43,22 @@ func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	}
 	if rows, _ := asMap(t, logs.Result)["logs"].([]any); len(rows) != 1 || asMap(t, rows[0])["log_id"] != fixture.logID {
 		t.Fatalf("runtime.logs rows = %#v, want log %s", asMap(t, logs.Result)["logs"], fixture.logID)
+	} else if got := asMap(t, rows[0])["source"]; got != "runtime" {
+		t.Fatalf("runtime.logs source = %#v, want runtime", got)
+	}
+	matchingSourceLogs := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"logs-source","method":"runtime.logs","params":{"run_id":%q,"component":"scheduler","level":"warn","source":"runtime","limit":10}}`, fixture.runID))
+	if matchingSourceLogs.Error != nil {
+		t.Fatalf("runtime.logs source match error = %#v", matchingSourceLogs.Error)
+	}
+	if rows, _ := asMap(t, matchingSourceLogs.Result)["logs"].([]any); len(rows) != 1 || asMap(t, rows[0])["log_id"] != fixture.logID {
+		t.Fatalf("runtime.logs source match rows = %#v, want log %s", asMap(t, matchingSourceLogs.Result)["logs"], fixture.logID)
+	}
+	nonmatchingSourceLogs := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"logs-source-miss","method":"runtime.logs","params":{"run_id":%q,"component":"scheduler","level":"warn","source":"agent-1","limit":10}}`, fixture.runID))
+	if nonmatchingSourceLogs.Error != nil {
+		t.Fatalf("runtime.logs source miss error = %#v", nonmatchingSourceLogs.Error)
+	}
+	if rows, _ := asMap(t, nonmatchingSourceLogs.Result)["logs"].([]any); len(rows) != 0 {
+		t.Fatalf("runtime.logs source miss rows = %#v, want none", rows)
 	}
 
 	server := httptest.NewServer(handler)
@@ -59,12 +75,23 @@ func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 		"filter":       map[string]any{"event_name": []any{"trace.visible"}},
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}, "event_id", fixture.eventID)
-	assertSQLiteSubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
+	logNotification := assertSQLiteSubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
 		"run_id":       fixture.runID,
 		"component":    "scheduler",
 		"level":        "warn",
+		"source":       "runtime",
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}, "log_id", fixture.logID)
+	if got := logNotification["source"]; got != "runtime" {
+		t.Fatalf("runtime.subscribe_logs source = %#v, want runtime", got)
+	}
+	assertSQLiteSubscriptionNoNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
+		"run_id":       fixture.runID,
+		"component":    "scheduler",
+		"level":        "warn",
+		"source":       "agent-1",
+		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	})
 }
 
 type sqliteObservabilitySurfaceFixture struct {
@@ -129,7 +156,7 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 	}
 }
 
-func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string, params map[string]any, key, want string) {
+func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string, params map[string]any, key, want string) map[string]any {
 	t.Helper()
 	conn := dialTestWS(t, serverURL)
 	defer conn.Close()
@@ -144,7 +171,26 @@ func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string
 		t.Fatalf("%s error = %#v", method, subscribe.Error)
 	}
 	notification := readWSNotification(t, conn)
-	if got := asMap(t, notification.Params.Result)[key]; got != want {
+	result := asMap(t, notification.Params.Result)
+	if got := result[key]; got != want {
 		t.Fatalf("%s notification %s = %#v, want %s", method, key, got, want)
 	}
+	return result
+}
+
+func assertSQLiteSubscriptionNoNotification(t *testing.T, serverURL, method string, params map[string]any) {
+	t.Helper()
+	conn := dialTestWS(t, serverURL)
+	defer conn.Close()
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      method + "-sqlite-miss",
+		"method":  method,
+		"params":  params,
+	})
+	subscribe := readWSResponse(t, conn)
+	if subscribe.Error != nil {
+		t.Fatalf("%s error = %#v", method, subscribe.Error)
+	}
+	requireNoWSMessage(t, conn, apiv1WebSocketNoMessageTimeout, method+" nonmatching source notification")
 }

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -521,7 +521,7 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 		  AND ($3 = '' OR COALESCE(e.payload->'details'->>'component', '') = $3)
 		  AND ($4 = '' OR COALESCE(e.payload->>'log_level', '') = $4)
 		  AND ($5 = '' OR COALESCE(e.payload->'details'->>'error_code', '') = $5)
-		  AND ($6 = '' OR COALESCE(e.payload->'details'->>'agent_id', e.produced_by, '') = $6)
+		  AND ($6 = '' OR COALESCE(NULLIF(BTRIM(e.payload->'details'->>'agent_id'), ''), NULLIF(BTRIM(e.produced_by), ''), 'runtime') = $6)
 		  AND ($7 = '' OR COALESCE(e.payload->'details'->>'action', '') = $7 OR COALESCE(e.payload->'details'->>'event_name', e.payload->'details'->>'event_type', '') = $7)
 		  AND ($8 = '' OR COALESCE(e.payload->'details'->>'session_id', '') = $8)
 		  AND ($9 = '' OR EXISTS (

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -314,6 +315,148 @@ func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	}
 	if bulk == nil || bulk.Count != 1005 {
 		t.Fatalf("bulk incident = %#v, want count 1005 in %#v", bulk, bulkIncidents.Incidents)
+	}
+}
+
+func TestPostgresRuntimeLogSourceFilterMatchesProjectionFallback(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	producedByValue := func(value string) *string {
+		return &value
+	}
+	insertLog := func(message, details string, producedBy *string, createdAt time.Time) string {
+		t.Helper()
+		eventID := uuid.NewString()
+		payload := `{
+			"log_level":"warn",
+			"message":"` + message + `",
+			"details":` + details + `
+		}`
+		var producer any
+		if producedBy != nil {
+			producer = *producedBy
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'platform.runtime_log', 'global', $3::jsonb, $4, 'platform', $5)
+		`, eventID, runID, payload, producer, createdAt); err != nil {
+			t.Fatalf("seed runtime log: %v", err)
+		}
+		return eventID
+	}
+	runtimeFallbackID := insertLog("runtime fallback", `{"component":"source-parity","action":"runtime_fallback"}`, nil, base.Add(time.Second))
+	producedByID := insertLog("producer fallback", `{"component":"source-parity","action":"producer_fallback"}`, producedByValue("operator-runtime"), base.Add(2*time.Second))
+	agentID := insertLog("agent source", `{"component":"source-parity","action":"agent_source","agent_id":"agent-1"}`, producedByValue("runtime"), base.Add(3*time.Second))
+	blankProducedByID := insertLog("blank producer fallback", `{"component":"source-parity","action":"blank_producer_fallback"}`, producedByValue("   "), base.Add(4*time.Second))
+	blankAgentID := insertLog("blank agent fallback", `{"component":"source-parity","action":"blank_agent_fallback","agent_id":"   "}`, producedByValue("operator-runtime-trimmed"), base.Add(5*time.Second))
+
+	all, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Limit:     10,
+		Order:     "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs all: %v", err)
+	}
+	if len(all.Logs) != 5 {
+		t.Fatalf("all logs = %#v, want five", all.Logs)
+	}
+	assertRuntimeLogIDsAndSources(t, all.Logs, map[string]string{
+		runtimeFallbackID: "runtime",
+		producedByID:      "operator-runtime",
+		agentID:           "agent-1",
+		blankProducedByID: "runtime",
+		blankAgentID:      "operator-runtime-trimmed",
+	})
+
+	runtimeRows, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "runtime",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs runtime source: %v", err)
+	}
+	assertRuntimeLogIDsAndSources(t, runtimeRows.Logs, map[string]string{
+		runtimeFallbackID: "runtime",
+		blankProducedByID: "runtime",
+	})
+
+	producerRows, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "operator-runtime",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs produced_by source: %v", err)
+	}
+	assertRuntimeLogIDsAndSources(t, producerRows.Logs, map[string]string{producedByID: "operator-runtime"})
+
+	trimmedProducerRows, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "operator-runtime-trimmed",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs trimmed produced_by source: %v", err)
+	}
+	assertRuntimeLogIDsAndSources(t, trimmedProducerRows.Logs, map[string]string{blankAgentID: "operator-runtime-trimmed"})
+
+	agentRows, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "agent-1",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs agent source: %v", err)
+	}
+	assertRuntimeLogIDsAndSources(t, agentRows.Logs, map[string]string{agentID: "agent-1"})
+
+	missingRows, err := pg.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "missing-source",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs missing source: %v", err)
+	}
+	if len(missingRows.Logs) != 0 {
+		t.Fatalf("missing source rows = %#v, want none", missingRows.Logs)
+	}
+}
+
+func assertRuntimeLogIDsAndSources(t *testing.T, logs []OperatorRuntimeLogEntry, want map[string]string) {
+	t.Helper()
+	if len(logs) != len(want) {
+		t.Fatalf("runtime logs = %#v, want %d rows", logs, len(want))
+	}
+	for _, log := range logs {
+		wantSource, ok := want[log.LogID]
+		if !ok {
+			t.Fatalf("unexpected runtime log row = %#v; want ids %#v", log, want)
+		}
+		if got := strings.TrimSpace(log.Source); got != wantSource {
+			t.Fatalf("runtime log %s source = %q, want %q", log.LogID, got, wantSource)
+		}
 	}
 }
 

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -87,6 +87,19 @@ func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by_type, created_at)
+		VALUES (?, ?, 'platform.runtime_log', 'global', ?, 'platform', ?)
+	`, uuid.NewString(), runID, json.RawMessage(`{"log_level":"warn","message":"direct fallback source","details":{"component":"source-parity","action":"direct_runtime_source"}}`), time.Now().UTC()); err != nil {
+		t.Fatalf("seed direct sqlite runtime log fallback row: %v", err)
+	}
+
 	logger := runtimepkg.NewRuntimeLogger(store)
 	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
 		Level:     "warn",
@@ -115,8 +128,8 @@ func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOperatorRuntimeLogs all: %v", err)
 	}
-	if len(all.Logs) != 2 {
-		t.Fatalf("all runtime logs = %#v, want two", all.Logs)
+	if len(all.Logs) != 3 {
+		t.Fatalf("all runtime logs = %#v, want three", all.Logs)
 	}
 
 	runtimeRows, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
@@ -129,8 +142,18 @@ func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOperatorRuntimeLogs runtime source: %v", err)
 	}
-	if len(runtimeRows.Logs) != 1 || runtimeRows.Logs[0].Source != "runtime" || runtimeRows.Logs[0].Message != "runtime-owned source" {
-		t.Fatalf("runtime source logs = %#v, want only runtime-owned row", runtimeRows.Logs)
+	if len(runtimeRows.Logs) != 2 {
+		t.Fatalf("runtime source logs = %#v, want direct fallback and runtime-owned rows", runtimeRows.Logs)
+	}
+	runtimeMessages := map[string]bool{}
+	for _, log := range runtimeRows.Logs {
+		if log.Source != "runtime" {
+			t.Fatalf("runtime source row = %#v, want source runtime", log)
+		}
+		runtimeMessages[log.Message] = true
+	}
+	if !runtimeMessages["direct fallback source"] || !runtimeMessages["runtime-owned source"] {
+		t.Fatalf("runtime source messages = %#v, want direct fallback and runtime-owned rows", runtimeMessages)
 	}
 
 	agentRows, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -61,6 +61,9 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 	if log.RunID != runID || log.SessionID != "session-1" || log.Message != "sqlite diagnostic persisted" {
 		t.Fatalf("sqlite runtime log = %#v, want run/session/message", log)
 	}
+	if log.Source != "runtime" {
+		t.Fatalf("sqlite runtime log source = %q, want runtime", log.Source)
+	}
 	gotParentEventID, _ := log.Details["parent_event_id"].(string)
 	if got := strings.TrimSpace(gotParentEventID); got != subjectEventID {
 		t.Fatalf("sqlite runtime log parent_event_id = %q, want %q", got, subjectEventID)
@@ -75,6 +78,87 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 	}
 	if sourceEventID != subjectEventID {
 		t.Fatalf("sqlite source_event_id = %q, want %q", sourceEventID, subjectEventID)
+	}
+}
+
+func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+
+	logger := runtimepkg.NewRuntimeLogger(store)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "runtime-owned source",
+		Component: "source-parity",
+		Action:    "runtime_source",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log runtime source: %v", err)
+	}
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "warn",
+		Message:   "agent-owned source",
+		Component: "source-parity",
+		Action:    "agent_source",
+		AgentID:   "agent-1",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log agent source: %v", err)
+	}
+
+	all, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs all: %v", err)
+	}
+	if len(all.Logs) != 2 {
+		t.Fatalf("all runtime logs = %#v, want two", all.Logs)
+	}
+
+	runtimeRows, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "runtime",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs runtime source: %v", err)
+	}
+	if len(runtimeRows.Logs) != 1 || runtimeRows.Logs[0].Source != "runtime" || runtimeRows.Logs[0].Message != "runtime-owned source" {
+		t.Fatalf("runtime source logs = %#v, want only runtime-owned row", runtimeRows.Logs)
+	}
+
+	agentRows, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "agent-1",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs agent source: %v", err)
+	}
+	if len(agentRows.Logs) != 1 || agentRows.Logs[0].Source != "agent-1" || agentRows.Logs[0].Message != "agent-owned source" {
+		t.Fatalf("agent source logs = %#v, want only agent-owned row", agentRows.Logs)
+	}
+
+	missingRows, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{
+		RunID:     runID,
+		Component: "source-parity",
+		Level:     "warn",
+		Source:    "missing-source",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeLogs missing source: %v", err)
+	}
+	if len(missingRows.Logs) != 0 {
+		t.Fatalf("missing source logs = %#v, want none", missingRows.Logs)
 	}
 }
 

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -256,6 +256,10 @@ func (s *SQLiteRuntimeStore) ListOperatorRuntimeLogs(ctx context.Context, opts O
 		where = append(where, "json_extract(payload, '$.details.component') = ?")
 		args = append(args, opts.Component)
 	}
+	if opts.Source != "" {
+		where = append(where, "COALESCE(NULLIF(TRIM(json_extract(payload, '$.details.agent_id')), ''), NULLIF(TRIM(produced_by), ''), 'runtime') = ?")
+		args = append(args, opts.Source)
+	}
 	if opts.SessionID != "" {
 		where = append(where, "json_extract(payload, '$.details.session_id') = ?")
 		args = append(args, opts.SessionID)
@@ -274,7 +278,7 @@ func (s *SQLiteRuntimeStore) ListOperatorRuntimeLogs(ctx context.Context, opts O
 	}
 	args = append(args, opts.Limit)
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT event_id, created_at, COALESCE(run_id, ''), COALESCE(entity_id, ''), payload
+		SELECT event_id, created_at, COALESCE(run_id, ''), COALESCE(entity_id, ''), COALESCE(produced_by, ''), payload
 		FROM events
 		WHERE `+strings.Join(where, " AND ")+`
 		ORDER BY created_at `+order+`, event_id `+order+`
@@ -286,17 +290,21 @@ func (s *SQLiteRuntimeStore) ListOperatorRuntimeLogs(ctx context.Context, opts O
 	defer rows.Close()
 	result := OperatorRuntimeLogListResult{Logs: []OperatorRuntimeLogEntry{}}
 	for rows.Next() {
-		var log OperatorRuntimeLogEntry
 		var createdRaw, payloadRaw any
-		if err := rows.Scan(&log.LogID, &createdRaw, &log.RunID, &log.EntityID, &payloadRaw); err != nil {
+		var logID, runID, entityID, producedBy string
+		if err := rows.Scan(&logID, &createdRaw, &runID, &entityID, &producedBy, &payloadRaw); err != nil {
 			return OperatorRuntimeLogListResult{}, fmt.Errorf("scan sqlite runtime log: %w", err)
 		}
+		var createdAt time.Time
 		if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
 			return OperatorRuntimeLogListResult{}, err
 		} else if ok {
-			log.TS = at
+			createdAt = at
 		}
-		applySQLiteRuntimeLogPayload(&log, sqliteJSONRawMessage(payloadRaw))
+		log, err := operatorRuntimeLogEntry(logID, runID, entityID, producedBy, createdAt, sqliteJSONRawMessage(payloadRaw))
+		if err != nil {
+			return OperatorRuntimeLogListResult{}, err
+		}
 		result.Logs = append(result.Logs, log)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1340,7 +1340,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 		RunID:       runID,
 		Type:        events.EventType("platform.runtime_log"),
 		SourceAgent: "runtime",
-		Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","session_id":"` + lease.SessionID + `"}}`),
+		Payload:     json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","action":"session_warning","session_id":"` + lease.SessionID + `"}}`),
 		CreatedAt:   now.Add(time.Second),
 	}); err != nil {
 		t.Fatalf("AppendEvent runtime log: %v", err)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11017,9 +11017,9 @@ cli_specification:
         - --cursor
         - --order
       output:
-        snapshot_table: TIME / LEVEL / COMPONENT / SOURCE / RUN / ENTITY / SESSION / ERROR / MESSAGE plus next_cursor when present
+        snapshot_table: TIME / LEVEL / COMPONENT / ACTION / SOURCE / RUN / ENTITY / SESSION / ERROR / MESSAGE plus next_cursor when present
         snapshot_empty: No runtime logs match the filter.
-        follow_notification_line: log log_id=<id> ts=<timestamp> level=<level> component=<component> source=<source> [run_id=<run>] [entity_id=<entity>] [session_id=<session>] [error_code=<code>] message=<message> [details=<compact-json>]
+        follow_notification_line: log log_id=<id> ts=<timestamp> level=<level> component=<component> [action=<details.action>] source=<source> [run_id=<run>] [entity_id=<entity>] [session_id=<session>] [error_code=<code>] message=<message> [details=<compact-json>]
       exit_codes:
         success: 0
         cli_validation: 2
@@ -11032,6 +11032,7 @@ cli_specification:
       - follow rejects --since, --until, --limit, --cursor, and --order before opening the WebSocket; --replay-since is accepted only with --follow
       - invalid flags and missing explicit token for non-loopback API targets make zero API or WS calls
       - malformed runtime.logs results, malformed runtime.subscribe_logs subscription results/notifications, auth/HTTP/RPC/WS failures, and cancellation are tested with closed exit-code behavior
+      - server-owned details.action renders as ACTION in snapshot mode and action=<value> in follow mode when present; action is display-only and is not required by LogEntry
       - no direct DB/store/runtime/EventBus/dashboard/process-log/container-log reads and no legacy /api/*, /rpc, /api/rpc, /ws, or /api/ws usage
     incidents:
       command: swarm incidents [filters]


### PR DESCRIPTION
## Summary

Closes #1369.

This PR closes the approved first-slice class `runtime_logs_source_ownership_projection_and_filter_parity` for supported runtime-log surfaces:

- aligns SQLite `/v1/rpc runtime.logs` source projection with the canonical runtime-log projector used by Postgres;
- adds SQLite source filtering using the same public source owner semantics: `details.agent_id`, then `events.produced_by`, then `runtime`;
- proves `/v1/ws runtime.subscribe_logs` inherits the corrected source output and source filter behavior through the same store owner;
- keeps `LogEntry.source` required and preserves CLI fail-closed validation for malformed snapshot/follow rows;
- adds the gate-approved, non-closure-bearing CLI UX display for `details.action` with matching `platform-spec.yaml` CLI output updates.

## Governing Refs / Context

- `platform-spec.yaml` `api_specification.method_catalog.runtime.logs`
- `platform-spec.yaml` `api_specification.method_catalog.runtime.subscribe_logs`
- `platform-spec.yaml` `components.schemas.LogEntry`, where `source` remains required
- `platform-spec.yaml` `cli_specification.command_catalog.logs`
- `openrpc.json` generated `runtime.logs`, `runtime.subscribe_logs`, and `LogEntry` schema
- #1369 pre-audit and repaired independent gate comments

## Semantic Migration

- New canonical owner consumed by SQLite runtime-log reads: package-level `operatorRuntimeLogEntry`, which decodes canonical runtime-log payloads and derives `LogEntry.source` from `payload.AgentID`, `events.produced_by`, then `runtime`.
- Old invalid path: SQLite `ListOperatorRuntimeLogs` projected source only from `details.source`, which canonical `RuntimeLogger` does not write.
- Production paths checked: SQLite `/v1/rpc runtime.logs`, SQLite `/v1/ws runtime.subscribe_logs`, CLI `swarm logs` snapshot/follow, Postgres `ListOperatorRuntimeLogs`, and existing direct run-debug summary helper as an explicit split/non-closure-bearing sibling.
- Migration completeness: complete for the approved supported `runtime.logs` / `runtime.subscribe_logs` / `swarm logs` source projection/filter class. Broad persisted-payload refactor and run-debug/report source semantics remain out of scope per gate.

## Validation

- `go test ./cmd/swarm -run TestLogs -count=1`
- `go test ./internal/store -run 'TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability|TestSQLiteRuntimeLogSourceProjectionAndFilterParity|TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor|TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage' -count=1`
- `go test ./internal/apiv1 -run 'TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces|TestRuntimeLog|TestRuntimeSubscribeLogs' -count=1`
- `go test ./internal/store -run TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility -count=1`
- `go test ./...`
