### PR TITLE
[codex] Add lifecycle probe test helper

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -18,7 +18,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
-	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -113,7 +113,7 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 	release := make(chan struct{})
 	var releaseOnce sync.Once
 	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
-	probe := runtimelifecycleprobe.New()
+	probe := lifecycletest.New(t)
 	opts := runStartTestEventBusOptions(source)
 	opts.TestLifecycleProbe = probe
 	opts.Interceptors = []runtimebus.EventInterceptor{blockingAPIV1PublishInterceptor{release: release}}
@@ -152,11 +152,7 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 		t.Fatalf("api_idempotency rows before dispatch release = %d, want 1", count)
 	}
 
-	startCtx, cancelStart := context.WithTimeout(ctx, time.Second)
-	defer cancelStart()
-	if _, err := probe.WaitForPostCommitDispatchStarted(startCtx, eventID); err != nil {
-		t.Fatalf("post-commit dispatch start for %s: %v", eventID, err)
-	}
+	probe.RequirePostCommitDispatchStarted(eventID)
 	requireNoAPIV1RuntimeBusEvent(t, ch, "event.publish delivery before post-commit release")
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
 		t.Fatalf("pipeline receipts before post-commit release = %d, want 0", got)
@@ -167,11 +163,7 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 	if got.ID() != eventID {
 		t.Fatalf("delivered event = %s, want %s", got.ID(), eventID)
 	}
-	doneCtx, cancelDone := context.WithTimeout(ctx, time.Second)
-	defer cancelDone()
-	if _, err := probe.WaitForPostCommitDispatchCompleted(doneCtx, eventID); err != nil {
-		t.Fatalf("post-commit dispatch completion for %s: %v", eventID, err)
-	}
+	probe.RequirePostCommitDispatchCompleted(eventID)
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts after post-commit release = %d, want 1", got)
 	}
@@ -599,7 +591,7 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 		err:           errors.New("simulated normal-run completion failure"),
 	}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
-	probe := runtimelifecycleprobe.New()
+	probe := lifecycletest.New(t, lifecycletest.WithTimeout(5*time.Second))
 	opts := runStartTestEventBusOptions(source)
 	opts.TestLifecycleProbe = probe
 	bus, err := runtimebus.NewEventBusWithOptions(failing, opts)
@@ -628,11 +620,7 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 	if count := countAPIIdempotencyRows(t, db); count != 1 {
 		t.Fatalf("api_idempotency rows after post-commit completion failure = %d, want 1", count)
 	}
-	doneCtx, cancelDone := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelDone()
-	if _, err := probe.WaitForPostCommitDispatchCompleted(doneCtx, eventID); err != nil {
-		t.Fatalf("post-commit dispatch completion for %s: %v", eventID, err)
-	}
+	probe.RequirePostCommitDispatchCompleted(eventID)
 	outcome, errText := loadPipelineReceiptOutcomeAndError(t, ctx, db, eventID)
 	if outcome != "dead_letter" || !strings.Contains(errText, "simulated normal-run completion failure") {
 		t.Fatalf("pipeline receipt outcome=%q error=%q, want dead_letter with completion failure", outcome, errText)

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -14,6 +14,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -264,47 +265,78 @@ func releaseMailboxWritePendingNodeDeliveries(t *testing.T, db *sql.DB, bus *run
 	if bus == nil {
 		t.Fatalf("%s runtime bus is required to release pending node deliveries", backend)
 	}
-	waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "pending")
-	if pending, _ := mailboxWriteNodeDeliveryCounts(t, db, backend, eventID); pending == 0 {
-		waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "delivered")
-		return
+	nodeID := mailboxWriteNodeDeliverySubscriberID(t, db, backend, eventID)
+	waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, nodeID, "pending")
+	if status := mailboxWriteNodeDeliveryStatus(t, db, backend, eventID, nodeID); status == "pending" {
+		evt := loadMailboxWritePersistedEvent(t, db, backend, eventID)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := bus.ReleasePendingPersistedDeliveriesForEvent(ctx, evt); err != nil {
+			t.Fatalf("%s release pending node deliveries for event %s: %v", backend, eventID, err)
+		}
 	}
