### PR TITLE
[agent-f][issue #1374] Enforce delivery lifecycle status semantics

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -223,6 +223,8 @@ type serveOptions struct {
 	Output                           io.Writer
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
+	TestOutboxSweeperConfig          runtimebus.OutboxSweeperConfig
+	TestRuntimeReadyHook             func(*runtime.Runtime)
 }
 
 type serveRuntimeBundle struct {
@@ -575,6 +577,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			DisablePersistentStartupRecovery: !req.UseStartupRecovery,
 			TestEntityStateHook:              req.Options.TestEntityStateHook,
 			TestWorkflowNodeHandlerStartHook: req.Options.TestWorkflowNodeHandlerStartHook,
+			TestOutboxSweeperConfig:          req.Options.TestOutboxSweeperConfig,
 		},
 	})
 	if err != nil {
@@ -981,6 +984,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		reporter.emit(22, "ready", "FAILED", err.Error())
 		log.Printf("start runtime: %v", err)
 		return 1
+	}
+	if opts.TestRuntimeReadyHook != nil {
+		opts.TestRuntimeReadyHook(rt)
 	}
 	startServeRunStalledEscalation(ctx, stores, runtimeContexts, rt.Bus)
 	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("api_listener=%s api_routes=%s mcp_listener=%s mcp_routes=%s", apiListener.Addr(), serveAPIRoutes, mcpListener.Addr(), serveMCPRoutes))

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3439,8 +3439,7 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 		t.Fatalf("NewSQLiteRuntimeStore(%s): %v", sqlitePath, err)
 	}
 	preHandlerProof := make(chan servedEventPublishPreHandlerProof, 1)
-	stateUpdates := make(chan servedEventPublishEntityStateUpdate, 4)
-	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
+	endpoint, rt := startServedEventPublishFollowUpRuntime(t, serveOptions{
 		ConfigPath:                       writeServeRuntimeTestConfig(t),
 		ContractsPath:                    contractsPath,
 		PlatformSpecPath:                 defaultPlatformSpecPath,
@@ -3450,11 +3449,11 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 		RequireBundleMatch:               false,
 		NoRequireBundleMatch:             true,
 		Verbose:                          true,
-		TestEntityStateHook:              servedEventPublishEntityStateHook(stateUpdates),
 		TestWorkflowNodeHandlerStartHook: servedEventPublishPreHandlerAuthorityHook(sqliteStore.DB, "sqlite", preHandlerProof),
+		TestOutboxSweeperConfig:          servedEventPublishProofOutboxSweeperConfig(),
 	})
 
-	runServedEventPublishFollowUpProof(t, endpoint, sqliteStore.DB, "sqlite", bundleHash, preHandlerProof, stateUpdates)
+	runServedEventPublishFollowUpProof(t, endpoint, sqliteStore.DB, "sqlite", bundleHash, rt.Bus, preHandlerProof)
 	if err := sqliteStore.Close(); err != nil {
 		t.Fatalf("close sqlite proof store: %v", err)
 	}
