### PR TITLE
[agent-c][issue #1380] Add runtime lifecycle test probe

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -18,6 +18,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -109,12 +110,13 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	started := make(chan string, 1)
 	release := make(chan struct{})
 	var releaseOnce sync.Once
 	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	probe := runtimelifecycleprobe.New()
 	opts := runStartTestEventBusOptions(source)
-	opts.Interceptors = []runtimebus.EventInterceptor{blockingAPIV1PublishInterceptor{started: started, release: release}}
+	opts.TestLifecycleProbe = probe
+	opts.Interceptors = []runtimebus.EventInterceptor{blockingAPIV1PublishInterceptor{release: release}}
 	bus, err := runtimebus.NewEventBusWithOptions(pg, opts)
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
@@ -150,7 +152,11 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 		t.Fatalf("api_idempotency rows before dispatch release = %d, want 1", count)
 	}
 
-	requireAPIV1RuntimeBusSignal(t, started, "post-commit interceptor started")
+	startCtx, cancelStart := context.WithTimeout(ctx, time.Second)
+	defer cancelStart()
+	if _, err := probe.WaitForPostCommitDispatchStarted(startCtx, eventID); err != nil {
+		t.Fatalf("post-commit dispatch start for %s: %v", eventID, err)
+	}
 	requireNoAPIV1RuntimeBusEvent(t, ch, "event.publish delivery before post-commit release")
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
 		t.Fatalf("pipeline receipts before post-commit release = %d, want 0", got)
@@ -161,7 +167,14 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 	if got.ID() != eventID {
 		t.Fatalf("delivered event = %s, want %s", got.ID(), eventID)
 	}
-	waitPipelineReceiptsForEvent(t, ctx, db, eventID, 1)
+	doneCtx, cancelDone := context.WithTimeout(ctx, time.Second)
+	defer cancelDone()
+	if _, err := probe.WaitForPostCommitDispatchCompleted(doneCtx, eventID); err != nil {
+		t.Fatalf("post-commit dispatch completion for %s: %v", eventID, err)
+	}
+	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after post-commit release = %d, want 1", got)
+	}
 }
 
 func TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock(t *testing.T) {
@@ -1421,15 +1434,10 @@ func eventPublishTestHandlerWithStores(t *testing.T, runs RunReadStore, observab
 }
 
 type blockingAPIV1PublishInterceptor struct {
-	started chan string
 	release <-chan struct{}
 }
 
 func (i blockingAPIV1PublishInterceptor) Intercept(_ context.Context, _ events.Event) (bool, []events.Event, error) {
-	select {
-	case i.started <- "started":
-	default:
-	}
 	<-i.release
 	return true, nil, nil
 }
@@ -1959,20 +1967,6 @@ func loadPipelineReceiptOutcomeAndError(t *testing.T, ctx context.Context, db *s
 		t.Fatalf("load pipeline receipt for %s: %v", eventID, err)
 	}
 	return outcome, errText
-}
-
-func waitPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string, want int) {
-	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for {
-		if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got == want {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("pipeline receipts for %s did not reach %d", eventID, want)
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
 }
 
 func containsMissingPipelineReceiptEvent(items []events.PersistedReplayEvent, eventID string) bool {

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -599,7 +599,10 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 		err:           errors.New("simulated normal-run completion failure"),
 	}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	bus, err := runtimebus.NewEventBusWithOptions(failing, runStartTestEventBusOptions(source))
+	probe := runtimelifecycleprobe.New()
+	opts := runStartTestEventBusOptions(source)
+	opts.TestLifecycleProbe = probe
+	bus, err := runtimebus.NewEventBusWithOptions(failing, opts)
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -624,6 +627,11 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 	}
 	if count := countAPIIdempotencyRows(t, db); count != 1 {
 		t.Fatalf("api_idempotency rows after post-commit completion failure = %d, want 1", count)
+	}
+	doneCtx, cancelDone := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelDone()
+	if _, err := probe.WaitForPostCommitDispatchCompleted(doneCtx, eventID); err != nil {
+		t.Fatalf("post-commit dispatch completion for %s: %v", eventID, err)
 	}
 	outcome, errText := loadPipelineReceiptOutcomeAndError(t, ctx, db, eventID)
 	if outcome != "dead_letter" || !strings.Contains(errText, "simulated normal-run completion failure") {

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -164,7 +164,8 @@ func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testin
 	source := semanticview.Wrap(bundle)
 	fact := bundleSourceFactForTestBundle(t, bundle)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil, nil)
+	probe := runtimelifecycleprobe.New()
+	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil, probe)
 
 	published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"alice"}`, "", "idem-mailbox-write-missing-materializer"))
 	if published.Error != nil {
@@ -172,7 +173,7 @@ func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testin
 	}
 	result := asMap(t, published.Result)
 	eventID := stringValue(t, result["event_id"], "event_id")
-	waitForSQLiteNodeMaterializerFailure(t, sqliteStore.DB, eventID, "reviewer")
+	waitForSQLiteNodeMaterializerFailure(t, sqliteStore.DB, probe, eventID, "reviewer")
 }
 
 func newMailboxWriteSupportedSurfaceHandler(
@@ -719,11 +720,18 @@ func loadMailboxWriteEntityState(t *testing.T, db *sql.DB, runID, backend string
 	return state, decodeJSONMap(t, json.RawMessage(fieldsRaw)), nil
 }
 
-func waitForSQLiteNodeMaterializerFailure(t *testing.T, db *sql.DB, eventID, nodeID string) {
+func waitForSQLiteNodeMaterializerFailure(t *testing.T, db *sql.DB, probe *runtimelifecycleprobe.Probe, eventID, nodeID string) {
 	t.Helper()
+	if probe == nil {
+		t.Fatalf("sqlite lifecycle probe is required for node/%s materializer failure on event %s", nodeID, eventID)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := probe.WaitForDeliveryStatus(ctx, eventID, "node", nodeID, "dead_letter"); err != nil {
+		t.Fatalf("sqlite node/%s materializer failure lifecycle for event %s: %v", nodeID, eventID, err)
+	}
 	var lastStatus, lastReason, lastError, lastReceiptOutcome, lastReceiptReason, lastReceiptError string
-	requireAPIV1Convergence(t, "sqlite node mailbox materializer failure", func() (bool, error) {
-		if err := db.QueryRow(`
+	if err := db.QueryRow(`
 			SELECT
 				COALESCE(d.status, ''),
 				COALESCE(d.reason_code, ''),
@@ -741,14 +749,8 @@ func waitForSQLiteNodeMaterializerFailure(t *testing.T, db *sql.DB, eventID, nod
 			  AND d.subscriber_id = ?
 			LIMIT 1
 		`, eventID, nodeID).Scan(&lastStatus, &lastReason, &lastError, &lastReceiptOutcome, &lastReceiptReason, &lastReceiptError); err != nil {
-			return false, err
-		}
-		if lastStatus != "dead_letter" || lastReceiptOutcome != "dead_letter" {
-			return false, nil
-		}
-		return strings.Contains(lastError, "mailbox_write requires mailbox materialization store") &&
-			strings.Contains(lastReceiptError, "mailbox_write requires mailbox materialization store"), nil
-	})
+		t.Fatalf("sqlite node/%s materializer failure row for event %s: %v", nodeID, eventID, err)
+	}
 	if lastStatus != "dead_letter" || lastReceiptOutcome != "dead_letter" ||
 		!strings.Contains(lastError, "mailbox_write requires mailbox materialization store") ||
 		!strings.Contains(lastReceiptError, "mailbox_write requires mailbox materialization store") {

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -13,6 +13,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -28,26 +29,28 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
-		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus)
+		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe)
 	}{
 		{
 			name: "sqlite_default_no_selector",
-			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
+			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
 				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
-				return handler, sqliteStore.DB, bus
+				probe := runtimelifecycleprobe.New()
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore, probe)
+				return handler, sqliteStore.DB, bus, probe
 			},
 		},
 		{
 			name: "postgres_explicit_opt_in",
-			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
+			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
 				_, db, cleanup := testutil.StartPostgres(t)
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
-				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
-				return handler, db, bus
+				probe := runtimelifecycleprobe.New()
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg, probe)
+				return handler, db, bus, probe
 			},
 		},
 	} {
@@ -55,7 +58,7 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 			bundle := mailboxWriteSupportedSurfaceBundle(t)
 			source := semanticview.Wrap(bundle)
 			fact := bundleSourceFactForTestBundle(t, bundle)
-			handler, db, bus := tc.setup(t, ctx, source, fact)
+			handler, db, bus, probe := tc.setup(t, ctx, source, fact)
 
 			published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"alice"}`, "", "idem-mailbox-write-"+tc.name))
 			if published.Error != nil {
@@ -89,8 +92,7 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 				t.Fatalf("event.publish deliveries = %#v, want durable workflow-runtime and reviewer node snapshot", deliveries)
 			}
 
-			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, eventID)
-			waitForMailboxWriteBusQuiescence(t, bus, "mailbox_write supported surface")
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, probe, tc.name, eventID)
 			waitForMailboxWriteSupportedSurface(t, handler, db, bus, runID, eventID, tc.name)
 		})
 	}
@@ -100,26 +102,28 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
-		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus)
+		setup func(*testing.T, context.Context, semanticview.Source, runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe)
 	}{
 		{
 			name: "sqlite_default_no_selector",
-			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
+			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
 				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore)
-				return handler, sqliteStore.DB, bus
+				probe := runtimelifecycleprobe.New()
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore, probe)
+				return handler, sqliteStore.DB, bus, probe
 			},
 		},
 		{
 			name: "postgres_explicit_opt_in",
-			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus) {
+			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
 				_, db, cleanup := testutil.StartPostgres(t)
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
-				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg)
-				return handler, db, bus
+				probe := runtimelifecycleprobe.New()
+				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, context.Background(), pg, db, source, fact, pg, probe)
+				return handler, db, bus, probe
 			},
 		},
 	} {
@@ -127,7 +131,7 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			bundle := conditionalRuleMailboxWriteSupportedSurfaceBundle(t)
 			source := semanticview.Wrap(bundle)
 			fact := bundleSourceFactForTestBundle(t, bundle)
-			handler, db, bus := tc.setup(t, ctx, source, fact)
+			handler, db, bus, probe := tc.setup(t, ctx, source, fact)
 
 			auto := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":50,"who":"alice"}`, "", "idem-rule-mailbox-write-auto-"+tc.name))
 			if auto.Error != nil {
@@ -136,8 +140,7 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			autoResult := asMap(t, auto.Result)
 			autoEventID := stringValue(t, autoResult["event_id"], "event_id")
 			autoRunID := stringValue(t, autoResult["run_id"], "run_id")
-			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, autoEventID)
-			waitForMailboxWriteBusQuiescence(t, bus, "rule mailbox_write auto branch")
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, probe, tc.name, autoEventID)
 			waitForConditionalRuleEntityState(t, db, autoRunID, tc.name, "approved", 50)
 			assertMailboxListCount(t, handler, autoRunID, 0)
 
