### PR TITLE
[agent-f][issue #1375] Expose delivery failure evidence

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -65,11 +65,12 @@ type diagnosticRunGetResult struct {
 }
 
 type diagnosticRunDiagnosisResult struct {
-	Run              diagnosticRunHeader `json:"run"`
-	OperationalState *string             `json:"operational_state"`
-	BlockingLayer    *string             `json:"blocking_layer"`
-	BlockingReason   *string             `json:"blocking_reason"`
-	Heuristics       []string            `json:"heuristics"`
+	Run              diagnosticRunHeader            `json:"run"`
+	OperationalState *string                        `json:"operational_state"`
+	BlockingLayer    *string                        `json:"blocking_layer"`
+	BlockingReason   *string                        `json:"blocking_reason"`
+	Heuristics       []string                       `json:"heuristics"`
+	FailedDeliveries []diagnosticRunFailureDelivery `json:"failed_deliveries"`
 }
 
 type diagnosticRunTraceResult struct {
@@ -106,16 +107,41 @@ type diagnosticRunHeader struct {
 }
 
 type diagnosticRunTraceRow struct {
-	EventID              string `json:"event_id"`
-	EventName            string `json:"event_name"`
-	EventCreatedAt       string `json:"event_created_at"`
-	EntityID             string `json:"entity_id,omitempty"`
-	DeliveryStatus       string `json:"delivery_status,omitempty"`
-	SubscriberType       string `json:"subscriber_type,omitempty"`
-	SubscriberID         string `json:"subscriber_id,omitempty"`
-	SessionID            string `json:"session_id,omitempty"`
-	TurnID               string `json:"turn_id,omitempty"`
-	TurnTriggerEventType string `json:"turn_trigger_event_type,omitempty"`
+	EventID               string `json:"event_id"`
+	EventName             string `json:"event_name"`
+	EventCreatedAt        string `json:"event_created_at"`
+	EntityID              string `json:"entity_id,omitempty"`
+	DeliveryStatus        string `json:"delivery_status,omitempty"`
+	DeliveryReasonCode    string `json:"delivery_reason_code,omitempty"`
+	DeliveryLastError     string `json:"delivery_last_error,omitempty"`
+	DeliveryRetryCount    int    `json:"delivery_retry_count,omitempty"`
+	DeliveryRetryEligible bool   `json:"delivery_retry_eligible,omitempty"`
+	DeliveryTerminal      bool   `json:"delivery_terminal,omitempty"`
+	SubscriberType        string `json:"subscriber_type,omitempty"`
+	SubscriberID          string `json:"subscriber_id,omitempty"`
+	SessionID             string `json:"session_id,omitempty"`
+	TurnID                string `json:"turn_id,omitempty"`
+	TurnTriggerEventType  string `json:"turn_trigger_event_type,omitempty"`
+}
+
+type diagnosticRunFailureDelivery struct {
+	EventID        string            `json:"event_id"`
+	EventName      string            `json:"event_name"`
+	EntityID       string            `json:"entity_id,omitempty"`
+	DeliveryID     string            `json:"delivery_id"`
+	SubscriberType string            `json:"subscriber_type"`
+	SubscriberID   string            `json:"subscriber_id"`
+	SessionID      string            `json:"session_id,omitempty"`
+	Status         string            `json:"status"`
+	ReasonCode     string            `json:"reason_code,omitempty"`
+	LastError      string            `json:"last_error,omitempty"`
+	RetryCount     int               `json:"retry_count"`
+	RetryEligible  bool              `json:"retry_eligible"`
+	Terminal       bool              `json:"terminal"`
+	CreatedAt      string            `json:"created_at,omitempty"`
+	StartedAt      string            `json:"started_at,omitempty"`
+	FinishedAt     string            `json:"finished_at,omitempty"`
+	DeadLetters    []eventDeadLetter `json:"dead_letters,omitempty"`
 }
 
 var diagnosticValidRunStatuses = map[string]struct{}{
@@ -966,6 +992,44 @@ func validateDiagnosticRunDiagnosis(result diagnosticRunDiagnosisResult) error {
 	if result.Heuristics == nil {
 		return fmt.Errorf("malformed run.diagnose result: heuristics is required")
 	}
+	for i, delivery := range result.FailedDeliveries {
+		if err := validateDiagnosticRunFailureDelivery(fmt.Sprintf("failed_deliveries[%d]", i), delivery); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDiagnosticRunFailureDelivery(prefix string, delivery diagnosticRunFailureDelivery) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "event_id", value: delivery.EventID},
+		{name: "event_name", value: delivery.EventName},
+		{name: "delivery_id", value: delivery.DeliveryID},
+		{name: "subscriber_type", value: delivery.SubscriberType},
+		{name: "subscriber_id", value: delivery.SubscriberID},
+		{name: "status", value: delivery.Status},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("malformed run.diagnose result: %s.%s is required", prefix, field.name)
+		}
+	}
+	if _, ok := eventObservationValidSubscriberTypes[strings.TrimSpace(delivery.SubscriberType)]; !ok {
+		return fmt.Errorf("malformed run.diagnose result: %s.subscriber_type=%q is not a valid SubscriberType", prefix, delivery.SubscriberType)
+	}
+	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
+		return fmt.Errorf("malformed run.diagnose result: %s.status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
+	}
+	if delivery.RetryCount < 0 {
+		return fmt.Errorf("malformed run.diagnose result: %s.retry_count must be >= 0", prefix)
+	}
+	for i, deadLetter := range delivery.DeadLetters {
+		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", prefix, i), deadLetter); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -1126,11 +1190,32 @@ func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisRes
 	)
 	if len(result.Heuristics) == 0 {
 		fmt.Fprintln(out, "heuristics=none")
+	} else {
+		fmt.Fprintln(out, "heuristics:")
+		for _, item := range result.Heuristics {
+			fmt.Fprintf(out, "- %s\n", item)
+		}
+	}
+	if len(result.FailedDeliveries) == 0 {
+		fmt.Fprintln(out, "failed_deliveries=none")
 		return
 	}
-	fmt.Fprintln(out, "heuristics:")
-	for _, item := range result.Heuristics {
-		fmt.Fprintf(out, "- %s\n", item)
+	fmt.Fprintln(out, "failed_deliveries:")
+	for _, delivery := range result.FailedDeliveries {
+		fmt.Fprintf(out, "  event_id=%s event_name=%s delivery_id=%s subscriber=%s/%s status=%s reason_code=%s last_error=%s retry_count=%d retry_eligible=%t terminal=%t dead_letters=%d\n",
+			delivery.EventID,
+			delivery.EventName,
+			delivery.DeliveryID,
+			delivery.SubscriberType,
+			delivery.SubscriberID,
+			delivery.Status,
+			emptyDash(delivery.ReasonCode),
+			emptyDash(delivery.LastError),
+			delivery.RetryCount,
+			delivery.RetryEligible,
+			delivery.Terminal,
+			len(delivery.DeadLetters),
+		)
 	}
 }
 

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -46,12 +46,21 @@ type eventPublishResult struct {
 }
 
 type eventPublishDelivery struct {
-	DeliveryID     string `json:"delivery_id"`
-	SubscriberType string `json:"subscriber_type"`
-	SubscriberID   string `json:"subscriber_id"`
-	SessionID      string `json:"session_id,omitempty"`
-	Status         string `json:"status"`
-	Attempt        int    `json:"attempt"`
+	DeliveryID     string            `json:"delivery_id"`
+	SubscriberType string            `json:"subscriber_type"`
+	SubscriberID   string            `json:"subscriber_id"`
+	SessionID      string            `json:"session_id,omitempty"`
+	Status         string            `json:"status"`
+	ReasonCode     string            `json:"reason_code,omitempty"`
+	LastError      string            `json:"last_error,omitempty"`
+	Attempt        int               `json:"attempt"`
+	RetryCount     int               `json:"retry_count"`
+	RetryEligible  bool              `json:"retry_eligible"`
+	Terminal       bool              `json:"terminal"`
+	CreatedAt      string            `json:"created_at,omitempty"`
+	StartedAt      string            `json:"started_at,omitempty"`
+	FinishedAt     string            `json:"finished_at,omitempty"`
+	DeadLetters    []eventDeadLetter `json:"dead_letters,omitempty"`
 }
 
 func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
@@ -253,6 +262,14 @@ func validateEventPublishDelivery(prefix string, delivery eventPublishDelivery) 
 	if delivery.Attempt < 1 {
 		return fmt.Errorf("malformed event.publish result: %s.attempt must be >= 1", prefix)
 	}
+	if delivery.RetryCount < 0 {
+		return fmt.Errorf("malformed event.publish result: %s.retry_count must be >= 0", prefix)
+	}
+	for i, deadLetter := range delivery.DeadLetters {
+		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", prefix, i), deadLetter); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -268,13 +285,19 @@ func writeEventPublishResult(out io.Writer, eventName string, result eventPublis
 		len(result.Deliveries),
 	)
 	for _, delivery := range result.Deliveries {
-		fmt.Fprintf(out, "delivery delivery_id=%s subscriber=%s/%s status=%s session_id=%s attempt=%d\n",
+		fmt.Fprintf(out, "delivery delivery_id=%s subscriber=%s/%s status=%s session_id=%s attempt=%d retry_count=%d retry_eligible=%t terminal=%t reason_code=%s last_error=%s dead_letters=%d\n",
 			delivery.DeliveryID,
 			delivery.SubscriberType,
 			delivery.SubscriberID,
 			delivery.Status,
 			eventObservationDash(delivery.SessionID),
 			delivery.Attempt,
+			delivery.RetryCount,
+			delivery.RetryEligible,
+			delivery.Terminal,
+			eventObservationDash(delivery.ReasonCode),
+			eventObservationDash(delivery.LastError),
+			len(delivery.DeadLetters),
 		)
 	}
 	if sourceEventID := strings.TrimSpace(result.SourceEventID); sourceEventID != "" {

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -81,13 +81,20 @@ type eventFull struct {
 }
 
 type eventDelivery struct {
-	DeliveryID     string `json:"delivery_id"`
-	SubscriberType string `json:"subscriber_type"`
-	SubscriberID   string `json:"subscriber_id"`
-	Status         string `json:"status"`
-	SessionID      string `json:"session_id,omitempty"`
-	ReasonCode     string `json:"reason_code,omitempty"`
-	LastError      string `json:"last_error,omitempty"`
+	DeliveryID     string            `json:"delivery_id"`
+	SubscriberType string            `json:"subscriber_type"`
+	SubscriberID   string            `json:"subscriber_id"`
+	Status         string            `json:"status"`
+	SessionID      string            `json:"session_id,omitempty"`
+	ReasonCode     string            `json:"reason_code,omitempty"`
+	LastError      string            `json:"last_error,omitempty"`
+	RetryCount     int               `json:"retry_count"`
+	RetryEligible  bool              `json:"retry_eligible"`
+	Terminal       bool              `json:"terminal"`
+	CreatedAt      string            `json:"created_at,omitempty"`
+	StartedAt      string            `json:"started_at,omitempty"`
+	FinishedAt     string            `json:"finished_at,omitempty"`
+	DeadLetters    []eventDeadLetter `json:"dead_letters,omitempty"`
 }
 
 type eventDeadLetter struct {
@@ -114,12 +121,21 @@ type eventReplayResult struct {
 }
 
 type eventReplayDelivery struct {
-	DeliveryID       string `json:"delivery_id"`
-	SubscriberID     string `json:"subscriber_id"`
-	SessionID        string `json:"session_id,omitempty"`
-	Status           string `json:"status"`
-	Attempt          int    `json:"attempt"`
-	SourceDeliveryID string `json:"source_delivery_id,omitempty"`
+	DeliveryID       string            `json:"delivery_id"`
+	SubscriberID     string            `json:"subscriber_id"`
+	SessionID        string            `json:"session_id,omitempty"`
+	Status           string            `json:"status"`
+	ReasonCode       string            `json:"reason_code,omitempty"`
+	LastError        string            `json:"last_error,omitempty"`
+	Attempt          int               `json:"attempt"`
+	RetryCount       int               `json:"retry_count"`
+	RetryEligible    bool              `json:"retry_eligible"`
+	Terminal         bool              `json:"terminal"`
+	CreatedAt        string            `json:"created_at,omitempty"`
+	StartedAt        string            `json:"started_at,omitempty"`
+	FinishedAt       string            `json:"finished_at,omitempty"`
+	DeadLetters      []eventDeadLetter `json:"dead_letters,omitempty"`
+	SourceDeliveryID string            `json:"source_delivery_id,omitempty"`
 }
 
 type eventSubscriptionNotification struct {
@@ -576,6 +592,14 @@ func validateEventDelivery(prefix string, delivery eventDelivery) error {
 	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
 		return fmt.Errorf("malformed %s: status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
 	}
+	if delivery.RetryCount < 0 {
+		return fmt.Errorf("malformed %s: retry_count must be >= 0", prefix)
+	}
+	for i, deadLetter := range delivery.DeadLetters {
+		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", prefix, i), deadLetter); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -674,6 +698,14 @@ func validateEventReplayDelivery(field string, delivery eventReplayDelivery, req
 	}
 	if delivery.Attempt < 1 {
 		return fmt.Errorf("malformed event.replay result: %s.attempt must be >= 1", field)
+	}
+	if delivery.RetryCount < 0 {
+		return fmt.Errorf("malformed event.replay result: %s.retry_count must be >= 0", field)
+	}
+	for i, deadLetter := range delivery.DeadLetters {
+		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", field, i), deadLetter); err != nil {
+			return err
+		}
 	}
 	if requireSource && strings.TrimSpace(delivery.SourceDeliveryID) == "" {
 		return fmt.Errorf("malformed event.replay result: %s.source_delivery_id is required", field)
@@ -842,7 +874,7 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 	} else {
 		fmt.Fprintln(out, "deliveries:")
 		for _, delivery := range event.Deliveries {
-			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s reason_code=%s last_error=%s\n",
+			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s reason_code=%s last_error=%s retry_count=%d retry_eligible=%t terminal=%t dead_letters=%d\n",
 				delivery.DeliveryID,
 				delivery.SubscriberType,
 				delivery.SubscriberID,
@@ -850,6 +882,10 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 				eventObservationDash(delivery.SessionID),
 				eventObservationDash(delivery.ReasonCode),
 				eventObservationDash(delivery.LastError),
+				delivery.RetryCount,
+				delivery.RetryEligible,
+				delivery.Terminal,
+				len(delivery.DeadLetters),
 			)
 		}
 	}
@@ -910,21 +946,33 @@ func writeEventReplayResult(out io.Writer, result eventReplayResult) {
 		len(result.NewDeliveries),
 	)
 	for _, delivery := range result.OriginalDeliveries {
-		fmt.Fprintf(out, "original_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d\n",
+		fmt.Fprintf(out, "original_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d retry_count=%d retry_eligible=%t terminal=%t reason_code=%s last_error=%s dead_letters=%d\n",
 			delivery.DeliveryID,
 			delivery.SubscriberID,
 			delivery.Status,
 			eventObservationDash(delivery.SessionID),
 			delivery.Attempt,
+			delivery.RetryCount,
+			delivery.RetryEligible,
+			delivery.Terminal,
+			eventObservationDash(delivery.ReasonCode),
+			eventObservationDash(delivery.LastError),
+			len(delivery.DeadLetters),
 		)
 	}
 	for _, delivery := range result.NewDeliveries {
-		fmt.Fprintf(out, "new_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d source_delivery_id=%s\n",
+		fmt.Fprintf(out, "new_delivery delivery_id=%s subscriber_id=%s status=%s session_id=%s attempt=%d retry_count=%d retry_eligible=%t terminal=%t reason_code=%s last_error=%s dead_letters=%d source_delivery_id=%s\n",
 			delivery.DeliveryID,
 			delivery.SubscriberID,
 			delivery.Status,
 			eventObservationDash(delivery.SessionID),
 			delivery.Attempt,
+			delivery.RetryCount,
+			delivery.RetryEligible,
+			delivery.Terminal,
+			eventObservationDash(delivery.ReasonCode),
+			eventObservationDash(delivery.LastError),
+			len(delivery.DeadLetters),
 			delivery.SourceDeliveryID,
 		)
 	}

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -20,8 +20,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 56 {
 		t.Fatalf("method count = %d, want 56", report.MethodCount)
 	}
-	if report.SchemaCount != 104 {
-		t.Fatalf("schema count = %d, want 104", report.SchemaCount)
+	if report.SchemaCount != 105 {
+		t.Fatalf("schema count = %d, want 105", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 39 {
 		t.Fatalf("error code count = %d, want 39", report.ErrorCodeCount)
@@ -83,8 +83,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 56 {
 		t.Fatalf("generated OpenRPC methods = %d, want 56", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 104 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 104", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 105 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 105", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 39 {
 		t.Fatalf("generated OpenRPC errors = %d, want 39", len(doc.Components.Errors))

--- a/internal/apiv1/operator_delivery_failure_evidence_test.go
+++ b/internal/apiv1/operator_delivery_failure_evidence_test.go
@@ -1,0 +1,65 @@
+package apiv1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/store"
+)
+
+func TestEventPublishDeliveriesExposeFailureEvidence(t *testing.T) {
+	at := time.Unix(1700000000, 0).UTC()
+	deliveries := eventPublishDeliveries([]store.OperatorEventDelivery{{
+		DeliveryID:     "delivery-1",
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Status:         "dead_letter",
+		ReasonCode:     "retry_exhausted",
+		LastError:      "boom",
+		RetryCount:     2,
+		CreatedAt:      &at,
+		FinishedAt:     &at,
+		DeadLetters: []store.OperatorDeadLetterRecord{{
+			DeadLetterID: "dead-1",
+			FailureType:  "retry_exhausted",
+			RetryCount:   2,
+			CreatedAt:    at,
+		}},
+	}})
+	if len(deliveries) != 1 {
+		t.Fatalf("deliveries len = %d, want 1", len(deliveries))
+	}
+	got := deliveries[0]
+	if got.RetryCount != 2 || got.Attempt != 3 || got.RetryEligible || !got.Terminal || got.ReasonCode != "retry_exhausted" || got.LastError != "boom" || len(got.DeadLetters) != 1 {
+		t.Fatalf("delivery failure evidence = %#v", got)
+	}
+}
+
+func TestEventReplayTargetsExposeOriginalFailureEvidence(t *testing.T) {
+	at := time.Unix(1700000000, 0).UTC()
+	original := store.OperatorEventFull{
+		EventID:   "event-1",
+		EventName: "task.failed",
+		Deliveries: []store.OperatorEventDelivery{{
+			DeliveryID:     "delivery-1",
+			SubscriberType: "agent",
+			SubscriberID:   "agent-a",
+			Status:         "failed",
+			ReasonCode:     "handler_error",
+			LastError:      "agent boom",
+			RetryCount:     1,
+			CreatedAt:      &at,
+		}},
+	}
+	deliveries, subscribers, err := eventReplayTargets(original, nil)
+	if err != nil {
+		t.Fatalf("eventReplayTargets: %v", err)
+	}
+	if len(subscribers) != 1 || subscribers[0] != "agent-a" || len(deliveries) != 1 {
+		t.Fatalf("targets subscribers=%#v deliveries=%#v", subscribers, deliveries)
+	}
+	got := deliveries[0]
+	if got.RetryCount != 1 || got.Attempt != 2 || !got.RetryEligible || got.Terminal || got.ReasonCode != "handler_error" || got.LastError != "agent boom" {
+		t.Fatalf("replay delivery evidence = %#v", got)
+	}
+}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -27,12 +27,21 @@ type eventPublishResult struct {
 }
 
 type eventPublishDelivery struct {
-	DeliveryID     string `json:"delivery_id"`
-	SubscriberType string `json:"subscriber_type"`
-	SubscriberID   string `json:"subscriber_id"`
-	SessionID      string `json:"session_id,omitempty"`
-	Status         string `json:"status"`
-	Attempt        int    `json:"attempt"`
+	DeliveryID     string                           `json:"delivery_id"`
+	SubscriberType string                           `json:"subscriber_type"`
+	SubscriberID   string                           `json:"subscriber_id"`
+	SessionID      string                           `json:"session_id,omitempty"`
+	Status         string                           `json:"status"`
+	ReasonCode     string                           `json:"reason_code,omitempty"`
+	LastError      string                           `json:"last_error,omitempty"`
+	Attempt        int                              `json:"attempt"`
+	RetryCount     int                              `json:"retry_count"`
+	RetryEligible  bool                             `json:"retry_eligible"`
+	Terminal       bool                             `json:"terminal"`
+	CreatedAt      *time.Time                       `json:"created_at,omitempty"`
+	StartedAt      *time.Time                       `json:"started_at,omitempty"`
+	FinishedAt     *time.Time                       `json:"finished_at,omitempty"`
+	DeadLetters    []store.OperatorDeadLetterRecord `json:"dead_letters,omitempty"`
 }
 
 type eventPublicationParams struct {
@@ -569,30 +578,53 @@ func eventPublishPublishError(params eventPublicationParams, err error) error {
 
 func eventPublishDeliveries(in []store.OperatorEventDelivery) []eventPublishDelivery {
 	out := make([]eventPublishDelivery, 0, len(in))
-	seen := map[eventPublishDelivery]struct{}{}
+	seen := map[string]struct{}{}
 	for _, delivery := range in {
 		if strings.TrimSpace(delivery.SubscriberID) == "__runtime_replay_scope__" {
 			continue
 		}
-		attempt := delivery.RetryCount + 1
-		if attempt < 1 {
-			attempt = 1
-		}
-		item := eventPublishDelivery{
-			DeliveryID:     strings.TrimSpace(delivery.DeliveryID),
-			SubscriberType: strings.TrimSpace(delivery.SubscriberType),
-			SubscriberID:   strings.TrimSpace(delivery.SubscriberID),
-			SessionID:      strings.TrimSpace(delivery.SessionID),
-			Status:         strings.TrimSpace(delivery.Status),
-			Attempt:        attempt,
-		}
-		if _, ok := seen[item]; ok {
+		item := eventPublishDeliveryFromStore(delivery)
+		key := strings.Join([]string{item.DeliveryID, item.SubscriberType, item.SubscriberID, item.Status}, "\x00")
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[item] = struct{}{}
+		seen[key] = struct{}{}
 		out = append(out, item)
 	}
 	return out
+}
+
+func eventPublishDeliveryFromStore(delivery store.OperatorEventDelivery) eventPublishDelivery {
+	attempt := delivery.RetryCount + 1
+	if attempt < 1 {
+		attempt = 1
+	}
+	status := strings.TrimSpace(delivery.Status)
+	return eventPublishDelivery{
+		DeliveryID:     strings.TrimSpace(delivery.DeliveryID),
+		SubscriberType: strings.TrimSpace(delivery.SubscriberType),
+		SubscriberID:   strings.TrimSpace(delivery.SubscriberID),
+		SessionID:      strings.TrimSpace(delivery.SessionID),
+		Status:         status,
+		ReasonCode:     strings.TrimSpace(delivery.ReasonCode),
+		LastError:      strings.TrimSpace(delivery.LastError),
+		Attempt:        attempt,
+		RetryCount:     delivery.RetryCount,
+		RetryEligible:  delivery.RetryEligible || store.OperatorDeliveryRetryEligible(status),
+		Terminal:       delivery.Terminal || store.OperatorDeliveryTerminal(status),
+		CreatedAt:      cloneTimePtr(delivery.CreatedAt),
+		StartedAt:      cloneTimePtr(delivery.StartedAt),
+		FinishedAt:     cloneTimePtr(delivery.FinishedAt),
+		DeadLetters:    append([]store.OperatorDeadLetterRecord(nil), delivery.DeadLetters...),
+	}
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
 }
 
 func eventDeclared(source semanticview.Source, eventName string) bool {

--- a/internal/apiv1/operator_event_replay.go
+++ b/internal/apiv1/operator_event_replay.go
@@ -44,12 +44,21 @@ type eventReplayResult struct {
 }
 
 type eventReplayDelivery struct {
-	DeliveryID       string `json:"delivery_id"`
-	SubscriberID     string `json:"subscriber_id"`
-	SessionID        string `json:"session_id,omitempty"`
-	Status           string `json:"status"`
-	Attempt          int    `json:"attempt"`
-	SourceDeliveryID string `json:"source_delivery_id,omitempty"`
+	DeliveryID       string                           `json:"delivery_id"`
+	SubscriberID     string                           `json:"subscriber_id"`
+	SessionID        string                           `json:"session_id,omitempty"`
+	Status           string                           `json:"status"`
+	ReasonCode       string                           `json:"reason_code,omitempty"`
+	LastError        string                           `json:"last_error,omitempty"`
+	Attempt          int                              `json:"attempt"`
+	RetryCount       int                              `json:"retry_count"`
+	RetryEligible    bool                             `json:"retry_eligible"`
+	Terminal         bool                             `json:"terminal"`
+	CreatedAt        *time.Time                       `json:"created_at,omitempty"`
+	StartedAt        *time.Time                       `json:"started_at,omitempty"`
+	FinishedAt       *time.Time                       `json:"finished_at,omitempty"`
+	DeadLetters      []store.OperatorDeadLetterRecord `json:"dead_letters,omitempty"`
+	SourceDeliveryID string                           `json:"source_delivery_id,omitempty"`
 }
 
 type agentReplayResult struct {
@@ -401,21 +410,13 @@ func validateReplayEligibleDelivery(eventID string, delivery store.OperatorEvent
 	case eventReplayStatusDelivered, eventReplayStatusFailed, eventReplayStatusDeadLetter:
 		return nil
 	case eventReplayStatusPending, eventReplayStatusInProgress, "":
-		return NewApplicationError(EventReplayNotEligibleCode, false, map[string]any{
-			"event_id":      eventID,
-			"delivery_id":   strings.TrimSpace(delivery.DeliveryID),
-			"subscriber_id": strings.TrimSpace(delivery.SubscriberID),
-			"status":        strings.TrimSpace(delivery.Status),
-			"reason":        "original delivery is not terminal",
-		})
+		data := eventReplayDeliveryFailureEvidence(eventID, delivery)
+		data["reason"] = "original delivery is not terminal"
+		return NewApplicationError(EventReplayNotEligibleCode, false, data)
 	default:
-		return NewApplicationError(EventReplayNotEligibleCode, false, map[string]any{
-			"event_id":      eventID,
-			"delivery_id":   strings.TrimSpace(delivery.DeliveryID),
-			"subscriber_id": strings.TrimSpace(delivery.SubscriberID),
-			"status":        strings.TrimSpace(delivery.Status),
-			"reason":        "unsupported delivery status",
-		})
+		data := eventReplayDeliveryFailureEvidence(eventID, delivery)
+		data["reason"] = "unsupported delivery status"
+		return NewApplicationError(EventReplayNotEligibleCode, false, data)
 	}
 }
 
@@ -426,13 +427,7 @@ func deliveriesForSubscribers(eventID string, index map[string]store.OperatorEve
 			if err := validateReplayEligibleDelivery(eventID, delivery); err != nil {
 				return nil, err
 			}
-			out = append(out, eventReplayDelivery{
-				DeliveryID:   strings.TrimSpace(delivery.DeliveryID),
-				SubscriberID: subscriber,
-				SessionID:    strings.TrimSpace(delivery.SessionID),
-				Status:       strings.TrimSpace(delivery.Status),
-				Attempt:      delivery.RetryCount + 1,
-			})
+			out = append(out, eventReplayDeliveryFromStore(delivery, ""))
 		}
 	}
 	return out, nil
@@ -529,16 +524,50 @@ func eventReplayNewDeliveries(deliveries []store.OperatorEventDelivery, original
 		if strings.TrimSpace(delivery.SubscriberType) != eventReplaySubscriberTypeAgent || subscriberID == "" || subscriberID == eventReplayScopeSubscriberID {
 			continue
 		}
-		out = append(out, eventReplayDelivery{
-			DeliveryID:       strings.TrimSpace(delivery.DeliveryID),
-			SubscriberID:     subscriberID,
-			SessionID:        strings.TrimSpace(delivery.SessionID),
-			Status:           strings.TrimSpace(delivery.Status),
-			Attempt:          delivery.RetryCount + 1,
-			SourceDeliveryID: sourceBySubscriber[subscriberID],
-		})
+		out = append(out, eventReplayDeliveryFromStore(delivery, sourceBySubscriber[subscriberID]))
 	}
 	return out
+}
+
+func eventReplayDeliveryFromStore(delivery store.OperatorEventDelivery, sourceDeliveryID string) eventReplayDelivery {
+	published := eventPublishDeliveryFromStore(delivery)
+	return eventReplayDelivery{
+		DeliveryID:       published.DeliveryID,
+		SubscriberID:     published.SubscriberID,
+		SessionID:        published.SessionID,
+		Status:           published.Status,
+		ReasonCode:       published.ReasonCode,
+		LastError:        published.LastError,
+		Attempt:          published.Attempt,
+		RetryCount:       published.RetryCount,
+		RetryEligible:    published.RetryEligible,
+		Terminal:         published.Terminal,
+		CreatedAt:        published.CreatedAt,
+		StartedAt:        published.StartedAt,
+		FinishedAt:       published.FinishedAt,
+		DeadLetters:      append([]store.OperatorDeadLetterRecord(nil), published.DeadLetters...),
+		SourceDeliveryID: strings.TrimSpace(sourceDeliveryID),
+	}
+}
+
+func eventReplayDeliveryFailureEvidence(eventID string, delivery store.OperatorEventDelivery) map[string]any {
+	data := map[string]any{
+		"event_id":       strings.TrimSpace(eventID),
+		"delivery_id":    strings.TrimSpace(delivery.DeliveryID),
+		"subscriber_id":  strings.TrimSpace(delivery.SubscriberID),
+		"status":         strings.TrimSpace(delivery.Status),
+		"retry_count":    delivery.RetryCount,
+		"retry_eligible": delivery.RetryEligible || store.OperatorDeliveryRetryEligible(delivery.Status),
+		"terminal":       delivery.Terminal || store.OperatorDeliveryTerminal(delivery.Status),
+		"dead_letters":   append([]store.OperatorDeadLetterRecord(nil), delivery.DeadLetters...),
+	}
+	if reason := strings.TrimSpace(delivery.ReasonCode); reason != "" {
+		data["reason_code"] = reason
+	}
+	if lastError := strings.TrimSpace(delivery.LastError); lastError != "" {
+		data["last_error"] = lastError
+	}
+	return data
 }
 
 func agentReplayResultFromEventReplay(agentID string, replay eventReplayResult) (agentReplayResult, error) {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -128,11 +128,12 @@ type runTraceListResult struct {
 }
 
 type runDiagnosis struct {
-	Run              store.RunHeader `json:"run"`
-	OperationalState string          `json:"operational_state"`
-	BlockingLayer    string          `json:"blocking_layer"`
-	BlockingReason   string          `json:"blocking_reason"`
-	Heuristics       []string        `json:"heuristics"`
+	Run              store.RunHeader                 `json:"run"`
+	OperationalState string                          `json:"operational_state"`
+	BlockingLayer    string                          `json:"blocking_layer"`
+	BlockingReason   string                          `json:"blocking_reason"`
+	Heuristics       []string                        `json:"heuristics"`
+	FailedDeliveries []store.RunDebugFailureDelivery `json:"failed_deliveries"`
 }
 
 var runListStatuses = map[string]struct{}{
@@ -217,12 +218,17 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 				return nil, err
 			}
 			status := store.ProjectRunOperationalStatus(report)
+			failedDeliveries := report.FailedDeliveries
+			if failedDeliveries == nil {
+				failedDeliveries = []store.RunDebugFailureDelivery{}
+			}
 			return runDiagnosis{
 				Run:              header,
 				OperationalState: strings.TrimSpace(status.State),
 				BlockingLayer:    strings.TrimSpace(status.BlockingLayer),
 				BlockingReason:   strings.TrimSpace(status.BlockingReason),
 				Heuristics:       status.Heuristics,
+				FailedDeliveries: failedDeliveries,
 			}, nil
 		},
 	}

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -56,14 +56,20 @@ type OperatorEventFull struct {
 }
 
 type OperatorEventDelivery struct {
-	DeliveryID     string `json:"delivery_id"`
-	SubscriberType string `json:"subscriber_type"`
-	SubscriberID   string `json:"subscriber_id"`
-	SessionID      string `json:"session_id,omitempty"`
-	Status         string `json:"status"`
-	ReasonCode     string `json:"reason_code,omitempty"`
-	LastError      string `json:"last_error,omitempty"`
-	RetryCount     int    `json:"-"`
+	DeliveryID     string                     `json:"delivery_id"`
+	SubscriberType string                     `json:"subscriber_type"`
+	SubscriberID   string                     `json:"subscriber_id"`
+	SessionID      string                     `json:"session_id,omitempty"`
+	Status         string                     `json:"status"`
+	ReasonCode     string                     `json:"reason_code,omitempty"`
+	LastError      string                     `json:"last_error,omitempty"`
+	RetryCount     int                        `json:"retry_count"`
+	RetryEligible  bool                       `json:"retry_eligible"`
+	Terminal       bool                       `json:"terminal"`
+	CreatedAt      *time.Time                 `json:"created_at,omitempty"`
+	StartedAt      *time.Time                 `json:"started_at,omitempty"`
+	FinishedAt     *time.Time                 `json:"finished_at,omitempty"`
+	DeadLetters    []OperatorDeadLetterRecord `json:"dead_letters,omitempty"`
 }
 
 type OperatorDeadLetterRecord struct {
@@ -183,7 +189,7 @@ func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Con
 		},
 		"event_deliveries": {
 			"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id",
-			"status", "retry_count", "reason_code", "last_error", "active_session_id", "created_at",
+			"status", "retry_count", "reason_code", "last_error", "active_session_id", "created_at", "started_at", "delivered_at",
 		},
 		"dead_letters": {
 			"dead_letter_id", "original_event_id", "failure_type", "error_message",
@@ -381,15 +387,15 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 		return OperatorEventFull{}, fmt.Errorf("decode operator event payload: %w", err)
 	}
 	event.Payload = payload
-	deliveries, err := s.loadOperatorEventDeliveries(ctx, event.EventID)
-	if err != nil {
-		return OperatorEventFull{}, err
-	}
 	deadLetters, err := s.loadOperatorEventDeadLetters(ctx, event.EventID)
 	if err != nil {
 		return OperatorEventFull{}, err
 	}
-	event.Deliveries = deliveries
+	deliveries, err := s.loadOperatorEventDeliveries(ctx, event.EventID)
+	if err != nil {
+		return OperatorEventFull{}, err
+	}
+	event.Deliveries = EnrichOperatorDeliveryFailureEvidence(deliveries, deadLetters)
 	event.DeadLetters = deadLetters
 	if event.Deliveries == nil {
 		event.Deliveries = []OperatorEventDelivery{}
@@ -407,11 +413,14 @@ func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID
 			COALESCE(d.subscriber_type, ''),
 			COALESCE(d.subscriber_id, ''),
 			COALESCE(d.active_session_id::text, ''),
-			COALESCE(d.status, ''),
-			COALESCE(d.reason_code, ''),
-			COALESCE(d.last_error, ''),
-			COALESCE(d.retry_count, 0)
-		FROM event_deliveries d
+				COALESCE(d.status, ''),
+				COALESCE(d.reason_code, ''),
+				COALESCE(d.last_error, ''),
+				COALESCE(d.retry_count, 0),
+				d.created_at,
+				d.started_at,
+				d.delivered_at
+			FROM event_deliveries d
 		WHERE d.event_id::text = $1
 		ORDER BY d.created_at ASC, d.delivery_id::text ASC
 	`, eventID)
@@ -422,15 +431,70 @@ func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID
 	out := []OperatorEventDelivery{}
 	for rows.Next() {
 		var item OperatorEventDelivery
-		if err := rows.Scan(&item.DeliveryID, &item.SubscriberType, &item.SubscriberID, &item.SessionID, &item.Status, &item.ReasonCode, &item.LastError, &item.RetryCount); err != nil {
+		var createdAt, startedAt, finishedAt sql.NullTime
+		if err := rows.Scan(&item.DeliveryID, &item.SubscriberType, &item.SubscriberID, &item.SessionID, &item.Status, &item.ReasonCode, &item.LastError, &item.RetryCount, &createdAt, &startedAt, &finishedAt); err != nil {
 			return nil, fmt.Errorf("scan operator event delivery: %w", err)
 		}
+		item.CreatedAt = nullTimePtr(createdAt)
+		item.StartedAt = nullTimePtr(startedAt)
+		item.FinishedAt = nullTimePtr(finishedAt)
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read operator event deliveries: %w", err)
 	}
 	return out, nil
+}
+
+func EnrichOperatorEventFailureEvidence(event OperatorEventFull) OperatorEventFull {
+	event.Deliveries = EnrichOperatorDeliveryFailureEvidence(event.Deliveries, event.DeadLetters)
+	if event.Deliveries == nil {
+		event.Deliveries = []OperatorEventDelivery{}
+	}
+	if event.DeadLetters == nil {
+		event.DeadLetters = []OperatorDeadLetterRecord{}
+	}
+	return event
+}
+
+func EnrichOperatorDeliveryFailureEvidence(deliveries []OperatorEventDelivery, deadLetters []OperatorDeadLetterRecord) []OperatorEventDelivery {
+	out := make([]OperatorEventDelivery, 0, len(deliveries))
+	for _, delivery := range deliveries {
+		delivery.Status = strings.TrimSpace(delivery.Status)
+		delivery.ReasonCode = strings.TrimSpace(delivery.ReasonCode)
+		delivery.LastError = strings.TrimSpace(delivery.LastError)
+		delivery.RetryEligible = OperatorDeliveryRetryEligible(delivery.Status)
+		delivery.Terminal = OperatorDeliveryTerminal(delivery.Status)
+		if delivery.Status == "dead_letter" && len(deadLetters) > 0 {
+			delivery.DeadLetters = append([]OperatorDeadLetterRecord(nil), deadLetters...)
+		}
+		out = append(out, delivery)
+	}
+	if out == nil {
+		return []OperatorEventDelivery{}
+	}
+	return out
+}
+
+func OperatorDeliveryRetryEligible(status string) bool {
+	return strings.TrimSpace(status) == "failed"
+}
+
+func OperatorDeliveryTerminal(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "delivered", "dead_letter":
+		return true
+	default:
+		return false
+	}
+}
+
+func nullTimePtr(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	at := value.Time.UTC()
+	return &at
 }
 
 func (s *PostgresStore) loadOperatorEventDeadLetters(ctx context.Context, eventID string) ([]OperatorDeadLetterRecord, error) {

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -33,9 +33,11 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 		t.Fatalf("seed events: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, created_at)
-		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-a', 'dead_letter', 3, 'retry_exhausted', 'boom', $3)
-	`, runID, olderEventID, base.Add(time.Second)); err != nil {
+			INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, created_at)
+			VALUES
+				($1::uuid, $2::uuid, 'agent', 'agent-a', 'dead_letter', 3, 'retry_exhausted', 'boom', $3),
+				($1::uuid, $2::uuid, 'node', 'node-a', 'failed', 1, 'handler_error', 'node boom', $4)
+		`, runID, olderEventID, base.Add(time.Second), base.Add(1500*time.Millisecond)); err != nil {
 		t.Fatalf("seed delivery: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -69,6 +71,17 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 	got := filtered.Events[0]
 	if got.EventID != olderEventID || got.Source != "agent-a" || got.Deliveries[0].ReasonCode != "retry_exhausted" || len(got.DeadLetters) != 1 {
 		t.Fatalf("filtered event = %#v", got)
+	}
+	if len(got.Deliveries) != 2 {
+		t.Fatalf("deliveries len = %d, want 2", len(got.Deliveries))
+	}
+	agentDelivery := got.Deliveries[0]
+	if agentDelivery.SubscriberType != "agent" || agentDelivery.RetryCount != 3 || agentDelivery.RetryEligible || !agentDelivery.Terminal || len(agentDelivery.DeadLetters) != 1 {
+		t.Fatalf("agent delivery evidence = %#v", agentDelivery)
+	}
+	nodeDelivery := got.Deliveries[1]
+	if nodeDelivery.SubscriberType != "node" || nodeDelivery.RetryCount != 1 || !nodeDelivery.RetryEligible || nodeDelivery.Terminal || nodeDelivery.LastError != "node boom" {
+		t.Fatalf("node delivery evidence = %#v", nodeDelivery)
 	}
 
 	page1, err := pg.ListOperatorEvents(ctx, OperatorEventListOptions{Filter: OperatorEventListFilter{RunID: runID}, Limit: 1})

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -696,11 +696,7 @@ func (s *PostgresStore) loadRunDebugFailureDeliveries(ctx context.Context, runID
 		INNER JOIN events e ON e.event_id = d.event_id
 		WHERE d.run_id = $1::uuid
 		  AND NOT (COALESCE(d.subscriber_type, '') = $3 AND COALESCE(d.subscriber_id, '') = $4)
-		  AND (
-			COALESCE(d.status, '') IN ('failed', 'dead_letter')
-			OR COALESCE(d.reason_code, '') <> ''
-			OR COALESCE(d.last_error, '') <> ''
-		  )
+		  AND COALESCE(d.status, '') IN ('failed', 'dead_letter')
 		ORDER BY COALESCE(d.delivered_at, d.started_at, d.created_at, e.created_at) DESC, d.delivery_id::text DESC
 		LIMIT $2
 	`, runID, limit, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -77,6 +77,26 @@ type RunDebugDeadLetter struct {
 	CreatedAt     time.Time `json:"created_at"`
 }
 
+type RunDebugFailureDelivery struct {
+	EventID        string                     `json:"event_id"`
+	EventName      string                     `json:"event_name"`
+	EntityID       string                     `json:"entity_id,omitempty"`
+	DeliveryID     string                     `json:"delivery_id"`
+	SubscriberType string                     `json:"subscriber_type"`
+	SubscriberID   string                     `json:"subscriber_id"`
+	SessionID      string                     `json:"session_id,omitempty"`
+	Status         string                     `json:"status"`
+	ReasonCode     string                     `json:"reason_code,omitempty"`
+	LastError      string                     `json:"last_error,omitempty"`
+	RetryCount     int                        `json:"retry_count"`
+	RetryEligible  bool                       `json:"retry_eligible"`
+	Terminal       bool                       `json:"terminal"`
+	CreatedAt      *time.Time                 `json:"created_at,omitempty"`
+	StartedAt      *time.Time                 `json:"started_at,omitempty"`
+	FinishedAt     *time.Time                 `json:"finished_at,omitempty"`
+	DeadLetters    []OperatorDeadLetterRecord `json:"dead_letters,omitempty"`
+}
+
 type RunDebugAgentTurn struct {
 	AgentID    string    `json:"agent_id"`
 	Turns      int       `json:"turns"`
@@ -106,25 +126,26 @@ type RunDebugRuntimeSummary struct {
 }
 
 type RunDebugReport struct {
-	RunID             string                   `json:"run_id"`
-	RunTableStatus    string                   `json:"run_table_status,omitempty"`
-	RootEventID       string                   `json:"root_event_id,omitempty"`
-	RootEventType     string                   `json:"root_event_type,omitempty"`
-	ErrorSummary      string                   `json:"error_summary,omitempty"`
-	StartedAt         time.Time                `json:"started_at,omitempty"`
-	LastEventAt       time.Time                `json:"last_event_at,omitempty"`
-	EndedAt           *time.Time               `json:"ended_at,omitempty"`
-	EventCount        int                      `json:"event_count"`
-	EntityCount       int                      `json:"entity_count"`
-	WarnErrorLogCount int                      `json:"warn_error_log_count"`
-	EventCounts       []RunDebugEventCount     `json:"event_counts,omitempty"`
-	Deliveries        []RunDebugDeliveryCount  `json:"deliveries,omitempty"`
-	Events            []RunDebugEvent          `json:"events,omitempty"`
-	DeadLetters       []RunDebugDeadLetter     `json:"dead_letters,omitempty"`
-	AgentTurns        []RunDebugAgentTurn      `json:"agent_turns,omitempty"`
-	Mutations         []RunDebugMutation       `json:"mutations,omitempty"`
-	RuntimeLogSummary []RunDebugRuntimeSummary `json:"runtime_log_summary,omitempty"`
-	RuntimeLogs       []RunDebugRuntimeLog     `json:"runtime_logs,omitempty"`
+	RunID             string                    `json:"run_id"`
+	RunTableStatus    string                    `json:"run_table_status,omitempty"`
+	RootEventID       string                    `json:"root_event_id,omitempty"`
+	RootEventType     string                    `json:"root_event_type,omitempty"`
+	ErrorSummary      string                    `json:"error_summary,omitempty"`
+	StartedAt         time.Time                 `json:"started_at,omitempty"`
+	LastEventAt       time.Time                 `json:"last_event_at,omitempty"`
+	EndedAt           *time.Time                `json:"ended_at,omitempty"`
+	EventCount        int                       `json:"event_count"`
+	EntityCount       int                       `json:"entity_count"`
+	WarnErrorLogCount int                       `json:"warn_error_log_count"`
+	EventCounts       []RunDebugEventCount      `json:"event_counts,omitempty"`
+	Deliveries        []RunDebugDeliveryCount   `json:"deliveries,omitempty"`
+	Events            []RunDebugEvent           `json:"events,omitempty"`
+	FailedDeliveries  []RunDebugFailureDelivery `json:"failed_deliveries,omitempty"`
+	DeadLetters       []RunDebugDeadLetter      `json:"dead_letters,omitempty"`
+	AgentTurns        []RunDebugAgentTurn       `json:"agent_turns,omitempty"`
+	Mutations         []RunDebugMutation        `json:"mutations,omitempty"`
+	RuntimeLogSummary []RunDebugRuntimeSummary  `json:"runtime_log_summary,omitempty"`
+	RuntimeLogs       []RunDebugRuntimeLog      `json:"runtime_logs,omitempty"`
 }
 
 type RunDebugTraceQueryOptions struct {
@@ -144,38 +165,42 @@ type RunDebugTraceFilter struct {
 }
 
 type RunDebugTraceRow struct {
-	EventID              string     `json:"event_id,omitempty"`
-	EventName            string     `json:"event_name,omitempty"`
-	SourceEventID        string     `json:"source_event_id,omitempty"`
-	EntityID             string     `json:"entity_id,omitempty"`
-	EventSource          string     `json:"event_source,omitempty"`
-	EventSourceType      string     `json:"event_source_type,omitempty"`
-	EventCreatedAt       time.Time  `json:"event_created_at"`
-	DeliveryID           string     `json:"delivery_id,omitempty"`
-	SubscriberType       string     `json:"subscriber_type,omitempty"`
-	SubscriberID         string     `json:"subscriber_id,omitempty"`
-	DeliveryStatus       string     `json:"delivery_status,omitempty"`
-	DeliveryReasonCode   string     `json:"delivery_reason_code,omitempty"`
-	ActiveSessionID      string     `json:"active_session_id,omitempty"`
-	DeliveryCreatedAt    *time.Time `json:"delivery_created_at,omitempty"`
-	DeliveryStartedAt    *time.Time `json:"delivery_started_at,omitempty"`
-	DeliveryDeliveredAt  *time.Time `json:"delivery_delivered_at,omitempty"`
-	SessionID            string     `json:"session_id,omitempty"`
-	SessionKind          string     `json:"session_kind,omitempty"`
-	SessionRuntimeMode   string     `json:"session_runtime_mode,omitempty"`
-	SessionStatus        string     `json:"session_status,omitempty"`
-	SessionUpdatedAt     *time.Time `json:"session_updated_at,omitempty"`
-	TurnID               string     `json:"turn_id,omitempty"`
-	TurnTriggerEventID   string     `json:"turn_trigger_event_id,omitempty"`
-	TurnTriggerEventType string     `json:"turn_trigger_event_type,omitempty"`
-	TurnRuntimeMode      string     `json:"turn_runtime_mode,omitempty"`
-	TurnScopeKey         string     `json:"turn_scope_key,omitempty"`
-	TurnEntityID         string     `json:"turn_entity_id,omitempty"`
-	TurnTaskID           string     `json:"turn_task_id,omitempty"`
-	TurnParseOK          bool       `json:"turn_parse_ok,omitempty"`
-	TurnRetryCount       int        `json:"turn_retry_count,omitempty"`
-	TurnError            string     `json:"turn_error,omitempty"`
-	TurnCreatedAt        *time.Time `json:"turn_created_at,omitempty"`
+	EventID               string     `json:"event_id,omitempty"`
+	EventName             string     `json:"event_name,omitempty"`
+	SourceEventID         string     `json:"source_event_id,omitempty"`
+	EntityID              string     `json:"entity_id,omitempty"`
+	EventSource           string     `json:"event_source,omitempty"`
+	EventSourceType       string     `json:"event_source_type,omitempty"`
+	EventCreatedAt        time.Time  `json:"event_created_at"`
+	DeliveryID            string     `json:"delivery_id,omitempty"`
+	SubscriberType        string     `json:"subscriber_type,omitempty"`
+	SubscriberID          string     `json:"subscriber_id,omitempty"`
+	DeliveryStatus        string     `json:"delivery_status,omitempty"`
+	DeliveryReasonCode    string     `json:"delivery_reason_code,omitempty"`
+	DeliveryLastError     string     `json:"delivery_last_error,omitempty"`
+	DeliveryRetryCount    int        `json:"delivery_retry_count,omitempty"`
+	DeliveryRetryEligible bool       `json:"delivery_retry_eligible,omitempty"`
+	DeliveryTerminal      bool       `json:"delivery_terminal,omitempty"`
+	ActiveSessionID       string     `json:"active_session_id,omitempty"`
+	DeliveryCreatedAt     *time.Time `json:"delivery_created_at,omitempty"`
+	DeliveryStartedAt     *time.Time `json:"delivery_started_at,omitempty"`
+	DeliveryDeliveredAt   *time.Time `json:"delivery_delivered_at,omitempty"`
+	SessionID             string     `json:"session_id,omitempty"`
+	SessionKind           string     `json:"session_kind,omitempty"`
+	SessionRuntimeMode    string     `json:"session_runtime_mode,omitempty"`
+	SessionStatus         string     `json:"session_status,omitempty"`
+	SessionUpdatedAt      *time.Time `json:"session_updated_at,omitempty"`
+	TurnID                string     `json:"turn_id,omitempty"`
+	TurnTriggerEventID    string     `json:"turn_trigger_event_id,omitempty"`
+	TurnTriggerEventType  string     `json:"turn_trigger_event_type,omitempty"`
+	TurnRuntimeMode       string     `json:"turn_runtime_mode,omitempty"`
+	TurnScopeKey          string     `json:"turn_scope_key,omitempty"`
+	TurnEntityID          string     `json:"turn_entity_id,omitempty"`
+	TurnTaskID            string     `json:"turn_task_id,omitempty"`
+	TurnParseOK           bool       `json:"turn_parse_ok,omitempty"`
+	TurnRetryCount        int        `json:"turn_retry_count,omitempty"`
+	TurnError             string     `json:"turn_error,omitempty"`
+	TurnCreatedAt         *time.Time `json:"turn_created_at,omitempty"`
 }
 
 func defaultRunDebugQueryOptions(opts RunDebugQueryOptions) RunDebugQueryOptions {
@@ -253,7 +278,8 @@ func RequireCanonicalRunDebugCapabilities(caps StoreSchemaCapabilities, catalog 
 	required := map[string][]string{
 		"runs":             {"run_id", "status", "error_summary", "started_at", "ended_at", "entity_count"},
 		"entity_state":     {"run_id", "entity_id"},
-		"dead_letters":     {"original_event_id", "original_event", "entity_id", "failure_type", "error_message", "handler_node", "created_at"},
+		"event_deliveries": {"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id", "status", "retry_count", "reason_code", "last_error", "active_session_id", "created_at", "started_at", "delivered_at"},
+		"dead_letters":     {"dead_letter_id", "original_event_id", "original_event", "entity_id", "failure_type", "error_message", "retry_count", "chain_depth", "handler_node", "created_at"},
 		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "old_value", "new_value", "caused_by_event", "writer_type", "writer_id", "handler_step", "created_at"},
 	}
 	for tableName, columns := range required {
@@ -502,6 +528,11 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	if err := deliveryRows.Err(); err != nil {
 		return RunDebugReport{}, fmt.Errorf("read deliveries: %w", err)
 	}
+	failedDeliveries, err := s.loadRunDebugFailureDeliveries(ctx, report.RunID, opts.DeadLetterLimit)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.FailedDeliveries = failedDeliveries
 
 	eventRows, err := s.DB.QueryContext(ctx, `
 		SELECT
@@ -641,6 +672,94 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	return report, nil
 }
 
+func (s *PostgresStore) loadRunDebugFailureDeliveries(ctx context.Context, runID string, limit int) ([]RunDebugFailureDelivery, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id::text,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.entity_id::text, ''),
+			d.delivery_id::text,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.active_session_id::text, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0),
+			d.created_at,
+			d.started_at,
+			d.delivered_at
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		WHERE d.run_id = $1::uuid
+		  AND NOT (COALESCE(d.subscriber_type, '') = $3 AND COALESCE(d.subscriber_id, '') = $4)
+		  AND (
+			COALESCE(d.status, '') IN ('failed', 'dead_letter')
+			OR COALESCE(d.reason_code, '') <> ''
+			OR COALESCE(d.last_error, '') <> ''
+		  )
+		ORDER BY COALESCE(d.delivered_at, d.started_at, d.created_at, e.created_at) DESC, d.delivery_id::text DESC
+		LIMIT $2
+	`, runID, limit, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	if err != nil {
+		return nil, fmt.Errorf("load run failed deliveries: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugFailureDelivery{}
+	for rows.Next() {
+		var item RunDebugFailureDelivery
+		var createdAt, startedAt, finishedAt sql.NullTime
+		if err := rows.Scan(
+			&item.EventID,
+			&item.EventName,
+			&item.EntityID,
+			&item.DeliveryID,
+			&item.SubscriberType,
+			&item.SubscriberID,
+			&item.SessionID,
+			&item.Status,
+			&item.ReasonCode,
+			&item.LastError,
+			&item.RetryCount,
+			&createdAt,
+			&startedAt,
+			&finishedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan run failed delivery: %w", err)
+		}
+		item.CreatedAt = nullTimePtr(createdAt)
+		item.StartedAt = nullTimePtr(startedAt)
+		item.FinishedAt = nullTimePtr(finishedAt)
+		normalizeRunDebugFailureDelivery(&item)
+		if item.Status == "dead_letter" {
+			deadLetters, err := s.loadOperatorEventDeadLetters(ctx, item.EventID)
+			if err != nil {
+				return nil, err
+			}
+			item.DeadLetters = deadLetters
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read run failed deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func normalizeRunDebugFailureDelivery(item *RunDebugFailureDelivery) {
+	if item == nil {
+		return
+	}
+	item.Status = strings.TrimSpace(item.Status)
+	item.ReasonCode = strings.TrimSpace(item.ReasonCode)
+	item.LastError = strings.TrimSpace(item.LastError)
+	item.RetryEligible = OperatorDeliveryRetryEligible(item.Status)
+	item.Terminal = OperatorDeliveryTerminal(item.Status)
+}
+
 func (s *PostgresStore) LoadRunDebugTrace(ctx context.Context, runID string, opts RunDebugTraceQueryOptions) ([]RunDebugTraceRow, error) {
 	rows, _, err := s.LoadRunDebugTracePage(ctx, runID, opts)
 	return rows, err
@@ -757,11 +876,13 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			e.created_at,
 			COALESCE(d.delivery_id::text, ''),
 			COALESCE(d.subscriber_type, ''),
-			COALESCE(d.subscriber_id, ''),
-			COALESCE(d.status, ''),
-			COALESCE(d.reason_code, ''),
-			COALESCE(d.active_session_id::text, ''),
-			d.created_at,
+				COALESCE(d.subscriber_id, ''),
+				COALESCE(d.status, ''),
+				COALESCE(d.reason_code, ''),
+				COALESCE(d.last_error, ''),
+				COALESCE(d.retry_count, 0),
+				COALESCE(d.active_session_id::text, ''),
+				d.created_at,
 			d.started_at,
 			d.delivered_at,
 			COALESCE(sess.session_id::text, ''),
@@ -842,6 +963,8 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			&item.SubscriberID,
 			&item.DeliveryStatus,
 			&item.DeliveryReasonCode,
+			&item.DeliveryLastError,
+			&item.DeliveryRetryCount,
 			&item.ActiveSessionID,
 			&deliveryCreatedAt,
 			&deliveryStartedAt,
@@ -868,6 +991,8 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 		item.DeliveryCreatedAt = nullableTimePtr(deliveryCreatedAt)
 		item.DeliveryStartedAt = nullableTimePtr(deliveryStartedAt)
 		item.DeliveryDeliveredAt = nullableTimePtr(deliveryDeliveredAt)
+		item.DeliveryRetryEligible = OperatorDeliveryRetryEligible(item.DeliveryStatus)
+		item.DeliveryTerminal = OperatorDeliveryTerminal(item.DeliveryStatus)
 		item.SessionUpdatedAt = nullableTimePtr(sessionUpdatedAt)
 		item.TurnCreatedAt = nullableTimePtr(turnCreatedAt)
 		out = append(out, item)

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -215,6 +215,15 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 		`, targetRunID, targetEventID, now.Add(10*time.Second), now.Add(5*time.Second)); err != nil {
 		t.Fatalf("seed delivery: %v", err)
 	}
+	successDeliveryID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, delivered_at, created_at
+			)
+			VALUES ($1::uuid, $2::uuid, $3::uuid, 'node', 'node-success', 'delivered', 0, 'node_processed', '', $4, $5)
+		`, successDeliveryID, targetRunID, targetEventID, now.Add(20*time.Second), now.Add(15*time.Second)); err != nil {
+		t.Fatalf("seed successful delivery: %v", err)
+	}
 	if err := runtimedeadletters.Insert(ctx, db, runtimedeadletters.Record{
 		OriginalEventID: targetEventID,
 		OriginalEvent:   "scan.requested",
@@ -265,14 +274,17 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	if len(report.DeadLetters) != 1 {
 		t.Fatalf("DeadLetters len = %d, want 1", len(report.DeadLetters))
 	}
-	if len(report.Deliveries) != 1 {
-		t.Fatalf("Deliveries len = %d, want 1", len(report.Deliveries))
+	if len(report.Deliveries) != 2 {
+		t.Fatalf("Deliveries len = %d, want 2", len(report.Deliveries))
 	}
 	if len(report.FailedDeliveries) != 1 {
 		t.Fatalf("FailedDeliveries len = %d, want 1: %#v", len(report.FailedDeliveries), report.FailedDeliveries)
 	}
 	if got := report.FailedDeliveries[0]; got.SubscriberType != "agent" || got.RetryCount != 2 || got.RetryEligible || !got.Terminal || len(got.DeadLetters) != 1 {
 		t.Fatalf("FailedDeliveries[0] = %#v", got)
+	}
+	if report.FailedDeliveries[0].DeliveryID == successDeliveryID {
+		t.Fatalf("successful delivered/node_processed delivery appeared in FailedDeliveries: %#v", report.FailedDeliveries)
 	}
 }
 

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -208,11 +208,11 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 		t.Fatalf("seed mutations: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO event_deliveries (
-			run_id, event_id, subscriber_type, subscriber_id, status, delivered_at, created_at
-		)
-		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'delivered', $3, $4)
-	`, targetRunID, targetEventID, now.Add(10*time.Second), now.Add(5*time.Second)); err != nil {
+			INSERT INTO event_deliveries (
+				run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, last_error, delivered_at, created_at
+			)
+			VALUES ($1::uuid, $2::uuid, 'agent', 'agent-1', 'dead_letter', 2, 'handler_error', 'boom', $3, $4)
+		`, targetRunID, targetEventID, now.Add(10*time.Second), now.Add(5*time.Second)); err != nil {
 		t.Fatalf("seed delivery: %v", err)
 	}
 	if err := runtimedeadletters.Insert(ctx, db, runtimedeadletters.Record{
@@ -268,6 +268,12 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	if len(report.Deliveries) != 1 {
 		t.Fatalf("Deliveries len = %d, want 1", len(report.Deliveries))
 	}
+	if len(report.FailedDeliveries) != 1 {
+		t.Fatalf("FailedDeliveries len = %d, want 1: %#v", len(report.FailedDeliveries), report.FailedDeliveries)
+	}
+	if got := report.FailedDeliveries[0]; got.SubscriberType != "agent" || got.RetryCount != 2 || got.RetryEligible || !got.Terminal || len(got.DeadLetters) != 1 {
+		t.Fatalf("FailedDeliveries[0] = %#v", got)
+	}
 }
 
 func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(t *testing.T) {
@@ -314,11 +320,12 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
-			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, active_session_id, started_at, created_at
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status,
+			retry_count, reason_code, last_error, active_session_id, started_at, created_at
 		)
 		VALUES (
-			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-source', 'in_progress', 'session_started',
-			$4::uuid, $5, $6
+			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-source', 'failed',
+			2, 'handler_error', 'trace boom', $4::uuid, $5, $6
 		)
 	`, deliveryID, runID, eventID, sessionID, now.Add(1*time.Second), now.Add(500*time.Millisecond)); err != nil {
 		t.Fatalf("seed delivery: %v", err)
@@ -351,8 +358,11 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	if got.EventID != eventID || got.EventName != "scan.requested" {
 		t.Fatalf("event trace = %#v", got)
 	}
-	if got.DeliveryID != deliveryID || got.DeliveryStatus != "in_progress" || got.SubscriberID != "agent-source" {
+	if got.DeliveryID != deliveryID || got.DeliveryStatus != "failed" || got.SubscriberID != "agent-source" {
 		t.Fatalf("delivery trace = %#v", got)
+	}
+	if got.DeliveryReasonCode != "handler_error" || got.DeliveryLastError != "trace boom" || got.DeliveryRetryCount != 2 || !got.DeliveryRetryEligible || got.DeliveryTerminal {
+		t.Fatalf("delivery failure trace evidence = %#v", got)
 	}
 	if got.SessionID != sessionID || got.SessionKind != "live_session" || got.SessionRuntimeMode != "session" {
 		t.Fatalf("session trace = %#v", got)

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -157,6 +157,11 @@ func (s *SQLiteRuntimeStore) LoadRunDebugReport(ctx context.Context, runID strin
 		return RunDebugReport{}, err
 	}
 	report.Deliveries = deliveries
+	failedDeliveries, err := s.sqliteRunDebugFailureDeliveries(ctx, header.RunID, opts.DeadLetterLimit)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.FailedDeliveries = failedDeliveries
 	events, err := s.sqliteRunDebugEvents(ctx, header.RunID, opts.EventLimit)
 	if err != nil {
 		return RunDebugReport{}, err
@@ -299,6 +304,83 @@ func (s *SQLiteRuntimeStore) sqliteRunDebugDeliveryCounts(ctx context.Context, r
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read sqlite run debug delivery counts: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunDebugFailureDeliveries(ctx context.Context, runID string, limit int) ([]RunDebugFailureDelivery, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			e.event_id,
+			COALESCE(e.event_name, ''),
+			COALESCE(e.entity_id, ''),
+			d.delivery_id,
+			COALESCE(d.subscriber_type, ''),
+			COALESCE(d.subscriber_id, ''),
+			COALESCE(d.active_session_id, ''),
+			COALESCE(d.status, ''),
+			COALESCE(d.reason_code, ''),
+			COALESCE(d.last_error, ''),
+			COALESCE(d.retry_count, 0),
+			d.created_at,
+			d.started_at,
+			d.delivered_at
+		FROM event_deliveries d
+		INNER JOIN events e ON e.event_id = d.event_id
+		WHERE d.run_id = ?
+		  AND NOT (COALESCE(d.subscriber_type, '') = ? AND COALESCE(d.subscriber_id, '') = ?)
+		  AND (
+			COALESCE(d.status, '') IN ('failed', 'dead_letter')
+			OR COALESCE(d.reason_code, '') <> ''
+			OR COALESCE(d.last_error, '') <> ''
+		  )
+		ORDER BY COALESCE(d.delivered_at, d.started_at, d.created_at, e.created_at) DESC, d.delivery_id DESC
+		LIMIT ?
+	`, runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite run failed deliveries: %w", err)
+	}
+	defer rows.Close()
+	out := []RunDebugFailureDelivery{}
+	for rows.Next() {
+		var item RunDebugFailureDelivery
+		var createdRaw, startedRaw, finishedRaw any
+		if err := rows.Scan(
+			&item.EventID,
+			&item.EventName,
+			&item.EntityID,
+			&item.DeliveryID,
+			&item.SubscriberType,
+			&item.SubscriberID,
+			&item.SessionID,
+			&item.Status,
+			&item.ReasonCode,
+			&item.LastError,
+			&item.RetryCount,
+			&createdRaw,
+			&startedRaw,
+			&finishedRaw,
+		); err != nil {
+			return nil, fmt.Errorf("scan sqlite run failed delivery: %w", err)
+		}
+		item.CreatedAt = sqliteTraceTimePtr(createdRaw)
+		item.StartedAt = sqliteTraceTimePtr(startedRaw)
+		item.FinishedAt = sqliteTraceTimePtr(finishedRaw)
+		normalizeRunDebugFailureDelivery(&item)
+		if item.Status == "dead_letter" {
+			deadLetters, err := s.sqliteOperatorEventDeadLetters(ctx, item.EventID)
+			if err != nil {
+				return nil, err
+			}
+			item.DeadLetters = deadLetters
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite run failed deliveries: %w", err)
 	}
 	return out, nil
 }

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -332,11 +332,7 @@ func (s *SQLiteRuntimeStore) sqliteRunDebugFailureDeliveries(ctx context.Context
 		INNER JOIN events e ON e.event_id = d.event_id
 		WHERE d.run_id = ?
 		  AND NOT (COALESCE(d.subscriber_type, '') = ? AND COALESCE(d.subscriber_id, '') = ?)
-		  AND (
-			COALESCE(d.status, '') IN ('failed', 'dead_letter')
-			OR COALESCE(d.reason_code, '') <> ''
-			OR COALESCE(d.last_error, '') <> ''
-		  )
+		  AND COALESCE(d.status, '') IN ('failed', 'dead_letter')
 		ORDER BY COALESCE(d.delivered_at, d.started_at, d.created_at, e.created_at) DESC, d.delivery_id DESC
 		LIMIT ?
 	`, runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, limit)

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -52,10 +52,33 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	seedSQLiteEntityStateRows(t, sqliteStore.DB, ctx, newer, newerEntityA, newerEntityB)
 	seedSQLiteEntityStateRows(t, sqliteStore.DB, ctx, older, olderEntity)
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
-		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
-		VALUES (?, ?, ?, 'agent', 'agent-1', 'pending', ?)
-	`, uuid.NewString(), newer, newerEvent, now.Add(3*time.Second)); err != nil {
+			INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+			VALUES (?, ?, ?, 'agent', 'agent-1', 'pending', ?)
+		`, uuid.NewString(), newer, newerEvent, now.Add(3*time.Second)); err != nil {
 		t.Fatalf("seed sqlite delivery: %v", err)
+	}
+	agentFailedDeliveryID := uuid.NewString()
+	nodeDeadDeliveryID := uuid.NewString()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, status,
+				retry_count, reason_code, last_error, created_at, started_at, delivered_at
+			)
+			VALUES
+				(?, ?, ?, 'agent', 'agent-failed', 'failed', 1, 'handler_error', 'agent boom', ?, ?, NULL),
+				(?, ?, ?, 'node', 'node-dead', 'dead_letter', 2, 'retry_exhausted', 'node boom', ?, ?, ?)
+		`, agentFailedDeliveryID, newer, newerMiddleEvent, now.Add(4*time.Second), now.Add(5*time.Second), nodeDeadDeliveryID, newer, newerLatestEvent, now.Add(6*time.Second), now.Add(7*time.Second), now.Add(8*time.Second)); err != nil {
+		t.Fatalf("seed sqlite failed deliveries: %v", err)
+	}
+	deadLetterID := uuid.NewString()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+			INSERT INTO dead_letters (
+				dead_letter_id, original_event_id, original_event, original_payload, flow_instance,
+				failure_type, error_message, retry_count, chain_depth, handler_node, created_at
+			)
+			VALUES (?, ?, 'scan.finished', '{}', 'flow-1', 'retry_exhausted', 'node boom', 2, 0, 'node-dead', ?)
+		`, deadLetterID, newerLatestEvent, now.Add(9*time.Second)); err != nil {
+		t.Fatalf("seed sqlite dead letter: %v", err)
 	}
 
 	header, err := sqliteStore.LoadRunHeader(ctx, older)
@@ -110,11 +133,45 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	if report.EntityCount != 2 {
 		t.Fatalf("report.EntityCount = %d, want entity_state count 2", report.EntityCount)
 	}
-	if len(report.Deliveries) != 1 || report.Deliveries[0].SubscriberID != "agent-1" {
-		t.Fatalf("report deliveries = %#v, want agent-1 delivery count", report.Deliveries)
+	if len(report.Deliveries) != 3 {
+		t.Fatalf("report deliveries = %#v, want pending/failed/dead_letter delivery count groups", report.Deliveries)
+	}
+	if len(report.FailedDeliveries) != 2 {
+		t.Fatalf("report failed deliveries = %#v, want 2", report.FailedDeliveries)
+	}
+	if got := report.FailedDeliveries[0]; got.DeliveryID != nodeDeadDeliveryID || got.SubscriberType != "node" || got.RetryCount != 2 || got.RetryEligible || !got.Terminal || len(got.DeadLetters) != 1 {
+		t.Fatalf("node failed delivery evidence = %#v", got)
+	}
+	if got := report.FailedDeliveries[1]; got.DeliveryID != agentFailedDeliveryID || got.SubscriberType != "agent" || got.RetryCount != 1 || !got.RetryEligible || got.Terminal || got.LastError != "agent boom" {
+		t.Fatalf("agent failed delivery evidence = %#v", got)
+	}
+	traceRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, newer, RunDebugTraceQueryOptions{
+		Limit: 10,
+		Filter: RunDebugTraceFilter{
+			DeliveryStatuses: []string{"failed"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage sqlite failed filter: %v", err)
+	}
+	if len(traceRows) != 1 {
+		t.Fatalf("sqlite failed trace rows = %#v, want one failed delivery row", traceRows)
+	}
+	if got := traceRows[0]; got.DeliveryID != agentFailedDeliveryID || got.DeliveryLastError != "agent boom" || got.DeliveryRetryCount != 1 || !got.DeliveryRetryEligible || got.DeliveryTerminal {
+		t.Fatalf("sqlite trace delivery failure evidence = %#v", got)
 	}
 	if len(report.Events) != 2 || report.Events[0].EventID != newerLatestEvent || report.Events[1].EventID != newerMiddleEvent {
 		t.Fatalf("report events = %#v, want latest non-log events first", report.Events)
+	}
+	full, err := sqliteStore.LoadOperatorEvent(ctx, newerLatestEvent)
+	if err != nil {
+		t.Fatalf("LoadOperatorEvent sqlite latest: %v", err)
+	}
+	if len(full.DeadLetters) != 1 || full.DeadLetters[0].DeadLetterID != deadLetterID {
+		t.Fatalf("sqlite event dead letters = %#v", full.DeadLetters)
+	}
+	if len(full.Deliveries) != 1 || len(full.Deliveries[0].DeadLetters) != 1 || !full.Deliveries[0].Terminal {
+		t.Fatalf("sqlite event delivery evidence = %#v", full.Deliveries)
 	}
 	if len(report.RuntimeLogs) != 1 || report.RuntimeLogs[0].Component != "runtime" || report.RuntimeLogs[0].Action != "proof" {
 		t.Fatalf("runtime logs = %#v, want runtime proof log", report.RuntimeLogs)

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -67,8 +67,18 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 			VALUES
 				(?, ?, ?, 'agent', 'agent-failed', 'failed', 1, 'handler_error', 'agent boom', ?, ?, NULL),
 				(?, ?, ?, 'node', 'node-dead', 'dead_letter', 2, 'retry_exhausted', 'node boom', ?, ?, ?)
-		`, agentFailedDeliveryID, newer, newerMiddleEvent, now.Add(4*time.Second), now.Add(5*time.Second), nodeDeadDeliveryID, newer, newerLatestEvent, now.Add(6*time.Second), now.Add(7*time.Second), now.Add(8*time.Second)); err != nil {
+	`, agentFailedDeliveryID, newer, newerMiddleEvent, now.Add(4*time.Second), now.Add(5*time.Second), nodeDeadDeliveryID, newer, newerLatestEvent, now.Add(6*time.Second), now.Add(7*time.Second), now.Add(8*time.Second)); err != nil {
 		t.Fatalf("seed sqlite failed deliveries: %v", err)
+	}
+	successDeliveryID := uuid.NewString()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+			INSERT INTO event_deliveries (
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, status,
+				retry_count, reason_code, last_error, created_at, started_at, delivered_at
+			)
+			VALUES (?, ?, ?, 'node', 'node-success', 'delivered', 0, 'node_processed', '', ?, ?, ?)
+		`, successDeliveryID, newer, newerMiddleEvent, now.Add(5*time.Second), now.Add(6*time.Second), now.Add(7*time.Second)); err != nil {
+		t.Fatalf("seed sqlite successful delivery: %v", err)
 	}
 	deadLetterID := uuid.NewString()
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
@@ -133,11 +143,16 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	if report.EntityCount != 2 {
 		t.Fatalf("report.EntityCount = %d, want entity_state count 2", report.EntityCount)
 	}
-	if len(report.Deliveries) != 3 {
-		t.Fatalf("report deliveries = %#v, want pending/failed/dead_letter delivery count groups", report.Deliveries)
+	if len(report.Deliveries) != 4 {
+		t.Fatalf("report deliveries = %#v, want pending/delivered/failed/dead_letter delivery count groups", report.Deliveries)
 	}
 	if len(report.FailedDeliveries) != 2 {
 		t.Fatalf("report failed deliveries = %#v, want 2", report.FailedDeliveries)
+	}
+	for _, got := range report.FailedDeliveries {
+		if got.DeliveryID == successDeliveryID {
+			t.Fatalf("successful delivered/node_processed delivery appeared in FailedDeliveries: %#v", report.FailedDeliveries)
+		}
 	}
 	if got := report.FailedDeliveries[0]; got.DeliveryID != nodeDeadDeliveryID || got.SubscriberType != "node" || got.RetryCount != 2 || got.RetryEligible || !got.Terminal || len(got.DeadLetters) != 1 {
 		t.Fatalf("node failed delivery evidence = %#v", got)

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -56,9 +56,10 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 		SELECT
 			e.event_id, e.event_name, COALESCE(e.source_event_id, ''), COALESCE(e.entity_id, ''),
 			COALESCE(e.produced_by, ''), COALESCE(e.produced_by_type, ''), e.created_at,
-			COALESCE(d.delivery_id, ''), COALESCE(d.subscriber_type, ''), COALESCE(d.subscriber_id, ''),
-			COALESCE(d.status, ''), COALESCE(d.reason_code, ''), COALESCE(d.active_session_id, ''),
-			d.created_at, d.started_at, d.delivered_at,
+				COALESCE(d.delivery_id, ''), COALESCE(d.subscriber_type, ''), COALESCE(d.subscriber_id, ''),
+				COALESCE(d.status, ''), COALESCE(d.reason_code, ''), COALESCE(d.last_error, ''), COALESCE(d.retry_count, 0),
+				COALESCE(d.active_session_id, ''),
+				d.created_at, d.started_at, d.delivered_at,
 			COALESCE(ses.session_id, ''), COALESCE(ses.scope, ''), COALESCE(ses.runtime_mode, ''),
 			COALESCE(ses.status, ''), ses.updated_at,
 			COALESCE(t.turn_id, ''), COALESCE(t.trigger_event_id, ''), COALESCE(t.trigger_event_type, ''),
@@ -85,7 +86,7 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 			&row.EventID, &row.EventName, &row.SourceEventID, &row.EntityID,
 			&row.EventSource, &row.EventSourceType, &eventCreatedRaw,
 			&row.DeliveryID, &row.SubscriberType, &row.SubscriberID,
-			&row.DeliveryStatus, &row.DeliveryReasonCode, &row.ActiveSessionID,
+			&row.DeliveryStatus, &row.DeliveryReasonCode, &row.DeliveryLastError, &row.DeliveryRetryCount, &row.ActiveSessionID,
 			&deliveryCreatedRaw, &deliveryStartedRaw, &deliveryDeliveredRaw,
 			&row.SessionID, &row.SessionKind, &row.SessionRuntimeMode,
 			&row.SessionStatus, &sessionUpdatedRaw,
@@ -104,6 +105,8 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 		row.DeliveryCreatedAt = sqliteTraceTimePtr(deliveryCreatedRaw)
 		row.DeliveryStartedAt = sqliteTraceTimePtr(deliveryStartedRaw)
 		row.DeliveryDeliveredAt = sqliteTraceTimePtr(deliveryDeliveredRaw)
+		row.DeliveryRetryEligible = OperatorDeliveryRetryEligible(row.DeliveryStatus)
+		row.DeliveryTerminal = OperatorDeliveryTerminal(row.DeliveryStatus)
 		row.SessionUpdatedAt = sqliteTraceTimePtr(sessionUpdatedRaw)
 		row.TurnCreatedAt = sqliteTraceTimePtr(turnCreatedRaw)
 		out = append(out, row)
@@ -224,12 +227,19 @@ func (s *SQLiteRuntimeStore) LoadOperatorEvent(ctx context.Context, eventID stri
 	}
 	event.Payload = map[string]any{}
 	_ = json.Unmarshal(sqliteJSONRawMessage(payloadRaw), &event.Payload)
+	deadLetters, err := s.sqliteOperatorEventDeadLetters(ctx, eventID)
+	if err != nil {
+		return OperatorEventFull{}, err
+	}
 	deliveries, err := s.sqliteOperatorEventDeliveries(ctx, eventID)
 	if err != nil {
 		return OperatorEventFull{}, err
 	}
-	event.Deliveries = deliveries
-	event.DeadLetters = []OperatorDeadLetterRecord{}
+	event.Deliveries = EnrichOperatorDeliveryFailureEvidence(deliveries, deadLetters)
+	event.DeadLetters = deadLetters
+	if event.DeadLetters == nil {
+		event.DeadLetters = []OperatorDeadLetterRecord{}
+	}
 	return event, nil
 }
 
@@ -342,7 +352,8 @@ func (s *SQLiteRuntimeStore) ListOperatorRuntimeIncidents(ctx context.Context, o
 func (s *SQLiteRuntimeStore) sqliteOperatorEventDeliveries(ctx context.Context, eventID string) ([]OperatorEventDelivery, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT delivery_id, subscriber_type, subscriber_id, COALESCE(active_session_id, ''),
-		       status, COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(retry_count, 0)
+		       status, COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(retry_count, 0),
+		       created_at, started_at, delivered_at
 		FROM event_deliveries
 		WHERE event_id = ?
 		ORDER BY created_at ASC, delivery_id ASC
@@ -354,13 +365,49 @@ func (s *SQLiteRuntimeStore) sqliteOperatorEventDeliveries(ctx context.Context, 
 	out := []OperatorEventDelivery{}
 	for rows.Next() {
 		var delivery OperatorEventDelivery
-		if err := rows.Scan(&delivery.DeliveryID, &delivery.SubscriberType, &delivery.SubscriberID, &delivery.SessionID, &delivery.Status, &delivery.ReasonCode, &delivery.LastError, &delivery.RetryCount); err != nil {
+		var createdRaw, startedRaw, finishedRaw any
+		if err := rows.Scan(&delivery.DeliveryID, &delivery.SubscriberType, &delivery.SubscriberID, &delivery.SessionID, &delivery.Status, &delivery.ReasonCode, &delivery.LastError, &delivery.RetryCount, &createdRaw, &startedRaw, &finishedRaw); err != nil {
 			return nil, fmt.Errorf("scan sqlite operator event delivery: %w", err)
 		}
+		delivery.CreatedAt = sqliteTraceTimePtr(createdRaw)
+		delivery.StartedAt = sqliteTraceTimePtr(startedRaw)
+		delivery.FinishedAt = sqliteTraceTimePtr(finishedRaw)
 		out = append(out, delivery)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read sqlite operator event deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteOperatorEventDeadLetters(ctx context.Context, eventID string) ([]OperatorDeadLetterRecord, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT dead_letter_id, COALESCE(failure_type, ''), COALESCE(error_message, ''),
+		       COALESCE(retry_count, 0), COALESCE(chain_depth, 0), COALESCE(handler_node, ''), created_at
+		FROM dead_letters
+		WHERE original_event_id = ?
+		ORDER BY created_at ASC, dead_letter_id ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite operator event dead letters: %w", err)
+	}
+	defer rows.Close()
+	out := []OperatorDeadLetterRecord{}
+	for rows.Next() {
+		var item OperatorDeadLetterRecord
+		var createdRaw any
+		if err := rows.Scan(&item.DeadLetterID, &item.FailureType, &item.ErrorMessage, &item.RetryCount, &item.ChainDepth, &item.HandlerNode, &createdRaw); err != nil {
+			return nil, fmt.Errorf("scan sqlite operator event dead letter: %w", err)
+		}
+		if at, ok, err := sqliteTimeValue(createdRaw); err != nil {
+			return nil, err
+		} else if ok {
+			item.CreatedAt = at
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read sqlite operator event dead letters: %w", err)
 	}
 	return out, nil
 }

--- a/openrpc.json
+++ b/openrpc.json
@@ -5256,7 +5256,7 @@
     },
     {
       "name": "run.diagnose",
-      "description": "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go. The single\ncanonical owner for \"why isn't this run progressing?\" — routes the\nexisting projection through the API instead of having every\nconsumer recompute it. Today the projection produces\noperational_state, blocking_layer, blocking_reason, and\nheuristics; richer fields (evidence pointers, suggested_next_action)\nare additive owner extensions for a future slice.\n",
+      "description": "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries. The single canonical owner for\n\"why isn't this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute it.\n",
       "params": [
         {
           "name": "run_id",
@@ -9303,7 +9303,7 @@
       },
       "DiagnosisEvidence": {
         "additionalProperties": false,
-        "description": "Reserved for future owner extension. Currently unreferenced by any\nv1 method — the operator-state projection does not yet emit\nevidence pointers. Kept in components.schemas as the canonical\nshape so that when the owner gains evidence emission (a follow-on\nslice), RunDiagnosis can additively reference this type.\n",
+        "description": "Generic evidence pointer shape for future diagnosis extensions. Current run.diagnose failure evidence is owner-backed by RunDebugFailureDelivery, which carries concrete event_deliveries/dead_letters facts instead of opaque pointers.\n",
         "properties": {
           "kind": {
             "description": "e.g., event, entity, turn, mailbox_item, dead_letter.",
@@ -9424,8 +9424,20 @@
       "EventDelivery": {
         "additionalProperties": false,
         "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "dead_letters": {
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterRecord"
+            },
+            "type": "array"
+          },
           "delivery_id": {
             "$ref": "#/components/schemas/OpaqueId"
+          },
+          "finished_at": {
+            "$ref": "#/components/schemas/Timestamp"
           },
           "last_error": {
             "type": "string"
@@ -9433,8 +9445,18 @@
           "reason_code": {
             "type": "string"
           },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "retry_eligible": {
+            "type": "boolean"
+          },
           "session_id": {
             "type": "string"
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
           },
           "status": {
             "$ref": "#/components/schemas/DeliveryStatus"
@@ -9444,13 +9466,19 @@
           },
           "subscriber_type": {
             "$ref": "#/components/schemas/SubscriberType"
+          },
+          "terminal": {
+            "type": "boolean"
           }
         },
         "required": [
           "delivery_id",
           "subscriber_type",
           "subscriber_id",
-          "status"
+          "status",
+          "retry_count",
+          "retry_eligible",
+          "terminal"
         ],
         "type": "object"
       },
@@ -9548,11 +9576,39 @@
             "minimum": 1,
             "type": "integer"
           },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "dead_letters": {
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterRecord"
+            },
+            "type": "array"
+          },
           "delivery_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
+          "finished_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "reason_code": {
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "retry_eligible": {
+            "type": "boolean"
+          },
           "session_id": {
             "type": "string"
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
           },
           "status": {
             "$ref": "#/components/schemas/DeliveryStatus"
@@ -9562,6 +9618,9 @@
           },
           "subscriber_type": {
             "$ref": "#/components/schemas/SubscriberType"
+          },
+          "terminal": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -9569,7 +9628,10 @@
           "subscriber_type",
           "subscriber_id",
           "status",
-          "attempt"
+          "attempt",
+          "retry_count",
+          "retry_eligible",
+          "terminal"
         ],
         "type": "object"
       },
@@ -9612,8 +9674,33 @@
             "minimum": 1,
             "type": "integer"
           },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "dead_letters": {
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterRecord"
+            },
+            "type": "array"
+          },
           "delivery_id": {
             "$ref": "#/components/schemas/OpaqueId"
+          },
+          "finished_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "reason_code": {
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "retry_eligible": {
+            "type": "boolean"
           },
           "session_id": {
             "type": "string"
@@ -9621,18 +9708,27 @@
           "source_delivery_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
           "status": {
             "$ref": "#/components/schemas/DeliveryStatus"
           },
           "subscriber_id": {
             "type": "string"
+          },
+          "terminal": {
+            "type": "boolean"
           }
         },
         "required": [
           "delivery_id",
           "subscriber_id",
           "status",
-          "attempt"
+          "attempt",
+          "retry_count",
+          "retry_eligible",
+          "terminal"
         ],
         "type": "object"
       },
@@ -10148,9 +10244,85 @@
         ],
         "type": "object"
       },
+      "RunDebugFailureDelivery": {
+        "additionalProperties": false,
+        "description": "Concrete failed or terminal delivery evidence for run.diagnose. Source of truth is event_deliveries joined to the owning event; dead_letters is event-scoped terminal evidence when present. Consumers MUST NOT infer this shape from aggregate delivery counts.",
+        "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "dead_letters": {
+            "description": "Event-scoped terminal dead-letter records linked to this failed or dead-letter delivery when present.",
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterRecord"
+            },
+            "type": "array"
+          },
+          "delivery_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "entity_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "event_name": {
+            "type": "string"
+          },
+          "finished_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "reason_code": {
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "retry_eligible": {
+            "description": "True exactly when status is failed, the retry-visible failure state.",
+            "type": "boolean"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeliveryStatus"
+          },
+          "subscriber_id": {
+            "type": "string"
+          },
+          "subscriber_type": {
+            "$ref": "#/components/schemas/SubscriberType"
+          },
+          "terminal": {
+            "description": "True exactly when status is delivered or dead_letter.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "event_id",
+          "event_name",
+          "delivery_id",
+          "subscriber_type",
+          "subscriber_id",
+          "status",
+          "retry_count",
+          "retry_eligible",
+          "terminal"
+        ],
+        "type": "object"
+      },
       "RunDiagnosis": {
         "additionalProperties": false,
-        "description": "Run header plus the canonical operator-state projection. Source of\ntruth: ProjectRunOperationalStatus. Spec exposes exactly what the\nowner produces in v1; richer fields (evidence pointers,\nsuggested_next_action) are additive owner extensions for a future\nslice — when the store owner gains them, the spec adds them\nadditively (no /v2/ bump).\n",
+        "description": "Run header plus the canonical operator-state projection and concrete failed-delivery evidence. Source of truth: ProjectRunOperationalStatus for operational_state/blocking fields and RunDebugReport.FailedDeliveries for event_deliveries/dead_letters failure evidence.\n",
         "properties": {
           "blocking_layer": {
             "$ref": "#/components/schemas/BlockingLayer"
@@ -10158,6 +10330,13 @@
           "blocking_reason": {
             "description": "Free-form reason string when operational_state is \"stalled\".\nEmpty when state is running or terminal. Current owner emits:\n  \"\" (empty)\n  \"terminal_scoring_outcome_missing\"\n  \"no_active_deliveries\"\nAdditional values may be added additively.\n",
             "type": "string"
+          },
+          "failed_deliveries": {
+            "description": "Failed or dead-letter delivery rows with persisted reason/error/retry/dead-letter evidence for this run.",
+            "items": {
+              "$ref": "#/components/schemas/RunDebugFailureDelivery"
+            },
+            "type": "array"
           },
           "heuristics": {
             "description": "Free-form diagnostic notes from the projection. Current owner\nemits one entry per detected condition, e.g. \"dead letters\nexist for this run\".\n",
@@ -10178,7 +10357,8 @@
           "operational_state",
           "blocking_layer",
           "blocking_reason",
-          "heuristics"
+          "heuristics",
+          "failed_deliveries"
         ],
         "type": "object"
       },
@@ -10364,14 +10544,27 @@
           "delivery_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
+          "delivery_last_error": {
+            "type": "string"
+          },
           "delivery_reason_code": {
             "type": "string"
+          },
+          "delivery_retry_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "delivery_retry_eligible": {
+            "type": "boolean"
           },
           "delivery_started_at": {
             "$ref": "#/components/schemas/Timestamp"
           },
           "delivery_status": {
             "$ref": "#/components/schemas/DeliveryStatus"
+          },
+          "delivery_terminal": {
+            "type": "boolean"
           },
           "entity_id": {
             "$ref": "#/components/schemas/OpaqueId"

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12278,9 +12278,9 @@ api_specification:
           \ exist\nAdditional values may be added as the operator-state owner gains\nmore diagnostic semantics. Type stays\
           \ string (not enum) for\nforward compatibility \u2014 additive owner extensions must not\nrequire a /v2/ bump.\n"
       DiagnosisEvidence:
-        description: "Reserved for future owner extension. Currently unreferenced by any\nv1 method \u2014 the operator-state\
-          \ projection does not yet emit\nevidence pointers. Kept in components.schemas as the canonical\nshape so that when\
-          \ the owner gains evidence emission (a follow-on\nslice), RunDiagnosis can additively reference this type.\n"
+        description: "Generic evidence pointer shape for future diagnosis extensions. Current run.diagnose failure evidence\
+          \ is owner-backed by RunDebugFailureDelivery, which carries concrete event_deliveries/dead_letters facts instead\
+          \ of opaque pointers.\n"
         type: object
         additionalProperties: false
         required:
@@ -12296,11 +12296,69 @@ api_specification:
           summary:
             type: string
             description: Human-readable one-line description of why this evidence supports the diagnosis.
+      RunDebugFailureDelivery:
+        description: >-
+          Concrete failed or terminal delivery evidence for run.diagnose. Source
+          of truth is event_deliveries joined to the owning event; dead_letters is
+          event-scoped terminal evidence when present. Consumers MUST NOT infer
+          this shape from aggregate delivery counts.
+        type: object
+        additionalProperties: false
+        required:
+        - event_id
+        - event_name
+        - delivery_id
+        - subscriber_type
+        - subscriber_id
+        - status
+        - retry_count
+        - retry_eligible
+        - terminal
+        properties:
+          event_id:
+            $ref: '#/components/schemas/OpaqueId'
+          event_name:
+            type: string
+          entity_id:
+            $ref: '#/components/schemas/OpaqueId'
+          delivery_id:
+            $ref: '#/components/schemas/OpaqueId'
+          subscriber_type:
+            $ref: '#/components/schemas/SubscriberType'
+          subscriber_id:
+            type: string
+          session_id:
+            type: string
+          status:
+            $ref: '#/components/schemas/DeliveryStatus'
+          reason_code:
+            type: string
+          last_error:
+            type: string
+          retry_count:
+            type: integer
+            minimum: 0
+          retry_eligible:
+            type: boolean
+            description: True exactly when status is failed, the retry-visible failure state.
+          terminal:
+            type: boolean
+            description: True exactly when status is delivered or dead_letter.
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          finished_at:
+            $ref: '#/components/schemas/Timestamp'
+          dead_letters:
+            type: array
+            description: Event-scoped terminal dead-letter records linked to this failed or dead-letter delivery when present.
+            items:
+              $ref: '#/components/schemas/DeadLetterRecord'
       RunDiagnosis:
-        description: "Run header plus the canonical operator-state projection. Source of\ntruth: ProjectRunOperationalStatus.\
-          \ Spec exposes exactly what the\nowner produces in v1; richer fields (evidence pointers,\nsuggested_next_action)\
-          \ are additive owner extensions for a future\nslice \u2014 when the store owner gains them, the spec adds them\n\
-          additively (no /v2/ bump).\n"
+        description: "Run header plus the canonical operator-state projection and concrete failed-delivery evidence. Source\
+          \ of truth: ProjectRunOperationalStatus for operational_state/blocking fields and RunDebugReport.FailedDeliveries\
+          \ for event_deliveries/dead_letters failure evidence.\n"
         type: object
         additionalProperties: false
         required:
@@ -12309,6 +12367,7 @@ api_specification:
         - blocking_layer
         - blocking_reason
         - heuristics
+        - failed_deliveries
         properties:
           run:
             $ref: '#/components/schemas/RunHeader'
@@ -12332,6 +12391,11 @@ api_specification:
               exist for this run".
 
               '
+          failed_deliveries:
+            type: array
+            description: Failed or dead-letter delivery rows with persisted reason/error/retry/dead-letter evidence for this run.
+            items:
+              $ref: '#/components/schemas/RunDebugFailureDelivery'
       EntitySummary:
         type: object
         additionalProperties: false
@@ -12449,6 +12513,9 @@ api_specification:
         - subscriber_type
         - subscriber_id
         - status
+        - retry_count
+        - retry_eligible
+        - terminal
         properties:
           delivery_id:
             $ref: '#/components/schemas/OpaqueId'
@@ -12464,6 +12531,23 @@ api_specification:
             type: string
           last_error:
             type: string
+          retry_count:
+            type: integer
+            minimum: 0
+          retry_eligible:
+            type: boolean
+          terminal:
+            type: boolean
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          finished_at:
+            $ref: '#/components/schemas/Timestamp'
+          dead_letters:
+            type: array
+            items:
+              $ref: '#/components/schemas/DeadLetterRecord'
       EventPublishDelivery:
         type: object
         additionalProperties: false
@@ -12473,6 +12557,9 @@ api_specification:
         - subscriber_id
         - status
         - attempt
+        - retry_count
+        - retry_eligible
+        - terminal
         properties:
           delivery_id:
             $ref: '#/components/schemas/OpaqueId'
@@ -12484,9 +12571,30 @@ api_specification:
             type: string
           status:
             $ref: '#/components/schemas/DeliveryStatus'
+          reason_code:
+            type: string
+          last_error:
+            type: string
           attempt:
             type: integer
             minimum: 1
+          retry_count:
+            type: integer
+            minimum: 0
+          retry_eligible:
+            type: boolean
+          terminal:
+            type: boolean
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          finished_at:
+            $ref: '#/components/schemas/Timestamp'
+          dead_letters:
+            type: array
+            items:
+              $ref: '#/components/schemas/DeadLetterRecord'
       EventPublishResult:
         type: object
         additionalProperties: false
@@ -12518,6 +12626,9 @@ api_specification:
         - subscriber_id
         - status
         - attempt
+        - retry_count
+        - retry_eligible
+        - terminal
         properties:
           delivery_id:
             $ref: '#/components/schemas/OpaqueId'
@@ -12527,9 +12638,30 @@ api_specification:
             type: string
           status:
             $ref: '#/components/schemas/DeliveryStatus'
+          reason_code:
+            type: string
+          last_error:
+            type: string
           attempt:
             type: integer
             minimum: 1
+          retry_count:
+            type: integer
+            minimum: 0
+          retry_eligible:
+            type: boolean
+          terminal:
+            type: boolean
+          created_at:
+            $ref: '#/components/schemas/Timestamp'
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          finished_at:
+            $ref: '#/components/schemas/Timestamp'
+          dead_letters:
+            type: array
+            items:
+              $ref: '#/components/schemas/DeadLetterRecord'
           source_delivery_id:
             $ref: '#/components/schemas/OpaqueId'
       EventReplayResult:
@@ -14073,6 +14205,15 @@ api_specification:
             $ref: '#/components/schemas/DeliveryStatus'
           delivery_reason_code:
             type: string
+          delivery_last_error:
+            type: string
+          delivery_retry_count:
+            type: integer
+            minimum: 0
+          delivery_retry_eligible:
+            type: boolean
+          delivery_terminal:
+            type: boolean
           active_session_id:
             $ref: '#/components/schemas/OpaqueId'
           delivery_created_at:
@@ -15575,11 +15716,10 @@ api_specification:
       - RUN_NOT_FOUND
     run.diagnose:
       tier: must_have
-      description: "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go.\
-        \ The single\ncanonical owner for \"why isn't this run progressing?\" \u2014 routes the\nexisting projection through\
-        \ the API instead of having every\nconsumer recompute it. Today the projection produces\noperational_state, blocking_layer,\
-        \ blocking_reason, and\nheuristics; richer fields (evidence pointers, suggested_next_action)\nare additive owner extensions\
-        \ for a future slice.\n"
+      description: "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go\
+        \ and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries. The single canonical owner for\n\"why\
+        \ isn't this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute\
+        \ it.\n"
       scope:
         required:
         - read:runs


### PR DESCRIPTION
## Summary

Part of #1375.

This PR exposes persisted delivery failure evidence through the supported event/run readback surfaces selected by the approved #1375 first-slice gate. It preserves `event.publish` durable/fast ACK semantics and does not change routing, event admission, delivery materialization, event construction, replay target selection, or handler execution.

## Governing Refs / Context

Exact governing spec refs exist and are updated in this PR:

- `platform-spec.yaml` `storage_schema.event_deliveries`: canonical owner for delivery status, retry count, reason, last error, active session, and timestamps.
- `platform-spec.yaml` `storage_schema.dead_letters`: durable terminal/intercepted failure evidence for original events.
- `platform-spec.yaml` OpenRPC schemas: `EventDelivery`, `EventPublishDelivery`, `EventReplayDelivery`, `RunTraceRow`, `RunDiagnosis`, and new `RunDebugFailureDelivery`.
- `platform-spec.yaml` method contracts: `event.publish`, `event.replay`, `event.get/list`, `run.trace`, and `run.diagnose`.
- #1375 pre-audit gate outcome: approved as first-slice public failure-evidence projection/readback over current persisted owners.

## Semantic Migration / Authority

New canonical readback owner introduced for this slice:

- Store/API projection over `event_deliveries` plus event-scoped `dead_letters`.

Old reduced paths now invalid/non-authoritative:

- EventFull hiding `retry_count` and timestamps from `OperatorEventDelivery`.
- SQLite EventFull omitting event-scoped dead letters.
- `event.publish` and `event.replay` DTOs reducing delivery evidence to status/attempt.
- `run.diagnose` exposing counts/dead-letter lists without failed-delivery rows.
- `run.trace` omitting delivery `last_error`, `retry_count`, retry eligibility, and terminality.

Production paths checked for surviving old behavior:

- Postgres and SQLite operator event reads.
- Postgres and SQLite run diagnosis/trace reads.
- API `event.publish`, `event.replay`, and `run.diagnose` mappers.
- CLI event view/events, event publish/replay, and run diagnose validators/rendering.
- Generated OpenRPC artifact.

Migration completeness:

- Complete for the approved first slice: public readback of current persisted delivery/dead-letter failure evidence across selected event/run/API/CLI surfaces.
- Remaining parent tails stay outside this PR: non-null `next_retry_at`, direct runtime-log deep links, and any route/admission/materialization/runtime-execution bugs.

## Validation

- `go test ./internal/store ./internal/apiv1 ./cmd/swarm`
- `go test ./internal/apispec`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen`