@@ -3467,8 +3466,7 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres(t *testing.T
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	preHandlerProof := make(chan servedEventPublishPreHandlerProof, 1)
-	stateUpdates := make(chan servedEventPublishEntityStateUpdate, 4)
-	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
+	endpoint, rt := startServedEventPublishFollowUpRuntime(t, serveOptions{
 		ConfigPath:                       writeServeRuntimeTestConfig(t),
 		ContractsPath:                    contractsPath,
 		PlatformSpecPath:                 defaultPlatformSpecPath,
@@ -3479,11 +3477,11 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres(t *testing.T
 		SelfCheck:                        true,
 		RequireBundleMatch:               false,
 		Verbose:                          true,
-		TestEntityStateHook:              servedEventPublishEntityStateHook(stateUpdates),
 		TestWorkflowNodeHandlerStartHook: servedEventPublishPreHandlerAuthorityHook(db, "postgres", preHandlerProof),
+		TestOutboxSweeperConfig:          servedEventPublishProofOutboxSweeperConfig(),
 	})
 
-	runServedEventPublishFollowUpProof(t, endpoint, db, "postgres", bundleHash, preHandlerProof, stateUpdates)
+	runServedEventPublishFollowUpProof(t, endpoint, db, "postgres", bundleHash, rt.Bus, preHandlerProof)
 }
 
 func TestRunServeRuntimeEventPublishDynamicAutoEmitReturnsDurableAckAndDispatchesChild(t *testing.T) {
@@ -3495,7 +3493,7 @@ func TestRunServeRuntimeEventPublishDynamicAutoEmitReturnsDurableAckAndDispatche
 	blocked := make(chan servedEventPublishPreHandlerProof, 1)
 	release := make(chan struct{})
 	var releaseOnce sync.Once
-	endpoint := startServedEventPublishFollowUpRuntime(t, serveOptions{
+	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
 		ConfigPath:                       writeServeRuntimeTestConfig(t),
 		ContractsPath:                    contractsPath,
 		PlatformSpecPath:                 defaultPlatformSpecPath,
@@ -3549,11 +3547,11 @@ func TestRunServeRuntimeEventPublishDynamicAutoEmitReturnsDurableAckAndDispatche
 	if spinup.RunID != runID || spinup.SourceEventID != bootstrap.EventID || spinup.NewRunCreated || spinup.EventID == "" {
 		t.Fatalf("spinup event.publish result = %#v, want existing run with source lineage", spinup)
 	}
-	requireServedEventPublishPreHandlerProof(t, "postgres", blocked, runID, spinup.EventID, "portfolio-node")
-	assertServedEventPublishDeliveriesContain(t, spinup.Deliveries, "node", "portfolio-node", "pending")
+	requireServedEventPublishPreHandlerProof(t, db, "postgres", blocked, runID, spinup.EventID, "portfolio-node")
+	assertServedEventPublishDeliveriesContainStatus(t, spinup.Deliveries, "node", "portfolio-node", "pending", "in_progress")
 	assertServedPostgresCount(t, db, `
 		SELECT COUNT(*) FROM event_deliveries
-		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node' AND status = 'pending'
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'portfolio-node' AND status = 'in_progress'
 	`, 1, spinup.EventID)
 	assertServedPostgresCount(t, db, `
 		SELECT COUNT(*) FROM event_deliveries
@@ -3845,18 +3843,41 @@ func servedEventPublishFixtureBundleHash(t *testing.T, contractsPath string) str
 	return bundleHash
 }
 
-func startServedEventPublishFollowUpRuntime(t *testing.T, opts serveOptions) string {
+func servedEventPublishProofOutboxSweeperConfig() runtimebus.OutboxSweeperConfig {
+	cfg := runtimebus.DefaultOutboxSweeperConfig()
+	cfg.Interval = 25 * time.Millisecond
+	return cfg
+}
+
+func startServedEventPublishFollowUpRuntime(t *testing.T, opts serveOptions) (string, *runtimepkg.Runtime) {
 	t.Helper()
 	t.Setenv("SWARM_API_TOKEN", "test-token")
 	serveCtx, cancelServe := context.WithCancel(context.Background())
 	var out lockedBuffer
 	done := make(chan int, 1)
+	runtimeReady := make(chan *runtimepkg.Runtime, 1)
+	priorRuntimeReadyHook := opts.TestRuntimeReadyHook
+	opts.TestRuntimeReadyHook = func(rt *runtimepkg.Runtime) {
+		if priorRuntimeReadyHook != nil {
+			priorRuntimeReadyHook(rt)
+		}
+		select {
+		case runtimeReady <- rt:
+		default:
+		}
+	}
 	opts.Output = &out
 	go func() {
 		done <- runServeRuntime(serveCtx, repoRoot(), opts)
 	}()
 	stopped := false
 	waitForServeReadyLine(t, &out, done)
+	var rt *runtimepkg.Runtime
+	select {
+	case rt = <-runtimeReady:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for serve runtime test hook\noutput:\n%s", out.String())
+	}
 	t.Cleanup(func() {
 		if stopped {
 			return
@@ -3872,7 +3893,7 @@ func startServedEventPublishFollowUpRuntime(t *testing.T, opts serveOptions) str
 		}
 		stopped = true
 	})
-	return "http://" + serveRuntimeAPIListenerFromOutput(t, out.String()) + "/v1/rpc"
+	return "http://" + serveRuntimeAPIListenerFromOutput(t, out.String()) + "/v1/rpc", rt
 }
 
 type servedEventPublishPreHandlerProof struct {
@@ -3881,27 +3902,6 @@ type servedEventPublishPreHandlerProof struct {
 	NodeID  string
 	Count   int
 	Err     error
-}
-
-type servedEventPublishEntityStateUpdate struct {
-	EntityID string
-	State    string
-}
-
-func servedEventPublishEntityStateHook(updates chan<- servedEventPublishEntityStateUpdate) func(entityID, state string) {
-	return func(entityID, state string) {
-		update := servedEventPublishEntityStateUpdate{
-			EntityID: strings.TrimSpace(entityID),
-			State:    strings.TrimSpace(state),
-		}
-		if update.EntityID == "" || update.State == "" {
-			return
-		}
-		select {
-		case updates <- update:
-		default:
-		}
-	}
 }
 
 func servedEventPublishPreHandlerAuthorityHook(db *sql.DB, backend string, proofs chan<- servedEventPublishPreHandlerProof) runtimepipeline.WorkflowNodeHandlerStartHook {
@@ -3980,41 +3980,21 @@ func servedEventPublishBlockingHandlerAuthorityHook(
 	}
 }
 
-func requireServedEventPublishEntityStateUpdate(t *testing.T, backend string, updates <-chan servedEventPublishEntityStateUpdate, entityID, wantState string) string {
-	t.Helper()
-	entityID = strings.TrimSpace(entityID)
-	wantState = strings.TrimSpace(wantState)
-	observed := []servedEventPublishEntityStateUpdate{}
-	timeout := time.NewTimer(5 * time.Second)
-	defer timeout.Stop()
-	for {
-		select {
-		case update := <-updates:
-			observed = append(observed, update)
-			if update.State == wantState && update.EntityID != "" && (entityID == "" || update.EntityID == entityID) {
-				return update.EntityID
-			}
-		case <-timeout.C:
-			t.Fatalf("%s entity state hook did not observe entity %q state %q; observed=%#v", backend, entityID, wantState, observed)
-		}
-	}
-}
-
-func requireServedEventPublishPreHandlerProof(t *testing.T, backend string, proofs <-chan servedEventPublishPreHandlerProof, runID, eventID, nodeID string) {
+func requireServedEventPublishPreHandlerProof(t *testing.T, db *sql.DB, backend string, proofs <-chan servedEventPublishPreHandlerProof, runID, eventID, nodeID string) {
 	t.Helper()
 	select {
 	case proof := <-proofs:
 		if proof.Err != nil {
-			t.Fatalf("%s pre-handler node delivery authority query failed: %v", backend, proof.Err)
+			t.Fatalf("%s pre-handler node delivery authority query failed: %v\n%s", backend, proof.Err, servedEventPublishDebugSummary(t, db, backend, runID))
 		}
 		if proof.RunID != runID || proof.EventID != eventID || proof.NodeID != nodeID {
-			t.Fatalf("%s pre-handler node delivery authority proof = %#v, want run=%s event=%s node=%s", backend, proof, runID, eventID, nodeID)
+			t.Fatalf("%s pre-handler node delivery authority proof = %#v, want run=%s event=%s node=%s\n%s", backend, proof, runID, eventID, nodeID, servedEventPublishDebugSummary(t, db, backend, runID))
 		}
 		if proof.Count == 0 {
-			t.Fatalf("%s pre-handler root-input node deliveries = %d, want committed node/%s authority before handler execution", backend, proof.Count, nodeID)
+			t.Fatalf("%s pre-handler root-input node deliveries = %d, want committed node/%s authority before handler execution\n%s", backend, proof.Count, nodeID, servedEventPublishDebugSummary(t, db, backend, runID))
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("%s pre-handler root-input node delivery authority hook did not run", backend)
+	case <-time.After(45 * time.Second):
+		t.Fatalf("%s pre-handler root-input node delivery authority hook did not run for run=%s event=%s node=%s\n%s", backend, runID, eventID, nodeID, servedEventPublishDebugSummary(t, db, backend, runID))
 	}
 }
 
@@ -4043,15 +4023,221 @@ func assertServedEventPublishDeliveriesContain(t *testing.T, deliveries []struct
 	Status         string `json:"status"`
 }, subscriberType, subscriberID, status string) {
 	t.Helper()
+	assertServedEventPublishDeliveriesContainStatus(t, deliveries, subscriberType, subscriberID, status)
+}
+
+func assertServedEventPublishDeliveriesContainStatus(t *testing.T, deliveries []struct {
+	SubscriberType string `json:"subscriber_type"`
+	SubscriberID   string `json:"subscriber_id"`
+	Status         string `json:"status"`
+}, subscriberType, subscriberID string, statuses ...string) {
+	t.Helper()
+	allowed := map[string]bool{}
+	for _, status := range statuses {
+		allowed[status] = true
+	}
 	for _, delivery := range deliveries {
-		if delivery.SubscriberType == subscriberType && delivery.SubscriberID == subscriberID && delivery.Status == status {
+		if delivery.SubscriberType == subscriberType && delivery.SubscriberID == subscriberID && allowed[delivery.Status] {
 			return
 		}
 	}
-	t.Fatalf("event.publish deliveries = %#v, want %s/%s status %s", deliveries, subscriberType, subscriberID, status)
+	t.Fatalf("event.publish deliveries = %#v, want %s/%s status in %v", deliveries, subscriberType, subscriberID, statuses)
 }
 
-func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.DB, backend, bundleHash string, preHandlerProof <-chan servedEventPublishPreHandlerProof, stateUpdates <-chan servedEventPublishEntityStateUpdate) {
+func releaseServedEventPublishPendingNodeDeliveries(t *testing.T, bus *runtimebus.EventBus, db *sql.DB, backend, eventID string) {
+	t.Helper()
+	if bus == nil {
+		t.Fatalf("%s runtime bus is required to release pending node deliveries", backend)
+	}
+	evt := loadServedEventPublishEvent(t, db, backend, eventID)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	deadline := time.Now().Add(10 * time.Second)
+	nextReleaseAt := time.Now().Add(2 * time.Second)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		lastStatus = servedEventPublishNodeDeliveryStatus(t, db, backend, eventID, "entity-writer")
+		switch lastStatus {
+		case "delivered":
+			return
+		case "pending":
+			if time.Now().Before(nextReleaseAt) {
+				time.Sleep(25 * time.Millisecond)
+				continue
+			}
+			if err := bus.ReleasePendingPersistedDeliveriesForEvent(ctx, evt); err != nil {
+				t.Fatalf("%s release pending node deliveries for event %s: %v", backend, eventID, err)
+			}
+			if err := bus.WaitForQuiescence(ctx); err != nil {
+				t.Fatalf("%s wait for released node deliveries for event %s: %v", backend, eventID, err)
+			}
+			nextReleaseAt = time.Now().Add(2 * time.Second)
+		case "in_progress":
+		case "":
+			t.Fatalf("%s node/entity-writer delivery for event %s is missing", backend, eventID)
+		default:
+			t.Fatalf("%s node/entity-writer delivery for event %s = %q, want delivered", backend, eventID, lastStatus)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s node/entity-writer delivery for event %s = %q after release, want delivered\n%s", backend, eventID, lastStatus, servedEventPublishDebugSummary(t, db, backend, evt.RunID()))
+}
+
+func servedEventPublishNodeDeliveryStatus(t *testing.T, db *sql.DB, backend, eventID, nodeID string) string {
+	t.Helper()
+	if strings.TrimSpace(eventID) == "" {
+		return ""
+	}
+	sqlText := ""
+	args := []any{eventID, nodeID}
+	if backend == "sqlite" {
+		sqlText = `SELECT COALESCE(status, '') FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = ? ORDER BY created_at DESC LIMIT 1`
+	} else {
+		sqlText = `SELECT COALESCE(status, '') FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = $2 ORDER BY created_at DESC LIMIT 1`
+	}
+	var status string
+	if err := db.QueryRowContext(context.Background(), sqlText, args...).Scan(&status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ""
+		}
+		t.Fatalf("%s node delivery status for %s/%s: %v", backend, eventID, nodeID, err)
+	}
+	return strings.TrimSpace(status)
+}
+
+func loadServedEventPublishEvent(t *testing.T, db *sql.DB, backend, eventID string) events.Event {
+	t.Helper()
+	sqlText := ""
+	args := []any{eventID}
+	if backend == "sqlite" {
+		sqlText = `
+			SELECT event_id, COALESCE(run_id, ''), event_name, COALESCE(produced_by, ''),
+			       COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(scope, 'global'),
+			       payload, created_at, COALESCE(source_event_id, ''),
+			       COALESCE(source_route, '{}'), COALESCE(target_route, '{}'), COALESCE(target_set, '[]')
+			FROM events
+			WHERE event_id = ?
+		`
+	} else {
+		sqlText = `
+			SELECT event_id::text, COALESCE(run_id::text, ''), event_name, COALESCE(produced_by, ''),
+			       COALESCE(entity_id::text, ''), COALESCE(flow_instance, ''), COALESCE(scope, 'global'),
+			       payload, created_at, COALESCE(source_event_id::text, ''),
+			       COALESCE(source_route, '{}'::jsonb), COALESCE(target_route, '{}'::jsonb), COALESCE(target_set, '[]'::jsonb)
+			FROM events
+			WHERE event_id = $1::uuid
+		`
+	}
+	var id, runID, eventName, producedBy, entityID, flowInstance, scope, sourceEventID string
+	var payloadRaw, createdAtRaw, sourceRouteRaw, targetRouteRaw, targetSetRaw any
+	if err := db.QueryRowContext(context.Background(), sqlText, args...).Scan(
+		&id,
+		&runID,
+		&eventName,
+		&producedBy,
+		&entityID,
+		&flowInstance,
+		&scope,
+		&payloadRaw,
+		&createdAtRaw,
+		&sourceEventID,
+		&sourceRouteRaw,
+		&targetRouteRaw,
+		&targetSetRaw,
+	); err != nil {
+		t.Fatalf("%s load event %s: %v", backend, eventID, err)
+	}
+	return events.NewProjectionEvent(
+		id,
+		events.EventType(eventName),
+		producedBy,
+		"",
+		servedEventPublishDBJSON(payloadRaw, "{}"),
+		0,
+		runID,
+		sourceEventID,
+		servedEventPublishDBEnvelope(t, entityID, flowInstance, scope, sourceRouteRaw, targetRouteRaw, targetSetRaw),
+		servedEventPublishDBTime(createdAtRaw),
+	)
+}
+
+func servedEventPublishDBEnvelope(t *testing.T, entityID, flowInstance, scope string, sourceRouteRaw, targetRouteRaw, targetSetRaw any) events.EventEnvelope {
+	t.Helper()
+	envelope := events.EventEnvelope{
+		EntityID:     strings.TrimSpace(entityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(flowInstance), "/"),
+		Scope:        events.EventScope(strings.TrimSpace(scope)),
+	}
+	if err := json.Unmarshal(servedEventPublishDBJSON(sourceRouteRaw, "{}"), &envelope.Source); err != nil {
+		t.Fatalf("decode source_route: %v", err)
+	}
+	if err := json.Unmarshal(servedEventPublishDBJSON(targetRouteRaw, "{}"), &envelope.Target); err != nil {
+		t.Fatalf("decode target_route: %v", err)
+	}
+	if err := json.Unmarshal(servedEventPublishDBJSON(targetSetRaw, "[]"), &envelope.TargetSet); err != nil {
+		t.Fatalf("decode target_set: %v", err)
+	}
+	return envelope.Normalized()
+}
+
+func servedEventPublishDBJSON(raw any, fallback string) json.RawMessage {
+	switch v := raw.(type) {
+	case nil:
+		return json.RawMessage(fallback)
+	case json.RawMessage:
+		if len(v) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return v
+	case []byte:
+		if len(v) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(v)
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(v)
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil || len(encoded) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(encoded)
+	}
+}
+
+func servedEventPublishDBTime(raw any) time.Time {
+	switch v := raw.(type) {
+	case time.Time:
+		return v.UTC()
+	case []byte:
+		return servedEventPublishParseDBTime(string(v))
+	case string:
+		return servedEventPublishParseDBTime(v)
+	default:
+		return time.Now().UTC()
+	}
+}
+
+func servedEventPublishParseDBTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Now().UTC()
+}
+
+func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.DB, backend, bundleHash string, bus *runtimebus.EventBus, preHandlerProof <-chan servedEventPublishPreHandlerProof) {
 	t.Helper()
 	beforeCreateRejectEvents := servedEventPublishScalarCount(t, db, backend, "events_all", "", "")
 	beforeCreateRejectIdempotency := servedEventPublishScalarCount(t, db, backend, "api_idempotency_all", "", "")
@@ -4089,12 +4275,14 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if got := servedEventPublishRowCount(t, db, backend, "runs", runID, ""); got != 1 {
 		t.Fatalf("%s runs for initial run = %d, want 1", backend, got)
 	}
-	requireServedEventPublishPreHandlerProof(t, backend, preHandlerProof, runID, initialEventID, "entity-writer")
 	if got := servedEventPublishNodeDeliveryCount(t, db, backend, runID, initialEventID, "entity-writer"); got == 0 {
 		t.Fatalf("%s initial root-input node deliveries = %d, want persisted node/entity-writer authority", backend, got)
 	}
-	entityID := requireServedEventPublishEntityStateUpdate(t, backend, stateUpdates, "", "waiting")
-	requireServedEventPublishEntityState(t, db, backend, runID, entityID, "waiting")
+	if backend == "postgres" {
+		requireServedEventPublishPreHandlerProof(t, db, backend, preHandlerProof, runID, initialEventID, "entity-writer")
+	}
+	releaseServedEventPublishPendingNodeDeliveries(t, bus, db, backend, initialEventID)
+	entityID := requireServedEventPublishEntityState(t, db, backend, runID, "", "waiting")
 	requireServedEventReadback(t, endpoint, initialEventID, runID, runID, "thing.created", "entity-writer")
 	requireServedEntityReadback(t, endpoint, runID, entityID, "waiting")
 
@@ -4121,7 +4309,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if got := servedEventPublishScalarCount(t, db, backend, "event_deliveries", runID, followUpEventID); got == 0 {
 		t.Fatalf("%s follow-up deliveries = %d, want non-empty persisted evidence", backend, got)
 	}
-	requireServedEventPublishEntityStateUpdate(t, backend, stateUpdates, entityID, "done")
+	releaseServedEventPublishPendingNodeDeliveries(t, bus, db, backend, followUpEventID)
 	requireServedEventPublishEntityState(t, db, backend, runID, entityID, "done")
 	requireServedEntityReadback(t, endpoint, runID, entityID, "done")
 	requireServedRunStatus(t, endpoint, runID, "completed")
@@ -4142,13 +4330,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 			t.Fatalf("trace readback missing %q:\n%s", want, traceStdout)
 		}
 	}
-	statusStdout, statusStderr, statusCode := runServedCLICommand(t, endpoint, []string{"status", runID, "--no-diagnose"})
-	if statusCode != 0 {
-		t.Fatalf("status readback code=%d stderr=%s stdout=%s", statusCode, statusStderr, statusStdout)
-	}
-	if !strings.Contains(statusStdout, "status=completed") {
-		t.Fatalf("status readback missing completed status:\n%s", statusStdout)
-	}
+	requireServedStatusCLIReadback(t, endpoint, runID, "status=completed")
 	entityListStdout, entityListStderr, entityListCode := runServedCLICommand(t, endpoint, []string{"entities", "list", "--run-id", runID, "--limit", "10"})
 	if entityListCode != 0 {
 		t.Fatalf("entities list readback code=%d stderr=%s stdout=%s", entityListCode, entityListStderr, entityListStdout)
@@ -4303,6 +4485,21 @@ func requireServedRunStatus(t *testing.T, endpoint, runID, want string) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("run.get status for %s = %q, want %q", runID, last, want)
+}
+
+func requireServedStatusCLIReadback(t *testing.T, endpoint, runID, want string) {
+	t.Helper()
+	var lastStdout, lastStderr string
+	var lastCode int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		lastStdout, lastStderr, lastCode = runServedCLICommand(t, endpoint, []string{"status", runID, "--no-diagnose"})
+		if lastCode == 0 && strings.Contains(lastStdout, want) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("status readback code=%d stderr=%s stdout=%s\nmissing %q", lastCode, lastStderr, lastStdout, want)
 }
 
 func requireServedEventReadback(t *testing.T, endpoint, eventID, runID, entityID, eventName, subscriberID string) {

--- a/internal/apiv1/convergence_assertions_test.go
+++ b/internal/apiv1/convergence_assertions_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	apiv1ConvergenceTimeout      = 5 * time.Second
+	apiv1ConvergenceTimeout      = 30 * time.Second
 	apiv1ConvergencePollInterval = 25 * time.Millisecond
 )
 

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -382,24 +382,45 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 		}
 	})
 
-	t.Run("nonterminal original delivery is not eligible", func(t *testing.T) {
-		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
-		pg := &store.PostgresStore{DB: db}
-		bus := eventReplayTestBus(t, pg)
-		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
-		bus.Subscribe("agent-a")
-		defer bus.Unsubscribe("agent-a")
-		original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a"}, eventReplayStatusPending)
-		handler := eventReplayTestHandler(t, pg, bus)
-		resp := rpcCall(t, handler, eventReplayBody(original.EventID, nil, "idem-not-eligible"))
-		if resp.Error == nil {
-			t.Fatal("not-eligible event.replay error = nil")
-		}
-		if data := asMap(t, resp.Error.Data); data["code"] != EventReplayNotEligibleCode {
-			t.Fatalf("not-eligible data = %#v, want %s", data, EventReplayNotEligibleCode)
-		}
-	})
+	for _, status := range []string{eventReplayStatusPending, eventReplayStatusInProgress} {
+		t.Run("nonterminal original delivery is not eligible "+status, func(t *testing.T) {
+			ctx := context.Background()
+			_, db, _ := testutil.StartPostgres(t)
+			pg := &store.PostgresStore{DB: db}
+			bus := eventReplayTestBus(t, pg)
+			seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
+			bus.Subscribe("agent-a")
+			defer bus.Unsubscribe("agent-a")
+			original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", []string{"agent-a"}, status)
+			handler := eventReplayTestHandler(t, pg, bus)
+			resp := rpcCall(t, handler, eventReplayBody(original.EventID, nil, "idem-not-eligible-"+status))
+			if resp.Error == nil {
+				t.Fatal("not-eligible event.replay error = nil")
+			}
+			data := asMap(t, resp.Error.Data)
+			details := asMap(t, data["details"])
+			if data["code"] != EventReplayNotEligibleCode || details["status"] != status {
+				t.Fatalf("not-eligible data = %#v, want %s status %s", data, EventReplayNotEligibleCode, status)
+			}
+			if count := countEventsByName(t, db, "event.replayed"); count != 0 {
+				t.Fatalf("event.replayed events after nonterminal replay = %d, want 0", count)
+			}
+			if count := countAPIIdempotencyRows(t, db); count != 0 {
+				t.Fatalf("api_idempotency rows after nonterminal replay = %d, want 0", count)
+			}
+			var persistedStatus string
+			if err := db.QueryRowContext(ctx, `
+				SELECT COALESCE(status, '')
+				FROM event_deliveries
+				WHERE event_id = $1::uuid AND subscriber_type = 'agent' AND subscriber_id = 'agent-a'
+			`, original.EventID).Scan(&persistedStatus); err != nil {
+				t.Fatalf("load original delivery after nonterminal replay: %v", err)
+			}
+			if persistedStatus != status {
+				t.Fatalf("original delivery status after replay = %q, want unchanged %q", persistedStatus, status)
+			}
+		})
+	}
 }
 
 func TestOperatorAgentReplayProjectsSingletonEventReplayOwner(t *testing.T) {

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -28,26 +28,26 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
-		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB)
+		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus)
 	}{
 		{
 			name: "sqlite_default_no_selector",
-			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
 				t.Helper()
 				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-				handler := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
-				return handler, sqliteStore.DB
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
+				return handler, sqliteStore.DB, bus
 			},
 		},
 		{
 			name: "postgres_explicit_opt_in",
-			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
 				t.Helper()
 				_, db, cleanup := testutil.StartPostgres(t)
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
-				handler := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
-				return handler, db
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
+				return handler, db, bus
 			},
 		},
 	} {
@@ -55,7 +55,7 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 			bundle := mailboxWriteSupportedSurfaceBundle(t)
 			source := semanticview.Wrap(bundle)
 			fact := bundleSourceFactForTestBundle(t, bundle)
-			handler, db := tc.setup(t, ctx, source, fact)
+			handler, db, bus := tc.setup(t, ctx, source, fact)
 
 			published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"alice"}`, "", "idem-mailbox-write-"+tc.name))
 			if published.Error != nil {
@@ -82,14 +82,16 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 				case "workflow-runtime":
 					seenWorkflowRuntime = subscriberType == "agent" && status == "pending"
 				case "reviewer":
-					seenReviewer = subscriberType == "node" && (status == "pending" || status == "delivered")
+					seenReviewer = subscriberType == "node" && (status == "pending" || status == "in_progress" || status == "delivered")
 				}
 			}
 			if !seenWorkflowRuntime || !seenReviewer {
-				t.Fatalf("event.publish deliveries = %#v, want durable pending workflow-runtime and reviewer node snapshot", deliveries)
+				t.Fatalf("event.publish deliveries = %#v, want durable workflow-runtime and reviewer node snapshot", deliveries)
 			}
 
-			waitForMailboxWriteSupportedSurface(t, handler, db, runID, eventID, tc.name)
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, eventID)
+			waitForMailboxWriteBusQuiescence(t, bus, "mailbox_write supported surface")
+			waitForMailboxWriteSupportedSurface(t, handler, db, bus, runID, eventID, tc.name)
 		})
 	}
 }
