### PR TITLE
[agent-c][issue #1388] Add backend-neutral runtime mutation boundary

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2474,7 +2474,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			RuntimeLogStore:     sqliteStore,
 			SchemaBootstrapper:  sqliteStore,
 			EventStore:          sqliteStore,
-			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB),
+			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore),
 			SessionRegistry:     sqliteStore,
 			ConversationStore:   sqliteStore,
 			ManagerStore:        sqliteStore,

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -524,6 +524,9 @@ func (eb *EventBus) publishTransactional(
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
+	if runner, ok := txStore.(EventTransactionRunner); ok && runner != nil {
+		return eb.publishTransactionalWithRunner(ctx, evt, start, deferredTransitions, txStore, runner)
+	}
 	tx, err := txStore.BeginEventTx(ctx)
 	if err != nil {
 		return fmt.Errorf("begin publish tx: %w", err)
@@ -643,6 +646,119 @@ func (eb *EventBus) publishTransactional(
 	return nil
 }
 
+func (eb *EventBus) publishTransactionalWithRunner(
+	ctx context.Context,
+	evt events.Event,
+	start time.Time,
+	deferredTransitions *[]runtimepipeline.DeferredPipelineTransition,
+	txStore TransactionalEventStore,
+	runner EventTransactionRunner,
+) error {
+	var inboundPlan RoutePlan
+	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
+	targetFailure := false
+	dispatchQueued := false
+	queueReason := ""
+	if err := runner.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
+		if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+			return fmt.Errorf("persist event: %w", err)
+		}
+		plan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
+		if err != nil {
+			return err
+		}
+		inboundPlan = plan
+		if inboundPlan.HasPersistentDeliveries() {
+			if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
+				return fmt.Errorf("persist event deliveries: %w", err)
+			}
+		}
+		if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
+			if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+				return fmt.Errorf("persist committed replay scope: %w", err)
+			}
+		} else if replayScopePersistenceRequired(eb.store) {
+			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		}
+		if inboundPlan.TargetFailure != "" {
+			applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
+			status, errText := pipelineReceiptStatus(txctx, nil)
+			if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
+				return fmt.Errorf("persist pipeline receipt: %w", err)
+			}
+			targetFailure = true
+			return nil
+		}
+		if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
+			return err
+		} else if reason != "" {
+			dispatchQueued = true
+			queueReason = reason
+			return nil
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
+	if targetFailure {
+		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
+		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
+		return nil
+	}
+	if dispatchQueued {
+		eb.logDispatchQueued(ctx, queueReason, evt, len(inboundPlan.RecipientIDs()), false, false)
+		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
+		return nil
+	}
+
+	postCommitActions := make([]func(), 0, 8)
+	dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
+	dispatchCtx = runtimepipeline.WithPipelinePostCommitActions(dispatchCtx, &postCommitActions)
+	dispatchCtx = runtimepipeline.WithPipelineReceiptOverride(dispatchCtx, receiptOverride)
+	passthrough, deferred, err := eb.runInterceptors(dispatchCtx, evt)
+	if err != nil {
+		eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
+		return err
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	if deferredTransitions != nil {
+		runtimepipeline.FlushDeferredPipelineTransitions(dispatchCtx, *deferredTransitions)
+	}
+
+	if passthrough {
+		recipients := inboundPlan.RecipientIDs()
+		if len(recipients) > 0 {
+			eb.logQueuedDeliveries(dispatchCtx, evt, inboundPlan.PersistedRecipientIDs(), "matched_agent_subscription", inboundPlan.ExtraDetail)
+			if err := eb.deliverToRecipientsWithRoutes(dispatchCtx, evt, recipients, inboundPlan.DeliveryRoutes()); err != nil {
+				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
+				return nil
+			}
+			eb.logDelivery(dispatchCtx, evt, recipients, inboundPlan.ExtraDetail)
+		}
+		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
+			if err := eb.publishDeferred(dispatchCtx, *inboundPlan.CycleEscalation); err != nil {
+				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
+				return nil
+			}
+		}
+		if strings.TrimSpace(inboundPlan.ContradictionReason) != "" {
+			_ = eb.emitContradiction(dispatchCtx, evt, inboundPlan.ContradictionReason)
+		}
+	}
+	eb.logPublished(dispatchCtx, evt, int(time.Since(start)/time.Microsecond))
+
+	for _, d := range deferred {
+		if err := eb.publishDeferred(dispatchCtx, d); err != nil {
+			eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
+			return nil
+		}
+	}
+	eb.recordCommittedPublishReceipt(dispatchCtx, evt, nil)
+	return nil
+}
+
 func (eb *EventBus) publishAcknowledgedTransactional(
 	ctx context.Context,
 	evt events.Event,
@@ -652,6 +768,9 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
+	}
+	if runner, ok := txStore.(EventTransactionRunner); ok && runner != nil {
+		return eb.publishAcknowledgedTransactionalWithRunner(ctx, evt, start, txStore, runner)
 	}
 	tx, err := txStore.BeginEventTx(ctx)
 	if err != nil {
@@ -725,6 +844,77 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 	committed = true
 	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
 	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
+	eb.dispatchCommittedPublishAsync(ctx, evt, inboundPlan)
+	return nil
+}
+
+func (eb *EventBus) publishAcknowledgedTransactionalWithRunner(
+	ctx context.Context,
+	evt events.Event,
+	start time.Time,
+	txStore TransactionalEventStore,
+	runner EventTransactionRunner,
+) error {
+	var inboundPlan RoutePlan
+	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
+	targetFailure := false
+	dispatchQueued := false
+	queueReason := ""
+	if err := runner.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
+		if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+			return fmt.Errorf("persist event: %w", err)
+		}
+		plan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
+		if err != nil {
+			return err
+		}
+		inboundPlan = plan
+		if inboundPlan.HasPersistentDeliveries() {
+			if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
+				return fmt.Errorf("persist event deliveries: %w", err)
+			}
+		}
+		if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
+			if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+				return fmt.Errorf("persist committed replay scope: %w", err)
+			}
+		} else if replayScopePersistenceRequired(eb.store) {
+			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		}
+		if inboundPlan.TargetFailure != "" {
+			applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
+			status, errText := pipelineReceiptStatus(txctx, nil)
+			if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
+				return fmt.Errorf("persist pipeline receipt: %w", err)
+			}
+			targetFailure = true
+			return nil
+		}
+		if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
+			return err
+		} else if reason != "" {
+			dispatchQueued = true
+			queueReason = reason
+			return nil
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
+	if targetFailure {
+		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
+		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
+		eb.recordCommittedPublishConvergence(ctx, evt)
+		return nil
+	}
+	if dispatchQueued {
+		eb.logDispatchQueued(ctx, queueReason, evt, len(inboundPlan.RecipientIDs()), false, true)
+		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
+		eb.recordCommittedPublishConvergence(ctx, evt)
+		return nil
+	}
 	eb.dispatchCommittedPublishAsync(ctx, evt, inboundPlan)
 	return nil
 }

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -141,6 +141,10 @@ type TransactionalEventStore interface {
 	UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status, errText string) error
 }
 
+type EventTransactionRunner interface {
+	RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error
+}
+
 type TransactionalEventDeliveryRoutePersistence interface {
 	InsertEventDeliveriesWithTargetsTx(ctx context.Context, tx *sql.Tx, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error
 }

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -98,6 +98,11 @@ type WorkflowInstanceStore struct {
 	db                 *sql.DB
 	dialect            workflowStoreDialect
 	sqlitePipelineTxMu sync.Mutex
+	runtimeMutation    RuntimeMutationRunner
+}
+
+type RuntimeMutationRunner interface {
+	RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error
 }
 
 type WorkflowInstanceFieldSelector struct {
@@ -136,6 +141,10 @@ func NewWorkflowInstanceStore(db *sql.DB) *WorkflowInstanceStore {
 
 func NewSQLiteWorkflowInstanceStore(db *sql.DB) *WorkflowInstanceStore {
 	return &WorkflowInstanceStore{db: db, dialect: workflowStoreDialectSQLite}
+}
+
+func NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db *sql.DB, runner RuntimeMutationRunner) *WorkflowInstanceStore {
+	return &WorkflowInstanceStore{db: db, dialect: workflowStoreDialectSQLite, runtimeMutation: runner}
 }
 
 func withWorkflowCreateEntityInitialValues(ctx context.Context, fields map[string]any) context.Context {
@@ -418,6 +427,9 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 		return fn(ctx, tx)
 	}
 	if s.isSQLite() {
+		if s.runtimeMutation != nil {
+			return s.runtimeMutation.RunRuntimeMutation(ctx, fn)
+		}
 		return s.runInSQLitePipelineTransaction(ctx, fn)
 	}
 	return s.runInPipelineTransactionOnce(ctx, fn)
@@ -451,8 +463,26 @@ func (s *WorkflowInstanceStore) runInSQLitePipelineTransactionWithBudget(ctx con
 			}
 			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
 		}
-		err := s.runInPipelineTransactionOnce(ctx, fn)
-		if err == nil || !sqlitePipelineBusyError(err) {
+		attemptCtx, cancel := context.WithDeadline(ctx, retryDeadline)
+		err := s.runInPipelineTransactionOnce(attemptCtx, fn)
+		attemptErr := attemptCtx.Err()
+		cancel()
+		if err == nil {
+			if attemptErr != nil {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
+			}
+			return nil
+		}
+		if attemptErr != nil {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
+		}
+		if !sqlitePipelineBusyError(err) {
 			return err
 		}
 		lastErr = err

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -212,11 +212,14 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionStopsRetryOnContext
 }
 
 func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionCapsProductionBusyTimeout(t *testing.T) {
-	const productionBusyTimeout = 5 * time.Second
-	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, productionBusyTimeout)
+	const (
+		driverBusyTimeout = 50 * time.Millisecond
+		retryBudget       = 120 * time.Millisecond
+	)
+	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, driverBusyTimeout)
 	store := NewSQLiteWorkflowInstanceStore(db)
 	baseCtx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-	ctx, cancel := context.WithTimeout(baseCtx, 3*productionBusyTimeout)
+	ctx, cancel := context.WithTimeout(baseCtx, time.Second)
 	defer cancel()
 
 	lockTx, err := lockDB.BeginTx(ctx, nil)
@@ -232,22 +235,27 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionCapsProductionBusyT
 	}
 
 	var attempts int32
-	err = store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	start := time.Now()
+	err = store.runInSQLitePipelineTransactionWithBudget(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		atomic.AddInt32(&attempts, 1)
 		_, err := tx.ExecContext(txctx, `
 			INSERT INTO runs (run_id, status, started_at)
 			VALUES (?, 'running', ?)
 		`, uuid.NewString(), time.Now().UTC())
 		return err
-	})
+	}, retryBudget)
+	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("RunInPipelineTransaction succeeded under persistent sqlite write lock")
 	}
 	if !strings.Contains(err.Error(), "retry budget") || !sqlitePipelineBusyError(err) {
 		t.Fatalf("RunInPipelineTransaction error = %v, want busy retry budget exhaustion", err)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
-		t.Fatalf("attempts = %d, want one production busy_timeout window", got)
+	if got := atomic.LoadInt32(&attempts); got == 0 {
+		t.Fatal("expected at least one sqlite busy attempt before retry budget exhaustion")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("elapsed = %s, want retry budget to cap sqlite busy retries", elapsed)
 	}
 }
 

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -242,103 +242,99 @@ func (s *SQLiteRuntimeStore) ApplyActiveRunQuiescence(ctx context.Context, req r
 		deliveryNote = out.ReasonCode
 	}
 