@@ -148,8 +151,7 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			humanResult := asMap(t, human.Result)
 			humanEventID := stringValue(t, humanResult["event_id"], "event_id")
 			humanRunID := stringValue(t, humanResult["run_id"], "run_id")
-			releaseMailboxWritePendingNodeDeliveries(t, db, bus, tc.name, humanEventID)
-			waitForMailboxWriteBusQuiescence(t, bus, "rule mailbox_write human branch")
+			releaseMailboxWritePendingNodeDeliveries(t, db, bus, probe, tc.name, humanEventID)
 			waitForConditionalRuleMailboxWrite(t, handler, db, bus, humanRunID, humanEventID, tc.name)
 			waitForConditionalRuleEntityState(t, db, humanRunID, tc.name, "awaiting_human", 250)
 		})
@@ -162,7 +164,7 @@ func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testin
 	source := semanticview.Wrap(bundle)
 	fact := bundleSourceFactForTestBundle(t, bundle)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil)
+	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil, nil)
 
 	published := rpcCall(t, handler, eventPublishBodyWithoutBundle("", "thing.created", `{"amount":250,"who":"alice"}`, "", "idem-mailbox-write-missing-materializer"))
 	if published.Error != nil {
@@ -181,13 +183,15 @@ func newMailboxWriteSupportedSurfaceHandler(
 	source semanticview.Source,
 	fact runtimecorrelation.BundleSourceFact,
 	materializer runtimepipeline.MailboxWriteMaterializationStore,
+	probe *runtimelifecycleprobe.Probe,
 ) (*Handler, *runtimebus.EventBus) {
 	t.Helper()
 	var coordinator *runtimepipeline.PipelineCoordinator
 	bus, err := runtimebus.NewEventBusWithOptions(persistence.(runtimebus.EventStore), runtimebus.EventBusOptions{
-		ContractBundle:    source,
-		BundleFingerprint: fact.BundleFingerprint,
-		BundleSourceFact:  fact,
+		ContractBundle:     source,
+		BundleFingerprint:  fact.BundleFingerprint,
+		BundleSourceFact:   fact,
+		TestLifecycleProbe: probe,
 		InterceptorProvider: func() []runtimebus.EventInterceptor {
 			if coordinator == nil {
 				return nil
@@ -209,6 +213,7 @@ func newMailboxWriteSupportedSurfaceHandler(
 		MailboxMaterializer:     materializer,
 		EventReceiptsCapability: eventReceiptsCapability(persistence),
 		BundleFingerprint:       fact.BundleFingerprint,
+		TestLifecycleProbe:      probe,
 	})
 	bus.RegisterRuntimeActiveAgentDescriptor(runtimebus.ActiveAgentDescriptor{AgentID: "workflow-runtime"})
 	bus.Subscribe("workflow-runtime", events.EventType("thing.created"))
@@ -253,19 +258,14 @@ func newMailboxWriteSupportedSurfaceHandler(
 	return handler, bus
 }
 
-func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *runtimebus.EventBus, backend, eventID string) {
+func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *runtimebus.EventBus, probe *runtimelifecycleprobe.Probe, backend, eventID string) {
 	t.Helper()
 	if bus == nil {
 		t.Fatalf("%s runtime bus is required to release pending node deliveries", backend)
 	}
-	requireAPIV1Convergence(t, fmt.Sprintf("%s node delivery authority for %s", backend, eventID), func() (bool, error) {
-		_, total := mailboxWriteNodeDeliveryCounts(t, db, backend, eventID)
-		if total > 0 {
-			return true, nil
-		}
-		return false, fmt.Errorf("node delivery row not visible yet")
-	})
+	waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "pending")
 	if pending, _ := mailboxWriteNodeDeliveryCounts(t, db, backend, eventID); pending == 0 {
+		waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "delivered")
 		return
 	}
 	evt := loadMailboxWritePersistedEvent(t, db, backend, eventID)
@@ -274,8 +274,18 @@ func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *run
 	if err := bus.ReleasePendingPersistedDeliveriesForEvent(ctx, evt); err != nil {
 		t.Fatalf("%s release pending node deliveries for event %s: %v", backend, eventID, err)
 	}
-	if err := bus.WaitForQuiescence(ctx); err != nil {
-		t.Fatalf("%s wait for released node deliveries for event %s: %v", backend, eventID, err)
+	waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "delivered")
+}
+
+func waitForMailboxWriteLifecycleDeliveryStatus(t *testing.T, probe *runtimelifecycleprobe.Probe, backend, eventID, status string) {
+	t.Helper()
+	if probe == nil {
+		t.Fatalf("%s lifecycle probe is required for node delivery %s on event %s", backend, status, eventID)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := probe.WaitForDeliveryStatus(ctx, eventID, "node", "", status); err != nil {
+		t.Fatalf("%s node delivery %s for event %s: %v", backend, status, eventID, err)
 	}
 }
 

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -12,6 +12,7 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -49,6 +50,7 @@ type EventBus struct {
 	runDispatchGate             RunDispatchGate
 	bundleFingerprint           string
 	bundleSourceFact            runtimecorrelation.BundleSourceFact
+	testLifecycleProbe          runtimelifecycleprobe.Observer
 	outboxSweeperActive         bool
 	inFlightPublishes           atomic.Int64
 }
@@ -95,6 +97,7 @@ type EventBusOptions struct {
 	RunDispatchGate             RunDispatchGate
 	BundleFingerprint           string
 	BundleSourceFact            runtimecorrelation.BundleSourceFact
+	TestLifecycleProbe          runtimelifecycleprobe.Observer
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -168,6 +171,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		runDispatchGate:             opts.RunDispatchGate,
 		bundleFingerprint:           strings.TrimSpace(opts.BundleFingerprint),
 		bundleSourceFact:            opts.BundleSourceFact.Normalized(),
+		testLifecycleProbe:          opts.TestLifecycleProbe,
 	}
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -364,6 +364,11 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
 	}
+	if eb.testLifecycleProbe != nil {
+		runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
+			eb.notifyTestPublishPersisted(context.WithoutCancel(txctx), evt, inboundPlan)
+		})
+	}
 	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
 		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 			return fmt.Errorf("persist committed replay scope: %w", err)