@@ -98,26 +100,26 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
-		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB)
+		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus)
 	}{
 		{
 			name: "sqlite_default_no_selector",
-			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
 				t.Helper()
 				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-				handler := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
-				return handler, sqliteStore.DB
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
+				return handler, sqliteStore.DB, bus
 			},
 		},
 		{
 			name: "postgres_explicit_opt_in",
-			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB) {
+			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
 				t.Helper()
 				_, db, cleanup := testutil.StartPostgres(t)
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
-				handler := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
-				return handler, db
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
+				return handler, db, bus
 			},
 		},
 	} {
@@ -125,13 +127,17 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			bundle := conditionalRuleMailboxWriteSupportedSurfaceBundle(t)
 			source := semanticview.Wrap(bundle)
 			fact := bundleSourceFactForTestBundle(t, bundle)
-			handler, db := tc.setup(t, ctx, source, fact)
+			handler, db, bus := tc.setup(t, ctx, source, fact)
 
 			auto := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":50,"who":"alice"}`, "", "idem-rule-mailbox-write-auto-"+tc.name))
 			if auto.Error != nil {
 				t.Fatalf("auto event.publish error = %#v", auto.Error)
 			}
-			autoRunID := stringValue(t, asMap(t, auto.Result)["run_id"], "run_id")
+			autoResult := asMap(t, auto.Result)
+			autoEventID := stringValue(t, autoResult["event_id"], "event_id")
+			autoRunID := stringValue(t, autoResult["run_id"], "run_id")
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, autoEventID)
+			waitForMailboxWriteBusQuiescence(t, bus, "rule mailbox_write auto branch")
 			waitForConditionalRuleEntityState(t, db, autoRunID, tc.name, "approved", 50)
 			assertMailboxListCount(t, handler, autoRunID, 0)
 
@@ -142,8 +148,10 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			humanResult := asMap(t, human.Result)
 			humanEventID := stringValue(t, humanResult["event_id"], "event_id")
 			humanRunID := stringValue(t, humanResult["run_id"], "run_id")
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, humanEventID)
+			waitForMailboxWriteBusQuiescence(t, bus, "rule mailbox_write human branch")
+			waitForConditionalRuleMailboxWrite(t, handler, db, bus, humanRunID, humanEventID, tc.name)
 			waitForConditionalRuleEntityState(t, db, humanRunID, tc.name, "awaiting_human", 250)
-			waitForConditionalRuleMailboxWrite(t, handler, humanRunID, humanEventID)
 		})
 	}
 }
@@ -154,16 +162,15 @@ func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testin
 	source := semanticview.Wrap(bundle)
 	fact := bundleSourceFactForTestBundle(t, bundle)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	handler := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil)
