### PR TITLE
[agent-c][issue #1394] Guard SQLite runtime writer boundary

### DIFF
--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -352,9 +352,9 @@ func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef s
 		return nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
-		return s.markTerminatedSQLite(ctx, storageRef, terminatedAt)
+		return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.markTerminatedSQLiteTx(txctx, tx, storageRef, terminatedAt)
+		})
 	}
 	storageRef = strings.TrimSpace(storageRef)
 	if storageRef == "" {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -188,15 +188,18 @@ func (s *WorkflowInstanceStore) mutateSQLite(ctx context.Context, instanceID str
 	})
 }
 
-func (s *WorkflowInstanceStore) markTerminatedSQLite(ctx context.Context, storageRef string, terminatedAt time.Time) error {
+func (s *WorkflowInstanceStore) markTerminatedSQLiteTx(ctx context.Context, tx *sql.Tx, storageRef string, terminatedAt time.Time) error {
 	storageRef = strings.TrimSpace(storageRef)
 	if storageRef == "" {
 		return fmt.Errorf("workflow instance storage_ref is required")
 	}
+	if tx == nil {
+		return fmt.Errorf("sqlite workflow instance transaction is required")
+	}
 	if terminatedAt.IsZero() {
 		terminatedAt = time.Now().UTC()
 	}
-	res, err := dbExecContext(ctx, s.db, `
+	res, err := tx.ExecContext(ctx, `
 		UPDATE flow_instances
 		SET status = 'terminated',
 		    terminated_at = COALESCE(terminated_at, ?)

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -99,6 +99,40 @@ func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *test
 	}
 }
 
+func TestSQLiteWorkflowInstanceStore_MarkTerminatedUsesRuntimeMutationRunner(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	runner := &recordingRuntimeMutationRunner{db: db}
+	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
+	storageRef := "root/terminated"
+	terminatedAt := time.Now().UTC().Truncate(time.Millisecond)
+	if _, err := db.Exec(`
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES (?, 'root', 'workflow', '{}', 'running', ?)
+	`, storageRef, time.Now().UTC()); err != nil {
+		t.Fatalf("seed flow instance: %v", err)
+	}
+
+	if err := store.MarkTerminated(context.Background(), storageRef, terminatedAt); err != nil {
+		t.Fatalf("MarkTerminated: %v", err)
+	}
+	if got := atomic.LoadInt32(&runner.calls); got != 1 {
+		t.Fatalf("runtime mutation calls = %d, want 1", got)
+	}
+
+	var status string
+	var hasTerminatedAt int
+	if err := db.QueryRow(`
+		SELECT COALESCE(status, ''), terminated_at IS NOT NULL
+		FROM flow_instances
+		WHERE instance_id = ?
+	`, storageRef).Scan(&status, &hasTerminatedAt); err != nil {
+		t.Fatalf("load terminated flow instance: %v", err)
+	}
+	if status != "terminated" || hasTerminatedAt != 1 {
+		t.Fatalf("flow instance status=%q hasTerminatedAt=%d, want terminated/1", status, hasTerminatedAt)
+	}
+}
+
 func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRetriesBusyAndFlushesPostCommitOnce(t *testing.T) {
 	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBs(t)
 	store := NewSQLiteWorkflowInstanceStore(db)
@@ -303,6 +337,34 @@ func TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDiale
 	if got := atomic.LoadInt32(&attempts); got != 1 {
 		t.Fatalf("attempts = %d, want no retry for postgres dialect", got)
 	}
+}
+
+type recordingRuntimeMutationRunner struct {
+	db    *sql.DB
+	calls int32
+}
+
+func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	atomic.AddInt32(&r.calls, 1)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	txctx := WithPipelineSQLTxContext(ctx, tx)
+	if err := fn(txctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {

--- a/internal/store/mailbox_materialization.go
+++ b/internal/store/mailbox_materialization.go
@@ -64,19 +64,21 @@ func (s *SQLiteRuntimeStore) MaterializeMailboxWrite(ctx context.Context, item r
 	if err != nil {
 		return err
 	}
-	exec := mailboxMaterializationDBExecutor(ctx, s.DB)
-	_, err = exec.ExecContext(ctx, `
-		INSERT INTO mailbox (
-			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
-			from_agent, severity, summary, payload, status, notified, created_at
-		)
-		VALUES (?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'pending', 0, ?)
-		ON CONFLICT(item_id) DO NOTHING
-	`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), time.Now().UTC())
-	if err != nil {
-		return fmt.Errorf("materialize sqlite mailbox_write: %w", err)
-	}
-	return nil
+	now := time.Now().UTC()
+	return s.runRuntimeMutation(ctx, "sqlite mailbox_write materialization", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO mailbox (
+				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+				from_agent, severity, summary, payload, status, notified, created_at
+			)
+			VALUES (?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'pending', 0, ?)
+			ON CONFLICT(item_id) DO NOTHING
+		`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), now)
+		if err != nil {
+			return fmt.Errorf("materialize sqlite mailbox_write: %w", err)
+		}
+		return nil
+	})
 }
 
 func mailboxMaterializationDBExecutor(ctx context.Context, db *sql.DB) mailboxMaterializationExecutor {

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -49,6 +49,7 @@ type runtimeWriterCallSite struct {
 	InEventTransactionCallback    bool
 	InPipelineTransactionCallback bool
 	UsesBoundaryCallbackTx        bool
+	UsesFunctionTxParam           bool
 	UsesReceiverDBArgument        bool
 	FunctionContainsWrite         bool
 	FunctionContainsBegin         bool
@@ -210,6 +211,32 @@ func (s *WorkflowInstanceStore) BadPipelineBypass(ctx context.Context) error {
 	}
 }
 
+func TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteRawDBHelperFixture(t *testing.T) {
+	const src = `package pipeline
+
+import (
+	"context"
+	"database/sql"
+)
+
+func badSQLitePipelineHelper(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "UPDATE flow_instances SET status = 'terminated'")
+	return err
+}
+`
+	sites, err := collectRuntimeWriterCallSitesFromSource("internal/runtime/pipeline/workflow_instance_store_sqlite.go", src)
+	if err != nil {
+		t.Fatalf("collect fixture call sites: %v", err)
+	}
+	_, failures := classifyRuntimeWriterCallSites(sites)
+	if len(failures) == 0 {
+		t.Fatal("expected receiverless SQLite pipeline raw DB helper bypass fixture to fail classification")
+	}
+	if !strings.Contains(strings.Join(failures, "\n"), "badSQLitePipelineHelper") {
+		t.Fatalf("expected failure to name badSQLitePipelineHelper, got:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
 func TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary(t *testing.T) {
 	root := repoRootForRuntimeWriterGuard(t)
 	mainData, err := os.ReadFile(filepath.Join(root, "cmd", "swarm", "main.go"))
@@ -318,6 +345,7 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 			function:         fn.Name.Name,
 			receiver:         runtimeWriterReceiverName(fn),
 			receiverVariable: runtimeWriterReceiverVariableName(fn),
+			txParamNames:     runtimeWriterFunctionTxParamNames(fn),
 		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -382,6 +410,7 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 				InEventTransactionCallback:    inScope && scope.event,
 				InPipelineTransactionCallback: inScope && scope.pipeline,
 				UsesBoundaryCallbackTx:        inScope && scope.txParamName[callReceiver],
+				UsesFunctionTxParam:           info.txParamNames[callReceiver],
 				UsesReceiverDBArgument:        runtimeWriterCallUsesReceiverDBArgument(call, info.receiverVariable),
 				FunctionContainsWrite:         info.containsWrite,
 				FunctionContainsBegin:         info.containsBegin,
@@ -405,6 +434,7 @@ type runtimeWriterFunctionInfo struct {
 	callsEventTransaction     bool
 	callsPipelineTransaction  bool
 	usesPipelineTxFromContext bool
+	txParamNames              map[string]bool
 	containsWrite             bool
 	containsBegin             bool
 	containsRead              bool
@@ -483,11 +513,25 @@ func innermostRuntimeWriterBoundaryCallbackScope(scopes []runtimeWriterBoundaryC
 }
 
 func runtimeWriterCallbackTxParamNames(lit *ast.FuncLit) map[string]bool {
-	out := map[string]bool{}
 	if lit == nil || lit.Type == nil || lit.Type.Params == nil {
+		return map[string]bool{}
+	}
+	return runtimeWriterTxParamNames(lit.Type.Params)
+}
+
+func runtimeWriterFunctionTxParamNames(fn *ast.FuncDecl) map[string]bool {
+	if fn == nil || fn.Type == nil || fn.Type.Params == nil {
+		return map[string]bool{}
+	}
+	return runtimeWriterTxParamNames(fn.Type.Params)
+}
+
+func runtimeWriterTxParamNames(params *ast.FieldList) map[string]bool {
+	out := map[string]bool{}
+	if params == nil {
 		return out
 	}
-	for _, field := range lit.Type.Params.List {
+	for _, field := range params.List {
 		if !runtimeWriterExprLooksSQLTx(field.Type) {
 			continue
 		}
@@ -621,6 +665,12 @@ func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterCla
 			return "", "", false
 		}
 	}
+	if classification, reason, ok := classifyWorkflowInstanceStoreSpecCallSite(site); ok {
+		return classification, reason, true
+	}
+	if sqlitePipelineTxHelper(site) {
+		return classActiveTxHelper, "SQLite pipeline helper uses caller-provided *sql.Tx instead of raw *sql.DB", true
+	}
 	if sqliteActiveTxHelper(site) {
 		return classActiveTxHelper, "helper writes only through caller-provided canonical transaction", true
 	}
@@ -645,6 +695,12 @@ func classifyWorkflowInstanceStoreCallSite(site runtimeWriterCallSite) (runtimeW
 	if (site.InPipelineTransactionCallback || site.InRuntimeMutationCallback) && site.UsesBoundaryCallbackTx {
 		return classConsumesCanonical, "WorkflowInstanceStore selected writer executes through the callback transaction", true
 	}
+	if sqlitePipelineTxHelper(site) {
+		return classActiveTxHelper, "SQLite WorkflowInstanceStore helper uses caller-provided *sql.Tx", true
+	}
+	if classification, reason, ok := classifyWorkflowInstanceStoreSpecCallSite(site); ok {
+		return classification, reason, true
+	}
 	if site.Primitive == "dbExecContext" && site.UsesReceiverDBArgument {
 		if site.InPipelineTransactionCallback || site.InRuntimeMutationCallback {
 			return classConsumesCanonical, "WorkflowInstanceStore helper-mediated write executes inside canonical transaction context", true
@@ -655,6 +711,32 @@ func classifyWorkflowInstanceStoreCallSite(site runtimeWriterCallSite) (runtimeW
 		site.ReceiverVariable != "" &&
 		site.CallReceiver == site.ReceiverVariable {
 		return "", "", false
+	}
+	return "", "", false
+}
+
+func classifyWorkflowInstanceStoreSpecCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
+	if site.Path != "internal/runtime/pipeline/workflow_instance_store.go" {
+		return "", "", false
+	}
+	switch site.Function {
+	case "runInPipelineTransactionOnce":
+		if site.Kind == primitiveBegin {
+			return classSplitLegacy, "named pipeline transaction owner opens a transaction before invoking the callback", true
+		}
+	case "workflowInstanceStoreTx":
+		if site.Kind == primitiveBegin {
+			return classSplitLegacy, "named old fallback helper opens a transaction when no active pipeline tx exists", true
+		}
+	case "MarkTerminated", "upsertSpec", "createSpec":
+		if site.CallReceiver == "tx" {
+			return classDifferentConcept, "named Postgres/spec workflow instance writer uses a local transaction after SQLite has delegated to the canonical path", true
+		}
+	case "workflowInstanceCreateTargetExists", "lockWorkflowInstanceMutation",
+		"insertWorkflowCreateEntityInitialValueMutations", "loadTrackedEntityStateProjection":
+		if site.UsesFunctionTxParam {
+			return classDifferentConcept, "named Postgres/spec helper uses caller-provided *sql.Tx", true
+		}
 	}
 	return "", "", false
 }
@@ -696,6 +778,22 @@ func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWrit
 		return classDifferentConcept, "SQLiteRuntimeStore read/capability surface; not mutation authority", true
 	}
 	return "", "", false
+}
+
+func sqlitePipelineTxHelper(site runtimeWriterCallSite) bool {
+	if site.Kind == primitiveBegin || site.Kind == primitiveBoundary {
+		return false
+	}
+	if !site.UsesFunctionTxParam {
+		return false
+	}
+	switch site.Path {
+	case "internal/runtime/pipeline/workflow_instance_store_sqlite.go",
+		"internal/runtime/pipeline/system_node_receipt_store.go":
+		return true
+	default:
+		return false
+	}
 }
 
 func sqliteActiveTxHelper(site runtimeWriterCallSite) bool {
@@ -783,20 +881,6 @@ func runtimeWriterRules() []runtimeWriterRule {
 			kinds:          allPrimitiveKinds(),
 			classification: classDifferentConcept,
 			reason:         "Postgres session registry implementation; SQLite session rows are owned by SQLiteRuntimeStore",
-		},
-		{
-			name:           "pipeline sqlite active tx helpers",
-			path:           rx(`^internal/runtime/pipeline/(workflow_instance_store_sqlite|system_node_receipt_store)\.go$`),
-			kinds:          allPrimitiveKinds(),
-			classification: classActiveTxHelper,
-			reason:         "SQLite pipeline helper executes inside WorkflowInstanceStore.RunInPipelineTransaction",
-		},
-		{
-			name:           "pipeline transaction owner and old fallback",
-			path:           rx(`^internal/runtime/pipeline/workflow_instance_store\.go$`),
-			kinds:          allPrimitiveKinds(),
-			classification: classSplitLegacy,
-			reason:         "WorkflowInstanceStore owns Postgres/spec txs and legacy SQLite fallback; production SQLite construction injects RunRuntimeMutation",
 		},
 		{
 			name:           "pipeline postgres raw sql helpers",

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -1,101 +1,691 @@
 package store
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
 
-func TestSQLiteRuntimeMutationWritersConsumeCanonicalBoundary(t *testing.T) {
-	files, err := filepath.Glob("*.go")
+type runtimeWriterPrimitiveKind string
+
+const (
+	primitiveBegin    runtimeWriterPrimitiveKind = "transaction-open"
+	primitiveWrite    runtimeWriterPrimitiveKind = "sql-write"
+	primitiveRead     runtimeWriterPrimitiveKind = "sql-read"
+	primitiveBoundary runtimeWriterPrimitiveKind = "canonical-boundary"
+)
+
+type runtimeWriterClassification string
+
+const (
+	classConsumesCanonical runtimeWriterClassification = "already consumes canonical boundary"
+	classActiveTxHelper    runtimeWriterClassification = "valid active-transaction helper under canonical boundary"
+	classDifferentConcept  runtimeWriterClassification = "different semantic concept"
+	classSplitLegacy       runtimeWriterClassification = "split / old non-authoritative path"
+)
+
+type runtimeWriterCallSite struct {
+	Path                      string
+	Line                      int
+	Function                  string
+	Receiver                  string
+	Primitive                 string
+	Kind                      runtimeWriterPrimitiveKind
+	CallsRuntimeMutation      bool
+	CallsEventTransaction     bool
+	CallsPipelineTransaction  bool
+	UsesPipelineTxFromContext bool
+	FunctionContainsWrite     bool
+	FunctionContainsBegin     bool
+	FunctionContainsRead      bool
+	FunctionContainsBoundary  bool
+	FunctionSourceDescription string
+}
+
+type runtimeWriterAuditRow struct {
+	Site           runtimeWriterCallSite
+	Classification runtimeWriterClassification
+	Reason         string
+}
+
+type runtimeWriterRule struct {
+	name           string
+	path           *regexp.Regexp
+	function       *regexp.Regexp
+	receiver       *regexp.Regexp
+	kinds          map[runtimeWriterPrimitiveKind]bool
+	classification runtimeWriterClassification
+	reason         string
+}
+
+func TestSelectedSQLiteRuntimeWriterBoundaryAudit(t *testing.T) {
+	root := repoRootForRuntimeWriterGuard(t)
+	sites, err := collectRuntimeWriterCallSites(root)
 	if err != nil {
-		t.Fatalf("list store files: %v", err)
+		t.Fatalf("collect runtime writer call sites: %v", err)
 	}
-	allowed := map[string]string{
-		"BeginEventTx":                 "legacy TransactionalEventStore fallback; SQLite production publish uses RunEventTransaction",
-		"runRuntimeMutationOnceLocked": "canonical SQLite runtime mutation executor opens the owned transaction while serialized",
-		"runRuntimeMutationOnce":       "canonical SQLite runtime mutation executor flushes successful post-commit actions",
-		"runRuntimeMutation":           "canonical SQLite runtime mutation executor",
-		"RunRuntimeMutation":           "canonical SQLite runtime mutation executor",
-		"RunEventTransaction":          "canonical SQLite event transaction executor",
+	if len(sites) == 0 {
+		t.Fatal("expected production SQL/transaction call sites")
 	}
-	for _, file := range files {
-		if strings.HasSuffix(file, "_test.go") {
-			continue
+
+	rows, failures := classifyRuntimeWriterCallSites(sites)
+	if len(failures) > 0 {
+		t.Fatalf("unclassified or invalid selected-runtime writer seams:\n%s", strings.Join(failures, "\n"))
+	}
+
+	byClass := map[runtimeWriterClassification]int{}
+	for _, row := range rows {
+		byClass[row.Classification]++
+	}
+	for _, required := range []runtimeWriterClassification{
+		classConsumesCanonical,
+		classActiveTxHelper,
+		classDifferentConcept,
+		classSplitLegacy,
+	} {
+		if byClass[required] == 0 {
+			t.Fatalf("runtime writer audit did not classify any seam as %q", required)
 		}
-		fset := token.NewFileSet()
-		parsed, err := parser.ParseFile(fset, file, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", file, err)
-		}
-		for _, decl := range parsed.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || !sqliteRuntimeStoreReceiver(fn) {
-				continue
-			}
-			if _, ok := allowed[fn.Name.Name]; ok {
-				continue
-			}
-			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				sel, ok := n.(*ast.SelectorExpr)
-				if !ok {
-					return true
-				}
-				switch selectorPath(sel) {
-				case "s.DB.BeginTx", "s.DB.Exec", "s.DB.ExecContext":
-					pos := fset.Position(sel.Pos())
-					t.Fatalf("%s:%d: SQLiteRuntimeStore.%s bypasses RunRuntimeMutation with %s", file, pos.Line, fn.Name.Name, selectorPath(sel))
-				}
-				return true
-			})
-		}
+	}
+	t.Logf("runtime writer boundary audit classified %d call sites: %s", len(rows), runtimeWriterAuditSummary(byClass))
+}
+
+func TestRuntimeWriterBoundaryGuardRejectsSelectedSQLiteBypassFixture(t *testing.T) {
+	const src = `package store
+
+import (
+	"context"
+	"database/sql"
+)
+
+type SQLiteRuntimeStore struct {
+	DB *sql.DB
+}
+
+func (s *SQLiteRuntimeStore) BadBypass(ctx context.Context) error {
+	_, err := s.DB.ExecContext(ctx, "INSERT INTO events(event_id) VALUES (?)", "evt")
+	return err
+}
+`
+	sites, err := collectRuntimeWriterCallSitesFromSource("internal/store/fixture_bypass.go", src)
+	if err != nil {
+		t.Fatalf("collect fixture call sites: %v", err)
+	}
+	_, failures := classifyRuntimeWriterCallSites(sites)
+	if len(failures) == 0 {
+		t.Fatal("expected selected SQLite direct write bypass fixture to fail classification")
+	}
+	if !strings.Contains(strings.Join(failures, "\n"), "BadBypass") {
+		t.Fatalf("expected failure to name BadBypass, got:\n%s", strings.Join(failures, "\n"))
 	}
 }
 
-func TestProductionSQLitePipelineStoreConsumesRuntimeMutationRunner(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("..", "..", "cmd", "swarm", "main.go"))
+func TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary(t *testing.T) {
+	root := repoRootForRuntimeWriterGuard(t)
+	mainData, err := os.ReadFile(filepath.Join(root, "cmd", "swarm", "main.go"))
 	if err != nil {
 		t.Fatalf("read cmd/swarm/main.go: %v", err)
 	}
-	text := string(data)
-	if !strings.Contains(text, "NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)") {
+	mainText := string(mainData)
+	if !strings.Contains(mainText, "NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)") {
 		t.Fatal("cmd/swarm SQLite store construction must wire WorkflowInstanceStore through SQLiteRuntimeStore.RunRuntimeMutation")
 	}
-	if strings.Contains(text, "NewSQLiteWorkflowInstanceStore(sqliteStore.DB)") {
+	if strings.Contains(mainText, "NewSQLiteWorkflowInstanceStore(sqliteStore.DB)") {
 		t.Fatal("cmd/swarm SQLite store construction uses legacy WorkflowInstanceStore without the runtime mutation boundary")
 	}
+	sqliteBlock := runtimeWriterSnippetAfter(mainText, "case storebackend.BackendSQLite:", "default:")
+	if strings.Contains(sqliteBlock, "RuntimeSQLDB:") {
+		t.Fatal("SQLite runtime construction must not expose raw runtime SQLDB to runtime.Stores")
+	}
+
+	facadeData, err := os.ReadFile(filepath.Join(root, "cmd", "swarm", "store_facade.go"))
+	if err != nil {
+		t.Fatalf("read cmd/swarm/store_facade.go: %v", err)
+	}
+	facadeText := string(facadeData)
+	if !strings.Contains(facadeText, "SQLDB:               s.RuntimeSQLDB,") {
+		t.Fatal("selected runtime facade must use RuntimeSQLDB, leaving runtime.Stores.SQLDB nil for SQLite")
+	}
+
+	publishData, err := os.ReadFile(filepath.Join(root, "internal", "runtime", "bus", "eventbus_publish.go"))
+	if err != nil {
+		t.Fatalf("read internal/runtime/bus/eventbus_publish.go: %v", err)
+	}
+	if !strings.Contains(string(publishData), ".RunEventTransaction(ctx,") {
+		t.Fatal("event publish must consume EventTransactionRunner.RunEventTransaction when available")
+	}
 }
 
-func sqliteRuntimeStoreReceiver(fn *ast.FuncDecl) bool {
-	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
-		return false
-	}
-	switch expr := fn.Recv.List[0].Type.(type) {
-	case *ast.StarExpr:
-		if ident, ok := expr.X.(*ast.Ident); ok {
-			return ident.Name == "SQLiteRuntimeStore"
+func collectRuntimeWriterCallSites(root string) ([]runtimeWriterCallSite, error) {
+	var out []runtimeWriterCallSite
+	for _, relRoot := range []string{"cmd", "internal"} {
+		base := filepath.Join(root, relRoot)
+		if _, err := os.Stat(base); err != nil {
+			return nil, err
 		}
-	case *ast.Ident:
-		return expr.Name == "SQLiteRuntimeStore"
+		err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				switch filepath.Base(path) {
+				case "testdata":
+					return filepath.SkipDir
+				}
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					return relErr
+				}
+				if rel == filepath.Join("internal", "testutil") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
+			sites, parseErr := collectRuntimeWriterCallSitesFromFile(path, filepath.ToSlash(rel))
+			if parseErr != nil {
+				return parseErr
+			}
+			out = append(out, sites...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
-	return false
+	sortRuntimeWriterCallSites(out)
+	return out, nil
 }
 
-func selectorPath(expr ast.Expr) string {
+func collectRuntimeWriterCallSitesFromFile(path, rel string) ([]runtimeWriterCallSite, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return collectRuntimeWriterCallSitesFromSource(rel, string(data))
+}
+
+func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterCallSite, error) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	var out []runtimeWriterCallSite
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		info := runtimeWriterFunctionInfo{
+			path:     filepath.ToSlash(path),
+			function: fn.Name.Name,
+			receiver: runtimeWriterReceiverName(fn),
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			primitive, kind, ok := runtimeWriterPrimitive(call)
+			if !ok {
+				return true
+			}
+			switch primitive {
+			case "RunRuntimeMutation":
+				info.callsRuntimeMutation = true
+			case "runRuntimeMutation":
+				info.callsRuntimeMutation = true
+			case "RunEventTransaction":
+				info.callsEventTransaction = true
+			case "RunInPipelineTransaction":
+				info.callsPipelineTransaction = true
+			case "PipelineSQLTxFromContext", "sqlTxFromContext":
+				info.usesPipelineTxFromContext = true
+			}
+			switch kind {
+			case primitiveWrite:
+				info.containsWrite = true
+			case primitiveBegin:
+				info.containsBegin = true
+			case primitiveRead:
+				info.containsRead = true
+			case primitiveBoundary:
+				info.containsBoundary = true
+			}
+			return true
+		})
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			primitive, kind, ok := runtimeWriterPrimitive(call)
+			if !ok {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+			out = append(out, runtimeWriterCallSite{
+				Path:                      info.path,
+				Line:                      pos.Line,
+				Function:                  info.function,
+				Receiver:                  info.receiver,
+				Primitive:                 primitive,
+				Kind:                      kind,
+				CallsRuntimeMutation:      info.callsRuntimeMutation,
+				CallsEventTransaction:     info.callsEventTransaction,
+				CallsPipelineTransaction:  info.callsPipelineTransaction,
+				UsesPipelineTxFromContext: info.usesPipelineTxFromContext,
+				FunctionContainsWrite:     info.containsWrite,
+				FunctionContainsBegin:     info.containsBegin,
+				FunctionContainsRead:      info.containsRead,
+				FunctionContainsBoundary:  info.containsBoundary,
+				FunctionSourceDescription: fmt.Sprintf("%s.%s", info.receiver, info.function),
+			})
+			return true
+		})
+	}
+	sortRuntimeWriterCallSites(out)
+	return out, nil
+}
+
+type runtimeWriterFunctionInfo struct {
+	path                      string
+	function                  string
+	receiver                  string
+	callsRuntimeMutation      bool
+	callsEventTransaction     bool
+	callsPipelineTransaction  bool
+	usesPipelineTxFromContext bool
+	containsWrite             bool
+	containsBegin             bool
+	containsRead              bool
+	containsBoundary          bool
+}
+
+func runtimeWriterPrimitive(call *ast.CallExpr) (string, runtimeWriterPrimitiveKind, bool) {
+	name := runtimeWriterCallName(call.Fun)
+	switch name {
+	case "Begin", "BeginTx", "BeginTxx":
+		return name, primitiveBegin, true
+	case "Exec", "ExecContext":
+		return name, primitiveWrite, true
+	case "Query", "QueryContext", "QueryRow", "QueryRowContext", "Prepare", "PrepareContext":
+		return name, primitiveRead, true
+	case "RunInPipelineTransaction", "RunRuntimeMutation", "runRuntimeMutation", "RunEventTransaction", "PipelineSQLTxFromContext", "sqlTxFromContext":
+		return name, primitiveBoundary, true
+	default:
+		return "", "", false
+	}
+}
+
+func runtimeWriterCallName(expr ast.Expr) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return e.Name
 	case *ast.SelectorExpr:
-		base := selectorPath(e.X)
-		if base == "" {
-			return e.Sel.Name
-		}
-		return base + "." + e.Sel.Name
+		return e.Sel.Name
 	default:
 		return ""
 	}
+}
+
+func classifyRuntimeWriterCallSites(sites []runtimeWriterCallSite) ([]runtimeWriterAuditRow, []string) {
+	rows := make([]runtimeWriterAuditRow, 0, len(sites))
+	failures := []string{}
+	for _, site := range sites {
+		classification, reason, ok := classifyRuntimeWriterCallSite(site)
+		if !ok {
+			failures = append(failures, fmt.Sprintf("- %s:%d %s %s.%s %s is not classified", site.Path, site.Line, site.Kind, site.Receiver, site.Function, site.Primitive))
+			continue
+		}
+		rows = append(rows, runtimeWriterAuditRow{
+			Site:           site,
+			Classification: classification,
+			Reason:         reason,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i].Site, rows[j].Site
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		if a.Function != b.Function {
+			return a.Function < b.Function
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.Primitive < b.Primitive
+	})
+	return rows, failures
+}
+
+func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
+	if site.Kind == primitiveBoundary {
+		switch site.Primitive {
+		case "RunRuntimeMutation", "runRuntimeMutation", "RunEventTransaction":
+			return classConsumesCanonical, "canonical runtime mutation/event transaction boundary", true
+		case "RunInPipelineTransaction":
+			return classConsumesCanonical, "pipeline transaction owner delegates production SQLite writes to RunRuntimeMutation", true
+		case "PipelineSQLTxFromContext", "sqlTxFromContext":
+			return classActiveTxHelper, "active transaction context probe; not a writer by itself", true
+		}
+	}
+
+	if site.Receiver == "SQLiteRuntimeStore" {
+		return classifySQLiteRuntimeStoreCallSite(site)
+	}
+	if sqliteActiveTxHelper(site) {
+		return classActiveTxHelper, "helper writes only through caller-provided canonical transaction", true
+	}
+	if site.Receiver == "PostgresStore" || strings.Contains(site.Path, "postgres") || strings.Contains(site.Function, "Postgres") {
+		return classDifferentConcept, "Postgres implementation keeps normal transaction semantics and does not consume SQLite serialization", true
+	}
+	for _, rule := range runtimeWriterRules() {
+		if rule.matches(site) {
+			return rule.classification, rule.reason, true
+		}
+	}
+	if site.Kind == primitiveRead && !site.FunctionContainsWrite && !site.FunctionContainsBegin {
+		return classDifferentConcept, "read-only projection/query surface; not selected SQLite mutation authority", true
+	}
+	return "", "", false
+}
+
+func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
+	switch site.Function {
+	case "RunRuntimeMutation", "RunEventTransaction", "runRuntimeMutation", "runRuntimeMutationOnce", "runRuntimeMutationOnceLocked":
+		return classConsumesCanonical, "canonical SQLite runtime mutation owner", true
+	case "BeginEventTx":
+		if site.Kind == primitiveBegin {
+			return classSplitLegacy, "legacy TransactionalEventStore fallback; production SQLite publish uses RunEventTransaction", true
+		}
+	}
+	if site.Kind == primitiveWrite || site.Kind == primitiveBegin {
+		if site.CallsRuntimeMutation || site.CallsEventTransaction {
+			return classConsumesCanonical, "SQLiteRuntimeStore selected writer enters RunRuntimeMutation before executing SQL", true
+		}
+		if sqliteActiveTxHelper(site) {
+			return classActiveTxHelper, "SQLite helper writes only through caller-provided canonical transaction", true
+		}
+		return "", "", false
+	}
+	if site.Kind == primitiveRead {
+		if site.CallsRuntimeMutation || sqliteActiveTxHelper(site) {
+			return classActiveTxHelper, "read/query inside canonical SQLite mutation helper", true
+		}
+		return classDifferentConcept, "SQLiteRuntimeStore read/capability surface; not mutation authority", true
+	}
+	return "", "", false
+}
+
+func sqliteActiveTxHelper(site runtimeWriterCallSite) bool {
+	if site.Receiver == "" && strings.HasPrefix(site.Path, "internal/store/") && strings.Contains(site.Function, "Tx") && site.Kind != primitiveBegin {
+		return true
+	}
+	if site.Receiver == "SQLiteRuntimeStore" {
+		if strings.Contains(site.Function, "Tx") {
+			return true
+		}
+		switch site.Function {
+		case "sqliteLockAgentDeliveryTx", "sqliteEnsureRunRow", "purgeExpiredSQLiteAPIIdempotency", "sqliteStoreAPIIdempotency",
+			"appendSQLiteMailboxV1ApprovalEventTx", "normalizeSQLiteMailboxV1DecisionReplayResult",
+			"loadSQLiteMailboxV1RowTx", "sqliteMarkRunTerminalTx", "sqliteNormalRunCompletionRunReadyTx",
+			"sqliteNormalRunCompletionSessionLeasesSettledTx", "ensureSQLiteTaskConversationAuditRowTx":
+			return true
+		}
+	}
+	switch site.Function {
+	case "sqliteEnsureRunRow", "purgeExpiredSQLiteAPIIdempotency", "sqliteStoreAPIIdempotency",
+		"sqliteSyncRunCounts", "sqlitePauseRunControl", "sqliteContinueRunControl", "sqliteStopRunControl",
+		"insertSQLiteEntityStateDiff":
+		return true
+	}
+	return strings.HasPrefix(site.Path, "internal/store/sqlite_") && strings.Contains(site.Function, "Tx")
+}
+
+func runtimeWriterRules() []runtimeWriterRule {
+	return []runtimeWriterRule{
+		{
+			name:           "sqlite schema bootstrap",
+			path:           rx(`^internal/store/(sqlite_schema|platformschema/platformschema)\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "schema/bootstrap owns dialect DDL and PRAGMA behavior, split from selected runtime mutation writers",
+		},
+		{
+			name:           "schema capability reads",
+			path:           rx(`^internal/store/schema_capabilities\.go$`),
+			kinds:          kinds(primitiveRead),
+			classification: classDifferentConcept,
+			reason:         "schema capability reader; not mutation authority",
+		},
+		{
+			name:           "api idempotency postgres helper",
+			path:           rx(`^internal/store/api_idempotency\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "Postgres API idempotency advisory-lock helper; SQLite owner is SQLiteRuntimeStore.WithAPIIdempotency",
+		},
+		{
+			name:           "postgres advisory lock helper",
+			path:           rx(`^internal/store/shared_store_claims\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "Postgres advisory-lock helper; not selected SQLite mutation authority",
+		},
+		{
+			name:           "run lifecycle postgres helper",
+			path:           rx(`^internal/store/runlifecycle/.*\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "run lifecycle helper operates on Postgres raw DB owner, not selected SQLite runtime store",
+		},
+		{
+			name:           "run bundle postgres helper",
+			path:           rx(`^internal/store/runbundle/.*\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "run bundle catalog/availability is a Postgres or split feature capability, not selected SQLite mutation authority",
+		},
+		{
+			name:           "bundle and reset split features",
+			path:           rx(`^internal/store/(bundle_|destructive_reset|preservation_cleanup|conversation_fork|run_fork).*\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "bundle/reset/fork feature family remains split or Postgres-owned unless independently promoted",
+		},
+		{
+			name:           "runtime postgres sessions",
+			path:           rx(`^internal/runtime/sessions/postgres\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "Postgres session registry implementation; SQLite session rows are owned by SQLiteRuntimeStore",
+		},
+		{
+			name:           "pipeline sqlite active tx helpers",
+			path:           rx(`^internal/runtime/pipeline/(workflow_instance_store_sqlite|system_node_receipt_store)\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classActiveTxHelper,
+			reason:         "SQLite pipeline helper executes inside WorkflowInstanceStore.RunInPipelineTransaction",
+		},
+		{
+			name:           "pipeline transaction owner and old fallback",
+			path:           rx(`^internal/runtime/pipeline/workflow_instance_store\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classSplitLegacy,
+			reason:         "WorkflowInstanceStore owns Postgres/spec txs and legacy SQLite fallback; production SQLite construction injects RunRuntimeMutation",
+		},
+		{
+			name:           "pipeline postgres raw sql helpers",
+			path:           rx(`^internal/runtime/pipeline/(node_system_runner|workflow_entity_type_repair|coordinator|engine_adapter|runtime_support|workflow_transitions)\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "raw-SQL pipeline helper is Postgres/raw runtime SQL path; SQLite runtime facade leaves SQLDB nil and uses typed stores",
+		},
+		{
+			name:           "runtime db tx helper",
+			path:           rx(`^internal/runtime/dbtx\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "generic DB/tx helper is not selected SQLite runtime writer authority",
+		},
+		{
+			name:           "runtime diagnostics adjacent raw sql",
+			path:           rx(`^internal/runtime/(deadletters/record|mutationlog/mutationlog)\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "diagnostic/dead-letter raw SQL helper is adjacent and split from selected SQLite mutation boundary",
+		},
+		{
+			name:           "workspace and digest stores",
+			path:           rx(`^internal/(runtime/workspace|digest)/.*\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "workspace/digest persistence is not selected runtime SQLite mutation authority",
+		},
+		{
+			name:           "agent directives read helper",
+			path:           rx(`^internal/store/agent_directive_run_target\.go$`),
+			kinds:          kinds(primitiveRead),
+			classification: classDifferentConcept,
+			reason:         "agent directive helper is read-only",
+		},
+		{
+			name:           "read surface files",
+			path:           rx(`^internal/store/.*(read_surface|read|list|debug|observability|usage).*\.go$`),
+			kinds:          kinds(primitiveRead),
+			classification: classDifferentConcept,
+			reason:         "read/projection surface; not selected SQLite mutation authority",
+		},
+		{
+			name:           "operator conversation read surface",
+			path:           rx(`^internal/store/operator_agent_conversation_read_surface\.go$`),
+			kinds:          kinds(primitiveRead),
+			classification: classDifferentConcept,
+			reason:         "operator conversation read surface; not selected SQLite mutation authority",
+		},
+		{
+			name:           "mailbox legacy postgres store",
+			path:           rx(`^internal/store/mailbox\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "legacy/Postgres mailbox store implementation; SQLite mailbox rows are owned by SQLiteRuntimeStore",
+		},
+		{
+			name:           "postgres selected store files",
+			path:           rx(`^internal/store/(agent_store|events|event_receipt_store|inbound|llm_store|mailbox_v1|run_completion|run_control|runtime_ingress_state|schedule_store|tool_persistence|active_run_quiescence)\.go$`),
+			receiver:       rx(`^PostgresStore$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "Postgres selected store implementation; SQLite counterpart is guarded separately",
+		},
+	}
+}
+
+func (r runtimeWriterRule) matches(site runtimeWriterCallSite) bool {
+	if r.path != nil && !r.path.MatchString(site.Path) {
+		return false
+	}
+	if r.function != nil && !r.function.MatchString(site.Function) {
+		return false
+	}
+	if r.receiver != nil && !r.receiver.MatchString(site.Receiver) {
+		return false
+	}
+	if len(r.kinds) > 0 && !r.kinds[site.Kind] {
+		return false
+	}
+	return true
+}
+
+func runtimeWriterReceiverName(fn *ast.FuncDecl) string {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	switch expr := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := expr.X.(*ast.Ident); ok {
+			return ident.Name
+		}
+	case *ast.Ident:
+		return expr.Name
+	}
+	return ""
+}
+
+func repoRootForRuntimeWriterGuard(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return root
+}
+
+func runtimeWriterSnippetAfter(text, start, end string) string {
+	startIdx := strings.Index(text, start)
+	if startIdx < 0 {
+		return ""
+	}
+	rest := text[startIdx+len(start):]
+	if endIdx := strings.Index(rest, end); endIdx >= 0 {
+		return rest[:endIdx]
+	}
+	return rest
+}
+
+func runtimeWriterAuditSummary(counts map[runtimeWriterClassification]int) string {
+	parts := make([]string, 0, len(counts))
+	for class, count := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", class, count))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+func sortRuntimeWriterCallSites(sites []runtimeWriterCallSite) {
+	sort.Slice(sites, func(i, j int) bool {
+		if sites[i].Path != sites[j].Path {
+			return sites[i].Path < sites[j].Path
+		}
+		if sites[i].Line != sites[j].Line {
+			return sites[i].Line < sites[j].Line
+		}
+		if sites[i].Function != sites[j].Function {
+			return sites[i].Function < sites[j].Function
+		}
+		return sites[i].Primitive < sites[j].Primitive
+	})
+}
+
+func rx(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(pattern)
+}
+
+func kinds(values ...runtimeWriterPrimitiveKind) map[runtimeWriterPrimitiveKind]bool {
+	out := map[runtimeWriterPrimitiveKind]bool{}
+	for _, value := range values {
+		out[value] = true
+	}
+	return out
+}
+
+func allPrimitiveKinds() map[runtimeWriterPrimitiveKind]bool {
+	return kinds(primitiveBegin, primitiveWrite, primitiveRead, primitiveBoundary)
 }

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -33,21 +33,27 @@ const (
 )
 
 type runtimeWriterCallSite struct {
-	Path                      string
-	Line                      int
-	Function                  string
-	Receiver                  string
-	Primitive                 string
-	Kind                      runtimeWriterPrimitiveKind
-	CallsRuntimeMutation      bool
-	CallsEventTransaction     bool
-	CallsPipelineTransaction  bool
-	UsesPipelineTxFromContext bool
-	FunctionContainsWrite     bool
-	FunctionContainsBegin     bool
-	FunctionContainsRead      bool
-	FunctionContainsBoundary  bool
-	FunctionSourceDescription string
+	Path                          string
+	Line                          int
+	Function                      string
+	Receiver                      string
+	ReceiverVariable              string
+	Primitive                     string
+	Kind                          runtimeWriterPrimitiveKind
+	CallReceiver                  string
+	CallsRuntimeMutation          bool
+	CallsEventTransaction         bool
+	CallsPipelineTransaction      bool
+	UsesPipelineTxFromContext     bool
+	InRuntimeMutationCallback     bool
+	InEventTransactionCallback    bool
+	InPipelineTransactionCallback bool
+	UsesBoundaryCallbackTx        bool
+	FunctionContainsWrite         bool
+	FunctionContainsBegin         bool
+	FunctionContainsRead          bool
+	FunctionContainsBoundary      bool
+	FunctionSourceDescription     string
 }
 
 type runtimeWriterAuditRow struct {
@@ -64,6 +70,15 @@ type runtimeWriterRule struct {
 	kinds          map[runtimeWriterPrimitiveKind]bool
 	classification runtimeWriterClassification
 	reason         string
+}
+
+type runtimeWriterBoundaryCallbackScope struct {
+	start       token.Pos
+	end         token.Pos
+	runtime     bool
+	event       bool
+	pipeline    bool
+	txParamName map[string]bool
 }
 
 func TestSelectedSQLiteRuntimeWriterBoundaryAudit(t *testing.T) {
@@ -125,6 +140,42 @@ func (s *SQLiteRuntimeStore) BadBypass(ctx context.Context) error {
 	}
 	if !strings.Contains(strings.Join(failures, "\n"), "BadBypass") {
 		t.Fatalf("expected failure to name BadBypass, got:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func TestRuntimeWriterBoundaryGuardRejectsSameFunctionSQLiteBypassFixture(t *testing.T) {
+	const src = `package store
+
+import (
+	"context"
+	"database/sql"
+)
+
+type SQLiteRuntimeStore struct {
+	DB *sql.DB
+}
+
+func (store *SQLiteRuntimeStore) BadMixedBypass(ctx context.Context) error {
+	if err := store.runRuntimeMutation(ctx, "valid write", func(txctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(txctx, "INSERT INTO events(event_id) VALUES (?)", "inside")
+		return err
+	}); err != nil {
+		return err
+	}
+	_, err := store.DB.ExecContext(ctx, "INSERT INTO events(event_id) VALUES (?)", "outside")
+	return err
+}
+`
+	sites, err := collectRuntimeWriterCallSitesFromSource("internal/store/fixture_mixed_bypass.go", src)
+	if err != nil {
+		t.Fatalf("collect fixture call sites: %v", err)
+	}
+	_, failures := classifyRuntimeWriterCallSites(sites)
+	if len(failures) == 0 {
+		t.Fatal("expected selected SQLite same-function direct write bypass fixture to fail classification")
+	}
+	if !strings.Contains(strings.Join(failures, "\n"), "BadMixedBypass") {
+		t.Fatalf("expected failure to name BadMixedBypass, got:\n%s", strings.Join(failures, "\n"))
 	}
 }
 
@@ -232,9 +283,10 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 			continue
 		}
 		info := runtimeWriterFunctionInfo{
-			path:     filepath.ToSlash(path),
-			function: fn.Name.Name,
-			receiver: runtimeWriterReceiverName(fn),
+			path:             filepath.ToSlash(path),
+			function:         fn.Name.Name,
+			receiver:         runtimeWriterReceiverName(fn),
+			receiverVariable: runtimeWriterReceiverVariableName(fn),
 		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -269,6 +321,7 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 			}
 			return true
 		})
+		scopes := collectRuntimeWriterBoundaryCallbackScopes(fn.Body)
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
@@ -278,23 +331,31 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 			if !ok {
 				return true
 			}
+			callReceiver := runtimeWriterCallReceiver(call.Fun)
+			scope, inScope := innermostRuntimeWriterBoundaryCallbackScope(scopes, call.Pos())
 			pos := fset.Position(call.Pos())
 			out = append(out, runtimeWriterCallSite{
-				Path:                      info.path,
-				Line:                      pos.Line,
-				Function:                  info.function,
-				Receiver:                  info.receiver,
-				Primitive:                 primitive,
-				Kind:                      kind,
-				CallsRuntimeMutation:      info.callsRuntimeMutation,
-				CallsEventTransaction:     info.callsEventTransaction,
-				CallsPipelineTransaction:  info.callsPipelineTransaction,
-				UsesPipelineTxFromContext: info.usesPipelineTxFromContext,
-				FunctionContainsWrite:     info.containsWrite,
-				FunctionContainsBegin:     info.containsBegin,
-				FunctionContainsRead:      info.containsRead,
-				FunctionContainsBoundary:  info.containsBoundary,
-				FunctionSourceDescription: fmt.Sprintf("%s.%s", info.receiver, info.function),
+				Path:                          info.path,
+				Line:                          pos.Line,
+				Function:                      info.function,
+				Receiver:                      info.receiver,
+				ReceiverVariable:              info.receiverVariable,
+				Primitive:                     primitive,
+				Kind:                          kind,
+				CallReceiver:                  callReceiver,
+				CallsRuntimeMutation:          info.callsRuntimeMutation,
+				CallsEventTransaction:         info.callsEventTransaction,
+				CallsPipelineTransaction:      info.callsPipelineTransaction,
+				UsesPipelineTxFromContext:     info.usesPipelineTxFromContext,
+				InRuntimeMutationCallback:     inScope && scope.runtime,
+				InEventTransactionCallback:    inScope && scope.event,
+				InPipelineTransactionCallback: inScope && scope.pipeline,
+				UsesBoundaryCallbackTx:        inScope && scope.txParamName[callReceiver],
+				FunctionContainsWrite:         info.containsWrite,
+				FunctionContainsBegin:         info.containsBegin,
+				FunctionContainsRead:          info.containsRead,
+				FunctionContainsBoundary:      info.containsBoundary,
+				FunctionSourceDescription:     fmt.Sprintf("%s.%s", info.receiver, info.function),
 			})
 			return true
 		})
@@ -307,6 +368,7 @@ type runtimeWriterFunctionInfo struct {
 	path                      string
 	function                  string
 	receiver                  string
+	receiverVariable          string
 	callsRuntimeMutation      bool
 	callsEventTransaction     bool
 	callsPipelineTransaction  bool
@@ -333,12 +395,122 @@ func runtimeWriterPrimitive(call *ast.CallExpr) (string, runtimeWriterPrimitiveK
 	}
 }
 
+func collectRuntimeWriterBoundaryCallbackScopes(body ast.Node) []runtimeWriterBoundaryCallbackScope {
+	var scopes []runtimeWriterBoundaryCallbackScope
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		primitive, _, ok := runtimeWriterPrimitive(call)
+		if !ok {
+			return true
+		}
+		scope := runtimeWriterBoundaryCallbackScope{}
+		switch primitive {
+		case "RunRuntimeMutation", "runRuntimeMutation":
+			scope.runtime = true
+		case "RunEventTransaction":
+			scope.event = true
+		case "RunInPipelineTransaction":
+			scope.pipeline = true
+		default:
+			return true
+		}
+		for _, arg := range call.Args {
+			lit, ok := arg.(*ast.FuncLit)
+			if !ok || lit.Body == nil {
+				continue
+			}
+			next := scope
+			next.start = lit.Body.Pos()
+			next.end = lit.Body.End()
+			next.txParamName = runtimeWriterCallbackTxParamNames(lit)
+			scopes = append(scopes, next)
+		}
+		return true
+	})
+	return scopes
+}
+
+func innermostRuntimeWriterBoundaryCallbackScope(scopes []runtimeWriterBoundaryCallbackScope, pos token.Pos) (runtimeWriterBoundaryCallbackScope, bool) {
+	var out runtimeWriterBoundaryCallbackScope
+	found := false
+	for _, scope := range scopes {
+		if pos < scope.start || pos > scope.end {
+			continue
+		}
+		if !found || (scope.end-scope.start) < (out.end-out.start) {
+			out = scope
+			found = true
+		}
+	}
+	return out, found
+}
+
+func runtimeWriterCallbackTxParamNames(lit *ast.FuncLit) map[string]bool {
+	out := map[string]bool{}
+	if lit == nil || lit.Type == nil || lit.Type.Params == nil {
+		return out
+	}
+	for _, field := range lit.Type.Params.List {
+		if !runtimeWriterExprLooksSQLTx(field.Type) {
+			continue
+		}
+		for _, name := range field.Names {
+			if name == nil || name.Name == "" || name.Name == "_" {
+				continue
+			}
+			out[name.Name] = true
+		}
+	}
+	return out
+}
+
+func runtimeWriterExprLooksSQLTx(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.StarExpr:
+		return runtimeWriterExprLooksSQLTx(e.X)
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "Tx"
+	case *ast.Ident:
+		return e.Name == "Tx"
+	case *ast.ParenExpr:
+		return runtimeWriterExprLooksSQLTx(e.X)
+	default:
+		return false
+	}
+}
+
 func runtimeWriterCallName(expr ast.Expr) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return e.Name
 	case *ast.SelectorExpr:
 		return e.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func runtimeWriterCallReceiver(expr ast.Expr) string {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	return runtimeWriterRootIdent(sel.X)
+}
+
+func runtimeWriterRootIdent(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return runtimeWriterRootIdent(e.X)
+	case *ast.ParenExpr:
+		return runtimeWriterRootIdent(e.X)
+	case *ast.StarExpr:
+		return runtimeWriterRootIdent(e.X)
 	default:
 		return ""
 	}
@@ -417,8 +589,8 @@ func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWrit
 		}
 	}
 	if site.Kind == primitiveWrite || site.Kind == primitiveBegin {
-		if site.CallsRuntimeMutation || site.CallsEventTransaction {
-			return classConsumesCanonical, "SQLiteRuntimeStore selected writer enters RunRuntimeMutation before executing SQL", true
+		if (site.InRuntimeMutationCallback || site.InEventTransactionCallback) && site.UsesBoundaryCallbackTx {
+			return classConsumesCanonical, "SQLiteRuntimeStore selected writer executes through the callback transaction", true
 		}
 		if sqliteActiveTxHelper(site) {
 			return classActiveTxHelper, "SQLite helper writes only through caller-provided canonical transaction", true
@@ -426,7 +598,7 @@ func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWrit
 		return "", "", false
 	}
 	if site.Kind == primitiveRead {
-		if site.CallsRuntimeMutation || sqliteActiveTxHelper(site) {
+		if ((site.InRuntimeMutationCallback || site.InEventTransactionCallback) && site.UsesBoundaryCallbackTx) || sqliteActiveTxHelper(site) {
 			return classActiveTxHelper, "read/query inside canonical SQLite mutation helper", true
 		}
 		return classDifferentConcept, "SQLiteRuntimeStore read/capability surface; not mutation authority", true
@@ -435,6 +607,9 @@ func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWrit
 }
 
 func sqliteActiveTxHelper(site runtimeWriterCallSite) bool {
+	if site.Receiver == "SQLiteRuntimeStore" && site.ReceiverVariable != "" && site.CallReceiver == site.ReceiverVariable {
+		return false
+	}
 	if site.Receiver == "" && strings.HasPrefix(site.Path, "internal/store/") && strings.Contains(site.Function, "Tx") && site.Kind != primitiveBegin {
 		return true
 	}
@@ -627,6 +802,16 @@ func runtimeWriterReceiverName(fn *ast.FuncDecl) string {
 		return expr.Name
 	}
 	return ""
+}
+
+func runtimeWriterReceiverVariableName(fn *ast.FuncDecl) string {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	if len(fn.Recv.List[0].Names) == 0 || fn.Recv.List[0].Names[0] == nil {
+		return ""
+	}
+	return fn.Recv.List[0].Names[0].Name
 }
 
 func repoRootForRuntimeWriterGuard(t *testing.T) string {

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -49,6 +49,7 @@ type runtimeWriterCallSite struct {
 	InEventTransactionCallback    bool
 	InPipelineTransactionCallback bool
 	UsesBoundaryCallbackTx        bool
+	UsesReceiverDBArgument        bool
 	FunctionContainsWrite         bool
 	FunctionContainsBegin         bool
 	FunctionContainsRead          bool
@@ -176,6 +177,36 @@ func (store *SQLiteRuntimeStore) BadMixedBypass(ctx context.Context) error {
 	}
 	if !strings.Contains(strings.Join(failures, "\n"), "BadMixedBypass") {
 		t.Fatalf("expected failure to name BadMixedBypass, got:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteDBHelperBypassFixture(t *testing.T) {
+	const src = `package pipeline
+
+import (
+	"context"
+	"database/sql"
+)
+
+type WorkflowInstanceStore struct {
+	db *sql.DB
+}
+
+func (s *WorkflowInstanceStore) BadPipelineBypass(ctx context.Context) error {
+	_, err := dbExecContext(ctx, s.db, "UPDATE flow_instances SET status = 'terminated'")
+	return err
+}
+`
+	sites, err := collectRuntimeWriterCallSitesFromSource("internal/runtime/pipeline/workflow_instance_store_sqlite.go", src)
+	if err != nil {
+		t.Fatalf("collect fixture call sites: %v", err)
+	}
+	_, failures := classifyRuntimeWriterCallSites(sites)
+	if len(failures) == 0 {
+		t.Fatal("expected selected SQLite pipeline helper-mediated write bypass fixture to fail classification")
+	}
+	if !strings.Contains(strings.Join(failures, "\n"), "BadPipelineBypass") {
+		t.Fatalf("expected failure to name BadPipelineBypass, got:\n%s", strings.Join(failures, "\n"))
 	}
 }
 
@@ -351,6 +382,7 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 				InEventTransactionCallback:    inScope && scope.event,
 				InPipelineTransactionCallback: inScope && scope.pipeline,
 				UsesBoundaryCallbackTx:        inScope && scope.txParamName[callReceiver],
+				UsesReceiverDBArgument:        runtimeWriterCallUsesReceiverDBArgument(call, info.receiverVariable),
 				FunctionContainsWrite:         info.containsWrite,
 				FunctionContainsBegin:         info.containsBegin,
 				FunctionContainsRead:          info.containsRead,
@@ -385,6 +417,8 @@ func runtimeWriterPrimitive(call *ast.CallExpr) (string, runtimeWriterPrimitiveK
 	case "Begin", "BeginTx", "BeginTxx":
 		return name, primitiveBegin, true
 	case "Exec", "ExecContext":
+		return name, primitiveWrite, true
+	case "dbExecContext":
 		return name, primitiveWrite, true
 	case "Query", "QueryContext", "QueryRow", "QueryRowContext", "Prepare", "PrepareContext":
 		return name, primitiveRead, true
@@ -501,6 +535,23 @@ func runtimeWriterCallReceiver(expr ast.Expr) string {
 	return runtimeWriterRootIdent(sel.X)
 }
 
+func runtimeWriterCallUsesReceiverDBArgument(call *ast.CallExpr, receiverVariable string) bool {
+	receiverVariable = strings.TrimSpace(receiverVariable)
+	if call == nil || receiverVariable == "" {
+		return false
+	}
+	for _, arg := range call.Args {
+		sel, ok := arg.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "db" && sel.Sel.Name != "DB" {
+			continue
+		}
+		if runtimeWriterRootIdent(sel.X) == receiverVariable {
+			return true
+		}
+	}
+	return false
+}
+
 func runtimeWriterRootIdent(expr ast.Expr) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
@@ -562,6 +613,14 @@ func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterCla
 	if site.Receiver == "SQLiteRuntimeStore" {
 		return classifySQLiteRuntimeStoreCallSite(site)
 	}
+	if site.Receiver == "WorkflowInstanceStore" {
+		if classification, reason, ok := classifyWorkflowInstanceStoreCallSite(site); ok {
+			return classification, reason, true
+		}
+		if workflowInstanceStoreSQLiteBypassCandidate(site) {
+			return "", "", false
+		}
+	}
 	if sqliteActiveTxHelper(site) {
 		return classActiveTxHelper, "helper writes only through caller-provided canonical transaction", true
 	}
@@ -577,6 +636,39 @@ func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterCla
 		return classDifferentConcept, "read-only projection/query surface; not selected SQLite mutation authority", true
 	}
 	return "", "", false
+}
+
+func classifyWorkflowInstanceStoreCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
+	if site.Kind != primitiveWrite && site.Kind != primitiveBegin {
+		return "", "", false
+	}
+	if (site.InPipelineTransactionCallback || site.InRuntimeMutationCallback) && site.UsesBoundaryCallbackTx {
+		return classConsumesCanonical, "WorkflowInstanceStore selected writer executes through the callback transaction", true
+	}
+	if site.Primitive == "dbExecContext" && site.UsesReceiverDBArgument {
+		if site.InPipelineTransactionCallback || site.InRuntimeMutationCallback {
+			return classConsumesCanonical, "WorkflowInstanceStore helper-mediated write executes inside canonical transaction context", true
+		}
+		return "", "", false
+	}
+	if site.Path == "internal/runtime/pipeline/workflow_instance_store_sqlite.go" &&
+		site.ReceiverVariable != "" &&
+		site.CallReceiver == site.ReceiverVariable {
+		return "", "", false
+	}
+	return "", "", false
+}
+
+func workflowInstanceStoreSQLiteBypassCandidate(site runtimeWriterCallSite) bool {
+	if site.Kind != primitiveWrite && site.Kind != primitiveBegin {
+		return false
+	}
+	if site.Primitive == "dbExecContext" && site.UsesReceiverDBArgument {
+		return true
+	}
+	return site.Path == "internal/runtime/pipeline/workflow_instance_store_sqlite.go" &&
+		site.ReceiverVariable != "" &&
+		site.CallReceiver == site.ReceiverVariable
 }
 
 func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -253,8 +253,7 @@ func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipel
 		if err := s.CancelScheduleExact(txctx, sc); err != nil {
 			return err
 		}
-		exec := sqliteScheduleDBExecutor(txctx, s.DB)
-		_, err := exec.ExecContext(txctx, `
+		_, err := tx.ExecContext(txctx, `
 			INSERT INTO timers (
 				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
 				fire_at, recurring, recurrence_cron, owner_agent, task_type, status, created_at
@@ -275,8 +274,7 @@ func (s *SQLiteRuntimeStore) CancelScheduleExact(ctx context.Context, sc runtime
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	if err := s.runRuntimeMutation(ctx, "sqlite schedule cancel", func(txctx context.Context, tx *sql.Tx) error {
-		exec := sqliteScheduleDBExecutor(txctx, s.DB)
-		_, err := exec.ExecContext(txctx, `
+		_, err := tx.ExecContext(txctx, `
 			UPDATE timers
 			SET status = 'cancelled'
 			WHERE COALESCE(run_id, '') = COALESCE(?, '')
@@ -342,8 +340,7 @@ func (s *SQLiteRuntimeStore) MarkScheduleFiredExact(ctx context.Context, sc runt
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	if err := s.runRuntimeMutation(ctx, "sqlite schedule fired", func(txctx context.Context, tx *sql.Tx) error {
-		exec := sqliteScheduleDBExecutor(txctx, s.DB)
-		_, err := exec.ExecContext(txctx, `
+		_, err := tx.ExecContext(txctx, `
 			UPDATE timers
 			SET status = 'fired', fired_at = ?
 			WHERE COALESCE(run_id, '') = COALESCE(?, '')


### PR DESCRIPTION
## Summary
- Replace the local SQLite runtime mutation guard with a repo-wide production writer/transaction primitive audit across `cmd` and `internal`.
- Add a targeted bypass fixture proving the guard rejects selected SQLite direct writes outside the canonical mutation boundary.
- Pin selected SQLite runtime construction invariants: no raw `runtime.Stores.SQLDB`, pipeline store constructed with `NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner`, and event publish through `RunEventTransaction`.
- Move SQLite mailbox write materialization behind `SQLiteRuntimeStore.runRuntimeMutation`, closing the live bypass found by the audit.

Closes #1394

## Governing refs/context
- `platform-spec.yaml` `runtime_store_backend_selection`
- `platform-spec.yaml` `runtime_core_persistence_store_contracts`
- `platform-spec.yaml` `selected_runtime_store_facade`
- `platform-spec.yaml` `backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml` `raw_sql_runtime_consumer_boundary_for_sqlite`
- `platform-spec.yaml` row-family contracts for pipeline, events/deliveries/replay/receipts, mailbox, API idempotency, ingress/run control/quiescence, sessions, startup ownership, tool/entity/human-task, budget, runtime diagnostics/log, and LLM turns
- Binding issue context: #1394 pre-audit and approved gate for `sqlite_selected_runtime_writer_boundary_bypass_guard`

## Semantic migration
- New/confirmed canonical owner: `SQLiteRuntimeStore.RunRuntimeMutation` / `runRuntimeMutation` for selected SQLite runtime mutation writers, `SQLiteRuntimeStore.RunEventTransaction` for selected SQLite event publish transactions, and `WorkflowInstanceStore.RunInPipelineTransaction` wired through `NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner` for selected SQLite pipeline writes.
- Old producer/reader/writer path now invalid: direct selected SQLite writer access through `SQLiteRuntimeStore.DB.Exec*` / `Begin*` outside the canonical boundary. The audit found `SQLiteRuntimeStore.MaterializeMailboxWrite`; this PR moves it to `runRuntimeMutation`.
- Production paths checked for surviving old behavior: repo-wide AST audit across production `.go` files under `cmd` and `internal`, excluding tests/testdata/testutil. The guard classified 776 production call sites and fails any unclassified selected-runtime writer primitive.
- Migration complete for this slice: yes, for the approved `sqlite_selected_runtime_writer_boundary_bypass_guard` class. Broader backend-neutral mutation architecture remains tracked separately.

## Tests
- `go test ./internal/store -run 'TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestRuntimeWriterBoundaryGuardRejectsSelectedSQLiteBypassFixture|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestSQLiteRuntimeMutation|TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks' -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres' -count=1`
- `go test ./internal/store -run 'TestSQLiteRuntimeStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner|TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner' -count=1`
- `go test ./internal/store -run TestSelectedSQLiteRuntimeWriterBoundaryAudit -count=1 -v`
- `go test ./...`