@@ -405,6 +410,9 @@ func (eb *EventBus) dispatchCommittedPublishAsync(ctx context.Context, evt event
 }
 
 func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Event, inboundPlan RoutePlan) {
+	eb.notifyTestPostCommitDispatchStarted(ctx, evt)
+	defer eb.notifyTestPostCommitDispatchCompleted(ctx, evt)
+
 	inboundPlan = inboundPlan.Normalized()
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
@@ -563,6 +571,7 @@ func (eb *EventBus) publishTransactional(
 		}
 		committed = true
 		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
@@ -575,6 +584,7 @@ func (eb *EventBus) publishTransactional(
 			return fmt.Errorf("commit publish tx: %w", err)
 		}
 		committed = true
+		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.RecipientIDs()), false, false)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
@@ -585,6 +595,7 @@ func (eb *EventBus) publishTransactional(
 	}
 	committed = true
 	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 
 	postCommitActions := make([]func(), 0, 8)
 	dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
@@ -688,6 +699,7 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 		}
 		committed = true
 		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		eb.recordCommittedPublishConvergence(ctx, evt)
@@ -701,6 +713,7 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 		}
 		committed = true
 		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.RecipientIDs()), false, true)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		eb.recordCommittedPublishConvergence(ctx, evt)
@@ -711,6 +724,7 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 	}
 	committed = true
 	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
+	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 	eb.dispatchCommittedPublishAsync(ctx, evt, inboundPlan)
 	return nil
 }