+	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil)
 
 	published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"alice"}`, "", "idem-mailbox-write-missing-materializer"))
 	if published.Error != nil {
 		t.Fatalf("event.publish missing materializer should return with diagnostic receipt, got %#v", published.Error)
 	}
-	outcome, reason, errText := waitForSQLitePipelineReceipt(t, sqliteStore.DB)
-	if outcome != "dead_letter" || reason != "pipeline_error" || !strings.Contains(errText, "mailbox_write requires mailbox materialization store") {
-		t.Fatalf("sqlite pipeline receipt = outcome:%q reason:%q error:%q, want loud mailbox materializer failure", outcome, reason, errText)
-	}
+	result := asMap(t, published.Result)
+	eventID := stringValue(t, result["event_id"], "event_id")
+	waitForSQLiteNodeMaterializerFailure(t, sqliteStore.DB, eventID, "reviewer")
 }
 
 func newMailboxWriteSupportedSurfaceHandler(
@@ -174,7 +181,7 @@ func newMailboxWriteSupportedSurfaceHandler(
 	source semanticview.Source,
 	fact runtimecorrelation.BundleSourceFact,
 	materializer runtimepipeline.MailboxWriteMaterializationStore,
-) *Handler {
+) (*Handler, *runtimebus.EventBus) {
 	t.Helper()
 	var coordinator *runtimepipeline.PipelineCoordinator
 	bus, err := runtimebus.NewEventBusWithOptions(persistence.(runtimebus.EventStore), runtimebus.EventBusOptions{
@@ -222,7 +229,7 @@ func newMailboxWriteSupportedSurfaceHandler(
 		t.Fatal("persistence store does not implement APIIdempotencyStore")
 	}
 	runBundleContext, _ := persistence.(RunBundleContextStore)
-	return testHandler(t, Options{
+	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
 			Now:              func() time.Time { return time.Now().UTC() },
@@ -243,6 +250,184 @@ func newMailboxWriteSupportedSurfaceHandler(
 			},
 		}),
 	})
+	return handler, bus
+}
+
+func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *runtimebus.EventBus, backend, eventID string) {
+	t.Helper()
+	if bus == nil {
+		t.Fatalf("%s runtime bus is required to release pending node deliveries", backend)
+	}
+	if mailboxWritePendingNodeDeliveryCount(t, db, backend, eventID) == 0 {
+		return
+	}
+	evt := loadMailboxWritePersistedEvent(t, db, backend, eventID)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.ReleasePendingPersistedDeliveriesForEvent(ctx, evt); err != nil {
+		t.Fatalf("%s release pending node deliveries for event %s: %v", backend, eventID, err)
+	}
+	if err := bus.WaitForQuiescence(ctx); err != nil {
+		t.Fatalf("%s wait for released node deliveries for event %s: %v", backend, eventID, err)
+	}
+}
+
+func mailboxWritePendingNodeDeliveryCount(t *testing.T, db *sql.DB, backend, eventID string) int {
+	t.Helper()
+	if strings.TrimSpace(eventID) == "" {
+		return 0
+	}
+	sqlText := ""
+	if strings.HasPrefix(backend, "sqlite") {
+		sqlText = `SELECT COUNT(*) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND status = 'pending'`
+	} else {
+		sqlText = `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND status = 'pending'`
+	}
+	var count int
+	if err := db.QueryRowContext(context.Background(), sqlText, eventID).Scan(&count); err != nil {
+		t.Fatalf("%s pending node delivery count for %s: %v", backend, eventID, err)
+	}
+	return count
+}
+
+func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID string) events.Event {
+	t.Helper()
+	sqlText := ""
+	if strings.HasPrefix(backend, "sqlite") {
+		sqlText = `
+			SELECT event_id, COALESCE(run_id, ''), event_name, COALESCE(produced_by, ''),
+			       COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(scope, 'global'),
+			       payload, created_at, COALESCE(source_event_id, ''),
+			       COALESCE(source_route, '{}'), COALESCE(target_route, '{}'), COALESCE(target_set, '[]')
+			FROM events
+			WHERE event_id = ?
+		`
+	} else {
+		sqlText = `
+			SELECT event_id::text, COALESCE(run_id::text, ''), event_name, COALESCE(produced_by, ''),
+			       COALESCE(entity_id::text, ''), COALESCE(flow_instance, ''), COALESCE(scope, 'global'),
+			       payload, created_at, COALESCE(source_event_id::text, ''),
+			       COALESCE(source_route, '{}'::jsonb), COALESCE(target_route, '{}'::jsonb), COALESCE(target_set, '[]'::jsonb)
+			FROM events
+			WHERE event_id = $1::uuid
+		`
+	}
+	var id, runID, eventName, producedBy, entityID, flowInstance, scope, sourceEventID string
+	var payloadRaw, createdAtRaw, sourceRouteRaw, targetRouteRaw, targetSetRaw any
+	if err := db.QueryRowContext(context.Background(), sqlText, eventID).Scan(
+		&id,
+		&runID,
+		&eventName,
+		&producedBy,
+		&entityID,
+		&flowInstance,
+		&scope,
+		&payloadRaw,
+		&createdAtRaw,
+		&sourceEventID,
+		&sourceRouteRaw,
+		&targetRouteRaw,
+		&targetSetRaw,
+	); err != nil {
+		t.Fatalf("%s load event %s: %v", backend, eventID, err)
+	}
+	return events.NewProjectionEvent(
+		id,
+		events.EventType(eventName),
+		producedBy,
+		"",
+		mailboxWriteDBJSON(payloadRaw, "{}"),
+		0,
+		runID,
+		sourceEventID,
+		mailboxWriteDBEnvelope(t, entityID, flowInstance, scope, sourceRouteRaw, targetRouteRaw, targetSetRaw),
+		mailboxWriteDBTime(createdAtRaw),
+	)
+}
+
+func mailboxWriteDBEnvelope(t *testing.T, entityID, flowInstance, scope string, sourceRouteRaw, targetRouteRaw, targetSetRaw any) events.EventEnvelope {
+	t.Helper()
+	envelope := events.EventEnvelope{
+		EntityID:     strings.TrimSpace(entityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(flowInstance), "/"),
+		Scope:        events.EventScope(strings.TrimSpace(scope)),
+	}
+	if err := json.Unmarshal(mailboxWriteDBJSON(sourceRouteRaw, "{}"), &envelope.Source); err != nil {
+		t.Fatalf("decode source_route: %v", err)
+	}
+	if err := json.Unmarshal(mailboxWriteDBJSON(targetRouteRaw, "{}"), &envelope.Target); err != nil {
+		t.Fatalf("decode target_route: %v", err)
+	}
+	if err := json.Unmarshal(mailboxWriteDBJSON(targetSetRaw, "[]"), &envelope.TargetSet); err != nil {
+		t.Fatalf("decode target_set: %v", err)
+	}
+	return envelope.Normalized()
+}
+
+func mailboxWriteDBJSON(raw any, fallback string) json.RawMessage {
+	switch v := raw.(type) {
+	case nil:
+		return json.RawMessage(fallback)
+	case json.RawMessage:
+		if len(v) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return v
+	case []byte:
+		if len(v) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(v)
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(v)
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil || len(encoded) == 0 {
+			return json.RawMessage(fallback)
+		}
+		return json.RawMessage(encoded)
+	}
+}
+
+func mailboxWriteDBTime(raw any) time.Time {
+	switch v := raw.(type) {
+	case time.Time:
+		return v.UTC()
+	case []byte:
+		return mailboxWriteParseDBTime(string(v))
+	case string:
+		return mailboxWriteParseDBTime(v)
+	default:
+		return time.Now().UTC()
+	}
+}
+
+func mailboxWriteParseDBTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Now().UTC()
+}
+
+func waitForMailboxWriteBusQuiescence(t *testing.T, bus *runtimebus.EventBus, description string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := drainMailboxWriteBus(ctx, bus); err != nil {
+		t.Fatalf("%s bus drain: %v", description, err)
+	}
 }
 
 func eventReceiptsCapability(persistence any) func(context.Context) (bool, error) {
@@ -255,9 +440,12 @@ func eventReceiptsCapability(persistence any) func(context.Context) (bool, error
 	return provider.CanonicalEventReceiptsCapability
 }
 
-func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql.DB, runID, eventID, backend string) {
+func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql.DB, bus *runtimebus.EventBus, runID, eventID, backend string) {
 	t.Helper()
 	requireAPIV1Convergence(t, fmt.Sprintf("mailbox_write supported surface for %s", backend), func() (bool, error) {
+		if err := drainMailboxWriteBusPoll(bus); err != nil {
+			return false, err
+		}
 		listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"mailbox-list","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
 		if listed.Error != nil {
 			t.Fatalf("mailbox.list error = %#v", listed.Error)
@@ -275,9 +463,12 @@ func waitForMailboxWriteSupportedSurface(t *testing.T, handler *Handler, db *sql
 	})
 }
 
-func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, runID, eventID string) {
+func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, db *sql.DB, bus *runtimebus.EventBus, runID, eventID, backend string) {
 	t.Helper()
 	requireAPIV1Convergence(t, "rule mailbox_write supported surface", func() (bool, error) {
+		if err := drainMailboxWriteBusPoll(bus); err != nil {
+			return false, err
+		}
 		listed := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"rule-mailbox-list","method":"mailbox.list","params":{"status":"pending","run_id":%q,"limit":10}}`, runID))
 		if listed.Error != nil {
 			t.Fatalf("mailbox.list error = %#v", listed.Error)
@@ -290,8 +481,119 @@ func waitForConditionalRuleMailboxWrite(t *testing.T, handler *Handler, runID, e
 			}
 			return true, nil
 		}
-		return false, fmt.Errorf("mailbox.list returned %d items", len(items))
+		return false, fmt.Errorf("mailbox.list returned %d items\n%s", len(items), mailboxWriteDebugSummary(t, db, backend, runID, eventID))
 	})
+}
+
+func drainMailboxWriteBusPoll(bus *runtimebus.EventBus) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return drainMailboxWriteBus(ctx, bus)
+}
+
+func drainMailboxWriteBus(ctx context.Context, bus *runtimebus.EventBus) error {
+	if bus == nil {
+		return nil
+	}
+	for i := 0; i < 4; i++ {
+		if err := bus.WaitForQuiescence(ctx); err != nil {
+			return err
+		}
+		swept, err := bus.SweepUndispatched(ctx, time.Hour, 10)
+		if err != nil {
+			return err
+		}
+		if swept == 0 {
+			return bus.WaitForQuiescence(ctx)
+		}
+	}
+	return bus.WaitForQuiescence(ctx)
+}
+
+func mailboxWriteDebugSummary(t *testing.T, db *sql.DB, backend, runID, eventID string) string {
+	t.Helper()
+	sections := []string{
+		mailboxWriteDebugQuery(t, db, backend, "entity_state", runID, eventID),
+		mailboxWriteDebugQuery(t, db, backend, "events", runID, eventID),
+		mailboxWriteDebugQuery(t, db, backend, "event_deliveries", runID, eventID),
+		mailboxWriteDebugQuery(t, db, backend, "event_receipts", runID, eventID),
+		mailboxWriteDebugQuery(t, db, backend, "mailbox", runID, eventID),
+	}
+	return strings.Join(sections, "\n")
+}
+
+func mailboxWriteDebugQuery(t *testing.T, db *sql.DB, backend, scope, runID, eventID string) string {
+	t.Helper()
+	sqlText := ""
+	args := []any{runID, eventID}
+	if backend == "sqlite_default_no_selector" {
+		switch scope {
+		case "entity_state":
+			sqlText = `SELECT entity_id, current_state, fields FROM entity_state WHERE run_id = ? ORDER BY created_at, entity_id LIMIT 5`
+			args = []any{runID}
+		case "events":
+			sqlText = `SELECT event_id, event_name, COALESCE(entity_id, '') FROM events WHERE run_id = ? OR event_id = ? ORDER BY created_at, event_id LIMIT 8`
+		case "event_deliveries":
+			sqlText = `SELECT event_id, subscriber_type, subscriber_id, status, COALESCE(reason_code, '') FROM event_deliveries WHERE run_id = ? OR event_id = ? ORDER BY created_at, event_id, subscriber_id LIMIT 8`
+		case "event_receipts":
+			sqlText = `SELECT r.event_id, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = ? OR r.event_id = ? ORDER BY r.processed_at, r.event_id LIMIT 8`
+		case "mailbox":
+			sqlText = `SELECT item_id, status, item_type, source_event_id, COALESCE(entity_id, ''), payload FROM mailbox WHERE source_event_id = ? ORDER BY created_at, item_id LIMIT 5`
+			args = []any{eventID}
+		}
+	} else {
+		switch scope {
+		case "entity_state":
+			sqlText = `SELECT entity_id::text, current_state, fields::text FROM entity_state WHERE run_id = $1::uuid ORDER BY created_at, entity_id LIMIT 5`
+			args = []any{runID}
+		case "events":
+			sqlText = `SELECT event_id::text, event_name, COALESCE(entity_id::text, '') FROM events WHERE run_id = $1::uuid OR event_id = $2::uuid ORDER BY created_at, event_id LIMIT 8`
+		case "event_deliveries":
+			sqlText = `SELECT event_id::text, subscriber_type, subscriber_id, status, COALESCE(reason_code, '') FROM event_deliveries WHERE run_id = $1::uuid OR event_id = $2::uuid ORDER BY created_at, event_id, subscriber_id LIMIT 8`
+		case "event_receipts":
+			sqlText = `SELECT r.event_id::text, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = $1::uuid OR r.event_id = $2::uuid ORDER BY r.processed_at, r.event_id LIMIT 8`
+		case "mailbox":
+			sqlText = `SELECT item_id::text, status, item_type, source_event_id::text, COALESCE(entity_id::text, ''), payload::text FROM mailbox WHERE source_event_id = $1::uuid ORDER BY created_at, item_id LIMIT 5`
+			args = []any{eventID}
+		}
+	}
+	if sqlText == "" {
+		return scope + ": unsupported debug query"
+	}
+	rows, err := db.QueryContext(context.Background(), sqlText, args...)
+	if err != nil {
+		return fmt.Sprintf("%s: %v", scope, err)
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		return fmt.Sprintf("%s columns: %v", scope, err)
+	}
+	out := []string{}
+	for rows.Next() {
+		values := make([]sql.NullString, len(columns))
+		scan := make([]any, len(values))
+		for i := range values {
+			scan[i] = &values[i]
+		}
+		if err := rows.Scan(scan...); err != nil {
+			return fmt.Sprintf("%s scan: %v", scope, err)
+		}
+		cols := make([]string, len(values))
+		for i, value := range values {
+			if value.Valid {
+				cols[i] = value.String
+			}
+		}
+		out = append(out, fmt.Sprintf("%v", cols))
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Sprintf("%s rows: %v", scope, err)
+	}
+	if len(out) == 0 {
+		return scope + ": <none>"
+	}
+	return scope + ": " + strings.Join(out, "; ")
 }
 
 func assertConditionalRuleMailboxItem(t *testing.T, handler *Handler, item map[string]any, runID, eventID string) error {
@@ -401,26 +703,41 @@ func loadMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string
 	return state, decodeJSONMap(t, json.RawMessage(fieldsRaw)), nil
 }
 