-	evt := loadMailboxWritePersistedEvent(t, db, backend, eventID)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := bus.ReleasePendingPersistedDeliveriesForEvent(ctx, evt); err != nil {
-		t.Fatalf("%s release pending node deliveries for event %s: %v", backend, eventID, err)
-	}
-	waitForMailboxWriteLifecycleDeliveryStatus(t, probe, backend, eventID, "delivered")
+	waitForMailboxWriteNodeDeliveryStatus(t, db, backend, eventID, nodeID, "delivered")
 }
 
-func waitForMailboxWriteLifecycleDeliveryStatus(t *testing.T, probe *runtimelifecycleprobe.Probe, backend, eventID, status string) {
+func waitForMailboxWriteLifecycleDeliveryStatus(t *testing.T, probe *runtimelifecycleprobe.Probe, backend, eventID, nodeID, status string) {
 	t.Helper()
 	if probe == nil {
-		t.Fatalf("%s lifecycle probe is required for node delivery %s on event %s", backend, status, eventID)
+		t.Fatalf("%s lifecycle probe is required for node delivery %s on event %s node %s", backend, status, eventID, nodeID)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if _, err := probe.WaitForDeliveryStatus(ctx, eventID, "node", "", status); err != nil {
-		t.Fatalf("%s node delivery %s for event %s: %v", backend, status, eventID, err)
-	}
+	lifecycletest.Wrap(t, probe, lifecycletest.WithTimeout(apiv1ConvergenceTimeout)).
+		RequireNodeStatus(eventID, nodeID, status)
 }
 
-func mailboxWriteNodeDeliveryCounts(t *testing.T, db *sql.DB, backend, eventID string) (pending int, total int) {
+func waitForMailboxWriteNodeDeliveryStatus(t *testing.T, db *sql.DB, backend, eventID, nodeID, wantStatus string) {
 	t.Helper()
-	if strings.TrimSpace(eventID) == "" {
-		return 0, 0
+	requireAPIV1Convergence(t, fmt.Sprintf("%s node delivery %s/%s status %s", backend, eventID, nodeID, wantStatus), func() (bool, error) {
+		status := mailboxWriteNodeDeliveryStatus(t, db, backend, eventID, nodeID)
+		if status == wantStatus {
+			return true, nil
+		}
+		return false, fmt.Errorf("delivery status = %q, want %q", status, wantStatus)
+	})
+}
+
+func mailboxWriteNodeDeliveryStatus(t *testing.T, db *sql.DB, backend, eventID, nodeID string) string {
+	t.Helper()
+	if strings.TrimSpace(eventID) == "" || strings.TrimSpace(nodeID) == "" {
+		t.Fatalf("%s node delivery status lookup requires event id and node id", backend)
 	}
 	sqlText := ""
+	args := []any{eventID, nodeID}
 	if strings.HasPrefix(backend, "sqlite") {
-		sqlText = `SELECT COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0), COUNT(*) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node'`
+		sqlText = `SELECT status FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = ?`
 	} else {
-		sqlText = `SELECT COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0), COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node'`
+		sqlText = `SELECT status FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = $2`
 	}
-	if err := db.QueryRowContext(context.Background(), sqlText, eventID).Scan(&pending, &total); err != nil {
-		t.Fatalf("%s node delivery counts for %s: %v", backend, eventID, err)
+	status := ""
+	if err := db.QueryRowContext(context.Background(), sqlText, args...).Scan(&status); err != nil {
+		t.Fatalf("%s node delivery status lookup for %s/%s: %v", backend, eventID, nodeID, err)
 	}
-	return pending, total
+	return status
+}
+
+func mailboxWriteNodeDeliverySubscriberID(t *testing.T, db *sql.DB, backend, eventID string) string {
+	t.Helper()
+	if strings.TrimSpace(eventID) == "" {
+		t.Fatalf("%s node delivery subscriber lookup requires event id", backend)
+	}
+	sqlText := ""
+	args := []any{eventID, eventReplayScopeSubscriberID}
+	if strings.HasPrefix(backend, "sqlite") {
+		sqlText = `SELECT subscriber_id FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id <> ? ORDER BY subscriber_id LIMIT 1`
+	} else {
+		sqlText = `SELECT subscriber_id FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id <> $2 ORDER BY subscriber_id LIMIT 1`
+	}
+	nodeID := ""
+	if err := db.QueryRowContext(context.Background(), sqlText, args...).Scan(&nodeID); err != nil {
+		t.Fatalf("%s node delivery subscriber lookup for %s: %v", backend, eventID, err)
+	}
+	if strings.TrimSpace(nodeID) == "" {
+		t.Fatalf("%s node delivery subscriber lookup for %s returned empty subscriber_id", backend, eventID)
+	}
+	return nodeID
 }
 
 func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID string) events.Event {

--- a/internal/runtime/lifecycleprobe/lifecycletest/expectation.go
+++ b/internal/runtime/lifecycleprobe/lifecycletest/expectation.go
@@ -1,0 +1,150 @@
+package lifecycletest
+
+import (
+	"context"
+	"time"
+
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+)
+
+type Expectation struct {
+	probe   *Probe
+	eventID string
+	steps   []expectationStep
+}
+
+type expectationStep struct {
+	label string
+	want  runtimelifecycleprobe.Signal
+}
+
+func (e *Expectation) EventPersisted() *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{Kind: runtimelifecycleprobe.EventPersisted})
+}
+
+func (e *Expectation) DeliveryPersisted(subscriberType, subscriberID string) *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.DeliveryPersisted,
+		SubscriberType: subscriberType,
+		SubscriberID:   subscriberID,
+	})
+}
+
+func (e *Expectation) DeliveryStatus(subscriberType, subscriberID, status string) *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.DeliveryStatusChanged,
+		SubscriberType: subscriberType,
+		SubscriberID:   subscriberID,
+		Status:         status,
+	})
+}
+
+func (e *Expectation) AgentStatus(agentID, status string) *Expectation {
+	return e.DeliveryStatus(SubscriberAgent, agentID, status)
+}
+
+func (e *Expectation) NodeStatus(nodeID, status string) *Expectation {
+	return e.DeliveryStatus(SubscriberNode, nodeID, status)
+}
+
+func (e *Expectation) NodePending(nodeID string) *Expectation {
+	return e.NodeStatus(nodeID, StatusPending)
+}
+
+func (e *Expectation) NodeInProgress(nodeID string) *Expectation {
+	return e.NodeStatus(nodeID, StatusInProgress)
+}
+
+func (e *Expectation) NodeDelivered(nodeID string) *Expectation {
+	return e.NodeStatus(nodeID, StatusDelivered)
+}
+
+func (e *Expectation) NodeFailed(nodeID string) *Expectation {
+	return e.NodeStatus(nodeID, StatusFailed)
+}
+
+func (e *Expectation) NodeDeadLetter(nodeID string) *Expectation {
+	return e.NodeStatus(nodeID, StatusDeadLetter)
+}
+
+func (e *Expectation) AgentPending(agentID string) *Expectation {
+	return e.AgentStatus(agentID, StatusPending)
+}
+
+func (e *Expectation) AgentInProgress(agentID string) *Expectation {
+	return e.AgentStatus(agentID, StatusInProgress)
+}
+
+func (e *Expectation) AgentDelivered(agentID string) *Expectation {
+	return e.AgentStatus(agentID, StatusDelivered)
+}
+
+func (e *Expectation) AgentFailed(agentID string) *Expectation {
+	return e.AgentStatus(agentID, StatusFailed)
+}
+
+func (e *Expectation) AgentDeadLetter(agentID string) *Expectation {
+	return e.AgentStatus(agentID, StatusDeadLetter)
+}
+
+func (e *Expectation) HandlerStarted(nodeID string) *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.HandlerStarted,
+		SubscriberType: SubscriberNode,
+		SubscriberID:   nodeID,
+	})
+}
+
+func (e *Expectation) HandlerCompleted(nodeID string) *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.HandlerCompleted,
+		SubscriberType: SubscriberNode,
+		SubscriberID:   nodeID,
+	})
+}
+
+func (e *Expectation) PostCommitDispatchStarted() *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{Kind: runtimelifecycleprobe.PostCommitDispatchStarted})
+}
+
+func (e *Expectation) PostCommitDispatchCompleted() *Expectation {
+	return e.append(runtimelifecycleprobe.Signal{Kind: runtimelifecycleprobe.PostCommitDispatchCompleted})
+}
+
+func (e *Expectation) Require() []runtimelifecycleprobe.Signal {
+	return e.Within(0)
+}
+
+func (e *Expectation) Within(timeout time.Duration) []runtimelifecycleprobe.Signal {
+	e.probe.t.Helper()
+	if timeout <= 0 {
+		timeout = e.probe.timeout
+	}
+	if e.eventID == "" {
+		e.probe.t.Fatal("lifecycle expectation event_id is required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	signals := make([]runtimelifecycleprobe.Signal, 0, len(e.steps))
+	var cursor runtimelifecycleprobe.Cursor
+	for i, step := range e.steps {
+		got, next, err := e.probe.inner.WaitAfter(ctx, cursor, step.want)
+		if err != nil {
+			e.probe.t.Fatalf("wait for lifecycle step %d %s: %v", i+1, step.label, err)
+		}
+		signals = append(signals, got)
+		cursor = next
+	}
+	return signals
+}
+
+func (e *Expectation) append(signal runtimelifecycleprobe.Signal) *Expectation {
+	e.probe.t.Helper()
+	signal.EventID = e.eventID
+	e.steps = append(e.steps, expectationStep{
+		label: stepLabel(signal),
+		want:  signal,
+	})
+	return e
+}

--- a/internal/runtime/lifecycleprobe/lifecycletest/probe.go
+++ b/internal/runtime/lifecycleprobe/lifecycletest/probe.go
@@ -1,0 +1,240 @@
+package lifecycletest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+)
+
+const (
+	SubscriberAgent = "agent"
+	SubscriberNode  = "node"
+
+	StatusPending    = "pending"
+	StatusInProgress = "in_progress"
+	StatusDelivered  = "delivered"
+	StatusFailed     = "failed"
+	StatusDeadLetter = "dead_letter"
+
+	defaultTimeout = 2 * time.Second
+)
+
+type Option func(*Probe)
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(p *Probe) {
+		if timeout > 0 {
+			p.timeout = timeout
+		}
+	}
+}
+
+type Probe struct {
+	t       testing.TB
+	inner   *runtimelifecycleprobe.Probe
+	timeout time.Duration
+}
+
+func New(t testing.TB, opts ...Option) *Probe {
+	t.Helper()
+	return Wrap(t, runtimelifecycleprobe.New(), opts...)
+}
+
+func Wrap(t testing.TB, probe *runtimelifecycleprobe.Probe, opts ...Option) *Probe {
+	t.Helper()
+	if probe == nil {
+		t.Fatal("lifecycle test probe is nil")
+	}
+	out := &Probe{
+		t:       t,
+		inner:   probe,
+		timeout: defaultTimeout,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(out)
+		}
+	}
+	return out
+}
+
+func (p *Probe) NotifyLifecycle(ctx context.Context, signal runtimelifecycleprobe.Signal) {
+	if p == nil || p.inner == nil {
+		return
+	}
+	p.inner.NotifyLifecycle(ctx, signal)
+}
+
+func (p *Probe) Raw() *runtimelifecycleprobe.Probe {
+	p.t.Helper()
+	return p.inner
+}
+
+func (p *Probe) RequireEventPersisted(eventID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:    runtimelifecycleprobe.EventPersisted,
+		EventID: eventID,
+	})
+}
+
+func (p *Probe) RequireDeliveryPersisted(eventID, subscriberType, subscriberID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.DeliveryPersisted,
+		EventID:        eventID,
+		SubscriberType: subscriberType,
+		SubscriberID:   subscriberID,
+	})
+}
+
+func (p *Probe) RequireDeliveryStatus(eventID, subscriberType, subscriberID, status string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.DeliveryStatusChanged,
+		EventID:        eventID,
+		SubscriberType: subscriberType,
+		SubscriberID:   subscriberID,
+		Status:         status,
+	})
+}
+
+func (p *Probe) RequireAgentStatus(eventID, agentID, status string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireDeliveryStatus(eventID, SubscriberAgent, agentID, status)
+}
+
+func (p *Probe) RequireNodeStatus(eventID, nodeID, status string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireDeliveryStatus(eventID, SubscriberNode, nodeID, status)
+}
+
+func (p *Probe) RequireNodePending(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireNodeStatus(eventID, nodeID, StatusPending)
+}
+
+func (p *Probe) RequireNodeInProgress(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireNodeStatus(eventID, nodeID, StatusInProgress)
+}
+
+func (p *Probe) RequireNodeDelivered(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireNodeStatus(eventID, nodeID, StatusDelivered)
+}
+
+func (p *Probe) RequireNodeFailed(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireNodeStatus(eventID, nodeID, StatusFailed)
+}
+
+func (p *Probe) RequireNodeDeadLetter(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireNodeStatus(eventID, nodeID, StatusDeadLetter)
+}
+
+func (p *Probe) RequireAgentPending(eventID, agentID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireAgentStatus(eventID, agentID, StatusPending)
+}
+
+func (p *Probe) RequireAgentInProgress(eventID, agentID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireAgentStatus(eventID, agentID, StatusInProgress)
+}
+
+func (p *Probe) RequireAgentDelivered(eventID, agentID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireAgentStatus(eventID, agentID, StatusDelivered)
+}
+
+func (p *Probe) RequireAgentFailed(eventID, agentID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireAgentStatus(eventID, agentID, StatusFailed)
+}
+
+func (p *Probe) RequireAgentDeadLetter(eventID, agentID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.RequireAgentStatus(eventID, agentID, StatusDeadLetter)
+}
+
+func (p *Probe) RequireHandlerStarted(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.HandlerStarted,
+		EventID:        eventID,
+		SubscriberType: SubscriberNode,
+		SubscriberID:   nodeID,
+	})
+}
+
+func (p *Probe) RequireHandlerCompleted(eventID, nodeID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.HandlerCompleted,
+		EventID:        eventID,
+		SubscriberType: SubscriberNode,
+		SubscriberID:   nodeID,
+	})
+}
+
+func (p *Probe) RequirePostCommitDispatchStarted(eventID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:    runtimelifecycleprobe.PostCommitDispatchStarted,
+		EventID: eventID,
+	})
+}
+
+func (p *Probe) RequirePostCommitDispatchCompleted(eventID string) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	return p.require(runtimelifecycleprobe.Signal{
+		Kind:    runtimelifecycleprobe.PostCommitDispatchCompleted,
+		EventID: eventID,
+	})
+}
+
+func (p *Probe) Expect(eventID string) *Expectation {
+	p.t.Helper()
+	return &Expectation{probe: p, eventID: strings.TrimSpace(eventID)}
+}
+
+func (p *Probe) require(want runtimelifecycleprobe.Signal) runtimelifecycleprobe.Signal {
+	p.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+	got, err := p.inner.Wait(ctx, want)
+	if err != nil {
+		p.t.Fatalf("wait for lifecycle %s: %v", describeSignal(want), err)
+	}
+	return got
+}
+
+func describeSignal(signal runtimelifecycleprobe.Signal) string {
+	parts := []string{string(signal.Kind), "event_id=" + signal.EventID}
+	if signal.EventType != "" {
+		parts = append(parts, "event_type="+signal.EventType)
+	}
+	if signal.SubscriberType != "" {
+		parts = append(parts, "subscriber_type="+signal.SubscriberType)
+	}
+	if signal.SubscriberID != "" {
+		parts = append(parts, "subscriber_id="+signal.SubscriberID)
+	}
+	if signal.Status != "" {
+		parts = append(parts, "status="+signal.Status)
+	}
+	return strings.Join(parts, " ")
+}
+
+func stepLabel(signal runtimelifecycleprobe.Signal) string {
+	if signal.Status != "" {
+		return fmt.Sprintf("%s:%s", signal.Kind, signal.Status)
+	}
+	return string(signal.Kind)
+}