@@ -1011,6 +1025,7 @@ func (eb *EventBus) persistSubscribedPublishPlan(ctx context.Context, evt events
 	if err := eb.persistEventRecord(ctx, evt, persistedRecipients, routePlan.DeliveryTargets(), routePlan.DeliveryRoutes(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
 		return err
 	}
+	eb.notifyTestPublishPersisted(ctx, evt, routePlan)
 	eb.logQueuedDeliveries(ctx, evt, persistedRecipients, "matched_agent_subscription", routePlan.ExtraDetail)
 	return nil
 }
@@ -1379,6 +1394,7 @@ func (eb *EventBus) PublishDirect(ctx context.Context, evt events.Event, recipie
 		return err
 	}
 	persisted = true
+	eb.notifyTestPublishPersisted(ctx, evt, plan)
 	if plan.TargetFailure != "" {
 		applyTargetDeliveryFailureReceipt(receiptOverride, plan.TargetFailure)
 		eb.recordTargetDeliveryFailure(ctx, evt, plan)

--- a/internal/runtime/bus/lifecycle_probe.go
+++ b/internal/runtime/bus/lifecycle_probe.go
@@ -1,0 +1,110 @@
+package bus
+
+import (
+	"context"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+)
+
+func (eb *EventBus) notifyTestEventPersisted(ctx context.Context, evt events.Event) {
+	if eb == nil || eb.testLifecycleProbe == nil {
+		return
+	}
+	eb.testLifecycleProbe.NotifyLifecycle(ctx, runtimelifecycleprobe.Signal{
+		Kind:      runtimelifecycleprobe.EventPersisted,
+		EventID:   evt.ID(),
+		EventType: string(evt.Type()),
+	})
+}
+
+func (eb *EventBus) notifyTestDeliveryRowsPersisted(ctx context.Context, evt events.Event, routePlan RoutePlan) {
+	if eb == nil || eb.testLifecycleProbe == nil {
+		return
+	}
+	for _, signal := range lifecycleDeliveryPersistedSignals(evt, routePlan) {
+		eb.testLifecycleProbe.NotifyLifecycle(ctx, signal)
+		eb.testLifecycleProbe.NotifyLifecycle(ctx, runtimelifecycleprobe.Signal{
+			Kind:           runtimelifecycleprobe.DeliveryStatusChanged,
+			EventID:        signal.EventID,
+			EventType:      signal.EventType,
+			SubscriberType: signal.SubscriberType,
+			SubscriberID:   signal.SubscriberID,
+			Status:         "pending",
+		})
+	}
+}
+
+func (eb *EventBus) notifyTestPublishPersisted(ctx context.Context, evt events.Event, routePlan RoutePlan) {
+	eb.notifyTestEventPersisted(ctx, evt)
+	eb.notifyTestDeliveryRowsPersisted(ctx, evt, routePlan)
+}
+
+func (eb *EventBus) notifyTestPostCommitDispatchStarted(ctx context.Context, evt events.Event) {
+	if eb == nil || eb.testLifecycleProbe == nil {
+		return
+	}
+	eb.testLifecycleProbe.NotifyLifecycle(ctx, runtimelifecycleprobe.Signal{
+		Kind:      runtimelifecycleprobe.PostCommitDispatchStarted,
+		EventID:   evt.ID(),
+		EventType: string(evt.Type()),
+	})
+}
+
+func (eb *EventBus) notifyTestPostCommitDispatchCompleted(ctx context.Context, evt events.Event) {
+	if eb == nil || eb.testLifecycleProbe == nil {
+		return
+	}
+	eb.testLifecycleProbe.NotifyLifecycle(ctx, runtimelifecycleprobe.Signal{
+		Kind:      runtimelifecycleprobe.PostCommitDispatchCompleted,
+		EventID:   evt.ID(),
+		EventType: string(evt.Type()),
+	})
+}
+
+func lifecycleDeliveryPersistedSignals(evt events.Event, routePlan RoutePlan) []runtimelifecycleprobe.Signal {
+	routePlan = routePlan.Normalized()
+	seen := map[string]struct{}{}
+	out := make([]runtimelifecycleprobe.Signal, 0, len(routePlan.DeliveryRoutes())+len(routePlan.PersistedRecipientIDs()))
+	for _, route := range routePlan.DeliveryRoutes() {
+		subscriberType := strings.TrimSpace(route.SubscriberType)
+		subscriberID := strings.TrimSpace(route.SubscriberID)
+		if subscriberType == "" || subscriberID == "" {
+			continue
+		}
+		key := subscriberType + "\x00" + subscriberID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, runtimelifecycleprobe.Signal{
+			Kind:           runtimelifecycleprobe.DeliveryPersisted,
+			EventID:        evt.ID(),
+			EventType:      string(evt.Type()),
+			SubscriberType: subscriberType,
+			SubscriberID:   subscriberID,
+			Status:         "pending",
+		})
+	}
+	for _, recipient := range routePlan.PersistedRecipientIDs() {
+		recipient = strings.TrimSpace(recipient)
+		if recipient == "" {
+			continue
+		}
+		key := "agent\x00" + recipient
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, runtimelifecycleprobe.Signal{
+			Kind:           runtimelifecycleprobe.DeliveryPersisted,
+			EventID:        evt.ID(),
+			EventType:      string(evt.Type()),
+			SubscriberType: "agent",
+			SubscriberID:   recipient,
+			Status:         "pending",
+		})
+	}
+	return out
+}

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -85,6 +85,13 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 				o.bus.recordTargetDeliveryFailure(context.WithoutCancel(ctx), failedEvent, failedPlan)
 			})
 		}
+		if o.bus.testLifecycleProbe != nil {
+			event := intent.Event
+			routePlan := plan
+			runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
+				o.bus.notifyTestPublishPersisted(context.WithoutCancel(ctx), event, routePlan)
+			})
+		}
 		o.bus.setPendingInternalDeliveryRoutes(intent.Event.ID(), plan.InternalDeliveryRoutes())
 	}
 	return nil

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -10,12 +10,13 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	runtimeeventpayload "github.com/division-sh/swarm/internal/runtime/eventpayload"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator, testLifecycleProbe runtimelifecycleprobe.Observer) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
@@ -27,6 +28,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 		PayloadValidator:    payloadValidator,
 		BundleFingerprint:   bundleFingerprint,
 		BundleSourceFact:    bundleSourceFact,
+		TestLifecycleProbe:  testLifecycleProbe,
 	})
 }
 