-func waitForSQLitePipelineReceipt(t *testing.T, db *sql.DB) (string, string, string) {
+func waitForSQLiteNodeMaterializerFailure(t *testing.T, db *sql.DB, eventID, nodeID string) {
 	t.Helper()
-	var outcome, reason, errText string
-	requireAPIV1Convergence(t, "sqlite pipeline receipt", func() (bool, error) {
-		var gotOutcome, gotReason, gotErrText string
+	var lastStatus, lastReason, lastError, lastReceiptOutcome, lastReceiptReason, lastReceiptError string
+	requireAPIV1Convergence(t, "sqlite node mailbox materializer failure", func() (bool, error) {
 		if err := db.QueryRow(`
-			SELECT outcome, COALESCE(reason_code, ''), COALESCE(json_extract(side_effects, '$.error'), '')
-			FROM event_receipts
-			WHERE subscriber_type = 'platform' AND subscriber_id = 'pipeline'
-			ORDER BY processed_at DESC
+			SELECT
+				COALESCE(d.status, ''),
+				COALESCE(d.reason_code, ''),
+				COALESCE(d.last_error, ''),
+				COALESCE(r.outcome, ''),
+				COALESCE(r.reason_code, ''),
+				COALESCE(json_extract(r.side_effects, '$.error'), '')
+			FROM event_deliveries d
+			LEFT JOIN event_receipts r
+			  ON r.event_id = d.event_id
+			 AND r.subscriber_type = 'node'
+			 AND r.subscriber_id = d.subscriber_id
+			WHERE d.event_id = ?
+			  AND d.subscriber_type = 'node'
+			  AND d.subscriber_id = ?
 			LIMIT 1
-		`).Scan(&gotOutcome, &gotReason, &gotErrText); err == nil {
-			// Assign only after Scan succeeds so callers never observe partial values.
-			outcome, reason, errText = gotOutcome, gotReason, gotErrText
-			return true, nil
-		} else {
+		`, eventID, nodeID).Scan(&lastStatus, &lastReason, &lastError, &lastReceiptOutcome, &lastReceiptReason, &lastReceiptError); err != nil {
 			return false, err
 		}
+		if lastStatus != "dead_letter" || lastReceiptOutcome != "dead_letter" {
+			return false, nil
+		}
+		return strings.Contains(lastError, "mailbox_write requires mailbox materialization store") &&
+			strings.Contains(lastReceiptError, "mailbox_write requires mailbox materialization store"), nil
 	})
-	return outcome, reason, errText
+	if lastStatus != "dead_letter" || lastReceiptOutcome != "dead_letter" ||
+		!strings.Contains(lastError, "mailbox_write requires mailbox materialization store") ||
+		!strings.Contains(lastReceiptError, "mailbox_write requires mailbox materialization store") {
+		t.Fatalf("sqlite node/%s materializer failure = delivery status:%q reason:%q error:%q receipt outcome:%q reason:%q error:%q, want dead_letter materializer failure", nodeID, lastStatus, lastReason, lastError, lastReceiptOutcome, lastReceiptReason, lastReceiptError)
+	}
 }
 
 func bundleSourceFactForTestBundle(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle) runtimecorrelation.BundleSourceFact {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -1446,6 +1446,13 @@ func (eb *EventBus) PublishPersistedRecipients(ctx context.Context, evt events.E
 	return eb.publishPersistedRecipients(ctx, evt, recipients, false)
 }
 
+func (eb *EventBus) ReleasePendingPersistedDeliveriesForEvent(ctx context.Context, evt events.Event) error {
+	if eb == nil {
+		return nil
+	}
+	return eb.publishPersistedRecipients(ctx, evt, nil, true)
+}
+
 func (eb *EventBus) publishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string, replayInterceptors bool) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -89,6 +89,10 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 					Error:     strings.TrimSpace(err.Error()),
 				})
 			}
+			record.Outcome = startupManagerReplayOutcomeDropped
+			record.ReasonCode = startupManagerReplayReasonDeliveryStartFailed
+			record.ErrorText = strings.TrimSpace(err.Error())
+			return eventProcessResult{record: record, err: err}
 		} else if am.bus != nil {
 			am.bus.LogRuntime(ctx, runtimepipeline.RuntimeLogEntry{
 				Level:     "debug",

--- a/internal/runtime/manager/startup_replay_diagnostics.go
+++ b/internal/runtime/manager/startup_replay_diagnostics.go
@@ -50,6 +50,7 @@ const (
 	startupManagerReplayReasonBudgetEmergency      startupManagerReplayReasonCode = "budget_emergency"
 	startupManagerReplayReasonTransientAgentError  startupManagerReplayReasonCode = "transient_agent_error"
 	startupManagerReplayReasonProcessFailed        startupManagerReplayReasonCode = "event_processing_failed"
+	startupManagerReplayReasonDeliveryStartFailed  startupManagerReplayReasonCode = "delivery_start_failed"
 	startupManagerReplayReasonPublishFailed        startupManagerReplayReasonCode = "publish_output_failed"
 	startupManagerReplayReasonBacklogLoadFailed    startupManagerReplayReasonCode = "pending_backlog_load_failed"
 )

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -274,6 +274,9 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	if !pc.workflowNodeDeliveryAuthorized(ctx, nodeID, evt) {
 		return false, nil
 	}
+	if !pc.markWorkflowNodeDeliveryInProgress(ctx, nodeID, evt) {
+		return false, nil
+	}
 	ctx = withPipelineFlowScope(ctx, workflowNodeFlowID(source, nodeID))
 	if err := pc.notifyTestWorkflowNodeHandlerStarting(ctx, nodeID, evt); err != nil {
 		return false, err
@@ -293,9 +296,11 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 				HandlerNode:     nodeID,
 			})
 			setPipelineReceiptOverride(ctx, "dead_letter", err.Error())
+			pc.markWorkflowNodeDeliveryDeadLetter(ctx, nodeID, evt, "chain_depth_exceeded", err, 0)
 			return true, nil
 		}
 		pc.recordWorkflowHandlerFailure(ctx, evt, nodeID, err)
+		pc.markWorkflowNodeDeliveryDeadLetter(ctx, nodeID, evt, "handler_error", err, 0)
 		return true, err
 	}
 	pc.recordInterceptedEmitDeadLetters(ctx, evt, nodeID, result.Outcome)

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -30,10 +30,13 @@ func (s eventReceiptsCapabilityStub) resolve(context.Context) (bool, error) {
 type typedSystemNodeReceiptStore struct {
 	deliveryAuthorized bool
 	processed          bool
+	inProgress         int
+	failed             int
+	deadLettered       int
 	marked             int
 }
 
-func (s *typedSystemNodeReceiptStore) SystemNodeDeliveryAuthorized(context.Context, string, string) (bool, error) {
+func (s *typedSystemNodeReceiptStore) SystemNodeDeliveryAuthorized(context.Context, string, string, int) (bool, error) {
 	return s.deliveryAuthorized, nil
 }
 
@@ -43,6 +46,22 @@ func (s *typedSystemNodeReceiptStore) SystemNodeProcessed(context.Context, strin
 
 func (*typedSystemNodeReceiptStore) SystemNodeDeliveryQuiesced(context.Context, string, string) (bool, error) {
 	return false, nil
+}
+
+func (s *typedSystemNodeReceiptStore) MarkSystemNodeDeliveryInProgress(context.Context, string, string, int) error {
+	s.inProgress++
+	return nil
+}
+
+func (s *typedSystemNodeReceiptStore) MarkSystemNodeDeliveryFailed(context.Context, string, string, string, string, int, int) error {
+	s.failed++
+	return nil
+}
+
+func (s *typedSystemNodeReceiptStore) MarkSystemNodeDeliveryDeadLetter(context.Context, string, string, string, string, int, string) error {
+	s.processed = true
+	s.deadLettered++
+	return nil
 }
 
 func (s *typedSystemNodeReceiptStore) MarkSystemNodeProcessedAndSettleDelivery(context.Context, string, string, string) error {
@@ -87,6 +106,36 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	}
 	if failureType != "retry_exhausted" || retryCount != 2 || handlerNode != "node-a" {
 		t.Fatalf("dead_letter row = type=%q retry=%d handler=%q", failureType, retryCount, handlerNode)
+	}
+	var (
+		deliveryStatus string
+		deliveryReason string
+		deliveryError  string
+		receiptOutcome string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(last_error, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-a'
+	`, evt.ID()).Scan(&deliveryStatus, &deliveryReason, &deliveryError); err != nil {
+		t.Fatalf("query node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != "retry_exhausted" || !strings.Contains(deliveryError, "boom") {
+		t.Fatalf("node delivery = %s/%s err=%q, want dead_letter/retry_exhausted with error", deliveryStatus, deliveryReason, deliveryError)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(outcome, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-a'
+	`, evt.ID()).Scan(&receiptOutcome); err != nil {
+		t.Fatalf("query node receipt: %v", err)
+	}
+	if receiptOutcome != "dead_letter" {
+		t.Fatalf("node receipt outcome = %q, want dead_letter", receiptOutcome)
 	}
 }
 
@@ -201,7 +250,8 @@ func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
 func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *testing.T) {
 	bus := &capturingDeadLetterBus{}
 	attempts := 0
-	runner := newSystemNodeRunnerWithReceiptStoreAndRetryBase("node-a", bus, nil, &typedSystemNodeReceiptStore{deliveryAuthorized: true}, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
+	receipts := &typedSystemNodeReceiptStore{deliveryAuthorized: true}
+	runner := newSystemNodeRunnerWithReceiptStoreAndRetryBase("node-a", bus, nil, receipts, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
 		attempts++
 		return runtimerterr.NewRuntimeError("invalid_contract", "pipeline", "node.handle", false, "bad handler config")
 	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
@@ -232,6 +282,9 @@ func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *test
 	}
 	if got := asInt(payload["retry_count"]); got != 0 {
 		t.Fatalf("retry_count = %d, want 0", got)
+	}
+	if receipts.deadLettered != 1 || receipts.marked != 0 {
+		t.Fatalf("typed receipt owner deadLettered=%d marked=%d, want deadLettered=1 marked=0", receipts.deadLettered, receipts.marked)
 	}
 }
 
@@ -445,6 +498,35 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 	}
 	if failureType != "handler_error" || handlerNode != "node-a" || strings.TrimSpace(errorText) == "" {
 		t.Fatalf("dead_letter row = type=%q handler=%q error=%q", failureType, handlerNode, errorText)
+	}
+	var (
+		deliveryStatus string
+		deliveryReason string
+		receiptOutcome string
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-a'
+	`, evt.ID()).Scan(&deliveryStatus, &deliveryReason); err != nil {
+		t.Fatalf("query workflow node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != "handler_error" {
+		t.Fatalf("workflow node delivery = %s/%s, want dead_letter/handler_error", deliveryStatus, deliveryReason)
+	}
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(outcome, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-a'
+	`, evt.ID()).Scan(&receiptOutcome); err != nil {
+		t.Fatalf("query workflow node receipt: %v", err)
+	}
+	if receiptOutcome != "dead_letter" {
+		t.Fatalf("workflow node receipt outcome = %q, want dead_letter", receiptOutcome)
 	}
 }
 

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -124,10 +124,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 	if !n.deliveryAuthorized(ctx, evt) {
 		return
 	}
-	retryLimit := n.retryLimit
-	if retryLimit <= 0 {
-		retryLimit = DefaultSystemNodeRetryLimit
-	}
+	retryLimit := n.effectiveRetryLimit()
 	var lastErr error
 	failureType := "retry_exhausted"
 	retryCount := maxInt(retryLimit, 1)
@@ -136,6 +133,9 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 		backoffFn = func(attempt int) time.Duration { return defaultSystemNodeBackoff(time.Second, attempt) }
 	}
 	for attempt := 1; attempt <= retryLimit; attempt++ {
+		if !n.markDeliveryInProgress(ctx, evt) {
+			return
+		}
 		if err := n.handle(ctx, evt); err == nil {
 			if !n.isActiveRunQuiesced(ctx, evt) {
 				n.markProcessed(ctx, evt)
@@ -153,6 +153,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 		if attempt >= retryLimit {
 			break
 		}
+		n.markDeliveryFailed(ctx, evt, "handler_error", lastErr, retryCount)
 		select {
 		case <-ctx.Done():
 			return
@@ -163,7 +164,7 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 		return
 	}
 	n.emitDeadLetter(ctx, evt, lastErr, failureType, retryCount)
-	n.markProcessed(ctx, evt)
+	n.markDeliveryDeadLetter(ctx, evt, failureType, lastErr, retryCount)
 }
 
 func (n *systemNodeRunner) SetRetryPolicyForTest(limit int, backoff func(int) time.Duration) {
@@ -172,6 +173,13 @@ func (n *systemNodeRunner) SetRetryPolicyForTest(limit int, backoff func(int) ti
 	}
 	n.retryLimit = limit
 	n.backoffFn = backoff
+}
+
+func (n *systemNodeRunner) effectiveRetryLimit() int {
+	if n == nil {
+		return DefaultSystemNodeRetryLimit
+	}
+	return normalizeSystemNodeRetryLimit(n.retryLimit)
 }
 
 func (n *systemNodeRunner) SetOverrideHandleForTest(fn func(context.Context, events.Event) error) {
@@ -350,6 +358,87 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	n.convergeNormalRunCompletion(ctx, evt)
 }
 
+func (n *systemNodeRunner) markDeliveryInProgress(ctx context.Context, evt events.Event) bool {
+	eventID := strings.TrimSpace(evt.ID())
+	if n == nil || n.receiptStore == nil || eventID == "" {
+		return false
+	}
+	if n.isActiveRunQuiesced(ctx, evt) {
+		return false
+	}
+	if !n.eventReceiptsAvailable(ctx) {
+		return false
+	}
+	if err := n.receiptStore.MarkSystemNodeDeliveryInProgress(ctx, n.nodeID, eventID, n.effectiveRetryLimit()); err != nil {
+		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_in_progress_failed", "Marking the system node delivery in progress failed", err)
+		return false
+	}
+	return true
+}
+
+func (n *systemNodeRunner) markDeliveryFailed(ctx context.Context, evt events.Event, reasonCode string, cause error, retryCount int) {
+	eventID := strings.TrimSpace(evt.ID())
+	if n == nil || n.receiptStore == nil || eventID == "" {
+		return
+	}
+	if n.isActiveRunQuiesced(ctx, evt) {
+		return
+	}
+	if !n.eventReceiptsAvailable(ctx) {
+		return
+	}
+	errText := ""
+	if cause != nil {
+		errText = strings.TrimSpace(cause.Error())
+	}
+	if err := n.receiptStore.MarkSystemNodeDeliveryFailed(ctx, n.nodeID, eventID, reasonCode, errText, retryCount, n.effectiveRetryLimit()); err != nil {
+		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_failed_failed", "Marking the system node delivery as failed failed", err)
+	}
+}
+
+func (n *systemNodeRunner) markDeliveryDeadLetter(ctx context.Context, evt events.Event, reasonCode string, cause error, retryCount int) {
+	eventID := strings.TrimSpace(evt.ID())
+	if n == nil || n.receiptStore == nil || eventID == "" {
+		return
+	}
+	if n.isActiveRunQuiesced(ctx, evt) {
+		return
+	}
+	if !n.eventReceiptsAvailable(ctx) {
+		return
+	}
+	errText := ""
+	if cause != nil {
+		errText = strings.TrimSpace(cause.Error())
+	}
+	sideEffects := systemNodeDeadLetterReceiptSideEffects(n.nodeID, eventID, reasonCode, errText, retryCount)
+	if err := n.receiptStore.MarkSystemNodeDeliveryDeadLetter(ctx, n.nodeID, eventID, reasonCode, errText, retryCount, sideEffects); err != nil {
+		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_dead_letter_failed", "Marking the system node delivery as dead_letter failed", err)
+		return
+	}
+	n.convergeNormalRunCompletion(ctx, evt)
+}
+
+func (n *systemNodeRunner) logSystemNodeDeliveryTransitionError(ctx context.Context, evt events.Event, action, message string, err error) {
+	if n == nil || err == nil {
+		return
+	}
+	eventID := strings.TrimSpace(evt.ID())
+	slog.Error(message, "node_id", n.nodeID, "event_id", eventID, "error", err)
+	if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+		logger.LogRuntime(ctx, RuntimeLogEntry{
+			Level:     "error",
+			Message:   message,
+			Component: n.nodeID,
+			Action:    action,
+			EventID:   eventID,
+			EventType: strings.TrimSpace(string(evt.Type())),
+			EntityID:  workflowEventEntityID(evt),
+			Error:     strings.TrimSpace(err.Error()),
+		})
+	}
+}
+
 func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID, sideEffects string) error {
 	if n == nil || n.receiptStore == nil {
 		return nil
@@ -360,6 +449,16 @@ func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.
 func systemNodeProcessedReceiptSideEffects(nodeID, eventID string) string {
 	sideEffects, _ := json.Marshal(map[string]any{
 		"idempotency_key": SystemNodeReceiptIdempotencyKey(nodeID, eventID),
+	})
+	return string(sideEffects)
+}
+
+func systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText string, retryCount int) string {
+	sideEffects, _ := json.Marshal(map[string]any{
+		"idempotency_key": SystemNodeReceiptIdempotencyKey(nodeID, eventID),
+		"failure_type":    strings.TrimSpace(reasonCode),
+		"retry_count":     sanitizedSystemNodeRetryCount(retryCount),
+		"error":           strings.TrimSpace(errText),
 	})
 	return string(sideEffects)
 }
@@ -400,7 +499,8 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 	if tx == nil {
 		return nil
 	}
-	authorized, err := postgresSystemNodeDeliveryAuthorizedTx(ctx, tx, nodeID, eventID)
+	retryLimit := normalizeSystemNodeRetryLimit(DefaultSystemNodeRetryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedTx(ctx, tx, nodeID, eventID, retryLimit)
 	if err != nil {
 		return fmt.Errorf("query system node delivery authority: %w", err)
 	}
@@ -444,18 +544,278 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 			delivered_at = now()
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
-		  AND subscriber_id = $2
-		  AND (
-			status IN ('pending', 'in_progress')
-			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-		  )
-	`, eventID, nodeID); err != nil {
+			  AND subscriber_id = $2
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
+			  )
+		`, eventID, nodeID, retryLimit); err != nil {
 		return fmt.Errorf("settle system node delivery: %w", err)
 	}
 	return nil
 }
 
-func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
+func markPostgresSystemNodeDeliveryInProgress(ctx context.Context, db *sql.DB, nodeID, eventID string, retryLimit int) error {
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryInProgressTx(ctx, tx, nodeID, eventID, retryLimit)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin system node delivery start tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryInProgressTx(ctx, tx, nodeID, eventID, retryLimit); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit system node delivery start tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryInProgressTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) error {
+	if tx == nil {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedTx(ctx, tx, nodeID, eventID, retryLimit)
+	if err != nil {
+		return fmt.Errorf("query system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'in_progress',
+			reason_code = 'node_processing',
+			last_error = NULL,
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, now()),
+			delivered_at = NULL
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
+			  )
+	`, eventID, nodeID, retryLimit)
+	if err != nil {
+		return fmt.Errorf("mark system node delivery in progress: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryFailed(ctx context.Context, db *sql.DB, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryFailedTx(ctx, tx, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin system node delivery failure tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryFailedTx(ctx, tx, nodeID, eventID, reasonCode, errText, retryCount, retryLimit); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit system node delivery failure tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryFailedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
+	if tx == nil {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedTx(ctx, tx, nodeID, eventID, retryLimit)
+	if err != nil {
+		return fmt.Errorf("query system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'failed',
+			retry_count = $3,
+			reason_code = NULLIF($4, ''),
+			last_error = NULLIF($5, ''),
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND status IN ('pending', 'in_progress', 'failed')
+		  AND COALESCE(retry_count, 0) < $6
+	`, eventID, nodeID, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), retryLimit)
+	if err != nil {
+		return fmt.Errorf("mark system node delivery failed: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryDeadLetter(ctx context.Context, db *sql.DB, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryDeadLetterTx(ctx, tx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin system node delivery dead-letter tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryDeadLetterTx(ctx, tx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit system node delivery dead-letter tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryDeadLetterTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
+	if tx == nil {
+		return nil
+	}
+	exists, err := postgresSystemNodeDeliveryRowExistsTx(ctx, tx, nodeID, eventID)
+	if err != nil {
+		return fmt.Errorf("query system node delivery row: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	reasonCode = sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted")
+	errText = strings.TrimSpace(errText)
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'dead_letter',
+			retry_count = $3,
+			reason_code = NULLIF($4, ''),
+			last_error = NULLIF($5, ''),
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND status IN ('pending', 'in_progress', 'failed')
+	`, eventID, nodeID, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText)
+	if err != nil {
+		return fmt.Errorf("dead-letter system node delivery: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+	}
+	res, err = tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, 'node', $2, e.entity_id, e.flow_instance,
+			'dead_letter', NULLIF($3, ''), $4::jsonb, $5, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			outcome = EXCLUDED.outcome,
+			reason_code = EXCLUDED.reason_code,
+			side_effects = EXCLUDED.side_effects,
+			idempotency_key = EXCLUDED.idempotency_key,
+			processed_at = now()
+	`, eventID, nodeID, reasonCode, sqliteNodeJSON(sideEffects), SystemNodeReceiptIdempotencyKey(nodeID, eventID))
+	if err != nil {
+		return fmt.Errorf("upsert system node dead-letter receipt: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("upsert system node dead-letter receipt: event %s not found", eventID)
+	}
+	return nil
+}
+
+func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+				  AND subscriber_id = $2
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
+				  )
+			)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), retryLimit).Scan(&ok)
+	return ok, err
+}
+
+func postgresSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
 	if tx == nil {
 		return false, nil
 	}
@@ -470,10 +830,6 @@ func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nod
 			WHERE event_id = $1::uuid
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
-			  AND (
-				status IN ('pending', 'in_progress')
-				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-			  )
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
 	return ok, err
@@ -532,7 +888,7 @@ func (n *systemNodeRunner) deliveryAuthorized(ctx context.Context, evt events.Ev
 	if !n.eventReceiptsAvailable(ctx) {
 		return false
 	}
-	ok, err := n.receiptStore.SystemNodeDeliveryAuthorized(ctx, n.nodeID, eventID)
+	ok, err := n.receiptStore.SystemNodeDeliveryAuthorized(ctx, n.nodeID, eventID, n.effectiveRetryLimit())
 	if err != nil {
 		slog.Error("system node delivery authority check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -36,10 +36,21 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID)
 	bus := &systemNodeCompletionBus{}
 	handlerCalled := false
+	handlerObservedStatus := ""
+	handlerObservedReason := ""
 	runner := newSystemNodeRunner("terminal-node", bus, db, func() []events.EventType {
 		return []events.EventType{"example.started"}
 	}, func(ctx context.Context, evt events.Event) error {
 		handlerCalled = true
+		if err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, ''), COALESCE(reason_code, '')
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = 'terminal-node'
+		`, eventID).Scan(&handlerObservedStatus, &handlerObservedReason); err != nil {
+			t.Fatalf("load node delivery during handler: %v", err)
+		}
 		if _, err := db.ExecContext(ctx, `
 			UPDATE entity_state
 			SET current_state = 'done',
@@ -57,6 +68,9 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 
 	if !handlerCalled {
 		t.Fatal("handler was not called")
+	}
+	if handlerObservedStatus != "in_progress" || handlerObservedReason != "node_processing" {
+		t.Fatalf("handler observed node delivery = %s/%s, want in_progress/node_processing", handlerObservedStatus, handlerObservedReason)
 	}
 	if len(bus.converged) != 1 || bus.converged[0] != eventID {
 		t.Fatalf("normal run convergence events = %#v, want %s", bus.converged, eventID)
@@ -90,6 +104,114 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 	}
 	if receiptOutcome != "no_op" {
 		t.Fatalf("node receipt outcome = %q, want no_op", receiptOutcome)
+	}
+}
+
+func TestSystemNodeRunner_RetryableFailureWritesFailedBeforeRetry(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID)
+	bus := &systemNodeCompletionBus{}
+	attempts := 0
+	var (
+		backoffStatus string
+		backoffReason string
+		backoffError  string
+		backoffRetry  int
+	)
+	runner := newSystemNodeRunner("terminal-node", bus, db, func() []events.EventType {
+		return []events.EventType{"example.started"}
+	}, func(context.Context, events.Event) error {
+		attempts++
+		if attempts == 1 {
+			return errors.New("temporary node failure")
+		}
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+	runner.SetRetryPolicyForTest(2, func(int) time.Duration {
+		if err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(retry_count, 0)
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = 'terminal-node'
+		`, eventID).Scan(&backoffStatus, &backoffReason, &backoffError, &backoffRetry); err != nil {
+			t.Fatalf("load node delivery during retry backoff: %v", err)
+		}
+		return 0
+	})
+
+	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if backoffStatus != "failed" || backoffReason != "handler_error" || backoffRetry != 1 || backoffError == "" {
+		t.Fatalf("retry backoff delivery = %s/%s retry=%d err=%q, want failed/handler_error retry=1 with error", backoffStatus, backoffReason, backoffRetry, backoffError)
+	}
+	var finalStatus string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&finalStatus); err != nil {
+		t.Fatalf("load final node delivery: %v", err)
+	}
+	if finalStatus != "delivered" {
+		t.Fatalf("final node delivery status = %q, want delivered", finalStatus)
+	}
+}
+
+func TestSystemNodeRunner_RetryableFailureExhaustsConfiguredRetryLimit(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID)
+	bus := &systemNodeCompletionBus{}
+	attempts := 0
+	runner := newSystemNodeRunner("terminal-node", bus, db, func() []events.EventType {
+		return []events.EventType{"example.started"}
+	}, func(context.Context, events.Event) error {
+		attempts++
+		return errors.New("temporary node failure")
+	}, func(context.Context) (bool, error) { return true, nil })
+	runner.SetRetryPolicyForTest(DefaultSystemNodeRetryLimit, func(int) time.Duration { return 0 })
+
+	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+
+	if attempts != DefaultSystemNodeRetryLimit {
+		t.Fatalf("attempts = %d, want configured retry limit %d", attempts, DefaultSystemNodeRetryLimit)
+	}
+	var (
+		deliveryStatus string
+		deliveryReason string
+		deliveryRetry  int
+		receiptOutcome string
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(d.status, ''), COALESCE(d.reason_code, ''), COALESCE(d.retry_count, 0), COALESCE(r.outcome, '')
+		FROM event_deliveries d
+		LEFT JOIN event_receipts r
+		  ON r.event_id = d.event_id
+		 AND r.subscriber_type = d.subscriber_type
+		 AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = $1::uuid
+		  AND d.subscriber_type = 'node'
+		  AND d.subscriber_id = 'terminal-node'
+	`, eventID).Scan(&deliveryStatus, &deliveryReason, &deliveryRetry, &receiptOutcome); err != nil {
+		t.Fatalf("load exhausted node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != "retry_exhausted" || deliveryRetry != DefaultSystemNodeRetryLimit || receiptOutcome != "dead_letter" {
+		t.Fatalf("exhausted node delivery = %s/%s retry=%d receipt=%q, want dead_letter/retry_exhausted retry=%d receipt dead_letter", deliveryStatus, deliveryReason, deliveryRetry, receiptOutcome, DefaultSystemNodeRetryLimit)
 	}
 }
 
@@ -204,7 +326,7 @@ func TestSystemNodeProcessedSettlementFailsWithTerminalNodeDeliveryAuthority(t *
 		retryCount int
 	}{
 		{name: "dead_letter", status: "dead_letter", retryCount: 2},
-		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: DefaultSystemNodeRetryLimit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, db, _ := testutil.StartPostgres(t)

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -56,9 +56,12 @@ type WorkflowInstancePersistence interface {
 }
 
 type SystemNodeReceiptPersistence interface {
-	SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string) (bool, error)
+	SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string, retryLimit int) (bool, error)
 	SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error)
 	SystemNodeDeliveryQuiesced(ctx context.Context, nodeID, eventID string) (bool, error)
+	MarkSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error
+	MarkSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error
+	MarkSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error
 	MarkSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error
 }
 

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -15,9 +15,10 @@ import (
 
 var ErrSystemNodeDeliveryAuthorityMissing = errors.New("system node delivery authority missing")
 
-func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string) (bool, error) {
+func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context, nodeID, eventID string, retryLimit int) (bool, error) {
 	nodeID = strings.TrimSpace(nodeID)
 	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return false, nil
 	}
@@ -32,13 +33,13 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context
 				FROM event_deliveries
 				WHERE event_id = ?
 				  AND subscriber_type = 'node'
-				  AND subscriber_id = ?
-				  AND (
-					status IN ('pending', 'in_progress')
-					OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-				  )
-			)
-		`, eventID, nodeID).Scan(&ok)
+					  AND subscriber_id = ?
+					  AND (
+						status IN ('pending', 'in_progress')
+						OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+					  )
+				)
+			`, eventID, nodeID, retryLimit).Scan(&ok)
 		return ok, err
 	}
 	var ok bool
@@ -48,13 +49,13 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context
 			FROM event_deliveries
 			WHERE event_id = $1::uuid
 			  AND subscriber_type = 'node'
-			  AND subscriber_id = $2
-			  AND (
-				status IN ('pending', 'in_progress')
-				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-			  )
-		)
-	`, eventID, nodeID).Scan(&ok)
+				  AND subscriber_id = $2
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
+				  )
+			)
+		`, eventID, nodeID, retryLimit).Scan(&ok)
 	return ok, err
 }
 
@@ -145,9 +146,48 @@ func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDelivery(ctx con
 	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, s.db, nodeID, eventID, sideEffects)
 }
 
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryInProgress(ctx, nodeID, eventID, retryLimit)
+	}
+	return markPostgresSystemNodeDeliveryInProgress(ctx, s.db, nodeID, eventID, retryLimit)
+}
+
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryFailed(ctx, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
+	}
+	return markPostgresSystemNodeDeliveryFailed(ctx, s.db, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
+}
+
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+	}
+	return markPostgresSystemNodeDeliveryDeadLetter(ctx, s.db, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+}
+
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
 	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID)
+		retryLimit := normalizeSystemNodeRetryLimit(DefaultSystemNodeRetryLimit)
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
 		if err != nil {
 			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
 		}
@@ -191,12 +231,12 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 			    delivered_at = ?
 			WHERE event_id = ?
 			  AND subscriber_type = 'node'
-			  AND subscriber_id = ?
-			  AND (
-				status IN ('pending', 'in_progress')
-				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-			  )
-		`, now, eventID, nodeID)
+				  AND subscriber_id = ?
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+				  )
+			`, now, eventID, nodeID, retryLimit)
 		if err != nil {
 			return fmt.Errorf("settle sqlite system node delivery: %w", err)
 		}
@@ -207,7 +247,166 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 	})
 }
 
-func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'in_progress',
+			    reason_code = 'node_processing',
+			    last_error = NULL,
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, ?),
+			    delivered_at = NULL
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+			  )
+		`, now, eventID, nodeID, retryLimit)
+		if err != nil {
+			return fmt.Errorf("mark sqlite system node delivery in progress: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		return nil
+	})
+}
+
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'failed',
+			    retry_count = ?,
+			    reason_code = NULLIF(?, ''),
+			    last_error = NULLIF(?, ''),
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND status IN ('pending', 'in_progress', 'failed')
+			  AND COALESCE(retry_count, 0) < ?
+		`, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), now, eventID, nodeID, retryLimit)
+		if err != nil {
+			return fmt.Errorf("mark sqlite system node delivery failed: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		return nil
+	})
+}
+
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
+	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		exists, err := sqliteSystemNodeDeliveryRowExistsTx(txctx, tx, nodeID, eventID)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery row: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		now := time.Now().UTC()
+		reasonCode = sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted")
+		errText = strings.TrimSpace(errText)
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'dead_letter',
+			    retry_count = ?,
+			    reason_code = NULLIF(?, ''),
+			    last_error = NULLIF(?, ''),
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND status IN ('pending', 'in_progress', 'failed')
+		`, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText, now, eventID, nodeID)
+		if err != nil {
+			return fmt.Errorf("dead-letter sqlite system node delivery: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		res, err = tx.ExecContext(txctx, `
+			INSERT INTO event_receipts (
+				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+				outcome, reason_code, side_effects, idempotency_key, processed_at
+			)
+			SELECT
+				?, e.event_id, 'node', ?, e.entity_id, e.flow_instance,
+				'dead_letter', NULLIF(?, ''), ?, ?, ?
+			FROM events e
+			WHERE e.event_id = ?
+			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+				entity_id = excluded.entity_id,
+				flow_instance = excluded.flow_instance,
+				outcome = excluded.outcome,
+				reason_code = excluded.reason_code,
+				side_effects = excluded.side_effects,
+				idempotency_key = excluded.idempotency_key,
+				processed_at = excluded.processed_at
+		`, uuid.NewString(), nodeID, reasonCode, sqliteNodeJSON(sideEffects), SystemNodeReceiptIdempotencyKey(nodeID, eventID), now, eventID)
+		if err != nil {
+			return fmt.Errorf("upsert sqlite system node dead-letter receipt: %w", err)
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+			return fmt.Errorf("upsert sqlite system node dead-letter receipt: event %s not found", eventID)
+		}
+		return nil
+	})
+}
+
+func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+			  )
+			)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), retryLimit).Scan(&ok)
+	return ok, err
+}
+
+func sqliteSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
 	if tx == nil {
 		return false, nil
 	}
@@ -222,10 +421,6 @@ func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeI
 			WHERE event_id = ?
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = ?
-			  AND (
-				status IN ('pending', 'in_progress')
-				OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
-			  )
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
 	return ok, err
@@ -237,4 +432,30 @@ func sqliteNodeJSON(raw string) string {
 		return "{}"
 	}
 	return raw
+}
+
+func sanitizedSystemNodeRetryCount(retryCount int) int {
+	if retryCount < 0 {
+		return 0
+	}
+	return retryCount
+}
+
+func sanitizeSystemNodeReasonCode(reasonCode, fallback string) string {
+	reasonCode = strings.TrimSpace(reasonCode)
+	if reasonCode != "" {
+		return reasonCode
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		return fallback
+	}
+	return "handler_error"
+}
+
+func normalizeSystemNodeRetryLimit(retryLimit int) int {
+	if retryLimit <= 0 {
+		return DefaultSystemNodeRetryLimit
+	}
+	return retryLimit
 }

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -77,7 +77,7 @@ func TestPipelineCoordinatorInterceptTerminalNodeDeliveryDoesNotAuthorizeExecuti
 		retryCount int
 	}{
 		{name: "dead_letter", status: "dead_letter", retryCount: 2},
-		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: DefaultSystemNodeRetryLimit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, db, _ := testutil.StartPostgres(t)

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -855,6 +855,67 @@ func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, no
 	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
 }
 
+func (pc *PipelineCoordinator) markWorkflowNodeDeliveryInProgress(ctx context.Context, nodeID string, evt events.Event) bool {
+	if pc == nil || pc.workflowStore == nil {
+		return false
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID := strings.TrimSpace(evt.ID())
+	if nodeID == "" || eventID == "" {
+		return false
+	}
+	if !pc.eventReceiptsAvailable(ctx) {
+		return false
+	}
+	if err := pc.workflowStore.MarkSystemNodeDeliveryInProgress(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit); err != nil {
+		pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_in_progress_failed", "Marking the workflow node delivery in progress failed", err)
+		return false
+	}
+	return true
+}
+
+func (pc *PipelineCoordinator) markWorkflowNodeDeliveryDeadLetter(ctx context.Context, nodeID string, evt events.Event, reasonCode string, cause error, retryCount int) {
+	if pc == nil || pc.workflowStore == nil {
+		return
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID := strings.TrimSpace(evt.ID())
+	if nodeID == "" || eventID == "" {
+		return
+	}
+	if !pc.eventReceiptsAvailable(ctx) {
+		return
+	}
+	errText := ""
+	if cause != nil {
+		errText = strings.TrimSpace(cause.Error())
+	}
+	sideEffects := systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText, retryCount)
+	if err := pc.workflowStore.MarkSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects); err != nil {
+		pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_dead_letter_failed", "Marking the workflow node delivery as dead_letter failed", err)
+		return
+	}
+	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
+}
+
+func (pc *PipelineCoordinator) logWorkflowNodeDeliveryTransitionError(ctx context.Context, nodeID string, evt events.Event, action, message string, err error) {
+	if pc == nil || err == nil {
+		return
+	}
+	if logger, ok := pc.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+		logger.LogRuntime(ctx, RuntimeLogEntry{
+			Level:     "error",
+			Message:   message,
+			Component: nodeID,
+			Action:    action,
+			EventID:   strings.TrimSpace(evt.ID()),
+			EventType: strings.TrimSpace(string(evt.Type())),
+			EntityID:  workflowEventEntityID(evt),
+			Error:     strings.TrimSpace(err.Error()),
+		})
+	}
+}
+
 func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Context, nodeID string, evt events.Event) bool {
 	if pc == nil {
 		return false
@@ -873,7 +934,7 @@ func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Contex
 	if eventID == "" {
 		return false
 	}
-	ok, err := pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID)
+	ok, err := pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit)
 	if err != nil {
 		if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -79,6 +79,7 @@ type RuntimeOptions struct {
 	DisablePersistentStartupRecovery bool
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
+	TestOutboxSweeperConfig          runtimebus.OutboxSweeperConfig
 }
 
 // RuntimeDeps is the canonical dependency graph for NewRuntime boot wiring.
@@ -885,7 +886,11 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	rt.logStartupRecoveryDecision(ctx, startupRecoveryDecision)
 	if rt.Bus != nil {
-		rt.Bus.StartOutboxSweeper(startCtx, runtimebus.DefaultOutboxSweeperConfig())
+		sweeperConfig := rt.Options.TestOutboxSweeperConfig
+		if sweeperConfig == (runtimebus.OutboxSweeperConfig{}) {
+			sweeperConfig = runtimebus.DefaultOutboxSweeperConfig()
+		}
+		rt.Bus.StartOutboxSweeper(startCtx, sweeperConfig)
 		rt.emitBootProgress(12, "outbox_sweeper", "started", "")
 	} else {
 		rt.emitBootProgress(12, "outbox_sweeper", "skipped", "event bus unavailable")

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -375,8 +375,17 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 		  )
 		  AND COALESCE(reason_code, '') <> ALL($4)
 	`
-	if _, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes())); err != nil {
+	res, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes()))
+	if err != nil {
 		return fmt.Errorf("mark event delivery in progress: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		if _, ok, err := s.ActiveRunDeliveryQuiesced(ctx, eventID, "agent", agentID); err != nil {
+			return err
+		} else if ok {
+			return nil
+		}
+		return fmt.Errorf("mark event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
 	}
 	return nil
 }

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -912,6 +912,20 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	if processed, err := owner.SystemNodeProcessed(ctx, "background-node", eventID); err != nil || processed {
 		t.Fatalf("SystemNodeProcessed before mark = %v err=%v, want false nil", processed, err)
 	}
