### PR TITLE
[agent-c][issue #1377] Harden persisted event admission

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4629,7 +4629,7 @@ func servedEventPublishDebugQuery(t *testing.T, db *sql.DB, backend, scope, runI
 		case "event_deliveries":
 			sqlText = `SELECT event_id::text, subscriber_type, subscriber_id, status, COALESCE(reason_code, '') FROM event_deliveries WHERE run_id = $1::uuid ORDER BY created_at, event_id LIMIT 8`
 		case "event_receipts":
-			sqlText = `SELECT r.event_id::text, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = $1::uuid ORDER BY r.processed_at, r.event_id LIMIT 8`
+			sqlText = `SELECT r.event_id::text, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, ''), COALESCE(r.side_effects::text, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = $1::uuid ORDER BY r.processed_at, r.event_id LIMIT 8`
 		case "dead_letters":
 			sqlText = `SELECT d.original_event, COALESCE(d.entity_id::text, ''), d.failure_type, COALESCE(d.error_message, '') FROM dead_letters d JOIN events e ON e.event_id = d.original_event_id WHERE e.run_id = $1::uuid ORDER BY d.created_at LIMIT 5`
 		}
@@ -4642,7 +4642,7 @@ func servedEventPublishDebugQuery(t *testing.T, db *sql.DB, backend, scope, runI
 		case "event_deliveries":
 			sqlText = `SELECT event_id, subscriber_type, subscriber_id, status, COALESCE(reason_code, '') FROM event_deliveries WHERE run_id = ? ORDER BY created_at, event_id LIMIT 8`
 		case "event_receipts":
-			sqlText = `SELECT r.event_id, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = ? ORDER BY r.processed_at, r.event_id LIMIT 8`
+			sqlText = `SELECT r.event_id, r.subscriber_type, r.subscriber_id, r.outcome, COALESCE(r.reason_code, ''), COALESCE(r.side_effects, '') FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = ? ORDER BY r.processed_at, r.event_id LIMIT 8`
 		case "dead_letters":
 			sqlText = `SELECT d.original_event, COALESCE(d.entity_id, ''), d.failure_type, COALESCE(d.error_message, '') FROM dead_letters d JOIN events e ON e.event_id = d.original_event_id WHERE e.run_id = ? ORDER BY d.created_at LIMIT 5`
 		}

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -721,7 +721,7 @@ func assertNoReplayEvent(t *testing.T, ch <-chan events.Event) {
 func fillAgentChannel(t *testing.T, ctx context.Context, bus *runtimebus.EventBus, agentID string, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		err := bus.PublishDirect(ctx, events.NewProjectionEvent(uuid.NewString(),
+		err := bus.PublishDirect(ctx, events.NewRootIngressEvent(uuid.NewString(),
 			events.EventType("filler.event"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()), []string{agentID})
 		if err != nil {
 			t.Fatalf("fill agent channel publish %d: %v", i, err)

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -53,7 +53,7 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	`, runID, entityID, base); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
@@ -371,7 +371,7 @@ func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID)); err != nil {
 		t.Fatalf("append source event: %v", err)
@@ -434,7 +434,7 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID)); err != nil {
 		t.Fatalf("append source event: %v", err)
@@ -548,7 +548,7 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
@@ -664,7 +664,7 @@ func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -258,7 +258,14 @@ func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *run
 	if bus == nil {
 		t.Fatalf("%s runtime bus is required to release pending node deliveries", backend)
 	}
-	if mailboxWritePendingNodeDeliveryCount(t, db, backend, eventID) == 0 {
+	requireAPIV1Convergence(t, fmt.Sprintf("%s node delivery authority for %s", backend, eventID), func() (bool, error) {
+		_, total := mailboxWriteNodeDeliveryCounts(t, db, backend, eventID)
+		if total > 0 {
+			return true, nil
+		}
+		return false, fmt.Errorf("node delivery row not visible yet")
+	})
+	if pending, _ := mailboxWriteNodeDeliveryCounts(t, db, backend, eventID); pending == 0 {
 		return
 	}
 	evt := loadMailboxWritePersistedEvent(t, db, backend, eventID)
@@ -272,22 +279,21 @@ func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *run
 	}
 }
 
-func mailboxWritePendingNodeDeliveryCount(t *testing.T, db *sql.DB, backend, eventID string) int {
+func mailboxWriteNodeDeliveryCounts(t *testing.T, db *sql.DB, backend, eventID string) (pending int, total int) {
 	t.Helper()
 	if strings.TrimSpace(eventID) == "" {
-		return 0
+		return 0, 0
 	}
 	sqlText := ""
 	if strings.HasPrefix(backend, "sqlite") {
-		sqlText = `SELECT COUNT(*) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND status = 'pending'`
+		sqlText = `SELECT COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0), COUNT(*) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node'`
 	} else {
-		sqlText = `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND status = 'pending'`
+		sqlText = `SELECT COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0), COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node'`
 	}
-	var count int
-	if err := db.QueryRowContext(context.Background(), sqlText, eventID).Scan(&count); err != nil {
-		t.Fatalf("%s pending node delivery count for %s: %v", backend, eventID, err)
+	if err := db.QueryRowContext(context.Background(), sqlText, eventID).Scan(&pending, &total); err != nil {
+		t.Fatalf("%s node delivery counts for %s: %v", backend, eventID, err)
 	}
-	return count
+	return pending, total
 }
 
 func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID string) events.Event {

--- a/internal/events/admission.go
+++ b/internal/events/admission.go
@@ -1,0 +1,138 @@
+package events
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type AdmissionOptions struct {
+	Class                    EventAdmissionClass
+	Now                      time.Time
+	RunIDCandidate           string
+	ParentEventIDCandidate   string
+	SelectedForkLineageOwner string
+	SourceAgentDefault       string
+}
+
+func AdmitForPublish(evt Event, opts AdmissionOptions) (Event, error) {
+	return admitPersistableEvent(evt, opts)
+}
+
+func AdmitForPersistence(evt Event, opts AdmissionOptions) (Event, error) {
+	return admitPersistableEvent(evt, opts)
+}
+
+func admitPersistableEvent(evt Event, opts AdmissionOptions) (Event, error) {
+	class := normalizedAdmissionClass(opts.Class)
+	if class == EventAdmissionUnknown {
+		class = normalizedAdmissionClass(evt.AdmissionClass())
+	}
+	if class == EventAdmissionUnknown {
+		return Event{}, fmt.Errorf("event admission class is required for persistence")
+	}
+	if class == EventAdmissionRouteProbe {
+		return Event{}, fmt.Errorf("route probe events are not persistable")
+	}
+	eventType := EventType(strings.TrimSpace(string(evt.Type())))
+	if eventType == "" {
+		return Event{}, fmt.Errorf("event type is required for persistence admission")
+	}
+	id := strings.TrimSpace(evt.ID())
+	if id == "" {
+		id = uuid.NewString()
+	}
+	createdAt := evt.CreatedAt()
+	if createdAt.IsZero() {
+		createdAt = opts.Now
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	createdAt = createdAt.UTC()
+
+	runID := firstNonEmpty(evt.RunID(), opts.RunIDCandidate)
+	parentEventID := firstNonEmpty(evt.ParentEventID(), opts.ParentEventIDCandidate)
+	sourceAgent := firstNonEmpty(evt.SourceAgent(), opts.SourceAgentDefault)
+
+	switch class {
+	case EventAdmissionRootIngress:
+		if runID == "" {
+			runID = uuid.NewString()
+		}
+	case EventAdmissionChild:
+		if runID == "" {
+			return Event{}, fmt.Errorf("%s event %s requires admitted run_id", class, eventType)
+		}
+		if parentEventID == "" {
+			return Event{}, fmt.Errorf("%s event %s requires admitted parent_event_id", class, eventType)
+		}
+	case EventAdmissionReplay:
+		if runID == "" {
+			return Event{}, fmt.Errorf("%s event %s requires admitted run_id", class, eventType)
+		}
+		if parentEventID == "" && strings.TrimSpace(opts.SelectedForkLineageOwner) == "" {
+			return Event{}, fmt.Errorf("%s event %s requires admitted parent_event_id or selected_fork_lineage_owner", class, eventType)
+		}
+	case EventAdmissionRuntimeControl, EventAdmissionRuntimeDiagnostic:
+		if isStandaloneRuntimePlatformEvent(eventType, sourceAgent) && runID == "" {
+			runID = uuid.NewString()
+		}
+	case EventAdmissionDiagnosticDirect, EventAdmissionProjection:
+		// These classes may be global/no-run records. If a run/parent is present
+		// it must come from the constructor or a bounded context candidate.
+	default:
+		return Event{}, fmt.Errorf("unsupported event admission class %q", class)
+	}
+
+	return newEvent(
+		class,
+		id,
+		eventType,
+		sourceAgent,
+		evt.TaskID(),
+		evt.Payload(),
+		evt.ChainDepth(),
+		runID,
+		parentEventID,
+		evt.NormalizedEnvelope(),
+		createdAt,
+	), nil
+}
+
+func normalizedAdmissionClass(class EventAdmissionClass) EventAdmissionClass {
+	return EventAdmissionClass(strings.TrimSpace(string(class)))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isStandaloneRuntimePlatformEvent(eventType EventType, sourceAgent string) bool {
+	if strings.TrimSpace(sourceAgent) != "runtime" {
+		return false
+	}
+	switch strings.TrimSpace(string(eventType)) {
+	case "platform.boot",
+		"platform.recovery_failed",
+		"platform.event_quarantined",
+		"platform.agent_panic",
+		"platform.agent_failed",
+		"platform.auth_required",
+		"platform.paused",
+		"platform.resumed",
+		"platform.dead_letter_escalation",
+		"platform.run_stalled",
+		"platform.budget_threshold_crossed":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/events/admission.go
+++ b/internal/events/admission.go
@@ -18,14 +18,14 @@ type AdmissionOptions struct {
 }
 
 func AdmitForPublish(evt Event, opts AdmissionOptions) (Event, error) {
-	return admitPersistableEvent(evt, opts)
+	return admitPersistableEvent(evt, opts, true)
 }
 
 func AdmitForPersistence(evt Event, opts AdmissionOptions) (Event, error) {
-	return admitPersistableEvent(evt, opts)
+	return admitPersistableEvent(evt, opts, false)
 }
 
-func admitPersistableEvent(evt Event, opts AdmissionOptions) (Event, error) {
+func admitPersistableEvent(evt Event, opts AdmissionOptions, allowProjectionDefaults bool) (Event, error) {
 	class := normalizedAdmissionClass(opts.Class)
 	if class == EventAdmissionUnknown {
 		class = normalizedAdmissionClass(evt.AdmissionClass())
@@ -39,6 +39,9 @@ func admitPersistableEvent(evt Event, opts AdmissionOptions) (Event, error) {
 	eventType := EventType(strings.TrimSpace(string(evt.Type())))
 	if eventType == "" {
 		return Event{}, fmt.Errorf("event type is required for persistence admission")
+	}
+	if class == EventAdmissionProjection && !allowProjectionDefaults {
+		return admitAuthoritativeProjectionForPersistence(evt, opts, eventType)
 	}
 	id := strings.TrimSpace(evt.ID())
 	if id == "" {
@@ -99,6 +102,38 @@ func admitPersistableEvent(evt Event, opts AdmissionOptions) (Event, error) {
 		parentEventID,
 		evt.NormalizedEnvelope(),
 		createdAt,
+	), nil
+}
+
+func admitAuthoritativeProjectionForPersistence(evt Event, opts AdmissionOptions, eventType EventType) (Event, error) {
+	id := strings.TrimSpace(evt.ID())
+	if id == "" {
+		return Event{}, fmt.Errorf("%s event %s requires authoritative event_id for persistence admission", EventAdmissionProjection, eventType)
+	}
+	createdAt := evt.CreatedAt()
+	if createdAt.IsZero() {
+		return Event{}, fmt.Errorf("%s event %s requires authoritative created_at for persistence admission", EventAdmissionProjection, eventType)
+	}
+	runID := strings.TrimSpace(evt.RunID())
+	if runID == "" && strings.TrimSpace(opts.RunIDCandidate) != "" {
+		return Event{}, fmt.Errorf("%s event %s requires authoritative run_id for persistence admission", EventAdmissionProjection, eventType)
+	}
+	parentEventID := strings.TrimSpace(evt.ParentEventID())
+	if parentEventID == "" && strings.TrimSpace(opts.ParentEventIDCandidate) != "" {
+		return Event{}, fmt.Errorf("%s event %s requires authoritative parent_event_id for persistence admission", EventAdmissionProjection, eventType)
+	}
+	return newEvent(
+		EventAdmissionProjection,
+		id,
+		eventType,
+		evt.SourceAgent(),
+		evt.TaskID(),
+		evt.Payload(),
+		evt.ChainDepth(),
+		runID,
+		parentEventID,
+		evt.NormalizedEnvelope(),
+		createdAt.UTC(),
 	), nil
 }
 

--- a/internal/events/admission_test.go
+++ b/internal/events/admission_test.go
@@ -85,6 +85,77 @@ func TestAdmissionDiagnosticDirectAllowsGlobalNoRun(t *testing.T) {
 	}
 }
 
+func TestAdmissionRejectsProjectionPersistenceWithoutAuthoritativeFacts(t *testing.T) {
+	_, err := AdmitForPersistence(NewProjectionEvent(
+		"",
+		EventType("task.completed"),
+		"agent-1",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{Now: time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)})
+	if err == nil {
+		t.Fatal("expected projection persistence admission error")
+	}
+	if !strings.Contains(err.Error(), "authoritative event_id") {
+		t.Fatalf("error = %v, want missing authoritative event_id", err)
+	}
+
+	_, err = AdmitForPersistence(NewProjectionEvent(
+		"evt-projection",
+		EventType("task.completed"),
+		"agent-1",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
+	), AdmissionOptions{RunIDCandidate: "run-from-context"})
+	if err == nil {
+		t.Fatal("expected projection persistence admission error for missing run_id")
+	}
+	if !strings.Contains(err.Error(), "authoritative run_id") {
+		t.Fatalf("error = %v, want missing authoritative run_id", err)
+	}
+}
+
+func TestAdmissionPublishStillDefaultsProjectionShell(t *testing.T) {
+	now := time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)
+	admitted, err := AdmitForPublish(NewProjectionEvent(
+		"",
+		EventType("task.completed"),
+		"agent-1",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{
+		Now:            now,
+		RunIDCandidate: "run-from-publish",
+	})
+	if err != nil {
+		t.Fatalf("AdmitForPublish projection shell: %v", err)
+	}
+	if admitted.ID() == "" {
+		t.Fatal("admitted projection shell event_id is empty")
+	}
+	if got := admitted.RunID(); got != "run-from-publish" {
+		t.Fatalf("admitted projection shell run_id = %q, want publish candidate", got)
+	}
+	if !admitted.CreatedAt().Equal(now) {
+		t.Fatalf("created_at = %s, want %s", admitted.CreatedAt(), now)
+	}
+}
+
 func TestAdmissionRejectsMissingChildLineage(t *testing.T) {
 	_, err := AdmitForPersistence(NewChildEventWithLineage(
 		"",

--- a/internal/events/admission_test.go
+++ b/internal/events/admission_test.go
@@ -1,0 +1,159 @@
+package events
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAdmissionRootIngressAllocatesPersistedFacts(t *testing.T) {
+	now := time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)
+	admitted, err := AdmitForPublish(NewRootIngressEvent(
+		"",
+		EventType("operator.started"),
+		"operator",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{Now: now})
+	if err != nil {
+		t.Fatalf("AdmitForPublish: %v", err)
+	}
+	if admitted.ID() == "" {
+		t.Fatal("admitted event_id is empty")
+	}
+	if admitted.RunID() == "" {
+		t.Fatal("admitted root run_id is empty")
+	}
+	if !admitted.CreatedAt().Equal(now) {
+		t.Fatalf("created_at = %s, want %s", admitted.CreatedAt(), now)
+	}
+}
+
+func TestAdmissionRuntimePlatformEventAllocatesStandaloneRun(t *testing.T) {
+	admitted, err := AdmitForPublish(NewRuntimeControlEvent(
+		"",
+		EventType("platform.boot"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{Now: time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("AdmitForPublish: %v", err)
+	}
+	if admitted.ID() == "" {
+		t.Fatal("admitted event_id is empty")
+	}
+	if admitted.RunID() == "" {
+		t.Fatal("admitted standalone runtime platform run_id is empty")
+	}
+}
+
+func TestAdmissionDiagnosticDirectAllowsGlobalNoRun(t *testing.T) {
+	admitted, err := AdmitForPersistence(NewDiagnosticDirectEvent(
+		"",
+		EventType("platform.runtime_log"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{Now: time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("AdmitForPersistence: %v", err)
+	}
+	if admitted.ID() == "" {
+		t.Fatal("admitted diagnostic event_id is empty")
+	}
+	if admitted.RunID() != "" {
+		t.Fatalf("diagnostic run_id = %q, want empty global/no-run", admitted.RunID())
+	}
+	if admitted.CreatedAt().IsZero() {
+		t.Fatal("diagnostic created_at is zero")
+	}
+}
+
+func TestAdmissionRejectsMissingChildLineage(t *testing.T) {
+	_, err := AdmitForPersistence(NewChildEventWithLineage(
+		"",
+		EventType("task.completed"),
+		"agent-1",
+		"",
+		nil,
+		0,
+		EventLineage{},
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{})
+	if err == nil {
+		t.Fatal("expected missing child lineage admission error")
+	}
+	if !strings.Contains(err.Error(), "requires admitted run_id") {
+		t.Fatalf("error = %v, want missing run_id", err)
+	}
+}
+
+func TestAdmissionReplayAllowsSelectedForkTypedLineageOwner(t *testing.T) {
+	admitted, err := AdmitForPublish(NewReplayEvent(
+		"evt-fork",
+		EventType("task.completed"),
+		"runtime.run_fork.selected_contract_execution",
+		"",
+		nil,
+		0,
+		EventLineage{RunID: "run-fork"},
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{
+		SelectedForkLineageOwner: "runtime.run_fork.selected_contract_execution.fork_local_runtime_container",
+		Now:                      time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("AdmitForPublish: %v", err)
+	}
+	if got := admitted.ParentEventID(); got != "" {
+		t.Fatalf("selected-fork replay parent_event_id = %q, want empty generic parent", got)
+	}
+}
+
+func TestAdmissionRejectsReplayWithoutParentOrSelectedForkLineage(t *testing.T) {
+	_, err := AdmitForPublish(NewReplayEvent(
+		"evt-fork",
+		EventType("task.completed"),
+		"runtime.run_fork.selected_contract_execution",
+		"",
+		nil,
+		0,
+		EventLineage{RunID: "run-fork"},
+		EventEnvelope{},
+		time.Time{},
+	), AdmissionOptions{})
+	if err == nil {
+		t.Fatal("expected missing replay lineage admission error")
+	}
+	if !strings.Contains(err.Error(), "selected_fork_lineage_owner") {
+		t.Fatalf("error = %v, want selected_fork_lineage_owner", err)
+	}
+}
+
+func TestAdmissionRejectsPersistedRouteProbe(t *testing.T) {
+	_, err := AdmitForPersistence(NewRouteProbeEvent(EventType("task.started")), AdmissionOptions{})
+	if err == nil {
+		t.Fatal("expected route probe persistence admission error")
+	}
+	if !strings.Contains(err.Error(), "not persistable") {
+		t.Fatalf("error = %v, want not persistable", err)
+	}
+}

--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -18,15 +18,12 @@ type eventConstructorCallsite struct {
 }
 
 var productionProjectionEventAllowlist = map[eventConstructorCallsite]int{
-	{Path: "internal/store/events.go", Scope: "PostgresStore.enrichEventCorrelation"}:                                              1,
 	{Path: "internal/store/events.go", Scope: "PostgresStore.listEventsMissingPipelineReceiptSpec"}:                                1,
 	{Path: "internal/store/events.go", Scope: "PostgresStore.listEventsMissingPipelineReceiptForRunSpec"}:                          1,
 	{Path: "internal/store/pending_delivery_read_surface.go", Scope: "scanPendingAgentDeliveryRecords"}:                            1,
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.ListPendingSubscribedEvents"}:            1,
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLiteEventsMissingPipelineReceipt"}: 1,
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLitePendingAgentDeliveryRecords"}:  1,
-	{Path: "internal/runtime/bus/eventbus_publish.go", Scope: "eventWithPublishDefaults"}:                                          1,
-	{Path: "internal/runtime/bus/eventbus_publish.go", Scope: "eventWithSourceAgent"}:                                              1,
 	{Path: "internal/runtime/bus/eventbus_routing.go", Scope: "EventBus.deliverToRecipientsWithRoutes"}:                            1,
 	{Path: "internal/runtime/bus/outbox.go", Scope: "clonePostCommitEvent"}:                                                        1,
 	{Path: "internal/runtime/core/pinrouting/pinrouting.go", Scope: "Resolve"}:                                                     1,
@@ -367,7 +364,7 @@ func rhsProducesEventsEvent(expr ast.Expr, eventAliases map[string]struct{}) boo
 		if isEventsPackageIdent(fun.X, eventAliases) {
 			name := fun.Sel.Name
 			return name == "EmptyEvent" || name == "NewRootIngressEvent" || name == "NewRuntimeControlEvent" ||
-				name == "NewRuntimeDiagnosticEvent" || name == "NewChildEvent" || name == "NewChildEventWithLineage" ||
+				name == "NewRuntimeDiagnosticEvent" || name == "NewDiagnosticDirectEvent" || name == "NewChildEvent" || name == "NewChildEventWithLineage" ||
 				name == "NewReplayEvent" || name == "NewProjectionEvent" || name == "NewRouteProbeEvent"
 		}
 	case *ast.Ident:

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -16,6 +16,20 @@ const (
 	EventScopeEntity EventScope = "entity"
 )
 
+type EventAdmissionClass string
+
+const (
+	EventAdmissionUnknown           EventAdmissionClass = ""
+	EventAdmissionRootIngress       EventAdmissionClass = "root_ingress"
+	EventAdmissionRuntimeControl    EventAdmissionClass = "runtime_control"
+	EventAdmissionRuntimeDiagnostic EventAdmissionClass = "runtime_diagnostic"
+	EventAdmissionDiagnosticDirect  EventAdmissionClass = "diagnostic_direct"
+	EventAdmissionChild             EventAdmissionClass = "child"
+	EventAdmissionReplay            EventAdmissionClass = "replay"
+	EventAdmissionProjection        EventAdmissionClass = "projection"
+	EventAdmissionRouteProbe        EventAdmissionClass = "route_probe"
+)
+
 type EventEnvelope struct {
 	EntityID     string          `json:"-"`
 	FlowInstance string          `json:"-"`
@@ -38,16 +52,17 @@ type DeliveryRoute struct {
 }
 
 type Event struct {
-	id            string
-	eventType     EventType
-	sourceAgent   string
-	taskID        string
-	payload       json.RawMessage
-	chainDepth    int
-	runID         string
-	parentEventID string
-	envelope      EventEnvelope
-	createdAt     time.Time
+	admissionClass EventAdmissionClass
+	id             string
+	eventType      EventType
+	sourceAgent    string
+	taskID         string
+	payload        json.RawMessage
+	chainDepth     int
+	runID          string
+	parentEventID  string
+	envelope       EventEnvelope
+	createdAt      time.Time
 }
 
 type eventJSON struct {
@@ -71,15 +86,19 @@ type EventLineage struct {
 }
 
 func NewRootIngressEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
-	return newEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+	return newEvent(EventAdmissionRootIngress, id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
 }
 
 func NewRuntimeControlEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
-	return newEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+	return newEvent(EventAdmissionRuntimeControl, id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
 }
 
 func NewRuntimeDiagnosticEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
-	return newEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+	return newEvent(EventAdmissionRuntimeDiagnostic, id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+func NewDiagnosticDirectEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
+	return newEvent(EventAdmissionDiagnosticDirect, id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
 }
 
 func NewChildEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, parent Event, envelope EventEnvelope, createdAt time.Time) Event {
@@ -91,24 +110,28 @@ func NewChildEventWithLineage(id string, eventType EventType, sourceAgent, taskI
 	if strings.TrimSpace(taskID) == "" {
 		taskID = lineage.TaskID
 	}
-	return newEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, lineage.RunID, lineage.ParentEventID, envelope, createdAt)
+	return newEvent(EventAdmissionChild, id, eventType, sourceAgent, taskID, payload, chainDepth, lineage.RunID, lineage.ParentEventID, envelope, createdAt)
 }
 
 func NewReplayEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, lineage EventLineage, envelope EventEnvelope, createdAt time.Time) Event {
-	return NewChildEventWithLineage(id, eventType, sourceAgent, taskID, payload, chainDepth, lineage, envelope, createdAt)
+	lineage = lineage.Normalized()
+	if strings.TrimSpace(taskID) == "" {
+		taskID = lineage.TaskID
+	}
+	return newEvent(EventAdmissionReplay, id, eventType, sourceAgent, taskID, payload, chainDepth, lineage.RunID, lineage.ParentEventID, envelope, createdAt)
 }
 
 // NewProjectionEvent reconstructs an event from already-authoritative facts.
 // Production call sites are restricted by TestProductionEventConstructionUsesPublicAPI;
 // new runtime producers must use the semantic constructors above.
 func NewProjectionEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
-	return newEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+	return newEvent(EventAdmissionProjection, id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
 }
 
 // NewRouteProbeEvent constructs a non-persisted route-query/sentinel event.
 // Production call sites are restricted by TestProductionEventConstructionUsesPublicAPI.
 func NewRouteProbeEvent(eventType EventType) Event {
-	return NewProjectionEvent("", eventType, "", "", nil, 0, "", "", EventEnvelope{}, time.Time{})
+	return newEvent(EventAdmissionRouteProbe, "", eventType, "", "", nil, 0, "", "", EventEnvelope{}, time.Time{})
 }
 
 func EmptyEvent() Event {
@@ -131,18 +154,19 @@ func (l EventLineage) Normalized() EventLineage {
 	}
 }
 
-func newEvent(id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
+func newEvent(class EventAdmissionClass, id string, eventType EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope EventEnvelope, createdAt time.Time) Event {
 	evt := Event{
-		id:            strings.TrimSpace(id),
-		eventType:     EventType(strings.TrimSpace(string(eventType))),
-		sourceAgent:   strings.TrimSpace(sourceAgent),
-		taskID:        strings.TrimSpace(taskID),
-		payload:       clonePayload(payload),
-		chainDepth:    chainDepth,
-		runID:         strings.TrimSpace(runID),
-		parentEventID: strings.TrimSpace(parentEventID),
-		envelope:      envelope.Normalized(),
-		createdAt:     createdAt,
+		admissionClass: EventAdmissionClass(strings.TrimSpace(string(class))),
+		id:             strings.TrimSpace(id),
+		eventType:      EventType(strings.TrimSpace(string(eventType))),
+		sourceAgent:    strings.TrimSpace(sourceAgent),
+		taskID:         strings.TrimSpace(taskID),
+		payload:        clonePayload(payload),
+		chainDepth:     chainDepth,
+		runID:          strings.TrimSpace(runID),
+		parentEventID:  strings.TrimSpace(parentEventID),
+		envelope:       envelope.Normalized(),
+		createdAt:      createdAt,
 	}
 	if !evt.createdAt.IsZero() {
 		evt.createdAt = evt.createdAt.UTC()
@@ -190,6 +214,10 @@ func clonePayload(payload json.RawMessage) json.RawMessage {
 
 func (e Event) ID() string {
 	return strings.TrimSpace(e.id)
+}
+
+func (e Event) AdmissionClass() EventAdmissionClass {
+	return EventAdmissionClass(strings.TrimSpace(string(e.admissionClass)))
 }
 
 func (e Event) Type() EventType {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -17,7 +17,6 @@ import (
 	runtimedelivery "github.com/division-sh/swarm/internal/runtime/deliverylifecycle"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
-	"github.com/google/uuid"
 )
 
 type pipelineTransitionSchemaCapabilityProvider interface {
@@ -173,8 +172,10 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 			return fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
-	ictx, evt := runtimecorrelation.CorrelateEvent(ctx, evt)
+	ictx, evt, err := admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return err
+	}
 
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
@@ -283,8 +284,10 @@ func (eb *EventBus) PublishAcknowledged(ctx context.Context, evt events.Event) e
 			return fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
-	ictx, evt := runtimecorrelation.CorrelateEvent(ctx, evt)
+	ictx, evt, err := admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return err
+	}
 
 	if txStore, ok := eb.store.(TransactionalEventStore); ok {
 		return eb.publishAcknowledgedTransactional(ictx, evt, start, txStore)
@@ -340,8 +343,10 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 			return fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
-	ictx, evt := runtimecorrelation.CorrelateEvent(ctx, evt)
+	ictx, evt, err := admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return err
+	}
 	txStore, ok := eb.store.(TransactionalEventStore)
 	if !ok || txStore == nil {
 		return errors.New("transactional event store is required")
@@ -761,48 +766,80 @@ func (eb *EventBus) runInterceptors(ctx context.Context, evt events.Event) (bool
 			passthrough = false
 		}
 		for _, d := range out {
-			deferred = append(deferred, eventWithPublishDefaults(d, time.Now()))
+			_, admitted, err := admitEventForPublish(ctx, d, time.Now(), "")
+			if err != nil {
+				return true, nil, err
+			}
+			deferred = append(deferred, admitted)
 		}
 	}
 	return passthrough, deferred, nil
 }
 
-func eventWithPublishDefaults(evt events.Event, now time.Time) events.Event {
-	id := evt.ID()
-	if id == "" {
-		id = uuid.NewString()
+func admitEventForPublish(ctx context.Context, evt events.Event, now time.Time, sourceAgentDefault string) (context.Context, events.Event, error) {
+	opts := events.AdmissionOptions{
+		Now:                      now,
+		RunIDCandidate:           publishRunIDCandidate(ctx, evt),
+		ParentEventIDCandidate:   publishParentEventIDCandidate(ctx, evt),
+		SelectedForkLineageOwner: publishSelectedForkLineageOwner(ctx),
+		SourceAgentDefault:       sourceAgentDefault,
 	}
-	createdAt := evt.CreatedAt()
-	if createdAt.IsZero() {
-		createdAt = now
+	admitted, err := events.AdmitForPublish(evt, opts)
+	if err != nil {
+		return ctx, events.EmptyEvent(), err
 	}
-	return events.NewProjectionEvent(
-		id,
-		evt.Type(),
-		evt.SourceAgent(),
-		evt.TaskID(),
-		evt.Payload(),
-		evt.ChainDepth(),
-		evt.RunID(),
-		evt.ParentEventID(),
-		evt.NormalizedEnvelope(),
-		createdAt,
-	)
+	if runID := strings.TrimSpace(admitted.RunID()); runID != "" {
+		ctx = runtimecorrelation.WithRunID(ctx, runID)
+	}
+	return ctx, admitted, nil
 }
 
-func eventWithSourceAgent(evt events.Event, sourceAgent string) events.Event {
-	return events.NewProjectionEvent(
-		evt.ID(),
-		evt.Type(),
-		sourceAgent,
-		evt.TaskID(),
-		evt.Payload(),
-		evt.ChainDepth(),
-		evt.RunID(),
-		evt.ParentEventID(),
-		evt.NormalizedEnvelope(),
-		evt.CreatedAt(),
-	)
+func publishRunIDCandidate(ctx context.Context, evt events.Event) string {
+	if runID := strings.TrimSpace(evt.RunID()); runID != "" {
+		return runID
+	}
+	if runID := runtimecorrelation.RunIDFromContext(ctx); runID != "" {
+		return runID
+	}
+	if lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx); ok {
+		if runID := strings.TrimSpace(lineage.RunID); runID != "" {
+			return runID
+		}
+	}
+	if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+		return strings.TrimSpace(inbound.RunID())
+	}
+	return ""
+}
+
+func publishParentEventIDCandidate(ctx context.Context, evt events.Event) string {
+	if parentID := strings.TrimSpace(evt.ParentEventID()); parentID != "" {
+		return parentID
+	}
+	if parentID := runtimecorrelation.RuntimeLineageParentForEvent(ctx, evt.ID()); parentID != "" {
+		return parentID
+	}
+	if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+		parentID := strings.TrimSpace(inbound.ID())
+		if parentID != "" && parentID != strings.TrimSpace(evt.ID()) {
+			return parentID
+		}
+	}
+	return ""
+}
+
+func publishSelectedForkLineageOwner(ctx context.Context) string {
+	lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx)
+	if !ok || !lineage.SelectedForkContext {
+		return ""
+	}
+	if lineage.Classification != runtimecorrelation.RuntimeLineageClassificationForkLocal {
+		return ""
+	}
+	if lineage.RowCategory != runtimecorrelation.RuntimeLineageRowCategoryRuntimeContainer {
+		return ""
+	}
+	return strings.TrimSpace(lineage.SelectedForkOwner)
 }
 
 func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err error) {
@@ -820,10 +857,9 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 	if !isValidEventTypeName(string(evt.Type())) {
 		return fmt.Errorf("invalid deferred event type: %s", strings.TrimSpace(string(evt.Type())))
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
-	ctx, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
-	if strings.TrimSpace(evt.SourceAgent()) == "" {
-		evt = eventWithSourceAgent(evt, "runtime")
+	ctx, evt, err = admitEventForPublish(ctx, evt, time.Now(), "runtime")
+	if err != nil {
+		return err
 	}
 	persisted := false
 	queued := false
@@ -1331,8 +1367,10 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 			return fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
-	ctx, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
+	ctx, evt, err = admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return err
+	}
 	plan, err := eb.planDirectRoutePlan(ctx, evt, recipients)
 	if err != nil {
 		return err
@@ -1465,7 +1503,11 @@ func (eb *EventBus) publishPersistedRecipients(ctx context.Context, evt events.E
 	if !isValidEventTypeName(string(evt.Type())) {
 		return fmt.Errorf("invalid event type: %s", strings.TrimSpace(string(evt.Type())))
 	}
-	evt = eventWithPublishDefaults(evt, time.Now())
+	var err error
+	ctx, evt, err = admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return err
+	}
 	if reason, err := eb.dispatchQueueReason(ctx, evt); err != nil {
 		return err
 	} else if reason != "" {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1598,16 +1598,23 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 		name      string
 		eventID   string
 		eventType events.EventType
+		event     func(id string, eventType events.EventType) events.Event
 	}{
 		{
 			name:      "platform.boot",
 			eventID:   "10000000-0000-0000-0000-000000000001",
 			eventType: events.EventType("platform.boot"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeControlEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 		{
 			name:      "platform.recovery_failed",
 			eventID:   "10000000-0000-0000-0000-000000000002",
 			eventType: events.EventType("platform.recovery_failed"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 	}
 
@@ -1616,10 +1623,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 			internal := eb.SubscribeInternal("internal-"+string(tc.eventType), tc.eventType)
 			defer eb.Unsubscribe("internal-" + string(tc.eventType))
 
-			if err := eb.Publish(ctx, events.NewProjectionEvent(tc.eventID,
-				tc.eventType,
-				"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			); err != nil {
+			if err := eb.Publish(ctx, tc.event(tc.eventID, tc.eventType)); err != nil {
 				t.Fatalf("Publish(%s): %v", tc.eventType, err)
 			}
 
@@ -1663,26 +1667,39 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 		name      string
 		eventID   string
 		eventType events.EventType
+		event     func(id string, eventType events.EventType) events.Event
 	}{
 		{
 			name:      "manager platform.agent_failed",
 			eventID:   "20000000-0000-0000-0000-000000000001",
 			eventType: events.EventType("platform.agent_failed"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 		{
 			name:      "receipts platform.paused",
 			eventID:   "20000000-0000-0000-0000-000000000002",
 			eventType: events.EventType("platform.paused"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeControlEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 		{
 			name:      "budget platform.budget_threshold_crossed",
 			eventID:   "20000000-0000-0000-0000-000000000003",
 			eventType: events.EventType("platform.budget_threshold_crossed"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 		{
 			name:      "run lifecycle platform.run_stalled",
 			eventID:   "20000000-0000-0000-0000-000000000004",
 			eventType: events.EventType("platform.run_stalled"),
+			event: func(id string, eventType events.EventType) events.Event {
+				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			},
 		},
 	}
 
@@ -1691,10 +1708,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			subscription := eb.Subscribe(agentID, tc.eventType)
 			defer eb.Unsubscribe(agentID)
 
-			if err := eb.Publish(ctx, events.NewProjectionEvent(tc.eventID,
-				tc.eventType,
-				"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			); err != nil {
+			if err := eb.Publish(ctx, tc.event(tc.eventID, tc.eventType)); err != nil {
 				t.Fatalf("Publish(%s): %v", tc.eventType, err)
 			}
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1387,7 +1387,7 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 	}
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
-	err = eb.PublishTx(ctx, tx, (events.NewProjectionEvent(eventID,
+	err = eb.PublishTx(ctx, tx, (events.NewRootIngressEvent(eventID,
 		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
 	if err != nil {
 		_ = tx.Rollback()
@@ -1501,7 +1501,7 @@ func TestEventBusPublishDeferred_RunsInterceptorsAfterDeferredEventCommit(t *tes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("11111111-1111-1111-1111-111111111111",
+	if err := eb.Publish(context.Background(), events.NewRootIngressEvent("11111111-1111-1111-1111-111111111111",
 		events.EventType("custom.root"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	); err != nil {
 		t.Fatalf("Publish: %v", err)

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -50,13 +50,13 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 	}
 	for i := range intents {
 		intent := &intents[i]
+		if strings.TrimSpace(string(intent.Event.Type())) == "" {
+			continue
+		}
 		var err error
 		intent.Event, err = normalizeOutboxEvent(ctx, intent.Event)
 		if err != nil {
 			return err
-		}
-		if strings.TrimSpace(string(intent.Event.Type())) == "" {
-			continue
 		}
 		plan, err := o.deliveryPlanForIntent(ctx, *intent)
 		if err != nil {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -101,12 +101,22 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 	if d.bus == nil || len(intents) == 0 {
 		return nil
 	}
+	normalized := make([]runtimeengine.EmitIntent, 0, len(intents))
 	for i := range intents {
+		if strings.TrimSpace(string(intents[i].Event.Type())) == "" {
+			continue
+		}
+		intent := intents[i]
 		var err error
-		intents[i].Event, err = normalizeOutboxEvent(ctx, intents[i].Event)
+		intent.Event, err = normalizeOutboxEvent(ctx, intent.Event)
 		if err != nil {
 			return err
 		}
+		normalized = append(normalized, intent)
+	}
+	intents = normalized
+	if len(intents) == 0 {
+		return nil
 	}
 	if runtimepipeline.CollectPipelineEmitIntents(ctx, intents) {
 		return nil

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -50,7 +50,11 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 	}
 	for i := range intents {
 		intent := &intents[i]
-		intent.Event = normalizeOutboxEvent(intent.Event)
+		var err error
+		intent.Event, err = normalizeOutboxEvent(ctx, intent.Event)
+		if err != nil {
+			return err
+		}
 		if strings.TrimSpace(string(intent.Event.Type())) == "" {
 			continue
 		}
@@ -98,7 +102,11 @@ func (d engineDispatcher) DispatchPostCommit(ctx context.Context, intents []runt
 		return nil
 	}
 	for i := range intents {
-		intents[i].Event = normalizeOutboxEvent(intents[i].Event)
+		var err error
+		intents[i].Event, err = normalizeOutboxEvent(ctx, intents[i].Event)
+		if err != nil {
+			return err
+		}
 	}
 	if runtimepipeline.CollectPipelineEmitIntents(ctx, intents) {
 		return nil
@@ -263,8 +271,9 @@ func (d engineDispatcher) dispatchExplicitDirectIntent(ctx context.Context, inte
 	return nil
 }
 
-func normalizeOutboxEvent(evt events.Event) events.Event {
-	return eventWithPublishDefaults(evt, time.Now().UTC())
+func normalizeOutboxEvent(ctx context.Context, evt events.Event) (events.Event, error) {
+	_, admitted, err := admitEventForPublish(ctx, evt, time.Now().UTC(), "")
+	return admitted, err
 }
 
 func replayScopeForEmitIntent(intent runtimeengine.EmitIntent) runtimereplayclaim.CommittedReplayScope {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -441,6 +441,19 @@ func TestEngineOutboxSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
 	}
 }
 
+func TestEngineDispatcherSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	intents := []runtimeengine.EmitIntent{{
+		Event: events.NewProjectionEvent("evt-empty-noop-dispatch", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+	}}
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), intents); err != nil {
+		t.Fatalf("DispatchPostCommit empty noop: %v", err)
+	}
+}
+
 func TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -404,6 +404,43 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	}
 }
 
+func TestEngineOutboxSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	recordingStore := &directRecipientTransactionalStore{}
+	eb, err := runtimebus.NewEventBus(recordingStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	intents := []runtimeengine.EmitIntent{{
+		Event: events.NewProjectionEvent("evt-empty-noop", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+	}}
+	if err := eb.EngineOutbox().WriteOutbox(ctx, intents); err != nil {
+		t.Fatalf("WriteOutbox empty noop: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if got := len(recordingStore.events); got != 0 {
+		t.Fatalf("persisted events = %d, want 0", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -261,7 +261,7 @@ func (fx *deliveryLifecycleFixture) publishDirectEvent(t *testing.T, ctx context
 	ch := fx.bus.Subscribe(fx.agentID)
 	defer fx.bus.Unsubscribe(fx.agentID)
 
-	evt := (events.NewProjectionEvent(eventID,
+	evt := (events.NewRootIngressEvent(eventID,
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour).UTC())).WithEntityID(uuid.NewString())
 	if err := fx.bus.PublishDirect(ctx, evt, []string{fx.agentID}); err != nil {

--- a/internal/runtime/correlation/context.go
+++ b/internal/runtime/correlation/context.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
-	"github.com/google/uuid"
 )
 
 type inboundEventContextKey struct{}
@@ -292,10 +291,9 @@ func CorrelateEvent(ctx context.Context, evt events.Event) (context.Context, eve
 			runID = inbound.RunID()
 		}
 	}
-	if runID == "" {
-		runID = uuid.NewString()
+	if runID != "" {
+		ctx = WithRunID(ctx, runID)
 	}
-	ctx = WithRunID(ctx, runID)
 
 	parentEventID := evt.ParentEventID()
 	if parentEventID == "" {

--- a/internal/runtime/correlation/context_test.go
+++ b/internal/runtime/correlation/context_test.go
@@ -29,15 +29,15 @@ func TestCorrelateEvent_InheritsRunAndParentWithoutGeneratingTrace(t *testing.T)
 	}
 }
 
-func TestCorrelateEvent_GeneratesRunWithoutGeneratingTrace(t *testing.T) {
+func TestCorrelateEvent_DoesNotGenerateRunWithoutAdmission(t *testing.T) {
 	ctx, evt := CorrelateEvent(context.Background(), events.NewProjectionEvent("evt-root",
 		events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 	)
-	if evt.RunID() == "" {
-		t.Fatal("expected generated run_id")
+	if evt.RunID() != "" {
+		t.Fatalf("run_id = %q, want empty before admission", evt.RunID())
 	}
-	if got := RunIDFromContext(ctx); got != evt.RunID() {
-		t.Fatalf("context run_id = %q, want %q", got, evt.RunID())
+	if got := RunIDFromContext(ctx); got != "" {
+		t.Fatalf("context run_id = %q, want empty before admission", got)
 	}
 	if evt.ParentEventID() != "" {
 		t.Fatalf("parent_event_id = %q, want empty", evt.ParentEventID())

--- a/internal/store/event_admission_persistence_test.go
+++ b/internal/store/event_admission_persistence_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -46,6 +47,60 @@ func TestPostgresEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 	}
 }
 
+func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFacts(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	err := pg.AppendEvent(ctx, events.NewProjectionEvent(
+		"",
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Time{},
+	))
+	if err == nil {
+		t.Fatal("expected malformed projection event to fail admission")
+	}
+	if !strings.Contains(err.Error(), "authoritative event_id") {
+		t.Fatalf("AppendEvent error = %v, want missing authoritative event_id admission error", err)
+	}
+
+	err = pg.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
+		RunID: uuid.NewString(),
+	}), events.NewProjectionEvent(
+		uuid.NewString(),
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
+	))
+	if err == nil {
+		t.Fatal("expected projection event missing own run_id to fail admission")
+	}
+	if !strings.Contains(err.Error(), "authoritative run_id") {
+		t.Fatalf("AppendEvent error = %v, want missing authoritative run_id admission error", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'task.completed'`).Scan(&count); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("persisted malformed projection rows = %d, want 0", count)
+	}
+}
+
 func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	ctx := context.Background()
@@ -74,6 +129,59 @@ func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("persisted malformed sqlite child rows = %d, want 0", count)
+	}
+}
+
+func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFacts(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+
+	err := sqliteStore.AppendEvent(ctx, events.NewProjectionEvent(
+		"",
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Time{},
+	))
+	if err == nil {
+		t.Fatal("expected malformed projection event to fail admission")
+	}
+	if !strings.Contains(err.Error(), "authoritative event_id") {
+		t.Fatalf("AppendEvent error = %v, want missing authoritative event_id admission error", err)
+	}
+
+	err = sqliteStore.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
+		RunID: uuid.NewString(),
+	}), events.NewProjectionEvent(
+		uuid.NewString(),
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
+	))
+	if err == nil {
+		t.Fatal("expected projection event missing own run_id to fail admission")
+	}
+	if !strings.Contains(err.Error(), "authoritative run_id") {
+		t.Fatalf("AppendEvent error = %v, want missing authoritative run_id admission error", err)
+	}
+
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'task.completed'`).Scan(&count); err != nil {
+		t.Fatalf("count sqlite events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("persisted malformed sqlite projection rows = %d, want 0", count)
 	}
 }
 

--- a/internal/store/event_admission_persistence_test.go
+++ b/internal/store/event_admission_persistence_test.go
@@ -1,0 +1,195 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	"github.com/division-sh/swarm/internal/runtime/diaglog"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestPostgresEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	err := pg.AppendEvent(ctx, events.NewChildEventWithLineage(
+		"",
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		events.EventLineage{},
+		events.EventEnvelope{},
+		time.Time{},
+	))
+	if err == nil {
+		t.Fatal("expected malformed child event to fail admission")
+	}
+	if !strings.Contains(err.Error(), "requires admitted run_id") {
+		t.Fatalf("AppendEvent error = %v, want missing run_id admission error", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'task.completed'`).Scan(&count); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("persisted malformed child rows = %d, want 0", count)
+	}
+}
+
+func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+
+	err := sqliteStore.AppendEvent(ctx, events.NewChildEventWithLineage(
+		"",
+		events.EventType("task.completed"),
+		"agent-1",
+		"",
+		json.RawMessage(`{"ok":true}`),
+		0,
+		events.EventLineage{},
+		events.EventEnvelope{},
+		time.Time{},
+	))
+	if err == nil {
+		t.Fatal("expected malformed child event to fail admission")
+	}
+	if !strings.Contains(err.Error(), "requires admitted run_id") {
+		t.Fatalf("AppendEvent error = %v, want missing run_id admission error", err)
+	}
+
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'task.completed'`).Scan(&count); err != nil {
+		t.Fatalf("count sqlite events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("persisted malformed sqlite child rows = %d, want 0", count)
+	}
+}
+
+func TestPostgresDiagnosticDirectWritersUseAdmissionFactsAndRemainNonRouted(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	logger := runtimepkg.NewRuntimeLogger(pg)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     diaglog.LevelWarn,
+		Message:   "admitted global runtime log",
+		Component: "admission",
+		Action:    "runtime_log_admission",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log: %v", err)
+	}
+
+	entityID := uuid.NewString()
+	providerEventID := "provider-event-admission"
+	provider := "webhook"
+	inserted, err := pg.RecordInboundEvent(ctx, providerEventID, entityID, provider)
+	if err != nil {
+		t.Fatalf("RecordInboundEvent: %v", err)
+	}
+	if !inserted {
+		t.Fatal("RecordInboundEvent inserted=false, want first insert")
+	}
+	duplicate, err := pg.RecordInboundEvent(ctx, providerEventID, entityID, provider)
+	if err != nil {
+		t.Fatalf("RecordInboundEvent duplicate: %v", err)
+	}
+	if duplicate {
+		t.Fatal("RecordInboundEvent duplicate inserted=true, want false")
+	}
+
+	logEventID, logRunID, logCreatedAt := loadPostgresAdmissionEventFacts(t, ctx, db, `
+		SELECT event_id::text, COALESCE(run_id::text, ''), created_at
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND payload->>'message' = $1
+	`, "admitted global runtime log")
+	if logEventID == "" || logRunID != "" || logCreatedAt.IsZero() {
+		t.Fatalf("runtime_log facts id=%q run=%q created_at=%s, want id/no-run/created", logEventID, logRunID, logCreatedAt)
+	}
+
+	inboundEventID, inboundRunID, inboundCreatedAt := loadPostgresAdmissionEventFacts(t, ctx, db, `
+		SELECT event_id::text, COALESCE(run_id::text, ''), created_at
+		FROM events
+		WHERE event_name = 'platform.inbound_recorded'
+		  AND idempotency_key = $1
+	`, inboundEventIdempotencyKey(providerEventID, entityID, provider))
+	if inboundEventID == "" || inboundRunID != "" || inboundCreatedAt.IsZero() {
+		t.Fatalf("inbound_recorded facts id=%q run=%q created_at=%s, want id/no-run/created", inboundEventID, inboundRunID, inboundCreatedAt)
+	}
+
+	assertPostgresNoDeliveries(t, ctx, db, logEventID)
+	assertPostgresNoDeliveries(t, ctx, db, inboundEventID)
+}
+
+func TestSQLiteRuntimeLogDiagnosticDirectUsesAdmissionFacts(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+
+	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     diaglog.LevelWarn,
+		Message:   "admitted sqlite global runtime log",
+		Component: "admission",
+		Action:    "sqlite_runtime_log_admission",
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log sqlite: %v", err)
+	}
+
+	var eventID, runID, createdAt string
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT event_id, COALESCE(run_id, ''), created_at
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND json_extract(payload, '$.message') = ?
+	`, "admitted sqlite global runtime log").Scan(&eventID, &runID, &createdAt); err != nil {
+		t.Fatalf("load sqlite runtime_log facts: %v", err)
+	}
+	if eventID == "" || runID != "" || strings.TrimSpace(createdAt) == "" {
+		t.Fatalf("sqlite runtime_log facts id=%q run=%q created_at=%s, want id/no-run/created", eventID, runID, createdAt)
+	}
+
+	var deliveries int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE event_id = ?`, eventID).Scan(&deliveries); err != nil {
+		t.Fatalf("count sqlite runtime_log deliveries: %v", err)
+	}
+	if deliveries != 0 {
+		t.Fatalf("sqlite runtime_log deliveries = %d, want 0", deliveries)
+	}
+}
+
+func loadPostgresAdmissionEventFacts(t *testing.T, ctx context.Context, db rowQueryer, query string, arg any) (string, string, time.Time) {
+	t.Helper()
+	var (
+		eventID   string
+		runID     string
+		createdAt time.Time
+	)
+	if err := db.QueryRowContext(ctx, query, arg).Scan(&eventID, &runID, &createdAt); err != nil {
+		t.Fatalf("load postgres event facts: %v", err)
+	}
+	return eventID, runID, createdAt
+}
+
+func assertPostgresNoDeliveries(t *testing.T, ctx context.Context, db rowQueryer, eventID string) {
+	t.Helper()
+	var deliveries int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid`, eventID).Scan(&deliveries); err != nil {
+		t.Fatalf("count event deliveries for %s: %v", eventID, err)
+	}
+	if deliveries != 0 {
+		t.Fatalf("event %s deliveries = %d, want 0", eventID, deliveries)
+	}
+}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -70,7 +70,11 @@ func (s *PostgresStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt event
 		return err
 	}
 	return withEventStoreRetry(ctx, tx, func() error {
-		evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, tx), evt)
+		var err error
+		evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, tx), evt))
+		if err != nil {
+			return err
+		}
 		switch caps.Events.Log {
 		case SchemaFlavorCanonical:
 			if tx == nil && persistedBundleRunCreationValidationRequired(ctx, caps) {
@@ -109,7 +113,10 @@ func (s *PostgresStore) PersistEventWithDeliveries(ctx context.Context, evt even
 	if err != nil {
 		return err
 	}
-	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, nil), evt))
+	if err != nil {
+		return err
+	}
 	switch {
 	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
 		return s.persistEventWithDeliveriesSpec(ctx, caps, evt, agentIDs)
@@ -131,7 +138,10 @@ func (s *PostgresStore) PersistEventWithDeliveriesAndScope(
 	if err != nil {
 		return err
 	}
-	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, nil), evt))
+	if err != nil {
+		return err
+	}
 	switch {
 	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
 		return s.persistEventWithDeliveriesAndScopeSpec(ctx, caps, evt, agentIDs, scope)
@@ -154,7 +164,10 @@ func (s *PostgresStore) PersistEventWithDeliveryRoutesAndScope(
 	if err != nil {
 		return err
 	}
-	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, nil), evt))
+	if err != nil {
+		return err
+	}
 	switch {
 	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
 		return s.persistEventWithDeliveryRoutesAndScopeSpec(ctx, caps, evt, agentIDs, deliveryTargets, scope)
@@ -176,7 +189,10 @@ func (s *PostgresStore) PersistEventWithDeliveryRouteSetAndScope(
 	if err != nil {
 		return err
 	}
-	evt = s.enrichEventCorrelation(ctx, caps, chooseRowQueryer(s.DB, nil), evt)
+	evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, nil), evt))
+	if err != nil {
+		return err
+	}
 	switch {
 	case caps.Events.Log == SchemaFlavorCanonical && caps.Events.Deliveries == SchemaFlavorCanonical:
 		return s.persistEventWithDeliveryRouteSetAndScopeSpec(ctx, caps, evt, deliveryRoutes, scope)
@@ -188,7 +204,7 @@ func (s *PostgresStore) PersistEventWithDeliveryRouteSetAndScope(
 	return nil
 }
 
-func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.Event {
+func (s *PostgresStore) eventPersistenceAdmissionOptions(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.AdmissionOptions {
 	runID := strings.TrimSpace(evt.RunID())
 	if runID == "" {
 		if lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx); ok {
@@ -213,20 +229,25 @@ func (s *PostgresStore) enrichEventCorrelation(ctx context.Context, caps StoreSc
 			runID = foundRunID
 		}
 	}
-	evt = events.NewProjectionEvent(
-		evt.ID(),
-		evt.Type(),
-		evt.SourceAgent(),
-		evt.TaskID(),
-		evt.Payload(),
-		evt.ChainDepth(),
-		runID,
-		parentID,
-		evt.NormalizedEnvelope(),
-		evt.CreatedAt(),
-	)
-	_, evt = runtimecorrelation.CorrelateEvent(ctx, evt)
-	return evt
+	return events.AdmissionOptions{
+		RunIDCandidate:           runID,
+		ParentEventIDCandidate:   parentID,
+		SelectedForkLineageOwner: selectedForkLineageOwnerFromContext(ctx),
+	}
+}
+
+func selectedForkLineageOwnerFromContext(ctx context.Context) string {
+	lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx)
+	if !ok || !lineage.SelectedForkContext {
+		return ""
+	}
+	if lineage.Classification != runtimecorrelation.RuntimeLineageClassificationForkLocal {
+		return ""
+	}
+	if lineage.RowCategory != runtimecorrelation.RuntimeLineageRowCategoryRuntimeContainer {
+		return ""
+	}
+	return strings.TrimSpace(lineage.SelectedForkOwner)
 }
 
 func sanitizeOptionalUUID(raw string) string {
@@ -1600,20 +1621,16 @@ func (s *PostgresStore) convergeStandaloneRuntimePlatformRunByEventID(
 	return nil
 }
 
-func runIDOrEventID(runID, eventID string) string {
-	if runID = nullUUIDString(runID); runID != "" {
-		return runID
-	}
-	return nullUUIDString(eventID)
-}
-
 func eventStorageEnvelope(evt events.Event) (id string, runID string, eventName string, entityID string, flowInstance string, scope string, payload []byte, chainDepth int, producedBy string, producedByType string, sourceEventID string, createdAt time.Time, err error) {
 	id = strings.TrimSpace(evt.ID())
 	if id == "" {
-		id = uuid.NewString()
+		return "", "", "", "", "", "", nil, 0, "", "", "", time.Time{}, fmt.Errorf("event_id is required after admission")
 	}
-	runID = runIDOrEventID(evt.RunID(), id)
+	runID = nullUUIDString(evt.RunID())
 	eventName = strings.TrimSpace(string(evt.Type()))
+	if eventName == "" {
+		return "", "", "", "", "", "", nil, 0, "", "", "", time.Time{}, fmt.Errorf("event_name is required after admission")
+	}
 	payload = eventPayloadForStorage(evt)
 	envelope := evt.NormalizedEnvelope()
 	entityID, err = validateOptionalEntityUUID(envelope.EntityID)
@@ -1637,7 +1654,7 @@ func eventStorageEnvelope(evt events.Event) (id string, runID string, eventName 
 	sourceEventID = sanitizeOptionalUUID(evt.ParentEventID())
 	createdAt = evt.CreatedAt()
 	if createdAt.IsZero() {
-		createdAt = time.Now().UTC()
+		return "", "", "", "", "", "", nil, 0, "", "", "", time.Time{}, fmt.Errorf("created_at is required after admission")
 	}
 	return
 }

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
@@ -236,32 +237,50 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 		return false, err
 	}
 	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
+	evt, err := events.AdmitForPersistence(
+		events.NewDiagnosticDirectEvent(
+			"",
+			events.EventType("platform.inbound_recorded"),
+			provider,
+			"",
+			payload,
+			0,
+			runID,
+			"",
+			events.EventEnvelope{EntityID: entityID},
+			time.Time{},
+		),
+		events.AdmissionOptions{},
+	)
+	if err != nil {
+		return false, err
+	}
 	insertQ := `
 		INSERT INTO events (
-			event_name, entity_id, flow_instance, scope, payload,
+			event_id, event_name, entity_id, flow_instance, scope, payload,
 			chain_depth, produced_by, produced_by_type, idempotency_key, created_at
 		)
 		VALUES (
-			'platform.inbound_recorded', $1::uuid, NULL, 'entity', $2::jsonb,
-			0, $3, 'external', $4, now()
+			$1::uuid, 'platform.inbound_recorded', $2::uuid, NULL, 'entity', $3::jsonb,
+			0, $4, 'external', $5, $6
 		)
 	`
-	args := []any{entityID, string(payload), provider, idempotencyKey}
+	args := []any{evt.ID(), entityID, string(evt.Payload()), provider, idempotencyKey, evt.CreatedAt()}
 	if caps.Events.LogRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
+		if err := s.ensureRunRow(ctx, caps, tx, evt.RunID(), "", "", true); err != nil {
 			return false, err
 		}
 		insertQ = `
 			INSERT INTO events (
-				run_id, event_name, entity_id, flow_instance, scope, payload,
+				event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
 				chain_depth, produced_by, produced_by_type, idempotency_key, created_at
 			)
 			VALUES (
-				NULLIF($1,'')::uuid, 'platform.inbound_recorded', $2::uuid, NULL, 'entity', $3::jsonb,
-				0, $4, 'external', $5, now()
+				$1::uuid, NULLIF($2,'')::uuid, 'platform.inbound_recorded', $3::uuid, NULL, 'entity', $4::jsonb,
+				0, $5, 'external', $6, $7
 			)
 		`
-		args = []any{runID, entityID, string(payload), provider, idempotencyKey}
+		args = []any{evt.ID(), evt.RunID(), entityID, string(evt.Payload()), provider, idempotencyKey, evt.CreatedAt()}
 	}
 	if _, err := tx.ExecContext(ctx, insertQ, args...); err != nil {
 		return false, fmt.Errorf("record inbound event in events: %w", err)

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -22,7 +22,7 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	runID := uuid.NewString()
-	if err := s.AppendEvent(ctx, events.NewProjectionEvent(sourceEventID,
+	if err := s.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
 		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
 		WithEntityID(entityID).WithFlowInstance("main/review")); err != nil {
 		t.Fatalf("append source event: %v", err)

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -344,10 +344,18 @@ func TestUpsertEventReceipt_ConcurrentTerminalReceiptsConvergeStandaloneRuntimeR
 		t.Fatalf("seed second agent: %v", err)
 	}
 	payload, _ := json.Marshal(map[string]any{"k": "v"})
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-
+	evt := events.NewRuntimeControlEvent(
+		uuid.NewString(),
 		events.EventType("platform.paused"),
-		"runtime", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().Add(-1*time.Hour))).WithEntityID(entityID)
+		"runtime",
+		"",
+		payload,
+		0,
+		"",
+		"",
+		events.EventEnvelope{EntityID: entityID},
+		time.Now().Add(-1*time.Hour),
+	)
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -1846,9 +1846,9 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 	); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), events.NewProjectionEvent(childID,
+	if err := pg.AppendEvent(context.Background(), events.NewChildEventWithLineage(childID,
 		events.EventType("child.event"),
-		"child", "", []byte(`{}`), 0, "", parentID, events.EventEnvelope{}, time.Now().UTC()),
+		"child", "", []byte(`{}`), 0, events.EventLineage{ParentEventID: parentID}, events.EventEnvelope{}, time.Now().UTC()),
 	); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}

--- a/internal/store/runtime_log_persistence.go
+++ b/internal/store/runtime_log_persistence.go
@@ -15,8 +15,8 @@ import (
 const runtimeLogEventName = "platform.runtime_log"
 
 func runtimeLogEvent(record runtimepkg.RuntimeLogPersistenceRecord) events.Event {
-	return events.NewRuntimeDiagnosticEvent(
-		uuid.NewString(),
+	return events.NewDiagnosticDirectEvent(
+		"",
 		events.EventType(runtimeLogEventName),
 		"runtime",
 		"",
@@ -25,7 +25,7 @@ func runtimeLogEvent(record runtimepkg.RuntimeLogPersistenceRecord) events.Event
 		strings.TrimSpace(record.RunID),
 		strings.TrimSpace(record.ParentEventID),
 		events.EventEnvelope{},
-		time.Now().UTC(),
+		time.Time{},
 	)
 }
 
@@ -76,8 +76,12 @@ func (s *PostgresStore) PersistRuntimeLog(ctx context.Context, record runtimepkg
 	if err := s.validateEventPayload(runtimeLogEventName, record.Payload); err != nil {
 		return err
 	}
+	evt, err := events.AdmitForPersistence(runtimeLogEvent(record), events.AdmissionOptions{})
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(record.RunID) != "" {
-		return s.AppendEvent(ctx, runtimeLogEvent(record))
+		return s.AppendEvent(ctx, evt)
 	}
 	_, err = s.DB.ExecContext(ctx, `
 		INSERT INTO events (
@@ -85,10 +89,10 @@ func (s *PostgresStore) PersistRuntimeLog(ctx context.Context, record runtimepkg
 			chain_depth, produced_by, produced_by_type, source_event_id, created_at
 		)
 		VALUES (
-			gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $1::jsonb,
-			0, 'runtime', 'platform', NULLIF($2,'')::uuid, now()
+			$1::uuid, 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
+			0, 'runtime', 'platform', NULLIF($3,'')::uuid, $4
 		)
-	`, string(record.Payload), strings.TrimSpace(record.ParentEventID))
+	`, evt.ID(), string(evt.Payload()), strings.TrimSpace(evt.ParentEventID()), evt.CreatedAt())
 	if err != nil {
 		return fmt.Errorf("persist postgres runtime log: %w", err)
 	}
@@ -142,8 +146,12 @@ func (s *SQLiteRuntimeStore) PersistRuntimeLog(ctx context.Context, record runti
 	if err := s.validateEventPayload(runtimeLogEventName, record.Payload); err != nil {
 		return err
 	}
+	evt, err := events.AdmitForPersistence(runtimeLogEvent(record), events.AdmissionOptions{})
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(record.RunID) != "" {
-		return s.AppendEvent(ctx, runtimeLogEvent(record))
+		return s.AppendEvent(ctx, evt)
 	}
 	_, err = s.DB.ExecContext(ctx, `
 		INSERT OR IGNORE INTO events (
@@ -152,7 +160,7 @@ func (s *SQLiteRuntimeStore) PersistRuntimeLog(ctx context.Context, record runti
 		)
 		VALUES (?, NULL, 'platform.runtime_log', NULL, NULL, '{}', '{}', '[]',
 			'global', ?, 0, 'runtime', 'platform', ?, ?)
-	`, uuid.NewString(), string(record.Payload), sqliteNullUUID(record.ParentEventID), time.Now().UTC())
+	`, evt.ID(), string(evt.Payload()), sqliteNullUUID(evt.ParentEventID()), evt.CreatedAt())
 	if err != nil {
 		return fmt.Errorf("persist sqlite runtime log: %w", err)
 	}

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -154,6 +154,10 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 	if caps.Events.Log != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("events", caps.Events.Log)
 	}
+	evt, err = events.AdmitForPersistence(evt, s.eventPersistenceAdmissionOptions(ctx, caps, chooseRowQueryer(s.DB, tx), evt))
+	if err != nil {
+		return err
+	}
 	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt, err := eventStorageEnvelope(evt)
 	if err != nil {
 		return err
@@ -201,6 +205,55 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 		committed = true
 	}
 	return nil
+}
+
+func (s *SQLiteRuntimeStore) eventPersistenceAdmissionOptions(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.AdmissionOptions {
+	runID := strings.TrimSpace(evt.RunID())
+	if runID == "" {
+		if lineage, ok := runtimecorrelation.RuntimeLineageFromContext(ctx); ok {
+			runID = strings.TrimSpace(lineage.RunID)
+		}
+	}
+	parentID := strings.TrimSpace(evt.ParentEventID())
+	if parentID == "" {
+		if lineageParentID := runtimecorrelation.RuntimeLineageParentForEvent(ctx, evt.ID()); lineageParentID != "" {
+			parentID = lineageParentID
+		}
+	}
+	if parentID == "" {
+		if inbound, ok := runtimecorrelation.InboundEventFromContext(ctx); ok {
+			if inboundID := strings.TrimSpace(inbound.ID()); inboundID != "" && inboundID != strings.TrimSpace(evt.ID()) {
+				parentID = inboundID
+			}
+		}
+	}
+	if runID == "" && parentID != "" {
+		if foundRunID := lookupSQLiteEventRunID(ctx, caps, q, parentID); foundRunID != "" {
+			runID = foundRunID
+		}
+	}
+	return events.AdmissionOptions{
+		RunIDCandidate:           runID,
+		ParentEventIDCandidate:   parentID,
+		SelectedForkLineageOwner: selectedForkLineageOwnerFromContext(ctx),
+	}
+}
+
+func lookupSQLiteEventRunID(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, eventID string) string {
+	eventID = strings.TrimSpace(eventID)
+	if q == nil || eventID == "" || caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID {
+		return ""
+	}
+	var runID string
+	if err := q.QueryRowContext(ctx, `
+		SELECT COALESCE(run_id, '')
+		FROM events
+		WHERE event_id = ?
+		LIMIT 1
+	`, eventID).Scan(&runID); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(runID)
 }
 
 func (s *SQLiteRuntimeStore) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -340,6 +340,24 @@ contract_formats:
         than a generic all-fields constructor. Constructor APIs MUST clone
         caller-owned payload bytes, normalize event-owned identity fields, and
         expose event facts through read-only accessors.
+
+        Persisted event admission is the canonical boundary between constructed
+        event shells, context/correlation candidates, and storage. The admission
+        owner MUST classify or consume the constructor class before any event row
+        is written. It may materialize explicitly admitted event_id and created_at
+        defaults, and may allocate root-ingress run_id when the ingress class
+        permits server allocation. Runtime-owned routable platform events emitted
+        by the runtime-control or runtime-diagnostic classes may also allocate an
+        explicit standalone run_id at admission so the platform event enters the
+        normal run/delivery lifecycle without relying on store fallbacks. It MUST
+        fail closed for missing child, replay, fork, or runtime-domain lineage
+        facts that are required by the event class. EventBus, transactional
+        outbox, direct store append/persist, runtime-log diagnostic-direct
+        persistence, inbound-marker persistence, and Postgres/SQLite storage
+        envelopes MUST consume this owner. Stores and database defaults are
+        schema fallbacks only; they MUST NOT silently invent event_id, run_id,
+        created_at, source_event_id, target, target_set, or other class-required
+        facts after admission.
       constructor_classes:
         root_ingress:
           rule: External/operator/root run ingress events carry their final
@@ -351,6 +369,13 @@ contract_formats:
         replay:
           rule: Replay/fork events use replay lineage constructors so replay
             source and run ownership are explicit before persistence or dispatch.
+            Selected-contract fork-local replay is the bounded exception where
+            the durable parent/source authority is
+            run_fork_selected_contract_executions rather than
+            events.source_event_id. Admission MUST consume the selected-fork
+            lineage owner instead of silently writing a generic source_event_id
+            parent, and the typed execution lineage row MUST be committed after
+            the fork event row exists and before selected-contract activation.
         runtime_control:
           rule: Platform control and directive events use runtime-control
             constructors so diagnostics/control traffic is not confused with
@@ -358,6 +383,13 @@ contract_formats:
         runtime_diagnostic:
           rule: Runtime diagnostic/dead-letter/status events use diagnostic
             constructors and remain separate from route or delivery authority.
+        diagnostic_direct:
+          rule: Diagnostic-direct persisted platform events such as
+            platform.runtime_log and platform.inbound_recorded are admitted as
+            non-routed/non-executable evidence markers before direct persistence.
+            Their event_id and created_at facts are explicit admission output,
+            not database defaults; optional run_id remains empty only when the
+            diagnostic-direct class is global/no-run by design.
         route_probe:
           rule: Route-query and sentinel probes may use dedicated probe
             constructors only when the event is not a persisted runtime emit and
@@ -2148,14 +2180,16 @@ engine:
         external API.'
     - step: 2
       name: validate_payload
-      action: Validate event payload against the schema in events.yaml before persistence. Supported producer emit surfaces
+      action: Validate event payload and admitted envelope facts before persistence. Supported producer emit surfaces
         perform their own fail-closed validation before publish; this event-loop admission check remains the canonical final
         guard for all events that reach the event store and the primary owner for ingress/direct/store append paths without
-        a more specific producer surface owner. Reject if schema mismatch. Log and discard invalid events.
+        a more specific producer surface owner. Reject if schema mismatch or if the event admission class is missing
+        required identity, time, run, or lineage facts. Log and discard invalid events.
     - step: 3
       name: persist_event
-      action: 'Write event to the event store (write-ahead). The event is durable before any processing begins. Crash after
-        this point: event replays on recovery.'
+      action: 'Write the already-admitted event to the event store (write-ahead). Storage translates admitted facts into
+        row columns and must not repair missing event-owned facts. The event is durable before any processing begins. Crash
+        after this point: event replays on recovery.'
     - step: 4
       name: resolve_subscribers
       action: 'Look up subscribers by event path. Two kinds: system nodes (from nodes.yaml subscribes_to) and agents (from


### PR DESCRIPTION
## Summary

- Adds a canonical persisted event admission/defaulting owner in `internal/events` and routes EventBus publish variants, deferred/outbox publish normalization, Postgres append/persist paths, SQLite append, runtime-log persistence, and inbound marker persistence through it.
- Stops Postgres/SQLite storage from silently inventing persisted event-owned facts after admission: `event_id`, `run_id`, `created_at`, and class-required lineage now come from constructors, bounded context candidates, or explicit admission rules.
- Adds explicit diagnostic-direct admission for `platform.runtime_log` and `platform.inbound_recorded`, plus selected-contract fork-local replay handling that consumes typed selected-fork lineage instead of writing generic `events.source_event_id` parentage.

Closes #1377

## Governing Refs / Context

Exact governing spec refs:

- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_split`
- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_identity`
- `platform-spec.yaml#contract_formats.event_schema.runtime_event_construction`
- `platform-spec.yaml#event_loop.validate_payload`
- `platform-spec.yaml#event_loop.persist_event`
- `platform-spec.yaml#persistent_schema.events`
- `platform-spec.yaml#/v1/rpc event.publish`

Approved gate boundary: #1377 repaired Pre-Implementation Coverage Audit and gate outcome `approved as first slice`, including `RecordInboundEvent` / `platform.inbound_recorded` as same-class in scope.

## Semantic Migration

New canonical owner: `internal/events` persisted event admission via `AdmitForPublish` / `AdmitForPersistence` and event admission classes.

Old non-authoritative producers/readers/writers now invalid:

- EventBus `eventWithPublishDefaults` and `eventWithSourceAgent` as unclassified write-side defaulting helpers.
- Store `enrichEventCorrelation` and `eventStorageEnvelope` as silent event fact repair owners.
- `runIDOrEventID` fallback for persisted event run identity.
- Runtime correlation allocating run IDs outside admission.
- Direct SQL diagnostic writers relying on DB defaults for `event_id` / `created_at`.

Production paths checked for surviving old behavior:

- EventBus publish, acknowledged publish, tx publish, direct publish, persisted-recipient publish, deferred/interceptor publish, and outbox normalization.
- Postgres `AppendEvent*` and `PersistEventWithDeliveries*` variants.
- SQLite `AppendEvent*` path.
- `PersistRuntimeLog` Postgres/SQLite direct diagnostic writers.
- `RecordInboundEvent` direct diagnostic marker writer.
- Selected-contract fork-local replay interaction with `run_fork_selected_contract_executions`.

Migration complete for #1377 chosen class. Route planning, delivery-row authority, run-fork replay-copy semantics, and broader routing pipeline ownership remain outside this slice unless separately gated.

## Validation

- `go test ./internal/runtime/runforkexecution ./internal/runtime/cataloge2e ./cmd/swarm`
- `go test ./internal/events ./internal/runtime/correlation ./internal/runtime/bus ./internal/store ./internal/apiv1 ./internal/runtime`
- `go test ./...`
- `go test -count=1 ./internal/apiv1 -run 'TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock|TestOperatorRuntimeControl|TestSQLiteObservabilitySupportedSurface'`
- `go test -count=1 ./internal/runtime -run 'TestRuntimeBoot|TestRuntimeLogger_Log_PersistsRuntimeLogPayloadViaCapabilityOwner|TestRuntimeLogger_Log_AppendsCanonicalFlightRecorderDefaults|TestRuntimeLogger_Log_PersistsCanonicalRunOwnershipFromContext'`
- `go test -count=1 ./internal/store -run 'TestPostgresEventAdmissionRejectsMalformedChildDirectAppend|TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend|TestPostgresDiagnosticDirectWritersUseAdmissionFactsAndRemainNonRouted|TestSQLiteRuntimeLogDiagnosticDirectUsesAdmissionFacts'`
