### PR TITLE
[agent-c][issue #1390] Retry SQLite pipeline busy transactions

### DIFF
--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -119,7 +119,7 @@ var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016
 const (
 	workflowInstanceTimerOwnerNode = "workflow_instance_store"
 
-	sqlitePipelineTransactionMaxAttempts = 100
+	sqlitePipelineTransactionRetryBudget = 5 * time.Second
 	sqlitePipelineTransactionBaseDelay   = 10 * time.Millisecond
 	sqlitePipelineTransactionMaxDelay    = 100 * time.Millisecond
 )
@@ -424,10 +424,32 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 }
 
 func (s *WorkflowInstanceStore) runInSQLitePipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return s.runInSQLitePipelineTransactionWithBudget(ctx, fn, sqlitePipelineTransactionRetryBudget)
+}
+
+func (s *WorkflowInstanceStore) runInSQLitePipelineTransactionWithBudget(ctx context.Context, fn func(context.Context, *sql.Tx) error, retryBudget time.Duration) error {
+	if retryBudget <= 0 {
+		retryBudget = sqlitePipelineTransactionRetryBudget
+	}
+	retryDeadline := time.Now().Add(retryBudget)
+	retryDeadlineOwnedByBudget := true
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(retryDeadline) {
+		retryDeadline = ctxDeadline
+		retryDeadlineOwnedByBudget = false
+	}
 	var lastErr error
-	for attempt := 0; attempt < sqlitePipelineTransactionMaxAttempts; attempt++ {
+	for attempt := 0; ; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if time.Until(retryDeadline) <= 0 {
+			if !retryDeadlineOwnedByBudget {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return context.DeadlineExceeded
+			}
+			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
 		}
 		err := s.runInPipelineTransactionOnce(ctx, fn)
 		if err == nil || !sqlitePipelineBusyError(err) {
@@ -435,6 +457,17 @@ func (s *WorkflowInstanceStore) runInSQLitePipelineTransaction(ctx context.Conte
 		}
 		lastErr = err
 		delay := sqlitePipelineTransactionRetryDelay(attempt)
+		if remaining := time.Until(retryDeadline); remaining <= 0 {
+			if !retryDeadlineOwnedByBudget {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return context.DeadlineExceeded
+			}
+			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
+		} else if delay > remaining {
+			delay = remaining
+		}
 		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
@@ -443,7 +476,13 @@ func (s *WorkflowInstanceStore) runInSQLitePipelineTransaction(ctx context.Conte
 		case <-timer.C:
 		}
 	}
-	return lastErr
+}
+
+func sqlitePipelineTransactionRetryBudgetError(retryBudget time.Duration, lastErr error) error {
+	if lastErr == nil {
+		return fmt.Errorf("sqlite pipeline transaction retry budget %s exceeded: %w", retryBudget, context.DeadlineExceeded)
+	}
+	return fmt.Errorf("sqlite pipeline transaction retry budget %s exceeded: %w", retryBudget, lastErr)
 }
 
 func sqlitePipelineTransactionRetryDelay(attempt int) time.Duration {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -116,7 +116,13 @@ const (
 
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
-const workflowInstanceTimerOwnerNode = "workflow_instance_store"
+const (
+	workflowInstanceTimerOwnerNode = "workflow_instance_store"
+
+	sqlitePipelineTransactionMaxAttempts = 100
+	sqlitePipelineTransactionBaseDelay   = 10 * time.Millisecond
+	sqlitePipelineTransactionMaxDelay    = 100 * time.Millisecond
+)
 
 type workflowCreateEntityInitialValuesContextKey struct{}
 
@@ -408,11 +414,61 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 	if fn == nil {
 		return nil
 	}
-	if s == nil || s.db == nil {
-		return fn(ctx, nil)
-	}
 	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
 		return fn(ctx, tx)
+	}
+	if s.isSQLite() {
+		return s.runInSQLitePipelineTransaction(ctx, fn)
+	}
+	return s.runInPipelineTransactionOnce(ctx, fn)
+}
+
+func (s *WorkflowInstanceStore) runInSQLitePipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	var lastErr error
+	for attempt := 0; attempt < sqlitePipelineTransactionMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := s.runInPipelineTransactionOnce(ctx, fn)
+		if err == nil || !sqlitePipelineBusyError(err) {
+			return err
+		}
+		lastErr = err
+		delay := sqlitePipelineTransactionRetryDelay(attempt)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+func sqlitePipelineTransactionRetryDelay(attempt int) time.Duration {
+	delay := time.Duration(attempt+1) * sqlitePipelineTransactionBaseDelay
+	if delay > sqlitePipelineTransactionMaxDelay {
+		return sqlitePipelineTransactionMaxDelay
+	}
+	return delay
+}
+
+func sqlitePipelineBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "sqlite_busy") ||
+		strings.Contains(text, "sqlite_locked") ||
+		strings.Contains(text, "database is locked") ||
+		strings.Contains(text, "database table is locked") ||
+		strings.Contains(text, "database is busy")
+}
+
+func (s *WorkflowInstanceStore) runInPipelineTransactionOnce(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	if s == nil || s.db == nil {
+		return fn(ctx, nil)
 	}
 	// SQLite has a single writer. Keep the local-dev pipeline transaction
 	// boundary authoritative instead of letting sibling handler activations

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -210,6 +211,50 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionStopsRetryOnContext
 	}
 }
 
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionCapsProductionBusyTimeout(t *testing.T) {
+	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, 5*time.Second)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	baseCtx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	ctx, cancel := context.WithTimeout(baseCtx, 7*time.Second)
+	defer cancel()
+
+	lockTx, err := lockDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	t.Cleanup(func() { _ = lockTx.Rollback() })
+	if _, err := lockTx.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	var attempts int32
+	started := time.Now()
+	err = store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, uuid.NewString(), time.Now().UTC())
+		return err
+	})
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("RunInPipelineTransaction succeeded under persistent sqlite write lock")
+	}
+	if !strings.Contains(err.Error(), "retry budget") || !sqlitePipelineBusyError(err) {
+		t.Fatalf("RunInPipelineTransaction error = %v, want busy retry budget exhaustion", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want one production busy_timeout window", got)
+	}
+	if elapsed >= 6500*time.Millisecond {
+		t.Fatalf("RunInPipelineTransaction elapsed = %s, want cap near one production busy_timeout window", elapsed)
+	}
+}
+
 func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryActiveTransaction(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := NewSQLiteWorkflowInstanceStore(db)
@@ -270,14 +315,19 @@ func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 
 func newSQLiteWorkflowInstanceStoreBusyTestDBs(t *testing.T) (*sql.DB, *sql.DB) {
 	t.Helper()
+	return newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, time.Millisecond)
+}
+
+func newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t *testing.T, busyTimeout time.Duration) (*sql.DB, *sql.DB) {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "workflow.db")
-	workflowDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path)
-	lockDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path)
+	workflowDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path, busyTimeout)
+	lockDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path, busyTimeout)
 	createSQLiteWorkflowInstanceStoreTestSchema(t, workflowDB)
 	return workflowDB, lockDB
 }
 