--- a/internal/runtime/lifecycleprobe/probe.go
+++ b/internal/runtime/lifecycleprobe/probe.go
@@ -1,0 +1,193 @@
+package lifecycleprobe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Kind string
+
+const (
+	EventPersisted              Kind = "event_persisted"
+	DeliveryPersisted           Kind = "delivery_persisted"
+	DeliveryStatusChanged       Kind = "delivery_status_changed"
+	HandlerStarted              Kind = "handler_started"
+	HandlerCompleted            Kind = "handler_completed"
+	PostCommitDispatchStarted   Kind = "post_commit_dispatch_started"
+	PostCommitDispatchCompleted Kind = "post_commit_dispatch_completed"
+)
+
+type Observer interface {
+	NotifyLifecycle(context.Context, Signal)
+}
+
+type Signal struct {
+	Kind           Kind
+	EventID        string
+	EventType      string
+	SubscriberType string
+	SubscriberID   string
+	Status         string
+	At             time.Time
+}
+
+type Probe struct {
+	mu      sync.Mutex
+	history []Signal
+	waiters map[uint64]waiter
+	nextID  uint64
+}
+
+type waiter struct {
+	want Signal
+	ch   chan Signal
+}
+
+const maxHistory = 4096
+
+func New() *Probe {
+	return &Probe{waiters: make(map[uint64]waiter)}
+}
+
+func (p *Probe) NotifyLifecycle(_ context.Context, signal Signal) {
+	if p == nil {
+		return
+	}
+	signal = signal.Normalized()
+	if signal.Kind == "" || signal.EventID == "" {
+		return
+	}
+	if signal.At.IsZero() {
+		signal.At = time.Now().UTC()
+	}
+	p.mu.Lock()
+	p.history = append(p.history, signal)
+	if len(p.history) > maxHistory {
+		p.history = append([]Signal(nil), p.history[len(p.history)-maxHistory:]...)
+	}
+	for id, waiting := range p.waiters {
+		if signalMatches(waiting.want, signal) {
+			delete(p.waiters, id)
+			waiting.ch <- signal
+			close(waiting.ch)
+		}
+	}
+	p.mu.Unlock()
+}
+
+func (p *Probe) Wait(ctx context.Context, want Signal) (Signal, error) {
+	if p == nil {
+		return Signal{}, errors.New("lifecycle probe is nil")
+	}
+	want = want.Normalized()
+	if want.Kind == "" {
+		return Signal{}, errors.New("lifecycle probe wait kind is required")
+	}
+	if want.EventID == "" {
+		return Signal{}, errors.New("lifecycle probe wait event_id is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p.mu.Lock()
+	for _, signal := range p.history {
+		if signalMatches(want, signal) {
+			p.mu.Unlock()
+			return signal, nil
+		}
+	}
+	p.nextID++
+	id := p.nextID
+	ch := make(chan Signal, 1)
+	if p.waiters == nil {
+		p.waiters = make(map[uint64]waiter)
+	}
+	p.waiters[id] = waiter{want: want, ch: ch}
+	p.mu.Unlock()
+
+	select {
+	case signal := <-ch:
+		return signal, nil
+	case <-ctx.Done():
+		p.mu.Lock()
+		delete(p.waiters, id)
+		p.mu.Unlock()
+		return Signal{}, fmt.Errorf("wait for lifecycle %s event %s: %w", want.Kind, want.EventID, ctx.Err())
+	}
+}
+
+func (p *Probe) WaitForDeliveryStatus(ctx context.Context, eventID, subscriberType, subscriberID, status string) (Signal, error) {
+	return p.Wait(ctx, Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        eventID,
+		SubscriberType: subscriberType,
+		SubscriberID:   subscriberID,
+		Status:         status,
+	})
+}
+
+func (p *Probe) WaitForHandlerStarted(ctx context.Context, eventID, nodeID string) (Signal, error) {
+	return p.Wait(ctx, Signal{
+		Kind:           HandlerStarted,
+		EventID:        eventID,
+		SubscriberType: "node",
+		SubscriberID:   nodeID,
+	})
+}
+
+func (p *Probe) WaitForHandlerCompleted(ctx context.Context, eventID, nodeID string) (Signal, error) {
+	return p.Wait(ctx, Signal{
+		Kind:           HandlerCompleted,
+		EventID:        eventID,
+		SubscriberType: "node",
+		SubscriberID:   nodeID,
+	})
+}
+
+func (p *Probe) WaitForPostCommitDispatchStarted(ctx context.Context, eventID string) (Signal, error) {
+	return p.Wait(ctx, Signal{Kind: PostCommitDispatchStarted, EventID: eventID})
+}
+
+func (p *Probe) WaitForPostCommitDispatchCompleted(ctx context.Context, eventID string) (Signal, error) {
+	return p.Wait(ctx, Signal{Kind: PostCommitDispatchCompleted, EventID: eventID})
+}
+
+func (s Signal) Normalized() Signal {
+	return Signal{
+		Kind:           Kind(strings.TrimSpace(string(s.Kind))),
+		EventID:        strings.TrimSpace(s.EventID),
+		EventType:      strings.TrimSpace(s.EventType),
+		SubscriberType: strings.TrimSpace(s.SubscriberType),
+		SubscriberID:   strings.TrimSpace(s.SubscriberID),
+		Status:         strings.TrimSpace(s.Status),
+		At:             s.At,
+	}
+}
+
+func signalMatches(want, got Signal) bool {
+	want = want.Normalized()
+	got = got.Normalized()
+	if want.Kind != "" && want.Kind != got.Kind {
+		return false
+	}
+	if want.EventID != "" && want.EventID != got.EventID {
+		return false
+	}
+	if want.EventType != "" && want.EventType != got.EventType {
+		return false
+	}
+	if want.SubscriberType != "" && want.SubscriberType != got.SubscriberType {
+		return false
+	}
+	if want.SubscriberID != "" && want.SubscriberID != got.SubscriberID {
+		return false
+	}
+	if want.Status != "" && want.Status != got.Status {
+		return false
+	}
+	return true
+}

--- a/internal/runtime/lifecycleprobe/probe_test.go
+++ b/internal/runtime/lifecycleprobe/probe_test.go
@@ -1,0 +1,68 @@
+package lifecycleprobe
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestProbeWaitReturnsHistoricalSignal(t *testing.T) {
+	probe := New()
+	probe.NotifyLifecycle(context.Background(), Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        "event-1",
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Status:         "delivered",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := probe.WaitForDeliveryStatus(ctx, "event-1", "node", "node-a", "delivered")
+	if err != nil {
+		t.Fatalf("WaitForDeliveryStatus: %v", err)
+	}
+	if got.Kind != DeliveryStatusChanged || got.EventID != "event-1" || got.Status != "delivered" {
+		t.Fatalf("signal = %#v, want delivered event-1", got)
+	}
+}
+
+func TestProbeWaitMatchesFutureSignal(t *testing.T) {
+	probe := New()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	done := make(chan Signal, 1)
+	go func() {
+		got, err := probe.WaitForPostCommitDispatchStarted(ctx, "event-2")
+		if err != nil {
+			t.Errorf("WaitForPostCommitDispatchStarted: %v", err)
+			return
+		}
+		done <- got
+	}()
+
+	probe.NotifyLifecycle(context.Background(), Signal{
+		Kind:    PostCommitDispatchStarted,
+		EventID: "event-2",
+	})
+
+	select {
+	case got := <-done:
+		if got.Kind != PostCommitDispatchStarted || got.EventID != "event-2" {
+			t.Fatalf("signal = %#v, want post-commit start event-2", got)
+		}
+	case <-ctx.Done():
+		t.Fatalf("waiter did not receive signal: %v", ctx.Err())
+	}
+}
+
+func TestProbeWaitReturnsContextError(t *testing.T) {
+	probe := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := probe.WaitForDeliveryStatus(ctx, "event-3", "node", "node-a", "delivered")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForDeliveryStatus error = %v, want context canceled", err)
+	}
+}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	"github.com/google/uuid"
 )
 