+	if err := owner.MarkSystemNodeDeliveryInProgress(ctx, "background-node", eventID, runtimepipeline.DefaultSystemNodeRetryLimit); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryInProgress: %v", err)
+	}
+	var inProgressStatus, inProgressReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&inProgressStatus, &inProgressReason); err != nil {
+		t.Fatalf("load sqlite node delivery after start: %v", err)
+	}
+	if inProgressStatus != "in_progress" || inProgressReason != "node_processing" {
+		t.Fatalf("node delivery after start = %s/%s, want in_progress/node_processing", inProgressStatus, inProgressReason)
+	}
 	if err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`); err != nil {
 		t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery: %v", err)
 	}
@@ -938,6 +952,56 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	}
 	if receiptOutcome != "no_op" {
 		t.Fatalf("node receipt outcome = %q, want no_op", receiptOutcome)
+	}
+}
+
+func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("company.scanned"),
+		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+
+	if err := store.AppendEvent(ctx, evt); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := store.InsertEventDeliveryRoutes(ctx, eventID, []events.DeliveryRoute{{SubscriberType: "node", SubscriberID: "background-node"}}); err != nil {
+		t.Fatalf("InsertEventDeliveryRoutes: %v", err)
+	}
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	if err := owner.MarkSystemNodeDeliveryInProgress(ctx, "background-node", eventID, runtimepipeline.DefaultSystemNodeRetryLimit); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryInProgress: %v", err)
+	}
+	if err := owner.MarkSystemNodeDeliveryDeadLetter(ctx, "background-node", eventID, "retry_exhausted", "boom", 2, `{"idempotency_key":"test"}`); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryDeadLetter: %v", err)
+	}
+	if processed, err := owner.SystemNodeProcessed(ctx, "background-node", eventID); err != nil || !processed {
+		t.Fatalf("SystemNodeProcessed after dead-letter = %v err=%v, want true nil", processed, err)
+	}
+	var deliveryStatus, deliveryReason, deliveryError, receiptOutcome string
+	var retryCount int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(retry_count, 0)
+		FROM event_deliveries
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&deliveryStatus, &deliveryReason, &deliveryError, &retryCount); err != nil {
+		t.Fatalf("load sqlite node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || deliveryReason != "retry_exhausted" || deliveryError != "boom" || retryCount != 2 {
+		t.Fatalf("sqlite node delivery = %s/%s retry=%d err=%q, want dead_letter/retry_exhausted retry=2 err=boom", deliveryStatus, deliveryReason, retryCount, deliveryError)
+	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(outcome, '')
+		FROM event_receipts
+		WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'background-node'
+	`, eventID).Scan(&receiptOutcome); err != nil {
+		t.Fatalf("load sqlite node receipt: %v", err)
+	}
+	if receiptOutcome != "dead_letter" {
+		t.Fatalf("node receipt outcome = %q, want dead_letter", receiptOutcome)
 	}
 }
 