-	runIDs := normalizeQuiescenceRunIDs(req.RunIDs)
-	if len(runIDs) == 0 && !req.AllActiveRuns {
+	requestedRunIDs := normalizeQuiescenceRunIDs(req.RunIDs)
+	if len(requestedRunIDs) == 0 && !req.AllActiveRuns {
 		return out, nil
 	}
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimerunquiescence.Result{}, fmt.Errorf("begin sqlite active run quiescence tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	baseOut := out
+	if err := s.runRuntimeMutation(ctx, "sqlite active run quiescence", func(txctx context.Context, tx *sql.Tx) error {
+		attemptOut := baseOut
+		var runs []runtimerunquiescence.QuiescedRun
+		var err error
+		if req.AllActiveRuns {
+			runs, err = sqliteLockAllActiveQuiescenceRunsTx(txctx, tx)
+		} else {
+			runs, err = sqliteLockActiveQuiescenceRunsTx(txctx, tx, requestedRunIDs)
 		}
-	}()
+		if err != nil {
+			return err
+		}
+		attemptRunIDs := quiescenceRunIDs(runs)
+		if len(attemptRunIDs) == 0 {
+			out = attemptOut
+			return nil
+		}
+		deliveries, err := sqliteLockActiveRunQuiescenceDeliveriesTx(txctx, tx, attemptRunIDs)
+		if err != nil {
+			return err
+		}
+		for _, delivery := range deliveries {
+			attemptOut.Deliveries = append(attemptOut.Deliveries, runtimerunquiescence.QuiescedDelivery{
+				DeliveryID:      delivery.DeliveryID,
+				RunID:           delivery.RunID,
+				EventID:         delivery.EventID,
+				SubscriberType:  delivery.SubscriberType,
+				SubscriberID:    delivery.SubscriberID,
+				PreviousStatus:  delivery.Status,
+				Status:          "dead_letter",
+				ReasonCode:      attemptOut.ReasonCode,
+				PreviousReason:  delivery.ReasonCode,
+				ActiveSessionID: delivery.ActiveSessionID,
+				Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != attemptOut.ReasonCode,
+			})
+		}
+		for _, run := range runs {
+			nextStatus := run.Status
+			changed := false
+			if activeRunQuiescenceRunStatusActive(run.Status) {
+				nextStatus = "cancelled"
+				changed = true
+			}
+			attemptOut.Runs = append(attemptOut.Runs, runtimerunquiescence.QuiescedRun{
+				RunID:          run.RunID,
+				PreviousStatus: run.Status,
+				Status:         nextStatus,
+				ReasonCode:     attemptOut.ReasonCode,
+				Changed:        changed,
+			})
+		}
+		if req.DryRun {
+			out = attemptOut
+			return nil
+		}
 
-	var runs []runtimerunquiescence.QuiescedRun
-	if req.AllActiveRuns {
-		runs, err = sqliteLockAllActiveQuiescenceRunsTx(ctx, tx)
-	} else {
-		runs, err = sqliteLockActiveQuiescenceRunsTx(ctx, tx, runIDs)
-	}
-	if err != nil {
+		eventIDs := map[string]struct{}{}
+		for _, delivery := range deliveries {
+			if err := sqliteTerminalizeActiveRunQuiescenceDeliveryTx(txctx, tx, delivery, attemptOut.ReasonCode, deliveryNote, now); err != nil {
+				return err
+			}
+			if delivery.EventID != "" {
+				eventIDs[delivery.EventID] = struct{}{}
+			}
+		}
+		for eventID := range eventIDs {
+			if err := sqliteUpsertActiveRunQuiescencePipelineReceiptTx(txctx, tx, eventID, attemptOut.ReasonCode, deliveryNote, now); err != nil {
+				return err
+			}
+			attemptOut.PipelineReceiptCount++
+		}
+		for _, run := range runs {
+			if !activeRunQuiescenceRunStatusActive(run.Status) {
+				continue
+			}
+			if err := sqliteMarkActiveRunQuiescenceRunTerminalTx(txctx, tx, run.RunID, now); err != nil {
+				return err
+			}
+			if err := sqliteUpsertActiveRunQuiescenceRunControlTx(txctx, tx, run.RunID, attemptOut.ReasonCode, attemptOut.ControlledBy, now); err != nil {
+				return err
+			}
+		}
+		out = attemptOut
+		return nil
+	}); err != nil {
 		return runtimerunquiescence.Result{}, err
 	}
-	runIDs = quiescenceRunIDs(runs)
-	if len(runIDs) == 0 {
-		return out, nil
-	}
-	deliveries, err := sqliteLockActiveRunQuiescenceDeliveriesTx(ctx, tx, runIDs)
-	if err != nil {
-		return runtimerunquiescence.Result{}, err
-	}
-	for _, delivery := range deliveries {
-		out.Deliveries = append(out.Deliveries, runtimerunquiescence.QuiescedDelivery{
-			DeliveryID:      delivery.DeliveryID,
-			RunID:           delivery.RunID,
-			EventID:         delivery.EventID,
-			SubscriberType:  delivery.SubscriberType,
-			SubscriberID:    delivery.SubscriberID,
-			PreviousStatus:  delivery.Status,
-			Status:          "dead_letter",
-			ReasonCode:      out.ReasonCode,
-			PreviousReason:  delivery.ReasonCode,
-			ActiveSessionID: delivery.ActiveSessionID,
-			Changed:         delivery.Status != "dead_letter" || delivery.ReasonCode != out.ReasonCode,
-		})
-	}
-	for _, run := range runs {
-		nextStatus := run.Status
-		changed := false
-		if activeRunQuiescenceRunStatusActive(run.Status) {
-			nextStatus = "cancelled"
-			changed = true
-		}
-		out.Runs = append(out.Runs, runtimerunquiescence.QuiescedRun{
-			RunID:          run.RunID,
-			PreviousStatus: run.Status,
-			Status:         nextStatus,
-			ReasonCode:     out.ReasonCode,
-			Changed:        changed,
-		})
-	}
-	if req.DryRun {
-		return out, nil
-	}
-
-	eventIDs := map[string]struct{}{}
-	for _, delivery := range deliveries {
-		if err := sqliteTerminalizeActiveRunQuiescenceDeliveryTx(ctx, tx, delivery, out.ReasonCode, deliveryNote, now); err != nil {
-			return runtimerunquiescence.Result{}, err
-		}
-		if delivery.EventID != "" {
-			eventIDs[delivery.EventID] = struct{}{}
-		}
-	}
-	for eventID := range eventIDs {
-		if err := sqliteUpsertActiveRunQuiescencePipelineReceiptTx(ctx, tx, eventID, out.ReasonCode, deliveryNote, now); err != nil {
-			return runtimerunquiescence.Result{}, err
-		}
-		out.PipelineReceiptCount++
-	}
-	for _, run := range runs {
-		if !activeRunQuiescenceRunStatusActive(run.Status) {
-			continue
-		}
-		if err := sqliteMarkActiveRunQuiescenceRunTerminalTx(ctx, tx, run.RunID, now); err != nil {
-			return runtimerunquiescence.Result{}, err
-		}
-		if err := sqliteUpsertActiveRunQuiescenceRunControlTx(ctx, tx, run.RunID, out.ReasonCode, out.ControlledBy, now); err != nil {
-			return runtimerunquiescence.Result{}, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return runtimerunquiescence.Result{}, fmt.Errorf("commit sqlite active run quiescence tx: %w", err)
-	}
-	committed = true
 	return out, nil
 }
 

--- a/internal/store/budget_spend.go
+++ b/internal/store/budget_spend.go
@@ -127,13 +127,15 @@ func (s *SQLiteRuntimeStore) RecordSpend(ctx context.Context, rec budgetspend.Sp
 	if err := validateBudgetSpendEntity(rec.EntityID); err != nil {
 		return err
 	}
-	_, err := s.DB.ExecContext(ctx, `
+	if err := s.runRuntimeMutation(ctx, "sqlite budget spend record", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
 			INSERT INTO spend_ledger (
 				entity_id, flow_instance, agent_id, model, model_alias, backend_profile, provider, transport, resolved_model,
 				input_tokens, output_tokens, cost_usd, invocation_type, usage_accounting, created_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, sqliteNullUUID(rec.EntityID), rec.FlowInstance, rec.AgentID, rec.Model, rec.ModelAlias, rec.BackendProfile, rec.Provider, rec.Transport, rec.ResolvedModel, rec.InputTokens, rec.OutputTokens, rec.CostUSD, rec.InvocationType, rec.UsageAccounting, rec.RecordedAt.UTC())
-	if err != nil {
+		return err
+	}); err != nil {
 		return fmt.Errorf("record sqlite spend: %w", err)
 	}
 	return nil

--- a/internal/store/runtime_log_persistence.go
+++ b/internal/store/runtime_log_persistence.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -153,16 +154,18 @@ func (s *SQLiteRuntimeStore) PersistRuntimeLog(ctx context.Context, record runti
 	if strings.TrimSpace(record.RunID) != "" {
 		return s.AppendEvent(ctx, evt)
 	}
-	_, err = s.DB.ExecContext(ctx, `
-		INSERT OR IGNORE INTO events (
-			event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
-			scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
-		)
-		VALUES (?, NULL, 'platform.runtime_log', NULL, NULL, '{}', '{}', '[]',
-			'global', ?, 0, 'runtime', 'platform', ?, ?)
-	`, evt.ID(), string(evt.Payload()), sqliteNullUUID(evt.ParentEventID()), evt.CreatedAt())
-	if err != nil {
-		return fmt.Errorf("persist sqlite runtime log: %w", err)
-	}
-	return nil
+	return s.runRuntimeMutation(ctx, "sqlite runtime log", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT OR IGNORE INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
+				scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
+			)
+			VALUES (?, NULL, 'platform.runtime_log', NULL, NULL, '{}', '{}', '[]',
+				'global', ?, 0, 'runtime', 'platform', ?, ?)
+		`, evt.ID(), string(evt.Payload()), sqliteNullUUID(evt.ParentEventID()), evt.CreatedAt())
+		if err != nil {
+			return fmt.Errorf("persist sqlite runtime log: %w", err)
+		}
+		return nil
+	})
 }

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+)
+
+const (
+	sqliteRuntimeMutationRetryBudget = 5 * time.Second
+	sqliteRuntimeMutationBaseDelay   = 10 * time.Millisecond
+	sqliteRuntimeMutationMaxDelay    = 100 * time.Millisecond
+)
+
+// RunRuntimeMutation is the canonical selected-store write boundary for the
+// SQLite runtime backend. It owns process-local write serialization, bounded
+// SQLITE_BUSY/database-locked retry, transaction context propagation, and
+// post-commit action flushing for runtime mutation producers.
+func (s *SQLiteRuntimeStore) RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return s.runRuntimeMutation(ctx, "sqlite runtime mutation", fn)
+}
+
+func (s *SQLiteRuntimeStore) RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return s.runRuntimeMutation(ctx, "sqlite event transaction", fn)
+}
+
+func (s *PostgresStore) RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	postCommit := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
+	if err := fn(txctx, tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) runRuntimeMutation(ctx context.Context, label string, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return fn(ctx, tx)
+	}
+	retryDeadline := time.Now().Add(sqliteRuntimeMutationRetryBudget)
+	ctxDeadline, hasCtxDeadline := ctx.Deadline()
+	if hasCtxDeadline && ctxDeadline.Before(retryDeadline) {
+		retryDeadline = ctxDeadline
+	}
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Until(retryDeadline) <= 0 {
+			if hasCtxDeadline && !time.Now().Before(ctxDeadline) {
+				return context.DeadlineExceeded
+			}
+			return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
+		}
+		attemptCtx, cancel := context.WithDeadline(ctx, retryDeadline)
+		err := s.runRuntimeMutationOnce(attemptCtx, fn)
+		attemptErr := attemptCtx.Err()
+		cancel()
+		if err == nil {
+			if attemptErr != nil {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
+			}
+			return nil
+		}
+		if attemptErr != nil {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
+		}
+		if !sqliteRuntimeMutationBusyError(err) {
+			return err
+		}
+		lastErr = err
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		delay := sqliteRuntimeMutationRetryDelay(attempt)
+		if remaining := time.Until(retryDeadline); remaining <= 0 {
+			if hasCtxDeadline && !time.Now().Before(ctxDeadline) {
+				return context.DeadlineExceeded
+			}
+			return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
+		} else if delay > remaining {
+			delay = remaining
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *SQLiteRuntimeStore) runRuntimeMutationOnce(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	postCommit, err := s.runRuntimeMutationOnceLocked(ctx, fn)
+	if err != nil {
+		return err
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) runRuntimeMutationOnceLocked(ctx context.Context, fn func(context.Context, *sql.Tx) error) ([]func(), error) {
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	postCommit := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
+	if err := fn(txctx, tx); err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return postCommit, nil
+}
+
+func sqliteRuntimeMutationRetryBudgetError(label string, lastErr error) error {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		label = "sqlite runtime mutation"
+	}
+	if lastErr == nil {
+		return fmt.Errorf("%s retry budget %s exceeded: %w", label, sqliteRuntimeMutationRetryBudget, context.DeadlineExceeded)
+	}
+	return fmt.Errorf("%s retry budget %s exceeded: %w", label, sqliteRuntimeMutationRetryBudget, lastErr)
+}
+
+func sqliteRuntimeMutationRetryDelay(attempt int) time.Duration {
+	delay := time.Duration(attempt+1) * sqliteRuntimeMutationBaseDelay
+	if delay > sqliteRuntimeMutationMaxDelay {
+		return sqliteRuntimeMutationMaxDelay
+	}
+	return delay
+}
+
+func sqliteRuntimeMutationBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "sqlite_busy") ||
+		strings.Contains(text, "sqlite_locked") ||
+		strings.Contains(text, "database is locked") ||
+		strings.Contains(text, "database table is locked") ||
+		strings.Contains(text, "database is busy")
+}

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteRuntimeMutationWritersConsumeCanonicalBoundary(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list store files: %v", err)
+	}
+	allowed := map[string]string{
+		"BeginEventTx":                 "legacy TransactionalEventStore fallback; SQLite production publish uses RunEventTransaction",
+		"runRuntimeMutationOnceLocked": "canonical SQLite runtime mutation executor opens the owned transaction while serialized",
+		"runRuntimeMutationOnce":       "canonical SQLite runtime mutation executor flushes successful post-commit actions",
+		"runRuntimeMutation":           "canonical SQLite runtime mutation executor",
+		"RunRuntimeMutation":           "canonical SQLite runtime mutation executor",
+		"RunEventTransaction":          "canonical SQLite event transaction executor",
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !sqliteRuntimeStoreReceiver(fn) {
+				continue
+			}
+			if _, ok := allowed[fn.Name.Name]; ok {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				switch selectorPath(sel) {
+				case "s.DB.BeginTx", "s.DB.Exec", "s.DB.ExecContext":
+					pos := fset.Position(sel.Pos())
+					t.Fatalf("%s:%d: SQLiteRuntimeStore.%s bypasses RunRuntimeMutation with %s", file, pos.Line, fn.Name.Name, selectorPath(sel))
+				}
+				return true
+			})
+		}
+	}
+}
+
+func TestProductionSQLitePipelineStoreConsumesRuntimeMutationRunner(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "cmd", "swarm", "main.go"))
+	if err != nil {
+		t.Fatalf("read cmd/swarm/main.go: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)") {
+		t.Fatal("cmd/swarm SQLite store construction must wire WorkflowInstanceStore through SQLiteRuntimeStore.RunRuntimeMutation")
+	}
+	if strings.Contains(text, "NewSQLiteWorkflowInstanceStore(sqliteStore.DB)") {
+		t.Fatal("cmd/swarm SQLite store construction uses legacy WorkflowInstanceStore without the runtime mutation boundary")
+	}
+}
+
+func sqliteRuntimeStoreReceiver(fn *ast.FuncDecl) bool {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return false
+	}
+	switch expr := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := expr.X.(*ast.Ident); ok {
+			return ident.Name == "SQLiteRuntimeStore"
+		}
+	case *ast.Ident:
+		return expr.Name == "SQLiteRuntimeStore"
+	}
+	return false
+}
+
+func selectorPath(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		base := selectorPath(e.X)
+		if base == "" {
+			return e.Sel.Name
+		}
+		return base + "." + e.Sel.Name
+	default:
+		return ""
+	}
+}