-func openSQLiteWorkflowInstanceStoreBusyTestDB(t *testing.T, path string) *sql.DB {
+func openSQLiteWorkflowInstanceStoreBusyTestDB(t *testing.T, path string, busyTimeout time.Duration) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -286,10 +336,14 @@ func openSQLiteWorkflowInstanceStoreBusyTestDB(t *testing.T, path string) *sql.D
 	db.SetMaxOpenConns(4)
 	db.SetMaxIdleConns(4)
 	t.Cleanup(func() { _ = db.Close() })
+	busyTimeoutMillis := int(busyTimeout / time.Millisecond)
+	if busyTimeout > 0 && busyTimeoutMillis == 0 {
+		busyTimeoutMillis = 1
+	}
 	for _, stmt := range []string{
 		`PRAGMA foreign_keys = ON`,
 		`PRAGMA journal_mode = WAL`,
-		`PRAGMA busy_timeout = 1`,
+		fmt.Sprintf(`PRAGMA busy_timeout = %d`, busyTimeoutMillis),
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("configure sqlite file db: %v", err)

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -3,7 +3,11 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -94,6 +98,164 @@ func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *test
 	}
 }
 
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRetriesBusyAndFlushesPostCommitOnce(t *testing.T) {
+	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBs(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	ctx, cancel := context.WithTimeout(runtimecorrelation.WithRunID(context.Background(), uuid.NewString()), 2*time.Second)
+	defer cancel()
+
+	lockTx, err := lockDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	lockCommitted := false
+	t.Cleanup(func() {
+		if !lockCommitted {
+			_ = lockTx.Rollback()
+		}
+	})
+	if _, err := lockTx.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	busySeen := make(chan struct{})
+	var closeBusy sync.Once
+	var attempts int32
+	var postCommitActions int32
+	done := make(chan error, 1)
+	go func() {
+		done <- store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if tx == nil {
+				return errors.New("pipeline transaction is required")
+			}
+			atomic.AddInt32(&attempts, 1)
+			if !QueuePipelinePostCommitAction(txctx, func() {
+				atomic.AddInt32(&postCommitActions, 1)
+			}) {
+				return errors.New("queue pipeline post-commit action")
+			}
+			_, err := tx.ExecContext(txctx, `
+				INSERT INTO runs (run_id, status, started_at)
+				VALUES (?, 'running', ?)
+			`, uuid.NewString(), time.Now().UTC())
+			if sqlitePipelineBusyError(err) {
+				closeBusy.Do(func() { close(busySeen) })
+			}
+			return err
+		})
+	}()
+
+	select {
+	case <-busySeen:
+	case <-ctx.Done():
+		t.Fatalf("wait for deterministic sqlite busy attempt: %v", ctx.Err())
+	}
+	if err := lockTx.Commit(); err != nil {
+		t.Fatalf("release sqlite write lock: %v", err)
+	}
+	lockCommitted = true
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunInPipelineTransaction after lock release: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("wait for retried pipeline transaction: %v", ctx.Err())
+	}
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Fatalf("attempts = %d, want retry after busy", got)
+	}
+	if got := atomic.LoadInt32(&postCommitActions); got != 1 {
+		t.Fatalf("post-commit actions = %d, want only successful attempt flushed", got)
+	}
+}
+
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionStopsRetryOnContextDeadline(t *testing.T) {
+	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBs(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	baseCtx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+
+	lockTx, err := lockDB.BeginTx(baseCtx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	t.Cleanup(func() { _ = lockTx.Rollback() })
+	if _, err := lockTx.ExecContext(baseCtx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(baseCtx, 35*time.Millisecond)
+	defer cancel()
+	var attempts int32
+	err = store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, uuid.NewString(), time.Now().UTC())
+		return err
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunInPipelineTransaction error = %v, want context deadline", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got == 0 {
+		t.Fatal("expected at least one busy attempt before context deadline")
+	}
+}
+
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryActiveTransaction(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin active tx: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	busyErr := errors.New("SQLITE_BUSY: database is locked")
+	var attempts int32
+	err = store.RunInPipelineTransaction(WithPipelineSQLTxContext(ctx, tx), func(txctx context.Context, gotTx *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		if gotTx != tx {
+			t.Fatalf("transaction = %#v, want active transaction", gotTx)
+		}
+		return busyErr
+	})
+	if !errors.Is(err, busyErr) {
+		t.Fatalf("RunInPipelineTransaction error = %v, want sentinel busy error", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want no retry inside active transaction", got)
+	}
+}
+
+func TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := NewWorkflowInstanceStore(db)
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	busyErr := errors.New("SQLITE_BUSY: database is locked")
+	var attempts int32
+
+	err := store.RunInPipelineTransaction(ctx, func(context.Context, *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		return busyErr
+	})
+	if !errors.Is(err, busyErr) {
+		t.Fatalf("RunInPipelineTransaction error = %v, want sentinel busy error", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want no retry for postgres dialect", got)
+	}
+}
+
 func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
@@ -102,6 +264,42 @@ func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
+	createSQLiteWorkflowInstanceStoreTestSchema(t, db)
+	return db
+}
+
+func newSQLiteWorkflowInstanceStoreBusyTestDBs(t *testing.T) (*sql.DB, *sql.DB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "workflow.db")
+	workflowDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path)
+	lockDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path)
+	createSQLiteWorkflowInstanceStoreTestSchema(t, workflowDB)
+	return workflowDB, lockDB
+}
+
+func openSQLiteWorkflowInstanceStoreBusyTestDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite file db: %v", err)
+	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
+	t.Cleanup(func() { _ = db.Close() })
+	for _, stmt := range []string{
+		`PRAGMA foreign_keys = ON`,
+		`PRAGMA journal_mode = WAL`,
+		`PRAGMA busy_timeout = 1`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("configure sqlite file db: %v", err)
+		}
+	}
+	return db
+}
+
+func createSQLiteWorkflowInstanceStoreTestSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
 	for _, stmt := range []string{
 		`CREATE TABLE runs (
 			run_id TEXT PRIMARY KEY,
@@ -209,7 +407,6 @@ func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 			t.Fatalf("create sqlite test schema: %v", err)
 		}
 	}
-	return db
 }
 
 func assertSQLiteMutationCount(t *testing.T, db *sql.DB, entityID, field, writerID, handlerStep, oldValue, newValue string, want int) {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2549,10 +2549,13 @@ engine:
       scope: >
         SQLite supports explicit local-dev pipeline coordination for workflow instance state, pipeline engine transaction/query
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
-        replay scope consumption. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
+        replay scope consumption. SQLite pipeline transactions own process-local serialization plus bounded SQLITE_BUSY /
+        database-locked retry at WorkflowInstanceStore.RunInPipelineTransaction, so pipeline producers do not branch on
+        backend write contention. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
       excludes:
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150
+      - broader runtime mutation-store write serialization outside WorkflowInstanceStore owned by #1388
     - name: runtime_budget_spend_rows
       owner: internal/runtime/budgetspend.Store consumed through runtime.Stores.BudgetSpendStore and internal/runtime.BudgetTracker
       sqlite_owner: internal/store.SQLiteRuntimeStore budget/spend methods over spend_ledger and entity_state

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2549,9 +2549,10 @@ engine:
       scope: >
         SQLite supports explicit local-dev pipeline coordination for workflow instance state, pipeline engine transaction/query
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
-        replay scope consumption. SQLite pipeline transactions own process-local serialization plus bounded SQLITE_BUSY /
-        database-locked retry at WorkflowInstanceStore.RunInPipelineTransaction, so pipeline producers do not branch on
-        backend write contention. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
+        replay scope consumption. SQLite pipeline transactions own process-local serialization plus elapsed-budgeted
+        SQLITE_BUSY / database-locked retry at WorkflowInstanceStore.RunInPipelineTransaction, so pipeline producers do not
+        branch on backend write contention. Postgres remains authoritative for production cross-runtime transaction and claim
+        semantics.
       excludes:
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150


### PR DESCRIPTION
## Summary

- Adds bounded SQLite busy/locked retry at the canonical `WorkflowInstanceStore.RunInPipelineTransaction` boundary.
- Preserves active transaction behavior: nested `PipelineSQLTxFromContext` work is not replayed.
- Preserves Postgres one-shot transaction semantics.
- Adds deterministic file-backed SQLite lock tests for retry success, context deadline, post-commit action single flush, active transaction no-retry, and Postgres dialect no-retry.
- Updates root `platform-spec.yaml` to account for the tactical SQLite pipeline transaction write-policy behavior.

Closes #1390

Parent remains open: #1388.  
Sibling remains split: #1389.

## Governing Context

Exact spec references:

- `platform-spec.yaml` `runtime_store_backend_selection.selected_contracts.pipeline_coordination_workflow_instance_and_replay_rows`.
- `platform-spec.yaml` `runtime_store_backend_selection.selected_contracts.event_delivery_receipt_and_replay_rows`.
- `platform-spec.yaml` `runtime_store_backend_selection.raw_sql_runtime_consumer_boundary_for_sqlite`.

Issue/gate context:

- Pre-audit: https://github.com/division-sh/swarm/issues/1390#issuecomment-4643142875
- Gate: https://github.com/division-sh/swarm/issues/1390#issuecomment-4643239883

## Semantic Migration Accounting

New canonical owner for this child slice:

- `internal/runtime/pipeline.WorkflowInstanceStore.RunInPipelineTransaction` owns SQLite pipeline transaction retry/backoff.

Old invalid paths:

- Producer-owned SQLite retry.
- API/test-level public readback retry as a backend contention workaround.
- One-transition-only system-node retry.

Production paths checked for surviving old behavior:

- `internal/runtime/pipeline/engine_adapter.go` pipeline engine transaction runner.
- `internal/runtime/pipeline/workflow_instance_store_sqlite.go` SQLite mutate/write/create/upsert paths.
- `internal/runtime/pipeline/system_node_receipt_store.go` SQLite in-progress/processed-failed/dead-letter delivery transitions.
- Nested active transaction context through `PipelineSQLTxFromContext`.
- Postgres dialect through `NewWorkflowInstanceStore`.

Migration completeness:

- Complete for the approved `sqlite_pipeline.workflow_instance_store_transaction_busy_retry` child class.
- Not complete for #1388 broader runtime mutation-store write serialization.

## Proof

- `go test ./internal/runtime/pipeline -run 'TestSQLiteWorkflowInstanceStore_RunInPipelineTransaction|TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect' -count=1 -v` -> passed.
- `go test ./internal/runtime/pipeline -count=1` -> passed.
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)$' -count=1 -v` -> passed.
- `go test ./internal/apiv1 -run 'TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends$' -count=1 -v` -> passed.
- `go test ./internal/apiv1 -count=1` -> passed.
- `go test ./internal/store -run 'TestSQLiteDynamicFlowActivation|TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction' -count=1 -v` -> passed.
- `go test ./...` -> passed.
