### PR TITLE
[agent-c][issue #1389] Gate readiness on system-node subscriptions

### DIFF
--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -103,6 +103,74 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_ClearsReadinessBeforeShut
 	}
 }
 
+func TestRuntimeProjectSupervisorReplaceCurrentRuntime_WaitsForRuntimeStartBeforeReady(t *testing.T) {
+	oldRT := &runtimepkg.Runtime{}
+	newRT := &runtimepkg.Runtime{}
+	var ready atomic.Bool
+	ready.Store(true)
+	started := make(chan struct{})
+	releaseStart := make(chan struct{})
+
+	supervisor := &runtimeProjectSupervisor{
+		ready:         &ready,
+		currentRoot:   "/tmp/old-project",
+		currentBundle: &runtimecontracts.WorkflowContractBundle{},
+		currentSource: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		currentRT:     oldRT,
+	}
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error {
+		return nil
+	}
+	supervisor.startRuntime = func(ctx context.Context, rt *runtimepkg.Runtime) error {
+		if rt != newRT {
+			t.Fatalf("start runtime = %p, want new runtime %p", rt, newRT)
+		}
+		close(started)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-releaseStart:
+			return nil
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := supervisor.replaceCurrentRuntime(
+			context.Background(),
+			"/tmp/new-project",
+			semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+			&runtimecontracts.WorkflowContractBundle{},
+			newRT,
+		)
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case err := <-done:
+		t.Fatalf("replaceCurrentRuntime returned before runtime start blocked: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runtime start")
+	}
+	if ready.Load() {
+		t.Fatal("ready flag became true before runtime start completed")
+	}
+
+	close(releaseStart)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("replaceCurrentRuntime after start release: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replaceCurrentRuntime")
+	}
+	if !ready.Load() {
+		t.Fatal("ready flag = false after runtime start completed")
+	}
+}
+
 func TestRuntimeProjectSupervisorCloseProjectWithShutdownOptionsUsesConfiguredGrace(t *testing.T) {
 	oldRT := &runtimepkg.Runtime{}
 	var ready atomic.Bool

--- a/internal/runtime/pipeline/node_background.go
+++ b/internal/runtime/pipeline/node_background.go
@@ -66,10 +66,14 @@ func (n *backgroundWorkflowNode) SetOverrideHandleForTest(fn func(context.Contex
 }
 
 func (n *backgroundWorkflowNode) SetOnSubscribeForTest(fn func()) {
+	n.AddSubscriptionReadyHook(fn)
+}
+
+func (n *backgroundWorkflowNode) AddSubscriptionReadyHook(fn func()) {
 	if n == nil || n.runner == nil {
 		return
 	}
-	n.runner.SetOnSubscribeForTest(fn)
+	n.runner.AddSubscriptionReadyHook(fn)
 }
 
 func (n *backgroundWorkflowNode) SetTestLifecycleProbe(probe runtimelifecycleprobe.Observer) {

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -42,7 +42,8 @@ type systemNodeRunner struct {
 	subscriptionsFn         func() []events.EventType
 	handleFn                func(context.Context, events.Event) error
 	overrideHandle          func(context.Context, events.Event) error
-	onSubscribe             func()
+	subscribeHookMu         sync.Mutex
+	onSubscribeHooks        []func()
 	eventReceiptsCapability func(context.Context) (bool, error)
 	testLifecycleProbe      runtimelifecycleprobe.Observer
 
@@ -89,9 +90,7 @@ func (n *systemNodeRunner) Run(ctx context.Context) {
 		return
 	}
 	ch := n.subscribe()
-	if n.onSubscribe != nil {
-		n.onSubscribe()
-	}
+	n.notifySubscribed()
 	for {
 		select {
 		case <-ctx.Done():
@@ -99,9 +98,7 @@ func (n *systemNodeRunner) Run(ctx context.Context) {
 		case evt, ok := <-ch:
 			if !ok {
 				ch = n.subscribe()
-				if n.onSubscribe != nil {
-					n.onSubscribe()
-				}
+				n.notifySubscribed()
 				continue
 			}
 			n.ProcessEventForTest(ctx, evt)
@@ -195,10 +192,33 @@ func (n *systemNodeRunner) SetOverrideHandleForTest(fn func(context.Context, eve
 }
 
 func (n *systemNodeRunner) SetOnSubscribeForTest(fn func()) {
+	n.AddSubscriptionReadyHook(fn)
+}
+
+func (n *systemNodeRunner) AddSubscriptionReadyHook(fn func()) {
 	if n == nil {
 		return
 	}
-	n.onSubscribe = fn
+	if fn == nil {
+		return
+	}
+	n.subscribeHookMu.Lock()
+	n.onSubscribeHooks = append(n.onSubscribeHooks, fn)
+	n.subscribeHookMu.Unlock()
+}
+
+func (n *systemNodeRunner) notifySubscribed() {
+	if n == nil {
+		return
+	}
+	n.subscribeHookMu.Lock()
+	hooks := append([]func(){}, n.onSubscribeHooks...)
+	n.subscribeHookMu.Unlock()
+	for _, hook := range hooks {
+		if hook != nil {
+			hook()
+		}
+	}
 }
 
 func (n *systemNodeRunner) SetTestLifecycleProbe(probe runtimelifecycleprobe.Observer) {

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -39,6 +39,11 @@ type BackgroundNode interface {
 	Run(context.Context)
 }
 
+type SubscriptionReadyBackgroundNode interface {
+	BackgroundNode
+	AddSubscriptionReadyHook(func())
+}
+
 type BackgroundWorkflowExecutorProvider interface {
 	BackgroundWorkflowExecutor() WorkflowNodeExecutor
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -764,14 +764,12 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	} else {
 		rt.emitBootProgress(8, "pipeline_maintenance", "skipped", "pipeline unavailable")
 	}
-	systemNodeCount := 0
-	for _, node := range rt.SystemNodes {
-		if node != nil {
-			go node.Run(startCtx)
-			systemNodeCount++
-		}
+	systemNodeCount, err := rt.startSystemNodesAndWaitForSubscriptions(ctx, startCtx)
+	if err != nil {
+		rt.emitBootProgress(9, "system_nodes_start", "FAILED", err.Error())
+		return err
 	}
-	rt.emitBootProgress(9, "system_nodes_start", "ok", fmt.Sprintf("%d nodes started", systemNodeCount))
+	rt.emitBootProgress(9, "system_nodes_start", "ok", fmt.Sprintf("%d nodes subscribed", systemNodeCount))
 	if skipPersistentStartupRecovery {
 		rt.emitBootProgress(10, "schedule_restoration", "skipped", "persistent startup recovery disabled")
 	} else if rt.Scheduler != nil && rt.Stores.ScheduleStore != nil {
@@ -986,6 +984,56 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	started = true
 	return nil
+}
+
+func (rt *Runtime) startSystemNodesAndWaitForSubscriptions(ctx context.Context, startCtx context.Context) (int, error) {
+	if rt == nil {
+		return 0, fmt.Errorf("runtime is nil")
+	}
+	nodes := make([]runtimepipeline.BackgroundNode, 0, len(rt.SystemNodes))
+	readiness := make(chan string, len(rt.SystemNodes))
+	for _, node := range rt.SystemNodes {
+		if node == nil {
+			continue
+		}
+		readyNode, ok := node.(runtimepipeline.SubscriptionReadyBackgroundNode)
+		if !ok {
+			return 0, fmt.Errorf("system node %s cannot report subscription readiness", runtimeBackgroundNodeName(node))
+		}
+		nodeName := runtimeBackgroundNodeName(node)
+		var once sync.Once
+		readyNode.AddSubscriptionReadyHook(func() {
+			once.Do(func() {
+				readiness <- nodeName
+			})
+		})
+		nodes = append(nodes, node)
+	}
+	for _, node := range nodes {
+		go node.Run(startCtx)
+	}
+	for subscribed := 0; subscribed < len(nodes); subscribed++ {
+		select {
+		case <-ctx.Done():
+			return len(nodes), fmt.Errorf("wait for system node subscriptions: %w", ctx.Err())
+		case <-startCtx.Done():
+			return len(nodes), fmt.Errorf("wait for system node subscriptions: %w", startCtx.Err())
+		case <-readiness:
+		}
+	}
+	return len(nodes), nil
+}
+
+func runtimeBackgroundNodeName(node runtimepipeline.BackgroundNode) string {
+	if node == nil {
+		return "<nil>"
+	}
+	if named, ok := node.(fmt.Stringer); ok {
+		if name := strings.TrimSpace(named.String()); name != "" {
+			return name
+		}
+	}
+	return fmt.Sprintf("%T", node)
 }
 
 func (rt *Runtime) Shutdown() error {

--- a/internal/runtime/runtime_startup_readiness_test.go
+++ b/internal/runtime/runtime_startup_readiness_test.go
@@ -1,0 +1,172 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type delayedSubscriptionBackgroundNode struct {
+	started chan struct{}
+	release chan struct{}
+
+	mu    sync.Mutex
+	hooks []func()
+}
+
+func newDelayedSubscriptionBackgroundNode() *delayedSubscriptionBackgroundNode {
+	return &delayedSubscriptionBackgroundNode{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (n *delayedSubscriptionBackgroundNode) Run(ctx context.Context) {
+	close(n.started)
+	select {
+	case <-ctx.Done():
+		return
+	case <-n.release:
+	}
+	n.mu.Lock()
+	hooks := append([]func(){}, n.hooks...)
+	n.mu.Unlock()
+	for _, hook := range hooks {
+		hook()
+	}
+	<-ctx.Done()
+}
+
+func (n *delayedSubscriptionBackgroundNode) AddSubscriptionReadyHook(fn func()) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.hooks = append(n.hooks, fn)
+}
+
+func (*delayedSubscriptionBackgroundNode) String() string {
+	return "delayed-system-node"
+}
+
+type startupReadinessWorkflowModule struct{}
+
+func (startupReadinessWorkflowModule) SemanticSource() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+}
+
+func (startupReadinessWorkflowModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return &runtimepipeline.WorkflowDefinition{}
+}
+
+func (startupReadinessWorkflowModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return nil
+}
+
+func (startupReadinessWorkflowModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return nil
+}
+
+func (startupReadinessWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return nil
+}
+
+func newStartupReadinessTestRuntime(nodes ...runtimepipeline.BackgroundNode) *Runtime {
+	return &Runtime{
+		Config:      testOperationalRuntimeConfig(),
+		SystemNodes: nodes,
+		Options: RuntimeOptions{
+			DisablePersistentStartupRecovery: true,
+			WorkflowModule:                   startupReadinessWorkflowModule{},
+		},
+	}
+}
+
+func TestRuntimeStartWaitsForSystemNodeSubscriptionReadiness(t *testing.T) {
+	node := newDelayedSubscriptionBackgroundNode()
+	rt := newStartupReadinessTestRuntime(node)
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- rt.Start(context.Background())
+	}()
+
+	select {
+	case <-node.started:
+	case err := <-startErr:
+		t.Fatalf("Start returned before node subscribed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for system node to start")
+	}
+
+	select {
+	case err := <-startErr:
+		t.Fatalf("Start returned before subscription readiness: %v", err)
+	default:
+	}
+
+	close(node.release)
+	select {
+	case err := <-startErr:
+		if err != nil {
+			t.Fatalf("Start after subscription readiness: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Start after subscription readiness")
+	}
+	if err := rt.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestRuntimeStartFailsClosedWhenSystemNodeSubscriptionReadinessIsCanceled(t *testing.T) {
+	node := newDelayedSubscriptionBackgroundNode()
+	rt := newStartupReadinessTestRuntime(node)
+	ctx, cancel := context.WithCancel(context.Background())
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- rt.Start(ctx)
+	}()
+
+	select {
+	case <-node.started:
+	case err := <-startErr:
+		t.Fatalf("Start returned before node subscribed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for system node to start")
+	}
+	cancel()
+
+	select {
+	case err := <-startErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start error = %v, want context canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled Start")
+	}
+}
+
+type nonReportingBackgroundNode struct {
+	ran bool
+}
+
+func (n *nonReportingBackgroundNode) Run(context.Context) {
+	n.ran = true
+}
+
+func TestRuntimeStartRejectsSystemNodeWithoutSubscriptionReadiness(t *testing.T) {
+	node := &nonReportingBackgroundNode{}
+	rt := newStartupReadinessTestRuntime(node)
+	err := rt.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "cannot report subscription readiness") {
+		t.Fatalf("Start error = %v, want subscription readiness reporting failure", err)
+	}
+	if node.ran {
+		t.Fatal("system node ran despite missing subscription readiness reporting")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a production subscription-readiness handshake for runtime system nodes started by `Runtime.Start`.
- Make `Runtime.Start` fail closed if a system node cannot report subscription readiness or startup is canceled before subscriptions are active.
- Preserve public readiness consumers by keeping the existing ready bit downstream of `Runtime.Start`, with reload supervisor coverage.

Closes #1389

## Governing Refs / Binding Context

Exact spec references:

- `platform-spec.yaml#runtime_model.boot_sequence`: `start_system_nodes` requires nodes subscribed/ready before `ready`; `start_agents` precedes `ready`; `ready` means platform accepting events.
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`: `/healthz`, `/readyz`, `/v1/rpc`, and `/v1/ws` share the API listener and startup fails closed before readiness when listener binding fails.
- `platform-spec.yaml#cli_specification.command_catalog.serve.boot_observability`: boot facts include `system_nodes_start`, `manager_event_loop_start`, `health_endpoints_respond`, and `ready`.
- `platform-spec.yaml#api_specification.process_probes`: `/readyz` returns OK only when runtime is ready to accept requests.
- Adjacent `/v1/rpc event.publish` contract: durable ACK semantics are unchanged; this PR gates readiness before public publish, not publish ACK after readiness.

## Semantic Migration

- New canonical implementation owner: `internal/runtime.Runtime.Start` waits for every `SubscriptionReadyBackgroundNode` started as a system node to report subscription readiness before it can return successfully.
- Old invalid path: `Runtime.Start` no longer treats `go node.Run(startCtx)` plus `system_nodes_start=ok` as subscription readiness.
- Production paths checked for surviving old behavior: `cmd/swarm` serve readiness bit, `/readyz`, `health.check`/operator readiness via the same ready callback, ready banner/boot progress, and `runtimeProjectSupervisor` reload readiness.
- Migration complete for the chosen class: all system nodes produced by `PipelineCoordinator.BackgroundNodesWithReceiptStore` expose the subscription-ready hook consumed by `Runtime.Start`; custom non-reporting nodes fail closed.

## Proof

- `go test ./internal/runtime -run 'TestRuntimeStart(WaitsForSystemNodeSubscriptionReadiness|FailsClosedWhenSystemNodeSubscriptionReadinessIsCanceled|RejectsSystemNodeWithoutSubscriptionReadiness)$' -count=1`
- `go test ./cmd/swarm -run 'TestRuntimeProjectSupervisorReplaceCurrentRuntime_(ClearsReadinessBeforeShutdown|WaitsForRuntimeStartBeforeReady)$' -count=1`
- `go test ./internal/runtime/pipeline -run 'Test.*Subscribe|Test.*SystemNode|Test.*LifecycleProbe|Test.*Completion' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)$' -count=1`
- `go test ./cmd/swarm -run 'Test(NewAPIServer.*Ready|WaitForServeHealthEndpointsProvesHealthAndReadyRoutes|RuntimeProjectSupervisorReplaceCurrentRuntime_WaitsForRuntimeStartBeforeReady)$' -count=1`
- `go test ./internal/runtime/manager -run 'Test.*(Agent|Flow|Recovery|Shutdown)' -count=1`
- `go test ./internal/runtime -run 'TestRuntime(Start|Boot|.*Agent|.*Startup|.*SelfCheck)' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./internal/runtime/pipeline -count=1`
- `go test ./...`