--- a/internal/store/runtime_mutation_test.go
+++ b/internal/store/runtime_mutation_test.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestSQLiteRuntimeStore_RunRuntimeMutationRetriesBusyAndFlushesPostCommitOnce(t *testing.T) {
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	lockTx, err := lockStore.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	lockCommitted := false
+	t.Cleanup(func() {
+		if !lockCommitted {
+			_ = lockTx.Rollback()
+		}
+	})
+	if _, err := lockTx.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	busySeen := make(chan struct{})
+	var closeBusy sync.Once
+	var attempts int32
+	var postCommitActions int32
+	done := make(chan error, 1)
+	go func() {
+		done <- store.RunRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if tx == nil {
+				return errors.New("runtime mutation transaction is required")
+			}
+			atomic.AddInt32(&attempts, 1)
+			if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
+				atomic.AddInt32(&postCommitActions, 1)
+			}) {
+				return errors.New("queue pipeline post-commit action")
+			}
+			_, err := tx.ExecContext(txctx, `
+				INSERT INTO runs (run_id, status, started_at)
+				VALUES (?, 'running', ?)
+			`, uuid.NewString(), time.Now().UTC())
+			if sqliteRuntimeMutationBusyError(err) {
+				closeBusy.Do(func() { close(busySeen) })
+			}
+			return err
+		})
+	}()
+
+	select {
+	case <-busySeen:
+	case <-ctx.Done():
+		t.Fatalf("wait for deterministic sqlite busy attempt: %v", ctx.Err())
+	}
+	if err := lockTx.Commit(); err != nil {
+		t.Fatalf("release sqlite write lock: %v", err)
+	}
+	lockCommitted = true
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunRuntimeMutation after lock release: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("wait for retried runtime mutation: %v", ctx.Err())
+	}
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Fatalf("attempts = %d, want retry after busy", got)
+	}
+	if got := atomic.LoadInt32(&postCommitActions); got != 1 {
+		t.Fatalf("post-commit actions = %d, want only successful attempt flushed", got)
+	}
+}
+
+func TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline(t *testing.T) {
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond)
+	baseCtx := context.Background()
+
+	lockTx, err := lockStore.DB.BeginTx(baseCtx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	t.Cleanup(func() { _ = lockTx.Rollback() })
+	if _, err := lockTx.ExecContext(baseCtx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(baseCtx, 35*time.Millisecond)
+	defer cancel()
+	var attempts int32
+	err = store.RunRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, uuid.NewString(), time.Now().UTC())
+		return err
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunRuntimeMutation error = %v, want context deadline", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got == 0 {
+		t.Fatal("expected at least one busy attempt before context deadline")
+	}
+}
+
+func TestSQLiteRuntimeStore_RunRuntimeMutationContextDeadlineCapsDriverBusyTimeout(t *testing.T) {
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, 50*time.Millisecond)
+	baseCtx := context.Background()
+
+	lockTx, err := lockStore.DB.BeginTx(baseCtx, nil)
+	if err != nil {
+		t.Fatalf("begin locking tx: %v", err)
+	}
+	t.Cleanup(func() { _ = lockTx.Rollback() })
+	if _, err := lockTx.ExecContext(baseCtx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, uuid.NewString(), time.Now().UTC()); err != nil {
+		t.Fatalf("hold sqlite write lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(baseCtx, 80*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err = store.RunRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, uuid.NewString(), time.Now().UTC())
+		return err
+	})
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunRuntimeMutation error = %v, want context deadline", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("elapsed = %s, want context deadline to cap sqlite busy_timeout", elapsed)
+	}
+}
+
+func TestSQLiteRuntimeStore_RunRuntimeMutationDoesNotRetryActiveTransaction(t *testing.T) {
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	tx, err := store.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin active tx: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	busyErr := errors.New("SQLITE_BUSY: database is locked")
+	var attempts int32
+	err = store.RunRuntimeMutation(runtimepipeline.WithPipelineSQLTxContext(ctx, tx), func(_ context.Context, gotTx *sql.Tx) error {
+		atomic.AddInt32(&attempts, 1)
+		if gotTx != tx {
+			t.Fatalf("transaction = %#v, want active transaction", gotTx)
+		}
+		return busyErr
+	})
+	if !errors.Is(err, busyErr) {
+		t.Fatalf("RunRuntimeMutation error = %v, want sentinel busy error", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want no retry inside active transaction", got)
+	}
+}
+
+func TestSQLiteRuntimeStore_RunRuntimeMutationPostCommitCanReenterRuntimeMutation(t *testing.T) {
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	innerDone := make(chan error, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- store.RunRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO runs (run_id, status, started_at)
+				VALUES (?, 'running', ?)
+			`, uuid.NewString(), time.Now().UTC()); err != nil {
+				return err
+			}
+			if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
+				innerCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
+				innerDone <- store.RunRuntimeMutation(innerCtx, func(innerTxCtx context.Context, innerTx *sql.Tx) error {
+					_, err := innerTx.ExecContext(innerTxCtx, `
+						INSERT INTO runs (run_id, status, started_at)
+						VALUES (?, 'running', ?)
+					`, uuid.NewString(), time.Now().UTC())
+					return err
+				})
+			}) {
+				return errors.New("queue pipeline post-commit action")
+			}
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunRuntimeMutation with re-entrant post-commit action: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("post-commit runtime mutation re-entry did not complete before context deadline: %v", ctx.Err())
+	}
+
+	select {
+	case err := <-innerDone:
+		if err != nil {
+			t.Fatalf("re-entrant RunRuntimeMutation from post-commit action: %v", err)
+		}
+	default:
+		t.Fatal("post-commit action did not run")
+	}
+}
+
+func TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	done := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			done <- store.RunEventTransaction(ctx, func(context.Context, *sql.Tx) error {
+				started <- struct{}{}
+				select {
+				case <-release:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			})
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			t.Fatalf("postgres event transaction callback %d did not enter concurrently: %v", i+1, ctx.Err())
+		}
+	}
+	close(release)
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("RunEventTransaction %d: %v", i+1, err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("wait for postgres event transaction %d: %v", i+1, ctx.Err())
+		}
+	}
+}
+
+func newSQLiteRuntimeMutationBusyStores(t *testing.T, busyTimeout time.Duration) (*SQLiteRuntimeStore, *SQLiteRuntimeStore) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	store := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
+	lockStore := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
+	for _, db := range []*sql.DB{store.DB, lockStore.DB} {
+		if _, err := db.ExecContext(context.Background(), fmt.Sprintf("PRAGMA busy_timeout = %d", int(busyTimeout/time.Millisecond))); err != nil {
+			t.Fatalf("set sqlite busy_timeout: %v", err)
+		}
+	}
+	return store, lockStore
+}

--- a/internal/store/sqlite_mailbox_v1.go
+++ b/internal/store/sqlite_mailbox_v1.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
-	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/google/uuid"
 )
 
@@ -138,160 +137,145 @@ func (s *SQLiteRuntimeStore) DecideV1MailboxItem(ctx context.Context, input Mail
 	default:
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("unsupported mailbox decision action %q", input.Action)
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return MailboxV1DecisionOutcome{}, fmt.Errorf("begin sqlite v1 mailbox decision tx: %w", err)
-	}
-	postCommitActions := make([]func(), 0, 4)
-	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
 	idempotencyReq, hasIdempotency, err := prepareMailboxV1IdempotencyRequest(input)
 	if err != nil {
 		return MailboxV1DecisionOutcome{}, err
 	}
-	if hasIdempotency {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, idempotencyReq.Now.UTC()); err != nil {
-			return MailboxV1DecisionOutcome{}, fmt.Errorf("purge expired sqlite api idempotency: %w", err)
-		}
-		existing, ok, err := sqliteLoadAPIIdempotency(ctx, tx, idempotencyReq)
-		if err != nil {
-			return MailboxV1DecisionOutcome{}, err
-		}
-		if ok {
-			if existing.RequestHash != idempotencyReq.RequestHash {
-				return MailboxV1DecisionOutcome{}, &APIIdempotencyConflictError{
-					OriginalRequestHash:    existing.RequestHash,
-					ConflictingRequestHash: idempotencyReq.RequestHash,
-					Method:                 idempotencyReq.Method,
-					ResourceID:             existing.ResourceID,
+	var outcome MailboxV1DecisionOutcome
+	if err := s.runRuntimeMutation(ctx, "sqlite v1 mailbox decision", func(txctx context.Context, tx *sql.Tx) error {
+		if hasIdempotency {
+			if _, err := tx.ExecContext(txctx, `DELETE FROM api_idempotency WHERE expires_at <= ?`, idempotencyReq.Now.UTC()); err != nil {
+				return fmt.Errorf("purge expired sqlite api idempotency: %w", err)
+			}
+			existing, ok, err := sqliteLoadAPIIdempotency(txctx, tx, idempotencyReq)
+			if err != nil {
+				return err
+			}
+			if ok {
+				if existing.RequestHash != idempotencyReq.RequestHash {
+					return &APIIdempotencyConflictError{
+						OriginalRequestHash:    existing.RequestHash,
+						ConflictingRequestHash: idempotencyReq.RequestHash,
+						Method:                 idempotencyReq.Method,
+						ResourceID:             existing.ResourceID,
+					}
 				}
+				var result MailboxV1DecisionResult
+				if err := json.Unmarshal(existing.Response, &result); err != nil {
+					return fmt.Errorf("decode sqlite api idempotency mailbox response: %w", err)
+				}
+				if err := normalizeSQLiteMailboxV1DecisionReplayResult(txctx, tx, &result); err != nil {
+					return err
+				}
+				outcome = MailboxV1DecisionOutcome{Result: result, Replayed: true}
+				return nil
 			}
-			var result MailboxV1DecisionResult
-			if err := json.Unmarshal(existing.Response, &result); err != nil {
-				return MailboxV1DecisionOutcome{}, fmt.Errorf("decode sqlite api idempotency mailbox response: %w", err)
-			}
-			if err := normalizeSQLiteMailboxV1DecisionReplayResult(ctx, tx, &result); err != nil {
-				return MailboxV1DecisionOutcome{}, err
-			}
-			if err := tx.Commit(); err != nil {
-				return MailboxV1DecisionOutcome{}, fmt.Errorf("commit sqlite v1 mailbox idempotency replay tx: %w", err)
-			}
-			committed = true
-			return MailboxV1DecisionOutcome{Result: result, Replayed: true}, nil
 		}
-	}
-	if action == "deferred" && !input.DeferUntil.After(input.Now) {
-		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
-	}
+		if action == "deferred" && !input.DeferUntil.After(input.Now) {
+			return &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
+		}
 
-	row, err := s.loadSQLiteMailboxV1RowTx(ctx, tx, input.MailboxID)
-	if err != nil {
+		row, err := s.loadSQLiteMailboxV1RowTx(txctx, tx, input.MailboxID)
+		if err != nil {
+			return err
+		}
+		if row.Status != "pending" {
+			return &MailboxV1AlreadyDecidedError{
+				MailboxID:        row.ID,
+				ExistingDecision: row.existingDecision(),
+				DecidedAt:        row.decisionTime(input.Now),
+			}
+		}
+		if action == "approved" && strings.TrimSpace(input.ApprovalEventType) == "" {
+			return &MailboxV1ApprovalRouteError{MailboxID: row.ID, ItemType: row.Type}
+		}
+
+		decisionID := uuid.NewString()
+		outcome = MailboxV1DecisionOutcome{
+			Result: MailboxV1DecisionResult{
+				OK:                true,
+				MailboxDecisionID: decisionID,
+				Status:            mailboxV1APIStatus("decided", action),
+			},
+		}
+		var expiresAt any
+		notes := strings.TrimSpace(input.Reason)
+		if action == "deferred" {
+			expiresAt = input.DeferUntil.UTC()
+			if notes == "" {
+				notes = "Deferred until " + input.DeferUntil.UTC().Format(time.RFC3339Nano)
+			}
+		}
+		if action == "approved" {
+			eventID := uuid.NewString()
+			evt, err := row.approvalEvent(eventID, decisionID, strings.TrimSpace(input.ApprovalEventType), input.ActorTokenID, input.DecisionPayload, input.Now)
+			if err != nil {
+				return err
+			}
+			subscribers := append([]string(nil), input.ApprovalEventSubscribers...)
+			if subscribers == nil {
+				subscribers = []string{}
+			}
+			subscriberSource := strings.TrimSpace(input.ApprovalEventSubscriberSource)
+			if subscriberSource == "" {
+				subscriberSource = "unavailable"
+			}
+			outcome.Result.DownstreamEventID = eventID
+			outcome.Result.DownstreamEventName = strings.TrimSpace(input.ApprovalEventType)
+			outcome.Result.DownstreamSubscribers = &subscribers
+			outcome.Result.DownstreamSubscriberSource = subscriberSource
+			outcome.ApprovalEvent = &evt
+		}
+		res, err := tx.ExecContext(txctx, `
+			UPDATE mailbox
+			SET status = 'decided',
+			    decision = ?,
+			    decision_notes = NULLIF(?, ''),
+			    decided_by = NULLIF(?, ''),
+			    decided_at = ?,
+			    expires_at = COALESCE(?, expires_at)
+			WHERE item_id = ?
+			  AND status = 'pending'
+		`, action, notes, strings.TrimSpace(input.ActorTokenID), input.Now, expiresAt, row.ID)
+		if err != nil {
+			return fmt.Errorf("decide sqlite v1 mailbox item: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			latest, latestErr := s.loadSQLiteMailboxV1RowTx(txctx, tx, row.ID)
+			if latestErr != nil {
+				return latestErr
+			}
+			return &MailboxV1AlreadyDecidedError{
+				MailboxID:        latest.ID,
+				ExistingDecision: latest.existingDecision(),
+				DecidedAt:        latest.decisionTime(input.Now),
+			}
+		}
+		if outcome.ApprovalEvent != nil {
+			publishTx := input.ApprovalEventTx
+			if publishTx == nil {
+				publishTx = s.appendSQLiteMailboxV1ApprovalEventTx
+			}
+			if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
+				return fmt.Errorf("publish sqlite v1 mailbox approval event: %w", err)
+			}
+		}
+		if hasIdempotency {
+			raw, err := json.Marshal(outcome.Result)
+			if err != nil {
+				return err
+			}
+			if err := sqliteStoreAPIIdempotency(txctx, tx, idempotencyReq, APIIdempotencyCompletion{
+				ResourceID: row.ID,
+				Response:   raw,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
 		return MailboxV1DecisionOutcome{}, err
 	}
-	if row.Status != "pending" {
-		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
-			MailboxID:        row.ID,
-			ExistingDecision: row.existingDecision(),
-			DecidedAt:        row.decisionTime(input.Now),
-		}
-	}
-	if action == "approved" && strings.TrimSpace(input.ApprovalEventType) == "" {
-		return MailboxV1DecisionOutcome{}, &MailboxV1ApprovalRouteError{MailboxID: row.ID, ItemType: row.Type}
-	}
-
-	decisionID := uuid.NewString()
-	outcome := MailboxV1DecisionOutcome{
-		Result: MailboxV1DecisionResult{
-			OK:                true,
-			MailboxDecisionID: decisionID,
-			Status:            mailboxV1APIStatus("decided", action),
-		},
-	}
-	var expiresAt any
-	notes := strings.TrimSpace(input.Reason)
-	if action == "deferred" {
-		expiresAt = input.DeferUntil.UTC()
-		if notes == "" {
-			notes = "Deferred until " + input.DeferUntil.UTC().Format(time.RFC3339Nano)
-		}
-	}
-	if action == "approved" {
-		eventID := uuid.NewString()
-		evt, err := row.approvalEvent(eventID, decisionID, strings.TrimSpace(input.ApprovalEventType), input.ActorTokenID, input.DecisionPayload, input.Now)
-		if err != nil {
-			return MailboxV1DecisionOutcome{}, err
-		}
-		subscribers := append([]string(nil), input.ApprovalEventSubscribers...)
-		if subscribers == nil {
-			subscribers = []string{}
-		}
-		subscriberSource := strings.TrimSpace(input.ApprovalEventSubscriberSource)
-		if subscriberSource == "" {
-			subscriberSource = "unavailable"
-		}
-		outcome.Result.DownstreamEventID = eventID
-		outcome.Result.DownstreamEventName = strings.TrimSpace(input.ApprovalEventType)
-		outcome.Result.DownstreamSubscribers = &subscribers
-		outcome.Result.DownstreamSubscriberSource = subscriberSource
-		outcome.ApprovalEvent = &evt
-	}
-	res, err := tx.ExecContext(ctx, `
-		UPDATE mailbox
-		SET status = 'decided',
-		    decision = ?,
-		    decision_notes = NULLIF(?, ''),
-		    decided_by = NULLIF(?, ''),
-		    decided_at = ?,
-		    expires_at = COALESCE(?, expires_at)
-		WHERE item_id = ?
-		  AND status = 'pending'
-	`, action, notes, strings.TrimSpace(input.ActorTokenID), input.Now, expiresAt, row.ID)
-	if err != nil {
-		return MailboxV1DecisionOutcome{}, fmt.Errorf("decide sqlite v1 mailbox item: %w", err)
-	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
-		latest, latestErr := s.loadSQLiteMailboxV1RowTx(ctx, tx, row.ID)
-		if latestErr != nil {
-			return MailboxV1DecisionOutcome{}, latestErr
-		}
-		return MailboxV1DecisionOutcome{}, &MailboxV1AlreadyDecidedError{
-			MailboxID:        latest.ID,
-			ExistingDecision: latest.existingDecision(),
-			DecidedAt:        latest.decisionTime(input.Now),
-		}
-	}
-	if outcome.ApprovalEvent != nil {
-		publishTx := input.ApprovalEventTx
-		if publishTx == nil {
-			publishTx = s.appendSQLiteMailboxV1ApprovalEventTx
-		}
-		if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
-			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish sqlite v1 mailbox approval event: %w", err)
-		}
-	}
-	if hasIdempotency {
-		raw, err := json.Marshal(outcome.Result)
-		if err != nil {
-			return MailboxV1DecisionOutcome{}, err
-		}
-		if err := sqliteStoreAPIIdempotency(ctx, tx, idempotencyReq, APIIdempotencyCompletion{
-			ResourceID: row.ID,
-			Response:   raw,
-		}); err != nil {
-			return MailboxV1DecisionOutcome{}, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return MailboxV1DecisionOutcome{}, fmt.Errorf("commit sqlite v1 mailbox decision tx: %w", err)
-	}
-	committed = true
-	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	return outcome, nil
 }
 

--- a/internal/store/sqlite_run_completion.go
+++ b/internal/store/sqlite_run_completion.go
@@ -42,24 +42,10 @@ func (s *SQLiteRuntimeStore) MarkRunTerminal(ctx context.Context, runID, status,
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("sqlite runtime store is required")
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite mark run terminal tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, runID, status, errorSummary, endedAt); err != nil {
+	return s.runRuntimeMutation(ctx, "sqlite mark run terminal", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := s.sqliteMarkRunTerminalTx(txctx, tx, runID, status, errorSummary, endedAt)
 		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite mark run terminal tx: %w", err)
-	}
-	committed = true
-	return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context, evt events.Event) error {
@@ -70,49 +56,24 @@ func (s *SQLiteRuntimeStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Co
 	if eventID == "" {
 		return nil
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite standalone platform run convergence tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	rec, found, err := sqliteLoadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID)
-	if err != nil || !found || !isStandaloneRuntimePlatformRunRecord(rec) {
-		return err
-	}
-	switch strings.TrimSpace(rec.RunStatus) {
-	case "completed":
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite standalone platform run convergence noop tx: %w", err)
-		}
-		return nil
-	case "failed", "cancelled", "forked":
-		return fmt.Errorf("standalone runtime platform run %s already terminal with status %s", rec.RunID, strings.TrimSpace(rec.RunStatus))
-	}
-	active, err := sqliteHasActiveRunDeliveries(ctx, tx, rec.RunID)
-	if err != nil || active {
-		if err != nil {
+	return s.runRuntimeMutation(ctx, "sqlite standalone platform run convergence", func(txctx context.Context, tx *sql.Tx) error {
+		rec, found, err := sqliteLoadStandaloneRuntimePlatformRunRecord(txctx, tx, eventID)
+		if err != nil || !found || !isStandaloneRuntimePlatformRunRecord(rec) {
 			return err
 		}
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite standalone platform active-delivery noop tx: %w", err)
+		switch strings.TrimSpace(rec.RunStatus) {
+		case "completed":
+			return nil
+		case "failed", "cancelled", "forked":
+			return fmt.Errorf("standalone runtime platform run %s already terminal with status %s", rec.RunID, strings.TrimSpace(rec.RunStatus))
 		}
-		return nil
-	}
-	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, rec.RunID, "completed", "", s.now()); err != nil {
+		active, err := sqliteHasActiveRunDeliveries(txctx, tx, rec.RunID)
+		if err != nil || active {
+			return err
+		}
+		_, err = s.sqliteMarkRunTerminalTx(txctx, tx, rec.RunID, "completed", "", s.now())
 		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite standalone platform run convergence tx: %w", err)
-	}
-	committed = true
-	return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) ConvergeNormalRunCompletion(ctx context.Context, eventID string, workflowTerminalStates []string, flowTerminalStates map[string][]string) error {
@@ -135,63 +96,30 @@ func (s *SQLiteRuntimeStore) ConvergeNormalRunCompletion(ctx context.Context, ev
 	if !normalRunCompletionSupported(caps) {
 		return nil
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite normal run completion tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	candidate, found, err := sqliteNormalRunCompletionCandidateTx(ctx, tx, eventID)
-	if err != nil || !found {
-		return err
-	}
-	switch candidate.Status {
-	case "completed":
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite normal run completion noop tx: %w", err)
-		}
-		return nil
-	case "running":
-	default:
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite normal run completion non-running noop tx: %w", err)
-		}
-		return nil
-	}
-	if platformRec, platformFound, err := sqliteLoadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID); err != nil {
-		return err
-	} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite normal run completion platform noop tx: %w", err)
-		}
-		return nil
-	}
-	ready, err := s.sqliteNormalRunCompletionRunReadyTx(ctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
-	if err != nil || !ready {
-		if err != nil {
+	return s.runRuntimeMutation(ctx, "sqlite normal run completion", func(txctx context.Context, tx *sql.Tx) error {
+		candidate, found, err := sqliteNormalRunCompletionCandidateTx(txctx, tx, eventID)
+		if err != nil || !found {
 			return err
 		}
-		committed = true
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite normal run completion not-ready noop tx: %w", err)
+		switch candidate.Status {
+		case "completed":
+			return nil
+		case "running":
+		default:
+			return nil
 		}
-		return nil
-	}
-	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, candidate.RunID, "completed", "", s.now()); err != nil {
+		if platformRec, platformFound, err := sqliteLoadStandaloneRuntimePlatformRunRecord(txctx, tx, eventID); err != nil {
+			return err
+		} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
+			return nil
+		}
+		ready, err := s.sqliteNormalRunCompletionRunReadyTx(txctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
+		if err != nil || !ready {
+			return err
+		}
+		_, err = s.sqliteMarkRunTerminalTx(txctx, tx, candidate.RunID, "completed", "", s.now())
 		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite normal run completion tx: %w", err)
-	}
-	committed = true
-	return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) sqliteLoadRunLifecycleSnapshot(ctx context.Context, q execQueryer, runID string) (storerunlifecycle.Snapshot, error) {

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -34,6 +34,7 @@ type SQLiteRuntimeStore struct {
 
 	eventPayloadValidator EventPayloadValidator
 	startupMu             sync.Mutex
+	mutationMu            sync.Mutex
 	sessionMu             sync.Mutex
 	replayMu              sync.Mutex
 	startupOwner          string
@@ -136,7 +137,9 @@ func (s *SQLiteRuntimeStore) CanonicalEventReceiptsCapability(ctx context.Contex
 }
 
 func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) error {
-	return s.AppendEventTx(ctx, nil, evt)
+	return s.runRuntimeMutation(ctx, "sqlite append event", func(txctx context.Context, tx *sql.Tx) error {
+		return s.AppendEventTx(txctx, tx, evt)
+	})
 }
 
 func (s *SQLiteRuntimeStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) {
@@ -147,6 +150,11 @@ func (s *SQLiteRuntimeStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) 
 }
 
 func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	if tx == nil {
+		return s.runRuntimeMutation(ctx, "sqlite append event", func(txctx context.Context, tx *sql.Tx) error {
+			return s.AppendEventTx(txctx, tx, evt)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -169,19 +177,6 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 	if eventHasRouteIdentity(evt) && !caps.Events.LogRouteIdentity {
 		return fmt.Errorf("events source_route/target_route/target_set columns required for routed event")
 	}
-	ownedTx := tx == nil
-	if ownedTx {
-		tx, err = s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin sqlite event tx: %w", err)
-		}
-	}
-	committed := false
-	defer func() {
-		if ownedTx && !committed {
-			_ = tx.Rollback()
-		}
-	}()
 	if caps.Events.LogRunID {
 		if err := sqliteEnsureRunRow(ctx, tx, runID, id, name, createdAt); err != nil {
 			return err
@@ -197,12 +192,6 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 		scope, string(payload), chainDepth, sqliteNullString(producedBy), producedByType, sqliteNullUUID(sourceEventID), createdAt.UTC())
 	if err != nil {
 		return fmt.Errorf("append sqlite event: %w", err)
-	}
-	if ownedTx {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite event tx: %w", err)
-		}
-		committed = true
 	}
 	return nil
 }
@@ -265,24 +254,15 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveriesTx(ctx context.Context, tx *sq
 	if eventID == "" || len(agentIDs) == 0 {
 		return nil
 	}
+	if tx == nil {
+		return s.runRuntimeMutation(ctx, "sqlite delivery manifest", func(txctx context.Context, tx *sql.Tx) error {
+			return s.InsertEventDeliveriesTx(txctx, tx, eventID, agentIDs)
+		})
+	}
 	var runID sql.NullString
 	if err := chooseRowQueryer(s.DB, tx).QueryRowContext(ctx, `SELECT run_id FROM events WHERE event_id = ?`, eventID).Scan(&runID); err != nil {
 		return fmt.Errorf("load event run for sqlite delivery manifest: %w", err)
 	}
-	ownedTx := tx == nil
-	var err error
-	if ownedTx {
-		tx, err = s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin sqlite delivery manifest tx: %w", err)
-		}
-	}
-	committed := false
-	defer func() {
-		if ownedTx && !committed {
-			_ = tx.Rollback()
-		}
-	}()
 	for _, agentID := range agentIDs {
 		agentID = strings.TrimSpace(agentID)
 		if agentID == "" {
@@ -296,12 +276,6 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveriesTx(ctx context.Context, tx *sq
 		`, uuid.NewString(), sqliteNullString(runID.String), eventID, agentID, time.Now().UTC()); err != nil {
 			return fmt.Errorf("insert sqlite event delivery: %w", err)
 		}
-	}
-	if ownedTx {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite delivery manifest tx: %w", err)
-		}
-		committed = true
 	}
 	return nil
 }