--- a/internal/runtime/lifecycleprobe/lifecycletest/probe_test.go
+++ b/internal/runtime/lifecycleprobe/lifecycletest/probe_test.go
@@ -1,0 +1,91 @@
+package lifecycletest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+)
+
+func TestRequireDeliveryStatusReturnsHistoricalSignal(t *testing.T) {
+	probe := New(t)
+	probe.NotifyLifecycle(context.Background(), runtimelifecycleprobe.Signal{
+		Kind:           runtimelifecycleprobe.DeliveryStatusChanged,
+		EventID:        "event-1",
+		SubscriberType: SubscriberNode,
+		SubscriberID:   "node-a",
+		Status:         StatusDelivered,
+	})
+
+	got := probe.RequireNodeDelivered("event-1", "node-a")
+	if got.EventID != "event-1" || got.SubscriberID != "node-a" || got.Status != StatusDelivered {
+		t.Fatalf("signal = %#v, want delivered node-a event-1", got)
+	}
+}
+
+func TestExpectationWaitsForFutureSignalsInOrder(t *testing.T) {
+	probe := New(t, WithTimeout(time.Second))
+	done := make(chan []runtimelifecycleprobe.Signal, 1)
+	go func() {
+		done <- probe.Expect("event-2").
+			PostCommitDispatchStarted().
+			NodeInProgress("node-a").
+			HandlerStarted("node-a").
+			HandlerCompleted("node-a").
+			NodeDelivered("node-a").
+			Require()
+	}()
+
+	signals := []runtimelifecycleprobe.Signal{
+		{Kind: runtimelifecycleprobe.PostCommitDispatchStarted, EventID: "event-2"},
+		{Kind: runtimelifecycleprobe.DeliveryStatusChanged, EventID: "event-2", SubscriberType: SubscriberNode, SubscriberID: "node-a", Status: StatusInProgress},
+		{Kind: runtimelifecycleprobe.HandlerStarted, EventID: "event-2", SubscriberType: SubscriberNode, SubscriberID: "node-a"},
+		{Kind: runtimelifecycleprobe.HandlerCompleted, EventID: "event-2", SubscriberType: SubscriberNode, SubscriberID: "node-a"},
+		{Kind: runtimelifecycleprobe.DeliveryStatusChanged, EventID: "event-2", SubscriberType: SubscriberNode, SubscriberID: "node-a", Status: StatusDelivered},
+	}
+	for _, signal := range signals {
+		probe.NotifyLifecycle(context.Background(), signal)
+	}
+
+	select {
+	case got := <-done:
+		if len(got) != len(signals) {
+			t.Fatalf("signals len = %d, want %d", len(got), len(signals))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expectation did not receive future lifecycle signals")
+	}
+}
+
+func TestExpectationConsumesDistinctHistoricalSignals(t *testing.T) {
+	probe := New(t, WithTimeout(time.Second))
+	times := []time.Time{
+		time.Unix(1, 0).UTC(),
+		time.Unix(2, 0).UTC(),
+		time.Unix(3, 0).UTC(),
+	}
+	for i, status := range []string{StatusInProgress, StatusFailed, StatusInProgress} {
+		probe.NotifyLifecycle(context.Background(), runtimelifecycleprobe.Signal{
+			Kind:           runtimelifecycleprobe.DeliveryStatusChanged,
+			EventID:        "event-3",
+			SubscriberType: SubscriberNode,
+			SubscriberID:   "node-a",
+			Status:         status,
+			At:             times[i],
+		})
+	}
+
+	got := probe.Expect("event-3").
+		NodeInProgress("node-a").
+		NodeFailed("node-a").
+		NodeInProgress("node-a").
+		Require()
+	if len(got) != 3 {
+		t.Fatalf("signals len = %d, want 3", len(got))
+	}
+	if got[0].At != times[0] || got[1].At != times[1] || got[2].At != times[2] {
+		t.Fatalf("expectation times = %s, %s, %s; want %s, %s, %s",
+			got[0].At, got[1].At, got[2].At, times[0], times[1], times[2])
+	}
+}

--- a/internal/runtime/lifecycleprobe/probe.go
+++ b/internal/runtime/lifecycleprobe/probe.go
@@ -35,16 +35,27 @@ type Signal struct {
 	At             time.Time
 }
 
+type Cursor struct {
+	nextSequence uint64
+}
+
 type Probe struct {
-	mu      sync.Mutex
-	history []Signal
-	waiters map[uint64]waiter
-	nextID  uint64
+	mu           sync.Mutex
+	history      []recordedSignal
+	waiters      map[uint64]waiter
+	nextID       uint64
+	nextSequence uint64
 }
 
 type waiter struct {
-	want Signal
-	ch   chan Signal
+	after uint64
+	want  Signal
+	ch    chan recordedSignal
+}
+
+type recordedSignal struct {
+	sequence uint64
+	signal   Signal
 }
 
 const maxHistory = 4096
@@ -65,14 +76,19 @@ func (p *Probe) NotifyLifecycle(_ context.Context, signal Signal) {
 		signal.At = time.Now().UTC()
 	}
 	p.mu.Lock()
-	p.history = append(p.history, signal)
+	p.nextSequence++
+	record := recordedSignal{
+		sequence: p.nextSequence,
+		signal:   signal,
+	}
+	p.history = append(p.history, record)
 	if len(p.history) > maxHistory {
-		p.history = append([]Signal(nil), p.history[len(p.history)-maxHistory:]...)
+		p.history = append([]recordedSignal(nil), p.history[len(p.history)-maxHistory:]...)
 	}
 	for id, waiting := range p.waiters {
-		if signalMatches(waiting.want, signal) {
+		if record.sequence >= waiting.after && signalMatches(waiting.want, signal) {
 			delete(p.waiters, id)
-			waiting.ch <- signal
+			waiting.ch <- record
 			close(waiting.ch)
 		}
 	}
@@ -80,43 +96,52 @@ func (p *Probe) NotifyLifecycle(_ context.Context, signal Signal) {
 }
 
 func (p *Probe) Wait(ctx context.Context, want Signal) (Signal, error) {
+	signal, _, err := p.WaitAfter(ctx, Cursor{}, want)
+	return signal, err
+}
+
+func (p *Probe) WaitAfter(ctx context.Context, cursor Cursor, want Signal) (Signal, Cursor, error) {
 	if p == nil {
-		return Signal{}, errors.New("lifecycle probe is nil")
+		return Signal{}, Cursor{}, errors.New("lifecycle probe is nil")
 	}
 	want = want.Normalized()
 	if want.Kind == "" {
-		return Signal{}, errors.New("lifecycle probe wait kind is required")
+		return Signal{}, Cursor{}, errors.New("lifecycle probe wait kind is required")
 	}
 	if want.EventID == "" {
-		return Signal{}, errors.New("lifecycle probe wait event_id is required")
+		return Signal{}, Cursor{}, errors.New("lifecycle probe wait event_id is required")
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	after := cursor.nextSequence
+	if after == 0 {
+		after = 1
+	}
 	p.mu.Lock()
-	for _, signal := range p.history {
-		if signalMatches(want, signal) {
+	for _, record := range p.history {
+		if record.sequence >= after && signalMatches(want, record.signal) {
 			p.mu.Unlock()
-			return signal, nil
+			return record.signal, Cursor{nextSequence: record.sequence + 1}, nil
 		}
 	}
 	p.nextID++
 	id := p.nextID
-	ch := make(chan Signal, 1)
+	ch := make(chan recordedSignal, 1)
 	if p.waiters == nil {
 		p.waiters = make(map[uint64]waiter)
 	}
-	p.waiters[id] = waiter{want: want, ch: ch}
+	p.waiters[id] = waiter{after: after, want: want, ch: ch}
 	p.mu.Unlock()
 
 	select {
-	case signal := <-ch:
-		return signal, nil
+	case record := <-ch:
+		return record.signal, Cursor{nextSequence: record.sequence + 1}, nil
 	case <-ctx.Done():
 		p.mu.Lock()
 		delete(p.waiters, id)
 		p.mu.Unlock()
-		return Signal{}, fmt.Errorf("wait for lifecycle %s event %s: %w", want.Kind, want.EventID, ctx.Err())
+		return Signal{}, Cursor{}, fmt.Errorf("wait for lifecycle %s event %s: %w", want.Kind, want.EventID, ctx.Err())
 	}
 }
 

--- a/internal/runtime/lifecycleprobe/probe_test.go
+++ b/internal/runtime/lifecycleprobe/probe_test.go
@@ -66,3 +66,81 @@ func TestProbeWaitReturnsContextError(t *testing.T) {
 		t.Fatalf("WaitForDeliveryStatus error = %v, want context canceled", err)
 	}
 }
+
+func TestProbeWaitAfterConsumesDistinctHistoricalSignals(t *testing.T) {
+	probe := New()
+	times := []time.Time{
+		time.Unix(1, 0).UTC(),
+		time.Unix(2, 0).UTC(),
+		time.Unix(3, 0).UTC(),
+	}
+	for i, status := range []string{"in_progress", "failed", "in_progress"} {
+		probe.NotifyLifecycle(context.Background(), Signal{
+			Kind:           DeliveryStatusChanged,
+			EventID:        "event-4",
+			SubscriberType: "node",
+			SubscriberID:   "node-a",
+			Status:         status,
+			At:             times[i],
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var cursor Cursor
+	first, next, err := probe.WaitAfter(ctx, cursor, Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        "event-4",
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Status:         "in_progress",
+	})
+	if err != nil {
+		t.Fatalf("WaitAfter first in_progress: %v", err)
+	}
+	failed, next, err := probe.WaitAfter(ctx, next, Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        "event-4",
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Status:         "failed",
+	})
+	if err != nil {
+		t.Fatalf("WaitAfter failed: %v", err)
+	}
+	second, _, err := probe.WaitAfter(ctx, next, Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        "event-4",
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Status:         "in_progress",
+	})
+	if err != nil {
+		t.Fatalf("WaitAfter second in_progress: %v", err)
+	}
+	if first.At != times[0] || failed.At != times[1] || second.At != times[2] {
+		t.Fatalf("WaitAfter sequence times = %s, %s, %s; want %s, %s, %s",
+			first.At, failed.At, second.At, times[0], times[1], times[2])
+	}
+}
+
+func TestProbeWaitForDeliveryStatusAllowsSubscriberIDWildcard(t *testing.T) {
+	probe := New()
+	probe.NotifyLifecycle(context.Background(), Signal{
+		Kind:           DeliveryStatusChanged,
+		EventID:        "event-5",
+		SubscriberType: "node",
+		SubscriberID:   "reviewer",
+		Status:         "delivered",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := probe.WaitForDeliveryStatus(ctx, "event-5", "node", "", "delivered")
+	if err != nil {
+		t.Fatalf("WaitForDeliveryStatus wildcard subscriber id: %v", err)
+	}
+	if got.SubscriberID != "reviewer" {
+		t.Fatalf("subscriber id = %q, want reviewer", got.SubscriberID)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/runtime/lifecycleprobe/lifecycletest`, a test helper wrapper around the shipped lifecycle probe.
- Provide typed subscriber/status constants, direct `Require...` wait helpers, and an `Expect(eventID).Step().Require()` chain for readable milestone assertions.
- Let the helper implement `lifecycleprobe.Observer`, so tests can pass it directly as `TestLifecycleProbe` while still using the helper methods.
- Migrate two APIV1 event.publish probe waits to the helper as a real usage example.

Related to #1380.

## Validation

- `go test ./internal/runtime/lifecycleprobe ./internal/runtime/lifecycleprobe/lifecycletest -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes|TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate' -count=1`
- `go test ./internal/runtime/lifecycleprobe/lifecycletest -count=1`
- `go test ./...`