@@ -63,6 +64,7 @@ type PipelineCoordinator struct {
 	testSubscribeHook                func()
 	testEntityStateHook              func(entityID, state string)
 	testWorkflowNodeHandlerStartHook WorkflowNodeHandlerStartHook
+	testLifecycleProbe               runtimelifecycleprobe.Observer
 }
 
 type WorkflowNodeHandlerStartHook func(context.Context, string, events.Event) error
@@ -81,6 +83,7 @@ type PipelineCoordinatorOptions struct {
 	BundleFingerprint                string
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook WorkflowNodeHandlerStartHook
+	TestLifecycleProbe               runtimelifecycleprobe.Observer
 }
 
 func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordinatorOptions) *PipelineCoordinator {
@@ -111,6 +114,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		bundleFingerprint:                strings.TrimSpace(opts.BundleFingerprint),
 		testEntityStateHook:              opts.TestEntityStateHook,
 		testWorkflowNodeHandlerStartHook: opts.TestWorkflowNodeHandlerStartHook,
+		testLifecycleProbe:               opts.TestLifecycleProbe,
 		entityLocks:                      make(map[string]*sync.Mutex),
 	}
 }
@@ -143,6 +147,15 @@ func (pc *PipelineCoordinator) SetTestWorkflowNodeHandlerStartHook(fn WorkflowNo
 	}
 	pc.mu.Lock()
 	pc.testWorkflowNodeHandlerStartHook = fn
+	pc.mu.Unlock()
+}
+
+func (pc *PipelineCoordinator) SetTestLifecycleProbe(probe runtimelifecycleprobe.Observer) {
+	if pc == nil {
+		return
+	}
+	pc.mu.Lock()
+	pc.testLifecycleProbe = probe
 	pc.mu.Unlock()
 }
 
@@ -281,12 +294,14 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 	if err := pc.notifyTestWorkflowNodeHandlerStarting(ctx, nodeID, evt); err != nil {
 		return false, err
 	}
+	pc.notifyTestLifecycleHandlerStarted(ctx, nodeID, evt)
 	result, err := pc.executeNodeContractHandler(ctx, nodeID, handler, workflowTriggerContext{
 		Event:           evt,
 		HandlerEventKey: handlerEventKey,
 		State:           pc.currentWorkflowState(ctx, workflowEventEntityID(evt)),
 	}, false)
 	if err != nil {
+		pc.notifyTestLifecycleHandlerCompleted(ctx, nodeID, evt, "failed")
 		if errors.Is(err, runtimeengine.ErrChainDepthExceeded) {
 			_ = runtimedeadletters.Insert(ctx, pc.db, runtimedeadletters.Record{
 				OriginalEventID: strings.TrimSpace(evt.ID()),
@@ -303,6 +318,7 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 		pc.markWorkflowNodeDeliveryDeadLetter(ctx, nodeID, evt, "handler_error", err, 0)
 		return true, err
 	}
+	pc.notifyTestLifecycleHandlerCompleted(ctx, nodeID, evt, "completed")
 	pc.recordInterceptedEmitDeadLetters(ctx, evt, nodeID, result.Outcome)
 	if result.Handled {
 		pc.reconcileWorkflowEventTimers(ctx, workflowEventEntityID(evt), trigger)

--- a/internal/runtime/pipeline/lifecycle_probe.go
+++ b/internal/runtime/pipeline/lifecycle_probe.go
@@ -1,0 +1,62 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+)
+
+func (pc *PipelineCoordinator) notifyTestLifecycleDeliveryStatus(ctx context.Context, nodeID string, evt events.Event, status string) {
+	if pc == nil || pc.testLifecycleProbe == nil {
+		return
+	}
+	pc.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.DeliveryStatusChanged, nodeID, evt, status))
+}
+
+func (pc *PipelineCoordinator) notifyTestLifecycleHandlerStarted(ctx context.Context, nodeID string, evt events.Event) {
+	if pc == nil || pc.testLifecycleProbe == nil {
+		return
+	}
+	pc.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.HandlerStarted, nodeID, evt, ""))
+}
+
+func (pc *PipelineCoordinator) notifyTestLifecycleHandlerCompleted(ctx context.Context, nodeID string, evt events.Event, status string) {
+	if pc == nil || pc.testLifecycleProbe == nil {
+		return
+	}
+	pc.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.HandlerCompleted, nodeID, evt, status))
+}
+
+func (n *systemNodeRunner) notifyTestLifecycleDeliveryStatus(ctx context.Context, evt events.Event, status string) {
+	if n == nil || n.testLifecycleProbe == nil {
+		return
+	}
+	n.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.DeliveryStatusChanged, n.nodeID, evt, status))
+}
+
+func (n *systemNodeRunner) notifyTestLifecycleHandlerStarted(ctx context.Context, evt events.Event) {
+	if n == nil || n.testLifecycleProbe == nil {
+		return
+	}
+	n.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.HandlerStarted, n.nodeID, evt, ""))
+}
+
+func (n *systemNodeRunner) notifyTestLifecycleHandlerCompleted(ctx context.Context, evt events.Event, status string) {
+	if n == nil || n.testLifecycleProbe == nil {
+		return
+	}
+	n.testLifecycleProbe.NotifyLifecycle(ctx, lifecycleNodeSignal(runtimelifecycleprobe.HandlerCompleted, n.nodeID, evt, status))
+}
+
+func lifecycleNodeSignal(kind runtimelifecycleprobe.Kind, nodeID string, evt events.Event, status string) runtimelifecycleprobe.Signal {
+	return runtimelifecycleprobe.Signal{
+		Kind:           kind,
+		EventID:        evt.ID(),
+		EventType:      string(evt.Type()),
+		SubscriberType: "node",
+		SubscriberID:   strings.TrimSpace(nodeID),
+		Status:         strings.TrimSpace(status),
+	}
+}

--- a/internal/runtime/pipeline/node_background.go
+++ b/internal/runtime/pipeline/node_background.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 )
 
 type backgroundWorkflowNode struct {
@@ -69,6 +70,13 @@ func (n *backgroundWorkflowNode) SetOnSubscribeForTest(fn func()) {
 		return
 	}
 	n.runner.SetOnSubscribeForTest(fn)
+}
+
+func (n *backgroundWorkflowNode) SetTestLifecycleProbe(probe runtimelifecycleprobe.Observer) {
+	if n == nil || n.runner == nil {
+		return
+	}
+	n.runner.SetTestLifecycleProbe(probe)
 }
 
 func (n *backgroundWorkflowNode) String() string {

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	runtimerterr "github.com/division-sh/swarm/internal/runtime/rterrors"
 	"github.com/google/uuid"
 )