@@ -357,38 +331,36 @@ func (s *SQLiteRuntimeStore) UpsertAgent(ctx context.Context, rec runtimemanager
 	if startedAt.IsZero() {
 		startedAt = time.Now().UTC()
 	}
-	q := execQueryer(s.DB)
-	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok {
-		q = tx
-	}
-	_, err = q.ExecContext(ctx, `
-		INSERT INTO agents (
-			agent_id, flow_instance, role, model, llm_backend, conversation_mode,
-			parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
-			runtime_descriptor, status, turn_count, last_active_at, created_at
-		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
-		ON CONFLICT(agent_id) DO UPDATE SET
-			flow_instance = excluded.flow_instance,
-			role = excluded.role,
-			model = excluded.model,
-			llm_backend = excluded.llm_backend,
-			conversation_mode = excluded.conversation_mode,
-			parent_agent_id = excluded.parent_agent_id,
-			entity_id = excluded.entity_id,
-			config = excluded.config,
-			subscriptions = excluded.subscriptions,
-			emit_events = excluded.emit_events,
-			tools = excluded.tools,
-			permissions = excluded.permissions,
-			runtime_descriptor = excluded.runtime_descriptor,
-			status = excluded.status,
-			last_active_at = excluded.last_active_at
-	`, projection.AgentID, sqliteNullString(projection.FlowInstance), projection.Role, projection.Model, projection.LLMBackend, projection.ConversationMode,
-		sqliteNullString(projection.ParentAgentID), sqliteNullUUID(projection.EntityID), string(projection.ConfigJSON), string(projection.SubscriptionsJSON),
-		string(projection.EmitEventsJSON), string(projection.ToolsJSON), string(projection.PermissionsJSON), string(projection.RuntimeDescriptor),
-		agentPersistedStatus(rec.Status), time.Now().UTC(), startedAt.UTC())
-	if err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite agent upsert", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO agents (
+				agent_id, flow_instance, role, model, llm_backend, conversation_mode,
+				parent_agent_id, entity_id, config, subscriptions, emit_events, tools, permissions,
+				runtime_descriptor, status, turn_count, last_active_at, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+			ON CONFLICT(agent_id) DO UPDATE SET
+				flow_instance = excluded.flow_instance,
+				role = excluded.role,
+				model = excluded.model,
+				llm_backend = excluded.llm_backend,
+				conversation_mode = excluded.conversation_mode,
+				parent_agent_id = excluded.parent_agent_id,
+				entity_id = excluded.entity_id,
+				config = excluded.config,
+				subscriptions = excluded.subscriptions,
+				emit_events = excluded.emit_events,
+				tools = excluded.tools,
+				permissions = excluded.permissions,
+				runtime_descriptor = excluded.runtime_descriptor,
+				status = excluded.status,
+				last_active_at = excluded.last_active_at
+		`, projection.AgentID, sqliteNullString(projection.FlowInstance), projection.Role, projection.Model, projection.LLMBackend, projection.ConversationMode,
+			sqliteNullString(projection.ParentAgentID), sqliteNullUUID(projection.EntityID), string(projection.ConfigJSON), string(projection.SubscriptionsJSON),
+			string(projection.EmitEventsJSON), string(projection.ToolsJSON), string(projection.PermissionsJSON), string(projection.RuntimeDescriptor),
+			agentPersistedStatus(rec.Status), time.Now().UTC(), startedAt.UTC())
+		return err
+	}); err != nil {
 		return fmt.Errorf("upsert sqlite agent: %w", err)
 	}
 	return nil
@@ -444,51 +416,42 @@ func (s *SQLiteRuntimeStore) MarkAgentTerminated(ctx context.Context, agentID st
 	}
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite mark agent terminated tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
 	now := s.now()
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agents
-		SET status = 'terminated',
-		    last_active_at = ?
-		WHERE agent_id = ?
-	`, now, agentID); err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite mark agent terminated", func(txctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agents
+			SET status = 'terminated',
+			    last_active_at = ?
+			WHERE agent_id = ?
+		`, now, agentID); err != nil {
+			return fmt.Errorf("mark sqlite agent terminated: %w", err)
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET status = 'terminated',
+			    termination_reason = 'cancelled',
+			    terminated_at = COALESCE(terminated_at, ?),
+			    lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = ?
+			WHERE agent_id = ?
+			  AND status IN ('active', 'suspended')
+		`, now, now, agentID); err != nil {
+			return fmt.Errorf("mark sqlite agent terminated sessions: %w", err)
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_conversation_audits
+			SET status = 'terminated',
+			    updated_at = ?
+			WHERE agent_id = ?
+			  AND status = 'active'
+		`, now, agentID); err != nil {
+			return fmt.Errorf("mark sqlite agent terminated conversation audits: %w", err)
+		}
+		return nil
+	}); err != nil {
 		return fmt.Errorf("mark sqlite agent terminated: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET status = 'terminated',
-		    termination_reason = 'cancelled',
-		    terminated_at = COALESCE(terminated_at, ?),
-		    lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = ?
-		WHERE agent_id = ?
-		  AND status IN ('active', 'suspended')
-	`, now, now, agentID); err != nil {
-		return fmt.Errorf("mark sqlite agent terminated sessions: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_conversation_audits
-		SET status = 'terminated',
-		    updated_at = ?
-		WHERE agent_id = ?
-		  AND status = 'active'
-	`, now, agentID); err != nil {
-		return fmt.Errorf("mark sqlite agent terminated conversation audits: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite mark agent terminated tx: %w", err)
-	}
-	committed = true
 	return nil
 }
 
@@ -522,10 +485,13 @@ func (s *SQLiteRuntimeStore) EnsureRuntimeIngressState(ctx context.Context, now 
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	if _, err := s.DB.ExecContext(ctx, `
-		INSERT OR IGNORE INTO runtime_ingress_state (id, status, controlled_by, updated_at)
-		VALUES (1, 'running', 'runtime', ?)
-	`, now.UTC()); err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite runtime ingress ensure", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT OR IGNORE INTO runtime_ingress_state (id, status, controlled_by, updated_at)
+			VALUES (1, 'running', 'runtime', ?)
+		`, now.UTC())
+		return err
+	}); err != nil {
 		return runtimeingress.State{}, fmt.Errorf("ensure sqlite runtime ingress state: %w", err)
 	}
 	return s.LoadRuntimeIngressState(ctx)