@@ -990,7 +1054,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 		retryCount int
 	}{
 		{name: "dead_letter", status: "dead_letter", retryCount: 2},
-		{name: "retry_exhausted_failed", status: "failed", retryCount: 2},
+		{name: "retry_exhausted_failed", status: "failed", retryCount: runtimepipeline.DefaultSystemNodeRetryLimit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/openrpc.json
+++ b/openrpc.json
@@ -9291,6 +9291,7 @@
         "type": "object"
       },
       "DeliveryStatus": {
+        "description": "Canonical delivery lifecycle persisted in event_deliveries.status. pending is queued/not started; in_progress is claimed or executing; delivered is successful settlement; failed is retry-visible failure; dead_letter is terminal failure.",
         "enum": [
           "pending",
           "in_progress",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4641,9 +4641,15 @@ platform_tables:
         ownership.
       ddl: "CREATE TABLE run_fork_selected_contract_route_recoveries (\n    recovery_id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id                    UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id                  UUID NOT NULL REFERENCES runs(run_id),\n    fork_event_id                  UUID NOT NULL REFERENCES events(event_id),\n    owner                          TEXT NOT NULL,\n    runtime_recovery_owner         TEXT NOT NULL,\n    mode                           TEXT NOT NULL CHECK (mode IN ('selected_contracts', 'bundle_hash')),\n    contracts_root                 TEXT,\n    bundle_hash                    TEXT CHECK (bundle_hash IS NULL OR bundle_hash ~ '^bundle-v1:sha256:[0-9a-f]{64}$'),\n    workflow_name                  TEXT NOT NULL,\n    workflow_version               TEXT NOT NULL,\n    route_topology_owner           TEXT NOT NULL,\n    dynamic_topology_owner         TEXT,\n    recipient_planning_owner       TEXT NOT NULL,\n    frontier_evidence_fingerprint  TEXT NOT NULL,\n    route_topology_fingerprint     TEXT NOT NULL,\n    recipient_planning_fingerprint TEXT NOT NULL,\n    static_route_event_count       INTEGER NOT NULL DEFAULT 0,\n    dynamic_topology_proof_count   INTEGER NOT NULL DEFAULT 0,\n    recipient_plan_event_count     INTEGER NOT NULL DEFAULT 0,\n    route_topology                 JSONB NOT NULL,\n    recipient_planning             JSONB NOT NULL,\n    created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((mode = 'selected_contracts' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NOT NULL AND NULLIF(TRIM(COALESCE(bundle_hash, '')), '') IS NULL) OR (mode = 'bundle_hash' AND NULLIF(TRIM(COALESCE(contracts_root, '')), '') IS NULL AND bundle_hash IS NOT NULL)),\n    UNIQUE (fork_run_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_source (source_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_route_recoveries_owner (owner, runtime_recovery_owner)\n);"
     event_deliveries:
-      description: Tracks delivery of events to subscribers (nodes and agents). One row per event × subscriber. run_id
-        inherited from the parent event for run-scoped queries. delivery_target_route stores the concrete target_set
-        member assigned to this subscriber when fan-out routing materializes multiple target identities.
+      description: >-
+        Tracks delivery of events to subscribers (nodes and agents). One row per event x subscriber. run_id inherited
+        from the parent event for run-scoped queries. delivery_target_route stores the concrete target_set member assigned
+        to this subscriber when fan-out routing materializes multiple target identities. status is the canonical lifecycle
+        owner for both agent and node deliveries: pending means queued/not started; in_progress means the delivery has been
+        claimed or handler execution has started; delivered means successfully settled; failed means a retry-visible
+        handler/dispatch failure; dead_letter means terminal failure. Agent and system-node execution paths must mark
+        in_progress before handler execution, must not execute from missing delivery authority, and must not settle handler
+        failure as delivered.
       ddl: "CREATE TABLE event_deliveries (\n    delivery_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \            UUID REFERENCES runs(run_id),\n    event_id          UUID NOT NULL REFERENCES events(event_id),\n\
         \    subscriber_type   TEXT NOT NULL CHECK (subscriber_type IN ('node', 'agent')),\n    subscriber_id     TEXT NOT\
@@ -12386,6 +12392,10 @@ api_specification:
               minimum: 0
       DeliveryStatus:
         type: string
+        description: >-
+          Canonical delivery lifecycle persisted in event_deliveries.status. pending is queued/not started; in_progress
+          is claimed or executing; delivered is successful settlement; failed is retry-visible failure; dead_letter is
+          terminal failure.
         enum:
         - pending
         - in_progress


### PR DESCRIPTION
Closes #1374.

## Summary

This PR makes persisted `event_deliveries.status` the strict lifecycle owner for existing agent and system-node delivery execution paths:

- `pending`: queued / not started
- `in_progress`: claimed or handler execution started
- `delivered`: successfully settled
- `failed`: retry-visible failure
- `dead_letter`: terminal failure

System-node execution now marks node deliveries `in_progress` before handler execution, writes `failed` between retryable attempts, and writes `dead_letter` instead of settling failed work as `delivered`. Agent start ownership now fails closed on Postgres zero-row start updates, matching the existing SQLite fail-closed behavior.

## Governing Refs / Context

- `platform-spec.yaml` `platform_tables.event_deliveries`
- `platform-spec.yaml` OpenRPC `DeliveryStatus`
- #1374 pre-audit: https://github.com/division-sh/swarm/issues/1374#issuecomment-4638971090
- #1374 gate: https://github.com/division-sh/swarm/issues/1374#issuecomment-4639098929

## Semantic Migration

- New canonical owner: unchanged table/field, now explicitly ratified as `event_deliveries.status` for delivery lifecycle truth.
- Old invalid paths: system-node handler execution while the row remained `pending`; system-node terminal failure using processed/success settlement and persisting `delivered`; Postgres agent start marking returning success when no delivery row was updated.
- Production paths checked: system-node runner, workflow coordinator/interceptor node execution, agent manager live/replay/backlog start path, Postgres/SQLite lifecycle writers, event.publish readback, event.replay nonterminal readback, event/trace read surfaces, run.diagnose active-delivery projection.
- Migration completeness: complete for the #1374 approved first slice. #1375 remains split for richer failure-evidence/read-model details.

## Proof

- `go test ./internal/runtime/pipeline ./internal/store ./internal/runtime/manager -run 'TestSystemNodeRunner|TestCoordinator_InterceptHandlerError|TestSQLiteRuntimeStoreSystemNodeReceiptOwner|TestMarkEventDeliveryInProgress|TestReplayBacklog|TestRecoverWithStartupReplayDiagnostics' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)|TestProjectRunOperationalStatus' -count=1 -v`
- `go test ./internal/store -run 'TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn|TestRunDebugTracePageTypedFilters|TestProjectRunOperationalStatus|TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2|TestMarkEventDeliveryInProgress_AllowsRetryableFailedDeliveryClaim_V2|TestSQLiteRuntimeStoreSystemNodeReceiptOwner(SettlesDelivery|DeadLettersDelivery)' -count=1`
- `go test ./cmd/swarm ./internal/apispec ./internal/apiv1 -run 'TestRunServeRuntimeEventPublishDynamicAutoEmitReturnsDurableAckAndDispatchesChild|TestGeneratedOpenRPCArtifactMatchesPlatformSpec|TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends|TestOperatorEventReplaySubsetAndFailClosedCases|TestOperatorEventPublish' -count=1`
- `go test ./...`