@@ -43,6 +44,7 @@ type systemNodeRunner struct {
 	overrideHandle          func(context.Context, events.Event) error
 	onSubscribe             func()
 	eventReceiptsCapability func(context.Context) (bool, error)
+	testLifecycleProbe      runtimelifecycleprobe.Observer
 
 	receiptsMu      sync.Mutex
 	receiptsChecked bool
@@ -136,12 +138,15 @@ func (n *systemNodeRunner) ProcessEventForTest(ctx context.Context, evt events.E
 		if !n.markDeliveryInProgress(ctx, evt) {
 			return
 		}
+		n.notifyTestLifecycleHandlerStarted(ctx, evt)
 		if err := n.handle(ctx, evt); err == nil {
+			n.notifyTestLifecycleHandlerCompleted(ctx, evt, "completed")
 			if !n.isActiveRunQuiesced(ctx, evt) {
 				n.markProcessed(ctx, evt)
 			}
 			return
 		} else {
+			n.notifyTestLifecycleHandlerCompleted(ctx, evt, "failed")
 			lastErr = err
 			if isNonRetryableHandlerError(err) {
 				failureType = "handler_error"
@@ -194,6 +199,13 @@ func (n *systemNodeRunner) SetOnSubscribeForTest(fn func()) {
 		return
 	}
 	n.onSubscribe = fn
+}
+
+func (n *systemNodeRunner) SetTestLifecycleProbe(probe runtimelifecycleprobe.Observer) {
+	if n == nil {
+		return
+	}
+	n.testLifecycleProbe = probe
 }
 
 func (n *systemNodeRunner) subscribe() <-chan events.Event {
@@ -356,6 +368,7 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 		return
 	}
 	n.convergeNormalRunCompletion(ctx, evt)
+	n.notifyTestLifecycleDeliveryStatus(ctx, evt, "delivered")
 }
 
 func (n *systemNodeRunner) markDeliveryInProgress(ctx context.Context, evt events.Event) bool {
@@ -373,6 +386,7 @@ func (n *systemNodeRunner) markDeliveryInProgress(ctx context.Context, evt event
 		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_in_progress_failed", "Marking the system node delivery in progress failed", err)
 		return false
 	}
+	n.notifyTestLifecycleDeliveryStatus(ctx, evt, "in_progress")
 	return true
 }
 
@@ -393,7 +407,9 @@ func (n *systemNodeRunner) markDeliveryFailed(ctx context.Context, evt events.Ev
 	}
 	if err := n.receiptStore.MarkSystemNodeDeliveryFailed(ctx, n.nodeID, eventID, reasonCode, errText, retryCount, n.effectiveRetryLimit()); err != nil {
 		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_failed_failed", "Marking the system node delivery as failed failed", err)
+		return
 	}
+	n.notifyTestLifecycleDeliveryStatus(ctx, evt, "failed")
 }
 
 func (n *systemNodeRunner) markDeliveryDeadLetter(ctx context.Context, evt events.Event, reasonCode string, cause error, retryCount int) {
@@ -417,6 +433,7 @@ func (n *systemNodeRunner) markDeliveryDeadLetter(ctx context.Context, evt event
 		return
 	}
 	n.convergeNormalRunCompletion(ctx, evt)
+	n.notifyTestLifecycleDeliveryStatus(ctx, evt, "dead_letter")
 }
 
 func (n *systemNodeRunner) logSystemNodeDeliveryTransitionError(ctx context.Context, evt events.Event, action, message string, err error) {

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -104,6 +105,96 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 	}
 	if receiptOutcome != "no_op" {
 		t.Fatalf("node receipt outcome = %q, want no_op", receiptOutcome)
+	}
+}
+
+func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionRun(t, db, runID, eventID, entityID)
+	bus := &systemNodeCompletionBus{}
+	probe := runtimelifecycleprobe.New()
+	handlerObservedStatus := ""
+	handlerObservedReason := ""
+	runner := newSystemNodeRunner("terminal-node", bus, db, func() []events.EventType {
+		return []events.EventType{"example.started"}
+	}, func(ctx context.Context, evt events.Event) error {
+		startedCtx, cancelStarted := context.WithTimeout(ctx, time.Second)
+		defer cancelStarted()
+		if _, err := probe.WaitForHandlerStarted(startedCtx, eventID, "terminal-node"); err != nil {
+			t.Fatalf("handler started lifecycle signal: %v", err)
+		}
+		if err := db.QueryRowContext(ctx, `
+			SELECT COALESCE(status, ''), COALESCE(reason_code, '')
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = 'terminal-node'
+		`, eventID).Scan(&handlerObservedStatus, &handlerObservedReason); err != nil {
+			t.Fatalf("load node delivery during handler: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			UPDATE entity_state
+			SET current_state = 'done',
+			    updated_at = now()
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+		`, runID, entityID); err != nil {
+			t.Fatalf("mark entity terminal: %v", err)
+		}
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+	runner.SetTestLifecycleProbe(probe)
+
+	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, time.Second)
+	defer cancelWait()
+	inProgress, err := probe.WaitForDeliveryStatus(waitCtx, eventID, "node", "terminal-node", "in_progress")
+	if err != nil {
+		t.Fatalf("node in_progress lifecycle signal: %v", err)
+	}
+	started, err := probe.WaitForHandlerStarted(waitCtx, eventID, "terminal-node")
+	if err != nil {
+		t.Fatalf("handler started lifecycle signal after process: %v", err)
+	}
+	completed, err := probe.WaitForHandlerCompleted(waitCtx, eventID, "terminal-node")
+	if err != nil {
+		t.Fatalf("handler completed lifecycle signal: %v", err)
+	}
+	if completed.Status != "completed" {
+		t.Fatalf("handler completed status = %q, want completed", completed.Status)
+	}
+	delivered, err := probe.WaitForDeliveryStatus(waitCtx, eventID, "node", "terminal-node", "delivered")
+	if err != nil {
+		t.Fatalf("node delivered lifecycle signal: %v", err)
+	}
+	if started.At.Before(inProgress.At) || completed.At.Before(started.At) || delivered.At.Before(completed.At) {
+		t.Fatalf("lifecycle signal order = in_progress:%s started:%s completed:%s delivered:%s, want in-progress before handler start before completion before delivered",
+			inProgress.At.Format(time.RFC3339Nano),
+			started.At.Format(time.RFC3339Nano),
+			completed.At.Format(time.RFC3339Nano),
+			delivered.At.Format(time.RFC3339Nano))
+	}
+	if handlerObservedStatus != "in_progress" || handlerObservedReason != "node_processing" {
+		t.Fatalf("handler observed node delivery = %s/%s, want in_progress/node_processing", handlerObservedStatus, handlerObservedReason)
+	}
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'terminal-node'
+	`, eventID).Scan(&status); err != nil {
+		t.Fatalf("load final node delivery: %v", err)
+	}
+	if status != "delivered" {
+		t.Fatalf("final node delivery status = %q, want delivered", status)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -683,6 +683,7 @@ func (pc *PipelineCoordinator) BackgroundNodesWithReceiptStore(bus systemNodeBus
 		}
 		if executor := pc.backgroundWorkflowExecutor(strings.TrimSpace(node.ID)); executor != nil {
 			if bg := newBackgroundWorkflowNodeWithReceiptStoreAndRetryBase(executor, bus, db, receiptStore, pc.eventReceiptsCapability, retryBase); bg != nil {
+				bg.SetTestLifecycleProbe(pc.testLifecycleProbe)
 				out = append(out, bg)
 			}
 		}
@@ -853,6 +854,7 @@ func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, no
 		return
 	}
 	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
+	pc.notifyTestLifecycleDeliveryStatus(ctx, nodeID, evt, "delivered")
 }
 
 func (pc *PipelineCoordinator) markWorkflowNodeDeliveryInProgress(ctx context.Context, nodeID string, evt events.Event) bool {
@@ -871,6 +873,7 @@ func (pc *PipelineCoordinator) markWorkflowNodeDeliveryInProgress(ctx context.Co
 		pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_in_progress_failed", "Marking the workflow node delivery in progress failed", err)
 		return false
 	}
+	pc.notifyTestLifecycleDeliveryStatus(ctx, nodeID, evt, "in_progress")
 	return true
 }
 
@@ -896,6 +899,7 @@ func (pc *PipelineCoordinator) markWorkflowNodeDeliveryDeadLetter(ctx context.Co
 		return
 	}
 	pc.convergeWorkflowNodeNormalRunCompletion(ctx, nodeID, evt)
+	pc.notifyTestLifecycleDeliveryStatus(ctx, nodeID, evt, "dead_letter")
 }
 
 func (pc *PipelineCoordinator) logWorkflowNodeDeliveryTransitionError(ctx context.Context, nodeID string, evt events.Event, action, message string, err error) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
@@ -79,6 +80,7 @@ type RuntimeOptions struct {
 	DisablePersistentStartupRecovery bool
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
+	TestLifecycleProbe               runtimelifecycleprobe.Observer
 	TestOutboxSweeperConfig          runtimebus.OutboxSweeperConfig
 }
 
@@ -390,7 +392,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			return nil
 		}
 		return []runtimebus.EventInterceptor{rt.Pipeline}