@@ -553,29 +519,52 @@ func (s *SQLiteRuntimeStore) TransitionRuntimeIngressState(ctx context.Context, 
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	if _, err := s.EnsureRuntimeIngressState(ctx, now); err != nil {
-		return runtimeingress.State{}, false, err
-	}
-	current, err := s.LoadRuntimeIngressState(ctx)
-	if err != nil {
-		return runtimeingress.State{}, false, err
-	}
-	if current.Status == target {
-		return current, false, nil
-	}
 	if controlledBy = strings.TrimSpace(controlledBy); controlledBy == "" {
 		controlledBy = "runtime"
 	}
-	_, err = s.DB.ExecContext(ctx, `
-		UPDATE runtime_ingress_state
-		SET status = ?, reason = ?, controlled_by = ?, transition_event_id = NULL, updated_at = ?
-		WHERE id = 1
-	`, string(target), sqliteNullString(reason), controlledBy, now.UTC())
-	if err != nil {
-		return runtimeingress.State{}, false, fmt.Errorf("update sqlite runtime ingress state: %w", err)
+	var state runtimeingress.State
+	changed := false
+	if err := s.runRuntimeMutation(ctx, "sqlite runtime ingress transition", func(txctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(txctx, `
+			INSERT OR IGNORE INTO runtime_ingress_state (id, status, controlled_by, updated_at)
+			VALUES (1, 'running', 'runtime', ?)
+		`, now.UTC()); err != nil {
+			return fmt.Errorf("ensure sqlite runtime ingress state: %w", err)
+		}
+		current, err := scanRuntimeIngressState(tx.QueryRowContext(txctx, `
+			SELECT status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id, ''), updated_at
+			FROM runtime_ingress_state
+			WHERE id = 1
+		`))
+		if err != nil {
+			return fmt.Errorf("load sqlite runtime ingress state: %w", err)
+		}
+		if current.Status == target {
+			state = current
+			changed = false
+			return nil
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE runtime_ingress_state
+			SET status = ?, reason = ?, controlled_by = ?, transition_event_id = NULL, updated_at = ?
+			WHERE id = 1
+		`, string(target), sqliteNullString(reason), controlledBy, now.UTC()); err != nil {
+			return fmt.Errorf("update sqlite runtime ingress state: %w", err)
+		}
+		state, err = scanRuntimeIngressState(tx.QueryRowContext(txctx, `
+			SELECT status, COALESCE(reason, ''), controlled_by, COALESCE(transition_event_id, ''), updated_at
+			FROM runtime_ingress_state
+			WHERE id = 1
+		`))
+		if err != nil {
+			return fmt.Errorf("load updated sqlite runtime ingress state: %w", err)
+		}
+		changed = true
+		return nil
+	}); err != nil {
+		return runtimeingress.State{}, false, err
 	}
-	state, err := s.LoadRuntimeIngressState(ctx)
-	return state, true, err
+	return state, changed, nil
 }
 
 func (s *SQLiteRuntimeStore) SetRuntimeIngressTransitionEvent(ctx context.Context, target runtimeingress.Status, eventID string, transitionAt time.Time) (bool, error) {
@@ -583,18 +572,28 @@ func (s *SQLiteRuntimeStore) SetRuntimeIngressTransitionEvent(ctx context.Contex
 	if eventID == "" {
 		return false, nil
 	}
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE runtime_ingress_state
-		SET transition_event_id = ?, updated_at = ?
-		WHERE id = 1
-		  AND status = ?
-		  AND updated_at = ?
-	`, eventID, transitionAt.UTC(), string(target), transitionAt.UTC())
-	if err != nil {
+	updated := false
+	if err := s.runRuntimeMutation(ctx, "sqlite runtime ingress transition event", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE runtime_ingress_state
+			SET transition_event_id = ?, updated_at = ?
+			WHERE id = 1
+			  AND status = ?
+			  AND updated_at = ?
+		`, eventID, transitionAt.UTC(), string(target), transitionAt.UTC())
+		if err != nil {
+			return err
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		updated = rows > 0
+		return nil
+	}); err != nil {
 		return false, fmt.Errorf("set sqlite runtime ingress transition event: %w", err)
 	}
-	rows, err := res.RowsAffected()
-	return rows > 0, err
+	return updated, nil
 }
 
 func (s *SQLiteRuntimeStore) StopRunControl(ctx context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
@@ -640,37 +639,27 @@ func (s *SQLiteRuntimeStore) sqliteRunControlTransition(ctx context.Context, req
 	if req.ControlledBy = strings.TrimSpace(req.ControlledBy); req.ControlledBy == "" {
 		req.ControlledBy = "api.v1"
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimeruncontrol.State{}, fmt.Errorf("begin sqlite run control transition: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	var state runtimeruncontrol.State
+	if err := s.runRuntimeMutation(ctx, "sqlite run control transition", func(txctx context.Context, tx *sql.Tx) error {
+		var err error
+		state, err = sqliteLoadRunControlState(txctx, tx, runID)
+		if err != nil {
+			return err
 		}
-	}()
-	state, err := sqliteLoadRunControlState(ctx, tx, runID)
-	if err != nil {
+		switch action {
+		case "pause":
+			state, err = sqlitePauseRunControl(txctx, tx, state, req)
+		case "continue":
+			state, err = sqliteContinueRunControl(txctx, tx, state, req)
+		case "stop":
+			state, err = sqliteStopRunControl(txctx, tx, state, req)
+		default:
+			err = fmt.Errorf("unsupported run control action %q", action)
+		}
+		return err
+	}); err != nil {
 		return runtimeruncontrol.State{}, err
 	}
-	switch action {
-	case "pause":
-		state, err = sqlitePauseRunControl(ctx, tx, state, req)
-	case "continue":
-		state, err = sqliteContinueRunControl(ctx, tx, state, req)
-	case "stop":
-		state, err = sqliteStopRunControl(ctx, tx, state, req)
-	default:
-		err = fmt.Errorf("unsupported run control action %q", action)
-	}
-	if err != nil {
-		return runtimeruncontrol.State{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return runtimeruncontrol.State{}, fmt.Errorf("commit sqlite run control transition: %w", err)
-	}
-	committed = true
 	return state, nil
 }
 
@@ -707,11 +696,16 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 	lock.Lock()
 	defer lock.Unlock()
 
-	if err := purgeExpiredSQLiteAPIIdempotency(ctx, s.DB, req.Now); err != nil {
-		return APIIdempotencyCompletion{}, false, err
-	}
-	existing, ok, err := sqliteLoadAPIIdempotency(ctx, s.DB, req)
-	if err != nil {
+	var existing apiIdempotencyRecord
+	var ok bool
+	if err := s.runRuntimeMutation(ctx, "sqlite api idempotency lookup", func(txctx context.Context, tx *sql.Tx) error {
+		if err := purgeExpiredSQLiteAPIIdempotency(txctx, tx, req.Now); err != nil {
+			return err
+		}
+		var err error
+		existing, ok, err = sqliteLoadAPIIdempotency(txctx, tx, req)
+		return err
+	}); err != nil {
 		return APIIdempotencyCompletion{}, false, err
 	}
 	if ok {
@@ -738,7 +732,9 @@ func (s *SQLiteRuntimeStore) WithAPIIdempotency(ctx context.Context, req APIIdem
 	if strings.TrimSpace(completion.ResourceID) == "" {
 		completion.ResourceID = req.ResourceID
 	}
-	if err := sqliteStoreAPIIdempotency(ctx, s.DB, req, completion); err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite api idempotency completion", func(txctx context.Context, tx *sql.Tx) error {
+		return sqliteStoreAPIIdempotency(txctx, tx, req, completion)
+	}); err != nil {
 		return APIIdempotencyCompletion{}, false, err
 	}
 	return completion, false, nil

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -31,6 +31,11 @@ func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sq
 	if eventID == "" {
 		return nil
 	}
+	if tx == nil {
+		return s.runRuntimeMutation(ctx, "sqlite pipeline receipt", func(txctx context.Context, tx *sql.Tx) error {
+			return s.UpsertPipelineReceiptTx(txctx, tx, eventID, status, errText)
+		})
+	}
 	status = strings.TrimSpace(strings.ToLower(status))
 	if status == "" {
 		status = "processed"
@@ -44,10 +49,6 @@ func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sq
 		return fmt.Errorf("marshal sqlite pipeline receipt side effects: %w", err)
 	}
 	outcome := mapPipelineStatusToOutcome(status)
-	exec := s.DB.ExecContext
-	if tx != nil {
-		exec = tx.ExecContext
-	}
 	terminalReasons := activeRunQuiescenceTerminalReasonCodes()
 	args := []any{uuid.NewString(), outcome, sqliteNullString(reasonCode), string(sideEffects), s.now(), eventID}
 	for _, reason := range terminalReasons {
@@ -56,7 +57,7 @@ func (s *SQLiteRuntimeStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sq
 	for _, reason := range terminalReasons {
 		args = append(args, reason)
 	}
-	_, err = exec(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, side_effects, processed_at
@@ -121,19 +122,11 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveryRoutesTx(ctx context.Context, tx
 		return fmt.Errorf("load event run for sqlite delivery routes: %w", err)
 	}
 	ownedTx := tx == nil
-	var err error
 	if ownedTx {
-		tx, err = s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin sqlite delivery routes tx: %w", err)
-		}
+		return s.runRuntimeMutation(ctx, "sqlite event delivery routes", func(txctx context.Context, tx *sql.Tx) error {
+			return s.InsertEventDeliveryRoutesTx(txctx, tx, eventID, deliveryRoutes)
+		})
 	}
-	committed := false
-	defer func() {
-		if ownedTx && !committed {
-			_ = tx.Rollback()
-		}
-	}()
 	for _, route := range deliveryRoutes {
 		route = route.Normalized()
 		if route.SubscriberType == "" || route.SubscriberID == "" {
@@ -150,12 +143,6 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveryRoutesTx(ctx context.Context, tx
 			return fmt.Errorf("insert sqlite event delivery route (%s=%s): %w", route.SubscriberType, route.SubscriberID, err)
 		}
 	}
-	if ownedTx {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit sqlite delivery routes tx: %w", err)
-		}
-		committed = true
-	}
 	return nil
 }
 
@@ -164,66 +151,39 @@ func (s *SQLiteRuntimeStore) PersistEventWithDeliveries(ctx context.Context, evt
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveriesAndScope(ctx context.Context, evt events.Event, agentIDs []string, scope runtimereplayclaim.CommittedReplayScope) error {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite event/delivery tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
-		return err
-	}
-	if err := s.InsertEventDeliveriesTx(ctx, tx, evt.ID(), agentIDs); err != nil {
-		return err
-	}
-	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID(), scope); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite event/delivery tx: %w", err)
-	}
-	return nil
+	return s.runRuntimeMutation(ctx, "sqlite event/delivery", func(txctx context.Context, tx *sql.Tx) error {
+		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
+			return err
+		}
+		if err := s.InsertEventDeliveriesTx(txctx, tx, evt.ID(), agentIDs); err != nil {
+			return err
+		}
+		return s.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), scope)
+	})
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRoutesAndScope(ctx context.Context, evt events.Event, agentIDs []string, deliveryTargets map[string]events.RouteIdentity, scope runtimereplayclaim.CommittedReplayScope) error {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite event/routes tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
-		return err
-	}
-	if err := s.InsertEventDeliveriesWithTargetsTx(ctx, tx, evt.ID(), agentIDs, deliveryTargets); err != nil {
-		return err
-	}
-	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID(), scope); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite event/routes tx: %w", err)
-	}
-	return nil
+	return s.runRuntimeMutation(ctx, "sqlite event/routes", func(txctx context.Context, tx *sql.Tx) error {
+		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
+			return err
+		}
+		if err := s.InsertEventDeliveriesWithTargetsTx(txctx, tx, evt.ID(), agentIDs, deliveryTargets); err != nil {
+			return err
+		}
+		return s.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), scope)
+	})
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRouteSetAndScope(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite event/route-set tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	if err := s.AppendEventTx(ctx, tx, evt); err != nil {
-		return err
-	}
-	if err := s.InsertEventDeliveryRoutesTx(ctx, tx, evt.ID(), deliveryRoutes); err != nil {
-		return err
-	}
-	if err := s.UpsertCommittedReplayScopeTx(ctx, tx, evt.ID(), scope); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite event/route-set tx: %w", err)
-	}
-	return nil
+	return s.runRuntimeMutation(ctx, "sqlite event/route-set", func(txctx context.Context, tx *sql.Tx) error {
+		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
+			return err
+		}
+		if err := s.InsertEventDeliveryRoutesTx(txctx, tx, evt.ID(), deliveryRoutes); err != nil {
+			return err
+		}
+		return s.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), scope)
+	})
 }
 
 func (s *SQLiteRuntimeStore) UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
@@ -235,16 +195,17 @@ func (s *SQLiteRuntimeStore) UpsertCommittedReplayScopeTx(ctx context.Context, t
 	if eventID == "" {
 		return nil
 	}
+	if tx == nil {
+		return s.runRuntimeMutation(ctx, "sqlite committed replay scope", func(txctx context.Context, tx *sql.Tx) error {
+			return s.UpsertCommittedReplayScopeTx(txctx, tx, eventID, scope)
+		})
+	}
 	reasonCode, err := committedReplayScopeReasonCode(scope)
 	if err != nil {
 		return err
 	}
-	exec := s.DB.ExecContext
-	if tx != nil {
-		exec = tx.ExecContext
-	}
 	now := s.now()
-	res, err := exec(ctx, `
+	res, err := tx.ExecContext(ctx, `
 		UPDATE event_deliveries
 		SET reason_code = ?,
 		    status = 'delivered',
@@ -259,7 +220,7 @@ func (s *SQLiteRuntimeStore) UpsertCommittedReplayScopeTx(ctx context.Context, t
 	if rows, _ := res.RowsAffected(); rows > 0 {
 		return nil
 	}
-	_, err = exec(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
 			status, reason_code, delivered_at, created_at
@@ -522,21 +483,28 @@ func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, ev
 	for _, reason := range terminalReasons {
 		args = append(args, reason)
 	}
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET status = 'in_progress',
-		    active_session_id = ?,
-		    started_at = COALESCE(started_at, ?)
-		WHERE event_id = ?
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = ?
-		  AND status IN ('pending', 'failed', 'in_progress')
-		  AND COALESCE(reason_code, '') NOT IN (`+sqlitePlaceholders(len(terminalReasons))+`)
-	`, args...)
-	if err != nil {
+	var rows int64
+	if err := s.runRuntimeMutation(ctx, "sqlite delivery in progress", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'in_progress',
+			    active_session_id = ?,
+			    started_at = COALESCE(started_at, ?)
+			WHERE event_id = ?
+			  AND subscriber_type = 'agent'
+			  AND subscriber_id = ?
+			  AND status IN ('pending', 'failed', 'in_progress')
+			  AND COALESCE(reason_code, '') NOT IN (`+sqlitePlaceholders(len(terminalReasons))+`)
+		`, args...)
+		if err != nil {
+			return err
+		}
+		rows, _ = res.RowsAffected()
+		return nil
+	}); err != nil {
 		return fmt.Errorf("mark sqlite event delivery in progress: %w", err)
 	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
+	if rows == 0 {
 		if _, ok, err := s.ActiveRunDeliveryQuiesced(ctx, eventID, "agent", agentID); err != nil {
 			return err
 		} else if ok {
@@ -556,59 +524,53 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, ag
 	if status == "" {
 		return fmt.Errorf("upsert sqlite event receipt: status required")
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite event receipt tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	delivery, err := s.sqliteLockAgentDeliveryTx(ctx, tx, eventID, agentID)
-	if err != nil {
-		return err
-	}
-	if !delivery.found {
-		return fmt.Errorf("upsert sqlite event receipt: delivery row required for event %s agent %s", eventID, agentID)
-	}
-	if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
+	return s.runRuntimeMutation(ctx, "sqlite event receipt", func(txctx context.Context, tx *sql.Tx) error {
+		delivery, err := s.sqliteLockAgentDeliveryTx(txctx, tx, eventID, agentID)
+		if err != nil {
+			return err
+		}
+		if !delivery.found {
+			return fmt.Errorf("upsert sqlite event receipt: delivery row required for event %s agent %s", eventID, agentID)
+		}
+		if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
+			return nil
+		}
+		state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
+		now := s.now()
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = ?,
+			    retry_count = ?,
+			    reason_code = ?,
+			    last_error = ?,
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'agent'
+			  AND subscriber_id = ?
+		`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), sqliteNullString(state.errorText), now, eventID, agentID); err != nil {
+			return fmt.Errorf("update sqlite event delivery receipt state: %w", err)
+		}
+		sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
+		if err != nil {
+			return fmt.Errorf("marshal sqlite agent receipt side effects: %w", err)
+		}
+		if _, err := tx.ExecContext(txctx, `
+			INSERT INTO event_receipts (
+				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+				outcome, reason_code, side_effects, processed_at
+			)
+			VALUES (?, ?, 'agent', ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+				outcome = excluded.outcome,
+				reason_code = excluded.reason_code,
+				side_effects = excluded.side_effects,
+				processed_at = excluded.processed_at
+		`, uuid.NewString(), eventID, agentID, sqliteNullUUID(delivery.entityID), sqliteNullString(delivery.flowInstance),
+			mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), string(sideEffects), now); err != nil {
+			return fmt.Errorf("upsert sqlite event receipt row: %w", err)
+		}
 		return nil
-	}
-	state := buildAgentReceiptWriteState(delivery.retryCount, status, errText)
-	now := s.now()
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET status = ?,
-		    retry_count = ?,
-		    reason_code = ?,
-		    last_error = ?,
-		    delivered_at = ?
-		WHERE event_id = ?
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = ?
-	`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), sqliteNullString(state.errorText), now, eventID, agentID); err != nil {
-		return fmt.Errorf("update sqlite event delivery receipt state: %w", err)
-	}
-	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
-	if err != nil {
-		return fmt.Errorf("marshal sqlite agent receipt side effects: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO event_receipts (
-			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-			outcome, reason_code, side_effects, processed_at
-		)
-		VALUES (?, ?, 'agent', ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
-			outcome = excluded.outcome,
-			reason_code = excluded.reason_code,
-			side_effects = excluded.side_effects,
-			processed_at = excluded.processed_at
-	`, uuid.NewString(), eventID, agentID, sqliteNullUUID(delivery.entityID), sqliteNullString(delivery.flowInstance),
-		mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), string(sideEffects), now); err != nil {
-		return fmt.Errorf("upsert sqlite event receipt row: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite event receipt tx: %w", err)
-	}
-	return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {

--- a/internal/store/sqlite_runtime_llm.go
+++ b/internal/store/sqlite_runtime_llm.go
@@ -45,66 +45,54 @@ func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm
 	runID := nullUUIDString(rec.RunID)
 	now := s.now()
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("append sqlite agent turn begin tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := sqliteEnsureRunRow(ctx, tx, runID, rec.TriggerEventID, rec.TriggerEventType, now); err != nil {
-		return err
-	}
-	if mode.IsStateless() {
-		if err := s.ensureSQLiteTaskConversationAuditRowTx(ctx, tx, rec, now); err != nil {
+	return s.runRuntimeMutation(ctx, "sqlite append agent turn", func(txctx context.Context, tx *sql.Tx) error {
+		if err := sqliteEnsureRunRow(txctx, tx, runID, rec.TriggerEventID, rec.TriggerEventType, now); err != nil {
 			return err
 		}
-	} else {
-		res, err := tx.ExecContext(ctx, `
-			UPDATE agent_sessions
-			SET run_id = COALESCE(?, run_id),
-			    updated_at = ?
-			WHERE agent_id = ?
-			  AND runtime_mode = ?
-			  AND session_id = ?
-			  AND status = 'active'
-		`, sqliteNullUUID(runID), now, strings.TrimSpace(rec.AgentID), mode.String(), strings.TrimSpace(rec.SessionID))
+		if mode.IsStateless() {
+			if err := s.ensureSQLiteTaskConversationAuditRowTx(txctx, tx, rec, now); err != nil {
+				return err
+			}
+		} else {
+			res, err := tx.ExecContext(txctx, `
+				UPDATE agent_sessions
+				SET run_id = COALESCE(?, run_id),
+				    updated_at = ?
+				WHERE agent_id = ?
+				  AND runtime_mode = ?
+				  AND session_id = ?
+				  AND status = 'active'
+			`, sqliteNullUUID(runID), now, strings.TrimSpace(rec.AgentID), mode.String(), strings.TrimSpace(rec.SessionID))
+			if err != nil {
+				return fmt.Errorf("append sqlite agent turn update session: %w", err)
+			}
+			if rows, _ := res.RowsAffected(); rows == 0 {
+				return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, mode.String(), rec.SessionID)
+			}
+		}
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO agent_turns (
+				turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+				trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+				emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+				request_payload, response_payload, turn_blocks, parse_ok, latency_ms, retry_count, error, created_at
+			) VALUES (
+				?, ?, ?, ?, ?, ?, ?,
+				?, ?, ?, ?, ?,
+				?, ?, ?, ?,
+				?, ?, ?, ?, ?, ?, ?, ?
+			)
+		`, uuid.NewString(), sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), strings.TrimSpace(rec.SessionID),
+			mode.String(), sqliteNullString(rec.ScopeKey), sqliteNullUUID(rec.EntityID), sqliteNullUUID(rec.TriggerEventID),
+			sqliteNullString(rec.TriggerEventType), sqliteNullString(rec.TaskID), availableToolsPayload, toolCallsPayload,
+			emittedEventsPayload, mcpServersPayload, mcpToolsListedPayload, mcpToolsVisiblePayload,
+			sqliteNullString(reqPayload), sqliteNullString(respPayload), turnBlocksPayload, rec.ParseOK, latencyMS,
+			rec.RetryCount, sqliteNullString(rec.Error), now)
 		if err != nil {
-			return fmt.Errorf("append sqlite agent turn update session: %w", err)
+			return fmt.Errorf("insert sqlite agent turn: %w", err)
 		}
-		if rows, _ := res.RowsAffected(); rows == 0 {
-			return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, mode.String(), rec.SessionID)
-		}
-	}
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO agent_turns (
-			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
-			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
-			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
-			request_payload, response_payload, turn_blocks, parse_ok, latency_ms, retry_count, error, created_at
-		) VALUES (
-			?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?,
-			?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?
-		)
-	`, uuid.NewString(), sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), strings.TrimSpace(rec.SessionID),
-		mode.String(), sqliteNullString(rec.ScopeKey), sqliteNullUUID(rec.EntityID), sqliteNullUUID(rec.TriggerEventID),
-		sqliteNullString(rec.TriggerEventType), sqliteNullString(rec.TaskID), availableToolsPayload, toolCallsPayload,
-		emittedEventsPayload, mcpServersPayload, mcpToolsListedPayload, mcpToolsVisiblePayload,
-		sqliteNullString(reqPayload), sqliteNullString(respPayload), turnBlocksPayload, rec.ParseOK, latencyMS,
-		rec.RetryCount, sqliteNullString(rec.Error), now)
-	if err != nil {
-		return fmt.Errorf("insert sqlite agent turn: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("append sqlite agent turn commit: %w", err)
-	}
-	committed = true
-	return nil
+		return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtimellm.ConversationRecord) error {
@@ -135,52 +123,43 @@ func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtime
 	runID := nullUUIDString(rec.RunID)
 	now := s.now()
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("upsert sqlite conversation begin tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return s.runRuntimeMutation(ctx, "sqlite conversation upsert", func(txctx context.Context, tx *sql.Tx) error {
+		if err := sqliteEnsureRunRow(txctx, tx, runID, "", "", now); err != nil {
+			return err
 		}
-	}()
-	if err := sqliteEnsureRunRow(ctx, tx, runID, "", "", now); err != nil {
-		return err
-	}
-	if resolved.Stateless {
-		_, err = tx.ExecContext(ctx, `
-			INSERT INTO agent_conversation_audits (
-				session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
-				conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
-			) VALUES (
-				?, ?, ?, ?, ?, ?, ?,
-				?, ?, ?, ?, ?, ?, ?
-			)
-			ON CONFLICT(session_id) DO UPDATE SET
-				run_id = COALESCE(excluded.run_id, agent_conversation_audits.run_id),
-				agent_id = excluded.agent_id,
-				entity_id = excluded.entity_id,
-				flow_instance = excluded.flow_instance,
-				scope_key = excluded.scope_key,
-				scope = excluded.scope,
-				conversation = excluded.conversation,
-				turn_count = excluded.turn_count,
-				runtime_mode = excluded.runtime_mode,
-				runtime_state = json_patch(COALESCE(agent_conversation_audits.runtime_state, '{}'), excluded.runtime_state),
-				status = excluded.status,
-				updated_at = excluded.updated_at
-		`, sessionID, sqliteNullUUID(runID), agentID, sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
-			sqliteNullString(resolved.ScopeKey), resolved.Scope.String(), string(msgJSON), rec.TurnCount, mode.String(),
-			runtimeStatePatch, status, now, now)
-		if err != nil {
-			return fmt.Errorf("upsert sqlite task conversation audit: %w", err)
+		if resolved.Stateless {
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO agent_conversation_audits (
+					session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+					conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+				) VALUES (
+					?, ?, ?, ?, ?, ?, ?,
+					?, ?, ?, ?, ?, ?, ?
+				)
+				ON CONFLICT(session_id) DO UPDATE SET
+					run_id = COALESCE(excluded.run_id, agent_conversation_audits.run_id),
+					agent_id = excluded.agent_id,
+					entity_id = excluded.entity_id,
+					flow_instance = excluded.flow_instance,
+					scope_key = excluded.scope_key,
+					scope = excluded.scope,
+					conversation = excluded.conversation,
+					turn_count = excluded.turn_count,
+					runtime_mode = excluded.runtime_mode,
+					runtime_state = json_patch(COALESCE(agent_conversation_audits.runtime_state, '{}'), excluded.runtime_state),
+					status = excluded.status,
+					updated_at = excluded.updated_at
+			`, sessionID, sqliteNullUUID(runID), agentID, sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+				sqliteNullString(resolved.ScopeKey), resolved.Scope.String(), string(msgJSON), rec.TurnCount, mode.String(),
+				runtimeStatePatch, status, now, now); err != nil {
+				return fmt.Errorf("upsert sqlite task conversation audit: %w", err)
+			}
+			return nil
 		}
-	} else {
 		if strings.TrimSpace(rec.SessionID) == "" {
 			return fmt.Errorf("session_id is required for live session conversation persistence")
 		}
-		res, err := tx.ExecContext(ctx, `
+		res, err := tx.ExecContext(txctx, `
 			UPDATE agent_sessions
 			SET conversation = ?,
 			    turn_count = ?,
@@ -200,12 +179,8 @@ func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtime
 		if rows, _ := res.RowsAffected(); rows == 0 {
 			return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, rec.SessionID, mode.String(), resolved.ScopeKey)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("upsert sqlite conversation commit: %w", err)
-	}
-	committed = true
-	return nil
+		return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) LoadActiveConversation(ctx context.Context, agentID, mode, sessionScope, scopeKey string) (runtimellm.ConversationRecord, bool, error) {
@@ -295,20 +270,27 @@ func (s *SQLiteRuntimeStore) UpdateLiveSessionWatchdog(ctx context.Context, upda
 	if err != nil {
 		return fmt.Errorf("marshal sqlite live session watchdog patch: %w", err)
 	}
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET runtime_state = json_patch(COALESCE(runtime_state, '{}'), ?),
-		    updated_at = ?
-		WHERE session_id = ?
-		  AND agent_id = ?
-		  AND scope_key = ?
-		  AND runtime_mode = ?
-		  AND status = 'active'
-	`, patch, s.now(), sessionID, agentID, resolved.ScopeKey, mode.String())
-	if err != nil {
+	var rows int64
+	if err := s.runRuntimeMutation(ctx, "sqlite live session watchdog update", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET runtime_state = json_patch(COALESCE(runtime_state, '{}'), ?),
+			    updated_at = ?
+			WHERE session_id = ?
+			  AND agent_id = ?
+			  AND scope_key = ?
+			  AND runtime_mode = ?
+			  AND status = 'active'
+		`, patch, s.now(), sessionID, agentID, resolved.ScopeKey, mode.String())
+		if err != nil {
+			return err
+		}
+		rows, _ = res.RowsAffected()
+		return nil
+	}); err != nil {
 		return fmt.Errorf("update sqlite live session watchdog: %w", err)
 	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
+	if rows == 0 {
 		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, sessionID, mode.String(), resolved.ScopeKey)
 	}
 	return nil

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -41,17 +41,19 @@ func (s *SQLiteRuntimeStore) InsertMailboxItem(ctx context.Context, item runtime
 		scope = "entity"
 	}
 	status, decision := mailboxStateForStoredStatus(item.Status, item.Decision)
-	_, err := s.DB.ExecContext(ctx, `
-		INSERT INTO mailbox (
-			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
-			from_agent, severity, summary, payload, status, decision, decision_notes,
-			notified, expires_at, created_at
-		)
-		VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, item.ID, sqliteNullUUID(coalesceMailboxEntityID(item)), scope, item.Type, sqliteNullUUID(item.EventID),
-		sqliteNullString(item.FromAgent), normalizeMailboxSeverity(item.Priority), sqliteNullString(item.Summary), string(item.Context),
-		status, sqliteNullString(decision), sqliteNullString(item.DecisionNotes), item.Notified, sqliteNullTime(item.TimeoutAt), time.Now().UTC())
-	if err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite mailbox insert", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO mailbox (
+				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+				from_agent, severity, summary, payload, status, decision, decision_notes,
+				notified, expires_at, created_at
+			)
+			VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, item.ID, sqliteNullUUID(coalesceMailboxEntityID(item)), scope, item.Type, sqliteNullUUID(item.EventID),
+			sqliteNullString(item.FromAgent), normalizeMailboxSeverity(item.Priority), sqliteNullString(item.Summary), string(item.Context),
+			status, sqliteNullString(decision), sqliteNullString(item.DecisionNotes), item.Notified, sqliteNullTime(item.TimeoutAt), time.Now().UTC())
+		return err
+	}); err != nil {
 		return "", fmt.Errorf("insert sqlite mailbox item: %w", err)
 	}
 	return item.ID, nil
@@ -121,15 +123,22 @@ func (s *SQLiteRuntimeStore) DecideMailboxItem(ctx context.Context, id, status, 
 		return err
 	}
 	rowStatus, rowDecision := mailboxDecisionState(status, decision)
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE mailbox
-		SET status = ?, decision = ?, decision_notes = ?, decided_at = ?
-		WHERE item_id = ? AND status = 'pending'
-	`, rowStatus, rowDecision, sqliteNullString(notes), time.Now().UTC(), id)
-	if err != nil {
+	var rows int64
+	if err := s.runRuntimeMutation(ctx, "sqlite mailbox decision", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE mailbox
+			SET status = ?, decision = ?, decision_notes = ?, decided_at = ?
+			WHERE item_id = ? AND status = 'pending'
+		`, rowStatus, rowDecision, sqliteNullString(notes), time.Now().UTC(), id)
+		if err != nil {
+			return err
+		}
+		rows, _ = res.RowsAffected()
+		return nil
+	}); err != nil {
 		return fmt.Errorf("decide sqlite mailbox item: %w", err)
 	}
-	if n, _ := res.RowsAffected(); n == 0 {
+	if rows == 0 {
 		return fmt.Errorf("mailbox item is not pending or not found: %s", id)
 	}
 	return nil
@@ -139,31 +148,37 @@ func (s *SQLiteRuntimeStore) ExpireMailboxItems(ctx context.Context, limit int) 
 	if limit <= 0 {
 		limit = 200
 	}
-	rows, err := s.DB.QueryContext(ctx, sqliteMailboxSelectSQL(`status = 'pending' AND expires_at IS NOT NULL AND expires_at <= ?`)+` ORDER BY expires_at ASC LIMIT ?`, time.Now().UTC(), limit)
-	if err != nil {
-		return nil, fmt.Errorf("query expiring sqlite mailbox items: %w", err)
-	}
-	items, err := scanSpecMailboxItems(rows)
-	rows.Close()
-	if err != nil {
+	var items []runtimetools.MailboxItem
+	if err := s.runRuntimeMutation(ctx, "sqlite mailbox expiry", func(txctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(txctx, sqliteMailboxSelectSQL(`status = 'pending' AND expires_at IS NOT NULL AND expires_at <= ?`)+` ORDER BY expires_at ASC LIMIT ?`, time.Now().UTC(), limit)
+		if err != nil {
+			return fmt.Errorf("query expiring sqlite mailbox items: %w", err)
+		}
+		items, err = scanSpecMailboxItems(rows)
+		rows.Close()
+		if err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		for i, item := range items {
+			if _, err := tx.ExecContext(txctx, `
+				UPDATE mailbox
+				SET status = 'expired',
+				    decision = COALESCE(NULLIF(decision, ''), ''),
+				    decision_notes = COALESCE(NULLIF(decision_notes, ''), 'Timed out without human decision'),
+				    decided_at = COALESCE(decided_at, ?)
+				WHERE item_id = ? AND status = 'pending'
+			`, now, item.ID); err != nil {
+				return fmt.Errorf("expire sqlite mailbox item: %w", err)
+			}
+			items[i].Status = "expired"
+			if strings.TrimSpace(items[i].DecisionNotes) == "" {
+				items[i].DecisionNotes = "Timed out without human decision"
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, err
-	}
-	now := time.Now().UTC()
-	for i, item := range items {
-		if _, err := s.DB.ExecContext(ctx, `
-			UPDATE mailbox
-			SET status = 'expired',
-			    decision = COALESCE(NULLIF(decision, ''), ''),
-			    decision_notes = COALESCE(NULLIF(decision_notes, ''), 'Timed out without human decision'),
-			    decided_at = COALESCE(decided_at, ?)
-			WHERE item_id = ? AND status = 'pending'
-		`, now, item.ID); err != nil {
-			return nil, fmt.Errorf("expire sqlite mailbox item: %w", err)
-		}
-		items[i].Status = "expired"
-		if strings.TrimSpace(items[i].DecisionNotes) == "" {
-			items[i].DecisionNotes = "Timed out without human decision"
-		}
 	}
 	return items, nil
 }
@@ -188,7 +203,10 @@ func (s *SQLiteRuntimeStore) MarkMailboxItemNotified(ctx context.Context, id str
 	if id == "" {
 		return fmt.Errorf("mailbox id is required")
 	}
-	if _, err := s.DB.ExecContext(ctx, `UPDATE mailbox SET notified = true WHERE item_id = ?`, id); err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite mailbox notified", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `UPDATE mailbox SET notified = true WHERE item_id = ?`, id)
+		return err
+	}); err != nil {
 		return fmt.Errorf("mark sqlite mailbox item notified: %w", err)
 	}
 	return nil
@@ -215,9 +233,6 @@ func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipel
 	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
-	if err := s.CancelScheduleExact(ctx, sc); err != nil {
-		return err
-	}
 	fireAt := sc.At
 	if fireAt.IsZero() {
 		fireAt = time.Now().UTC()
@@ -234,16 +249,21 @@ func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipel
 	if timerName == "" {
 		timerName = strings.TrimSpace(sc.EventType)
 	}
-	exec := sqliteScheduleDBExecutor(ctx, s.DB)
-	_, err := exec.ExecContext(ctx, `
-		INSERT INTO timers (
-			timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
-			fire_at, recurring, recurrence_cron, owner_agent, task_type, status, created_at
-		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
-	`, uuid.NewString(), sqliteNullUUID(sc.RunID), timerName, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance),
-		sc.EventType, string(persistedSchedulePayload(sc)), fireAt.UTC(), recurring, sqliteNullString(sc.Cron), sc.AgentID, taskType, time.Now().UTC())
-	if err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite schedule upsert", func(txctx context.Context, tx *sql.Tx) error {
+		if err := s.CancelScheduleExact(txctx, sc); err != nil {
+			return err
+		}
+		exec := sqliteScheduleDBExecutor(txctx, s.DB)
+		_, err := exec.ExecContext(txctx, `
+			INSERT INTO timers (
+				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
+				fire_at, recurring, recurrence_cron, owner_agent, task_type, status, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+		`, uuid.NewString(), sqliteNullUUID(sc.RunID), timerName, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance),
+			sc.EventType, string(persistedSchedulePayload(sc)), fireAt.UTC(), recurring, sqliteNullString(sc.Cron), sc.AgentID, taskType, time.Now().UTC())
+		return err
+	}); err != nil {
 		return fmt.Errorf("insert sqlite timer: %w", err)
 	}
 	return nil
@@ -254,19 +274,21 @@ func (s *SQLiteRuntimeStore) CancelScheduleExact(ctx context.Context, sc runtime
 	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
-	exec := sqliteScheduleDBExecutor(ctx, s.DB)
-	_, err := exec.ExecContext(ctx, `
-		UPDATE timers
-		SET status = 'cancelled'
-		WHERE COALESCE(run_id, '') = COALESCE(?, '')
-		  AND owner_agent = ?
-		  AND fire_event = ?
-		  AND COALESCE(entity_id, '') = COALESCE(?, '')
-		  AND COALESCE(flow_instance, '') = COALESCE(?, '')
-		  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
-		  AND status = 'active'
-	`, sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
-	if err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite schedule cancel", func(txctx context.Context, tx *sql.Tx) error {
+		exec := sqliteScheduleDBExecutor(txctx, s.DB)
+		_, err := exec.ExecContext(txctx, `
+			UPDATE timers
+			SET status = 'cancelled'
+			WHERE COALESCE(run_id, '') = COALESCE(?, '')
+			  AND owner_agent = ?
+			  AND fire_event = ?
+			  AND COALESCE(entity_id, '') = COALESCE(?, '')
+			  AND COALESCE(flow_instance, '') = COALESCE(?, '')
+			  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
+			  AND status = 'active'
+		`, sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
+		return err
+	}); err != nil {
 		return fmt.Errorf("cancel sqlite timer exact: %w", err)
 	}
 	return nil
@@ -319,19 +341,21 @@ func (s *SQLiteRuntimeStore) MarkScheduleFiredExact(ctx context.Context, sc runt
 	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
-	exec := sqliteScheduleDBExecutor(ctx, s.DB)
-	_, err := exec.ExecContext(ctx, `
-		UPDATE timers
-		SET status = 'fired', fired_at = ?
-		WHERE COALESCE(run_id, '') = COALESCE(?, '')
-		  AND owner_agent = ?
-		  AND fire_event = ?
-		  AND COALESCE(entity_id, '') = COALESCE(?, '')
-		  AND COALESCE(flow_instance, '') = COALESCE(?, '')
-		  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
-		  AND status = 'active'
-	`, time.Now().UTC(), sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
-	if err != nil {
+	if err := s.runRuntimeMutation(ctx, "sqlite schedule fired", func(txctx context.Context, tx *sql.Tx) error {
+		exec := sqliteScheduleDBExecutor(txctx, s.DB)
+		_, err := exec.ExecContext(txctx, `
+			UPDATE timers
+			SET status = 'fired', fired_at = ?
+			WHERE COALESCE(run_id, '') = COALESCE(?, '')
+			  AND owner_agent = ?
+			  AND fire_event = ?
+			  AND COALESCE(entity_id, '') = COALESCE(?, '')
+			  AND COALESCE(flow_instance, '') = COALESCE(?, '')
+			  AND COALESCE(json_extract(fire_payload, '$.__schedule_task_id'), '') = ?
+			  AND status = 'active'
+		`, time.Now().UTC(), sqliteNullUUID(sc.RunID), sc.AgentID, sc.EventType, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance), strings.TrimSpace(sc.TaskID))
+		return err
+	}); err != nil {
 		return fmt.Errorf("mark sqlite timer fired exact: %w", err)
 	}
 	return nil

--- a/internal/store/sqlite_runtime_sessions.go
+++ b/internal/store/sqlite_runtime_sessions.go
@@ -65,79 +65,68 @@ func (s *SQLiteRuntimeStore) Acquire(ctx context.Context, agentID string, runtim
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("begin sqlite session acquire tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	var lease *runtimesessions.Lease
+	if err := s.runRuntimeMutation(ctx, "sqlite session acquire", func(txctx context.Context, tx *sql.Tx) error {
+		rec, found, err := sqliteLoadLiveSession(txctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
+		if err != nil {
+			return err
 		}
-	}()
-
-	rec, found, err := sqliteLoadLiveSession(ctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
-	if err != nil {
+		now := s.now()
+		expires := now.Add(s.sessionLockTTL)
+		if !found {
+			sessionID := uuid.NewString()
+			if _, err := tx.ExecContext(txctx, `
+				INSERT INTO agent_sessions (
+					session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+					conversation, turn_count, runtime_mode, runtime_state,
+					lease_holder, lease_expires_at, status, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, '{}', ?, ?, 'active', ?, ?)
+			`, sessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+				resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), strings.TrimSpace(lockOwner), expires, now, now); err != nil {
+				return fmt.Errorf("insert sqlite session row: %w", err)
+			}
+			lease = &runtimesessions.Lease{
+				SessionID:    sessionID,
+				AgentID:      strings.TrimSpace(agentID),
+				RuntimeMode:  resolved.RuntimeMode,
+				SessionScope: resolved.Scope,
+				LockOwner:    strings.TrimSpace(lockOwner),
+				ScopeKey:     resolved.ScopeKey,
+				ExpiresAt:    expires,
+			}
+			return nil
+		}
+		if strings.TrimSpace(rec.status) == "suspended" {
+			return runtimesessions.ErrSessionSuspended
+		}
+		if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
+			return runtimesessions.ErrSessionLeased
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET lease_holder = ?, lease_expires_at = ?, updated_at = ?
+			WHERE session_id = ?
+		`, strings.TrimSpace(lockOwner), expires, now, rec.sessionID); err != nil {
+			return fmt.Errorf("update sqlite session lease: %w", err)
+		}
+		lease = &runtimesessions.Lease{
+			SessionID:            rec.sessionID,
+			ProviderSessionID:    rec.providerSessionID,
+			AgentID:              strings.TrimSpace(agentID),
+			RuntimeMode:          resolved.RuntimeMode,
+			SessionScope:         resolved.Scope,
+			RetryReason:          rec.retryReason,
+			RetriesFromSessionID: rec.retriesFromSessionID,
+			LockOwner:            strings.TrimSpace(lockOwner),
+			ScopeKey:             resolved.ScopeKey,
+			ExpiresAt:            expires,
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	now := s.now()
-	expires := now.Add(s.sessionLockTTL)
-	if !found {
-		sessionID := uuid.NewString()
-		if _, err := tx.ExecContext(ctx, `
-			INSERT INTO agent_sessions (
-				session_id, agent_id, entity_id, flow_instance, scope_key, scope,
-				conversation, turn_count, runtime_mode, runtime_state,
-				lease_holder, lease_expires_at, status, created_at, updated_at
-			)
-			VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, '{}', ?, ?, 'active', ?, ?)
-		`, sessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
-			resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), strings.TrimSpace(lockOwner), expires, now, now); err != nil {
-			return nil, fmt.Errorf("insert sqlite session row: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return nil, fmt.Errorf("commit sqlite session acquire new: %w", err)
-		}
-		committed = true
-		return &runtimesessions.Lease{
-			SessionID:    sessionID,
-			AgentID:      strings.TrimSpace(agentID),
-			RuntimeMode:  resolved.RuntimeMode,
-			SessionScope: resolved.Scope,
-			LockOwner:    strings.TrimSpace(lockOwner),
-			ScopeKey:     resolved.ScopeKey,
-			ExpiresAt:    expires,
-		}, nil
-	}
-	if strings.TrimSpace(rec.status) == "suspended" {
-		return nil, runtimesessions.ErrSessionSuspended
-	}
-	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
-		return nil, runtimesessions.ErrSessionLeased
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET lease_holder = ?, lease_expires_at = ?, updated_at = ?
-		WHERE session_id = ?
-	`, strings.TrimSpace(lockOwner), expires, now, rec.sessionID); err != nil {
-		return nil, fmt.Errorf("update sqlite session lease: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit sqlite session acquire existing: %w", err)
-	}
-	committed = true
-	return &runtimesessions.Lease{
-		SessionID:            rec.sessionID,
-		ProviderSessionID:    rec.providerSessionID,
-		AgentID:              strings.TrimSpace(agentID),
-		RuntimeMode:          resolved.RuntimeMode,
-		SessionScope:         resolved.Scope,
-		RetryReason:          rec.retryReason,
-		RetriesFromSessionID: rec.retriesFromSessionID,
-		LockOwner:            strings.TrimSpace(lockOwner),
-		ScopeKey:             resolved.ScopeKey,
-		ExpiresAt:            expires,
-	}, nil
+	return lease, nil
 }
 
 func (s *SQLiteRuntimeStore) Release(ctx context.Context, lease *runtimesessions.Lease) error {
@@ -149,22 +138,29 @@ func (s *SQLiteRuntimeStore) Release(ctx context.Context, lease *runtimesessions
 	}
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = ?
-		WHERE agent_id = ?
-		  AND runtime_mode = ?
-		  AND session_id = ?
-		  AND scope_key = ?
-		  AND lease_holder = ?
-		  AND status = 'active'
-	`, s.now(), strings.TrimSpace(lease.AgentID), lease.RuntimeMode.String(), strings.TrimSpace(lease.SessionID), strings.TrimSpace(lease.ScopeKey), strings.TrimSpace(lease.LockOwner))
-	if err != nil {
+	var rows int64
+	if err := s.runRuntimeMutation(ctx, "sqlite session release", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = ?
+			WHERE agent_id = ?
+			  AND runtime_mode = ?
+			  AND session_id = ?
+			  AND scope_key = ?
+			  AND lease_holder = ?
+			  AND status = 'active'
+		`, s.now(), strings.TrimSpace(lease.AgentID), lease.RuntimeMode.String(), strings.TrimSpace(lease.SessionID), strings.TrimSpace(lease.ScopeKey), strings.TrimSpace(lease.LockOwner))
+		if err != nil {
+			return err
+		}
+		rows, _ = res.RowsAffected()
+		return nil
+	}); err != nil {
 		return fmt.Errorf("release sqlite session lease: %w", err)
 	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
+	if rows == 0 {
 		return fmt.Errorf("no active lease to release for agent=%s session=%s", lease.AgentID, lease.SessionID)
 	}
 	return nil
@@ -188,85 +184,78 @@ func (s *SQLiteRuntimeStore) Rotate(ctx context.Context, agentID string, runtime
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("begin sqlite session rotate tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	var lease *runtimesessions.Lease
+	if err := s.runRuntimeMutation(ctx, "sqlite session rotate", func(txctx context.Context, tx *sql.Tx) error {
+		rec, found, err := sqliteLoadActiveSession(txctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
+		if err != nil {
+			return err
 		}
-	}()
-	rec, found, err := sqliteLoadActiveSession(ctx, tx, strings.TrimSpace(agentID), resolved.RuntimeMode, resolved.ScopeKey)
-	if err != nil {
+		if !found {
+			return fmt.Errorf("no active session to rotate for agent=%s", strings.TrimSpace(agentID))
+		}
+		now := s.now()
+		if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
+			return runtimesessions.ErrSessionLeased
+		}
+		retryReason := strings.TrimSpace(rotation.RetryReason)
+		terminationReason := rotation.TerminationReason
+		if terminationReason == "" {
+			terminationReason = runtimesessions.TerminationReasonContaminated
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET status = 'terminated',
+			    termination_reason = ?,
+			    termination_detail = ?,
+			    terminated_at = COALESCE(terminated_at, ?),
+			    successor_session_id = NULL,
+			    lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = ?
+			WHERE session_id = ?
+			  AND status = 'active'
+		`, terminationReason.String(), sqliteNullString(retryReason), now, now, rec.sessionID); err != nil {
+			return fmt.Errorf("terminate sqlite rotated session row: %w", err)
+		}
+		newSessionID := uuid.NewString()
+		expires := now.Add(s.sessionLockTTL)
+		runtimeState := sqliteSessionRuntimeStateJSON(strings.TrimSpace(rotation.CheckpointSummary), retryReason, rec.sessionID)
+		if _, err := tx.ExecContext(txctx, `
+			INSERT INTO agent_sessions (
+				session_id, agent_id, entity_id, flow_instance, scope_key, scope,
+				conversation, turn_count, runtime_mode, runtime_state,
+				lease_holder, lease_expires_at, status,
+				created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, ?, ?, ?, 'active', ?, ?)
+		`, newSessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
+			resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), runtimeState, strings.TrimSpace(lockOwner), expires, now, now); err != nil {
+			return fmt.Errorf("insert sqlite rotated successor session row: %w", err)
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET successor_session_id = ?, updated_at = ?
+			WHERE session_id = ?
+			  AND status = 'terminated'
+		`, newSessionID, now, rec.sessionID); err != nil {
+			return fmt.Errorf("link sqlite rotated successor session row: %w", err)
+		}
+		lease = &runtimesessions.Lease{
+			SessionID:            newSessionID,
+			AgentID:              strings.TrimSpace(agentID),
+			RuntimeMode:          resolved.RuntimeMode,
+			SessionScope:         resolved.Scope,
+			RetryReason:          retryReason,
+			RetriesFromSessionID: rec.sessionID,
+			LockOwner:            strings.TrimSpace(lockOwner),
+			ScopeKey:             resolved.ScopeKey,
+			ExpiresAt:            expires,
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	if !found {
-		return nil, fmt.Errorf("no active session to rotate for agent=%s", strings.TrimSpace(agentID))
-	}
-	now := s.now()
-	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != strings.TrimSpace(lockOwner) {
-		return nil, runtimesessions.ErrSessionLeased
-	}
-	retryReason := strings.TrimSpace(rotation.RetryReason)
-	terminationReason := rotation.TerminationReason
-	if terminationReason == "" {
-		terminationReason = runtimesessions.TerminationReasonContaminated
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET status = 'terminated',
-		    termination_reason = ?,
-		    termination_detail = ?,
-		    terminated_at = COALESCE(terminated_at, ?),
-		    successor_session_id = NULL,
-		    lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = ?
-		WHERE session_id = ?
-		  AND status = 'active'
-	`, terminationReason.String(), sqliteNullString(retryReason), now, now, rec.sessionID); err != nil {
-		return nil, fmt.Errorf("terminate sqlite rotated session row: %w", err)
-	}
-	newSessionID := uuid.NewString()
-	expires := now.Add(s.sessionLockTTL)
-	runtimeState := sqliteSessionRuntimeStateJSON(strings.TrimSpace(rotation.CheckpointSummary), retryReason, rec.sessionID)
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO agent_sessions (
-			session_id, agent_id, entity_id, flow_instance, scope_key, scope,
-			conversation, turn_count, runtime_mode, runtime_state,
-			lease_holder, lease_expires_at, status,
-			created_at, updated_at
-		)
-		VALUES (?, ?, ?, ?, ?, ?, '[]', 0, ?, ?, ?, ?, 'active', ?, ?)
-	`, newSessionID, strings.TrimSpace(agentID), sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
-		resolved.ScopeKey, resolved.Scope.String(), resolved.RuntimeMode.String(), runtimeState, strings.TrimSpace(lockOwner), expires, now, now); err != nil {
-		return nil, fmt.Errorf("insert sqlite rotated successor session row: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET successor_session_id = ?, updated_at = ?
-		WHERE session_id = ?
-		  AND status = 'terminated'
-	`, newSessionID, now, rec.sessionID); err != nil {
-		return nil, fmt.Errorf("link sqlite rotated successor session row: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit sqlite session rotate: %w", err)
-	}
-	committed = true
-	return &runtimesessions.Lease{
-		SessionID:            newSessionID,
-		AgentID:              strings.TrimSpace(agentID),
-		RuntimeMode:          resolved.RuntimeMode,
-		SessionScope:         resolved.Scope,
-		RetryReason:          retryReason,
-		RetriesFromSessionID: rec.sessionID,
-		LockOwner:            strings.TrimSpace(lockOwner),
-		ScopeKey:             resolved.ScopeKey,
-		ExpiresAt:            expires,
-	}, nil
+	return lease, nil
 }
 
 func (s *SQLiteRuntimeStore) IncrementTurn(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, sessionID, scopeKey string) error {
@@ -277,20 +266,27 @@ func (s *SQLiteRuntimeStore) IncrementTurn(ctx context.Context, agentID string, 
 	if err != nil {
 		return err
 	}
-	res, err := s.DB.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET turn_count = turn_count + 1,
-		    updated_at = ?
-		WHERE agent_id = ?
-		  AND runtime_mode = ?
-		  AND session_id = ?
-		  AND scope_key = ?
-		  AND status = 'active'
-	`, s.now(), strings.TrimSpace(agentID), resolved.RuntimeMode.String(), strings.TrimSpace(sessionID), resolved.ScopeKey)
-	if err != nil {
+	var rows int64
+	if err := s.runRuntimeMutation(ctx, "sqlite session turn increment", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET turn_count = turn_count + 1,
+			    updated_at = ?
+			WHERE agent_id = ?
+			  AND runtime_mode = ?
+			  AND session_id = ?
+			  AND scope_key = ?
+			  AND status = 'active'
+		`, s.now(), strings.TrimSpace(agentID), resolved.RuntimeMode.String(), strings.TrimSpace(sessionID), resolved.ScopeKey)
+		if err != nil {
+			return err
+		}
+		rows, _ = res.RowsAffected()
+		return nil
+	}); err != nil {
 		return fmt.Errorf("increment sqlite session turn: %w", err)
 	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
+	if rows == 0 {
 		return fmt.Errorf("session not found for turn increment: agent=%s runtime=%s scope=%s session=%s", agentID, runtimeMode, scopeKey, sessionID)
 	}
 	return nil
@@ -316,42 +312,30 @@ func (s *SQLiteRuntimeStore) AdoptSessionID(ctx context.Context, agentID string,
 	s.sessionMu.Lock()
 	defer s.sessionMu.Unlock()
 
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite adopt session id tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return s.runRuntimeMutation(ctx, "sqlite adopt session id", func(txctx context.Context, tx *sql.Tx) error {
+		rec, found, err := sqliteLoadActiveSession(txctx, tx, agentID, resolved.RuntimeMode, resolved.ScopeKey)
+		if err != nil {
+			return err
 		}
-	}()
-	rec, found, err := sqliteLoadActiveSession(ctx, tx, agentID, resolved.RuntimeMode, resolved.ScopeKey)
-	if err != nil {
-		return err
-	}
-	if !found {
-		return fmt.Errorf("no active session to adopt for agent=%s", agentID)
-	}
-	now := s.now()
-	if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != lockOwner {
-		return runtimesessions.ErrSessionLeased
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE agent_sessions
-		SET runtime_state = json_set(COALESCE(runtime_state, '{}'), '$.provider_session_id', ?),
-		    lease_holder = ?,
-		    lease_expires_at = ?,
-		    updated_at = ?
-		WHERE session_id = ?
-	`, newSessionID, lockOwner, now.Add(s.sessionLockTTL), now, rec.sessionID); err != nil {
-		return fmt.Errorf("update sqlite provider session id: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite adopt session id: %w", err)
-	}
-	committed = true
-	return nil
+		if !found {
+			return fmt.Errorf("no active session to adopt for agent=%s", agentID)
+		}
+		now := s.now()
+		if rec.leaseHolder != "" && rec.leaseExpiresAt.After(now) && rec.leaseHolder != lockOwner {
+			return runtimesessions.ErrSessionLeased
+		}
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET runtime_state = json_set(COALESCE(runtime_state, '{}'), '$.provider_session_id', ?),
+			    lease_holder = ?,
+			    lease_expires_at = ?,
+			    updated_at = ?
+			WHERE session_id = ?
+		`, newSessionID, lockOwner, now.Add(s.sessionLockTTL), now, rec.sessionID); err != nil {
+			return fmt.Errorf("update sqlite provider session id: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, metadata runtimesessions.ResetMetadata) (runtimesessions.ResetSummary, error) {
@@ -369,41 +353,47 @@ func (s *SQLiteRuntimeStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, m
 		where += " AND runtime_mode = ?"
 		args = append(args, runtimeMode.String())
 	}
-	rows, err := s.DB.Query(`
-		SELECT session_id, agent_id, scope_key, runtime_mode, status
-		FROM agent_sessions
-		WHERE `+where+`
-		ORDER BY agent_id ASC, scope_key ASC, session_id ASC
-	`, args[4:]...)
-	if err != nil {
-		return runtimesessions.ResetSummary{}, fmt.Errorf("list sqlite sessions for reset: %w", err)
-	}
-	defer rows.Close()
 	summary := runtimesessions.ResetSummary{}
-	for rows.Next() {
-		var d runtimesessions.ResetDisposition
-		if err := rows.Scan(&d.SessionID, &d.AgentID, &d.ScopeKey, &d.RuntimeMode, &d.PreviousStatus); err != nil {
-			return runtimesessions.ResetSummary{}, fmt.Errorf("scan sqlite session reset summary: %w", err)
+	ctx := context.Background()
+	if err := s.runRuntimeMutation(ctx, "sqlite session reset", func(txctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(txctx, `
+			SELECT session_id, agent_id, scope_key, runtime_mode, status
+			FROM agent_sessions
+			WHERE `+where+`
+			ORDER BY agent_id ASC, scope_key ASC, session_id ASC
+		`, args[4:]...)
+		if err != nil {
+			return fmt.Errorf("list sqlite sessions for reset: %w", err)
 		}
-		d.TerminationReason = runtimesessions.TerminationReasonOrphaned.String()
-		d.TerminationDetail = source
-		summary.OrphanedSessions = append(summary.OrphanedSessions, d)
-	}
-	if err := rows.Err(); err != nil {
-		return runtimesessions.ResetSummary{}, fmt.Errorf("read sqlite session reset summary: %w", err)
-	}
-	updateArgs := append([]any{}, args...)
-	if _, err := s.DB.Exec(`
-		UPDATE agent_sessions
-		SET status = 'terminated',
-		    termination_reason = ?,
-		    termination_detail = ?,
-		    terminated_at = COALESCE(terminated_at, ?),
-		    lease_holder = NULL,
-		    lease_expires_at = NULL,
-		    updated_at = ?
-		WHERE `+where, updateArgs...); err != nil {
-		return runtimesessions.ResetSummary{}, fmt.Errorf("reset sqlite sessions: %w", err)
+		defer rows.Close()
+		for rows.Next() {
+			var d runtimesessions.ResetDisposition
+			if err := rows.Scan(&d.SessionID, &d.AgentID, &d.ScopeKey, &d.RuntimeMode, &d.PreviousStatus); err != nil {
+				return fmt.Errorf("scan sqlite session reset summary: %w", err)
+			}
+			d.TerminationReason = runtimesessions.TerminationReasonOrphaned.String()
+			d.TerminationDetail = source
+			summary.OrphanedSessions = append(summary.OrphanedSessions, d)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("read sqlite session reset summary: %w", err)
+		}
+		updateArgs := append([]any{}, args...)
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE agent_sessions
+			SET status = 'terminated',
+			    termination_reason = ?,
+			    termination_detail = ?,
+			    terminated_at = COALESCE(terminated_at, ?),
+			    lease_holder = NULL,
+			    lease_expires_at = NULL,
+			    updated_at = ?
+			WHERE `+where, updateArgs...); err != nil {
+			return fmt.Errorf("reset sqlite sessions: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return runtimesessions.ResetSummary{}, err
 	}
 	return summary, nil
 }

--- a/internal/store/sqlite_schema.go
+++ b/internal/store/sqlite_schema.go
@@ -23,6 +23,8 @@ type SQLiteSchemaStore struct {
 	schemaCapsBound bool
 }
 
+const sqliteDriverBusyTimeoutMillis = 50
+
 func NewSQLiteSchemaStore(path string) (*SQLiteSchemaStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -63,7 +65,7 @@ func sqliteFileDSN(path string) string {
 	u := url.URL{Scheme: "file", Opaque: path}
 	q := u.Query()
 	q.Add("_pragma", "foreign_keys(ON)")
-	q.Add("_pragma", "busy_timeout(5000)")
+	q.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteDriverBusyTimeoutMillis))
 	q.Add("_pragma", "journal_mode(WAL)")
 	u.RawQuery = q.Encode()
 	return u.String()
@@ -102,7 +104,7 @@ func (s *SQLiteSchemaStore) configure(ctx context.Context) error {
 	if _, err := s.DB.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
 		return fmt.Errorf("enable sqlite foreign keys: %w", err)
 	}
-	if _, err := s.DB.ExecContext(ctx, `PRAGMA busy_timeout = 5000`); err != nil {
+	if _, err := s.DB.ExecContext(ctx, fmt.Sprintf(`PRAGMA busy_timeout = %d`, sqliteDriverBusyTimeoutMillis)); err != nil {
 		return fmt.Errorf("configure sqlite busy timeout: %w", err)
 	}
 	return s.DB.PingContext(ctx)

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -173,68 +173,59 @@ func (s *SQLiteRuntimeStore) SaveEntityField(ctx context.Context, update runtime
 	if err != nil {
 		return 0, err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("begin sqlite entity field update: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	var fieldsRaw any
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(fields, '{}')
-		FROM entity_state
-		WHERE run_id = ? AND entity_id = ?
-	`, runID, entityID).Scan(&fieldsRaw); err != nil {
-		if err == sql.ErrNoRows {
-			return 0, fmt.Errorf("entity not found: %s", entityID)
-		}
-		return 0, fmt.Errorf("load sqlite entity fields: %w", err)
-	}
-	fields, err := toolDecodeJSONMap(fieldsRaw)
-	if err != nil {
-		return 0, fmt.Errorf("decode sqlite entity fields: %w", err)
-	}
-	oldValue, _ := toolPathValue(fields, segments)
-	newValue, err := toolDecodeJSONValue(valueJSON)
-	if err != nil {
-		return 0, fmt.Errorf("decode sqlite entity field value: %w", err)
-	}
-	toolSetPath(fields, segments, newValue)
-	fieldsJSON, err := json.Marshal(fields)
-	if err != nil {
-		return 0, fmt.Errorf("marshal sqlite entity fields: %w", err)
-	}
-	now := s.now()
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE entity_state
-		SET fields = ?, revision = revision + 1, updated_at = ?
-		WHERE run_id = ? AND entity_id = ?
-	`, string(fieldsJSON), now, runID, entityID); err != nil {
-		return 0, fmt.Errorf("update sqlite entity field: %w", err)
-	}
 	var revision int
-	if err := tx.QueryRowContext(ctx, `
-		SELECT revision
-		FROM entity_state
-		WHERE run_id = ? AND entity_id = ?
-	`, runID, entityID).Scan(&revision); err != nil {
-		return 0, fmt.Errorf("load sqlite entity revision: %w", err)
+	if err := s.runRuntimeMutation(ctx, "sqlite entity field update", func(txctx context.Context, tx *sql.Tx) error {
+		var fieldsRaw any
+		if err := tx.QueryRowContext(txctx, `
+			SELECT COALESCE(fields, '{}')
+			FROM entity_state
+			WHERE run_id = ? AND entity_id = ?
+		`, runID, entityID).Scan(&fieldsRaw); err != nil {
+			if err == sql.ErrNoRows {
+				return fmt.Errorf("entity not found: %s", entityID)
+			}
+			return fmt.Errorf("load sqlite entity fields: %w", err)
+		}
+		fields, err := toolDecodeJSONMap(fieldsRaw)
+		if err != nil {
+			return fmt.Errorf("decode sqlite entity fields: %w", err)
+		}
+		oldValue, _ := toolPathValue(fields, segments)
+		newValue, err := toolDecodeJSONValue(valueJSON)
+		if err != nil {
+			return fmt.Errorf("decode sqlite entity field value: %w", err)
+		}
+		toolSetPath(fields, segments, newValue)
+		fieldsJSON, err := json.Marshal(fields)
+		if err != nil {
+			return fmt.Errorf("marshal sqlite entity fields: %w", err)
+		}
+		now := s.now()
+		if _, err := tx.ExecContext(txctx, `
+			UPDATE entity_state
+			SET fields = ?, revision = revision + 1, updated_at = ?
+			WHERE run_id = ? AND entity_id = ?
+		`, string(fieldsJSON), now, runID, entityID); err != nil {
+			return fmt.Errorf("update sqlite entity field: %w", err)
+		}
+		if err := tx.QueryRowContext(txctx, `
+			SELECT revision
+			FROM entity_state
+			WHERE run_id = ? AND entity_id = ?
+		`, runID, entityID).Scan(&revision); err != nil {
+			return fmt.Errorf("load sqlite entity revision: %w", err)
+		}
+		if err := insertSQLiteEntityStateDiff(txctx, tx, runID, entityID, runtimemutationlog.EntityStateProjection{
+			Fields: map[string]any{update.FieldPath: oldValue},
+		}, runtimemutationlog.EntityStateProjection{
+			Fields: map[string]any{update.FieldPath: newValue},
+		}, mutationWriter(update.Writer), now); err != nil {
+			return fmt.Errorf("record sqlite entity mutation: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return 0, err
 	}
-	if err := insertSQLiteEntityStateDiff(ctx, tx, runID, entityID, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{update.FieldPath: oldValue},
-	}, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{update.FieldPath: newValue},
-	}, mutationWriter(update.Writer), now); err != nil {
-		return 0, fmt.Errorf("record sqlite entity mutation: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit sqlite entity field update: %w", err)
-	}
-	committed = true
 	return revision, nil
 }
 
@@ -291,38 +282,26 @@ func (s *SQLiteRuntimeStore) CreateEntity(ctx context.Context, rec runtimetools.
 	if err != nil {
 		return err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite entity create: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return s.runRuntimeMutation(ctx, "sqlite entity create", func(txctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(txctx, `
+			INSERT INTO entity_state (
+				run_id, entity_id, flow_instance, entity_type, name,
+				current_state, gates, fields, accumulator, revision,
+				entered_state_at, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, '{}', ?, '{}', 1, ?, ?, ?)
+		`, rec.RunID, rec.EntityID, rec.FlowInstance, rec.EntityType, sqliteNullString(rec.Name),
+			rec.CurrentState, string(rec.FieldsJSON), rec.CreatedAt, rec.CreatedAt, rec.CreatedAt); err != nil {
+			return fmt.Errorf("insert sqlite entity: %w", err)
 		}
-	}()
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO entity_state (
-			run_id, entity_id, flow_instance, entity_type, name,
-			current_state, gates, fields, accumulator, revision,
-			entered_state_at, created_at, updated_at
-		)
-		VALUES (?, ?, ?, ?, ?, ?, '{}', ?, '{}', 1, ?, ?, ?)
-	`, rec.RunID, rec.EntityID, rec.FlowInstance, rec.EntityType, sqliteNullString(rec.Name),
-		rec.CurrentState, string(rec.FieldsJSON), rec.CreatedAt, rec.CreatedAt, rec.CreatedAt); err != nil {
-		return fmt.Errorf("insert sqlite entity: %w", err)
-	}
-	if err := insertSQLiteEntityStateDiff(ctx, tx, rec.RunID, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
-		CurrentState: rec.CurrentState,
-		Fields:       fields,
-	}, mutationWriter(rec.Writer), rec.CreatedAt); err != nil {
-		return fmt.Errorf("record sqlite entity create mutation: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite entity create: %w", err)
-	}
-	committed = true
-	return nil
+		if err := insertSQLiteEntityStateDiff(txctx, tx, rec.RunID, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
+			CurrentState: rec.CurrentState,
+			Fields:       fields,
+		}, mutationWriter(rec.Writer), rec.CreatedAt); err != nil {
+			return fmt.Errorf("record sqlite entity create mutation: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *PostgresStore) CreateHumanTask(ctx context.Context, rec runtimetools.HumanTaskCreateRecord) (string, error) {
@@ -443,60 +422,48 @@ func (s *SQLiteRuntimeStore) DecideHumanTask(ctx context.Context, rec runtimetoo
 		return fmt.Errorf("sqlite human-task persistence store is required")
 	}
 	rec = normalizeHumanTaskDecisionRecord(rec)
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin sqlite human task decision: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return s.runRuntimeMutation(ctx, "sqlite human task decision", func(txctx context.Context, tx *sql.Tx) error {
+		var payloadRaw any
+		if err := tx.QueryRowContext(txctx, `
+			SELECT COALESCE(payload, '{}')
+			FROM mailbox
+			WHERE item_id = ? AND item_type = 'human_task'
+		`, rec.TaskID).Scan(&payloadRaw); err != nil {
+			return fmt.Errorf("load sqlite human task payload: %w", err)
 		}
-	}()
-	var payloadRaw any
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COALESCE(payload, '{}')
-		FROM mailbox
-		WHERE item_id = ? AND item_type = 'human_task'
-	`, rec.TaskID).Scan(&payloadRaw); err != nil {
-		return fmt.Errorf("load sqlite human task payload: %w", err)
-	}
-	payload, err := toolDecodeJSONMap(payloadRaw)
-	if err != nil {
-		return fmt.Errorf("decode sqlite human task payload: %w", err)
-	}
-	if rec.Status == "deferred" {
-		payload["requeue_count"] = toolIntValue(payload["requeue_count"]) + 1
-	}
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshal sqlite human task payload: %w", err)
-	}
-	rowStatus := "decided"
-	if rec.Status == "timed_out" {
-		rowStatus = "expired"
-	}
-	res, err := tx.ExecContext(ctx, `
-		UPDATE mailbox
-		SET status = ?,
-		    decision = ?,
-		    decision_notes = COALESCE(NULLIF(?, ''), decision_notes),
-		    decided_by = ?,
-		    decided_at = ?,
-		    payload = ?
-		WHERE item_id = ? AND item_type = 'human_task'
-	`, rowStatus, rec.Status, rec.Reason, sqliteNullString(rec.ActorID), rec.DecidedAt.UTC(), string(payloadJSON), rec.TaskID)
-	if err != nil {
-		return fmt.Errorf("decide sqlite human task: %w", err)
-	}
-	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
-		return fmt.Errorf("human task not found: %s", rec.TaskID)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite human task decision: %w", err)
-	}
-	committed = true
-	return nil
+		payload, err := toolDecodeJSONMap(payloadRaw)
+		if err != nil {
+			return fmt.Errorf("decode sqlite human task payload: %w", err)
+		}
+		if rec.Status == "deferred" {
+			payload["requeue_count"] = toolIntValue(payload["requeue_count"]) + 1
+		}
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal sqlite human task payload: %w", err)
+		}
+		rowStatus := "decided"
+		if rec.Status == "timed_out" {
+			rowStatus = "expired"
+		}
+		res, err := tx.ExecContext(txctx, `
+			UPDATE mailbox
+			SET status = ?,
+			    decision = ?,
+			    decision_notes = COALESCE(NULLIF(?, ''), decision_notes),
+			    decided_by = ?,
+			    decided_at = ?,
+			    payload = ?
+			WHERE item_id = ? AND item_type = 'human_task'
+		`, rowStatus, rec.Status, rec.Reason, sqliteNullString(rec.ActorID), rec.DecidedAt.UTC(), string(payloadJSON), rec.TaskID)
+		if err != nil {
+			return fmt.Errorf("decide sqlite human task: %w", err)
+		}
+		if affected, err := res.RowsAffected(); err == nil && affected == 0 {
+			return fmt.Errorf("human task not found: %s", rec.TaskID)
+		}
+		return nil
+	})
 }
 
 type mailboxPersistence interface {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2524,6 +2524,31 @@ engine:
       - swarm serve explicit --store sqlite
       - local foreground run startup through buildStores
       - runtime.NewRuntime store dependency graph
+    - name: backend_neutral_runtime_mutation_write_boundary
+      owner: internal/store.SQLiteRuntimeStore.RunRuntimeMutation and internal/store.SQLiteRuntimeStore.RunEventTransaction for SQLite-local selected runtime mutations
+      promoted_by: '#1388'
+      sqlite_owner: internal/store.SQLiteRuntimeStore mutation executor
+      postgres_owner: internal/store.PostgresStore normal transaction methods with no global write serialization or SQLite retry semantics
+      scope: >
+        SQLite local/dev selected runtime mutation writers must enter one canonical backend-neutral mutation boundary before
+        opening SQLite write transactions. The boundary owns process-local SQLite write serialization, elapsed-budgeted
+        SQLITE_BUSY / database-locked retry, context cancellation/deadline handling, active pipeline transaction detection,
+        and exactly-once post-commit action flushing for successful commits. It covers the selected runtime mutation row
+        families named in this section: event/delivery/replay/receipt, runtime log, mailbox/idempotency, ingress/run
+        control/quiescence, session/conversation/turn, schedule/timer, tool entity/human-task, budget/spend, manager/agent,
+        and run-completion mutations. Postgres remains the production runtime backend and must not inherit SQLite global
+        serialization or retry behavior.
+      rules:
+      - SQLite runtime mutation producers must not implement local SQLITE_BUSY retry loops or open independent write transactions when a selected runtime store boundary is available.
+      - SQLite driver busy_timeout must stay short; elapsed retry budget, cancellation, and backoff are owned by the selected mutation boundary rather than by long driver-level waits.
+      - SQLite post-commit action flushing must happen after the selected mutation boundary releases its process-local write serialization lock, so post-commit callbacks can safely re-enter selected runtime mutation APIs.
+      - SQLite API idempotency callback execution must stay outside the idempotency row write transaction; failed callbacks must not persist completion.
+      - Active pipeline transactions are already inside the selected mutation boundary and must be reused rather than nested.
+      - Schema/bootstrap, bundle catalog, destructive reset, preservation cleanup, fork-specific mutation/recovery, and read-only projections remain separate concepts unless independently gated.
+      consumers:
+      - runtimebus transactional publish through EventTransactionRunner
+      - runtimepipeline.WorkflowInstanceStore production SQLite construction through NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner
+      - SQLiteRuntimeStore selected runtime mutation methods for the named row families
     - name: event_append_and_run_lifecycle_rows
       owner: runtimebus.EventStore
       sqlite_owner: internal/store.SQLiteRuntimeStore.AppendEvent
@@ -2544,15 +2569,14 @@ engine:
       - cross-process timer claim/locking semantics owned by #1087
     - name: pipeline_coordination_workflow_instance_and_replay_rows
       owner: runtimepipeline.WorkflowInstanceStore consumed through runtime.Stores.PipelineStore and PipelineCoordinator
-      sqlite_owner: internal/runtime/pipeline.NewSQLiteWorkflowInstanceStore over the selected SQLite runtime store
+      sqlite_owner: internal/runtime/pipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner over the selected SQLite runtime store
       postgres_owner: internal/runtime/pipeline.NewWorkflowInstanceStore over PostgresStore.DB
       scope: >
         SQLite supports explicit local-dev pipeline coordination for workflow instance state, pipeline engine transaction/query
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
-        replay scope consumption. SQLite pipeline transactions own process-local serialization plus elapsed-budgeted
-        SQLITE_BUSY / database-locked retry at WorkflowInstanceStore.RunInPipelineTransaction, so pipeline producers do not
-        branch on backend write contention. Postgres remains authoritative for production cross-runtime transaction and claim
-        semantics.
+        replay scope consumption. Production SQLite pipeline writes consume the backend_neutral_runtime_mutation_write_boundary
+        instead of owning a separate local retry/serialization policy, so pipeline producers do not branch on backend write
+        contention. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
       excludes:
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150


### PR DESCRIPTION
## Summary

Closes #1388.

This PR introduces the canonical selected-runtime mutation boundary approved by the #1388 gate:

- adds `SQLiteRuntimeStore.RunRuntimeMutation` / `RunEventTransaction` as the SQLite write executor with process-local write serialization, bounded `SQLITE_BUSY` / database-locked retry, context deadline handling, active transaction reuse, and post-commit action flushing
- adds `PostgresStore.RunEventTransaction` as the Postgres one-shot transactional implementation without SQLite-style global serialization
- wires served SQLite pipeline construction through the selected runtime store rather than a raw standalone SQLite pipeline store
- migrates selected SQLite runtime mutation writer families onto the boundary: event/delivery/replay/receipt, runtime log, mailbox/idempotency, ingress/run control/quiescence, sessions/conversations/turns, schedules/timers, tool/entity/human-task, budget/spend, manager/agent, and run completion
- adds a static guard/allowlist so future `SQLiteRuntimeStore` selected mutation methods cannot silently bypass the canonical executor

## Governing Refs / Context

Exact governing spec refs updated in this PR:

- `platform-spec.yaml` `runtime_core_persistence_store_contracts.backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml` `runtime_core_persistence_store_contracts.pipeline_coordination_workflow_instance_and_replay_rows`

Binding issue/gate context:

- #1388 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1388#issuecomment-4643615934
- #1388 gate outcome: https://github.com/division-sh/swarm/issues/1388#issuecomment-4643976136

## Semantic Migration

New canonical owner:

- SQLite: `internal/store.SQLiteRuntimeStore.RunRuntimeMutation` and `RunEventTransaction`
- Postgres: `internal/store.PostgresStore.RunEventTransaction` preserving normal DB transaction semantics
- Production SQLite pipeline writes: `runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)`

Old producer / reader / writer path now invalid:

- selected SQLite runtime mutation methods opening independent write transactions or local retry loops outside `SQLiteRuntimeStore.RunRuntimeMutation`
- production SQLite pipeline construction through raw `runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB)`
- event bus transactional publish using `BeginEventTx` when the selected store exposes `EventTransactionRunner`

Production paths checked for surviving old behavior:

- event bus transactional publish and acknowledged publish
- production SQLite `cmd/swarm buildStores` pipeline wiring
- `SQLiteRuntimeStore` selected writer families named in the #1388 gate
- explicit split/different-concept paths remain outside: schema/bootstrap, bundle catalog, destructive reset, preservation cleanup, fork-specific mutation/recovery, read-only projections, and legacy `BeginEventTx` fallback

Migration status: complete for the approved #1388 chosen class. The parent remains bounded by the gate exclusions above.

## Validation

- `go test ./internal/store`
- `go test ./internal/store ./internal/runtime/bus ./internal/runtime/pipeline ./cmd/swarm`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)$'`
- `go test ./internal/apiv1 -run 'TestOperatorEventPublish(SQLiteIdempotentFirstEventPublishesWithoutLock|SQLiteExplicitRunFollowUpUsesSelectedRun)$|TestOperatorMailbox(HandlersSupportedRPCPath|ApproveRunsPublishDispatchAfterDecisionCommit|ApproveQueuesTransactionalPublishWhileRuntimePaused)$'`
- `go test ./internal/store -run 'Test(SQLiteRuntimeStore_RunRuntimeMutation|SQLiteRuntimeMutationWritersConsumeCanonicalBoundary|ProductionSQLitePipelineStoreConsumesRuntimeMutationRunner|PostgresStore_RunEventTransactionDoesNotSerializeCallbacks|PostgresStore_V1MailboxReadDecisionAndIdempotencyOwners|SQLiteRuntimeStoreV1MailboxAPISelectedOwner)'`
- `go test ./...`