-	}, payloadValidator)
+	}, payloadValidator, opts.TestLifecycleProbe)
 	if err != nil {
 		return nil, fmt.Errorf("build event bus: %w", err)
 	}
@@ -464,6 +466,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			BundleFingerprint:                opts.BundleFingerprint,
 			TestEntityStateHook:              opts.TestEntityStateHook,
 			TestWorkflowNodeHandlerStartHook: opts.TestWorkflowNodeHandlerStartHook,
+			TestLifecycleProbe:               opts.TestLifecycleProbe,
 		})
 		if rt.Pipeline != nil {
 			rt.SystemNodes = append(rt.SystemNodes, rt.Pipeline.BackgroundNodesWithReceiptStore(rt.Bus, stores.SQLDB, pipelineStore)...)


### PR DESCRIPTION
## Summary

Closes #1380.

Adds an internal test-only runtime lifecycle probe for selected async event/delivery milestones and migrates the approved first-slice tests away from proxy waits:

- adds `internal/runtime/lifecycleprobe` with historical/future milestone waits;
- wires `TestLifecycleProbe` through EventBus, Runtime, PipelineCoordinator, and background/system-node runners;
- emits probe signals only after existing owners complete event persistence, delivery-row persistence, post-commit dispatch start/completion, node delivery status transitions, and handler start/completion;
- migrates APIV1 event.publish quick-ACK proof from a local interceptor-start channel and receipt polling to post-commit dispatch milestones;
- migrates APIV1 mailbox-write node delivery release from delivery-row polling plus bus quiescence to canonical node delivery `pending` / `delivered` milestones.

## Governing refs/context

Exact spec constraints:

- `platform-spec.yaml` `routing_derivation.delivery_filter.internal_observation_hooks`: test-only observers are not routing-execution authority.
- `platform-spec.yaml` `event_loop.persist_event` / `event_loop.agent_delivery`: persistence and delivery remain runtime/store owned.
- `platform-spec.yaml` `event_deliveries`: canonical persisted delivery lifecycle is `event_deliveries.status`.
- `platform-spec.yaml` workflow-node route/delivery authority sections: executable workflow-node work requires persisted delivery authority before handler execution.
- `platform-spec.yaml` `/v1/rpc event.publish`: `event.publish` must not wait for handler completion, agent processing, downstream delivery, or dynamic side effects.

Binding issue/gate context:

- #1380 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1380#issuecomment-4640409946
- #1380 gate approval: https://github.com/division-sh/swarm/issues/1380#issuecomment-4640447275

## Semantic migration

New canonical owner for the selected test-observation concept:

- `internal/runtime/lifecycleprobe.Probe` owns test-only milestone observation/waiting.

Old paths now invalid for the selected first-slice manifestations:

- APIV1 quick-ACK proof no longer uses a local interceptor-start channel or `waitPipelineReceiptsForEvent` polling.
- APIV1 mailbox-write node delivery release no longer uses row-visibility polling plus `WaitForQuiescence` as proof that the node delivery lifecycle reached the release/terminal milestones.

Checked production paths:

- Probe is disabled by default and only reachable through `TestLifecycleProbe` options.
- No public API, CLI, OpenRPC, platform configuration, routing, admission, delivery, receipt, replay, or settlement behavior changed.
- Default behavior was execution-proven by existing bus post-commit action tests, which caught and prevented no-op probe action registration when the probe is nil.

Migration completeness:

- Complete for the selected #1380 first-slice manifestations.
- #1233/#1196 remain open for broader async wait cleanup across APIV1, served/CLI, dashboard, store/fork, runtime manager, provider, harness, catalog, and CI sibling families.

## Proof

- `go test ./internal/runtime/lifecycleprobe`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes|TestOperator.*MailboxWrite.*' -count=1`
- `go test ./...`
